### PR TITLE
feat: add local/self-host multi-provider backends + MLX/ANE strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Rust-first autonomous agent runtime with functional parity goals against `NousRe
 
 - Fully Rust-native core runtime (agent loop, tools, gateway, skills, CLI/TUI)
 - Multi-provider inference routing and OAuth-capable provider flows
+- First-class local/self-host backends: Ollama, llama.cpp, vLLM, MLX, Apple ANE endpoint, SGLang, TGI
 - Tool runtime with policy enforcement, MCP integration, cron, and memory backends
 - Parity upkeep system for upstream drift triage and controlled roll-forward
 - Production operations surface (`doctor`, replay traces, sync gates, parity artifacts)
@@ -103,6 +104,30 @@ Optional Sentrux MCP profile:
 hermes-ultra mcp sentrux
 hermes-ultra mcp sentrux-status
 ```
+
+## Local Backends
+
+`hermes-ultra setup` now includes local/self-host provider options with no mandatory API key:
+
+- `ollama-local` (default `http://127.0.0.1:11434/v1`)
+- `llama-cpp` (default `http://127.0.0.1:8080/v1`)
+- `vllm` (default `http://127.0.0.1:8000/v1`)
+- `mlx` (default `http://127.0.0.1:8080/v1`)
+- `apple-ane` (default `http://127.0.0.1:8081/v1`)
+- `sglang` (default `http://127.0.0.1:30000/v1`)
+- `tgi` (default `http://127.0.0.1:8082/v1`)
+
+Override endpoint URLs via env vars:
+
+- `OLLAMA_BASE_URL`
+- `LLAMA_CPP_BASE_URL`
+- `VLLM_BASE_URL`
+- `MLX_BASE_URL`
+- `APPLE_ANE_BASE_URL`
+- `SGLANG_BASE_URL`
+- `TGI_BASE_URL`
+
+Detailed guide: [docs/local-backends.md](./docs/local-backends.md)
 
 ## Built-In Context + Memory Behavior
 

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -1092,6 +1092,13 @@ mod tests {
             ("HF_TOKEN", "huggingface"),
             ("KILOCODE_API_KEY", "kilocode"),
             ("NVIDIA_API_KEY", "nvidia"),
+            ("OLLAMA_LOCAL_API_KEY", "ollama-local"),
+            ("LLAMA_CPP_API_KEY", "llama-cpp"),
+            ("VLLM_API_KEY", "vllm"),
+            ("MLX_API_KEY", "mlx"),
+            ("APPLE_ANE_API_KEY", "apple-ane"),
+            ("SGLANG_API_KEY", "sglang"),
+            ("TGI_API_KEY", "tgi"),
             ("OPENCODE_GO_API_KEY", "opencode-go"),
             ("OPENCODE_ZEN_API_KEY", "opencode-zen"),
             ("XAI_API_KEY", "xai"),
@@ -1122,6 +1129,37 @@ mod tests {
             "qwen"
         );
         assert_eq!(normalize_runtime_provider_name("opencode"), "opencode-zen");
+        assert_eq!(normalize_runtime_provider_name("ollama"), "ollama-local");
+        assert_eq!(normalize_runtime_provider_name("llama.cpp"), "llama-cpp");
+        assert_eq!(normalize_runtime_provider_name("ollvm"), "vllm");
+        assert_eq!(normalize_runtime_provider_name("llvm"), "vllm");
+        assert_eq!(normalize_runtime_provider_name("mlx-lm"), "mlx");
+        assert_eq!(normalize_runtime_provider_name("ane"), "apple-ane");
+    }
+
+    #[test]
+    fn test_allow_no_api_key_for_local_backends_and_private_base_urls() {
+        assert!(allow_no_api_key("ollama-local", "ollama-local", None));
+        assert!(allow_no_api_key(
+            "openai",
+            "openai",
+            Some("http://127.0.0.1:11434/v1")
+        ));
+        assert!(allow_no_api_key(
+            "custom",
+            "custom",
+            Some("http://192.168.1.20:8000/v1")
+        ));
+        assert!(allow_no_api_key(
+            "custom",
+            "custom",
+            Some("http://[::1]:11434/v1")
+        ));
+        assert!(!allow_no_api_key(
+            "openai",
+            "openai",
+            Some("https://api.openai.com/v1")
+        ));
     }
 
     #[test]
@@ -1294,6 +1332,13 @@ const ZAI_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
 const ARCEE_BASE_URL: &str = "https://api.arcee.ai/api/v1";
 const OLLAMA_CLOUD_BASE_URL: &str = "https://ollama.com/v1";
 const DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/v1";
+const OLLAMA_LOCAL_BASE_URL: &str = "http://127.0.0.1:11434/v1";
+const LLAMA_CPP_BASE_URL: &str = "http://127.0.0.1:8080/v1";
+const VLLM_BASE_URL: &str = "http://127.0.0.1:8000/v1";
+const MLX_BASE_URL: &str = "http://127.0.0.1:8080/v1";
+const APPLE_ANE_BASE_URL: &str = "http://127.0.0.1:8081/v1";
+const SGLANG_BASE_URL: &str = "http://127.0.0.1:30000/v1";
+const TGI_BASE_URL: &str = "http://127.0.0.1:8082/v1";
 
 fn normalize_runtime_provider_name(provider: &str) -> String {
     let normalized = provider.trim().to_ascii_lowercase();
@@ -1309,6 +1354,12 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
+        "ollama" => "ollama-local".to_string(),
+        "llama.cpp" | "llamacpp" => "llama-cpp".to_string(),
+        "ollvm" | "llvm" => "vllm".to_string(),
+        "mlx-lm" | "apple-mlx" => "mlx".to_string(),
+        "ane" | "apple-neural-engine" | "neural-engine" => "apple-ane".to_string(),
+        "text-generation-inference" => "tgi".to_string(),
         _ => normalized,
     }
 }
