### PR TITLE
feat: add live parity/about status surfaces + quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ cargo install --git https://github.com/sheawinkler/hermes-agent-ultra hermes-cli
 
 ## Quick Start
 
+Need a shorter path? See [README_QUICKSTART.md](./README_QUICKSTART.md).
+
 Setup:
 
 ```bash
@@ -138,11 +140,19 @@ Ultra uses controlled sync workflows, not blind merges.
 - Parity artifacts:
   - `docs/parity/`
   - `.sync-reports/`
+<!-- BEGIN:ULTRA_SYNC_STATUS -->
+### Live Upstream Sync Status (auto-generated)
 
-Current local sync snapshot (fetched on 2026-04-28):
-
-- `origin/main`: `22e5906eaac119e3788109c9554476d2a5ea301f`
-- `upstream/main`: `4bf0e75ae95fe33b47391a73bcf9bf5c128dd75b`
+- Generated at: `20260428-182056`
+- Source report: [`upstream-sync-20260428-182056.txt`](./.sync-reports/upstream-sync-20260428-182056.txt)
+- Sync timestamp (`timestamp_utc`): `20260428-182056`
+- `origin/main` at sync: `22e5906eaac119e3788109c9554476d2a5ea301f`
+- `upstream/main` at sync: `4bf0e75ae95fe33b47391a73bcf9bf5c128dd75b`
+- Pending commits captured in report: `944`
+- Queue summary (`docs/parity/upstream-missing-queue.json`): pending `320`, ported `45`, superseded `310`
+- Parity gates (`docs/parity/global-parity-proof.json`): release `fail`, ci `fail`
+- Workstream snapshot (`docs/parity/workstream-status.json`): `upstream/main` @ `93ddff53e339b859e88d1d1be97624212722b7f1` (generated `2026-04-24T14:52:58-06:00`)
+<!-- END:ULTRA_SYNC_STATUS -->
 
 Note: this repository intentionally tracks parity via queue/gate workflows because upstream and ultra history can diverge materially.
 

--- a/README_QUICKSTART.md
+++ b/README_QUICKSTART.md
@@ -1,0 +1,77 @@
+# Hermes Agent Ultra Quickstart
+
+This guide is the fastest path from install to a working interactive session.
+
+## 1) Install
+
+From source:
+
+```bash
+cargo install --git https://github.com/sheawinkler/hermes-agent-ultra hermes-cli --locked --bin hermes-agent-ultra --bin hermes-ultra --bin hermes
+hash -r
+```
+
+## 2) Run Setup Wizard
+
+```bash
+hermes-ultra setup
+```
+
+Recommended wizard flow:
+
+1. Choose `Quick setup` (or `Full setup` if you want platform/tool tuning immediately).
+2. Select provider first.
+3. Complete OAuth/API-key auth for that provider.
+4. Pick model from the provider model list.
+5. Save config when prompted.
+
+Setup writes config under:
+
+- `~/.hermes-agent-ultra/config.yaml`
+- `~/.hermes-agent-ultra/auth/`
+
+## 3) Start Interactive Session
+
+```bash
+hermes-ultra
+```
+
+Useful in-session commands:
+
+- `/help` — command catalog
+- `/model` — interactive provider/model switcher
+- `/personality list` — built-in personalities with usage guidance
+- `/tools` — tool registry view
+- `/about` — build + parity + upstream sync snapshot
+
+## 4) Verify Runtime Health
+
+```bash
+hermes-ultra doctor --deep --snapshot
+```
+
+Optional support bundle:
+
+```bash
+hermes-ultra doctor --deep --snapshot --bundle
+```
+
+## 5) Gateway Mode (Optional)
+
+```bash
+hermes-ultra gateway --live
+```
+
+## 6) Upstream/Parity Visibility
+
+Refresh parity and README sync status:
+
+```bash
+python3 scripts/generate-parity-dashboard.py
+python3 scripts/generate-readme-sync-status.py
+```
+
+Artifacts:
+
+- `docs/parity/PARITY_DASHBOARD.md`
+- `README.md` auto-generated live sync block

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -5,7 +5,11 @@
 
 use std::process::Stdio;
 use std::sync::Arc;
-use std::{collections::HashSet, fmt::Write as _};
+use std::{
+    collections::HashSet,
+    fmt::Write as _,
+    path::{Path, PathBuf},
+};
 
 use hermes_core::AgentError;
 use regex::Regex;
@@ -125,6 +129,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/stop", "Stop current agent execution"),
     ("/status", "Show session status (model, turns, token count)"),
     ("/agent", "Alias for /status"),
+    (
+        "/about",
+        "Show build/parity/upstream snapshot and enabled Ultra features",
+    ),
     ("/ops", "Operator control plane (status + quick controls)"),
     (
         "/platforms",
@@ -1750,6 +1758,7 @@ pub async fn handle_slash_command(
         "/insights" => handle_insights_command(app),
         "/stop" => handle_stop_command(app),
         "/status" => handle_status_command(app),
+        "/about" => handle_about_command(app),
         "/ops" => handle_ops_command(app, args).await,
         "/platforms" => handle_platforms_command(app),
         "/commands" => {
@@ -2261,6 +2270,316 @@ fn handle_status_command(app: &mut App) -> Result<CommandResult, AgentError> {
             app.config.max_turns
         ),
     );
+    Ok(CommandResult::Handled)
+}
+
+fn discover_repo_root_for_about() -> Option<PathBuf> {
+    if let Ok(explicit) = std::env::var("HERMES_REPO_ROOT") {
+        let path = PathBuf::from(explicit.trim());
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let mut probes: Vec<PathBuf> = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        probes.push(cwd);
+    }
+    probes.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+
+    for probe in probes {
+        for candidate in probe.ancestors() {
+            if candidate.join("docs/parity").exists() && candidate.join("README.md").exists() {
+                return Some(candidate.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+fn read_json_file(path: &Path) -> Option<serde_json::Value> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str::<serde_json::Value>(&raw).ok()
+}
+
+fn json_value_at_path<'a>(
+    value: &'a serde_json::Value,
+    path: &[&str],
+) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn json_str_at_path(value: &serde_json::Value, path: &[&str]) -> Option<String> {
+    json_value_at_path(value, path)?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn json_u64_at_path(value: &serde_json::Value, path: &[&str]) -> Option<u64> {
+    json_value_at_path(value, path)?.as_u64()
+}
+
+fn latest_upstream_sync_report(report_dir: &Path) -> Option<PathBuf> {
+    let mut reports: Vec<PathBuf> = std::fs::read_dir(report_dir)
+        .ok()?
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            let name = path.file_name()?.to_string_lossy();
+            if name.starts_with("upstream-sync-") && name.ends_with(".txt") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    reports.sort();
+    reports.into_iter().last()
+}
+
+fn parse_sync_report_metadata(path: &Path) -> (std::collections::HashMap<String, String>, usize) {
+    let mut meta = std::collections::HashMap::new();
+    let mut pending_commit_lines = 0usize;
+    let raw = std::fs::read_to_string(path).unwrap_or_default();
+
+    let mut in_pending_section = false;
+    let mut in_pending_block = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if !in_pending_section {
+            if trimmed.starts_with("## Pending Upstream Commits") {
+                in_pending_section = true;
+                continue;
+            }
+            if let Some((k, v)) = line.split_once(':') {
+                let key = k.trim();
+                if !key.is_empty()
+                    && key
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'))
+                {
+                    meta.insert(key.to_string(), v.trim().to_string());
+                }
+            }
+            continue;
+        }
+
+        if trimmed == "```" {
+            if !in_pending_block {
+                in_pending_block = true;
+            } else {
+                break;
+            }
+            continue;
+        }
+        if in_pending_block && !trimmed.is_empty() {
+            pending_commit_lines = pending_commit_lines.saturating_add(1);
+        }
+    }
+
+    (meta, pending_commit_lines)
+}
+
+fn yes_no(flag: bool) -> &'static str {
+    if flag {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn handle_about_command(app: &mut App) -> Result<CommandResult, AgentError> {
+    let mut out = String::new();
+    let _ = writeln!(out, "Hermes Agent Ultra — About");
+    let _ = writeln!(out, "  Version:         {}", env!("CARGO_PKG_VERSION"));
+    let _ = writeln!(out, "  Session model:   {}", app.current_model);
+    let _ = writeln!(
+        out,
+        "  Personality:     {}",
+        app.current_personality.as_deref().unwrap_or("(none)")
+    );
+    if let Ok(exe) = std::env::current_exe() {
+        let _ = writeln!(out, "  Binary:          {}", exe.display());
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        let _ = writeln!(out, "  Current dir:     {}", cwd.display());
+    }
+
+    let raw_mode = app.tool_registry.raw_mode_state();
+    let policy_mode = std::env::var("HERMES_TOOL_POLICY_MODE")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "enforce".to_string());
+    let policy_preset = std::env::var("HERMES_TOOL_POLICY_PRESET")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "balanced".to_string());
+
+    let has_contextlattice_mcp = app.config.mcp_servers.iter().any(|entry| {
+        let name_hit = entry.name.to_ascii_lowercase().contains("contextlattice");
+        let url_hit = entry
+            .url
+            .as_ref()
+            .map(|u| u.to_ascii_lowercase().contains("contextlattice"))
+            .unwrap_or(false);
+        name_hit || url_hit
+    });
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Enabled Ultra Features:");
+    let _ = writeln!(
+        out,
+        "  - RTK raw-mode: enabled={} once={}",
+        yes_no(raw_mode.enabled),
+        yes_no(raw_mode.once_pending)
+    );
+    let _ = writeln!(
+        out,
+        "  - Tool policy: mode={} preset={}",
+        policy_mode, policy_preset
+    );
+    let _ = writeln!(
+        out,
+        "  - Code indexing: {} (max_files={}, max_symbols={})",
+        yes_no(app.config.agent.code_index_enabled),
+        app.config.agent.code_index_max_files,
+        app.config.agent.code_index_max_symbols
+    );
+    let _ = writeln!(
+        out,
+        "  - LSP context injection: {} (max_chars={})",
+        yes_no(app.config.agent.lsp_context_enabled),
+        app.config.agent.lsp_context_max_chars
+    );
+    let _ = writeln!(
+        out,
+        "  - Background review loop: {}",
+        yes_no(app.config.agent.background_review_enabled)
+    );
+    let _ = writeln!(out, "  - Multi-registry skills: yes");
+    let _ = writeln!(out, "  - Skill security scanning: yes");
+    let _ = writeln!(
+        out,
+        "  - ContextLattice MCP configured: {}",
+        yes_no(has_contextlattice_mcp)
+    );
+
+    if let Some(repo_root) = discover_repo_root_for_about() {
+        let report_dir = repo_root.join(".sync-reports");
+        let workstream_path = repo_root.join("docs/parity/workstream-status.json");
+        let queue_path = repo_root.join("docs/parity/upstream-missing-queue.json");
+        let proof_path = repo_root.join("docs/parity/global-parity-proof.json");
+
+        let mut upstream_ref = String::from("unknown");
+        let mut upstream_sha = String::from("unknown");
+        let mut workstream_generated = String::from("unknown");
+        if let Some(workstream) = read_json_file(&workstream_path) {
+            if let Some(v) = json_str_at_path(&workstream, &["upstream_ref"]) {
+                upstream_ref = v;
+            }
+            if let Some(v) = json_str_at_path(&workstream, &["upstream_sha"]) {
+                upstream_sha = v;
+            }
+            if let Some(v) = json_str_at_path(&workstream, &["generated_at_utc"]) {
+                workstream_generated = v;
+            }
+        }
+
+        let mut queue_pending = 0u64;
+        let mut queue_ported = 0u64;
+        let mut queue_superseded = 0u64;
+        if let Some(queue) = read_json_file(&queue_path) {
+            queue_pending =
+                json_u64_at_path(&queue, &["summary", "by_disposition", "pending"]).unwrap_or(0);
+            queue_ported =
+                json_u64_at_path(&queue, &["summary", "by_disposition", "ported"]).unwrap_or(0);
+            queue_superseded =
+                json_u64_at_path(&queue, &["summary", "by_disposition", "superseded"]).unwrap_or(0);
+        }
+
+        let mut release_gate_pass = String::from("unknown");
+        let mut ci_gate_pass = String::from("unknown");
+        if let Some(proof) = read_json_file(&proof_path) {
+            if let Some(v) =
+                json_value_at_path(&proof, &["release_gate", "pass"]).and_then(|v| v.as_bool())
+            {
+                release_gate_pass = yes_no(v).to_string();
+            }
+            if let Some(v) =
+                json_value_at_path(&proof, &["ci_gate", "pass"]).and_then(|v| v.as_bool())
+            {
+                ci_gate_pass = yes_no(v).to_string();
+            }
+        }
+
+        let mut latest_report_name = String::from("none");
+        let mut latest_origin_sha = String::from("unknown");
+        let mut latest_upstream_sha = String::from("unknown");
+        let mut latest_timestamp = String::from("unknown");
+        let mut latest_pending_count = 0usize;
+        if let Some(report_path) = latest_upstream_sync_report(&report_dir) {
+            latest_report_name = report_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| report_path.display().to_string());
+            let (meta, pending_count) = parse_sync_report_metadata(&report_path);
+            latest_pending_count = pending_count;
+            if let Some(v) = meta.get("origin_sha") {
+                latest_origin_sha = v.clone();
+            }
+            if let Some(v) = meta.get("upstream_sha") {
+                latest_upstream_sha = v.clone();
+            }
+            if let Some(v) = meta.get("timestamp_utc") {
+                latest_timestamp = v.clone();
+            }
+        }
+
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Parity Snapshot:");
+        let _ = writeln!(out, "  - Repo root: {}", repo_root.display());
+        let _ = writeln!(out, "  - Upstream ref: {}", upstream_ref);
+        let _ = writeln!(out, "  - Upstream sha: {}", upstream_sha);
+        let _ = writeln!(
+            out,
+            "  - Workstream report generated_at: {}",
+            workstream_generated
+        );
+        let _ = writeln!(
+            out,
+            "  - Queue (pending/ported/superseded): {}/{}/{}",
+            queue_pending, queue_ported, queue_superseded
+        );
+        let _ = writeln!(
+            out,
+            "  - Gate status (release/ci): {}/{}",
+            release_gate_pass, ci_gate_pass
+        );
+        let _ = writeln!(out, "  - Latest sync report: {}", latest_report_name);
+        let _ = writeln!(out, "  - Latest sync timestamp_utc: {}", latest_timestamp);
+        let _ = writeln!(out, "  - Latest report origin_sha: {}", latest_origin_sha);
+        let _ = writeln!(
+            out,
+            "  - Latest report upstream_sha: {}",
+            latest_upstream_sha
+        );
+        let _ = writeln!(
+            out,
+            "  - Pending upstream commits in latest report: {}",
+            latest_pending_count
+        );
+    } else {
+        let _ = writeln!(out);
+        let _ = writeln!(
+            out,
+            "Parity Snapshot: unavailable (run from a source checkout to load docs/parity + .sync-reports)."
+        );
+    }
+
+    emit_command_output(app, out.trim_end());
     Ok(CommandResult::Handled)
 }
 

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,0 +1,67 @@
+# Parity Dashboard
+
+_Generated from source artifacts: `2026-04-27T13:01:56.073823+00:00`_
+
+## Snapshot
+
+- Upstream target: `upstream/main` @ `93ddff53e339b859e88d1d1be97624212722b7f1`
+- Workstream snapshot generated: `2026-04-24T14:52:58-06:00`
+- Parity matrix generated: `2026-04-24T21:19:39.155201+00:00`
+- Queue snapshot generated: `2026-04-27T08:01:12.277794+00:00`
+- Proof snapshot generated: `2026-04-27T13:01:56.073823+00:00`
+
+## Gate Status
+
+- Release gate: **FAIL**
+- CI/tree-drift gate: **FAIL**
+- Release gate failures: max_queue_pending_commits (actual=320.0, limit=0)
+- CI gate failures: max_files_only_upstream (actual=2512.0, limit=2500); max_queue_pending_commits (actual=320.0, limit=100)
+
+## Queue Summary
+
+| Metric | Value |
+| --- | ---: |
+| Total commits in queue | 675 |
+| Pending | 320 |
+| Ported | 45 |
+| Superseded | 310 |
+
+## Tree/Patch Drift
+
+| Metric | Value |
+| --- | ---: |
+| commits_behind | 298 |
+| commits_ahead | 302 |
+| upstream_patch_missing | 286 |
+| upstream_patch_represented | 0 |
+| local_patch_unique | 291 |
+| files_only_upstream | 2512 |
+| files_only_local | 414 |
+| files_shared_identical | 2 |
+| files_shared_different | 8 |
+
+## Workstream States
+
+| State | Count |
+| --- | ---: |
+| complete | 7 |
+
+## Workstream Detail
+
+| WS | Title | State |
+| --- | --- | --- |
+| WS2 | Core runtime parity | complete |
+| WS3 | Tools/adapters parity | complete |
+| WS4 | Skills parity | complete |
+| WS5 | UX parity | complete |
+| WS6 | Tests and CI parity | complete |
+| WS7 | Security/secrets/store/webhook parity | complete |
+| WS8 | Compatibility and divergence policy | complete |
+
+## Source Artifacts
+
+- `docs/parity/parity-matrix.json`
+- `docs/parity/workstream-status.json`
+- `docs/parity/upstream-missing-queue.json`
+- `docs/parity/global-parity-proof.json`
+

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -15,6 +15,7 @@ python3 scripts/generate-adapter-matrix.py
 python3 scripts/validate-intentional-divergence.py --check --allow-warnings
 python3 scripts/generate-upstream-patch-queue.py --max-commits 0
 python3 scripts/generate-global-parity-proof.py --check-ci
