### PR TITLE
feat: implement control-plane, guardrails, and gate upgrades

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -31,6 +31,7 @@ use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
 
 use crate::cli::Cli;
+use crate::model_switch::provider_model_ids;
 use crate::runtime_tool_wiring::{wire_cron_scheduler_backend, wire_stdio_clarify_backend};
 use crate::terminal_backend::build_terminal_backend;
 use crate::tui::StreamHandle;
@@ -529,67 +530,91 @@ impl App {
     /// Checks the interrupt controller before running and clears it after.
     async fn run_agent(&mut self) -> Result<(), AgentError> {
         self.interrupt_controller.clear_interrupt();
+        let mut remediation_attempted = false;
+        loop {
+            let messages = self.messages.clone();
+            let result = if self.config.streaming.enabled {
+                let stream_handle = self.stream_handle.clone();
+                let stream_cb: Option<Box<dyn Fn(hermes_core::StreamChunk) + Send + Sync>> =
+                    stream_handle.map(|h| {
+                        Box::new(move |chunk: hermes_core::StreamChunk| {
+                            h.send_chunk(chunk);
+                        })
+                            as Box<dyn Fn(hermes_core::StreamChunk) + Send + Sync>
+                    });
+                self.agent
+                    .run_stream(messages, Some(self.tool_schemas.clone()), stream_cb)
+                    .await
+            } else {
+                self.agent
+                    .run(messages, Some(self.tool_schemas.clone()))
+                    .await
+            };
 
-        let messages = self.messages.clone();
-        let result = if self.config.streaming.enabled {
-            let stream_handle = self.stream_handle.clone();
-            let stream_cb: Option<Box<dyn Fn(hermes_core::StreamChunk) + Send + Sync>> =
-                stream_handle.map(|h| {
-                    Box::new(move |chunk: hermes_core::StreamChunk| {
-                        h.send_chunk(chunk);
-                    }) as Box<dyn Fn(hermes_core::StreamChunk) + Send + Sync>
-                });
-            self.agent
-                .run_stream(messages, Some(self.tool_schemas.clone()), stream_cb)
-                .await
-        } else {
-            self.agent
-                .run(messages, Some(self.tool_schemas.clone()))
-                .await
-        };
-
-        match result {
-            Ok(result) => {
-                self.messages = result.messages;
-                self.prune_ui_after_current_messages();
-                if let Some(handle) = &self.stream_handle {
-                    handle.send_done();
+            match result {
+                Ok(result) => {
+                    self.messages = result.messages;
+                    self.prune_ui_after_current_messages();
+                    if let Some(handle) = &self.stream_handle {
+                        handle.send_done();
+                    }
+                    if result.interrupted {
+                        tracing::info!("Agent loop returned interrupted=true (graceful stop)");
+                        if self.stream_handle.is_some() {
+                            self.push_ui_assistant("[Agent execution interrupted]");
+                        } else {
+                            println!("[Agent execution interrupted]");
+                        }
+                    } else if !result.finished_naturally {
+                        tracing::warn!(
+                            "Agent stopped after {} turns (did not finish naturally)",
+                            result.total_turns
+                        );
+                    }
+                    break;
                 }
-                if result.interrupted {
-                    tracing::info!("Agent loop returned interrupted=true (graceful stop)");
+                Err(AgentError::Interrupted { message }) => {
+                    self.interrupt_controller.clear_interrupt();
+                    if let Some(handle) = &self.stream_handle {
+                        handle.send_done();
+                    }
+                    if let Some(redirect) = message {
+                        tracing::info!("Agent interrupted with redirect: {}", redirect);
+                    } else {
+                        tracing::info!("Agent interrupted by user");
+                    }
                     if self.stream_handle.is_some() {
                         self.push_ui_assistant("[Agent execution interrupted]");
                     } else {
                         println!("[Agent execution interrupted]");
                     }
-                } else if !result.finished_naturally {
-                    tracing::warn!(
-                        "Agent stopped after {} turns (did not finish naturally)",
-                        result.total_turns
-                    );
+                    break;
                 }
-            }
-            Err(AgentError::Interrupted { message }) => {
-                self.interrupt_controller.clear_interrupt();
-                if let Some(handle) = &self.stream_handle {
-                    handle.send_done();
+                Err(e) => {
+                    if let Some(handle) = &self.stream_handle {
+                        handle.send_done();
+                    }
+                    if !remediation_attempted {
+                        if let Some((next_model, notice)) =
+                            self.model_auto_remediation_target(&e).await
+                        {
+                            tracing::warn!(
+                                "Model auto-remediation triggered: {} -> {}",
+                                self.current_model,
+                                next_model
+                            );
+                            if self.stream_handle.is_some() {
+                                self.push_ui_assistant(notice.clone());
+                            } else {
+                                println!("{notice}");
+                            }
+                            self.switch_model(&next_model);
+                            remediation_attempted = true;
+                            continue;
+                        }
+                    }
+                    return Err(e);
                 }
-                if let Some(redirect) = message {
-                    tracing::info!("Agent interrupted with redirect: {}", redirect);
-                } else {
-                    tracing::info!("Agent interrupted by user");
-                }
-                if self.stream_handle.is_some() {
-                    self.push_ui_assistant("[Agent execution interrupted]");
-                } else {
-                    println!("[Agent execution interrupted]");
-                }
-            }
-            Err(e) => {
-                if let Some(handle) = &self.stream_handle {
-                    handle.send_done();
-                }
-                return Err(e);
             }
         }
 
@@ -675,6 +700,72 @@ impl App {
             message_count: self.messages.len(),
             created_at: chrono::Utc::now().to_rfc3339(),
         }
+    }
+
+    fn model_auto_remediation_enabled() -> bool {
+        !matches!(
+            std::env::var("HERMES_MODEL_AUTO_REMEDIATE")
+                .ok()
+                .as_deref()
+                .map(|v| v.trim().to_ascii_lowercase()),
+            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+        )
+    }
+
+    fn is_model_not_found_error(err: &AgentError) -> bool {
+        let message = match err {
+            AgentError::LlmApi(msg)
+            | AgentError::Config(msg)
+            | AgentError::ToolExecution(msg)
+            | AgentError::Gateway(msg) => msg.to_ascii_lowercase(),
+            _ => return false,
+        };
+        let model_not_found = message.contains("model not found")
+            || message.contains("requested model does not exist")
+            || message.contains("404 not found")
+            || message.contains("openrouter catalog");
+        model_not_found && message.contains("model")
+    }
+
+    async fn model_auto_remediation_target(&self, err: &AgentError) -> Option<(String, String)> {
+        if !Self::model_auto_remediation_enabled() || !Self::is_model_not_found_error(err) {
+            return None;
+        }
+
+        let (provider, current_model_id) = self
+            .current_model
+            .split_once(':')
+            .unwrap_or(("openai", self.current_model.as_str()));
+        let provider = provider.trim().to_ascii_lowercase();
+        if provider.is_empty() {
+            return None;
+        }
+
+        let catalog = provider_model_ids(&provider).await;
+        if catalog.is_empty() {
+            return None;
+        }
+
+        let current_trimmed = current_model_id.trim().to_ascii_lowercase();
+        let slash_suffix = format!("/{}", current_trimmed);
+        let selected = catalog
+            .iter()
+            .find(|m| {
+                let lower = m.trim().to_ascii_lowercase();
+                lower == current_trimmed || lower.ends_with(&slash_suffix)
+            })
+            .cloned()
+            .or_else(|| catalog.first().cloned())?;
+
+        let next_model = format!("{}:{}", provider, selected.trim());
+        if next_model.eq_ignore_ascii_case(&self.current_model) {
+            return None;
+        }
+        let notice = format!(
+            "Model catalog remediation: `{}` failed with not-found; switching to `{}` and retrying once.",
+            self.current_model, next_model
+        );
+        Some((next_model, notice))
     }
 
     /// Navigate backward in input history.
@@ -1057,6 +1148,20 @@ mod tests {
         assert!(!default_rtk_raw_mode());
 
         std::env::remove_var("HERMES_RTK_RAW");
+    }
+
+    #[test]
+    fn test_is_model_not_found_error_detects_provider_404_shape() {
+        let err = AgentError::LlmApi(
+            "API error 404 Not Found: model foo/bar not found in OpenRouter catalog".to_string(),
+        );
+        assert!(App::is_model_not_found_error(&err));
+    }
+
+    #[test]
+    fn test_is_model_not_found_error_ignores_non_catalog_errors() {
+        let err = AgentError::LlmApi("Rate limit exceeded".to_string());
+        assert!(!App::is_model_not_found_error(&err));
     }
 }
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -136,6 +136,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "Show build/parity/upstream snapshot and enabled Ultra features",
     ),
     ("/ops", "Operator control plane (status + quick controls)"),
+    ("/dashboard", "Dashboard control (status|on|off|url)"),
     (
         "/platforms",
         "Show enabled gateway/messaging platform adapters",
@@ -2411,6 +2412,7 @@ pub async fn handle_slash_command(
         "/status" => handle_status_command(app),
         "/about" => handle_about_command(app),
         "/ops" => handle_ops_command(app, args).await,
+        "/dashboard" => handle_dashboard_command(app, args).await,
         "/platforms" => handle_platforms_command(app),
         "/commands" => {
             print_help(app);
@@ -2502,6 +2504,80 @@ fn split_provider_model(provider_model: &str) -> (&str, &str) {
         .unwrap_or(("openai", provider_model))
 }
 
+fn model_catalog_guard_enabled() -> bool {
+    !matches!(
+        std::env::var("HERMES_MODEL_CATALOG_GUARD")
+            .ok()
+            .as_deref()
+            .map(|v| v.trim().to_ascii_lowercase()),
+        Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+    )
+}
+
+fn resolve_catalog_model_candidate(requested_model: &str, catalog: &[String]) -> Option<String> {
+    if catalog.is_empty() {
+        return None;
+    }
+    let requested_trimmed = requested_model.trim();
+    if requested_trimmed.is_empty() {
+        return catalog.first().cloned();
+    }
+    if let Some(hit) = catalog
+        .iter()
+        .find(|m| m.trim().eq_ignore_ascii_case(requested_trimmed))
+    {
+        return Some(hit.clone());
+    }
+    let requested_lc = requested_trimmed.to_ascii_lowercase();
+    let slash_suffix = format!("/{requested_lc}");
+    if let Some(hit) = catalog.iter().find(|m| {
+        let lower = m.trim().to_ascii_lowercase();
+        lower.ends_with(&slash_suffix) || lower == requested_lc
+    }) {
+        return Some(hit.clone());
+    }
+    catalog.first().cloned()
+}
+
+async fn guard_provider_model_selection(
+    provider_model: &str,
+) -> Result<(String, Option<String>), AgentError> {
+    if !model_catalog_guard_enabled() {
+        return Ok((provider_model.to_string(), None));
+    }
+
+    let (provider, model_id) = split_provider_model(provider_model);
+    let provider = provider.trim().to_ascii_lowercase();
+    if provider.is_empty() {
+        return Ok((provider_model.to_string(), None));
+    }
+    if !curated_provider_slugs()
+        .iter()
+        .any(|slug| slug.eq_ignore_ascii_case(&provider))
+    {
+        return Ok((provider_model.to_string(), None));
+    }
+
+    let catalog = provider_model_ids(&provider).await;
+    if catalog.is_empty() {
+        return Ok((provider_model.to_string(), None));
+    }
+    let Some(candidate) = resolve_catalog_model_candidate(model_id, &catalog) else {
+        return Ok((provider_model.to_string(), None));
+    };
+    let guarded = format!("{}:{}", provider, candidate);
+    if guarded.eq_ignore_ascii_case(provider_model) {
+        return Ok((provider_model.to_string(), None));
+    }
+    Ok((
+        guarded.clone(),
+        Some(format!(
+            "Model catalog guard remapped `{}` -> `{}` based on provider catalog.",
+            provider_model, guarded
+        )),
+    ))
+}
+
 fn normalize_model_target(current_model: &str, raw: &str) -> Result<String, AgentError> {
     let trimmed = raw.trim();
     if trimmed.contains(':') {
@@ -2554,8 +2630,14 @@ async fn pick_model_for_provider(
         return Ok(false);
     }
     let provider_model = format!("{}:{}", provider, models[pick.index].trim());
-    app.switch_model(&provider_model);
-    emit_command_output(app, format!("Model switched to: {}", provider_model));
+    let (guarded, note) = guard_provider_model_selection(&provider_model).await?;
+    app.switch_model(&guarded);
+    let mut msg = format!("Model switched to: {}", guarded);
+    if let Some(n) = note {
+        msg.push_str("\n");
+        msg.push_str(&n);
+    }
+    emit_command_output(app, msg);
     Ok(true)
 }
 
@@ -2564,8 +2646,14 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
     match parse_model_switch_request(args, &known_providers) {
         ModelSwitchRequest::SetDirect(raw) => {
             let provider_model = normalize_model_target(&app.current_model, &raw)?;
-            app.switch_model(&provider_model);
-            emit_command_output(app, format!("Model switched to: {}", provider_model));
+            let (guarded, note) = guard_provider_model_selection(&provider_model).await?;
+            app.switch_model(&guarded);
+            let mut msg = format!("Model switched to: {}", guarded);
+            if let Some(n) = note {
+                msg.push_str("\n");
+                msg.push_str(&n);
+            }
+            emit_command_output(app, msg);
         }
         ModelSwitchRequest::PickModelFromProvider(provider) => {
             let current_model = app.current_model.clone();
@@ -3380,9 +3468,387 @@ fn handle_about_command(app: &mut App) -> Result<CommandResult, AgentError> {
     Ok(CommandResult::Handled)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillsExecutionTier {
+    Trusted,
+    Balanced,
+    Open,
+}
+
+impl SkillsExecutionTier {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "trusted" => Some(Self::Trusted),
+            "balanced" => Some(Self::Balanced),
+            "open" | "permissive" => Some(Self::Open),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Balanced => "balanced",
+            Self::Open => "open",
+        }
+    }
+}
+
+fn skills_execution_tier() -> SkillsExecutionTier {
+    std::env::var("HERMES_SKILLS_EXECUTION_TIER")
+        .ok()
+        .as_deref()
+        .and_then(SkillsExecutionTier::parse)
+        .unwrap_or(SkillsExecutionTier::Balanced)
+}
+
+fn skills_tier_bypass_enabled() -> bool {
+    std::env::var("HERMES_SKILLS_TIER_BYPASS")
+        .ok()
+        .is_some_and(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+}
+
+fn skills_action_blocked_by_tier(
+    tier: SkillsExecutionTier,
+    action: &str,
+    name: Option<&str>,
+) -> bool {
+    let name_lc = name.map(|v| v.to_ascii_lowercase());
+    match tier {
+        SkillsExecutionTier::Trusted => {
+            matches!(
+                action,
+                "install" | "update" | "publish" | "uninstall" | "reset" | "subscribe"
+            ) || (action == "tap" && matches!(name_lc.as_deref(), Some("add" | "remove")))
+                || (action == "snapshot" && matches!(name_lc.as_deref(), Some("import")))
+        }
+        SkillsExecutionTier::Balanced => {
+            matches!(action, "publish" | "reset")
+                || (action == "snapshot" && matches!(name_lc.as_deref(), Some("import")))
+        }
+        SkillsExecutionTier::Open => false,
+    }
+}
+
+fn latest_json_report(report_dir: &Path, prefix: &str) -> Option<PathBuf> {
+    let mut reports: Vec<PathBuf> = std::fs::read_dir(report_dir)
+        .ok()?
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            let name = path.file_name()?.to_string_lossy();
+            if name.starts_with(prefix) && name.ends_with(".json") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    reports.sort();
+    reports.into_iter().last()
+}
+
+fn summarize_gate_report(path: &Path, key: &str) -> Option<String> {
+    let report = read_json_file(path)?;
+    let ok = report
+        .get("ok")
+        .and_then(|v| v.as_bool())
+        .map(|v| if v { "pass" } else { "fail" })
+        .unwrap_or("unknown");
+    let generated = report
+        .get("generated_at")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    Some(format!(
+        "{}={} @ {} ({})",
+        key,
+        ok,
+        generated,
+        path.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.display().to_string())
+    ))
+}
+
+fn dashboard_status_line_from_payload(payload: &serde_json::Value) -> String {
+    let enabled = payload
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let url = payload.get("url").and_then(|v| v.as_str()).unwrap_or("n/a");
+    format!(
+        "dashboard: {} ({})",
+        if enabled { "ON" } else { "OFF" },
+        url
+    )
+}
+
+async fn handle_dashboard_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let action = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .to_ascii_lowercase();
+    let mut params = serde_json::json!({
+        "action": action
+    });
+    if let Some(host) = args.get(1) {
+        params["host"] = serde_json::Value::String((*host).to_string());
+    }
+    if let Some(port) = args.get(2).and_then(|raw| raw.parse::<u16>().ok()) {
+        params["port"] = serde_json::json!(port);
+    }
+    if args
+        .iter()
+        .any(|arg| arg.eq_ignore_ascii_case("--insecure"))
+    {
+        params["insecure"] = serde_json::json!(true);
+    }
+
+    let raw = app
+        .tool_registry
+        .dispatch_async("dashboard_control", params)
+        .await;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({"result": raw}));
+
+    if let Some(err) = parsed.get("error").and_then(|v| v.as_str()) {
+        emit_command_output(app, format!("Dashboard command failed: {err}"));
+        return Ok(CommandResult::Handled);
+    }
+
+    let rendered = match action.as_str() {
+        "enable" | "on" => format!(
+            "Dashboard enabled at {}\nConfig: {}",
+            parsed
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown"),
+            parsed
+                .get("config_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+        ),
+        "disable" | "off" => format!(
+            "Dashboard disabled (URL: {})\nConfig: {}",
+            parsed
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown"),
+            parsed
+                .get("config_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+        ),
+        "url" => format!(
+            "{}\n{}",
+            parsed
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown"),
+            parsed
+                .get("config_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+        ),
+        _ => format!(
+            "{}\nConfig: {}",
+            dashboard_status_line_from_payload(&parsed),
+            parsed
+                .get("config_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+        ),
+    };
+    emit_command_output(app, rendered);
+    Ok(CommandResult::Handled)
+}
+
+async fn run_ops_shell_command(command: &str) -> Result<String, AgentError> {
+    let output = tokio::process::Command::new("bash")
+        .arg("-lc")
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| AgentError::Io(format!("ops shell command failed: {e}")))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let mut msg = String::new();
+    if !stdout.is_empty() {
+        msg.push_str(&stdout);
+    }
+    if !stderr.is_empty() {
+        if !msg.is_empty() {
+            msg.push_str("\n\n");
+        }
+        msg.push_str("stderr:\n");
+        msg.push_str(&stderr);
+    }
+    if msg.is_empty() {
+        msg = format!("(exit: {})", output.status);
+    } else if !output.status.success() {
+        msg = format!("(exit: {})\n{}", output.status, msg);
+    }
+    Ok(msg)
+}
+
+fn handle_ops_skills_tier_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    if args.is_empty() || args[0].eq_ignore_ascii_case("status") {
+        emit_command_output(
+            app,
+            format!(
+                "skills_tier={} (bypass={})",
+                skills_execution_tier().as_str(),
+                if skills_tier_bypass_enabled() {
+                    "ON"
+                } else {
+                    "OFF"
+                }
+            ),
+        );
+        return Ok(CommandResult::Handled);
+    }
+
+    let Some(next) = SkillsExecutionTier::parse(args[0]) else {
+        emit_command_output(
+            app,
+            "Usage: /ops skills-tier [status|trusted|balanced|open]",
+        );
+        return Ok(CommandResult::Handled);
+    };
+    std::env::set_var("HERMES_SKILLS_EXECUTION_TIER", next.as_str());
+    emit_command_output(
+        app,
+        format!(
+            "skills_tier set to '{}' for this runtime process.",
+            next.as_str()
+        ),
+    );
+    Ok(CommandResult::Handled)
+}
+
+async fn handle_ops_gate_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let sub = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .to_ascii_lowercase();
+    match sub.as_str() {
+        "status" => {
+            if let Some(repo_root) = discover_repo_root_for_about() {
+                let report_dir = repo_root.join(".sync-reports");
+                let eval = latest_json_report(&report_dir, "eval-trend-gate-")
+                    .and_then(|p| summarize_gate_report(&p, "eval_trend"))
+                    .unwrap_or_else(|| "eval_trend=unknown".to_string());
+                let slo = latest_json_report(&report_dir, "slo-auto-rollback-")
+                    .and_then(|p| summarize_gate_report(&p, "slo_rollback"))
+                    .unwrap_or_else(|| "slo_rollback=unknown".to_string());
+                let elite = latest_json_report(&report_dir, "elite-sync-gate-")
+                    .and_then(|p| summarize_gate_report(&p, "elite_sync_gate"))
+                    .unwrap_or_else(|| "elite_sync_gate=unknown".to_string());
+                emit_command_output(app, format!("{}\n{}\n{}", eval, slo, elite));
+            } else {
+                emit_command_output(app, "Gate status unavailable outside source checkout.");
+            }
+            Ok(CommandResult::Handled)
+        }
+        "eval" => {
+            let out = run_ops_shell_command(
+                "python3 scripts/run-eval-trend-gate.py --allow-missing-baseline --json",
+            )
+            .await?;
+            emit_command_output(app, out);
+            Ok(CommandResult::Handled)
+        }
+        "elite" => {
+            let out =
+                run_ops_shell_command("python3 scripts/run-elite-sync-gate.py --json").await?;
+            emit_command_output(app, out);
+            Ok(CommandResult::Handled)
+        }
+        "slo" => {
+            let check_cmd = std::env::var("HERMES_SLO_CHECK_CMD").ok();
+            let rollback_cmd = std::env::var("HERMES_SLO_ROLLBACK_CMD").ok();
+            let (Some(check), Some(rollback)) = (check_cmd, rollback_cmd) else {
+                emit_command_output(
+                    app,
+                    "Set HERMES_SLO_CHECK_CMD and HERMES_SLO_ROLLBACK_CMD, then run `/ops gate slo`.",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let cmd = format!(
+                "python3 scripts/run-slo-auto-rollback.py --check-cmd {} --rollback-cmd {} --json",
+                shell_escape(&check),
+                shell_escape(&rollback)
+            );
+            let out = run_ops_shell_command(&cmd).await?;
+            emit_command_output(app, out);
+            Ok(CommandResult::Handled)
+        }
+        _ => {
+            emit_command_output(app, "Usage: /ops gate [status|eval|elite|slo]");
+            Ok(CommandResult::Handled)
+        }
+    }
+}
+
+fn shell_escape(input: &str) -> String {
+    let escaped = input.replace('\'', "'\"'\"'");
+    format!("'{}'", escaped)
+}
+
 async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     if args.is_empty() || args[0].eq_ignore_ascii_case("status") {
         let yolo = !app.config.approval.require_approval;
+        let policy_mode = std::env::var("HERMES_TOOL_POLICY_MODE")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "enforce".to_string());
+        let policy_preset = std::env::var("HERMES_TOOL_POLICY_PRESET")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "balanced".to_string());
+        let counters = app.tool_registry.policy_counters();
+        let dashboard_status = {
+            let raw = app
+                .tool_registry
+                .dispatch_async("dashboard_control", serde_json::json!({"action":"status"}))
+                .await;
+            let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap_or_else(
+                |_| serde_json::json!({"enabled":false,"url":"unknown","error":"unparseable"}),
+            );
+            dashboard_status_line_from_payload(&parsed)
+        };
+        let gate_status = if let Some(repo_root) = discover_repo_root_for_about() {
+            let report_dir = repo_root.join(".sync-reports");
+            let eval = latest_json_report(&report_dir, "eval-trend-gate-")
+                .and_then(|p| summarize_gate_report(&p, "eval"))
+                .unwrap_or_else(|| "eval=unknown".to_string());
+            let slo = latest_json_report(&report_dir, "slo-auto-rollback-")
+                .and_then(|p| summarize_gate_report(&p, "slo"))
+                .unwrap_or_else(|| "slo=unknown".to_string());
+            format!("{eval}; {slo}")
+        } else {
+            "unavailable (non-source checkout)".to_string()
+        };
+
         let out = format!(
             "Operator Control Plane\n\
              \n\
@@ -3399,6 +3865,13 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                raw:          toggle via `/ops raw`\n\
                verbose:      toggle via `/ops verbose`\n\
              \n\
+             Policy/Gates:\n\
+               tool_policy:  mode={} preset={}\n\
+               policy_counts allow={} deny={} audit_only={} simulate={} would_block={}\n\
+               skills_tier:  {} (bypass={})\n\
+               {}\n\
+               gate_status:  {}\n\
+             \n\
              Quick actions:\n\
                /ops model [provider|provider:model]\n\
                /ops personality [list|name]\n\
@@ -3407,12 +3880,30 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                /ops reasoning\n\
                /ops raw [on|off|toggle|once]\n\
                /ops verbose\n\
+               /ops dashboard [status|on|off|url] [host] [port]\n\
+               /ops skills-tier [status|trusted|balanced|open]\n\
+               /ops gate [status|eval|elite|slo]\n\
                /ops help",
             app.session_id,
             app.current_model,
             app.current_personality.as_deref().unwrap_or("(none)"),
             if yolo { "ON" } else { "OFF" },
             if app.mouse_enabled() { "ON" } else { "OFF" },
+            policy_mode,
+            policy_preset,
+            counters.allow,
+            counters.deny,
+            counters.audit_only,
+            counters.simulate,
+            counters.would_block,
+            skills_execution_tier().as_str(),
+            if skills_tier_bypass_enabled() {
+                "ON"
+            } else {
+                "OFF"
+            },
+            dashboard_status,
+            gate_status,
         );
         emit_command_output(app, out);
         return Ok(CommandResult::Handled);
@@ -3431,7 +3922,10 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                  - /ops reasoning\n\
                  - /ops raw [on|off|toggle|once]\n\
                  - /ops verbose\n\
-                 - /ops statusbar",
+                 - /ops statusbar\n\
+                 - /ops dashboard [status|on|off|url] [host] [port]\n\
+                 - /ops skills-tier [status|trusted|balanced|open]\n\
+                 - /ops gate [status|eval|elite|slo]",
             );
             Ok(CommandResult::Handled)
         }
@@ -3443,6 +3937,9 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
         "raw" => handle_raw_command(app, &args[1..]),
         "verbose" => handle_verbose_command(app),
         "statusbar" => handle_statusbar_command(app),
+        "dashboard" => handle_dashboard_command(app, &args[1..]).await,
+        "skills-tier" => handle_ops_skills_tier_command(app, &args[1..]),
+        "gate" => handle_ops_gate_command(app, &args[1..]).await,
         other => {
             emit_command_output(
                 app,
@@ -4594,6 +5091,20 @@ pub async fn handle_cli_skills(
     name: Option<String>,
     extra: Option<String>,
 ) -> Result<(), hermes_core::AgentError> {
+    let requested_action = action.as_deref().unwrap_or("list");
+    if !skills_tier_bypass_enabled() {
+        let tier = skills_execution_tier();
+        let denied = skills_action_blocked_by_tier(tier, requested_action, name.as_deref());
+
+        if denied {
+            return Err(hermes_core::AgentError::Config(format!(
+                "skills action '{}' is blocked by skills tier '{}'. Use `/ops skills-tier open` or set HERMES_SKILLS_TIER_BYPASS=1 to override intentionally.",
+                requested_action,
+                tier.as_str()
+            )));
+        }
+    }
+
     let skills_dir = hermes_config::hermes_home().join("skills");
 
     match action.as_deref().unwrap_or("list") {
@@ -9205,5 +9716,49 @@ mod tests {
         let masked = mask_secret_value(raw);
         assert!(!masked.contains(raw));
         assert!(masked.contains("***"));
+    }
+
+    #[test]
+    fn resolve_catalog_model_candidate_prefers_suffix_match() {
+        let catalog = vec![
+            "nousresearch/hermes-4-405b".to_string(),
+            "moonshotai/kimi-k2.6".to_string(),
+        ];
+        let chosen = resolve_catalog_model_candidate("kimi-k2.6", &catalog).expect("candidate");
+        assert_eq!(chosen, "moonshotai/kimi-k2.6");
+    }
+
+    #[test]
+    fn skills_action_blocked_by_tier_enforces_expected_matrix() {
+        assert!(skills_action_blocked_by_tier(
+            SkillsExecutionTier::Trusted,
+            "install",
+            None
+        ));
+        assert!(skills_action_blocked_by_tier(
+            SkillsExecutionTier::Trusted,
+            "tap",
+            Some("add")
+        ));
+        assert!(!skills_action_blocked_by_tier(
+            SkillsExecutionTier::Trusted,
+            "list",
+            None
+        ));
+        assert!(skills_action_blocked_by_tier(
+            SkillsExecutionTier::Balanced,
+            "publish",
+            None
+        ));
+        assert!(!skills_action_blocked_by_tier(
+            SkillsExecutionTier::Balanced,
+            "install",
+            None
+        ));
+        assert!(!skills_action_blocked_by_tier(
+            SkillsExecutionTier::Open,
+            "publish",
+            None
+        ));
     }
 }

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -53,6 +53,7 @@ pub use tools::clarify::{ClarifyBackend, ClarifyHandler};
 pub use tools::code_execution::{CodeExecutionBackend, ExecuteCodeHandler};
 pub use tools::credential_files::CredentialFilesHandler;
 pub use tools::cronjob::{CronjobBackend, CronjobHandler};
+pub use tools::dashboard_control::DashboardControlHandler;
 pub use tools::delegation::{DelegateTaskHandler, DelegationBackend};
 pub use tools::env_passthrough::EnvPassthroughHandler;
 pub use tools::file::{

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -291,6 +291,15 @@ pub fn register_builtin_tools(
         vec![],
     );
 
+    // -- Dashboard control ---------------------------------------------------
+    reg(
+        registry,
+        "dashboard",
+        Arc::new(crate::tools::dashboard_control::DashboardControlHandler),
+        "🖥️",
+        vec![],
+    );
+
     // -- Home Assistant (4 tools) --------------------------------------------
     {
         let ha_backend: Arc<dyn crate::tools::homeassistant::HomeAssistantBackend> =

--- a/crates/hermes-tools/src/tools/dashboard_control.rs
+++ b/crates/hermes-tools/src/tools/dashboard_control.rs
@@ -1,0 +1,281 @@
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde_json::{json, Value};
+
+use hermes_config::{
+    hermes_home, load_user_config_file, save_config_yaml, validate_config, PlatformConfig,
+};
+use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+
+fn normalize_host(input: Option<&Value>) -> String {
+    let raw = input
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("127.0.0.1");
+    raw.to_string()
+}
+
+fn normalize_port(input: Option<&Value>) -> Result<u16, ToolError> {
+    let Some(v) = input else {
+        return Ok(8080);
+    };
+    if let Some(p) = v.as_u64() {
+        return u16::try_from(p).map_err(|_| ToolError::InvalidParams("port out of range".into()));
+    }
+    if let Some(s) = v.as_str() {
+        let parsed = s
+            .trim()
+            .parse::<u16>()
+            .map_err(|_| ToolError::InvalidParams("port must be a valid integer".into()))?;
+        return Ok(parsed);
+    }
+    Err(ToolError::InvalidParams(
+        "port must be an integer or numeric string".into(),
+    ))
+}
+
+fn parse_bool(input: Option<&Value>, default: bool) -> bool {
+    input.and_then(Value::as_bool).unwrap_or(default)
+}
+
+fn is_local_host(host: &str) -> bool {
+    matches!(host.trim(), "127.0.0.1" | "localhost" | "::1")
+}
+
+fn dashboard_url(host: &str, port: u16) -> String {
+    let display_host = if host.trim() == "0.0.0.0" {
+        "127.0.0.1"
+    } else {
+        host.trim()
+    };
+    format!("http://{}:{}/", display_host, port)
+}
+
+fn read_dashboard_platform() -> Result<(std::path::PathBuf, PlatformConfig), ToolError> {
+    let cfg_path = hermes_home().join("config.yaml");
+    let cfg = load_user_config_file(&cfg_path)
+        .map_err(|e| ToolError::ExecutionFailed(format!("load config: {e}")))?;
+    let platform = cfg.platforms.get("api_server").cloned().unwrap_or_default();
+    Ok((cfg_path, platform))
+}
+
+fn current_host_and_port(platform: &PlatformConfig) -> (String, u16) {
+    let host = platform
+        .extra
+        .get("host")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("127.0.0.1")
+        .to_string();
+    let port = platform
+        .extra
+        .get("port")
+        .and_then(Value::as_u64)
+        .and_then(|v| u16::try_from(v).ok())
+        .unwrap_or(8080);
+    (host, port)
+}
+
+fn emit_status_payload(cfg_path: &std::path::Path, platform: &PlatformConfig) -> String {
+    let (host, port) = current_host_and_port(platform);
+    json!({
+        "status": "ok",
+        "enabled": platform.enabled,
+        "host": host,
+        "port": port,
+        "url": dashboard_url(&host, port),
+        "config_path": cfg_path.display().to_string(),
+    })
+    .to_string()
+}
+
+fn persist_dashboard_platform(
+    enabled: bool,
+    host: String,
+    port: u16,
+    insecure: bool,
+) -> Result<String, ToolError> {
+    if enabled && !insecure && !is_local_host(&host) {
+        return Err(ToolError::InvalidParams(
+            "refusing non-localhost bind without insecure=true".into(),
+        ));
+    }
+
+    let cfg_path = hermes_home().join("config.yaml");
+    let mut cfg = load_user_config_file(&cfg_path)
+        .map_err(|e| ToolError::ExecutionFailed(format!("load config: {e}")))?;
+
+    let platform = cfg
+        .platforms
+        .entry("api_server".to_string())
+        .or_insert_with(PlatformConfig::default);
+    platform.enabled = enabled;
+    platform
+        .extra
+        .insert("host".to_string(), Value::String(host.clone()));
+    platform.extra.insert("port".to_string(), json!(port));
+
+    validate_config(&cfg)
+        .map_err(|e| ToolError::ExecutionFailed(format!("validate config: {e}")))?;
+    save_config_yaml(&cfg_path, &cfg)
+        .map_err(|e| ToolError::ExecutionFailed(format!("save config: {e}")))?;
+
+    Ok(json!({
+        "status": "ok",
+        "enabled": enabled,
+        "host": host,
+        "port": port,
+        "url": dashboard_url(&host, port),
+        "config_path": cfg_path.display().to_string(),
+    })
+    .to_string())
+}
+
+#[derive(Default)]
+pub struct DashboardControlHandler;
+
+#[async_trait]
+impl ToolHandler for DashboardControlHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        let action = params
+            .get("action")
+            .and_then(Value::as_str)
+            .unwrap_or("status")
+            .trim()
+            .to_ascii_lowercase();
+
+        match action.as_str() {
+            "status" => {
+                let (cfg_path, platform) = read_dashboard_platform()?;
+                Ok(emit_status_payload(&cfg_path, &platform))
+            }
+            "enable" | "on" => {
+                let host = normalize_host(params.get("host"));
+                let port = normalize_port(params.get("port"))?;
+                let insecure = parse_bool(params.get("insecure"), false);
+                persist_dashboard_platform(true, host, port, insecure)
+            }
+            "disable" | "off" => {
+                let (cfg_path, platform) = read_dashboard_platform()?;
+                let (host, port) = current_host_and_port(&platform);
+                persist_dashboard_platform(false, host, port, true).map(|raw| {
+                    let parsed: Value = serde_json::from_str(&raw).unwrap_or_else(|_| json!({}));
+                    json!({
+                        "status": "ok",
+                        "enabled": false,
+                        "host": parsed.get("host").and_then(Value::as_str).unwrap_or("127.0.0.1"),
+                        "port": parsed.get("port").and_then(Value::as_u64).unwrap_or(8080),
+                        "url": parsed.get("url").and_then(Value::as_str).unwrap_or(""),
+                        "config_path": cfg_path.display().to_string(),
+                    })
+                    .to_string()
+                })
+            }
+            "url" => {
+                let (cfg_path, platform) = read_dashboard_platform()?;
+                let (host, port) = current_host_and_port(&platform);
+                Ok(json!({
+                    "status": "ok",
+                    "enabled": platform.enabled,
+                    "url": dashboard_url(&host, port),
+                    "host": host,
+                    "port": port,
+                    "config_path": cfg_path.display().to_string(),
+                })
+                .to_string())
+            }
+            other => Err(ToolError::InvalidParams(format!(
+                "unsupported action '{other}' (expected status|enable|disable|url)"
+            ))),
+        }
+    }
+
+    fn schema(&self) -> ToolSchema {
+        let mut props = IndexMap::new();
+        props.insert(
+            "action".into(),
+            json!({"type":"string","enum":["status","enable","on","disable","off","url"]}),
+        );
+        props.insert("host".into(), json!({"type":"string"}));
+        props.insert(
+            "port".into(),
+            json!({"type":"integer","minimum":1,"maximum":65535}),
+        );
+        props.insert(
+            "insecure".into(),
+            json!({
+                "type":"boolean",
+                "description":"Allow non-localhost bind when enabling dashboard."
+            }),
+        );
+        tool_schema(
+            "dashboard_control",
+            "Inspect and configure dashboard/api_server host/port enablement in Hermes config.",
+            JsonSchema::object(props, vec![]),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock poisoned")
+    }
+
+    #[tokio::test]
+    async fn enable_status_disable_roundtrip() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", temp.path());
+
+        let handler = DashboardControlHandler;
+        let enabled = handler
+            .execute(json!({"action":"enable","host":"127.0.0.1","port":9191}))
+            .await
+            .expect("enable");
+        let enabled_json: Value = serde_json::from_str(&enabled).expect("json");
+        assert_eq!(enabled_json["enabled"], true);
+        assert_eq!(enabled_json["port"], 9191);
+
+        let status = handler
+            .execute(json!({"action":"status"}))
+            .await
+            .expect("status");
+        let status_json: Value = serde_json::from_str(&status).expect("json");
+        assert_eq!(status_json["enabled"], true);
+        assert_eq!(status_json["host"], "127.0.0.1");
+        assert_eq!(status_json["port"], 9191);
+
+        let disabled = handler
+            .execute(json!({"action":"disable"}))
+            .await
+            .expect("disable");
+        let disabled_json: Value = serde_json::from_str(&disabled).expect("json");
+        assert_eq!(disabled_json["enabled"], false);
+    }
+
+    #[tokio::test]
+    async fn rejects_non_local_without_insecure() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", temp.path());
+
+        let handler = DashboardControlHandler;
+        let err = handler
+            .execute(json!({"action":"enable","host":"0.0.0.0","port":8080}))
+            .await
+            .expect_err("non-local should fail");
+        match err {
+            ToolError::InvalidParams(msg) => assert!(msg.contains("non-localhost")),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}

--- a/crates/hermes-tools/src/tools/mod.rs
+++ b/crates/hermes-tools/src/tools/mod.rs
@@ -8,6 +8,7 @@ pub mod clarify;
 pub mod code_execution;
 pub mod credential_files;
 pub mod cronjob;
+pub mod dashboard_control;
 pub mod delegation;
 pub mod env_passthrough;
 pub mod file;


### PR DESCRIPTION
## Summary
- add new built-in `dashboard_control` tool for status/on/off/url dashboard configuration management
- add `/dashboard` slash command and extend `/ops` with dashboard, skills-tier, and gate controls
- add model catalog guardrails on `/model` selection and runtime auto-remediation for provider model-not-found failures
- add policy-backed skills execution tiers (`trusted|balanced|open`) with explicit bypass env
- surface tool-policy counters and latest eval/SLO gate status in operator control plane

## Validation
- `cargo fmt`
- `cargo test -p hermes-tools dashboard_control -- --nocapture`
- `cargo test -p hermes-cli commands:: -- --nocapture`
- `cargo test -p hermes-cli is_model_not_found_error -- --nocapture`
- `cargo check -p hermes-tools -p hermes-cli`
