### PR TITLE
Fix provider auth parity for Nous + codex/qwen runtime wiring

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -569,6 +569,41 @@ mod tests {
         std::env::remove_var(hermes_var);
         std::env::remove_var(stepfun_var);
     }
+
+    #[test]
+    fn test_provider_api_key_from_env_supports_openai_codex() {
+        let var = "HERMES_OPENAI_CODEX_API_KEY";
+        std::env::remove_var(var);
+        std::env::set_var(var, "codex-oauth-token");
+        assert_eq!(
+            provider_api_key_from_env("openai-codex").as_deref(),
+            Some("codex-oauth-token")
+        );
+        std::env::remove_var(var);
+    }
+
+    #[test]
+    fn test_provider_api_key_from_env_supports_qwen_oauth() {
+        let oauth_var = "HERMES_QWEN_OAUTH_API_KEY";
+        let fallback_var = "DASHSCOPE_API_KEY";
+        std::env::remove_var(oauth_var);
+        std::env::remove_var(fallback_var);
+
+        std::env::set_var(fallback_var, "dashscope-fallback");
+        assert_eq!(
+            provider_api_key_from_env("qwen-oauth").as_deref(),
+            Some("dashscope-fallback")
+        );
+
+        std::env::set_var(oauth_var, "qwen-oauth-token");
+        assert_eq!(
+            provider_api_key_from_env("qwen-oauth").as_deref(),
+            Some("qwen-oauth-token")
+        );
+
+        std::env::remove_var(oauth_var);
+        std::env::remove_var(fallback_var);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -671,6 +706,7 @@ pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
 // ---------------------------------------------------------------------------
 
 const STEPFUN_BASE_URL: &str = "https://api.stepfun.ai/step_plan/v1";
+const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
 fn resolve_provider_and_model(config: &GatewayConfig, model: &str) -> (String, String) {
     let trimmed = model.trim();
@@ -716,6 +752,9 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
             .filter(|s| !s.trim().is_empty())
             .or_else(|| std::env::var("OPENAI_API_KEY").ok())
             .filter(|s| !s.trim().is_empty()),
+        "openai-codex" | "codex" => std::env::var("HERMES_OPENAI_CODEX_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
         "anthropic" => std::env::var("ANTHROPIC_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
@@ -724,6 +763,11 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
             .filter(|s| !s.trim().is_empty()),
         "qwen" => std::env::var("DASHSCOPE_API_KEY")
             .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "qwen-oauth" => std::env::var("HERMES_QWEN_OAUTH_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("DASHSCOPE_API_KEY").ok())
             .filter(|s| !s.trim().is_empty()),
         "kimi" | "moonshot" => std::env::var("MOONSHOT_API_KEY")
             .ok()
@@ -784,6 +828,11 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             }
             Arc::new(p)
         }
+        "openai-codex" | "codex" => {
+            let mut p = OpenAiProvider::new(&api_key).with_model(model_name.as_str());
+            p = p.with_base_url(base_url.unwrap_or_else(|| OPENAI_CODEX_BASE_URL.to_string()));
+            Arc::new(p)
+        }
         "anthropic" => {
             let mut p = AnthropicProvider::new(&api_key).with_model(model_name.as_str());
             if let Some(url) = base_url {
@@ -795,7 +844,7 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             let p = OpenRouterProvider::new(&api_key).with_model(model_name.as_str());
             Arc::new(p)
         }
-        "qwen" => {
+        "qwen" | "qwen-oauth" => {
             let mut p = QwenProvider::new(&api_key).with_model(model_name.as_str());
             if let Some(url) = base_url {
                 p = p.with_base_url(url);

--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -1,4 +1,810 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
 use hermes_core::AgentError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const DEFAULT_NOUS_PORTAL_URL: &str = "https://portal.nousresearch.com";
+pub const DEFAULT_NOUS_INFERENCE_URL: &str = "https://inference-api.nousresearch.com/v1";
+pub const DEFAULT_NOUS_CLIENT_ID: &str = "hermes-cli";
+pub const DEFAULT_NOUS_SCOPE: &str = "inference:mint_agent_key";
+pub const DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS: u32 = 30 * 60;
+
+pub const DEFAULT_CODEX_ISSUER: &str = "https://auth.openai.com";
+pub const DEFAULT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+pub const CODEX_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+pub const CODEX_OAUTH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+
+#[derive(Debug, Clone)]
+pub struct NousDeviceCodeOptions {
+    pub portal_base_url: Option<String>,
+    pub inference_base_url: Option<String>,
+    pub client_id: Option<String>,
+    pub scope: Option<String>,
+    pub open_browser: bool,
+    pub timeout_seconds: f64,
+    pub min_key_ttl_seconds: u32,
+}
+
+impl Default for NousDeviceCodeOptions {
+    fn default() -> Self {
+        Self {
+            portal_base_url: None,
+            inference_base_url: None,
+            client_id: None,
+            scope: None,
+            open_browser: true,
+            timeout_seconds: 15.0,
+            min_key_ttl_seconds: DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexDeviceCodeOptions {
+    pub open_browser: bool,
+    pub timeout_seconds: f64,
+}
+
+impl Default for CodexDeviceCodeOptions {
+    fn default() -> Self {
+        Self {
+            open_browser: true,
+            timeout_seconds: 15.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NousAuthState {
+    pub portal_base_url: String,
+    pub inference_base_url: String,
+    pub client_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    pub token_type: String,
+    pub access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    pub obtained_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_in: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_key_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_key_expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_key_expires_in: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_key_reused: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_key_obtained_at: Option<String>,
+}
+
+impl NousAuthState {
+    pub fn runtime_api_key(&self) -> Option<String> {
+        if let Some(agent_key) = self
+            .agent_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Some(agent_key.to_string());
+        }
+        let access = self.access_token.trim();
+        if access.is_empty() {
+            None
+        } else {
+            Some(access.to_string())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexAuthState {
+    pub tokens: CodexTokens,
+    pub base_url: String,
+    pub last_refresh: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexTokens {
+    pub access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_in: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AuthStore {
+    #[serde(default = "default_auth_store_version")]
+    version: u32,
+    #[serde(default)]
+    providers: BTreeMap<String, Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    active_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    updated_at: Option<String>,
+}
+
+const fn default_auth_store_version() -> u32 {
+    1
+}
+
+impl Default for AuthStore {
+    fn default() -> Self {
+        Self {
+            version: default_auth_store_version(),
+            providers: BTreeMap::new(),
+            active_provider: None,
+            updated_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct NousDeviceCodeResponse {
+    device_code: Option<String>,
+    user_code: Option<String>,
+    verification_uri: Option<String>,
+    verification_uri_complete: Option<String>,
+    expires_in: Option<i64>,
+    interval: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NousTokenResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    token_type: Option<String>,
+    scope: Option<String>,
+    expires_in: Option<i64>,
+    inference_base_url: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NousAgentKeyResponse {
+    api_key: Option<String>,
+    key_id: Option<String>,
+    expires_at: Option<String>,
+    expires_in: Option<i64>,
+    reused: Option<bool>,
+    inference_base_url: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexDeviceUserCodeResponse {
+    user_code: Option<String>,
+    device_auth_id: Option<String>,
+    interval: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexDevicePollResponse {
+    authorization_code: Option<String>,
+    code_verifier: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexTokenResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_in: Option<i64>,
+}
+
+fn auth_json_path() -> PathBuf {
+    hermes_config::paths::auth_json_path()
+}
+
+fn load_auth_store(path: &Path) -> Result<AuthStore, AgentError> {
+    if !path.exists() {
+        return Ok(AuthStore::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| AgentError::Io(format!("read {}: {}", path.display(), e)))?;
+    if raw.trim().is_empty() {
+        return Ok(AuthStore::default());
+    }
+    serde_json::from_str(&raw)
+        .map_err(|e| AgentError::Config(format!("parse {}: {}", path.display(), e)))
+}
+
+fn save_auth_store(path: &Path, store: &AuthStore) -> Result<(), AgentError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AgentError::Io(format!("mkdir {}: {}", parent.display(), e)))?;
+    }
+    let mut raw = serde_json::to_string_pretty(store)
+        .map_err(|e| AgentError::Config(format!("serialize auth store: {}", e)))?;
+    raw.push('\n');
+    std::fs::write(path, raw)
+        .map_err(|e| AgentError::Io(format!("write {}: {}", path.display(), e)))
+}
+
+pub fn save_provider_auth_state(provider: &str, state: Value) -> Result<PathBuf, AgentError> {
+    let provider = provider.trim().to_ascii_lowercase();
+    let path = auth_json_path();
+    let mut store = load_auth_store(&path)?;
+    store.providers.insert(provider.clone(), state);
+    store.active_provider = Some(provider);
+    store.updated_at = Some(Utc::now().to_rfc3339());
+    save_auth_store(&path, &store)?;
+    Ok(path)
+}
+
+pub fn read_provider_auth_state(provider: &str) -> Result<Option<Value>, AgentError> {
+    let provider = provider.trim().to_ascii_lowercase();
+    let path = auth_json_path();
+    let store = load_auth_store(&path)?;
+    Ok(store.providers.get(&provider).cloned())
+}
+
+pub fn clear_provider_auth_state(provider: &str) -> Result<bool, AgentError> {
+    let provider = provider.trim().to_ascii_lowercase();
+    let path = auth_json_path();
+    let mut store = load_auth_store(&path)?;
+    let removed = store.providers.remove(&provider).is_some();
+    if store.active_provider.as_deref() == Some(provider.as_str()) {
+        store.active_provider = None;
+    }
+    if removed {
+        store.updated_at = Some(Utc::now().to_rfc3339());
+        save_auth_store(&path, &store)?;
+    }
+    Ok(removed)
+}
+
+pub fn save_nous_auth_state(state: &NousAuthState) -> Result<PathBuf, AgentError> {
+    let value = serde_json::to_value(state)
+        .map_err(|e| AgentError::Config(format!("encode state: {}", e)))?;
+    save_provider_auth_state("nous", value)
+}
+
+pub fn save_codex_auth_state(state: &CodexAuthState) -> Result<PathBuf, AgentError> {
+    let value = serde_json::to_value(state)
+        .map_err(|e| AgentError::Config(format!("encode state: {}", e)))?;
+    save_provider_auth_state("openai-codex", value)
+}
+
+fn env_or_default(name: &str, default: &str) -> String {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn extract_error_message(body: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    let err = value.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    let desc = value
+        .get("error_description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if err.is_empty() && desc.is_empty() {
+        None
+    } else if err.is_empty() {
+        Some(desc.to_string())
+    } else if desc.is_empty() {
+        Some(err.to_string())
+    } else {
+        Some(format!("{err}: {desc}"))
+    }
+}
+
+fn try_open_url(url: &str) -> Result<(), AgentError> {
+    #[cfg(target_os = "macos")]
+    let mut cmd = std::process::Command::new("open");
+    #[cfg(target_os = "linux")]
+    let mut cmd = std::process::Command::new("xdg-open");
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut c = std::process::Command::new("cmd");
+        c.args(["/C", "start", "", url]);
+        c
+    };
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    cmd.arg(url);
+
+    let status = cmd
+        .status()
+        .map_err(|e| AgentError::Io(format!("open browser command failed: {}", e)))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(AgentError::Io(format!(
+            "open browser command exited with status {}",
+            status
+        )))
+    }
+}
+
+pub async fn login_nous_device_code(
+    options: NousDeviceCodeOptions,
+) -> Result<NousAuthState, AgentError> {
+    let portal_base_url = options
+        .portal_base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| {
+            env_or_default(
+                "HERMES_PORTAL_BASE_URL",
+                &env_or_default("NOUS_PORTAL_BASE_URL", DEFAULT_NOUS_PORTAL_URL),
+            )
+            .trim_end_matches('/')
+            .to_string()
+        });
+    let requested_inference_base_url = options
+        .inference_base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| env_or_default("NOUS_INFERENCE_BASE_URL", DEFAULT_NOUS_INFERENCE_URL));
+    let client_id = options
+        .client_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_NOUS_CLIENT_ID)
+        .to_string();
+    let scope = options
+        .scope
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_NOUS_SCOPE)
+        .to_string();
+    let timeout_secs = if options.timeout_seconds.is_finite() {
+        options.timeout_seconds.clamp(5.0, 120.0)
+    } else {
+        15.0
+    };
+    let min_key_ttl_seconds = options.min_key_ttl_seconds.max(60);
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("hermes-agent-ultra/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs_f64(timeout_secs))
+        .build()
+        .map_err(|e| AgentError::Io(format!("build oauth client: {}", e)))?;
+
+    println!("Starting Hermes login via Nous Portal...");
+    println!("Portal: {}", portal_base_url);
+
+    let mut device_form: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    device_form.insert("client_id".to_string(), client_id.clone());
+    if !scope.is_empty() {
+        device_form.insert("scope".to_string(), scope.clone());
+    }
+
+    let device_resp = client
+        .post(format!("{portal_base_url}/api/oauth/device/code"))
+        .form(&device_form)
+        .send()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("device code request failed: {}", e)))?;
+    let device_status = device_resp.status();
+    let device_body = device_resp
+        .text()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("device code response read failed: {}", e)))?;
+    if !device_status.is_success() {
+        let detail = extract_error_message(&device_body).unwrap_or(device_body);
+        return Err(AgentError::AuthFailed(format!(
+            "Nous device code request failed ({}): {}",
+            device_status, detail
+        )));
+    }
+    let device_data: NousDeviceCodeResponse = serde_json::from_str(&device_body)
+        .map_err(|e| AgentError::AuthFailed(format!("invalid device code response: {}", e)))?;
+
+    let device_code = device_data
+        .device_code
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AgentError::AuthFailed("device code response missing device_code".into()))?
+        .to_string();
+    let user_code = device_data
+        .user_code
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AgentError::AuthFailed("device code response missing user_code".into()))?
+        .to_string();
+    let verification_uri = device_data
+        .verification_uri_complete
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            device_data
+                .verification_uri
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        })
+        .ok_or_else(|| {
+            AgentError::AuthFailed("device code response missing verification_uri".into())
+        })?
+        .to_string();
+    let expires_in = device_data.expires_in.unwrap_or(900).max(60) as u64;
+    let mut poll_interval = device_data.interval.unwrap_or(5).clamp(1, 30) as u64;
+
+    println!();
+    println!("To continue:");
+    println!("  1. Open: {}", verification_uri);
+    println!("  2. If prompted, enter code: {}", user_code);
+    if options.open_browser {
+        match try_open_url(&verification_uri) {
+            Ok(_) => println!("  (Opened browser for verification)"),
+            Err(err) => println!("  Could not open browser automatically: {}", err),
+        }
+    }
+    println!("Waiting for approval (polling every {}s)...", poll_interval);
+
+    let deadline = Instant::now() + Duration::from_secs(expires_in);
+    let token_payload = loop {
+        if Instant::now() >= deadline {
+            return Err(AgentError::AuthFailed(
+                "timed out waiting for Nous device authorization".into(),
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(poll_interval)).await;
+
+        let mut token_form: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        token_form.insert(
+            "grant_type".to_string(),
+            "urn:ietf:params:oauth:grant-type:device_code".to_string(),
+        );
+        token_form.insert("client_id".to_string(), client_id.clone());
+        token_form.insert("device_code".to_string(), device_code.clone());
+
+        let token_resp = client
+            .post(format!("{portal_base_url}/api/oauth/token"))
+            .form(&token_form)
+            .send()
+            .await
+            .map_err(|e| AgentError::AuthFailed(format!("token poll request failed: {}", e)))?;
+        let status = token_resp.status();
+        let body = token_resp.text().await.map_err(|e| {
+            AgentError::AuthFailed(format!("token poll response read failed: {}", e))
+        })?;
+        if status.is_success() {
+            let payload: NousTokenResponse = serde_json::from_str(&body)
+                .map_err(|e| AgentError::AuthFailed(format!("invalid token response: {}", e)))?;
+            let has_access_token = payload
+                .access_token
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|s| !s.is_empty());
+            if !has_access_token {
+                return Err(AgentError::AuthFailed(
+                    "token response missing access_token".into(),
+                ));
+            }
+            break payload;
+        }
+        let payload: NousTokenResponse = serde_json::from_str(&body).unwrap_or(NousTokenResponse {
+            access_token: None,
+            refresh_token: None,
+            token_type: None,
+            scope: None,
+            expires_in: None,
+            inference_base_url: None,
+            error: None,
+            error_description: extract_error_message(&body),
+        });
+        match payload.error.as_deref() {
+            Some("authorization_pending") => continue,
+            Some("slow_down") => {
+                poll_interval = (poll_interval + 1).min(30);
+                continue;
+            }
+            _ => {
+                let detail = payload
+                    .error_description
+                    .or(payload.error)
+                    .unwrap_or_else(|| format!("status {}: {}", status, body));
+                return Err(AgentError::AuthFailed(format!(
+                    "Nous token exchange failed: {}",
+                    detail
+                )));
+            }
+        }
+    };
+
+    let access_token = token_payload
+        .access_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AgentError::AuthFailed("token response missing access_token".into()))?
+        .to_string();
+    let access_expires_in = token_payload.expires_in.filter(|v| *v > 0);
+    let now = Utc::now();
+    let access_expires_at = access_expires_in.map(|secs| {
+        (now + chrono::Duration::seconds(secs)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    });
+
+    let mint_resp = client
+        .post(format!("{portal_base_url}/api/oauth/agent-key"))
+        .bearer_auth(&access_token)
+        .json(&serde_json::json!({
+            "min_ttl_seconds": min_key_ttl_seconds,
+        }))
+        .send()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("agent key mint request failed: {}", e)))?;
+    let mint_status = mint_resp.status();
+    let mint_body = mint_resp.text().await.map_err(|e| {
+        AgentError::AuthFailed(format!("agent key mint response read failed: {}", e))
+    })?;
+    if !mint_status.is_success() {
+        let parsed = serde_json::from_str::<NousAgentKeyResponse>(&mint_body).ok();
+        let detail = parsed
+            .and_then(|payload| payload.error_description.or(payload.error))
+            .or_else(|| extract_error_message(&mint_body))
+            .unwrap_or(mint_body);
+        if detail.contains("subscription_required") {
+            return Err(AgentError::AuthFailed(format!(
+                "Nous subscription required. Subscribe at {}/billing",
+                portal_base_url
+            )));
+        }
+        return Err(AgentError::AuthFailed(format!(
+            "Nous agent key mint failed ({}): {}",
+            mint_status, detail
+        )));
+    }
+    let mint_payload: NousAgentKeyResponse = serde_json::from_str(&mint_body)
+        .map_err(|e| AgentError::AuthFailed(format!("invalid agent key response: {}", e)))?;
+    let agent_key = mint_payload
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AgentError::AuthFailed("agent key mint response missing api_key".into()))?
+        .to_string();
+
+    let resolved_inference_url = mint_payload
+        .inference_base_url
+        .or(token_payload.inference_base_url)
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| {
+            requested_inference_base_url
+                .trim_end_matches('/')
+                .to_string()
+        });
+
+    Ok(NousAuthState {
+        portal_base_url,
+        inference_base_url: resolved_inference_url,
+        client_id,
+        scope: token_payload.scope.or(Some(scope)),
+        token_type: token_payload
+            .token_type
+            .unwrap_or_else(|| "Bearer".to_string()),
+        access_token,
+        refresh_token: token_payload.refresh_token,
+        obtained_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        expires_at: access_expires_at,
+        expires_in: access_expires_in,
+        agent_key: Some(agent_key),
+        agent_key_id: mint_payload.key_id,
+        agent_key_expires_at: mint_payload.expires_at,
+        agent_key_expires_in: mint_payload.expires_in,
+        agent_key_reused: mint_payload.reused,
+        agent_key_obtained_at: Some(Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+    })
+}
+
+pub async fn login_openai_codex_device_code(
+    options: CodexDeviceCodeOptions,
+) -> Result<CodexAuthState, AgentError> {
+    let issuer = DEFAULT_CODEX_ISSUER;
+    let timeout_secs = if options.timeout_seconds.is_finite() {
+        options.timeout_seconds.clamp(5.0, 120.0)
+    } else {
+        15.0
+    };
+    let client = reqwest::Client::builder()
+        .user_agent(format!("hermes-agent-ultra/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs_f64(timeout_secs))
+        .build()
+        .map_err(|e| AgentError::Io(format!("build oauth client: {}", e)))?;
+
+    let usercode_resp = client
+        .post(format!("{issuer}/api/accounts/deviceauth/usercode"))
+        .json(&serde_json::json!({
+            "client_id": CODEX_OAUTH_CLIENT_ID,
+        }))
+        .send()
+        .await
+        .map_err(|e| {
+            AgentError::AuthFailed(format!("failed to request codex device code: {}", e))
+        })?;
+    let usercode_status = usercode_resp.status();
+    let usercode_body = usercode_resp.text().await.map_err(|e| {
+        AgentError::AuthFailed(format!("failed reading codex device code response: {}", e))
+    })?;
+    if !usercode_status.is_success() {
+        let detail = extract_error_message(&usercode_body).unwrap_or(usercode_body);
+        return Err(AgentError::AuthFailed(format!(
+            "codex device code request failed ({}): {}",
+            usercode_status, detail
+        )));
+    }
+    let usercode_payload: CodexDeviceUserCodeResponse = serde_json::from_str(&usercode_body)
+        .map_err(|e| {
+            AgentError::AuthFailed(format!("invalid codex device code response: {}", e))
+        })?;
+    let user_code = usercode_payload
+        .user_code
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed("codex device code response missing user_code".into())
+        })?
+        .to_string();
+    let device_auth_id = usercode_payload
+        .device_auth_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed("codex device code response missing device_auth_id".into())
+        })?
+        .to_string();
+    let poll_interval = usercode_payload.interval.unwrap_or(5).max(1) as u64;
+
+    let verify_url = format!("{issuer}/codex/device");
+    println!("To continue, follow these steps:\n");
+    println!("  1. Open this URL in your browser:");
+    println!("     {}", verify_url);
+    println!("\n  2. Enter this code:");
+    println!("     {}", user_code);
+    println!("\nWaiting for sign-in... (press Ctrl+C to cancel)");
+    if options.open_browser {
+        let _ = try_open_url(&verify_url);
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(15 * 60);
+    let mut code_payload: Option<CodexDevicePollResponse> = None;
+    while Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_secs(poll_interval)).await;
+        let poll_resp = client
+            .post(format!("{issuer}/api/accounts/deviceauth/token"))
+            .json(&serde_json::json!({
+                "device_auth_id": device_auth_id,
+                "user_code": user_code,
+            }))
+            .send()
+            .await
+            .map_err(|e| AgentError::AuthFailed(format!("codex device poll failed: {}", e)))?;
+        match poll_resp.status().as_u16() {
+            200 => {
+                let body = poll_resp.text().await.map_err(|e| {
+                    AgentError::AuthFailed(format!("codex poll response read failed: {}", e))
+                })?;
+                let payload: CodexDevicePollResponse =
+                    serde_json::from_str(&body).map_err(|e| {
+                        AgentError::AuthFailed(format!("invalid codex poll response: {}", e))
+                    })?;
+                code_payload = Some(payload);
+                break;
+            }
+            403 | 404 => continue,
+            status => {
+                return Err(AgentError::AuthFailed(format!(
+                    "codex device poll failed with status {}",
+                    status
+                )));
+            }
+        }
+    }
+    let code_payload = code_payload
+        .ok_or_else(|| AgentError::AuthFailed("codex device login timed out".into()))?;
+    let authorization_code = code_payload
+        .authorization_code
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed("codex poll response missing authorization_code".into())
+        })?
+        .to_string();
+    let code_verifier = code_payload
+        .code_verifier
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AgentError::AuthFailed("codex poll response missing code_verifier".into()))?
+        .to_string();
+
+    let token_resp = client
+        .post(CODEX_OAUTH_TOKEN_URL)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", authorization_code.as_str()),
+            (
+                "redirect_uri",
+                "https://auth.openai.com/deviceauth/callback",
+            ),
+            ("client_id", CODEX_OAUTH_CLIENT_ID),
+            ("code_verifier", code_verifier.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("codex token exchange failed: {}", e)))?;
+    let token_status = token_resp.status();
+    let token_body = token_resp
+        .text()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("codex token response read failed: {}", e)))?;
+    if !token_status.is_success() {
+        let detail = extract_error_message(&token_body).unwrap_or(token_body);
+        return Err(AgentError::AuthFailed(format!(
+            "codex token exchange failed ({}): {}",
+            token_status, detail
+        )));
+    }
+    let token_payload: CodexTokenResponse = serde_json::from_str(&token_body)
+        .map_err(|e| AgentError::AuthFailed(format!("invalid codex token response: {}", e)))?;
+    let access_token = token_payload
+        .access_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AgentError::AuthFailed("codex token response missing access_token".into()))?
+        .to_string();
+    let refresh_token = token_payload
+        .refresh_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    let base_url = std::env::var("HERMES_CODEX_BASE_URL")
+        .ok()
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string());
+    Ok(CodexAuthState {
+        tokens: CodexTokens {
+            access_token,
+            refresh_token,
+            expires_in: token_payload.expires_in,
+        },
+        base_url,
+        last_refresh: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        auth_mode: Some("chatgpt".to_string()),
+        source: Some("device_code".to_string()),
+    })
+}
 
 /// Human-readable line after a successful non-OAuth LLM login (API key stored in token store).
 pub async fn login(provider: &str) -> Result<String, AgentError> {
@@ -13,4 +819,39 @@ pub async fn logout(provider: &str) -> Result<String, AgentError> {
         "Removed stored credential for provider '{}'.",
         provider.trim()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nous_runtime_api_key_prefers_agent_key() {
+        let state = NousAuthState {
+            portal_base_url: DEFAULT_NOUS_PORTAL_URL.to_string(),
+            inference_base_url: DEFAULT_NOUS_INFERENCE_URL.to_string(),
+            client_id: DEFAULT_NOUS_CLIENT_ID.to_string(),
+            scope: Some(DEFAULT_NOUS_SCOPE.to_string()),
+            token_type: "Bearer".to_string(),
+            access_token: "portal-access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            obtained_at: Utc::now().to_rfc3339(),
+            expires_at: None,
+            expires_in: None,
+            agent_key: Some("agent-key".to_string()),
+            agent_key_id: None,
+            agent_key_expires_at: None,
+            agent_key_expires_in: None,
+            agent_key_reused: None,
+            agent_key_obtained_at: None,
+        };
+        assert_eq!(state.runtime_api_key().as_deref(), Some("agent-key"));
+    }
+
+    #[test]
+    fn clear_provider_auth_state_is_noop_when_missing() {
+        let provider = format!("missing-{}", uuid::Uuid::new_v4().simple());
+        let removed = clear_provider_auth_state(&provider).expect("clear");
+        assert!(!removed);
+    }
 }

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -16,6 +16,11 @@ use hermes_auth::{AuthManager, FileTokenStore, OAuthCredential};
 use hermes_cli::app::{
     bridge_tool_registry, build_agent_config, build_provider, provider_api_key_from_env,
 };
+use hermes_cli::auth::{
+    clear_provider_auth_state, login_nous_device_code, login_openai_codex_device_code,
+    read_provider_auth_state, save_codex_auth_state, save_nous_auth_state, CodexDeviceCodeOptions,
+    NousDeviceCodeOptions,
+};
 use hermes_cli::cli::{Cli, CliCommand};
 use hermes_cli::config_env::hydrate_env_from_config;
 use hermes_cli::model_switch::{
@@ -241,8 +246,32 @@ async fn main() {
         CliCommand::Insights { days, source } => {
             hermes_cli::commands::handle_cli_insights(days, source).await
         }
-        CliCommand::Login { provider } => hermes_cli::commands::handle_cli_login(provider).await,
-        CliCommand::Logout { provider } => hermes_cli::commands::handle_cli_logout(provider).await,
+        CliCommand::Login { provider } => {
+            run_auth(
+                cli,
+                Some("login".to_string()),
+                provider,
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+        }
+        CliCommand::Logout { provider } => {
+            run_auth(
+                cli,
+                Some("logout".to_string()),
+                provider,
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+        }
         CliCommand::Whatsapp { action } => hermes_cli::commands::handle_cli_whatsapp(action).await,
         CliCommand::Pairing { action, device_id } => {
             hermes_cli::commands::handle_cli_pairing(action, device_id).await
@@ -3211,7 +3240,7 @@ async fn run_telegram_poll_loop(gateway: Arc<Gateway>, adapter: Arc<TelegramAdap
     }
 }
 
-/// Default auth provider: CLI arg, then `HERMES_AUTH_DEFAULT_PROVIDER`, then `openai`.
+/// Default auth provider: CLI arg, then `HERMES_AUTH_DEFAULT_PROVIDER`, then `nous`.
 ///
 /// Set `HERMES_AUTH_DEFAULT_PROVIDER=telegram` if you primarily use the Telegram gateway.
 fn resolve_auth_provider(provider: Option<String>) -> String {
@@ -3231,8 +3260,19 @@ fn resolve_auth_provider(provider: Option<String>) -> String {
     let raw = std::env::var("HERMES_AUTH_DEFAULT_PROVIDER")
         .ok()
         .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "openai".to_string());
+        .or_else(|| infer_default_auth_provider_from_config())
+        .unwrap_or_else(|| "nous".to_string());
     normalize_auth_provider(&raw)
+}
+
+fn infer_default_auth_provider_from_config() -> Option<String> {
+    let cfg = load_config(None).ok()?;
+    let model = cfg.model?;
+    let provider = model
+        .split_once(':')
+        .map(|(provider, _)| provider.trim())
+        .filter(|provider| !provider.is_empty())?;
+    Some(provider.to_string())
 }
 
 fn normalize_auth_provider(provider: &str) -> String {
@@ -3240,6 +3280,7 @@ fn normalize_auth_provider(provider: &str) -> String {
         "wechat" | "wx" => "weixin".to_string(),
         "qq" => "qqbot".to_string(),
         "tg" => "telegram".to_string(),
+        "codex" => "openai-codex".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "api-server" => "api_server".to_string(),
         "home-assistant" => "homeassistant".to_string(),
@@ -3277,6 +3318,7 @@ fn normalize_secret_provider(provider: &str) -> String {
     let p = provider.trim().to_ascii_lowercase();
     match p.as_str() {
         "github-copilot" => "copilot".to_string(),
+        "codex" => "openai-codex".to_string(),
         _ => p,
     }
 }
@@ -3287,6 +3329,7 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
         "kimi" => vec!["kimi".to_string(), "moonshot".to_string()],
         "stepfun" => vec!["stepfun".to_string(), "step".to_string()],
         "copilot" => vec!["copilot".to_string(), "github-copilot".to_string()],
+        "openai-codex" => vec!["openai-codex".to_string(), "codex".to_string()],
         p => vec![p.to_string()],
     }
 }
@@ -3294,9 +3337,11 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
 fn provider_env_var(provider: &str) -> Option<&'static str> {
     match normalize_secret_provider(provider).as_str() {
         "openai" => Some("HERMES_OPENAI_API_KEY"),
+        "openai-codex" => Some("HERMES_OPENAI_CODEX_API_KEY"),
         "anthropic" => Some("ANTHROPIC_API_KEY"),
         "openrouter" => Some("OPENROUTER_API_KEY"),
         "qwen" => Some("DASHSCOPE_API_KEY"),
+        "qwen-oauth" => Some("HERMES_QWEN_OAUTH_API_KEY"),
         "moonshot" | "kimi" => Some("MOONSHOT_API_KEY"),
         "minimax" => Some("MINIMAX_API_KEY"),
         "stepfun" => Some("STEPFUN_API_KEY"),
@@ -3304,6 +3349,30 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "copilot" => Some("GITHUB_COPILOT_TOKEN"),
         _ => None,
     }
+}
+
+fn provider_supports_oauth(provider: &str) -> bool {
+    matches!(
+        normalize_auth_provider(provider).as_str(),
+        "nous" | "openai-codex"
+    )
+}
+
+fn resolve_auth_type_for_provider(provider: &str, requested: Option<&str>) -> String {
+    if let Some(raw) = requested.map(str::trim).filter(|v| !v.is_empty()) {
+        return raw.replace('-', "_").to_ascii_lowercase();
+    }
+    if provider_supports_oauth(provider) {
+        "oauth".to_string()
+    } else {
+        "api_key".to_string()
+    }
+}
+
+fn parse_rfc3339_utc(value: Option<&str>) -> Option<chrono::DateTime<chrono::Utc>> {
+    value
+        .and_then(|v| chrono::DateTime::parse_from_rfc3339(v).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc))
 }
 
 fn secret_vault_path_for_cli(cli: &Cli) -> PathBuf {
@@ -3389,9 +3458,11 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
     let env_bindings = [
         ("HERMES_OPENAI_API_KEY", "openai"),
         ("OPENAI_API_KEY", "openai"),
+        ("HERMES_OPENAI_CODEX_API_KEY", "openai-codex"),
         ("ANTHROPIC_API_KEY", "anthropic"),
         ("OPENROUTER_API_KEY", "openrouter"),
         ("DASHSCOPE_API_KEY", "qwen"),
+        ("HERMES_QWEN_OAUTH_API_KEY", "qwen-oauth"),
         ("MOONSHOT_API_KEY", "moonshot"),
         ("MINIMAX_API_KEY", "minimax"),
         ("STEPFUN_API_KEY", "stepfun"),
@@ -4190,7 +4261,16 @@ async fn print_auth_status_matrix(cli: &Cli, manager: &AuthManager) -> Result<()
     println!("Auth status matrix:");
     println!("-------------------");
 
-    for provider in ["openai", "anthropic", "openrouter", "stepfun", "copilot"] {
+    for provider in [
+        "openai",
+        "anthropic",
+        "openrouter",
+        "stepfun",
+        "nous",
+        "openai-codex",
+        "qwen-oauth",
+        "copilot",
+    ] {
         let env_present = provider_api_key_from_env(provider).is_some()
             || (provider == "copilot"
                 && std::env::var("GITHUB_COPILOT_TOKEN")
@@ -4198,14 +4278,24 @@ async fn print_auth_status_matrix(cli: &Cli, manager: &AuthManager) -> Result<()
                     .map(|v| !v.trim().is_empty())
                     .unwrap_or(false));
         let store_present = manager.get_access_token(provider).await?.is_some();
+        let auth_state_present = if provider_supports_oauth(provider) {
+            read_provider_auth_state(provider)?.is_some()
+        } else {
+            false
+        };
         let (present, source) = if env_present {
             (true, "env")
         } else if store_present {
             (true, "token_store")
+        } else if auth_state_present {
+            (true, "auth_json")
         } else {
             (false, "none")
         };
-        println!("  - {:<16} present={} source={}", provider, present, source);
+        println!(
+            "  - {:<16} present={} source={} oauth_state_present={}",
+            provider, present, source, auth_state_present
+        );
     }
 
     for provider in [
@@ -4275,12 +4365,103 @@ async fn run_auth(
     let mut pool_store = load_auth_pool_store(&pool_path)?;
     match action.as_deref().unwrap_or("status") {
         "add" => {
-            let provider = provider.trim().to_ascii_lowercase();
-            let auth_type = auth_type
-                .as_deref()
-                .unwrap_or("api_key")
-                .replace('-', "_")
-                .to_ascii_lowercase();
+            let provider = normalize_auth_provider(provider.trim());
+            let auth_type = resolve_auth_type_for_provider(&provider, auth_type.as_deref());
+
+            if auth_type == "oauth" {
+                match provider.as_str() {
+                    "nous" => {
+                        let state =
+                            login_nous_device_code(NousDeviceCodeOptions::default()).await?;
+                        let auth_path = save_nous_auth_state(&state)?;
+                        let runtime_key = state.runtime_api_key().ok_or_else(|| {
+                            AgentError::AuthFailed(
+                                "Nous login succeeded but no runtime API key was returned".into(),
+                            )
+                        })?;
+                        let expires_at = parse_rfc3339_utc(state.agent_key_expires_at.as_deref())
+                            .or_else(|| parse_rfc3339_utc(state.expires_at.as_deref()));
+                        manager
+                            .save_credential(OAuthCredential {
+                                provider: "nous".to_string(),
+                                access_token: runtime_key.clone(),
+                                refresh_token: state.refresh_token.clone(),
+                                token_type: state.token_type.clone(),
+                                scope: state.scope.clone(),
+                                expires_at,
+                            })
+                            .await?;
+                        let entries = pool_store.providers.entry(provider.clone()).or_default();
+                        let default_label = format!("{provider}-{}", entries.len() + 1);
+                        let entry = AuthPoolEntry {
+                            id: uuid::Uuid::new_v4().simple().to_string()[..6].to_string(),
+                            label: label.unwrap_or(default_label),
+                            auth_type: "oauth".to_string(),
+                            source: "device_code".to_string(),
+                            access_token: runtime_key,
+                            last_status: None,
+                            last_status_at: None,
+                            last_error_code: None,
+                        };
+                        entries.push(entry.clone());
+                        save_auth_pool_store(&pool_path, &pool_store)?;
+                        println!(
+                            "Added Nous OAuth credential (label='{}', id={}).",
+                            entry.label, entry.id
+                        );
+                        println!("Saved OAuth state: {}", auth_path.display());
+                        return Ok(());
+                    }
+                    "openai-codex" => {
+                        let state =
+                            login_openai_codex_device_code(CodexDeviceCodeOptions::default())
+                                .await?;
+                        let auth_path = save_codex_auth_state(&state)?;
+                        let expires_at = state
+                            .tokens
+                            .expires_in
+                            .filter(|secs| *secs > 0)
+                            .map(|secs| chrono::Utc::now() + chrono::Duration::seconds(secs));
+                        manager
+                            .save_credential(OAuthCredential {
+                                provider: "openai-codex".to_string(),
+                                access_token: state.tokens.access_token.clone(),
+                                refresh_token: state.tokens.refresh_token.clone(),
+                                token_type: "bearer".to_string(),
+                                scope: None,
+                                expires_at,
+                            })
+                            .await?;
+                        let entries = pool_store.providers.entry(provider.clone()).or_default();
+                        let default_label = format!("{provider}-{}", entries.len() + 1);
+                        let entry = AuthPoolEntry {
+                            id: uuid::Uuid::new_v4().simple().to_string()[..6].to_string(),
+                            label: label.unwrap_or(default_label),
+                            auth_type: "oauth".to_string(),
+                            source: "device_code".to_string(),
+                            access_token: state.tokens.access_token.clone(),
+                            last_status: None,
+                            last_status_at: None,
+                            last_error_code: None,
+                        };
+                        entries.push(entry.clone());
+                        save_auth_pool_store(&pool_path, &pool_store)?;
+                        println!(
+                            "Added OpenAI Codex OAuth credential (label='{}', id={}).",
+                            entry.label, entry.id
+                        );
+                        println!("Saved OAuth state: {}", auth_path.display());
+                        return Ok(());
+                    }
+                    _ => {
+                        return Err(AgentError::Config(format!(
+                            "OAuth flow is not implemented for provider '{}'",
+                            provider
+                        )));
+                    }
+                }
+            }
+
             let token = if let Some(raw) = api_key {
                 raw.trim().to_string()
             } else {
@@ -4368,6 +4549,9 @@ async fn run_auth(
             if entries.is_empty() {
                 pool_store.providers.remove(&provider);
                 token_store.remove(&provider).await?;
+                if provider_supports_oauth(&provider) {
+                    let _ = clear_provider_auth_state(&provider)?;
+                }
             } else if let Some(next) = entries.first() {
                 manager
                     .save_credential(OAuthCredential {
@@ -4604,6 +4788,55 @@ async fn run_auth(
                 );
                 return Ok(());
             }
+            if provider == "nous" {
+                let state = login_nous_device_code(NousDeviceCodeOptions::default()).await?;
+                let auth_path = save_nous_auth_state(&state)?;
+                let runtime_key = state.runtime_api_key().ok_or_else(|| {
+                    AgentError::AuthFailed(
+                        "Nous login succeeded but no runtime API key was returned".into(),
+                    )
+                })?;
+                let expires_at = parse_rfc3339_utc(state.agent_key_expires_at.as_deref())
+                    .or_else(|| parse_rfc3339_utc(state.expires_at.as_deref()));
+                manager
+                    .save_credential(OAuthCredential {
+                        provider: "nous".to_string(),
+                        access_token: runtime_key,
+                        refresh_token: state.refresh_token.clone(),
+                        token_type: state.token_type.clone(),
+                        scope: state.scope.clone(),
+                        expires_at,
+                    })
+                    .await?;
+                println!("Nous device login complete; credential saved as provider 'nous'.");
+                println!("Saved OAuth state: {}", auth_path.display());
+                return Ok(());
+            }
+            if provider == "openai-codex" {
+                let state =
+                    login_openai_codex_device_code(CodexDeviceCodeOptions::default()).await?;
+                let auth_path = save_codex_auth_state(&state)?;
+                let expires_at = state
+                    .tokens
+                    .expires_in
+                    .filter(|secs| *secs > 0)
+                    .map(|secs| chrono::Utc::now() + chrono::Duration::seconds(secs));
+                manager
+                    .save_credential(OAuthCredential {
+                        provider: "openai-codex".to_string(),
+                        access_token: state.tokens.access_token.clone(),
+                        refresh_token: state.tokens.refresh_token.clone(),
+                        token_type: "bearer".to_string(),
+                        scope: None,
+                        expires_at,
+                    })
+                    .await?;
+                println!(
+                    "OpenAI Codex device login complete; credential saved as provider 'openai-codex'."
+                );
+                println!("Saved OAuth state: {}", auth_path.display());
+                return Ok(());
+            }
             if provider == "copilot" || provider == "github-copilot" {
                 let access_token = hermes_cli::copilot_auth::start_copilot_device_flow().await?;
                 manager
@@ -4690,6 +4923,9 @@ async fn run_auth(
             }
             let msg = hermes_cli::auth::logout(&provider).await?;
             token_store.remove(&provider).await?;
+            if provider_supports_oauth(&provider) {
+                let _ = clear_provider_auth_state(&provider)?;
+            }
             println!("{} (removed credential for provider: {})", msg, provider);
         }
         _ => {
@@ -4783,16 +5019,23 @@ async fn run_auth(
             }
             let env_present = provider_api_key_from_env(&provider).is_some();
             let store_present = manager.get_access_token(&provider).await?.is_some();
+            let auth_state_present = if provider_supports_oauth(&provider) {
+                read_provider_auth_state(&provider)?.is_some()
+            } else {
+                false
+            };
             let (has_token, source) = if env_present {
                 (true, "env")
             } else if store_present {
                 (true, "token_store")
+            } else if auth_state_present {
+                (true, "auth_json")
             } else {
                 (false, "none")
             };
             println!(
-                "Auth status: provider='{}', credential_present={}, source={}",
-                provider, has_token, source
+                "Auth status: provider='{}', credential_present={}, source={}, oauth_state_present={}",
+                provider, has_token, source, auth_state_present
             );
         }
     }
@@ -5805,6 +6048,31 @@ fn merge_missing_env_keys(src: &Path, dst: &Path, label: &str) -> Result<usize, 
     Ok(to_import.len())
 }
 
+fn upsert_env_key(path: &Path, key: &str, value: &str) -> Result<(), AgentError> {
+    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let mut updated_lines = Vec::new();
+    let mut replaced = false;
+    for line in existing.lines() {
+        if let Some((k, _)) = parse_env_assignment(line) {
+            if k == key {
+                updated_lines.push(format!("{key}={value}"));
+                replaced = true;
+                continue;
+            }
+        }
+        updated_lines.push(line.to_string());
+    }
+    if !replaced {
+        updated_lines.push(format!("{key}={value}"));
+    }
+    let mut updated = updated_lines.join("\n");
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    std::fs::write(path, updated)
+        .map_err(|e| AgentError::Io(format!("write {}: {}", path.display(), e)))
+}
+
 fn maybe_import_legacy_env(
     reader: &mut dyn std::io::BufRead,
     env_path: &Path,
@@ -5894,16 +6162,19 @@ async fn run_setup() -> Result<(), AgentError> {
 
     // 3. Prompt for model/provider
     println!("\nAvailable models:");
-    println!("  1) openai:gpt-4o          (recommended)");
+    println!("  1) openai:gpt-4o");
     println!("  2) openai:gpt-4o-mini     (fast & cheap)");
     println!("  3) anthropic:claude-3-5-sonnet");
     println!("  4) openrouter:auto        (multi-provider)");
-    println!("  5) nous:hermes-3-llama-3.1-405b");
+    println!("  5) nous:hermes-3-llama-3.1-405b (recommended)");
     let has_nous_key = std::env::var("NOUS_API_KEY")
         .ok()
         .is_some_and(|v| !v.trim().is_empty())
         || read_env_key(&env_path, "NOUS_API_KEY").is_some();
-    let default_model_choice = if has_nous_key { "5" } else { "1" };
+    let default_model_choice = "5";
+    if !has_nous_key {
+        println!("  (Nous is the default; setup can complete OAuth login automatically.)");
+    }
     print!("Choose model [{}]: ", default_model_choice);
     io::stdout().flush().ok();
     let mut model_choice = String::new();
@@ -5919,31 +6190,69 @@ async fn run_setup() -> Result<(), AgentError> {
     let selected_provider_env_keys = setup_provider_env_keys(&selected_provider);
     let env_keys_display = selected_provider_env_keys.join("/");
 
-    // 4. Prompt for selected provider API key
+    // 4. Prompt for selected provider API key (or OAuth device login where supported)
     let has_selected_provider_env_key = selected_provider_env_keys.iter().any(|key| {
         std::env::var(key)
             .ok()
             .is_some_and(|v| !v.trim().is_empty())
             || read_env_key(&env_path, key).is_some()
     });
-    if has_selected_provider_env_key {
-        print!(
-            "\n{} API key (leave blank to keep {} from environment/{}): ",
-            selected_provider_label,
-            env_keys_display,
-            env_path.display()
-        );
-    } else {
-        print!(
-            "\n{} API key (leave blank to skip): ",
-            selected_provider_label
-        );
-    }
-    io::stdout().flush().ok();
+    let mut nous_oauth_state: Option<hermes_cli::auth::NousAuthState> = None;
     let mut api_key = String::new();
-    reader.read_line(&mut api_key).ok();
-    let api_key = api_key.trim().to_string();
     let mut stored_provider_secret_in_vault = false;
+
+    if selected_provider == "nous" {
+        print!("\nAuthenticate with Nous Portal OAuth device login now? [Y/n]: ");
+        io::stdout().flush().ok();
+        let mut answer = String::new();
+        reader.read_line(&mut answer).ok();
+        let use_nous_oauth = !matches!(answer.trim().to_ascii_lowercase().as_str(), "n" | "no");
+        if use_nous_oauth {
+            let state = login_nous_device_code(NousDeviceCodeOptions::default()).await?;
+            let auth_path = save_nous_auth_state(&state)?;
+            println!("  ✓ Saved Nous OAuth state: {}", auth_path.display());
+            let runtime_key = state.runtime_api_key().ok_or_else(|| {
+                AgentError::AuthFailed(
+                    "Nous login succeeded but no runtime API key was returned".into(),
+                )
+            })?;
+            let store = FileTokenStore::new(config_dir.join("auth").join("tokens.json")).await?;
+            let manager = AuthManager::new(store);
+            manager
+                .save_credential(OAuthCredential {
+                    provider: "nous".to_string(),
+                    access_token: runtime_key,
+                    refresh_token: state.refresh_token.clone(),
+                    token_type: state.token_type.clone(),
+                    scope: state.scope.clone(),
+                    expires_at: parse_rfc3339_utc(state.agent_key_expires_at.as_deref())
+                        .or_else(|| parse_rfc3339_utc(state.expires_at.as_deref())),
+                })
+                .await?;
+            stored_provider_secret_in_vault = true;
+            nous_oauth_state = Some(state);
+        }
+    }
+
+    if nous_oauth_state.is_none() {
+        if has_selected_provider_env_key {
+            print!(
+                "\n{} API key (leave blank to keep {} from environment/{}): ",
+                selected_provider_label,
+                env_keys_display,
+                env_path.display()
+            );
+        } else {
+            print!(
+                "\n{} API key (leave blank to skip): ",
+                selected_provider_label
+            );
+        }
+        io::stdout().flush().ok();
+        reader.read_line(&mut api_key).ok();
+        api_key = api_key.trim().to_string();
+    }
+
     if !api_key.is_empty() {
         print!(
             "Store {} key in encrypted vault (recommended) [Y/n]: ",
@@ -6004,6 +6313,25 @@ async fn run_setup() -> Result<(), AgentError> {
     disk.model = Some(model.to_string());
     disk.personality = Some(personality.to_string());
     disk.max_turns = 50;
+
+    let _ = upsert_env_key(
+        &env_path,
+        "HERMES_AUTH_DEFAULT_PROVIDER",
+        selected_provider.as_str(),
+    );
+
+    if let Some(state) = &nous_oauth_state {
+        let provider = disk
+            .llm_providers
+            .entry("nous".to_string())
+            .or_insert_with(hermes_config::LlmProviderConfig::default);
+        provider.base_url = Some(state.inference_base_url.clone());
+        provider.oauth_token_url = Some(format!(
+            "{}/api/oauth/token",
+            state.portal_base_url.trim_end_matches('/')
+        ));
+        provider.oauth_client_id = Some(state.client_id.clone());
+    }
 
     if !api_key.is_empty() && !stored_provider_secret_in_vault {
         let provider = disk
@@ -7699,15 +8027,42 @@ mod tests {
         assert_eq!(normalize_auth_provider("tg"), "telegram");
         assert_eq!(normalize_auth_provider("wechat"), "weixin");
         assert_eq!(normalize_auth_provider("wx"), "weixin");
+        assert_eq!(normalize_auth_provider("codex"), "openai-codex");
         assert_eq!(normalize_auth_provider("step-plan"), "stepfun");
         assert_eq!(normalize_auth_provider("api-server"), "api_server");
         assert_eq!(normalize_auth_provider("mm"), "mattermost");
     }
 
     #[test]
+    fn resolve_auth_type_prefers_oauth_for_supported_providers() {
+        assert_eq!(resolve_auth_type_for_provider("nous", None), "oauth");
+        assert_eq!(
+            resolve_auth_type_for_provider("openai-codex", None),
+            "oauth"
+        );
+        assert_eq!(resolve_auth_type_for_provider("openai", None), "api_key");
+        assert_eq!(
+            resolve_auth_type_for_provider("openai", Some("API-KEY")),
+            "api_key"
+        );
+        assert_eq!(
+            resolve_auth_type_for_provider("openai", Some("oauth")),
+            "oauth"
+        );
+    }
+
+    #[test]
     fn provider_env_var_maps_stepfun() {
         assert_eq!(provider_env_var("stepfun"), Some("STEPFUN_API_KEY"));
         assert_eq!(provider_env_var("step"), None);
+        assert_eq!(
+            provider_env_var("openai-codex"),
+            Some("HERMES_OPENAI_CODEX_API_KEY")
+        );
+        assert_eq!(
+            provider_env_var("qwen-oauth"),
+            Some("HERMES_QWEN_OAUTH_API_KEY")
+        );
         assert_eq!(secret_provider_aliases("stepfun"), vec!["stepfun", "step"]);
     }
 
@@ -7761,6 +8116,23 @@ mod tests {
         assert!(contents.contains("OPENAI_API_KEY=real-key"));
         assert!(!contents.contains("OPENROUTER_API_KEY="));
         assert!(!contents.contains("MINIMAX_API_KEY="));
+    }
+
+    #[test]
+    fn upsert_env_key_rewrites_existing_and_appends_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let env_file = tmp.path().join(".env");
+        std::fs::write(
+            &env_file,
+            "OPENAI_API_KEY=old\nHERMES_AUTH_DEFAULT_PROVIDER=openai\n",
+        )
+        .expect("write env");
+        upsert_env_key(&env_file, "HERMES_AUTH_DEFAULT_PROVIDER", "nous").expect("upsert");
+        upsert_env_key(&env_file, "NOUS_API_KEY", "tok").expect("append");
+        let raw = std::fs::read_to_string(&env_file).expect("read env");
+        assert!(raw.contains("HERMES_AUTH_DEFAULT_PROVIDER=nous"));
+        assert!(raw.contains("NOUS_API_KEY=tok"));
+        assert!(!raw.contains("HERMES_AUTH_DEFAULT_PROVIDER=openai"));
     }
 
     #[test]

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -227,6 +227,7 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
 
     // Layer 3: environment variables (highest priority)
     apply_env_overrides(&mut config);
+    normalize_provider_secrets(&mut config);
 
     // Record the effective home dir
     config.home_dir = Some(effective_home);
@@ -256,10 +257,68 @@ pub fn load_from_yaml(path: &Path) -> Result<GatewayConfig, ConfigError> {
 /// Load `config.yaml` from disk if it exists; otherwise return defaults (no env merge).
 pub fn load_user_config_file(path: &Path) -> Result<GatewayConfig, ConfigError> {
     if path.exists() {
-        load_from_yaml(path)
+        let mut cfg = load_from_yaml(path)?;
+        normalize_provider_secrets(&mut cfg);
+        Ok(cfg)
     } else {
         Ok(GatewayConfig::default())
     }
+}
+
+fn normalize_provider_secrets(config: &mut GatewayConfig) {
+    for provider in config.llm_providers.values_mut() {
+        if provider
+            .api_key
+            .as_ref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            provider.api_key = None;
+        }
+        if provider
+            .api_key_env
+            .as_ref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            provider.api_key_env = None;
+        }
+        if provider
+            .base_url
+            .as_ref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            provider.base_url = None;
+        }
+        if provider
+            .oauth_token_url
+            .as_ref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            provider.oauth_token_url = None;
+        }
+        if provider
+            .oauth_client_id
+            .as_ref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            provider.oauth_client_id = None;
+        }
+    }
+
+    config.llm_providers.retain(|_, provider| {
+        provider.api_key.is_some()
+            || provider.api_key_env.is_some()
+            || provider.base_url.is_some()
+            || provider.command.is_some()
+            || !provider.args.is_empty()
+            || provider.model.is_some()
+            || provider.max_tokens.is_some()
+            || provider.temperature.is_some()
+            || provider.extra_body.is_some()
+            || provider.rate_limit.is_some()
+            || !provider.credential_pool.is_empty()
+            || provider.oauth_token_url.is_some()
+            || provider.oauth_client_id.is_some()
+    });
 }
 
 const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, llm.<provider>.api_key|api_key_env|base_url|model|command|args|oauth_token_url|oauth_client_id, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
@@ -763,7 +822,9 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
     for (env_var, provider_name) in [
         ("ANTHROPIC_API_KEY", "anthropic"),
         ("OPENROUTER_API_KEY", "openrouter"),
+        ("HERMES_OPENAI_CODEX_API_KEY", "openai-codex"),
         ("DASHSCOPE_API_KEY", "qwen"),
+        ("HERMES_QWEN_OAUTH_API_KEY", "qwen-oauth"),
         ("MOONSHOT_API_KEY", "kimi"),
         ("MINIMAX_API_KEY", "minimax"),
         ("NOUS_API_KEY", "nous"),
@@ -821,7 +882,7 @@ pub fn validate_config(config: &GatewayConfig) -> Result<(), ConfigError> {
 
     for (name, provider) in &config.llm_providers {
         if let Some(key) = &provider.api_key {
-            if key.is_empty() {
+            if key.trim().is_empty() {
                 return Err(ConfigError::ValidationError(format!(
                     "llm_providers.{name}.api_key must not be empty"
                 )));
@@ -877,6 +938,57 @@ mod tests {
         );
         config.llm_providers = providers;
         assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn validate_whitespace_api_key() {
+        let mut config = GatewayConfig::default();
+        let mut providers = HashMap::new();
+        providers.insert(
+            "test".into(),
+            crate::config::LlmProviderConfig {
+                api_key: Some("   ".into()),
+                ..Default::default()
+            },
+        );
+        config.llm_providers = providers;
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn normalize_provider_secrets_removes_empty_provider_entries() {
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "minimax".into(),
+            crate::config::LlmProviderConfig {
+                api_key: Some("".into()),
+                ..Default::default()
+            },
+        );
+        config.llm_providers.insert(
+            "openrouter".into(),
+            crate::config::LlmProviderConfig {
+                api_key: Some("   ".into()),
+                oauth_token_url: Some("  ".into()),
+                ..Default::default()
+            },
+        );
+        config.llm_providers.insert(
+            "nous".into(),
+            crate::config::LlmProviderConfig {
+                api_key: Some("tok-abc".into()),
+                ..Default::default()
+            },
+        );
+        normalize_provider_secrets(&mut config);
+        assert_eq!(config.llm_providers.len(), 1);
+        assert_eq!(
+            config
+                .llm_providers
+                .get("nous")
+                .and_then(|cfg| cfg.api_key.as_deref()),
+            Some("tok-abc")
+        );
     }
 
     #[test]
@@ -1111,6 +1223,39 @@ mod tests {
         unsafe {
             std::env::remove_var("HERMES_OPENAI_API_KEY");
             std::env::remove_var("OPENAI_API_KEY");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_supports_codex_and_qwen_oauth_env_vars() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::set_var("HERMES_OPENAI_CODEX_API_KEY", "codex-token");
+            std::env::set_var("HERMES_QWEN_OAUTH_API_KEY", "qwen-oauth-token");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_env_overrides(&mut cfg);
+
+        assert_eq!(
+            cfg.llm_providers
+                .get("openai-codex")
+                .and_then(|p| p.api_key.as_deref()),
+            Some("codex-token")
+        );
+        assert_eq!(
+            cfg.llm_providers
+                .get("qwen-oauth")
+                .and_then(|p| p.api_key.as_deref()),
+            Some("qwen-oauth-token")
+        );
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("HERMES_OPENAI_CODEX_API_KEY");
+            std::env::remove_var("HERMES_QWEN_OAUTH_API_KEY");
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement full Nous device-code OAuth path in Rust auth/setup flow and persist auth.json + token store state
- route top-level `login/logout` through unified `run_auth` so provider-specific flows are no longer bypassed
- harden config loading by normalizing empty provider secrets so stale empty keys (for example minimax) no longer break startup
- add codex/qwen OAuth runtime env wiring (`HERMES_OPENAI_CODEX_API_KEY`, `HERMES_QWEN_OAUTH_API_KEY`) for vault hydration + provider resolution
- improve setup defaults to prefer Nous and persist `HERMES_AUTH_DEFAULT_PROVIDER`

## Validation
- cargo fmt --all
- cargo test -p hermes-config apply_env_overrides_supports_codex_and_qwen_oauth_env_vars -- --nocapture
- cargo test -p hermes-config validate_whitespace_api_key -- --nocapture
- cargo test -p hermes-config normalize_provider_secrets_removes_empty_provider_entries -- --nocapture
- cargo test -p hermes-cli auth_provider_aliases_cover_primary_chains -- --nocapture
- cargo test -p hermes-cli resolve_auth_type_prefers_oauth_for_supported_providers -- --nocapture
- cargo test -p hermes-cli provider_env_var_maps_stepfun -- --nocapture
- cargo test -p hermes-cli test_provider_api_key_from_env_supports_openai_codex -- --nocapture
- cargo test -p hermes-cli test_provider_api_key_from_env_supports_qwen_oauth -- --nocapture
- cargo test -p hermes-cli upsert_env_key_rewrites_existing_and_appends_missing -- --nocapture
- cargo check -p hermes-cli
- manual smoke: `hermes-ultra --config-dir <tmp> auth status nous` with `llm_providers.minimax.api_key: ""` in config