+python3 scripts/generate-parity-dashboard.py
 ```
 
 By default this command fetches upstream directly from GitHub
@@ -36,6 +37,7 @@ By default this command fetches upstream directly from GitHub
   - `release_thresholds`: functional parity gate (GPAR/workstream + divergence/test integrity)
 - `global-parity-proof.json`: consolidated parity proof with gate results for tickets #19-#28
 - `global-parity-proof.md`: human-readable parity proof summary
+- `PARITY_DASHBOARD.md`: operator-facing dashboard synthesized from parity JSON artifacts
 - `shared-different-classification.json`: functional-vs-policy classification for shared-different files
 - `upstream-missing-queue.md` / `upstream-missing-queue.json`: auditable upstream missing commit queue
 - `intentional-divergence.json`: tracked, approved ultra-only deltas used by the report

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -13,6 +13,8 @@ fork-specific history.
   - Runs adversarial regression gate by default (`scripts/run-redteam-gate.py`)
   - Supports `--no-redteam-gate` and `--redteam-cmd` overrides
   - Supports optional consolidated elite gate: `--elite-gate` / `--elite-cmd`
+  - Refreshes generated parity docs by default (`README` sync status + parity dashboard)
+  - Supports `--no-doc-refresh` and `--doc-refresh-cmd` overrides
   - Supports `--strategy merge|cherry-pick`
   - Supports strict risk gating via `--strict-risk-gate`
   - Emits timestamped reports under `.sync-reports/`
@@ -40,6 +42,10 @@ fork-specific history.
   - Emits gate artifact under `.sync-reports/eval-trend-gate-<timestamp>.json`
 - `scripts/compare-adapter-chaos-reports.py`
   - Compares chaos reports and fails on attempts/fallback/outcome regressions
+- `scripts/generate-readme-sync-status.py`
+  - Regenerates README “Live Upstream Sync Status” block from latest `.sync-reports/upstream-sync-*.txt`
+- `scripts/generate-parity-dashboard.py`
+  - Builds `docs/parity/PARITY_DASHBOARD.md` from parity JSON artifacts
 
 ## One-shot Manual Sync
 
@@ -52,6 +58,8 @@ bash scripts/sync-upstream.sh --redteam-cmd "python3 scripts/run-redteam-gate.py
 python3 scripts/run-adapter-chaos-harness.py --repo-root .
 python3 scripts/run-zero-copy-hotpath-bench.py --repo-root .
 python3 scripts/run-elite-sync-gate.py --repo-root .
+python3 scripts/generate-parity-dashboard.py --repo-root .
+python3 scripts/generate-readme-sync-status.py --repo-root .
 bash scripts/sync-upstream.sh --elite-gate
 bash scripts/sync-upstream.sh --elite-gate --elite-rollback-cmd "git reset --hard origin/main"
 ```