@@ -1335,6 +1386,13 @@ fn provider_default_base_url(provider: &str) -> Option<&'static str> {
         "zai" => Some(ZAI_BASE_URL),
         "arcee" => Some(ARCEE_BASE_URL),
         "ollama-cloud" => Some(OLLAMA_CLOUD_BASE_URL),
+        "ollama-local" | "ollama" => Some(OLLAMA_LOCAL_BASE_URL),
+        "llama-cpp" | "llama.cpp" | "llamacpp" => Some(LLAMA_CPP_BASE_URL),
+        "vllm" | "ollvm" | "llvm" => Some(VLLM_BASE_URL),
+        "mlx" | "mlx-lm" | "apple-mlx" => Some(MLX_BASE_URL),
+        "apple-ane" | "ane" | "apple-neural-engine" => Some(APPLE_ANE_BASE_URL),
+        "sglang" => Some(SGLANG_BASE_URL),
+        "tgi" | "text-generation-inference" => Some(TGI_BASE_URL),
         "deepseek" => Some(DEEPSEEK_BASE_URL),
         _ => None,
     }
@@ -1443,6 +1501,71 @@ fn default_rtk_raw_mode() -> bool {
     }
 }
 
+fn provider_base_url_from_env(provider: &str) -> Option<String> {
+    let env_var = match provider.trim().to_ascii_lowercase().as_str() {
+        "ollama-local" | "ollama" => "OLLAMA_BASE_URL",
+        "llama-cpp" | "llama.cpp" | "llamacpp" => "LLAMA_CPP_BASE_URL",
+        "vllm" | "ollvm" | "llvm" => "VLLM_BASE_URL",
+        "mlx" | "mlx-lm" | "apple-mlx" => "MLX_BASE_URL",
+        "apple-ane" | "ane" | "apple-neural-engine" => "APPLE_ANE_BASE_URL",
+        "sglang" => "SGLANG_BASE_URL",
+        "tgi" | "text-generation-inference" => "TGI_BASE_URL",
+        _ => return None,
+    };
+    std::env::var(env_var)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn provider_is_local_backend(provider: &str) -> bool {
+    matches!(
+        provider.trim().to_ascii_lowercase().as_str(),
+        "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi"
+    )
+}
+
+fn allow_no_api_key(provider_name: &str, runtime_provider: &str, base_url: Option<&str>) -> bool {
+    provider_is_local_backend(runtime_provider)
+        || provider_is_local_backend(provider_name)
+        || base_url.is_some_and(url_is_local_or_private)
+}
+
+fn url_is_local_or_private(base_url: &str) -> bool {
+    let trimmed = base_url.trim();
+    let no_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(trimmed);
+    let authority = no_scheme.split('/').next().unwrap_or(no_scheme).trim();
+    let host = if authority.starts_with('[') {
+        authority
+            .find(']')
+            .map(|idx| authority[1..idx].to_string())
+            .unwrap_or_else(|| authority.trim_matches(&['[', ']'][..]).to_string())
+    } else {
+        authority
+            .split(':')
+            .next()
+            .unwrap_or(authority)
+            .trim()
+            .to_string()
+    }
+    .to_ascii_lowercase();
+
+    if host == "localhost" {
+        return true;
+    }
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return match ip {
+            std::net::IpAddr::V4(v4) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+            std::net::IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local(),
+        };
+    }
+    false
+}
+
 /// Resolve API key / token for a named LLM provider from well-known environment variables.
 pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
     let provider = normalize_runtime_provider_name(provider);
