### PR TITLE
skills: add autoresearch default tap and align MiniMax default path

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -177,8 +177,9 @@ const DEFAULT_SKILL_TAPS: &[&str] = &[
     "https://github.com/openai/skills::skills",
     "https://github.com/anthropics/skills::skills",
     "https://github.com/VoltAgent/awesome-agent-skills::skills",
+    "https://github.com/github/awesome-copilot::skills",
     "https://github.com/garrytan/gstack::",
-    "https://github.com/MiniMax-AI/cli::skills",
+    "https://github.com/MiniMax-AI/cli::skill",
 ];
 
 const GITHUB_API_BASE: &str = "https://api.github.com";
@@ -7842,18 +7843,26 @@ mod tests {
         let merged = merged_skill_taps(&[]);
         assert!(merged
             .iter()
-            .any(|tap| tap == "https://github.com/MiniMax-AI/cli::skills"));
+            .any(|tap| tap == "https://github.com/MiniMax-AI/cli::skill"));
+    }
+
+    #[test]
+    fn test_autoresearch_default_skill_tap_present_in_merged_list() {
+        let merged = merged_skill_taps(&[]);
+        assert!(merged
+            .iter()
+            .any(|tap| tap == "https://github.com/github/awesome-copilot::skills"));
     }
 
     #[test]
     fn test_merged_skill_taps_deduplicates_default() {
         let merged = merged_skill_taps(&vec![
-            "https://github.com/MiniMax-AI/cli::skills".to_string()
+            "https://github.com/MiniMax-AI/cli::skill".to_string()
         ]);
         assert_eq!(
             merged
                 .iter()
-                .filter(|tap| tap.as_str() == "https://github.com/MiniMax-AI/cli::skills")
+                .filter(|tap| tap.as_str() == "https://github.com/MiniMax-AI/cli::skill")
                 .count(),
             1
         );


### PR DESCRIPTION
## Summary
- add `github/awesome-copilot::skills` to built-in default taps so `autoresearch` is available without manual tap setup
- align MiniMax default tap from `MiniMax-AI/cli::skills` to `MiniMax-AI/cli::skill` for upstream parity and real repo layout
- update and extend unit tests for default tap presence and dedupe behavior

## Validation
- `cargo test -p hermes-cli test_default_skill_tap_present_in_merged_list`
- `cargo test -p hermes-cli test_autoresearch_default_skill_tap_present_in_merged_list`
- `cargo test -p hermes-cli test_merged_skill_taps_deduplicates_default`