--- a/scripts/generate-parity-dashboard.py
+++ b/scripts/generate-parity-dashboard.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Generate docs/parity/PARITY_DASHBOARD.md from parity JSON artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument(
+        "--parity-matrix",
+        default="docs/parity/parity-matrix.json",
+        help="Parity matrix JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--workstream-status",
+        default="docs/parity/workstream-status.json",
+        help="Workstream status JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--queue-json",
+        default="docs/parity/upstream-missing-queue.json",
+        help="Upstream queue JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--proof-json",
+        default="docs/parity/global-parity-proof.json",
+        help="Global parity proof JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--output",
+        default="docs/parity/PARITY_DASHBOARD.md",
+        help="Output markdown path relative to repo root",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def gate_status(value: Any) -> str:
+    if value is True:
+        return "PASS"
+    if value is False:
+        return "FAIL"
+    return "UNKNOWN"
+
+
+def format_failed_checks(gate: dict[str, Any]) -> str:
+    checks = gate.get("checks")
+    if not isinstance(checks, list):
+        return "none"
+    failed: list[str] = []
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        metric = str(check.get("metric", "unknown_metric"))
+        status = str(check.get("status", "unknown")).lower()
+        if status != "pass":
+            actual = check.get("actual", "n/a")
+            limit = check.get("limit", "n/a")
+            failed.append(f"{metric} (actual={actual}, limit={limit})")
+    if not failed:
+        return "none"
+    return "; ".join(failed)
+
+
+def render_dashboard(
+    parity_matrix: dict[str, Any],
+    workstream_status: dict[str, Any],
+    queue_json: dict[str, Any],
+    proof_json: dict[str, Any],
+) -> str:
+    summary = parity_matrix.get("summary", {}) if isinstance(parity_matrix.get("summary"), dict) else {}
+    queue_summary = queue_json.get("summary", {}) if isinstance(queue_json.get("summary"), dict) else {}
+    by_disp = queue_summary.get("by_disposition", {}) if isinstance(queue_summary.get("by_disposition"), dict) else {}
+    ws_states = workstream_status.get("states", {}) if isinstance(workstream_status.get("states"), dict) else {}
+
+    release_gate = proof_json.get("release_gate", {}) if isinstance(proof_json.get("release_gate"), dict) else {}
+    ci_gate = proof_json.get("ci_gate", {}) if isinstance(proof_json.get("ci_gate"), dict) else {}
+
+    upstream_ref = str(workstream_status.get("upstream_ref") or "unknown")
+    upstream_sha = str(workstream_status.get("upstream_sha") or "unknown")
+    ws_generated = str(workstream_status.get("generated_at_utc") or "unknown")
+    pm_generated = str(parity_matrix.get("generated_at_utc") or "unknown")
+    queue_generated = str(queue_json.get("generated_at_utc") or "unknown")
+    proof_generated = str(proof_json.get("generated_at_utc") or "unknown")
+    derived_generated = next(
+        (
+            candidate
+            for candidate in [proof_generated, queue_generated, pm_generated, ws_generated]
+            if candidate and candidate != "unknown"
+        ),
+        "unknown",
+    )
+
+    lines: list[str] = []
+    lines.append("# Parity Dashboard")
+    lines.append("")
+    lines.append(f"_Generated from source artifacts: `{derived_generated}`_")
+    lines.append("")
+    lines.append("## Snapshot")
+    lines.append("")
+    lines.append(f"- Upstream target: `{upstream_ref}` @ `{upstream_sha}`")
+    lines.append(f"- Workstream snapshot generated: `{ws_generated}`")
+    lines.append(f"- Parity matrix generated: `{pm_generated}`")
+    lines.append(f"- Queue snapshot generated: `{queue_generated}`")
+    lines.append(f"- Proof snapshot generated: `{proof_generated}`")
+    lines.append("")
+    lines.append("## Gate Status")
+    lines.append("")
+    lines.append(f"- Release gate: **{gate_status(release_gate.get('pass'))}**")
+    lines.append(f"- CI/tree-drift gate: **{gate_status(ci_gate.get('pass'))}**")
+    lines.append(f"- Release gate failures: {format_failed_checks(release_gate)}")
+    lines.append(f"- CI gate failures: {format_failed_checks(ci_gate)}")
+    lines.append("")
+    lines.append("## Queue Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | ---: |")
+    lines.append(f"| Total commits in queue | {int(queue_summary.get('total_commits', 0) or 0)} |")
+    lines.append(f"| Pending | {int(by_disp.get('pending', 0) or 0)} |")
+    lines.append(f"| Ported | {int(by_disp.get('ported', 0) or 0)} |")
+    lines.append(f"| Superseded | {int(by_disp.get('superseded', 0) or 0)} |")
+    lines.append("")
+    lines.append("## Tree/Patch Drift")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | ---: |")
+    for key in [
+        "commits_behind",
+        "commits_ahead",
+        "upstream_patch_missing",
+        "upstream_patch_represented",
+        "local_patch_unique",
+        "files_only_upstream",
+        "files_only_local",
+        "files_shared_identical",
+        "files_shared_different",
+    ]:
+        lines.append(f"| {key} | {int(summary.get(key, 0) or 0)} |")
+    lines.append("")
+    lines.append("## Workstream States")
+    lines.append("")
+    lines.append("| State | Count |")
+    lines.append("| --- | ---: |")
+    for state_name in sorted(ws_states):
+        lines.append(f"| {state_name} | {int(ws_states[state_name] or 0)} |")
+    lines.append("")
+
+    workstreams = workstream_status.get("workstreams")
+    if isinstance(workstreams, list) and workstreams:
+        lines.append("## Workstream Detail")
+        lines.append("")
+        lines.append("| WS | Title | State |")
+        lines.append("| --- | --- | --- |")
+        for ws in workstreams:
+            if not isinstance(ws, dict):
+                continue
+            ws_id = str(ws.get("workstream", "?"))
+            title = str(ws.get("title", ""))
+            state = str(ws.get("state", ""))
+            lines.append(f"| {ws_id} | {title} | {state} |")
+        lines.append("")
+
+    lines.append("## Source Artifacts")
+    lines.append("")
+    lines.append("- `docs/parity/parity-matrix.json`")
+    lines.append("- `docs/parity/workstream-status.json`")
+    lines.append("- `docs/parity/upstream-missing-queue.json`")
+    lines.append("- `docs/parity/global-parity-proof.json`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+
+    parity_matrix = load_json((repo_root / args.parity_matrix).resolve())
+    workstream_status = load_json((repo_root / args.workstream_status).resolve())
+    queue_json = load_json((repo_root / args.queue_json).resolve())
+    proof_json = load_json((repo_root / args.proof_json).resolve())
+
+    output = (repo_root / args.output).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    dashboard = render_dashboard(parity_matrix, workstream_status, queue_json, proof_json)
+    output.write_text(dashboard + "\n", encoding="utf-8")
+    print(f"Wrote parity dashboard: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-readme-sync-status.py
+++ b/scripts/generate-readme-sync-status.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Render/update README upstream sync status block from .sync-reports artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+BEGIN_MARKER = "<!-- BEGIN:ULTRA_SYNC_STATUS -->"
+END_MARKER = "<!-- END:ULTRA_SYNC_STATUS -->"
+UPSTREAM_SECTION = "## Upstream Sync and Parity Upkeep"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument("--readme", default="README.md", help="README path relative to repo root")
+    parser.add_argument(
+        "--report-dir",
+        default=".sync-reports",
+        help="Sync report dir relative to repo root",
+    )
+    parser.add_argument(
+        "--queue-json",
+        default="docs/parity/upstream-missing-queue.json",
+        help="Queue summary JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--proof-json",
+        default="docs/parity/global-parity-proof.json",
+        help="Global parity proof JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--workstream-json",
+        default="docs/parity/workstream-status.json",
+        help="Workstream status JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files; exit non-zero if README block would change",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def latest_upstream_sync_report(report_dir: Path) -> Path | None:
+    reports = sorted(report_dir.glob("upstream-sync-*.txt"))
+    return reports[-1] if reports else None
+
+
+def parse_sync_report(path: Path) -> tuple[dict[str, str], int]:
+    meta: dict[str, str] = {}
+    pending_count = 0
+    text = path.read_text(encoding="utf-8", errors="replace")
+    in_pending = False
+    in_block = False
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not in_pending:
+            if stripped.startswith("## Pending Upstream Commits"):
+                in_pending = True
+                continue
+            if ":" in line:
+                key, value = line.split(":", 1)
+                key = key.strip()
+                if key and all(ch.isalnum() or ch in {"_", "-"} for ch in key):
+                    meta[key] = value.strip()
+            continue
+
+        if stripped == "```":
+            if not in_block:
+                in_block = True
+            else:
+                break
+            continue
+        if in_block and stripped:
+            pending_count += 1
+
+    return meta, pending_count
+
+
+def gate_status(value: Any) -> str:
+    if value is True:
+        return "pass"
+    if value is False:
+        return "fail"
+    return "unknown"
+
+
+def build_block(
+    generated_at: str,
+    report_rel: str,
+    report_name: str,
+    report_meta: dict[str, str],
+    report_pending_count: int,
+    queue: dict[str, Any],
+    proof: dict[str, Any],
+    workstream: dict[str, Any],
+) -> str:
+    queue_summary = queue.get("summary", {}) if isinstance(queue.get("summary"), dict) else {}
+    by_disp = queue_summary.get("by_disposition", {}) if isinstance(queue_summary.get("by_disposition"), dict) else {}
+    pending = int(by_disp.get("pending", 0) or 0)
+    ported = int(by_disp.get("ported", 0) or 0)
+    superseded = int(by_disp.get("superseded", 0) or 0)
+
+    release_gate = gate_status((proof.get("release_gate") or {}).get("pass") if isinstance(proof.get("release_gate"), dict) else None)
+    ci_gate = gate_status((proof.get("ci_gate") or {}).get("pass") if isinstance(proof.get("ci_gate"), dict) else None)
+
+    upstream_ref = str(workstream.get("upstream_ref") or "unknown")
+    upstream_sha = str(workstream.get("upstream_sha") or "unknown")
+    workstream_generated = str(workstream.get("generated_at_utc") or "unknown")
+
+    timestamp_utc = report_meta.get("timestamp_utc", "unknown")
+    origin_sha = report_meta.get("origin_sha", "unknown")
+    upstream_sync_sha = report_meta.get("upstream_sha", "unknown")
+
+    lines = [
+        BEGIN_MARKER,
+        "### Live Upstream Sync Status (auto-generated)",
+        "",
+        f"- Generated at: `{generated_at}`",
+        f"- Source report: [`{report_name}`](./{report_rel})",
+        f"- Sync timestamp (`timestamp_utc`): `{timestamp_utc}`",
+        f"- `origin/main` at sync: `{origin_sha}`",
+        f"- `upstream/main` at sync: `{upstream_sync_sha}`",
+        f"- Pending commits captured in report: `{report_pending_count}`",
+        (
+            "- Queue summary (`docs/parity/upstream-missing-queue.json`): "
+            f"pending `{pending}`, ported `{ported}`, superseded `{superseded}`"
+        ),
+        (
+            "- Parity gates (`docs/parity/global-parity-proof.json`): "
+            f"release `{release_gate}`, ci `{ci_gate}`"
+        ),
+        (
+            "- Workstream snapshot (`docs/parity/workstream-status.json`): "
+            f"`{upstream_ref}` @ `{upstream_sha}` (generated `{workstream_generated}`)"
+        ),
+        END_MARKER,
+    ]
+    return "\n".join(lines)
+
+
+def replace_or_insert_block(readme: str, block: str) -> str:
+    if BEGIN_MARKER in readme and END_MARKER in readme:
+        start = readme.index(BEGIN_MARKER)
+        end = readme.index(END_MARKER) + len(END_MARKER)
+        return readme[:start] + block + readme[end:]
+
+    if UPSTREAM_SECTION in readme:
+        section_idx = readme.index(UPSTREAM_SECTION)
+        section_end = readme.find("\n", section_idx)
+        if section_end != -1:
+            section_end += 1
+            return readme[:section_end] + "\n" + block + "\n\n" + readme[section_end:]
+
+    return readme.rstrip() + "\n\n" + block + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    readme_path = (repo_root / args.readme).resolve()
+    report_dir = (repo_root / args.report_dir).resolve()
+    queue_path = (repo_root / args.queue_json).resolve()
+    proof_path = (repo_root / args.proof_json).resolve()
+    workstream_path = (repo_root / args.workstream_json).resolve()
+
+    if not readme_path.exists():
+        raise SystemExit(f"README not found: {readme_path}")
+    if not report_dir.exists():
+        raise SystemExit(f"report directory not found: {report_dir}")
+
+    report = latest_upstream_sync_report(report_dir)
+    if report is None:
+        raise SystemExit(f"no upstream-sync reports found in {report_dir}")
+    report_meta, report_pending_count = parse_sync_report(report)
+
+    queue = load_json(queue_path)
+    proof = load_json(proof_path)
+    workstream = load_json(workstream_path)
+
+    generated_at = report_meta.get("timestamp_utc", "") or report.stem.removeprefix("upstream-sync-")
+    report_rel = str(report.relative_to(repo_root))
+    block = build_block(
+        generated_at=generated_at,
+        report_rel=report_rel,
+        report_name=report.name,
+        report_meta=report_meta,
+        report_pending_count=report_pending_count,
+        queue=queue,
+        proof=proof,
+        workstream=workstream,
+    )
+
+    original = readme_path.read_text(encoding="utf-8")
+    updated = replace_or_insert_block(original, block)
+
+    if args.check:
+        if original != updated:
+            print("README sync status block is stale.")
+            return 1
+        print("README sync status block is up-to-date.")
+        return 0
+
+    if original != updated:
+        readme_path.write_text(updated, encoding="utf-8")
+        print(f"Updated README sync status block in {readme_path}")
+    else:
+        print(f"README sync status block already up-to-date in {readme_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -30,6 +30,8 @@ Options:
   --no-elite-gate           Skip consolidated elite sync gate (default)
   --elite-cmd <command>     Elite gate command (default: python3 scripts/run-elite-sync-gate.py)
   --elite-rollback-cmd <c>  Optional rollback command executed by elite gate on failure
+  --no-doc-refresh          Skip generated parity/readme doc refresh
+  --doc-refresh-cmd <cmd>   Override generated docs refresh command
   --no-pr                   Do not open a PR in branch-pr mode
   --draft-pr                Open PR as draft in branch-pr mode
   --pr-labels <csv>         Labels to apply on created PR (default: upstream-sync,parity-sync)
@@ -61,6 +63,8 @@ REDTEAM_CMD="${REDTEAM_CMD:-python3 scripts/run-redteam-gate.py}"
 RUN_ELITE_GATE="${RUN_ELITE_GATE:-0}"
 ELITE_CMD="${ELITE_CMD:-python3 scripts/run-elite-sync-gate.py}"
 ELITE_ROLLBACK_CMD="${ELITE_ROLLBACK_CMD:-}"
+RUN_DOC_REFRESH="${RUN_DOC_REFRESH:-1}"
+DOC_REFRESH_CMD="${DOC_REFRESH_CMD:-python3 scripts/generate-parity-dashboard.py --repo-root . && python3 scripts/generate-readme-sync-status.py --repo-root .}"
 CREATE_PR="1"
 PR_DRAFT="0"
 PR_LABELS="${PR_LABELS:-upstream-sync,parity-sync}"
@@ -161,6 +165,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --elite-rollback-cmd)
       ELITE_ROLLBACK_CMD="${2:?missing value for --elite-rollback-cmd}"
+      shift 2
+      ;;
+    --no-doc-refresh)
+      RUN_DOC_REFRESH="0"
+      shift
+      ;;
+    --doc-refresh-cmd)
+      DOC_REFRESH_CMD="${2:?missing value for --doc-refresh-cmd}"
       shift 2
       ;;
     --no-pr)
@@ -569,6 +581,23 @@ if [[ "${RUN_ELITE_GATE}" == "1" ]]; then
     ELITE_REPORT_LINE="$(printf '%s\n' "${ELITE_OUTPUT}" | awk '/\[elite-sync-gate\] Report: /{line=$0} END{print line}')"
     ELITE_REPORT_PATH="${ELITE_REPORT_LINE#*Report: }"
     append_report "elite_report: ${ELITE_REPORT_PATH}"
+  fi
+fi
+
+if [[ "${RUN_DOC_REFRESH}" == "1" ]]; then
+  log "Refreshing generated parity/readme docs..."
+  DOC_REFRESH_OUTPUT="$(bash -lc "${DOC_REFRESH_CMD}" 2>&1)" || {
+    append_report "status: doc-refresh-failed"
+    append_report "doc_refresh_output: ${DOC_REFRESH_OUTPUT//$'\n'/\\n}"
+    printf '%s\n' "${DOC_REFRESH_OUTPUT}"
+    die "Generated doc refresh failed"
+  }
+  printf '%s\n' "${DOC_REFRESH_OUTPUT}"
+  DOC_CHANGED="$(git status --porcelain -- README.md docs/parity/PARITY_DASHBOARD.md || true)"
+  if [[ -n "${DOC_CHANGED}" ]]; then
+    git add README.md docs/parity/PARITY_DASHBOARD.md
+    git commit -m "chore(sync): refresh parity dashboard and README sync status"
+    append_report "doc_refresh_commit: $(git rev-parse HEAD)"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- add `/about` slash command showing build/runtime/parity snapshot and enabled Ultra feature flags
- add generated docs scripts for README live sync block and parity dashboard
- wire sync script doc refresh stage and add quickstart + parity docs updates

## Validation
- `cargo fmt --all`
- `cargo test -p hermes-cli`
- `python3 -m py_compile scripts/generate-readme-sync-status.py scripts/generate-parity-dashboard.py`
- `python3 scripts/generate-readme-sync-status.py --repo-root . --check`
