### PR TITLE
Fix /model picker integration and improve TUI layout

### DIFF
--- a/crates/hermes-cli/src/checklist.rs
+++ b/crates/hermes-cli/src/checklist.rs
@@ -77,7 +77,28 @@ pub fn curses_select(title: &str, items: &[String], initial_index: usize) -> Sel
         return numbered_select_fallback(title, items, clamped_initial);
     }
 
-    match curses_select_inner(title, items, clamped_initial) {
+    match curses_select_inner(title, items, clamped_initial, true) {
+        Ok(result) => result,
+        Err(_) => numbered_select_fallback(title, items, clamped_initial),
+    }
+}
+
+/// Run a single-select list inside an already-active TUI/raw-mode session.
+///
+/// Unlike `curses_select`, this does not enter/leave alternate-screen or toggle
+/// raw mode. It only draws over the current terminal and restores cursor state.
+pub fn curses_select_embedded(title: &str, items: &[String], initial_index: usize) -> SelectResult {
+    if items.is_empty() {
+        return SelectResult {
+            index: 0,
+            confirmed: false,
+        };
+    }
+    let clamped_initial = initial_index.min(items.len().saturating_sub(1));
+    if !atty_is_tty() {
+        return numbered_select_fallback(title, items, clamped_initial);
+    }
+    match curses_select_inner(title, items, clamped_initial, false) {
         Ok(result) => result,
         Err(_) => numbered_select_fallback(title, items, clamped_initial),
     }
@@ -342,13 +363,18 @@ fn curses_select_inner(
     title: &str,
     items: &[String],
     initial_index: usize,
+    manage_terminal: bool,
 ) -> Result<SelectResult, io::Error> {
     let mut cursor_pos = initial_index;
     let mut scroll_offset: usize = 0;
     let mut stdout = io::stdout();
 
-    enable_raw_mode()?;
-    execute!(stdout, terminal::EnterAlternateScreen, cursor::Hide)?;
+    if manage_terminal {
+        enable_raw_mode()?;
+        execute!(stdout, terminal::EnterAlternateScreen, cursor::Hide)?;
+    } else {
+        execute!(stdout, cursor::Hide)?;
+    }
 
     let result = loop {
         let (cols, rows) = terminal::size().unwrap_or((80, 24));
@@ -437,8 +463,12 @@ fn curses_select_inner(
         }
     };
 
-    execute!(stdout, cursor::Show, terminal::LeaveAlternateScreen)?;
-    disable_raw_mode()?;
+    if manage_terminal {
+        execute!(stdout, cursor::Show, terminal::LeaveAlternateScreen)?;
+        disable_raw_mode()?;
+    } else {
+        execute!(stdout, cursor::Show)?;
+    }
 
     Ok(result)
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -6,7 +6,6 @@
 use std::process::Stdio;
 use std::sync::Arc;
 
-use crossterm::{cursor, execute, terminal};
 use hermes_core::AgentError;
 use regex::Regex;
 
@@ -223,8 +222,7 @@ fn split_provider_model(provider_model: &str) -> (&str, &str) {
 
 /// Run `curses_select` safely from both plain CLI and active TUI sessions.
 ///
-/// In TUI mode, we temporarily suspend ratatui's alternate-screen/raw-mode
-/// ownership before invoking the standalone picker, then restore it.
+/// In TUI mode, use an embedded selector that does not toggle terminal mode.
 fn run_model_picker_select(
     app: &App,
     title: &str,
@@ -232,18 +230,7 @@ fn run_model_picker_select(
     initial_index: usize,
 ) -> crate::SelectResult {
     if app.stream_handle.is_some() {
-        let mut stdout = std::io::stdout();
-        let _ = terminal::disable_raw_mode();
-        let _ = execute!(stdout, cursor::Show, terminal::LeaveAlternateScreen);
-        let result = crate::curses_select(title, items, initial_index);
-        let _ = terminal::enable_raw_mode();
-        let _ = execute!(
-            stdout,
-            terminal::EnterAlternateScreen,
-            cursor::Hide,
-            terminal::Clear(terminal::ClearType::All)
-        );
-        result
+        crate::curses_select_embedded(title, items, initial_index)
     } else {
         crate::curses_select(title, items, initial_index)
     }

--- a/crates/hermes-cli/src/lib.rs
+++ b/crates/hermes-cli/src/lib.rs
@@ -43,7 +43,9 @@ pub mod webhook_delivery;
 
 // Re-export primary types
 pub use app::App;
-pub use checklist::{curses_checklist, curses_select, ChecklistResult, SelectResult};
+pub use checklist::{
+    curses_checklist, curses_select, curses_select_embedded, ChecklistResult, SelectResult,
+};
 pub use claw_migrate::{run_migration, MigrateOptions, MigrationResult};
 pub use cli::{Cli, CliCommand};
 pub use commands::CommandResult;

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -793,11 +793,13 @@ pub fn render(frame: &mut Frame, app: &App, state: &TuiState, theme: &Theme) {
 
     // Layout: header, messages, completions (optional), input, status bar
     let header_height = 2;
-    let input_height = 4;
+    let composer_lines = state.input.matches('\n').count() as u16 + 1;
+    let input_height = (composer_lines + 2).clamp(3, 6);
+    let completion_rows = state.completions.len().min(6) as u16;
     let completion_height = if state.completions.is_empty() {
         0
     } else {
-        state.completions.len() as u16 + 2
+        completion_rows + 2
     };
     let status_height = 1;
 
@@ -1276,15 +1278,32 @@ fn render_messages(
     colors: &crate::theme::RatatuiColors,
 ) {
     let lines = build_transcript_lines(&app.messages, state, styles, colors);
-    let viewport_rows = usize::from(area.height.max(1));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Conversation ")
+        .border_style(Style::default().fg(colors.status_bar_dim));
+    let inner = block.inner(area);
+    if inner.width == 0 || inner.height == 0 {
+        frame.render_widget(block, area);
+        return;
+    }
+
+    let viewport_rows = usize::from(inner.height.max(1));
     let max_hidden_from_bottom = lines.len().saturating_sub(viewport_rows);
     let hidden_from_bottom = usize::from(state.scroll_offset).min(max_hidden_from_bottom);
     let end = lines.len().saturating_sub(hidden_from_bottom);
     let start = end.saturating_sub(viewport_rows);
-    let visible_lines: Vec<Line<'static>> = lines[start..end].to_vec();
+    let mut visible_lines: Vec<Line<'static>> = lines[start..end].to_vec();
+    if visible_lines.len() < viewport_rows {
+        let pad = viewport_rows - visible_lines.len();
+        let mut padded = Vec::with_capacity(viewport_rows);
+        padded.extend((0..pad).map(|_| Line::from(String::new())));
+        padded.extend(visible_lines);
+        visible_lines = padded;
+    }
 
     let paragraph = Paragraph::new(Text::from(visible_lines))
-        .block(Block::default().borders(Borders::NONE))
+        .block(block)
         .wrap(Wrap { trim: false });
 
     frame.render_widget(paragraph, area);
@@ -1298,9 +1317,22 @@ fn render_completions(
     area: Rect,
     colors: &crate::theme::RatatuiColors,
 ) {
+    let inner_rows = usize::from(area.height.saturating_sub(2));
+    if inner_rows == 0 {
+        return;
+    }
+    let mut start = 0usize;
+    if let Some(sel) = selected {
+        if sel >= inner_rows {
+            start = sel + 1 - inner_rows;
+        }
+    }
+    let end = (start + inner_rows).min(completions.len());
     let items: Vec<Line<'static>> = completions
         .iter()
         .enumerate()
+        .skip(start)
+        .take(end.saturating_sub(start))
         .map(|(i, cmd)| {
             let style = if selected == Some(i) {
                 Style::default()


### PR DESCRIPTION
## Summary
- use embedded single-select picker inside active TUI sessions (no alt-screen toggling)
- keep standalone picker behavior for non-TUI CLI flows
- improve chat readability: conversation panel border, bottom anchoring when transcript is short
- tighten composer and slash-completion panel sizing for cleaner vertical rhythm

## Validation
- cargo fmt
- cargo test -p hermes-cli -- --nocapture