### PR TITLE
Fix /model picker rendering in TUI

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -6,6 +6,7 @@
 use std::process::Stdio;
 use std::sync::Arc;
 
+use crossterm::{cursor, execute, terminal};
 use hermes_core::AgentError;
 use regex::Regex;
 
@@ -220,6 +221,34 @@ fn split_provider_model(provider_model: &str) -> (&str, &str) {
         .unwrap_or(("openai", provider_model))
 }
 
+/// Run `curses_select` safely from both plain CLI and active TUI sessions.
+///
+/// In TUI mode, we temporarily suspend ratatui's alternate-screen/raw-mode
+/// ownership before invoking the standalone picker, then restore it.
+fn run_model_picker_select(
+    app: &App,
+    title: &str,
+    items: &[String],
+    initial_index: usize,
+) -> crate::SelectResult {
+    if app.stream_handle.is_some() {
+        let mut stdout = std::io::stdout();
+        let _ = terminal::disable_raw_mode();
+        let _ = execute!(stdout, cursor::Show, terminal::LeaveAlternateScreen);
+        let result = crate::curses_select(title, items, initial_index);
+        let _ = terminal::enable_raw_mode();
+        let _ = execute!(
+            stdout,
+            terminal::EnterAlternateScreen,
+            cursor::Hide,
+            terminal::Clear(terminal::ClearType::All)
+        );
+        result
+    } else {
+        crate::curses_select(title, items, initial_index)
+    }
+}
+
 async fn pick_model_for_provider(
     app: &mut App,
     provider: &str,
@@ -241,7 +270,7 @@ async fn pick_model_for_provider(
         .unwrap_or(0);
     let labels: Vec<String> = models.clone();
     let title = format!("Select {} model ({} available)", provider, labels.len());
-    let pick = crate::curses_select(&title, &labels, default_index);
+    let pick = run_model_picker_select(app, &title, &labels, default_index);
     if !pick.confirmed || pick.index >= models.len() {
         emit_command_output(app, "Model switch cancelled.");
         return Ok(false);
@@ -277,7 +306,7 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
                 .position(|p| p.eq_ignore_ascii_case(current_provider))
                 .unwrap_or(0);
             let provider_pick =
-                crate::curses_select("Select provider", &providers, default_provider_index);
+                run_model_picker_select(app, "Select provider", &providers, default_provider_index);
             if !provider_pick.confirmed || provider_pick.index >= providers.len() {
                 emit_command_output(app, "Model switch cancelled.");
                 return Ok(CommandResult::Handled);


### PR DESCRIPTION
## Summary
- add TUI-safe wrapper for model picker selection
- suspend ratatui screen ownership before curses select
- restore alternate screen/raw mode after selection

## Validation
- cargo fmt
- cargo test -p hermes-cli commands:: -- --nocapture