@@ -1530,6 +1653,31 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
         "ollama-cloud" => std::env::var("OLLAMA_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
+        "ollama-local" => std::env::var("OLLAMA_LOCAL_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("OLLAMA_API_KEY").ok())
+            .filter(|s| !s.trim().is_empty()),
+        "llama-cpp" => std::env::var("LLAMA_CPP_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "vllm" => std::env::var("VLLM_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "mlx" => std::env::var("MLX_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "apple-ane" => std::env::var("APPLE_ANE_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "sglang" => std::env::var("SGLANG_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "tgi" => std::env::var("TGI_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("HUGGINGFACE_API_KEY").ok())
+            .filter(|s| !s.trim().is_empty()),
         "opencode-go" => std::env::var("OPENCODE_GO_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
@@ -1575,6 +1723,11 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
 
     let default_base_url = provider_default_base_url(provider_name.as_str())
         .or_else(|| provider_default_base_url(runtime_provider.as_str()));
+    let base_url = provider_config
+        .and_then(|c| c.base_url.clone())
+        .or_else(|| provider_base_url_from_env(provider_name.as_str()))
+        .or_else(|| provider_base_url_from_env(runtime_provider.as_str()))
+        .or_else(|| default_base_url.map(ToString::to_string));
 
     let api_key = provider_config
         .and_then(|c| c.api_key.as_deref())
@@ -1590,8 +1743,15 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         .or_else(|| provider_api_key_from_env(provider_name.as_str()))
         .or_else(|| provider_api_key_from_env(runtime_provider.as_str()));
 
+    let local_no_key_ok = allow_no_api_key(
+        provider_name.as_str(),
+        runtime_provider.as_str(),
+        base_url.as_deref(),
+    );
+
     let api_key = match api_key {
         Some(k) => k,
+        None if local_no_key_ok => "local-no-key".to_string(),
         None => {
             tracing::warn!(
                 "No API key for provider '{}'(runtime '{}'); using NoBackendProvider",
@@ -1603,10 +1763,6 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             });
         }
     };
-
-    let base_url = provider_config
-        .and_then(|c| c.base_url.clone())
-        .or_else(|| default_base_url.map(ToString::to_string));
 
     match runtime_provider.as_str() {
         "openai" => {
@@ -1671,6 +1827,10 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             )
             .with_model(model_name.as_str());
             Arc::new(p)
+        }
+        "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi" => {
+            let url = base_url.unwrap_or_else(|| "http://127.0.0.1:11434/v1".to_string());
+            Arc::new(GenericProvider::new(url, &api_key, model_name.as_str()))
         }
         _ => {
             let url = base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string());

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -3705,6 +3705,12 @@ fn normalize_auth_provider(provider: &str) -> String {
         }
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "zen" => "opencode-zen".to_string(),
+        "ollama" => "ollama-local".to_string(),
+        "llama.cpp" | "llamacpp" => "llama-cpp".to_string(),
+        "ollvm" | "llvm" => "vllm".to_string(),
+        "mlx-lm" | "apple-mlx" => "mlx".to_string(),
+        "ane" | "apple-neural-engine" | "neural-engine" => "apple-ane".to_string(),
+        "text-generation-inference" => "tgi".to_string(),
         "aigateway" | "vercel" | "vercel-ai-gateway" => "ai-gateway".to_string(),
         "x-ai" | "x.ai" | "grok" => "xai".to_string(),
         "glm" | "z-ai" | "z.ai" | "zhipu" => "zai".to_string(),
@@ -3753,6 +3759,12 @@ fn normalize_secret_provider(provider: &str) -> String {
         "moonshot" | "kimi" => "kimi-coding".to_string(),
         "aigateway" | "vercel" | "vercel-ai-gateway" => "ai-gateway".to_string(),
         "opencode" | "zen" => "opencode-zen".to_string(),
+        "ollama" => "ollama-local".to_string(),
+        "llama.cpp" | "llamacpp" => "llama-cpp".to_string(),
+        "ollvm" | "llvm" => "vllm".to_string(),
+        "mlx-lm" | "apple-mlx" => "mlx".to_string(),
+        "ane" | "apple-neural-engine" | "neural-engine" => "apple-ane".to_string(),
+        "text-generation-inference" => "tgi".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "x-ai" | "x.ai" | "grok" => "xai".to_string(),
         "glm" | "z-ai" | "z.ai" | "zhipu" => "zai".to_string(),
@@ -3808,6 +3820,21 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
         "ai-gateway" => vec!["ai-gateway".to_string(), "aigateway".to_string()],
         "opencode-zen" => vec!["opencode-zen".to_string(), "opencode".to_string()],
         "kilocode" => vec!["kilocode".to_string(), "kilo".to_string()],
+        "ollama-local" => vec!["ollama-local".to_string(), "ollama".to_string()],
+        "llama-cpp" => vec![
+            "llama-cpp".to_string(),
+            "llama.cpp".to_string(),
+            "llamacpp".to_string(),
+        ],
+        "vllm" => vec!["vllm".to_string(), "ollvm".to_string(), "llvm".to_string()],
+        "mlx" => vec!["mlx".to_string(), "mlx-lm".to_string()],
+        "apple-ane" => vec![
+            "apple-ane".to_string(),
+            "ane".to_string(),
+            "apple-neural-engine".to_string(),
+        ],
+        "sglang" => vec!["sglang".to_string()],
+        "tgi" => vec!["tgi".to_string(), "text-generation-inference".to_string()],
         p => vec![p.to_string()],
     }
 }
@@ -3837,6 +3864,13 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "kilocode" => Some("KILOCODE_API_KEY"),
         "nvidia" => Some("NVIDIA_API_KEY"),
         "ollama-cloud" => Some("OLLAMA_API_KEY"),
+        "ollama-local" => Some("OLLAMA_LOCAL_API_KEY"),
+        "llama-cpp" => Some("LLAMA_CPP_API_KEY"),
+        "vllm" => Some("VLLM_API_KEY"),
+        "mlx" => Some("MLX_API_KEY"),
+        "apple-ane" => Some("APPLE_ANE_API_KEY"),
+        "sglang" => Some("SGLANG_API_KEY"),
+        "tgi" => Some("TGI_API_KEY"),
         "opencode-go" => Some("OPENCODE_GO_API_KEY"),
         "opencode-zen" => Some("OPENCODE_ZEN_API_KEY"),
         "xai" => Some("XAI_API_KEY"),
@@ -3955,34 +3989,42 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
     }
     let store = FileTokenStore::new(path).await?;
     let manager = AuthManager::new(store.clone());
+    let mut hydrated_nous_from_vault = false;
 
-    match resolve_nous_runtime_credentials(
-        false,
-        true,
-        NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
-        DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
-    )
-    .await
-    {
-        Ok(creds) => {
-            std::env::set_var("NOUS_API_KEY", creds.api_key.clone());
-            if !creds.base_url.trim().is_empty() {
-                std::env::set_var("NOUS_INFERENCE_BASE_URL", creds.base_url.clone());
+    if let Some((_provider, token)) = lookup_secret_from_vault(&store, "nous").await {
+        std::env::set_var("NOUS_API_KEY", token);
+        hydrated_nous_from_vault = true;
+    }
+
+    if !hydrated_nous_from_vault {
+        match resolve_nous_runtime_credentials(
+            false,
+            true,
+            NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+            DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
+        )
+        .await
+        {
+            Ok(creds) => {
+                std::env::set_var("NOUS_API_KEY", creds.api_key.clone());
+                if !creds.base_url.trim().is_empty() {
+                    std::env::set_var("NOUS_INFERENCE_BASE_URL", creds.base_url.clone());
+                }
+                let expires_at = parse_rfc3339_utc(creds.expires_at.as_deref());
+                let _ = manager
+                    .save_credential(OAuthCredential {
+                        provider: "nous".to_string(),
+                        access_token: creds.api_key,
+                        refresh_token: creds.refresh_token,
+                        token_type: creds.token_type,
+                        scope: creds.scope,
+                        expires_at,
+                    })
+                    .await;
             }
-            let expires_at = parse_rfc3339_utc(creds.expires_at.as_deref());
-            let _ = manager
-                .save_credential(OAuthCredential {
-                    provider: "nous".to_string(),
-                    access_token: creds.api_key,
-                    refresh_token: creds.refresh_token,
-                    token_type: creds.token_type,
-                    scope: creds.scope,
-                    expires_at,
-                })
-                .await;
-        }
-        Err(err) => {
-            tracing::debug!("Nous runtime credential refresh skipped: {}", err);
+            Err(err) => {
+                tracing::debug!("Nous runtime credential refresh skipped: {}", err);
+            }
         }
     }
 
@@ -4017,6 +4059,13 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
         ("KILOCODE_API_KEY", "kilocode"),
         ("NVIDIA_API_KEY", "nvidia"),
         ("OLLAMA_API_KEY", "ollama-cloud"),
+        ("OLLAMA_LOCAL_API_KEY", "ollama-local"),
+        ("LLAMA_CPP_API_KEY", "llama-cpp"),
+        ("VLLM_API_KEY", "vllm"),
+        ("MLX_API_KEY", "mlx"),
+        ("APPLE_ANE_API_KEY", "apple-ane"),
+        ("SGLANG_API_KEY", "sglang"),
+        ("TGI_API_KEY", "tgi"),
         ("OPENCODE_GO_API_KEY", "opencode-go"),
         ("OPENCODE_ZEN_API_KEY", "opencode-zen"),
         ("XAI_API_KEY", "xai"),
@@ -7044,6 +7093,13 @@ const SETUP_HUGGINGFACE_ENV_KEYS: &[&str] = &["HF_TOKEN"];
 const SETUP_KILOCODE_ENV_KEYS: &[&str] = &["KILOCODE_API_KEY"];
 const SETUP_NVIDIA_ENV_KEYS: &[&str] = &["NVIDIA_API_KEY"];
 const SETUP_OLLAMA_CLOUD_ENV_KEYS: &[&str] = &["OLLAMA_API_KEY"];
+const SETUP_OLLAMA_LOCAL_ENV_KEYS: &[&str] = &["OLLAMA_LOCAL_API_KEY", "OLLAMA_API_KEY"];
+const SETUP_LLAMA_CPP_ENV_KEYS: &[&str] = &["LLAMA_CPP_API_KEY"];
+const SETUP_VLLM_ENV_KEYS: &[&str] = &["VLLM_API_KEY"];
+const SETUP_MLX_ENV_KEYS: &[&str] = &["MLX_API_KEY"];
+const SETUP_APPLE_ANE_ENV_KEYS: &[&str] = &["APPLE_ANE_API_KEY"];
+const SETUP_SGLANG_ENV_KEYS: &[&str] = &["SGLANG_API_KEY"];
+const SETUP_TGI_ENV_KEYS: &[&str] = &["TGI_API_KEY"];
 const SETUP_OPENCODE_GO_ENV_KEYS: &[&str] = &["OPENCODE_GO_API_KEY"];
 const SETUP_OPENCODE_ZEN_ENV_KEYS: &[&str] = &["OPENCODE_ZEN_API_KEY"];
 const SETUP_XAI_ENV_KEYS: &[&str] = &["XAI_API_KEY"];
@@ -7210,6 +7266,41 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
         label: "Ollama Cloud",
     },
     SetupModelOption {
+        provider: "ollama-local",
+        model: "ollama-local:qwen3:14b",
+        label: "Ollama Local (OpenAI-compatible)",
+    },
+    SetupModelOption {
+        provider: "llama-cpp",
+        model: "llama-cpp:local-gguf",
+        label: "llama.cpp server (local)",
+    },
+    SetupModelOption {
+        provider: "vllm",
+        model: "vllm:NousResearch/Meta-Llama-3-8B-Instruct",
+        label: "vLLM server (local/self-host)",
+    },
+    SetupModelOption {
+        provider: "mlx",
+        model: "mlx:mlx-community/Qwen3-8B-4bit",
+        label: "MLX server (Apple Silicon)",
+    },
+    SetupModelOption {
+        provider: "apple-ane",
+        model: "apple-ane:ane-default",
+        label: "Apple ANE private endpoint",
+    },
+    SetupModelOption {
+        provider: "sglang",
+        model: "sglang:default",
+        label: "SGLang OpenAI-compatible",
+    },
+    SetupModelOption {
+        provider: "tgi",
+        model: "tgi:default",
+        label: "Text Generation Inference",
+    },
+    SetupModelOption {
         provider: "copilot",
         model: "copilot:gpt-5.4",
         label: "GitHub Copilot",
@@ -7304,6 +7395,13 @@ fn setup_provider_display(provider: &str) -> &'static str {
         "kilocode" => "KiloCode",
         "nvidia" => "NVIDIA NIM",
         "ollama-cloud" => "Ollama Cloud",
+        "ollama-local" => "Ollama Local",
+        "llama-cpp" => "llama.cpp Server",
+        "vllm" => "vLLM Server",
+        "mlx" => "MLX Server",
+        "apple-ane" => "Apple ANE Endpoint",
+        "sglang" => "SGLang Server",
+        "tgi" => "Text Gen Inference",
         "opencode-go" => "OpenCode Go",
         "opencode-zen" => "OpenCode Zen",
         "xai" => "xAI",
@@ -7339,6 +7437,13 @@ fn setup_provider_env_keys(provider: &str) -> &'static [&'static str] {
         "kilocode" => SETUP_KILOCODE_ENV_KEYS,
         "nvidia" => SETUP_NVIDIA_ENV_KEYS,
         "ollama-cloud" => SETUP_OLLAMA_CLOUD_ENV_KEYS,
+        "ollama-local" => SETUP_OLLAMA_LOCAL_ENV_KEYS,
+        "llama-cpp" => SETUP_LLAMA_CPP_ENV_KEYS,
+        "vllm" => SETUP_VLLM_ENV_KEYS,
+        "mlx" => SETUP_MLX_ENV_KEYS,
+        "apple-ane" => SETUP_APPLE_ANE_ENV_KEYS,
+        "sglang" => SETUP_SGLANG_ENV_KEYS,
+        "tgi" => SETUP_TGI_ENV_KEYS,
         "opencode-go" => SETUP_OPENCODE_GO_ENV_KEYS,
         "opencode-zen" => SETUP_OPENCODE_ZEN_ENV_KEYS,
         "xai" => SETUP_XAI_ENV_KEYS,
@@ -7366,11 +7471,38 @@ fn setup_provider_default_base_url(provider: &str) -> Option<&'static str> {
         "kilocode" => Some("https://api.kilo.ai/api/gateway"),
         "nvidia" => Some("https://integrate.api.nvidia.com/v1"),
         "ollama-cloud" => Some("https://ollama.com/v1"),
+        "ollama-local" => Some("http://127.0.0.1:11434/v1"),
+        "llama-cpp" => Some("http://127.0.0.1:8080/v1"),
+        "vllm" => Some("http://127.0.0.1:8000/v1"),
+        "mlx" => Some("http://127.0.0.1:8080/v1"),
+        "apple-ane" => Some("http://127.0.0.1:8081/v1"),
+        "sglang" => Some("http://127.0.0.1:30000/v1"),
+        "tgi" => Some("http://127.0.0.1:8082/v1"),
         "opencode-go" => Some("https://opencode.ai/zen/go/v1"),
         "opencode-zen" => Some("https://opencode.ai/zen/v1"),
         "xai" => Some("https://api.x.ai/v1"),
         "xiaomi" => Some("https://api.xiaomimimo.com/v1"),
         "zai" => Some("https://api.z.ai/api/paas/v4"),
+        _ => None,
+    }
+}
+
+fn setup_provider_requires_api_key(provider: &str) -> bool {
+    !matches!(
+        provider,
+        "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi"
+    )
+}
+
+fn local_backend_base_url_env_var(provider: &str) -> Option<&'static str> {
+    match provider {
+        "ollama-local" => Some("OLLAMA_BASE_URL"),
+        "llama-cpp" => Some("LLAMA_CPP_BASE_URL"),
+        "vllm" => Some("VLLM_BASE_URL"),
+        "mlx" => Some("MLX_BASE_URL"),
+        "apple-ane" => Some("APPLE_ANE_BASE_URL"),
+        "sglang" => Some("SGLANG_BASE_URL"),
+        "tgi" => Some("TGI_BASE_URL"),
         _ => None,
     }
 }
@@ -7552,6 +7684,8 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
         .map(|option| {
             let auth_label = if provider_supports_oauth(option.provider) {
                 "OAuth/API key"
+            } else if !setup_provider_requires_api_key(option.provider) {
+                "Local / optional key"
             } else if option.provider == "bedrock" {
                 "AWS credentials"
             } else {
@@ -7834,6 +7968,22 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
         println!(
             "\nAWS Bedrock uses AWS credential chain (env/profile/role). Skipping API key prompt."
         );
+    } else if !setup_provider_requires_api_key(&selected_provider) {
+        println!(
+            "\n{} is a local/self-host OpenAI-compatible backend. API key is optional.",
+            selected_provider_label
+        );
+        if has_selected_provider_env_key {
+            print!(
+                "{} API key (optional, leave blank to keep {} from environment/{}): ",
+                selected_provider_label,
+                env_keys_display,
+                env_path.display()
+            );
+            io::stdout().flush().ok();
+            reader.read_line(&mut api_key).ok();
+            api_key = api_key.trim().to_string();
+        }
     } else if !stored_provider_secret_in_vault {
         if has_selected_provider_env_key {
             print!(
@@ -8362,6 +8512,7 @@ async fn run_doctor(
     let mut config_summary = serde_json::json!({
         "loaded": false
     });
+    let mut loaded_config: Option<GatewayConfig> = None;
     println!("\nConfiguration:");
     print!("  Loading config... ");
     match load_config(cli.config_dir.as_deref()) {
@@ -8374,6 +8525,7 @@ async fn run_doctor(
             println!("  Max turns: {}", config.max_turns);
             let platform_count = config.platforms.iter().filter(|(_, p)| p.enabled).count();
             println!("  Enabled platforms: {}", platform_count);
+            loaded_config = Some(config.clone());
             config_summary = serde_json::json!({
                 "loaded": true,
                 "model": config.model,
@@ -8393,6 +8545,63 @@ async fn run_doctor(
                 "error": e.to_string()
             }));
         }
+    }
+
+    println!("\nLocal backend endpoints:");
+    for provider in [
+        "ollama-local",
+        "llama-cpp",
+        "vllm",
+        "mlx",
+        "apple-ane",
+        "sglang",
+        "tgi",
+    ] {
+        let configured = loaded_config
+            .as_ref()
+            .and_then(|cfg| cfg.llm_providers.get(provider))
+            .and_then(|entry| entry.base_url.clone())
+            .filter(|value| !value.trim().is_empty());
+        let env_override = local_backend_base_url_env_var(provider)
+            .and_then(|name| std::env::var(name).ok())
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let base_url = configured
+            .or(env_override)
+            .or_else(|| setup_provider_default_base_url(provider).map(ToString::to_string));
+
+        let (reachable, probed_url) = if let Some(url) = base_url.clone() {
+            let models_url = format!("{}/models", url.trim_end_matches('/'));
+            let ok = reqwest::Client::new()
+                .get(models_url.as_str())
+                .timeout(std::time::Duration::from_millis(900))
+                .send()
+                .await
+                .map(|resp| resp.status().is_success())
+                .unwrap_or(false);
+            (ok, Some(models_url))
+        } else {
+            (false, None)
+        };
+
+        println!(
+            "  {:<12} ... {}",
+            provider,
+            if reachable {
+                "✓ reachable"
+            } else {
+                "(optional, endpoint not reachable)"
+            }
+        );
+        checks.push(serde_json::json!({
+            "name": format!("local_backend_{provider}"),
+            "ok": true,
+            "provider": provider,
+            "base_url": base_url,
+            "probe_url": probed_url,
+            "reachable": reachable,
+            "optional": true
+        }));
     }
 
     if deep {
@@ -11551,6 +11760,13 @@ mod tests {
         assert_eq!(normalize_auth_provider("z-ai"), "zai");
         assert_eq!(normalize_auth_provider("grok"), "xai");
         assert_eq!(normalize_auth_provider("hf"), "huggingface");
+        assert_eq!(normalize_auth_provider("ollama"), "ollama-local");
+        assert_eq!(normalize_auth_provider("llama.cpp"), "llama-cpp");
+        assert_eq!(normalize_auth_provider("ollvm"), "vllm");
+        assert_eq!(normalize_auth_provider("llvm"), "vllm");
+        assert_eq!(normalize_auth_provider("mlx-lm"), "mlx");
+        assert_eq!(normalize_auth_provider("ane"), "apple-ane");
+        assert_eq!(normalize_auth_provider("text-generation-inference"), "tgi");
         assert_eq!(normalize_auth_provider("api-server"), "api_server");
         assert_eq!(normalize_auth_provider("mm"), "mattermost");
     }
@@ -11599,6 +11815,15 @@ mod tests {
         assert_eq!(
             secret_provider_aliases("claude"),
             vec!["anthropic", "claude", "claude-code"]
+        );
+        assert_eq!(provider_env_var("ollama"), Some("OLLAMA_LOCAL_API_KEY"));
+        assert_eq!(provider_env_var("llama.cpp"), Some("LLAMA_CPP_API_KEY"));
+        assert_eq!(provider_env_var("ollvm"), Some("VLLM_API_KEY"));
+        assert_eq!(provider_env_var("mlx-lm"), Some("MLX_API_KEY"));
+        assert_eq!(provider_env_var("ane"), Some("APPLE_ANE_API_KEY"));
+        assert_eq!(
+            provider_env_var("text-generation-inference"),
+            Some("TGI_API_KEY")
         );
     }
 
@@ -11661,6 +11886,17 @@ mod tests {
     fn setup_provider_env_keys_include_nous() {
         assert_eq!(setup_provider_display("nous"), "Nous");
         assert_eq!(setup_provider_env_keys("nous"), &["NOUS_API_KEY"]);
+        assert_eq!(
+            setup_provider_env_keys("ollama-local"),
+            &["OLLAMA_LOCAL_API_KEY", "OLLAMA_API_KEY"]
+        );
+        assert_eq!(
+            setup_provider_default_base_url("vllm"),
+            Some("http://127.0.0.1:8000/v1")
+        );
+        assert!(!setup_provider_requires_api_key("ollama-local"));
+        assert!(!setup_provider_requires_api_key("apple-ane"));
+        assert!(setup_provider_requires_api_key("openai"));
         assert_eq!(setup_provider_display("alibaba"), "Alibaba Cloud DashScope");
         assert_eq!(
             setup_provider_env_keys("google-gemini-cli"),

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -14,6 +14,13 @@ use sha2::{Digest, Sha256};
 use crate::providers::provider_capability_for;
 const NOUS_DEFAULT_INFERENCE_BASE_URL: &str = "https://inference-api.nousresearch.com/v1";
 const PROVIDER_CATALOG_CACHE_VERSION: u32 = 1;
+const OLLAMA_LOCAL_DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
+const LLAMA_CPP_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080/v1";
+const VLLM_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
+const MLX_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080/v1";
+const APPLE_ANE_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8081/v1";
+const SGLANG_DEFAULT_BASE_URL: &str = "http://127.0.0.1:30000/v1";
+const TGI_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8082/v1";
 
 const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
     (
@@ -115,6 +122,58 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
         &[
             "nvidia/llama-3.3-nemotron-super-49b-v1.5",
             "nvidia/nemotron-3-super-120b-a12b",
+        ],
+    ),
+    (
+        "ollama-local",
+        &["qwen3:14b", "llama3.1:8b", "deepseek-r1:14b", "mistral:7b"],
+    ),
+    (
+        "llama-cpp",
+        &[
+            "local-gguf",
+            "qwen3-14b-instruct-q4_k_m.gguf",
+            "llama-3.1-8b-instruct-q4_k_m.gguf",
+        ],
+    ),
+    (
+        "vllm",
+        &[
+            "NousResearch/Meta-Llama-3-8B-Instruct",
+            "Qwen/Qwen3-14B-Instruct",
+            "deepseek-ai/DeepSeek-V3.2",
+        ],
+    ),
+    (
+        "mlx",
+        &[
+            "mlx-community/Qwen3-8B-4bit",
+            "mlx-community/Llama-3.1-8B-Instruct-4bit",
+            "mlx-community/Mistral-7B-Instruct-v0.3-4bit",
+        ],
+    ),
+    (
+        "apple-ane",
+        &[
+            "ane-default",
+            "foundation-model",
+            "apple-on-device-openai-compatible",
+        ],
+    ),
+    (
+        "sglang",
+        &[
+            "default",
+            "Qwen/Qwen3-14B-Instruct",
+            "meta-llama/Llama-3.1-8B-Instruct",
+        ],
+    ),
+    (
+        "tgi",
+        &[
+            "default",
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "Qwen/Qwen3-14B-Instruct",
         ],
     ),
     (
@@ -404,6 +463,117 @@ pub fn provider_curated_models(provider: &str) -> &'static [&'static str] {
     &[]
 }
 
+fn is_local_openai_compatible_provider(provider: &str) -> bool {
+    matches!(
+        provider.trim().to_ascii_lowercase().as_str(),
+        "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi"
+    )
+}
+
+fn local_provider_default_base_url(provider: &str) -> Option<&'static str> {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "ollama-local" => Some(OLLAMA_LOCAL_DEFAULT_BASE_URL),
+        "llama-cpp" => Some(LLAMA_CPP_DEFAULT_BASE_URL),
+        "vllm" => Some(VLLM_DEFAULT_BASE_URL),
+        "mlx" => Some(MLX_DEFAULT_BASE_URL),
+        "apple-ane" => Some(APPLE_ANE_DEFAULT_BASE_URL),
+        "sglang" => Some(SGLANG_DEFAULT_BASE_URL),
+        "tgi" => Some(TGI_DEFAULT_BASE_URL),
+        _ => None,
+    }
+}
+
+fn local_provider_base_url_env_var(provider: &str) -> Option<&'static str> {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "ollama-local" => Some("OLLAMA_BASE_URL"),
+        "llama-cpp" => Some("LLAMA_CPP_BASE_URL"),
+        "vllm" => Some("VLLM_BASE_URL"),
+        "mlx" => Some("MLX_BASE_URL"),
+        "apple-ane" => Some("APPLE_ANE_BASE_URL"),
+        "sglang" => Some("SGLANG_BASE_URL"),
+        "tgi" => Some("TGI_BASE_URL"),
+        _ => None,
+    }
+}
+
+fn local_provider_api_key(provider: &str) -> Option<String> {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "ollama-local" => std::env::var("OLLAMA_LOCAL_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or_else(|| std::env::var("OLLAMA_API_KEY").ok())
+            .filter(|v| !v.trim().is_empty()),
+        "llama-cpp" => std::env::var("LLAMA_CPP_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty()),
+        "vllm" => std::env::var("VLLM_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty()),
+        "mlx" => std::env::var("MLX_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty()),
+        "apple-ane" => std::env::var("APPLE_ANE_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty()),
+        "sglang" => std::env::var("SGLANG_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty()),
+        "tgi" => std::env::var("TGI_API_KEY")
+            .ok()
+            .filter(|v| !v.trim().is_empty()),
+        _ => None,
+    }
+}
+
+fn local_provider_resolved_base_url(provider: &str) -> Option<String> {
+    local_provider_base_url_env_var(provider)
+        .and_then(|name| std::env::var(name).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| local_provider_default_base_url(provider).map(ToString::to_string))
+}
+
+async fn fetch_openai_compatible_live_models(base_url: &str, api_key: Option<&str>) -> Vec<String> {
+    if cfg!(test) {
+        return Vec::new();
+    }
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let mut request = client.get(url);
+    if let Some(key) = api_key.map(str::trim).filter(|v| !v.is_empty()) {
+        request = request.bearer_auth(key);
+    }
+    let response = match request.send().await {
+        Ok(resp) => resp,
+        Err(_) => return Vec::new(),
+    };
+    if !response.status().is_success() {
+        return Vec::new();
+    }
+    let payload: Value = match response.json().await {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let mut models = payload
+        .get("data")
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| row.get("id").and_then(Value::as_str))
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+        })
+        .unwrap_or_default();
+    if models.is_empty() {
+        return models;
+    }
+    let mut seen = HashSet::new();
+    models.retain(|model| seen.insert(model.to_ascii_lowercase()));
+    models
+}
+
 async fn resolve_nous_catalog_endpoint_and_token() -> Option<(String, String)> {
     if let Ok(creds) = crate::auth::resolve_nous_runtime_credentials(
         false,
@@ -560,6 +730,29 @@ pub async fn provider_model_ids_with_client(
         } else {
             merged
         }
+    } else if is_local_openai_compatible_provider(&normalized) {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut merged: Vec<String> = Vec::new();
+        if let Some(base_url) = local_provider_resolved_base_url(&normalized) {
+            let live = fetch_openai_compatible_live_models(
+                base_url.as_str(),
+                local_provider_api_key(&normalized).as_deref(),
+            )
+            .await;
+            for model in live {
+                let key = model.to_ascii_lowercase();
+                if seen.insert(key) {
+                    merged.push(model);
+                }
+            }
+        }
+        for model in curated {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                merged.push((*model).to_string());
+            }
+        }
+        merged
     } else if !is_models_dev_preferred_provider(&normalized) {
         curated.iter().map(|model| model.to_string()).collect()
     } else {
@@ -683,6 +876,15 @@ mod tests {
     }
 
     #[test]
+    fn local_backend_curated_models_include_ollama_llamacpp_and_vllm() {
+        assert!(provider_curated_models("ollama-local").contains(&"qwen3:14b"));
+        assert!(provider_curated_models("llama-cpp").contains(&"local-gguf"));
+        assert!(provider_curated_models("vllm").contains(&"NousResearch/Meta-Llama-3-8B-Instruct"));
+        assert!(provider_curated_models("mlx").contains(&"mlx-community/Qwen3-8B-4bit"));
+        assert!(provider_curated_models("apple-ane").contains(&"ane-default"));
+    }
+
+    #[test]
     fn openrouter_curated_models_include_gpt55_variants() {
         let models = provider_curated_models("openrouter");
         assert!(models.contains(&"openai/gpt-5.5"));
@@ -754,6 +956,23 @@ mod tests {
             .map(|m| (*m).to_string())
             .collect();
         assert_eq!(out, expected);
+    }
+
+    #[tokio::test]
+    async fn local_provider_catalog_returns_curated_without_network_dependency() {
+        let client = seeded_client(json!({}));
+        let out = provider_model_ids_with_client("ollama-local", &client).await;
+        let expected: Vec<String> = provider_curated_models("ollama-local")
+            .iter()
+            .map(|m| (*m).to_string())
+            .collect();
+        assert!(out.len() >= expected.len());
+        for model in expected {
+            assert!(
+                out.iter().any(|item| item == &model),
+                "missing model {model}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -27,6 +27,13 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "kilocode",
     "nvidia",
     "ollama-cloud",
+    "ollama-local",
+    "llama-cpp",
+    "vllm",
+    "mlx",
+    "apple-ane",
+    "sglang",
+    "tgi",
     "opencode-go",
     "opencode-zen",
     "xai",
@@ -203,5 +210,28 @@ mod tests {
             "models.dev merged providers missing capability bit: {:?}",
             missing
         );
+    }
+
+    #[test]
+    fn local_backends_are_known_and_not_oauth() {
+        for provider in [
+            "ollama-local",
+            "llama-cpp",
+            "vllm",
+            "mlx",
+            "apple-ane",
+            "sglang",
+            "tgi",
+        ] {
+            let cap = provider_capability_for(provider).expect("capability");
+            assert!(
+                !cap.oauth_supported,
+                "{provider} should not advertise oauth"
+            );
+            assert!(
+                !cap.models_dev_merged,
+                "{provider} should not require models.dev merge"
+            );
+        }
     }
 }

--- a/docs/local-backends.md
+++ b/docs/local-backends.md
@@ -1,0 +1,58 @@
+# Local/Self-Host Backends
+
+Hermes Agent Ultra supports OpenAI-compatible local or private inference endpoints directly.
+
+## Provider IDs
+
+- `ollama-local`
+- `llama-cpp`
+- `vllm` (aliases: `ollvm`, `llvm`)
+- `mlx`
+- `apple-ane`
+- `sglang`
+- `tgi`
+
+## Endpoint env overrides
+
+- `OLLAMA_BASE_URL` (default `http://127.0.0.1:11434/v1`)
+- `LLAMA_CPP_BASE_URL` (default `http://127.0.0.1:8080/v1`)
+- `VLLM_BASE_URL` (default `http://127.0.0.1:8000/v1`)
+- `MLX_BASE_URL` (default `http://127.0.0.1:8080/v1`)
+- `APPLE_ANE_BASE_URL` (default `http://127.0.0.1:8081/v1`)
+- `SGLANG_BASE_URL` (default `http://127.0.0.1:30000/v1`)
+- `TGI_BASE_URL` (default `http://127.0.0.1:8082/v1`)
+
+Optional API-key env vars are also supported if your server enforces auth:
+
+- `OLLAMA_LOCAL_API_KEY`, `LLAMA_CPP_API_KEY`, `VLLM_API_KEY`, `MLX_API_KEY`,
+  `APPLE_ANE_API_KEY`, `SGLANG_API_KEY`, `TGI_API_KEY`
+
+## Setup flow
+
+Run:
+
+```bash
+hermes-ultra setup
+```
+
+Pick a local provider in the provider menu. Local providers do not require OAuth and do not require an API key by default.
+
+## Model selection
+
+Use:
+
+```bash
+/model
+```
+
+Hermes will show curated model suggestions and attempt live model discovery via `GET /v1/models` where the backend exposes it.
+
+## Health checks
+
+Run:
+
+```bash
+hermes-ultra doctor --deep
+```
+
+Doctor prints optional reachability checks for each local backend endpoint.

--- a/docs/roadmaps/LOCAL_BACKEND_STRATEGY_ADR_2026-05-02.md
+++ b/docs/roadmaps/LOCAL_BACKEND_STRATEGY_ADR_2026-05-02.md
@@ -1,0 +1,39 @@
+# ADR: Local Backend Strategy (Ollama/llama.cpp/vLLM/MLX/ANE)
+
+## Status
+Accepted (2026-05-02)
+
+## Context
+Hermes Agent Ultra needs broad multi-provider support for cloud + self-host inference with minimal operator friction. Users requested first-class local backend support and asked whether we should build a native Rust inference backend now.
+
+## Decision
+1. Treat OpenAI-compatible local inference servers as first-class providers in Hermes Ultra.
+2. Support these provider families directly in setup/model/runtime:
+   - `ollama-local`
+   - `llama-cpp`
+   - `vllm` (plus aliases `ollvm`/`llvm`)
+   - `mlx`
+   - `apple-ane`
+   - `sglang`
+   - `tgi`
+3. Allow local/private endpoint operation without mandatory API keys.
+4. Keep runtime Rust-first in orchestration and tooling, while inference execution is delegated to external specialized engines.
+5. Defer a full native Rust inference server to a separate phase with explicit performance gates.
+
+## Rationale
+- Existing local backends already provide mature model execution, batching, quantization, and GPU/ANE integrations.
+- Hermes Ultra value is orchestration quality, policy/safety, memory, tooling, and operator UX.
+- Building a full in-process inference engine now would add substantial maintenance risk and slow parity/upkeep velocity.
+
+## Rust-native backend note
+Rust-native projects exist in the ecosystem (for example around Candle/mistral.rs/llama-rs style stacks), but a production replacement for all current backend capabilities is not yet a short-path objective for Hermes Ultra.
+
+Decision rule:
+- keep external backends as default execution layer now;
+- revisit native backend only if a measurable reliability/latency/cost advantage is demonstrated under Hermes Ultra workloads.
+
+## Follow-up criteria for future native backend evaluation
+- P95 latency improvement >= 20% on representative tool-calling workloads
+- No regression in tool-calling correctness and structured output reliability
+- Operational footprint stays compatible with current setup/doctor/deploy workflows
+- Security and provenance controls remain at or above current levels


### PR DESCRIPTION
## Summary\nThis PR implements items 1-8 for multi-provider backend expansion with Rust-first runtime behavior:\n- provider registry + alias expansion (ollama-local, llama-cpp, vllm/ollvm/llvm, mlx, apple-ane, sglang, tgi)\n- no-key local runtime path for local/private endpoints\n- setup wizard onboarding for local providers\n- /model catalog support for local families with best-effort live /v1/models merge\n- env/config wiring updates\n- doctor diagnostics for local endpoint reachability\n- regression tests across provider/setup/model-switch paths\n- docs + ADR for backend strategy\n\n## Validation\n- cargo fmt --all\n- cargo test -p hermes-cli -- --nocapture\n\n## Tracking\nCloses #132\nCloses #133\nCloses #134\nCloses #135\nCloses #136\nCloses #137\nCloses #138\nCloses #139\nCloses #140\n