### PR TITLE
feat(auth): add gemini + anthropic oauth parity flows in rust

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -1615,20 +1615,38 @@ impl AgentLoop {
                 .or_else(|| std::env::var("STEPFUN_API_KEY").ok())
                 .filter(|v| !v.trim().is_empty());
         }
-        let env_var = match provider {
-            "anthropic" => "ANTHROPIC_API_KEY",
-            "openrouter" => "OPENROUTER_API_KEY",
-            "qwen" | "qwen-oauth" => "DASHSCOPE_API_KEY",
-            "kimi" | "moonshot" => "MOONSHOT_API_KEY",
-            "minimax" => "MINIMAX_API_KEY",
-            "nous" => "NOUS_API_KEY",
-            "copilot" | "copilot-acp" => "GITHUB_COPILOT_TOKEN",
-            _ => "",
-        };
-        if env_var.is_empty() {
-            None
-        } else {
-            std::env::var(env_var).ok().filter(|v| !v.trim().is_empty())
+        match provider {
+            "anthropic" | "claude" | "claude-code" => std::env::var("ANTHROPIC_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("ANTHROPIC_TOKEN").ok())
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok())
+                .filter(|v| !v.trim().is_empty()),
+            "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => {
+                std::env::var("HERMES_GEMINI_OAUTH_API_KEY")
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+            }
+            "openrouter" => std::env::var("OPENROUTER_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "qwen" | "qwen-oauth" => std::env::var("DASHSCOPE_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "kimi" | "moonshot" => std::env::var("MOONSHOT_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "minimax" => std::env::var("MINIMAX_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "nous" => std::env::var("NOUS_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "copilot" | "copilot-acp" => std::env::var("GITHUB_COPILOT_TOKEN")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            _ => None,
         }
     }
 
@@ -1657,6 +1675,8 @@ impl AgentLoop {
                     Some("https://api.openai.com/v1".to_string())
                 } else if provider == "qwen-oauth" {
                     Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string())
+                } else if provider == "google-gemini-cli" {
+                    Some("cloudcode-pa://google".to_string())
                 } else if provider == "stepfun" {
                     Some("https://api.stepfun.ai/step_plan/v1".to_string())
                 } else {
@@ -1669,6 +1689,8 @@ impl AgentLoop {
         let provider_key = match provider {
             "openai-codex" | "codex" => "openai-codex",
             "qwen-oauth" => "qwen-oauth",
+            "anthropic" | "claude" | "claude-code" => "anthropic",
+            "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => "google-gemini-cli",
             _ => return None,
         };
         let path = self.auth_tokens_path();
@@ -1693,6 +1715,8 @@ impl AgentLoop {
         self.refresh_single_oauth_store_token_if_needed("openai-codex")
             .await;
         self.refresh_single_oauth_store_token_if_needed("qwen-oauth")
+            .await;
+        self.refresh_single_oauth_store_token_if_needed("anthropic")
             .await;
     }
 
@@ -1780,20 +1804,40 @@ impl AgentLoop {
                 "HERMES_OPENAI_CODEX_OAUTH_CLIENT_ID",
             ),
             "qwen-oauth" => ("HERMES_QWEN_OAUTH_TOKEN_URL", "HERMES_QWEN_OAUTH_CLIENT_ID"),
+            "anthropic" => (
+                "HERMES_ANTHROPIC_OAUTH_TOKEN_URL",
+                "HERMES_ANTHROPIC_OAUTH_CLIENT_ID",
+            ),
             _ => return cfg_token_url.zip(cfg_client_id),
         };
-        let token_url = cfg_token_url.or_else(|| {
-            std::env::var(token_url_env)
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-        })?;
-        let client_id = cfg_client_id.or_else(|| {
-            std::env::var(client_id_env)
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-        })?;
+        let token_url = cfg_token_url
+            .or_else(|| {
+                std::env::var(token_url_env)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            })
+            .or_else(|| {
+                if provider_key == "anthropic" {
+                    Some("https://console.anthropic.com/v1/oauth/token".to_string())
+                } else {
+                    None
+                }
+            })?;
+        let client_id = cfg_client_id
+            .or_else(|| {
+                std::env::var(client_id_env)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            })
+            .or_else(|| {
+                if provider_key == "anthropic" {
+                    Some("9d1c250a-e61b-44d9-88ed-5944d1962f5e".to_string())
+                } else {
+                    None
+                }
+            })?;
         Some((token_url, client_id))
     }
 
@@ -7482,6 +7526,117 @@ mod tests {
         let resolved = agent.resolve_runtime_api_key("custom", None, None);
         assert_eq!(resolved.as_deref(), Some("env-secret"));
         std::env::remove_var("MY_FALLBACK_KEY");
+    }
+
+    #[test]
+    fn test_runtime_provider_api_key_env_supports_anthropic_aliases_and_gemini_oauth() {
+        use futures::stream::BoxStream;
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let agent = AgentLoop::new(
+            AgentConfig::default(),
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("ANTHROPIC_TOKEN");
+        std::env::set_var("CLAUDE_CODE_OAUTH_TOKEN", "claude-code-token");
+        assert_eq!(
+            agent
+                .resolve_runtime_api_key("anthropic", None, None)
+                .as_deref(),
+            Some("claude-code-token")
+        );
+        std::env::remove_var("CLAUDE_CODE_OAUTH_TOKEN");
+
+        std::env::set_var("HERMES_GEMINI_OAUTH_API_KEY", "gemini-oauth-token");
+        assert_eq!(
+            agent
+                .resolve_runtime_api_key("google-gemini-cli", None, None)
+                .as_deref(),
+            Some("gemini-oauth-token")
+        );
+        std::env::remove_var("HERMES_GEMINI_OAUTH_API_KEY");
+    }
+
+    #[test]
+    fn test_oauth_refresh_config_anthropic_defaults_available() {
+        use futures::stream::BoxStream;
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        std::env::remove_var("HERMES_ANTHROPIC_OAUTH_TOKEN_URL");
+        std::env::remove_var("HERMES_ANTHROPIC_OAUTH_CLIENT_ID");
+        let agent = AgentLoop::new(
+            AgentConfig::default(),
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+        let (token_url, client_id) = agent.oauth_refresh_config("anthropic").unwrap();
+        assert_eq!(token_url, "https://console.anthropic.com/v1/oauth/token");
+        assert_eq!(client_id, "9d1c250a-e61b-44d9-88ed-5944d1962f5e");
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -583,6 +583,38 @@ mod tests {
     }
 
     #[test]
+    fn test_provider_api_key_from_env_supports_anthropic_aliases() {
+        let primary = "ANTHROPIC_API_KEY";
+        let secondary = "ANTHROPIC_TOKEN";
+        let tertiary = "CLAUDE_CODE_OAUTH_TOKEN";
+        std::env::remove_var(primary);
+        std::env::remove_var(secondary);
+        std::env::remove_var(tertiary);
+
+        std::env::set_var(tertiary, "claude-oauth-token");
+        assert_eq!(
+            provider_api_key_from_env("anthropic").as_deref(),
+            Some("claude-oauth-token")
+        );
+
+        std::env::set_var(secondary, "anthropic-token");
+        assert_eq!(
+            provider_api_key_from_env("anthropic").as_deref(),
+            Some("anthropic-token")
+        );
+
+        std::env::set_var(primary, "anthropic-api-key");
+        assert_eq!(
+            provider_api_key_from_env("anthropic").as_deref(),
+            Some("anthropic-api-key")
+        );
+
+        std::env::remove_var(primary);
+        std::env::remove_var(secondary);
+        std::env::remove_var(tertiary);
+    }
+
+    #[test]
     fn test_provider_api_key_from_env_supports_qwen_oauth() {
         let oauth_var = "HERMES_QWEN_OAUTH_API_KEY";
         let fallback_var = "DASHSCOPE_API_KEY";
@@ -603,6 +635,18 @@ mod tests {
 
         std::env::remove_var(oauth_var);
         std::env::remove_var(fallback_var);
+    }
+
+    #[test]
+    fn test_provider_api_key_from_env_supports_google_gemini_cli() {
+        let var = "HERMES_GEMINI_OAUTH_API_KEY";
+        std::env::remove_var(var);
+        std::env::set_var(var, "google-gemini-oauth-token");
+        assert_eq!(
+            provider_api_key_from_env("google-gemini-cli").as_deref(),
+            Some("google-gemini-oauth-token")
+        );
+        std::env::remove_var(var);
     }
 }
 
@@ -755,9 +799,18 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
         "openai-codex" | "codex" => std::env::var("HERMES_OPENAI_CODEX_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
-        "anthropic" => std::env::var("ANTHROPIC_API_KEY")
+        "anthropic" | "claude" | "claude-code" => std::env::var("ANTHROPIC_API_KEY")
             .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("ANTHROPIC_TOKEN").ok())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok())
             .filter(|s| !s.trim().is_empty()),
+        "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => {
+            std::env::var("HERMES_GEMINI_OAUTH_API_KEY")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        }
         "openrouter" => std::env::var("OPENROUTER_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),

--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -1,11 +1,17 @@
 use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use chrono::Utc;
 use hermes_core::AgentError;
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 pub const DEFAULT_NOUS_PORTAL_URL: &str = "https://portal.nousresearch.com";
 pub const DEFAULT_NOUS_INFERENCE_URL: &str = "https://inference-api.nousresearch.com/v1";
@@ -17,10 +23,29 @@ pub const DEFAULT_CODEX_ISSUER: &str = "https://auth.openai.com";
 pub const DEFAULT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 pub const CODEX_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const CODEX_OAUTH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+pub const ANTHROPIC_OAUTH_AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
+pub const ANTHROPIC_OAUTH_TOKEN_URL: &str = "https://console.anthropic.com/v1/oauth/token";
+pub const ANTHROPIC_OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+pub const ANTHROPIC_OAUTH_REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
+pub const ANTHROPIC_OAUTH_SCOPE: &str = "org:create_api_key user:profile user:inference";
+pub const ANTHROPIC_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS: i64 = 60;
 pub const DEFAULT_QWEN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 pub const QWEN_OAUTH_CLIENT_ID: &str = "f0304373b74a44d2b584a3fb70ca9e56";
 pub const QWEN_OAUTH_TOKEN_URL: &str = "https://chat.qwen.ai/api/v1/oauth2/token";
 pub const QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS: i64 = 120;
+pub const DEFAULT_GEMINI_CLOUDCODE_BASE_URL: &str = "cloudcode-pa://google";
+pub const GEMINI_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS: i64 = 60;
+const GEMINI_AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const GEMINI_TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+const GEMINI_USERINFO_ENDPOINT: &str = "https://www.googleapis.com/oauth2/v1/userinfo";
+const GEMINI_OAUTH_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
+const GEMINI_CALLBACK_HOST: &str = "127.0.0.1";
+const GEMINI_CALLBACK_PORT: u16 = 8085;
+const GEMINI_CALLBACK_PATH: &str = "/oauth2callback";
+const GEMINI_CALLBACK_WAIT_SECS: u64 = 300;
+const DEFAULT_GEMINI_CLIENT_ID_PROJECT_NUM: &str = "681255809395";
+const DEFAULT_GEMINI_CLIENT_ID_HASH: &str = "oo8ft2oprdrnp9e3aqf6av3hmdib135j";
+const DEFAULT_GEMINI_CLIENT_SECRET_SUFFIX: &str = "4uHgMPm-1o7Sk-geV6Cu5clXFsxl";
 
 #[derive(Debug, Clone)]
 pub struct NousDeviceCodeOptions {
@@ -238,6 +263,95 @@ pub struct QwenRuntimeCredentials {
 pub struct QwenAuthStatus {
     pub logged_in: bool,
     pub auth_file: PathBuf,
+    pub source: Option<String>,
+    pub api_key: Option<String>,
+    pub expires_at_ms: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeminiOAuthLoginOptions {
+    pub open_browser: bool,
+    pub timeout_seconds: f64,
+}
+
+impl Default for GeminiOAuthLoginOptions {
+    fn default() -> Self {
+        Self {
+            open_browser: true,
+            timeout_seconds: 20.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GeminiOAuthFileState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    refresh: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    access: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expires: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    managed_project_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AnthropicOAuthLoginOptions {
+    pub open_browser: bool,
+    pub timeout_seconds: f64,
+}
+
+impl Default for AnthropicOAuthLoginOptions {
+    fn default() -> Self {
+        Self {
+            open_browser: true,
+            timeout_seconds: 20.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicOAuthState {
+    pub access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeminiRuntimeCredentials {
+    pub provider: String,
+    pub base_url: String,
+    pub api_key: String,
+    pub source: String,
+    pub expires_at_ms: Option<i64>,
+    pub auth_file: PathBuf,
+    pub email: Option<String>,
+    pub project_id: Option<String>,
+    pub refresh_token: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeminiOAuthStatus {
+    pub logged_in: bool,
+    pub auth_file: PathBuf,
+    pub source: Option<String>,
+    pub api_key: Option<String>,
+    pub expires_at_ms: Option<i64>,
+    pub email: Option<String>,
+    pub project_id: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AnthropicOAuthStatus {
+    pub logged_in: bool,
     pub source: Option<String>,
     pub api_key: Option<String>,
     pub expires_at_ms: Option<i64>,
@@ -602,6 +716,973 @@ pub async fn get_qwen_auth_status() -> QwenAuthStatus {
             expires_at_ms: None,
             error: Some(err.to_string()),
         },
+    }
+}
+
+fn gemini_cli_auth_path() -> PathBuf {
+    if let Ok(path) = std::env::var("HERMES_GEMINI_OAUTH_FILE") {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    hermes_config::paths::hermes_home()
+        .join("auth")
+        .join("google_oauth.json")
+}
+
+fn parse_packed_gemini_refresh(
+    raw_refresh: Option<&str>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let Some(raw) = raw_refresh.map(str::trim).filter(|s| !s.is_empty()) else {
+        return (None, None, None);
+    };
+    let mut parts = raw.splitn(3, '|');
+    let refresh_token = parts
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let project_id = parts
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let managed_project_id = parts
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    (refresh_token, project_id, managed_project_id)
+}
+
+fn pack_gemini_refresh(
+    refresh_token: Option<&str>,
+    project_id: Option<&str>,
+    managed_project_id: Option<&str>,
+) -> Option<String> {
+    let refresh_token = refresh_token
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)?;
+    let project_id = project_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("");
+    let managed_project_id = managed_project_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("");
+    if project_id.is_empty() && managed_project_id.is_empty() {
+        Some(refresh_token)
+    } else {
+        Some(format!(
+            "{}|{}|{}",
+            refresh_token, project_id, managed_project_id
+        ))
+    }
+}
+
+fn read_gemini_cli_state() -> Result<GeminiOAuthFileState, AgentError> {
+    let auth_path = gemini_cli_auth_path();
+    if !auth_path.exists() {
+        return Err(AgentError::AuthFailed(
+            "Google OAuth credentials not found. Run `hermes auth google-gemini-cli` first.".into(),
+        ));
+    }
+    let raw = std::fs::read_to_string(&auth_path)
+        .map_err(|e| AgentError::Io(format!("read {}: {}", auth_path.display(), e)))?;
+    let payload: Value = serde_json::from_str(&raw)
+        .map_err(|e| AgentError::Config(format!("parse {}: {}", auth_path.display(), e)))?;
+    let object = payload.as_object().ok_or_else(|| {
+        AgentError::Config(format!(
+            "invalid Google OAuth credentials in {}",
+            auth_path.display()
+        ))
+    })?;
+
+    let packed_refresh = object
+        .get("refresh")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let refresh_value = packed_refresh.as_deref().or_else(|| {
+        object
+            .get("refresh_token")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    });
+    let (refresh_token, packed_project_id, packed_managed_project_id) =
+        parse_packed_gemini_refresh(refresh_value);
+
+    let project_id = object
+        .get("project_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or(packed_project_id);
+    let managed_project_id = object
+        .get("managed_project_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or(packed_managed_project_id);
+    let packed = pack_gemini_refresh(
+        refresh_token.as_deref(),
+        project_id.as_deref(),
+        managed_project_id.as_deref(),
+    );
+    let access = object
+        .get("access")
+        .or_else(|| object.get("access_token"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let email = object
+        .get("email")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let expires = object
+        .get("expires")
+        .or_else(|| object.get("expires_at_ms"))
+        .and_then(value_as_i64);
+
+    Ok(GeminiOAuthFileState {
+        refresh: packed,
+        access,
+        expires,
+        email,
+        project_id,
+        managed_project_id,
+    })
+}
+
+fn save_gemini_cli_state(state: &GeminiOAuthFileState) -> Result<PathBuf, AgentError> {
+    let auth_path = gemini_cli_auth_path();
+    if let Some(parent) = auth_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AgentError::Io(format!("mkdir {}: {}", parent.display(), e)))?;
+    }
+    let tmp_path = auth_path.with_extension("tmp");
+    let mut raw = serde_json::to_string_pretty(state)
+        .map_err(|e| AgentError::Config(format!("serialize Google OAuth credentials: {}", e)))?;
+    raw.push('\n');
+    std::fs::write(&tmp_path, raw)
+        .map_err(|e| AgentError::Io(format!("write {}: {}", tmp_path.display(), e)))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(&tmp_path, perms).map_err(|e| {
+            AgentError::Io(format!("set permissions on {}: {}", tmp_path.display(), e))
+        })?;
+    }
+    std::fs::rename(&tmp_path, &auth_path).map_err(|e| {
+        AgentError::Io(format!(
+            "rename {} -> {}: {}",
+            tmp_path.display(),
+            auth_path.display(),
+            e
+        ))
+    })?;
+    Ok(auth_path)
+}
+
+fn gemini_access_token_is_expiring(expiry_ms: Option<i64>, skew_seconds: i64) -> bool {
+    let Some(expiry_ms) = expiry_ms else {
+        return true;
+    };
+    let skew = skew_seconds.max(0);
+    Utc::now().timestamp_millis() + skew.saturating_mul(1000) >= expiry_ms
+}
+
+fn default_http_timeout_seconds(timeout_seconds: f64, fallback: f64) -> f64 {
+    if timeout_seconds.is_finite() {
+        timeout_seconds.clamp(5.0, 120.0)
+    } else {
+        fallback
+    }
+}
+
+fn default_gemini_client_id() -> String {
+    format!(
+        "{}-{}.apps.googleusercontent.com",
+        DEFAULT_GEMINI_CLIENT_ID_PROJECT_NUM, DEFAULT_GEMINI_CLIENT_ID_HASH
+    )
+}
+
+fn default_gemini_client_secret() -> String {
+    format!("GOCSPX-{}", DEFAULT_GEMINI_CLIENT_SECRET_SUFFIX)
+}
+
+fn build_oauth_pkce_pair() -> (String, String) {
+    let mut verifier_bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut verifier_bytes);
+    let verifier = BASE64_URL_SAFE_NO_PAD.encode(verifier_bytes);
+    let challenge = BASE64_URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    (verifier, challenge)
+}
+
+fn build_oauth_state_token() -> String {
+    let mut state_bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut state_bytes);
+    BASE64_URL_SAFE_NO_PAD.encode(state_bytes)
+}
+
+fn maybe_open_browser(url: &str, enabled: bool) {
+    if !enabled {
+        return;
+    }
+    match try_open_url(url) {
+        Ok(_) => println!("  (Opened browser for authorization)"),
+        Err(err) => println!("  Could not open browser automatically: {}", err),
+    }
+}
+
+fn parse_code_from_manual_input(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        let parsed = reqwest::Url::parse(trimmed).ok()?;
+        for (k, v) in parsed.query_pairs() {
+            if k == "code" {
+                let code = v.trim().to_string();
+                if !code.is_empty() {
+                    return Some(code);
+                }
+            }
+        }
+        return None;
+    }
+    if let Some(query) = trimmed.strip_prefix('?') {
+        let parsed = reqwest::Url::parse(&format!("http://localhost/?{}", query)).ok()?;
+        for (k, v) in parsed.query_pairs() {
+            if k == "code" {
+                let code = v.trim().to_string();
+                if !code.is_empty() {
+                    return Some(code);
+                }
+            }
+        }
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn prompt_line_blocking(prompt: &str) -> Result<String, AgentError> {
+    print!("{}", prompt);
+    let _ = std::io::stdout().flush();
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_line(&mut buf)
+        .map_err(|e| AgentError::Io(format!("stdin: {}", e)))?;
+    Ok(buf.trim().to_string())
+}
+
+fn respond_oauth_callback(stream: &mut std::net::TcpStream, status: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status,
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+fn wait_for_gemini_oauth_callback(
+    listener: &TcpListener,
+    expected_state: &str,
+    wait_secs: u64,
+) -> Result<Option<String>, AgentError> {
+    let listener = listener
+        .try_clone()
+        .map_err(|e| AgentError::Io(format!("clone OAuth callback listener: {}", e)))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| AgentError::Io(format!("set nonblocking callback listener: {}", e)))?;
+    let deadline = Instant::now() + Duration::from_secs(wait_secs.max(1));
+    while Instant::now() < deadline {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let mut buf = [0u8; 8192];
+                let read = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..read]);
+                let request_line = request.lines().next().unwrap_or("");
+                let path = request_line.split_whitespace().nth(1).unwrap_or("/");
+                let parsed = reqwest::Url::parse(&format!("http://localhost{}", path)).ok();
+                let Some(url) = parsed else {
+                    respond_oauth_callback(
+                        &mut stream,
+                        "400 Bad Request",
+                        "<html><body><h1>Invalid callback</h1></body></html>",
+                    );
+                    continue;
+                };
+                if url.path() != GEMINI_CALLBACK_PATH {
+                    respond_oauth_callback(
+                        &mut stream,
+                        "404 Not Found",
+                        "<html><body><h1>Not found</h1></body></html>",
+                    );
+                    continue;
+                }
+
+                let mut code = None;
+                let mut state = None;
+                let mut error = None;
+                for (k, v) in url.query_pairs() {
+                    if k == "code" {
+                        let value = v.trim().to_string();
+                        if !value.is_empty() {
+                            code = Some(value);
+                        }
+                    } else if k == "state" {
+                        let value = v.trim().to_string();
+                        if !value.is_empty() {
+                            state = Some(value);
+                        }
+                    } else if k == "error" {
+                        let value = v.trim().to_string();
+                        if !value.is_empty() {
+                            error = Some(value);
+                        }
+                    }
+                }
+                if let Some(err) = error {
+                    respond_oauth_callback(
+                        &mut stream,
+                        "400 Bad Request",
+                        &format!(
+                            "<html><body><h1>Google sign-in failed</h1><p>{}</p></body></html>",
+                            err
+                        ),
+                    );
+                    return Err(AgentError::AuthFailed(format!(
+                        "Google OAuth authorization failed: {}",
+                        err
+                    )));
+                }
+                if state.as_deref() != Some(expected_state) {
+                    respond_oauth_callback(
+                        &mut stream,
+                        "400 Bad Request",
+                        "<html><body><h1>State mismatch</h1></body></html>",
+                    );
+                    return Err(AgentError::AuthFailed(
+                        "Google OAuth callback state mismatch".into(),
+                    ));
+                }
+                if let Some(code) = code {
+                    respond_oauth_callback(
+                        &mut stream,
+                        "200 OK",
+                        "<html><body><h1>Signed in to Google</h1><p>You can close this tab and return to Hermes.</p></body></html>",
+                    );
+                    return Ok(Some(code));
+                }
+                respond_oauth_callback(
+                    &mut stream,
+                    "400 Bad Request",
+                    "<html><body><h1>Missing authorization code</h1></body></html>",
+                );
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => {
+                return Err(AgentError::Io(format!(
+                    "listen for Google OAuth callback failed: {}",
+                    err
+                )));
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn fetch_gemini_user_email(access_token: &str, timeout_seconds: f64) -> Option<String> {
+    let timeout = default_http_timeout_seconds(timeout_seconds, 15.0);
+    let client = reqwest::Client::builder()
+        .user_agent(format!("hermes-agent-ultra/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs_f64(timeout))
+        .build()
+        .ok()?;
+    let response = client
+        .get(format!("{}?alt=json", GEMINI_USERINFO_ENDPOINT))
+        .bearer_auth(access_token)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body = response.text().await.ok()?;
+    let payload: Value = serde_json::from_str(&body).ok()?;
+    payload
+        .get("email")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+async fn refresh_gemini_cli_state(
+    state: &GeminiOAuthFileState,
+    timeout_seconds: f64,
+) -> Result<GeminiOAuthFileState, AgentError> {
+    let (refresh_token, _, _) = parse_packed_gemini_refresh(state.refresh.as_deref());
+    let refresh_token = refresh_token.ok_or_else(|| {
+        AgentError::AuthFailed(
+            "Google OAuth refresh token missing. Re-run `hermes auth google-gemini-cli`.".into(),
+        )
+    })?;
+    let token_url = std::env::var("HERMES_GEMINI_OAUTH_TOKEN_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| GEMINI_TOKEN_ENDPOINT.to_string());
+    let client_id = std::env::var("HERMES_GEMINI_CLIENT_ID")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(default_gemini_client_id);
+    let client_secret = std::env::var("HERMES_GEMINI_CLIENT_SECRET")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(default_gemini_client_secret);
+
+    let timeout = default_http_timeout_seconds(timeout_seconds, 20.0);
+    let client = reqwest::Client::builder()
+        .user_agent(format!("hermes-agent-ultra/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs_f64(timeout))
+        .build()
+        .map_err(|e| AgentError::Io(format!("build Google OAuth client: {}", e)))?;
+
+    let mut form: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    form.insert("grant_type".to_string(), "refresh_token".to_string());
+    form.insert("refresh_token".to_string(), refresh_token.clone());
+    form.insert("client_id".to_string(), client_id);
+    if !client_secret.is_empty() {
+        form.insert("client_secret".to_string(), client_secret);
+    }
+    let response = client
+        .post(token_url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("Google OAuth refresh failed: {}", e)))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| AgentError::AuthFailed(format!("Google OAuth refresh read failed: {}", e)))?;
+    if !status.is_success() {
+        let detail = extract_error_message(&body).unwrap_or(body);
+        return Err(AgentError::AuthFailed(format!(
+            "Google OAuth refresh failed ({}): {}",
+            status, detail
+        )));
+    }
+    let payload: Value = serde_json::from_str(&body).map_err(|e| {
+        AgentError::AuthFailed(format!("Google OAuth refresh JSON parse failed: {}", e))
+    })?;
+    let object = payload.as_object().ok_or_else(|| {
+        AgentError::AuthFailed("Google OAuth refresh response is not a JSON object".into())
+    })?;
+    let access_token = object
+        .get("access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed("Google OAuth refresh response missing access_token".into())
+        })?
+        .to_string();
+    let refreshed_refresh_token = object
+        .get("refresh_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(refresh_token.as_str())
+        .to_string();
+    let expires_in_seconds = object
+        .get("expires_in")
+        .and_then(value_as_i64)
+        .unwrap_or(3600)
+        .max(60);
+    let email = if state.email.is_some() {
+        state.email.clone()
+    } else {
+        fetch_gemini_user_email(&access_token, timeout).await
+    };
+    Ok(GeminiOAuthFileState {
+        refresh: pack_gemini_refresh(
+            Some(refreshed_refresh_token.as_str()),
+            state.project_id.as_deref(),
+            state.managed_project_id.as_deref(),
+        ),
+        access: Some(access_token),
+        expires: Some(Utc::now().timestamp_millis() + expires_in_seconds * 1000),
+        email,
+        project_id: state.project_id.clone(),
+        managed_project_id: state.managed_project_id.clone(),
+    })
+}
+
+pub async fn resolve_gemini_oauth_runtime_credentials(
+    force_refresh: bool,
+) -> Result<GeminiRuntimeCredentials, AgentError> {
+    let mut state = read_gemini_cli_state()?;
+    if force_refresh
+        || gemini_access_token_is_expiring(
+            state.expires,
+            GEMINI_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+        )
+    {
+        state = refresh_gemini_cli_state(&state, 20.0).await?;
+        let _ = save_gemini_cli_state(&state)?;
+    }
+    let api_key = state
+        .access
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed(
+                "Google OAuth access token missing. Re-run `hermes auth google-gemini-cli`.".into(),
+            )
+        })?
+        .to_string();
+    Ok(GeminiRuntimeCredentials {
+        provider: "google-gemini-cli".to_string(),
+        base_url: DEFAULT_GEMINI_CLOUDCODE_BASE_URL.to_string(),
+        api_key,
+        source: "google-oauth".to_string(),
+        expires_at_ms: state.expires,
+        auth_file: gemini_cli_auth_path(),
+        email: state.email,
+        project_id: state.project_id,
+        refresh_token: parse_packed_gemini_refresh(state.refresh.as_deref()).0,
+    })
+}
+
+pub async fn get_gemini_oauth_auth_status() -> GeminiOAuthStatus {
+    let auth_file = gemini_cli_auth_path();
+    match read_gemini_cli_state() {
+        Ok(state) => {
+            let api_key = state
+                .access
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            GeminiOAuthStatus {
+                logged_in: api_key.is_some(),
+                auth_file,
+                source: Some("google-oauth".to_string()),
+                api_key,
+                expires_at_ms: state.expires,
+                email: state.email,
+                project_id: state.project_id,
+                error: None,
+            }
+        }
+        Err(err) => GeminiOAuthStatus {
+            logged_in: false,
+            auth_file,
+            source: None,
+            api_key: None,
+            expires_at_ms: None,
+            email: None,
+            project_id: None,
+            error: Some(err.to_string()),
+        },
+    }
+}
+
+fn resolve_gemini_project_id_from_env() -> Option<String> {
+    for name in [
+        "HERMES_GEMINI_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_PROJECT_ID",
+    ] {
+        if let Ok(value) = std::env::var(name) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub async fn login_google_gemini_cli_oauth(
+    options: GeminiOAuthLoginOptions,
+) -> Result<GeminiRuntimeCredentials, AgentError> {
+    let timeout = default_http_timeout_seconds(options.timeout_seconds, 20.0);
+    let client_id = std::env::var("HERMES_GEMINI_CLIENT_ID")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(default_gemini_client_id);
+    let client_secret = std::env::var("HERMES_GEMINI_CLIENT_SECRET")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(default_gemini_client_secret);
+    let token_url = std::env::var("HERMES_GEMINI_OAUTH_TOKEN_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| GEMINI_TOKEN_ENDPOINT.to_string());
+
+    let (code_verifier, code_challenge) = build_oauth_pkce_pair();
+    let state_token = build_oauth_state_token();
+    let listener = TcpListener::bind((GEMINI_CALLBACK_HOST, GEMINI_CALLBACK_PORT))
+        .or_else(|_| TcpListener::bind((GEMINI_CALLBACK_HOST, 0)))
+        .map_err(|e| {
+            AgentError::Io(format!("bind Google OAuth callback listener failed: {}", e))
+        })?;
+    let callback_port = listener
+        .local_addr()
+        .map_err(|e| AgentError::Io(format!("read callback listener addr failed: {}", e)))?
+        .port();
+    let redirect_uri = format!(
+        "http://{}:{}{}",
+        GEMINI_CALLBACK_HOST, callback_port, GEMINI_CALLBACK_PATH
+    );
+
+    let mut auth_url = reqwest::Url::parse(GEMINI_AUTH_ENDPOINT)
+        .map_err(|e| AgentError::Config(format!("invalid Google OAuth authorize URL: {}", e)))?;
+    {
+        let mut pairs = auth_url.query_pairs_mut();
+        pairs.append_pair("client_id", &client_id);
+        pairs.append_pair("redirect_uri", &redirect_uri);
+        pairs.append_pair("response_type", "code");
+        pairs.append_pair("scope", GEMINI_OAUTH_SCOPE);
+        pairs.append_pair("state", &state_token);
+        pairs.append_pair("code_challenge", &code_challenge);
+        pairs.append_pair("code_challenge_method", "S256");
+        pairs.append_pair("access_type", "offline");
+        pairs.append_pair("prompt", "consent");
+    }
+    let auth_url = auth_url.to_string();
+
+    println!();
+    println!("Authorize Hermes with Google (Gemini CLI OAuth).");
+    println!("Open this URL:");
+    println!("  {}", auth_url);
+    maybe_open_browser(&auth_url, options.open_browser);
+
+    let code =
+        match wait_for_gemini_oauth_callback(&listener, &state_token, GEMINI_CALLBACK_WAIT_SECS)? {
+            Some(code) => code,
+            None => {
+                println!();
+                println!(
+                    "OAuth callback timed out. Paste the full callback URL or the code value:"
+                );
+                let raw = prompt_line_blocking("Callback URL or code: ")?;
+                parse_code_from_manual_input(&raw).ok_or_else(|| {
+                    AgentError::AuthFailed(
+                        "No Google OAuth authorization code provided. Aborting.".into(),
+                    )
+                })?
+            }
+        };
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("hermes-agent-ultra/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs_f64(timeout))
+        .build()
+        .map_err(|e| AgentError::Io(format!("build Google OAuth client: {}", e)))?;
+    let mut form: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    form.insert("grant_type".to_string(), "authorization_code".to_string());
+    form.insert("code".to_string(), code.clone());
+    form.insert("code_verifier".to_string(), code_verifier.clone());
+    form.insert("client_id".to_string(), client_id.clone());
+    form.insert("redirect_uri".to_string(), redirect_uri.clone());
+    if !client_secret.is_empty() {
+        form.insert("client_secret".to_string(), client_secret.clone());
+    }
+    let token_response = client
+        .post(token_url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| {
+            AgentError::AuthFailed(format!("Google OAuth token exchange failed: {}", e))
+        })?;
+    let token_status = token_response.status();
+    let token_body = token_response.text().await.map_err(|e| {
+        AgentError::AuthFailed(format!("Google OAuth token response read failed: {}", e))
+    })?;
+    if !token_status.is_success() {
+        let detail = extract_error_message(&token_body).unwrap_or(token_body);
+        return Err(AgentError::AuthFailed(format!(
+            "Google OAuth token exchange failed ({}): {}",
+            token_status, detail
+        )));
+    }
+    let token_payload: Value = serde_json::from_str(&token_body).map_err(|e| {
+        AgentError::AuthFailed(format!("invalid Google OAuth token response: {}", e))
+    })?;
+    let object = token_payload.as_object().ok_or_else(|| {
+        AgentError::AuthFailed("Google OAuth token response is not a JSON object".into())
+    })?;
+    let access_token = object
+        .get("access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed("Google OAuth token response missing access_token".into())
+        })?
+        .to_string();
+    let refresh_token = object
+        .get("refresh_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed(
+                "Google OAuth token response missing refresh_token; re-run login and grant offline access."
+                    .into(),
+            )
+        })?
+        .to_string();
+    let expires_in_seconds = object
+        .get("expires_in")
+        .and_then(value_as_i64)
+        .unwrap_or(3600)
+        .max(60);
+    let email = fetch_gemini_user_email(&access_token, timeout).await;
+    let project_id = resolve_gemini_project_id_from_env();
+    let state = GeminiOAuthFileState {
+        refresh: pack_gemini_refresh(Some(&refresh_token), project_id.as_deref(), None),
+        access: Some(access_token.clone()),
+        expires: Some(Utc::now().timestamp_millis() + expires_in_seconds * 1000),
+        email: email.clone(),
+        project_id: project_id.clone(),
+        managed_project_id: None,
+    };
+    let auth_file = save_gemini_cli_state(&state)?;
+    Ok(GeminiRuntimeCredentials {
+        provider: "google-gemini-cli".to_string(),
+        base_url: DEFAULT_GEMINI_CLOUDCODE_BASE_URL.to_string(),
+        api_key: access_token,
+        source: "google-oauth".to_string(),
+        expires_at_ms: state.expires,
+        auth_file,
+        email,
+        project_id,
+        refresh_token: Some(refresh_token),
+    })
+}
+
+pub async fn login_anthropic_oauth(
+    options: AnthropicOAuthLoginOptions,
+) -> Result<AnthropicOAuthState, AgentError> {
+    let timeout = default_http_timeout_seconds(options.timeout_seconds, 20.0);
+    let authorize_url = std::env::var("HERMES_ANTHROPIC_OAUTH_AUTHORIZE_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| ANTHROPIC_OAUTH_AUTHORIZE_URL.to_string());
+    let token_url = std::env::var("HERMES_ANTHROPIC_OAUTH_TOKEN_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| ANTHROPIC_OAUTH_TOKEN_URL.to_string());
+    let client_id = std::env::var("HERMES_ANTHROPIC_OAUTH_CLIENT_ID")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| ANTHROPIC_OAUTH_CLIENT_ID.to_string());
+
+    let (code_verifier, code_challenge) = build_oauth_pkce_pair();
+    let mut auth_url = reqwest::Url::parse(&authorize_url)
+        .map_err(|e| AgentError::Config(format!("invalid Anthropic authorize URL: {}", e)))?;
+    {
+        let mut pairs = auth_url.query_pairs_mut();
+        pairs.append_pair("code", "true");
+        pairs.append_pair("client_id", &client_id);
+        pairs.append_pair("response_type", "code");
+        pairs.append_pair("redirect_uri", ANTHROPIC_OAUTH_REDIRECT_URI);
+        pairs.append_pair("scope", ANTHROPIC_OAUTH_SCOPE);
+        pairs.append_pair("code_challenge", &code_challenge);
+        pairs.append_pair("code_challenge_method", "S256");
+        pairs.append_pair("state", &code_verifier);
+    }
+    let auth_url = auth_url.to_string();
+
+    println!();
+    println!("Authorize Hermes with Claude Pro/Max.");
+    println!("Open this URL:");
+    println!("  {}", auth_url);
+    maybe_open_browser(&auth_url, options.open_browser);
+    println!();
+    println!("After authorizing, Claude will show a code. Paste it below.");
+    let raw_input = prompt_line_blocking("Authorization code: ")?;
+    if raw_input.trim().is_empty() {
+        return Err(AgentError::AuthFailed(
+            "No authorization code entered for Anthropic OAuth".into(),
+        ));
+    }
+    let mut split = raw_input.splitn(2, '#');
+    let code = split.next().unwrap_or("").trim().to_string();
+    let state = split.next().unwrap_or("").trim().to_string();
+    if code.is_empty() {
+        return Err(AgentError::AuthFailed(
+            "Anthropic OAuth authorization code is empty".into(),
+        ));
+    }
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("hermes-agent-ultra/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs_f64(timeout))
+        .build()
+        .map_err(|e| AgentError::Io(format!("build Anthropic OAuth client: {}", e)))?;
+    let exchange_payload = serde_json::json!({
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "code": code,
+        "state": state,
+        "redirect_uri": ANTHROPIC_OAUTH_REDIRECT_URI,
+        "code_verifier": code_verifier,
+    });
+    let response = client
+        .post(token_url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .json(&exchange_payload)
+        .send()
+        .await
+        .map_err(|e| {
+            AgentError::AuthFailed(format!("Anthropic OAuth token exchange failed: {}", e))
+        })?;
+    let status = response.status();
+    let body = response.text().await.map_err(|e| {
+        AgentError::AuthFailed(format!("Anthropic OAuth response read failed: {}", e))
+    })?;
+    if !status.is_success() {
+        let detail = extract_error_message(&body).unwrap_or(body);
+        return Err(AgentError::AuthFailed(format!(
+            "Anthropic OAuth token exchange failed ({}): {}",
+            status, detail
+        )));
+    }
+    let payload: Value = serde_json::from_str(&body)
+        .map_err(|e| AgentError::AuthFailed(format!("invalid Anthropic OAuth response: {}", e)))?;
+    let object = payload.as_object().ok_or_else(|| {
+        AgentError::AuthFailed("Anthropic OAuth response is not a JSON object".into())
+    })?;
+    let access_token = object
+        .get("access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AgentError::AuthFailed("Anthropic OAuth response missing access_token".into())
+        })?
+        .to_string();
+    let refresh_token = object
+        .get("refresh_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let expires_at_ms = object
+        .get("expires_in")
+        .and_then(value_as_i64)
+        .filter(|v| *v > 0)
+        .map(|secs| Utc::now().timestamp_millis() + secs * 1000);
+    Ok(AnthropicOAuthState {
+        access_token,
+        refresh_token,
+        expires_at_ms,
+    })
+}
+
+pub async fn get_anthropic_oauth_status() -> AnthropicOAuthStatus {
+    let auth_state = match read_provider_auth_state("anthropic") {
+        Ok(value) => value,
+        Err(err) => {
+            return AnthropicOAuthStatus {
+                logged_in: false,
+                source: None,
+                api_key: None,
+                expires_at_ms: None,
+                error: Some(err.to_string()),
+            };
+        }
+    };
+    let Some(value) = auth_state else {
+        return AnthropicOAuthStatus {
+            logged_in: false,
+            source: None,
+            api_key: None,
+            expires_at_ms: None,
+            error: Some("not logged in".to_string()),
+        };
+    };
+    let object = match value.as_object() {
+        Some(v) => v,
+        None => {
+            return AnthropicOAuthStatus {
+                logged_in: false,
+                source: None,
+                api_key: None,
+                expires_at_ms: None,
+                error: Some("invalid stored anthropic oauth state".to_string()),
+            };
+        }
+    };
+    let api_key = object
+        .get("access_token")
+        .or_else(|| object.get("api_key"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let source = object
+        .get("source")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or(Some("hermes_pkce".to_string()));
+    let expires_at_ms = object
+        .get("expires_at_ms")
+        .or_else(|| object.get("expires"))
+        .and_then(value_as_i64);
+    let is_expired = expires_at_ms
+        .map(|exp| {
+            gemini_access_token_is_expiring(
+                Some(exp),
+                ANTHROPIC_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+            )
+        })
+        .unwrap_or(false);
+    AnthropicOAuthStatus {
+        logged_in: api_key.is_some() && !is_expired,
+        source,
+        api_key,
+        expires_at_ms,
+        error: None,
     }
 }
 
@@ -1150,6 +2231,7 @@ mod tests {
     use std::sync::Mutex;
 
     static QWEN_ENV_LOCK: Mutex<()> = Mutex::new(());
+    static GEMINI_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn nous_runtime_api_key_prefers_agent_key() {
@@ -1187,6 +2269,56 @@ mod tests {
         assert!(qwen_access_token_is_expiring(None, 120));
         assert!(qwen_access_token_is_expiring(Some(now_ms + 30_000), 120));
         assert!(!qwen_access_token_is_expiring(Some(now_ms + 300_000), 120));
+    }
+
+    #[test]
+    fn gemini_packed_refresh_roundtrip() {
+        let packed =
+            pack_gemini_refresh(Some("r1"), Some("proj"), Some("managed")).expect("packed refresh");
+        assert_eq!(packed, "r1|proj|managed");
+        let parsed = parse_packed_gemini_refresh(Some(&packed));
+        assert_eq!(parsed.0.as_deref(), Some("r1"));
+        assert_eq!(parsed.1.as_deref(), Some("proj"));
+        assert_eq!(parsed.2.as_deref(), Some("managed"));
+    }
+
+    #[test]
+    fn gemini_access_token_is_expiring_honors_skew() {
+        let now_ms = Utc::now().timestamp_millis();
+        assert!(gemini_access_token_is_expiring(None, 60));
+        assert!(gemini_access_token_is_expiring(Some(now_ms + 1_000), 60));
+        assert!(!gemini_access_token_is_expiring(Some(now_ms + 120_000), 60));
+    }
+
+    #[test]
+    fn gemini_state_read_write_roundtrip() {
+        let _guard = GEMINI_ENV_LOCK.lock().expect("lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let auth_path = tmp.path().join("google_oauth.json");
+        std::env::set_var(
+            "HERMES_GEMINI_OAUTH_FILE",
+            auth_path.to_string_lossy().to_string(),
+        );
+        let state = GeminiOAuthFileState {
+            refresh: Some("refresh-token|proj-1|managed-1".to_string()),
+            access: Some("access-token".to_string()),
+            expires: Some(Utc::now().timestamp_millis() + 5 * 60 * 1000),
+            email: Some("dev@example.com".to_string()),
+            project_id: Some("proj-1".to_string()),
+            managed_project_id: Some("managed-1".to_string()),
+        };
+        save_gemini_cli_state(&state).expect("save");
+        let loaded = read_gemini_cli_state().expect("read");
+        assert_eq!(loaded.access.as_deref(), Some("access-token"));
+        assert_eq!(
+            parse_packed_gemini_refresh(loaded.refresh.as_deref())
+                .0
+                .as_deref(),
+            Some("refresh-token")
+        );
+        assert_eq!(loaded.project_id.as_deref(), Some("proj-1"));
+        assert_eq!(loaded.managed_project_id.as_deref(), Some("managed-1"));
+        std::env::remove_var("HERMES_GEMINI_OAUTH_FILE");
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -17,10 +17,12 @@ use hermes_cli::app::{
     bridge_tool_registry, build_agent_config, build_provider, provider_api_key_from_env,
 };
 use hermes_cli::auth::{
-    clear_provider_auth_state, get_qwen_auth_status, login_nous_device_code,
-    login_openai_codex_device_code, read_provider_auth_state, resolve_qwen_runtime_credentials,
-    save_codex_auth_state, save_nous_auth_state, save_provider_auth_state, CodexDeviceCodeOptions,
-    NousDeviceCodeOptions, QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    clear_provider_auth_state, get_anthropic_oauth_status, get_gemini_oauth_auth_status,
+    get_qwen_auth_status, login_anthropic_oauth, login_google_gemini_cli_oauth,
+    login_nous_device_code, login_openai_codex_device_code, read_provider_auth_state,
+    resolve_qwen_runtime_credentials, save_codex_auth_state, save_nous_auth_state,
+    save_provider_auth_state, AnthropicOAuthLoginOptions, CodexDeviceCodeOptions,
+    GeminiOAuthLoginOptions, NousDeviceCodeOptions, QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 };
 use hermes_cli::cli::{Cli, CliCommand};
 use hermes_cli::config_env::hydrate_env_from_config;
@@ -3281,8 +3283,10 @@ fn normalize_auth_provider(provider: &str) -> String {
         "wechat" | "wx" => "weixin".to_string(),
         "qq" => "qqbot".to_string(),
         "tg" => "telegram".to_string(),
+        "claude" | "claude-code" => "anthropic".to_string(),
         "codex" => "openai-codex".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
+        "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "api-server" => "api_server".to_string(),
         "home-assistant" => "homeassistant".to_string(),
@@ -3320,18 +3324,30 @@ fn normalize_secret_provider(provider: &str) -> String {
     let p = provider.trim().to_ascii_lowercase();
     match p.as_str() {
         "github-copilot" => "copilot".to_string(),
+        "claude" | "claude-code" => "anthropic".to_string(),
         "codex" => "openai-codex".to_string(),
+        "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         _ => p,
     }
 }
 
 fn secret_provider_aliases(provider: &str) -> Vec<String> {
     match normalize_secret_provider(provider).as_str() {
+        "anthropic" => vec![
+            "anthropic".to_string(),
+            "claude".to_string(),
+            "claude-code".to_string(),
+        ],
         "moonshot" => vec!["moonshot".to_string(), "kimi".to_string()],
         "kimi" => vec!["kimi".to_string(), "moonshot".to_string()],
         "stepfun" => vec!["stepfun".to_string(), "step".to_string()],
         "copilot" => vec!["copilot".to_string(), "github-copilot".to_string()],
         "openai-codex" => vec!["openai-codex".to_string(), "codex".to_string()],
+        "google-gemini-cli" => vec![
+            "google-gemini-cli".to_string(),
+            "gemini-cli".to_string(),
+            "gemini-oauth".to_string(),
+        ],
         p => vec![p.to_string()],
     }
 }
@@ -3341,6 +3357,7 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "openai" => Some("HERMES_OPENAI_API_KEY"),
         "openai-codex" => Some("HERMES_OPENAI_CODEX_API_KEY"),
         "anthropic" => Some("ANTHROPIC_API_KEY"),
+        "google-gemini-cli" => Some("HERMES_GEMINI_OAUTH_API_KEY"),
         "openrouter" => Some("OPENROUTER_API_KEY"),
         "qwen" => Some("DASHSCOPE_API_KEY"),
         "qwen-oauth" => Some("HERMES_QWEN_OAUTH_API_KEY"),
@@ -3356,7 +3373,7 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
 fn provider_supports_oauth(provider: &str) -> bool {
     matches!(
         normalize_auth_provider(provider).as_str(),
-        "nous" | "openai-codex" | "qwen-oauth"
+        "anthropic" | "nous" | "openai-codex" | "qwen-oauth" | "google-gemini-cli"
     )
 }
 
@@ -3466,6 +3483,9 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
         ("OPENAI_API_KEY", "openai"),
         ("HERMES_OPENAI_CODEX_API_KEY", "openai-codex"),
         ("ANTHROPIC_API_KEY", "anthropic"),
+        ("ANTHROPIC_TOKEN", "anthropic"),
+        ("CLAUDE_CODE_OAUTH_TOKEN", "anthropic"),
+        ("HERMES_GEMINI_OAUTH_API_KEY", "google-gemini-cli"),
         ("OPENROUTER_API_KEY", "openrouter"),
         ("DASHSCOPE_API_KEY", "qwen"),
         ("HERMES_QWEN_OAUTH_API_KEY", "qwen-oauth"),
@@ -4275,6 +4295,7 @@ async fn print_auth_status_matrix(cli: &Cli, manager: &AuthManager) -> Result<()
         "nous",
         "openai-codex",
         "qwen-oauth",
+        "google-gemini-cli",
         "copilot",
     ] {
         let env_present = provider_api_key_from_env(provider).is_some()
@@ -4459,6 +4480,50 @@ async fn run_auth(
                         println!("Saved OAuth state: {}", auth_path.display());
                         return Ok(());
                     }
+                    "anthropic" => {
+                        let state =
+                            login_anthropic_oauth(AnthropicOAuthLoginOptions::default()).await?;
+                        let access_token = state.access_token.clone();
+                        let refresh_token = state.refresh_token.clone();
+                        let expires_at_ms = state.expires_at_ms;
+                        let auth_state = serde_json::json!({
+                            "access_token": access_token.clone(),
+                            "refresh_token": refresh_token.clone(),
+                            "expires_at_ms": expires_at_ms,
+                            "source": "hermes_pkce",
+                        });
+                        let auth_path = save_provider_auth_state("anthropic", auth_state)?;
+                        manager
+                            .save_credential(OAuthCredential {
+                                provider: "anthropic".to_string(),
+                                access_token: access_token.clone(),
+                                refresh_token: refresh_token.clone(),
+                                token_type: "bearer".to_string(),
+                                scope: None,
+                                expires_at: parse_unix_millis_utc(expires_at_ms),
+                            })
+                            .await?;
+                        let entries = pool_store.providers.entry(provider.clone()).or_default();
+                        let default_label = format!("{provider}-{}", entries.len() + 1);
+                        let entry = AuthPoolEntry {
+                            id: uuid::Uuid::new_v4().simple().to_string()[..6].to_string(),
+                            label: label.unwrap_or(default_label),
+                            auth_type: "oauth".to_string(),
+                            source: "hermes_pkce".to_string(),
+                            access_token: access_token.clone(),
+                            last_status: None,
+                            last_status_at: None,
+                            last_error_code: None,
+                        };
+                        entries.push(entry.clone());
+                        save_auth_pool_store(&pool_path, &pool_store)?;
+                        println!(
+                            "Added Anthropic OAuth credential (label='{}', id={}).",
+                            entry.label, entry.id
+                        );
+                        println!("Saved OAuth state: {}", auth_path.display());
+                        return Ok(());
+                    }
                     "qwen-oauth" => {
                         let creds = resolve_qwen_runtime_credentials(
                             false,
@@ -4498,6 +4563,57 @@ async fn run_auth(
                             entry.label, entry.id
                         );
                         println!("Qwen auth file: {}", creds.auth_file.display());
+                        println!("Saved OAuth state: {}", auth_path.display());
+                        return Ok(());
+                    }
+                    "google-gemini-cli" => {
+                        let creds =
+                            login_google_gemini_cli_oauth(GeminiOAuthLoginOptions::default())
+                                .await?;
+                        let access_token = creds.api_key.clone();
+                        let refresh_token = creds.refresh_token.clone();
+                        let expires_at_ms = creds.expires_at_ms;
+                        let email = creds.email.clone();
+                        let project_id = creds.project_id.clone();
+                        let source = creds.source.clone();
+                        let auth_state = serde_json::json!({
+                            "access_token": access_token.clone(),
+                            "refresh_token": refresh_token.clone(),
+                            "expires_at_ms": expires_at_ms,
+                            "email": email.clone(),
+                            "project_id": project_id.clone(),
+                            "source": source.clone(),
+                        });
+                        let auth_path = save_provider_auth_state("google-gemini-cli", auth_state)?;
+                        manager
+                            .save_credential(OAuthCredential {
+                                provider: "google-gemini-cli".to_string(),
+                                access_token: access_token.clone(),
+                                refresh_token: refresh_token.clone(),
+                                token_type: "bearer".to_string(),
+                                scope: None,
+                                expires_at: parse_unix_millis_utc(expires_at_ms),
+                            })
+                            .await?;
+                        let entries = pool_store.providers.entry(provider.clone()).or_default();
+                        let default_label = format!("{provider}-{}", entries.len() + 1);
+                        let entry = AuthPoolEntry {
+                            id: uuid::Uuid::new_v4().simple().to_string()[..6].to_string(),
+                            label: label.unwrap_or_else(|| email.clone().unwrap_or(default_label)),
+                            auth_type: "oauth".to_string(),
+                            source: source,
+                            access_token: access_token.clone(),
+                            last_status: None,
+                            last_status_at: None,
+                            last_error_code: None,
+                        };
+                        entries.push(entry.clone());
+                        save_auth_pool_store(&pool_path, &pool_store)?;
+                        println!(
+                            "Added Google Gemini OAuth credential (label='{}', id={}).",
+                            entry.label, entry.id
+                        );
+                        println!("Google auth file: {}", creds.auth_file.display());
                         println!("Saved OAuth state: {}", auth_path.display());
                         return Ok(());
                     }
@@ -4885,6 +5001,34 @@ async fn run_auth(
                 println!("Saved OAuth state: {}", auth_path.display());
                 return Ok(());
             }
+            if provider == "anthropic" {
+                let state = login_anthropic_oauth(AnthropicOAuthLoginOptions::default()).await?;
+                let access_token = state.access_token.clone();
+                let refresh_token = state.refresh_token.clone();
+                let expires_at_ms = state.expires_at_ms;
+                let auth_state = serde_json::json!({
+                    "access_token": access_token.clone(),
+                    "refresh_token": refresh_token.clone(),
+                    "expires_at_ms": expires_at_ms,
+                    "source": "hermes_pkce",
+                });
+                let auth_path = save_provider_auth_state("anthropic", auth_state)?;
+                manager
+                    .save_credential(OAuthCredential {
+                        provider: "anthropic".to_string(),
+                        access_token,
+                        refresh_token,
+                        token_type: "bearer".to_string(),
+                        scope: None,
+                        expires_at: parse_unix_millis_utc(expires_at_ms),
+                    })
+                    .await?;
+                println!(
+                    "Anthropic OAuth login complete; credential saved as provider 'anthropic'."
+                );
+                println!("Saved OAuth state: {}", auth_path.display());
+                return Ok(());
+            }
             if provider == "qwen-oauth" {
                 let creds = resolve_qwen_runtime_credentials(
                     false,
@@ -4909,6 +5053,38 @@ async fn run_auth(
                     "Qwen OAuth credential imported from {} and stored as provider 'qwen-oauth'.",
                     creds.auth_file.display()
                 );
+                println!("Saved OAuth state: {}", auth_path.display());
+                return Ok(());
+            }
+            if provider == "google-gemini-cli" {
+                let creds =
+                    login_google_gemini_cli_oauth(GeminiOAuthLoginOptions::default()).await?;
+                let access_token = creds.api_key.clone();
+                let refresh_token = creds.refresh_token.clone();
+                let expires_at_ms = creds.expires_at_ms;
+                let auth_state = serde_json::json!({
+                    "access_token": access_token.clone(),
+                    "refresh_token": refresh_token.clone(),
+                    "expires_at_ms": expires_at_ms,
+                    "email": creds.email.clone(),
+                    "project_id": creds.project_id.clone(),
+                    "source": creds.source.clone(),
+                });
+                let auth_path = save_provider_auth_state("google-gemini-cli", auth_state)?;
+                manager
+                    .save_credential(OAuthCredential {
+                        provider: "google-gemini-cli".to_string(),
+                        access_token,
+                        refresh_token,
+                        token_type: "bearer".to_string(),
+                        scope: None,
+                        expires_at: parse_unix_millis_utc(expires_at_ms),
+                    })
+                    .await?;
+                println!(
+                    "Google Gemini OAuth login complete; credential saved as provider 'google-gemini-cli'."
+                );
+                println!("Google auth file: {}", creds.auth_file.display());
                 println!("Saved OAuth state: {}", auth_path.display());
                 return Ok(());
             }
@@ -5121,6 +5297,83 @@ async fn run_auth(
                 }
                 if let Some(err) = qwen_status.error.as_deref() {
                     println!("Qwen OAuth detail: {}", err);
+                }
+                println!(
+                    "Auth status: provider='{}', credential_present={}, source={}, oauth_state_present={}",
+                    provider, has_token, source, auth_state_present
+                );
+                return Ok(());
+            }
+            if provider == "google-gemini-cli" {
+                let google_status = get_gemini_oauth_auth_status().await;
+                let auth_state_present = read_provider_auth_state(&provider)?.is_some();
+                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let env_present = provider_api_key_from_env(&provider).is_some();
+                let (has_token, source) = if env_present {
+                    (true, "env")
+                } else if store_present {
+                    (true, "token_store")
+                } else if auth_state_present {
+                    (true, "auth_json")
+                } else {
+                    (false, "none")
+                };
+                println!(
+                    "Google Gemini OAuth: logged_in={} auth_file={} source={} expires_at_ms={}",
+                    google_status.logged_in,
+                    google_status.auth_file.display(),
+                    google_status.source.as_deref().unwrap_or("none"),
+                    google_status
+                        .expires_at_ms
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "unknown".to_string())
+                );
+                if let Some(email) = google_status.email.as_deref() {
+                    println!("Google account: {}", email);
+                }
+                if let Some(project_id) = google_status.project_id.as_deref() {
+                    println!("Google project_id: {}", project_id);
+                }
+                if let Some(token) = google_status.api_key.as_deref() {
+                    println!("Google OAuth token: {}", mask_secret(token));
+                }
+                if let Some(err) = google_status.error.as_deref() {
+                    println!("Google OAuth detail: {}", err);
+                }
+                println!(
+                    "Auth status: provider='{}', credential_present={}, source={}, oauth_state_present={}",
+                    provider, has_token, source, auth_state_present
+                );
+                return Ok(());
+            }
+            if provider == "anthropic" {
+                let anthropic_status = get_anthropic_oauth_status().await;
+                let auth_state_present = read_provider_auth_state(&provider)?.is_some();
+                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let env_present = provider_api_key_from_env(&provider).is_some();
+                let (has_token, source) = if env_present {
+                    (true, "env")
+                } else if store_present {
+                    (true, "token_store")
+                } else if auth_state_present {
+                    (true, "auth_json")
+                } else {
+                    (false, "none")
+                };
+                println!(
+                    "Anthropic OAuth: logged_in={} source={} expires_at_ms={}",
+                    anthropic_status.logged_in,
+                    anthropic_status.source.as_deref().unwrap_or("none"),
+                    anthropic_status
+                        .expires_at_ms
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "unknown".to_string())
+                );
+                if let Some(token) = anthropic_status.api_key.as_deref() {
+                    println!("Anthropic OAuth token: {}", mask_secret(token));
+                }
+                if let Some(err) = anthropic_status.error.as_deref() {
+                    println!("Anthropic OAuth detail: {}", err);
                 }
                 println!(
                     "Auth status: provider='{}', credential_present={}, source={}, oauth_state_present={}",
@@ -8138,8 +8391,10 @@ mod tests {
         assert_eq!(normalize_auth_provider("tg"), "telegram");
         assert_eq!(normalize_auth_provider("wechat"), "weixin");
         assert_eq!(normalize_auth_provider("wx"), "weixin");
+        assert_eq!(normalize_auth_provider("claude"), "anthropic");
         assert_eq!(normalize_auth_provider("codex"), "openai-codex");
         assert_eq!(normalize_auth_provider("qwen-cli"), "qwen-oauth");
+        assert_eq!(normalize_auth_provider("gemini-cli"), "google-gemini-cli");
         assert_eq!(normalize_auth_provider("step-plan"), "stepfun");
         assert_eq!(normalize_auth_provider("api-server"), "api_server");
         assert_eq!(normalize_auth_provider("mm"), "mattermost");
@@ -8153,6 +8408,11 @@ mod tests {
             "oauth"
         );
         assert_eq!(resolve_auth_type_for_provider("qwen-oauth", None), "oauth");
+        assert_eq!(
+            resolve_auth_type_for_provider("google-gemini-cli", None),
+            "oauth"
+        );
+        assert_eq!(resolve_auth_type_for_provider("anthropic", None), "oauth");
         assert_eq!(resolve_auth_type_for_provider("openai", None), "api_key");
         assert_eq!(
             resolve_auth_type_for_provider("openai", Some("API-KEY")),
@@ -8176,7 +8436,15 @@ mod tests {
             provider_env_var("qwen-oauth"),
             Some("HERMES_QWEN_OAUTH_API_KEY")
         );
+        assert_eq!(
+            provider_env_var("google-gemini-cli"),
+            Some("HERMES_GEMINI_OAUTH_API_KEY")
+        );
         assert_eq!(secret_provider_aliases("stepfun"), vec!["stepfun", "step"]);
+        assert_eq!(
+            secret_provider_aliases("claude"),
+            vec!["anthropic", "claude", "claude-code"]
+        );
     }
 
     #[test]

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -7,6 +7,7 @@ pub fn known_providers() -> Vec<&'static str> {
         "openai-codex",
         "qwen",
         "qwen-oauth",
+        "google-gemini-cli",
         "kimi",
         "minimax",
         "stepfun",


### PR DESCRIPTION
Summary: add Rust-native Google Gemini OAuth flow + Anthropic OAuth flow and wire auth add/login/status parity paths, aliases, env precedence, and runtime hydration defaults.\n\nValidation:\n- cargo check\n- cargo test -p hermes-cli\n- cargo test -p hermes-agent oauth_refresh_config\n- cargo test -p hermes-agent runtime_provider_api_key_env_supports_anthropic_aliases_and_gemini_oauth