### PR TITLE
Port upstream parity tranche: compression, gateway, slack, touchdesigner

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Ultra now supports Google's `DESIGN.md` workflow in two ways:
    - `optional-skills/creative/design-md/SKILL.md`
    - `optional-skills/creative/design-md/templates/starter.md`
    - `optional-skills/creative/embedding-atlas/SKILL.md`
+   - `optional-skills/creative/touchdesigner-mcp/SKILL.md`
 
 The skill is designed for author/lint/diff/export flows with `@google/design.md`.
 

--- a/crates/hermes-agent/src/compression.rs
+++ b/crates/hermes-agent/src/compression.rs
@@ -173,6 +173,10 @@ pub struct ContextCompressor {
     last_prompt_tokens: u64,
     previous_summary: Option<String>,
     failure_cooldown_until: Option<Instant>,
+    summary_model_fallen_back: bool,
+    last_summary_error: Option<String>,
+    last_summary_dropped_count: usize,
+    last_summary_fallback_used: bool,
 }
 
 impl ContextCompressor {
@@ -212,6 +216,10 @@ impl ContextCompressor {
             last_prompt_tokens: 0,
             previous_summary: None,
             failure_cooldown_until: None,
+            summary_model_fallen_back: false,
+            last_summary_error: None,
+            last_summary_dropped_count: 0,
+            last_summary_fallback_used: false,
         }
     }
 
