### PR TITLE
Parity impl-18: Feishu streaming edit formatting fix

### DIFF
--- a/crates/hermes-gateway/src/platforms/feishu.rs
+++ b/crates/hermes-gateway/src/platforms/feishu.rs
@@ -453,6 +453,7 @@ impl FeishuAdapter {
     pub async fn send_text(&self, chat_id: &str, text: &str) -> Result<String, GatewayError> {
         let token = self.get_tenant_token().await?;
         let url = format!("{}/im/v1/messages?receive_id_type=chat_id", FEISHU_API_BASE);
+        let text = format_message(text);
 
         let body = serde_json::json!({
             "receive_id": chat_id,
@@ -480,6 +481,7 @@ impl FeishuAdapter {
     pub async fn edit_text(&self, message_id: &str, text: &str) -> Result<(), GatewayError> {
         let token = self.get_tenant_token().await?;
         let url = format!("{}/im/v1/messages/{}", FEISHU_API_BASE, message_id);
+        let text = format_message(text);
 
         let body = serde_json::json!({
             "msg_type": "text",
@@ -1267,6 +1269,10 @@ fn image_fallback_text(image_url: &str, caption: Option<&str>) -> String {
     }
 }
 
+fn format_message(content: &str) -> String {
+    content.trim().to_string()
+}
+
 // ---------------------------------------------------------------------------
 // PlatformAdapter trait implementation
 // ---------------------------------------------------------------------------
@@ -1705,5 +1711,11 @@ mod tests {
     fn image_fallback_text_with_caption() {
         let text = image_fallback_text("https://cdn.example.com/path/diagram", Some("Figure 1"));
         assert_eq!(text, "Figure 1\nhttps://cdn.example.com/path/diagram");
+    }
+
+    #[test]
+    fn format_message_trims_whitespace() {
+        assert_eq!(format_message("\n\nhello world\n"), "hello world");
+        assert_eq!(format_message("  hello world  "), "hello world");
     }
 }

--- a/docs/parity/batch-triage-log.md
+++ b/docs/parity/batch-triage-log.md
@@ -1099,3 +1099,19 @@
   - `python3 scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch`
   - `python3 scripts/generate-global-parity-proof.py --repo-root .`
   - `python3 scripts/generate-workstream-status.py --repo-root .`
+
+## 2026-04-23 impl-18 (feishu streaming edit formatting parity)
+- Scope:
+  - Port Feishu streaming-edit formatting fix so update payloads do not preserve leading/trailing whitespace artifacts.
+- Rust implementation commit:
+  - `792affd06` fix(parity): trim feishu edit payload text for streaming updates.
+    - Added `format_message(content.trim())` helper in `crates/hermes-gateway/src/platforms/feishu.rs`.
+    - Applied formatting in both `send_text` and `edit_text` payload paths for consistency.
+    - Added regression test `format_message_trims_whitespace`.
+- Upstream SHA updated:
+  - `9dba75bc3862dcf9732029af35a616e0ab034b0d` → `ported`
+- Verification:
+  - `cargo test -p hermes-gateway --features feishu format_message_trims_whitespace -- --nocapture`
+  - `python3 scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch`
+  - `python3 scripts/generate-global-parity-proof.py --repo-root .`
+  - `python3 scripts/generate-workstream-status.py --repo-root .`

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -46,7 +46,7 @@
     ],
     "pass": true
   },
-  "generated_at_utc": "2026-04-23T20:06:09.077604+00:00",
+  "generated_at_utc": "2026-04-23T20:14:24.719066+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -75,8 +75,8 @@
   },
   "queue_summary": {
     "by_disposition": {
-      "pending": 70,
-      "ported": 4
+      "pending": 69,
+      "ported": 5
     },
     "by_target_ticket": {
       "20": 16,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-04-23T20:06:09.077604+00:00`
+Generated: `2026-04-23T20:14:24.719066+00:00`
 
 ## Gate Status
 

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -423,12 +423,12 @@
       "target_ticket_name": "GPAR-07 upstream queue backfill"
     },
     {
-      "disposition": "pending",
+      "disposition": "ported",
       "files_sample": [
         "gateway/platforms/feishu.py"
       ],
       "files_touched": 1,
-      "notes": "",
+      "notes": "ported in Rust via crates/hermes-gateway/src/platforms/feishu.rs: normalize outbound text in edit/send paths with format_message(content.trim()) to prevent leading newline artifacts during streaming edits (commit 792affd06)",
       "owner": "",
       "sha": "9dba75bc3862dcf9732029af35a616e0ab034b0d",
       "subject": "fix(feishu): issue where streaming edits in Feishu show extra leading newlines",
@@ -1030,7 +1030,7 @@
       "target_ticket_name": "GPAR-03 UX parity"
     }
   ],
-  "generated_at_utc": "2026-04-23T20:06:09.016533+00:00",
+  "generated_at_utc": "2026-04-23T20:14:24.658832+00:00",
   "refs": {
     "local_ref": "main",
     "range": "main..upstream/main",
@@ -1038,8 +1038,8 @@
   },
   "summary": {
     "by_disposition": {
-      "pending": 70,
-      "ported": 4
+      "pending": 69,
+      "ported": 5
     },
     "by_target_ticket": {
       "20": 16,

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-04-23T20:06:09.016533+00:00`
+Generated: `2026-04-23T20:14:24.658832+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `74`.
 
@@ -13,8 +13,8 @@ Generated: `2026-04-23T20:06:09.016533+00:00`
 
 | Disposition | Commit Count |
 | --- | ---: |
-| pending | 70 |
-| ported | 4 |
+| pending | 69 |
+| ported | 5 |
 
 ## First 100 Pending Commits
 
@@ -47,7 +47,6 @@ Generated: `2026-04-23T20:06:09.016533+00:00`
 | `911f57ad979d` | #26 | chore(release): map TaroballzChen in AUTHOR_MAP |
 | `be99feff1f42` | #20 | fix(image-gen): force-refresh plugin providers in long-lived sessions |
 | `8f50f2834a0d` | #26 | chore(release): add Wysie to AUTHOR_MAP |
-| `9dba75bc3862` | #23 | fix(feishu): issue where streaming edits in Feishu show extra leading newlines |
 | `08cb345e242e` | #26 | chore(release): map Lind3ey in AUTHOR_MAP |
 | `51c1d2de16bc` | #20 | fix(profiles): stage profile imports to prevent directory clobbering |
 | `4c02e4597ec9` | #26 | fix(status): catch OSError in os.kill(pid, 0) for Windows compatibility |

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,6 +1,6 @@
 {
-  "generated_at_utc": "2026-04-23T14:05:46-06:00",
-  "head_sha": "5013f2cfa400757b912a3be27239eb6fe270553c",
+  "generated_at_utc": "2026-04-23T14:14:10-06:00",
+  "head_sha": "792affd06b9d98375f4a7cc3884763064623565f",
   "states": {
     "complete": 7
   },

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,6 +1,6 @@
 # Workstream Status
 
-- Local HEAD: `5013f2cfa400757b912a3be27239eb6fe270553c`
+- Local HEAD: `792affd06b9d98375f4a7cc3884763064623565f`
 - Upstream: `upstream/main` (`b6ca3c28dc434d1d0dca3bd2a029f394014eefbc`)
 
 | Workstream | Title | State |


### PR DESCRIPTION
## Summary
- port Feishu parity fix for streaming edits showing extra leading newlines
- add `format_message` normalization in Rust Feishu adapter and apply to both send/edit text paths
- add regression test for whitespace-trim formatting
- mark upstream commit `9dba75bc...` as ported and refresh parity queue/proof/workstream artifacts

## Verification
- cargo test -p hermes-gateway --features feishu format_message_trims_whitespace -- --nocapture
- cargo check -q
- python3 scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch
- python3 scripts/generate-global-parity-proof.py --repo-root .
- python3 scripts/generate-workstream-status.py --repo-root .
