### PR TITLE
Setup: expand Nous model catalog in picker

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -7065,8 +7065,11 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
     let env_keys_display = selected_provider_env_keys.join("/");
 
     let suggested_provider_models = provider_model_ids(&selected_provider).await;
-    let displayed_suggested_models: Vec<String> =
-        suggested_provider_models.into_iter().take(25).collect();
+    let suggested_limit = if selected_provider == "nous" { 50 } else { 25 };
+    let displayed_suggested_models: Vec<String> = suggested_provider_models
+        .into_iter()
+        .take(suggested_limit)
+        .collect();
     if displayed_suggested_models.is_empty() {
         print!("Model ID for {} [{}]: ", selected_provider_label, model);
         io::stdout().flush().ok();

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -222,6 +222,31 @@ pub async fn provider_model_ids_with_client(
     }
 
     let normalized = provider.trim().to_ascii_lowercase();
+    if normalized == "nous" {
+        // Nous Portal fronts a large OpenRouter-compatible catalog.
+        // Keep curated picks first, then append dynamic agentic models.
+        client.fetch(false).await;
+        let models_dev = client.list_agentic_models("openrouter");
+        if models_dev.is_empty() {
+            return curated.iter().map(|model| model.to_string()).collect();
+        }
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut merged: Vec<String> = Vec::with_capacity(curated.len() + models_dev.len());
+        for model in curated {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                merged.push((*model).to_string());
+            }
+        }
+        for model in models_dev {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                merged.push(model);
+            }
+        }
+        return merged;
+    }
+
     if !is_models_dev_preferred_provider(&normalized) {
         return curated.iter().map(|model| model.to_string()).collect();
     }
@@ -398,6 +423,32 @@ mod tests {
             .map(|m| (*m).to_string())
             .collect();
         assert_eq!(out, expected);
+    }
+
+    #[tokio::test]
+    async fn nous_provider_uses_curated_plus_openrouter_agentic_catalog() {
+        let client = seeded_client(json!({
+            "openrouter": {
+                "models": {
+                    "moonshotai/kimi-k2.6": {"tool_call": true},
+                    "openai/gpt-5.5": {"tool_call": true},
+                    "anthropic/claude-opus-4.7": {"tool_call": true}
+                }
+            }
+        }));
+        let out = provider_model_ids_with_client("nous", &client).await;
+        assert!(
+            out.starts_with(&[
+                "moonshotai/kimi-k2.6".to_string(),
+                "xiaomi/mimo-v2.5-pro".to_string(),
+                "anthropic/claude-sonnet-4.5".to_string()
+            ]),
+            "nous list should keep curated models first"
+        );
+        assert!(
+            out.iter().any(|m| m == "openai/gpt-5.5"),
+            "expected openrouter-derived models in nous catalog"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- expand Nous provider model discovery to merge curated picks with dynamic OpenRouter agentic catalog
- keep curated models first and dedupe case-insensitively
- increase setup suggested model cap for Nous from 25 to 50
- add regression test for Nous merged catalog behavior

## Validation
- cargo fmt --all
- cargo test -p hermes-cli
- manual setup smoke run confirmed expanded 'Select Nous model' picker and OAuth prompt