@@ -223,6 +231,21 @@ impl ContextCompressor {
     /// How many compactions this instance has performed.
     pub fn compression_count(&self) -> u64 {
         self.compression_count
+    }
+
+    /// Last summary-generation error captured by this compressor instance.
+    pub fn last_summary_error(&self) -> Option<&str> {
+        self.last_summary_error.as_deref()
+    }
+
+    /// Number of historical messages dropped in the most recent fallback path.
+    pub fn last_summary_dropped_count(&self) -> usize {
+        self.last_summary_dropped_count
+    }
+
+    /// Whether the most recent `compress()` used static fallback text.
+    pub fn last_summary_fallback_used(&self) -> bool {
+        self.last_summary_fallback_used
     }
 
     /// Update the tracked usage from the latest response.
@@ -391,6 +414,7 @@ Write only the summary body. Do not include any preamble or prefix."
         &mut self,
         turns: &[Message],
     ) -> Result<Option<String>, CompressionError> {
+        self.last_summary_error = None;
         if let Some(deadline) = self.failure_cooldown_until {
             let now = Instant::now();
             if now < deadline {
@@ -403,37 +427,66 @@ Write only the summary body. Do not include any preamble or prefix."
         let block = self.serialize_for_summary(turns);
         let prompt = self.build_summary_prompt(&block, budget);
 
-        let mut request =
-            AuxiliaryRequest::new(AuxiliaryTask::Compression, vec![Message::user(prompt)])
-                .with_max_tokens((budget * 2) as u32);
-        if let Some(model) = self.config.summary_model_override.as_ref() {
-            request = request.with_model(model.clone());
-        }
-
-        match self.auxiliary.call(request).await {
-            Ok(resp) => {
-                let body = resp
-                    .text()
-                    .map(|s| s.trim().to_string())
-                    .unwrap_or_default();
-                if body.is_empty() {
-                    self.arm_cooldown();
-                    Ok(None)
-                } else {
-                    self.previous_summary = Some(body.clone());
-                    Ok(Some(with_summary_prefix(&body)))
-                }
+        let mut retry_on_main_pending =
+            self.config.summary_model_override.is_some() && !self.summary_model_fallen_back;
+        loop {
+            let mut request = AuxiliaryRequest::new(
+                AuxiliaryTask::Compression,
+                vec![Message::user(prompt.clone())],
+            )
+            .with_max_tokens((budget * 2) as u32);
+            if let Some(model) = self.config.summary_model_override.as_ref() {
+                request = request.with_model(model.clone());
             }
-            Err(err) => {
-                self.arm_cooldown();
-                if !self.config.quiet_mode {
-                    tracing::warn!(
-                        "Failed to generate context summary: {err}. \
-                         Further summary attempts paused for {:?}.",
-                        SUMMARY_FAILURE_COOLDOWN
-                    );
+
+            match self.auxiliary.call(request).await {
+                Ok(resp) => {
+                    let body = resp
+                        .text()
+                        .map(|s| s.trim().to_string())
+                        .unwrap_or_default();
+                    if body.is_empty() {
+                        self.last_summary_error = Some("empty summary response".to_string());
+                        self.arm_cooldown();
+                        return Ok(None);
+                    } else {
+                        self.previous_summary = Some(body.clone());
+                        self.failure_cooldown_until = None;
+                        self.summary_model_fallen_back = false;
+                        self.last_summary_error = None;
+                        return Ok(Some(with_summary_prefix(&body)));
+                    }
                 }
-                Err(CompressionError::Auxiliary(err))
+                Err(err) => {
+                    let err_text = err.to_string();
+                    if retry_on_main_pending {
+                        retry_on_main_pending = false;
+                        self.summary_model_fallen_back = true;
+                        if let Some(model) = self.config.summary_model_override.as_ref() {
+                            if !self.config.quiet_mode {
+                                tracing::warn!(
+                                    "Summary model '{}' failed ({}). Retrying on main model before giving up.",
+                                    model,
+                                    err_text
+                                );
+                            }
+                        }
+                        self.config.summary_model_override = None;
+                        self.failure_cooldown_until = None;
+                        continue;
+                    }
+
+                    self.last_summary_error = Some(err_text.clone());
+                    self.arm_cooldown();
+                    if !self.config.quiet_mode {
+                        tracing::warn!(
+                            "Failed to generate context summary: {err}. \
+                             Further summary attempts paused for {:?}.",
+                            SUMMARY_FAILURE_COOLDOWN
+                        );
+                    }
+                    return Err(CompressionError::Auxiliary(err));
+                }
             }
         }
     }
@@ -629,6 +682,10 @@ Write only the summary body. Do not include any preamble or prefix."
         messages: Vec<Message>,
         current_tokens: Option<u64>,
     ) -> Vec<Message> {
+        self.last_summary_error = None;
+        self.last_summary_dropped_count = 0;
+        self.last_summary_fallback_used = false;
+
         let n_messages = messages.len();
         let min_for_compress = self.config.protect_first_n + 3 + 1;
         if n_messages <= min_for_compress {
@@ -715,10 +772,12 @@ Write only the summary body. Do not include any preamble or prefix."
                     "Summary generation failed — inserting static fallback context marker"
                 );
             }
+            self.last_summary_dropped_count = n_dropped;
+            self.last_summary_fallback_used = true;
             format!(
                 "{SUMMARY_PREFIX}\nSummary generation was unavailable. {n_dropped} \
-                 conversation turns were removed to free context space but could not be \
-                 summarized. The removed turns contained earlier work in this session. \
+                 message(s) were removed to free context space but could not be \
+                 summarized. The removed messages contained earlier work in this session. \
                  Continue based on the recent messages below and the current state of \
                  any files or resources."
             )
@@ -901,6 +960,7 @@ mod tests {
     use async_trait::async_trait;
     use futures::stream::BoxStream;
     use hermes_core::{LlmProvider, LlmResponse, StreamChunk, ToolSchema, UsageStats};
+    use std::collections::VecDeque;
     use std::sync::Mutex;
 
     // ---------- helpers ----------
@@ -1025,6 +1085,79 @@ mod tests {
             _eb: Option<&serde_json::Value>,
         ) -> Result<LlmResponse, AgentError> {
             Err(AgentError::LlmApi("HTTP 402: insufficient credits".into()))
+        }
+        fn chat_completion_stream(
+            &self,
+            _m: &[Message],
+            _t: &[ToolSchema],
+            _x: Option<u32>,
+            _temp: Option<f64>,
+            _model: Option<&str>,
+            _eb: Option<&serde_json::Value>,
+        ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// LLM provider that returns a scripted sequence of outcomes.
+    struct SequencedProvider {
+        outcomes: Mutex<VecDeque<Result<String, AgentError>>>,
+        calls: Mutex<usize>,
+    }
+
+    impl SequencedProvider {
+        fn new(outcomes: Vec<Result<String, AgentError>>) -> Arc<Self> {
+            Arc::new(Self {
+                outcomes: Mutex::new(VecDeque::from(outcomes)),
+                calls: Mutex::new(0),
+            })
+        }
+
+        fn call_count(&self) -> usize {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for SequencedProvider {
+        async fn chat_completion(
+            &self,
+            _m: &[Message],
+            _t: &[ToolSchema],
+            _x: Option<u32>,
+            _temp: Option<f64>,
+            model: Option<&str>,
+            _eb: Option<&serde_json::Value>,
+        ) -> Result<LlmResponse, AgentError> {
+            *self.calls.lock().unwrap() += 1;
+            let outcome = self
+                .outcomes
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Err(AgentError::LlmApi("sequenced provider exhausted".into())));
+            match outcome {
+                Ok(text) => Ok(LlmResponse {
+                    message: Message {
+                        role: MessageRole::Assistant,
+                        content: Some(text),
+                        tool_calls: None,
+                        tool_call_id: None,
+                        name: None,
+                        reasoning_content: None,
+                        cache_control: None,
+                    },
+                    finish_reason: Some("stop".into()),
+                    model: model.unwrap_or("test").to_string(),
+                    usage: Some(UsageStats {
+                        prompt_tokens: 1,
+                        completion_tokens: 1,
+                        total_tokens: 2,
+                        estimated_cost: None,
+                    }),
+                }),
+                Err(err) => Err(err),
+            }
         }
         fn chat_completion_stream(
             &self,
@@ -1212,6 +1345,62 @@ mod tests {
         // Second call within cooldown window short-circuits.
         let err2 = compressor.generate_summary(&turns).await.unwrap_err();
         assert!(matches!(err2, CompressionError::CooldownActive(_)));
+    }
+
+    #[tokio::test]
+    async fn generate_summary_retries_once_on_main_after_aux_failure() {
+        let provider = SequencedProvider::new(vec![
+            Err(AgentError::LlmApi(
+                "HTTP 400: provider rejected model".into(),
+            )),
+            Ok("summary via main model".to_string()),
+        ]);
+        let aux = aux_with_provider(provider.clone());
+        let mut cfg = quiet_config();
+        cfg.summary_model_override = Some("broken-aux-model".to_string());
+        let mut compressor = ContextCompressor::new(cfg, aux);
+        let turns = vec![msg(MessageRole::User, "x")];
+
+        let out = compressor.generate_summary(&turns).await.unwrap();
+        assert!(out.unwrap().contains("summary via main model"));
+        assert_eq!(provider.call_count(), 2);
+        assert_eq!(compressor.last_summary_error(), None);
+    }
+
+    #[tokio::test]
+    async fn generate_summary_with_no_aux_override_does_not_retry() {
+        let provider = SequencedProvider::new(vec![
+            Err(AgentError::LlmApi(
+                "HTTP 400: provider rejected model".into(),
+            )),
+            Ok("should not be reached".to_string()),
+        ]);
+        let aux = aux_with_provider(provider.clone());
+        let mut compressor = ContextCompressor::new(quiet_config(), aux);
+        let turns = vec![msg(MessageRole::User, "x")];
+
+        let err = compressor.generate_summary(&turns).await.unwrap_err();
+        assert!(matches!(err, CompressionError::Auxiliary(_)));
+        assert_eq!(provider.call_count(), 1);
+        assert!(compressor.last_summary_error().is_some());
+    }
+
+    #[tokio::test]
+    async fn generate_summary_only_retries_once_when_both_attempts_fail() {
+        let provider = SequencedProvider::new(vec![
+            Err(AgentError::LlmApi("HTTP 404: model_not_found".into())),
+            Err(AgentError::LlmApi("HTTP 500: upstream exploded".into())),
+        ]);
+        let aux = aux_with_provider(provider.clone());
+        let mut cfg = quiet_config();
+        cfg.summary_model_override = Some("broken-aux-model".to_string());
+        let mut compressor = ContextCompressor::new(cfg, aux);
+        let turns = vec![msg(MessageRole::User, "x")];
+
+        let err = compressor.generate_summary(&turns).await.unwrap_err();
+        assert!(matches!(err, CompressionError::Auxiliary(_)));
+        assert_eq!(provider.call_count(), 2);
+        assert!(compressor.last_summary_error().is_some());
     }
 
     // ---------- sanitiser ----------
@@ -1408,5 +1597,9 @@ mod tests {
             })
             .expect("static fallback banner missing");
         assert!(banner.contains(SUMMARY_PREFIX));
+        assert!(banner.contains("message(s) were removed"));
+        assert!(compressor.last_summary_fallback_used());
+        assert!(compressor.last_summary_dropped_count() > 0);
+        assert!(compressor.last_summary_error().is_some());
     }
 }

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -8,6 +8,7 @@ pub use hermes_core::ConfigError;
 use crate::config::{GatewayConfig, LlmProviderConfig, ProxyConfig};
 use crate::merge::merge_configs;
 use crate::paths;
+use crate::platform::PlatformConfig;
 
 // ---------------------------------------------------------------------------
 // ConfigError conversion helpers
@@ -250,8 +251,37 @@ pub fn load_from_yaml(path: &Path) -> Result<GatewayConfig, ConfigError> {
     if let serde_yaml::Value::Mapping(ref mut m) = root {
         crate::python_yaml_compat::normalize_config_yaml_root(m);
     }
+    mark_platform_enabled_explicit(&mut root, "slack");
     let config: GatewayConfig = serde_yaml::from_value(root).map_err(yaml_to_config_error)?;
     Ok(config)
+}
+
+fn mark_platform_enabled_explicit(root: &mut serde_yaml::Value, platform: &str) {
+    let serde_yaml::Value::Mapping(root_map) = root else {
+        return;
+    };
+    let platforms_key = serde_yaml::Value::String("platforms".to_string());
+    let platform_key = serde_yaml::Value::String(platform.to_string());
+    let enabled_key = serde_yaml::Value::String("enabled".to_string());
+    let extra_key = serde_yaml::Value::String("extra".to_string());
+    let marker_key = serde_yaml::Value::String("_enabled_explicit".to_string());
+
+    let Some(serde_yaml::Value::Mapping(platforms)) = root_map.get_mut(&platforms_key) else {
+        return;
+    };
+    let Some(serde_yaml::Value::Mapping(platform_block)) = platforms.get_mut(&platform_key) else {
+        return;
+    };
+    if !platform_block.contains_key(&enabled_key) {
+        return;
+    }
+
+    let extra_entry = platform_block
+        .entry(extra_key)
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    if let serde_yaml::Value::Mapping(extra_map) = extra_entry {
+        extra_map.insert(marker_key, serde_yaml::Value::Bool(true));
+    }
 }
 
 /// Load `config.yaml` from disk if it exists; otherwise return defaults (no env merge).
@@ -850,6 +880,25 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
         }
     }
 
+    if let Ok(token) = std::env::var("SLACK_BOT_TOKEN") {
+        let trimmed = token.trim();
+        if !trimmed.is_empty() {
+            let slack = config
+                .platforms
+                .entry("slack".to_string())
+                .or_insert_with(PlatformConfig::default);
+            let enabled_was_explicit = slack
+                .extra
+                .remove("_enabled_explicit")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !slack.enabled && !enabled_was_explicit {
+                slack.enabled = true;
+            }
+            slack.token = Some(trimmed.to_string());
+        }
+    }
+
     crate::python_platform_env::apply_python_named_platform_env(config);
 }
 
@@ -1256,6 +1305,68 @@ mod tests {
         unsafe {
             std::env::remove_var("HERMES_OPENAI_CODEX_API_KEY");
             std::env::remove_var("HERMES_QWEN_OAUTH_API_KEY");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_slack_env_token_enables_platform_by_default() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        unsafe {
+            std::env::set_var("SLACK_BOT_TOKEN", "xoxb-live-token");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        let slack = cfg
+            .platforms
+            .entry("slack".to_string())
+            .or_insert_with(crate::platform::PlatformConfig::default);
+        slack.enabled = false;
+        slack.extra.insert(
+            "channel_prompts".to_string(),
+            serde_json::json!({"C1":"ops"}),
+        );
+
+        apply_env_overrides(&mut cfg);
+
+        let slack = cfg.platforms.get("slack").expect("slack config");
+        assert!(slack.enabled, "env token should auto-enable slack");
+        assert_eq!(slack.token.as_deref(), Some("xoxb-live-token"));
+
+        unsafe {
+            std::env::remove_var("SLACK_BOT_TOKEN");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_slack_env_token_respects_explicit_disable_marker() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        unsafe {
+            std::env::set_var("SLACK_BOT_TOKEN", "xoxb-live-token");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        let slack = cfg
+            .platforms
+            .entry("slack".to_string())
+            .or_insert_with(crate::platform::PlatformConfig::default);
+        slack.enabled = false;
+        slack
+            .extra
+            .insert("_enabled_explicit".to_string(), serde_json::json!(true));
+
+        apply_env_overrides(&mut cfg);
+
+        let slack = cfg.platforms.get("slack").expect("slack config");
+        assert!(
+            !slack.enabled,
+            "explicitly disabled slack config must remain disabled"
+        );
+        assert_eq!(slack.token.as_deref(), Some("xoxb-live-token"));
+
+        unsafe {
+            std::env::remove_var("SLACK_BOT_TOKEN");
         }
     }
 }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -72,6 +72,15 @@ fn default_true() -> bool {
     true
 }
 
+fn role_label(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::Tool => "tool",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // IncomingMessage (platform-agnostic)
 // ---------------------------------------------------------------------------
@@ -173,6 +182,12 @@ struct UsageStats {
     input_chars: u64,
     output_chars: u64,
     last_updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CompressionOutcome {
+    removed_messages: usize,
+    summary_warning: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -737,8 +752,15 @@ impl Gateway {
                 Ok(true)
             }
             GatewayCommandResult::CompressContext(_) => {
-                let removed = self.compress_context(session_key, 24).await;
-                let reply = format!("📦 Context compressed. Removed {} old messages.", removed);
+                let outcome = self.compress_context(session_key, 24).await;
+                let mut reply = format!(
+                    "📦 Context compressed. Removed {} old messages.",
+                    outcome.removed_messages
+                );
+                if let Some(warning) = outcome.summary_warning {
+                    reply.push_str("\n\n");
+                    reply.push_str(&warning);
+                }
                 self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
                     .await?;
                 Ok(true)
@@ -1442,28 +1464,87 @@ impl Gateway {
         )
     }
 
-    async fn compress_context(&self, session_key: &str, max_messages: usize) -> usize {
+    fn summarize_removed_messages(messages: &[Message]) -> Result<String, String> {
+        let mut bullets = Vec::new();
+        for msg in messages {
+            let Some(raw) = msg.content.as_ref() else {
+                continue;
+            };
+            let compact = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+            if compact.is_empty() {
+                continue;
+            }
+            let truncated = if compact.chars().count() > 180 {
+                let mut head = compact.chars().take(177).collect::<String>();
+                head.push_str("...");
+                head
+            } else {
+                compact
+            };
+            bullets.push(format!("• {}: {}", role_label(msg.role), truncated));
+            if bullets.len() >= 6 {
+                break;
+            }
+        }
+
+        if bullets.is_empty() {
+            return Err("no textual content available to summarize".to_string());
+        }
+
+        let mut out =
+            String::from("[CONTEXT COMPACTION] Earlier conversation was compacted. Key points:\n");
+        out.push_str(&bullets.join("\n"));
+        Ok(out)
+    }
+
+    async fn compress_context(&self, session_key: &str, max_messages: usize) -> CompressionOutcome {
         let current = self.session_manager.get_messages(session_key).await;
         if current.len() <= max_messages {
-            return 0;
+            return CompressionOutcome::default();
         }
 
         let mut compressed = Vec::new();
+        let mut head_count = 0usize;
         if let Some(first) = current.first() {
             if first.role == MessageRole::System {
                 compressed.push(first.clone());
+                head_count = 1;
             }
         }
         let keep_tail = max_messages.saturating_sub(compressed.len());
         let mut tail: Vec<Message> = current.iter().rev().take(keep_tail).cloned().collect();
         tail.reverse();
+        let tail_start = current.len().saturating_sub(keep_tail);
+        let middle = if tail_start > head_count {
+            &current[head_count..tail_start]
+        } else {
+            &[]
+        };
+        let removed_messages = middle.len();
+
+        let mut summary_warning = None;
+        if removed_messages > 0 {
+            match Self::summarize_removed_messages(middle) {
+                Ok(summary) => compressed.push(Message::assistant(&summary)),
+                Err(err) => {
+                    compressed.push(Message::assistant(&format!(
+                        "[CONTEXT COMPACTION] Summary generation was unavailable. {removed_messages} message(s) were removed to free context space but could not be summarized. Continue from recent messages and current workspace state."
+                    )));
+                    summary_warning = Some(format!(
+                        "⚠️ Context compression summary failed ({err}). {removed_messages} historical message(s) were removed and replaced with a placeholder."
+                    ));
+                }
+            }
+        }
         compressed.extend(tail);
 
-        let removed = current.len().saturating_sub(compressed.len());
         self.session_manager
             .replace_messages(session_key, compressed)
             .await;
-        removed
+        CompressionOutcome {
+            removed_messages,
+            summary_warning,
+        }
     }
 
     async fn build_status_text(&self, session_key: &str) -> String {
@@ -2230,6 +2311,125 @@ mod tests {
 
         let msgs = sent.lock().unwrap();
         assert!(msgs.iter().any(|(_, text)| text.contains("Gateway status")));
+    }
+
+    #[tokio::test]
+    async fn gateway_compress_command_appends_warning_when_summary_unavailable() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+
+        let session_key = gw
+            .session_manager
+            .compose_session_key("test", "chat1", "user1");
+        let _ = gw
+            .session_manager
+            .get_or_create_session("test", "chat1", "user1")
+            .await;
+        gw.session_manager
+            .add_message(&session_key, Message::system("sys"))
+            .await;
+        for _ in 0..40 {
+            gw.session_manager
+                .add_message(
+                    &session_key,
+                    Message {
+                        role: MessageRole::Tool,
+                        content: None,
+                        tool_calls: None,
+                        tool_call_id: None,
+                        name: None,
+                        reasoning_content: None,
+                        cache_control: None,
+                    },
+                )
+                .await;
+        }
+
+        let incoming = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/compress".into(),
+            message_id: None,
+            is_dm: true,
+        };
+
+        assert!(gw.route_message(&incoming).await.is_ok());
+
+        let msgs = sent.lock().unwrap();
+        let reply = msgs.last().map(|(_, t)| t.clone()).unwrap_or_default();
+        assert!(reply.contains("Context compressed"));
+        assert!(reply.contains("⚠️ Context compression summary failed"));
+        assert!(reply.contains("historical message(s) were removed"));
+    }
+
+    #[tokio::test]
+    async fn gateway_compress_command_emits_summary_without_warning() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+
+        let session_key = gw
+            .session_manager
+            .compose_session_key("test", "chat1", "user1");
+        let _ = gw
+            .session_manager
+            .get_or_create_session("test", "chat1", "user1")
+            .await;
+        gw.session_manager
+            .add_message(&session_key, Message::system("sys"))
+            .await;
+        for i in 0..40 {
+            let message = if i % 2 == 0 {
+                Message::user(format!("turn {i} content"))
+            } else {
+                Message::assistant(format!("turn {i} content"))
+            };
+            gw.session_manager.add_message(&session_key, message).await;
+        }
+
+        let incoming = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/compress".into(),
+            message_id: None,
+            is_dm: true,
+        };
+
+        assert!(gw.route_message(&incoming).await.is_ok());
+
+        let msgs = sent.lock().unwrap();
+        let reply = msgs.last().map(|(_, t)| t.clone()).unwrap_or_default();
+        assert!(reply.contains("Context compressed"));
+        assert!(!reply.contains("⚠️"));
+        drop(msgs);
+
+        let updated = gw.session_manager.get_messages(&session_key).await;
+        assert!(
+            updated.iter().any(|m| {
+                m.content
+                    .as_deref()
+                    .unwrap_or("")
+                    .contains("[CONTEXT COMPACTION] Earlier conversation was compacted")
+            }),
+            "summary marker should be persisted into compressed transcript"
+        );
     }
 
     #[tokio::test]

--- a/optional-skills/creative/DESCRIPTION.md
+++ b/optional-skills/creative/DESCRIPTION.md
@@ -8,3 +8,5 @@ Current bundles include:
 - `design-md`: author/lint/export Google `DESIGN.md` system specs.
 - `embedding-atlas`: interactive embedding-space visualization and metadata
   exploration with Apple's Embedding Atlas.
+- `touchdesigner-mcp`: TouchDesigner scene automation, diagnostics, and
+  audio-reactive pipeline orchestration through MCP-compatible control flows.

--- a/optional-skills/creative/touchdesigner-mcp/SKILL.md
+++ b/optional-skills/creative/touchdesigner-mcp/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: touchdesigner-mcp
+description: Control and debug TouchDesigner projects through MCP-backed tooling for scene graph edits, operator introspection, timeline automation, and audio-reactive visuals.
+version: 1.0.0
+author: Hermes Agent Ultra
+license: MIT
+metadata:
+  hermes:
+    tags: [touchdesigner, mcp, realtime, visual, audio-reactive, op, glsl]
+    category: creative
+---
+
+# touchdesigner-mcp
+
+Use this skill when users want production-style TouchDesigner assistance that
+is agent-friendly and terminal-repeatable.
+
+## Use Cases
+
+- Build or modify node networks from prompts
+- Diagnose broken TOP/CHOP/DAT/COMP operator chains
+- Automate timeline/cue playback and scene state transitions
+- Drive reactive visuals from audio or event streams
+- Generate reproducible patch notes for `.toe` workflows
+
+## Workflow
+
+1. Discover available MCP commands for TouchDesigner runtime control.
+2. Snapshot current network state (operators, links, key params).
+3. Apply minimal graph edits in small batches.
+4. Validate output (render path, FPS, operator errors, cue timing).
+5. Emit structured changelog + rollback instructions.
+
+## Guardrails
+
+- Keep edits additive unless user explicitly requests destructive rewrites.
+- Prefer parameter-level changes before deleting operators.
+- Preserve naming conventions on critical nodes (`in_*`, `fx_*`, `out_*`).
+- When performance regresses, prioritize cook-time hotspots and texture size.
+
+## Suggested Prompt Add-ons
+
+- "Optimize for 60fps at 1080p."
+- "Keep existing scene naming and transition cues."
+- "Use deterministic naming and provide rollback steps."
+
+## References
+
+- `references/mcp-tools.md`

--- a/optional-skills/creative/touchdesigner-mcp/references/mcp-tools.md
+++ b/optional-skills/creative/touchdesigner-mcp/references/mcp-tools.md
@@ -1,0 +1,11 @@
+# TouchDesigner MCP Reference
+
+Recommended command families when exposing TouchDesigner through MCP:
+
+- Graph inspection: list operators, parents, links, tags.
+- Parameter I/O: read/write operator parameters with type-safe coercion.
+- Timeline control: play/pause/seek/loop and cue triggering.
+- Diagnostics: operator warnings/errors, cook time, dropped frames.
+- Render probes: output dimensions, pixel format, frame export paths.
+
+Keep command outputs compact and include operator paths in every response.


### PR DESCRIPTION
## Summary
- ported compressor parity fixes: single retry on main summary model + fallback state tracking + message wording alignment
- ported gateway /compress warning behavior with persisted compacted summaries
- ported slack env-token enable behavior with explicit-disable preservation
- bundled touchdesigner-mcp optional creative skill and docs updates

## Validation
- cargo fmt
- cargo test -p hermes-config apply_env_overrides_slack_env_token -- --nocapture
- cargo test -p hermes-agent generate_summary_ -- --nocapture
- cargo test -p hermes-agent compress_falls_back_to_static_marker_on_summary_failure -- --nocapture
- cargo test -p hermes-gateway gateway_compress_command_ -- --nocapture
