### PR TITLE
Add /objective session command with durable directive injection

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -89,6 +89,8 @@ pub struct App {
     stream_handle_shared: Arc<StdMutex<Option<StreamHandle>>>,
     /// Whether TUI mouse events are enabled.
     pub mouse_enabled: bool,
+    /// Optional durable objective for the current interactive session.
+    pub session_objective: Option<String>,
 }
 
 impl std::fmt::Debug for App {
@@ -100,6 +102,7 @@ impl std::fmt::Debug for App {
             .field("current_personality", &self.current_personality)
             .field("history_index", &self.history_index)
             .field("mouse_enabled", &self.mouse_enabled)
+            .field("session_objective", &self.session_objective)
             .finish_non_exhaustive()
     }
 }
@@ -132,6 +135,8 @@ pub struct UiTranscriptMessage {
 // ---------------------------------------------------------------------------
 
 impl App {
+    const SESSION_OBJECTIVE_PREFIX: &'static str = "[SESSION_OBJECTIVE] ";
+
     fn push_stream_extra_event(
         shared: &Arc<StdMutex<Option<StreamHandle>>>,
         payload: serde_json::Value,
@@ -342,6 +347,7 @@ impl App {
             stream_handle: None,
             stream_handle_shared,
             mouse_enabled: default_mouse_enabled(),
+            session_objective: None,
         })
     }
 
@@ -458,6 +464,7 @@ impl App {
         self.session_id = Uuid::new_v4().to_string();
         self.messages.clear();
         self.ui_messages.clear();
+        self.session_objective = None;
         self.input_history.clear();
         self.history_index = 0;
     }
@@ -466,8 +473,37 @@ impl App {
     pub fn reset_session(&mut self) {
         self.messages.clear();
         self.ui_messages.clear();
+        self.session_objective = None;
         self.input_history.clear();
         self.history_index = 0;
+    }
+
+    /// Set or clear a durable session objective.
+    ///
+    /// The objective is represented as a synthetic system message so it is
+    /// applied consistently on every turn without requiring user re-entry.
+    pub fn set_session_objective(&mut self, objective: Option<String>) {
+        self.messages.retain(|m| {
+            if m.role != hermes_core::MessageRole::System {
+                return true;
+            }
+            !m.content
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with(Self::SESSION_OBJECTIVE_PREFIX)
+        });
+
+        self.session_objective = objective
+            .as_ref()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        if let Some(obj) = &self.session_objective {
+            let system =
+                hermes_core::Message::system(format!("{}{}", Self::SESSION_OBJECTIVE_PREFIX, obj));
+            self.messages.insert(0, system);
+        }
+        self.prune_ui_after_current_messages();
     }
 
     /// Retry the last user message by re-sending it to the agent.
@@ -834,6 +870,43 @@ mod tests {
     use super::*;
     use hermes_config::LlmProviderConfig;
     use std::collections::HashMap;
+
+    fn build_minimal_test_app() -> App {
+        let config = Arc::new(GatewayConfig::default());
+        let tool_registry = Arc::new(ToolRegistry::new());
+        let agent_tool_registry = Arc::new(bridge_tool_registry(&tool_registry));
+        let agent_config = build_agent_config(config.as_ref(), "openai:gpt-4o");
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoBackendProvider {
+            model: "openai:gpt-4o".to_string(),
+        });
+        let agent_inner = AgentLoop::new(agent_config, agent_tool_registry, provider)
+            .with_callbacks(App::stream_callbacks(Arc::new(StdMutex::new(None))));
+        let orchestrator = Arc::new(SubAgentOrchestrator::from_parent(
+            &agent_inner,
+            hermes_home_dir(),
+        ));
+        let agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
+
+        App {
+            config,
+            agent,
+            tool_registry,
+            tool_schemas: Vec::new(),
+            messages: Vec::new(),
+            ui_messages: Vec::new(),
+            session_id: "test-session".to_string(),
+            running: true,
+            current_model: "openai:gpt-4o".to_string(),
+            current_personality: None,
+            input_history: Vec::new(),
+            history_index: 0,
+            interrupt_controller: InterruptController::new(),
+            stream_handle: None,
+            stream_handle_shared: Arc::new(StdMutex::new(None)),
+            mouse_enabled: true,
+            session_objective: None,
+        }
+    }
 
     #[test]
     fn test_session_info_serialization() {
@@ -1211,6 +1284,53 @@ mod tests {
     fn test_is_model_not_found_error_ignores_non_catalog_errors() {
         let err = AgentError::LlmApi("Rate limit exceeded".to_string());
         assert!(!App::is_model_not_found_error(&err));
+    }
+
+    #[test]
+    fn test_set_session_objective_injects_replaces_and_clears_system_message() {
+        let mut app = build_minimal_test_app();
+        app.messages
+            .push(hermes_core::Message::user("hello before objective"));
+
+        app.set_session_objective(Some(
+            "Ship parity with upstream plus stronger UX".to_string(),
+        ));
+        assert_eq!(
+            app.session_objective.as_deref(),
+            Some("Ship parity with upstream plus stronger UX")
+        );
+        assert_eq!(app.messages.len(), 2);
+        assert_eq!(app.messages[0].role, hermes_core::MessageRole::System);
+        let system = app.messages[0].content.clone().unwrap_or_default();
+        assert!(system.starts_with("[SESSION_OBJECTIVE] "));
+        assert!(system.contains("Ship parity with upstream plus stronger UX"));
+
+        app.set_session_objective(Some("Minimize latency regressions".to_string()));
+        let system_count = app
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == hermes_core::MessageRole::System
+                    && m.content
+                        .as_deref()
+                        .unwrap_or_default()
+                        .starts_with("[SESSION_OBJECTIVE] ")
+            })
+            .count();
+        assert_eq!(system_count, 1);
+        assert_eq!(
+            app.session_objective.as_deref(),
+            Some("Minimize latency regressions")
+        );
+
+        app.set_session_objective(None);
+        assert!(app.session_objective.is_none());
+        assert!(app.messages.iter().all(|m| {
+            !m.content
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("[SESSION_OBJECTIVE] ")
+        }));
     }
 }
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -118,6 +118,11 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/tasks", "Alias for /agents"),
     ("/queue", "Queue a follow-up prompt"),
     ("/q", "Alias for /queue"),
+    (
+        "/objective",
+        "Set/show/clear a durable session objective injected as system context",
+    ),
+    ("/goal", "Alias for /objective"),
     ("/steer", "Inject non-interrupt steering instruction"),
     ("/btw", "Run an ephemeral side-question"),
     ("/plan", "Show planning helper status"),
@@ -2856,6 +2861,7 @@ fn canonical_command(cmd: &str) -> &str {
         "/snap" => "/snapshot",
         "/set-home" => "/sethome",
         "/q" => "/queue",
+        "/goal" => "/objective",
         "/sb" => "/statusbar",
         "/exit" => "/quit",
         other => other,
@@ -2898,6 +2904,7 @@ pub async fn handle_slash_command(
         "/history" => handle_history_command(app),
         "/title" | "/branch" | "/snapshot" | "/rollback" | "/queue" | "/steer" | "/btw"
         | "/sethome" => handle_session_compat_command(app, canonical_command(cmd), args),
+        "/objective" => handle_objective_command(app, args),
         "/model" => handle_model_command(app, args).await,
         "/provider" => handle_provider_command(app).await,
         "/personality" => handle_personality_command(app, args),
@@ -5695,6 +5702,49 @@ fn handle_capability_surface_command(
         _ => "Command surface available.",
     };
     emit_command_output(app, msg);
+    Ok(CommandResult::Handled)
+}
+
+fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    if args.is_empty() {
+        let msg = match app.session_objective.as_deref() {
+            Some(v) => format!(
+                "Current objective:\n{}\n\nUse `/objective clear` to remove, or `/objective <text>` to replace.",
+                v
+            ),
+            None => {
+                "No objective set.\nUsage: `/objective <text>` or `/objective clear`."
+                    .to_string()
+            }
+        };
+        emit_command_output(app, msg);
+        return Ok(CommandResult::Handled);
+    }
+
+    let first = args[0].trim();
+    if first.eq_ignore_ascii_case("clear")
+        || first.eq_ignore_ascii_case("off")
+        || first.eq_ignore_ascii_case("none")
+        || first.eq_ignore_ascii_case("reset")
+    {
+        app.set_session_objective(None);
+        emit_command_output(app, "Session objective cleared.");
+        return Ok(CommandResult::Handled);
+    }
+
+    let objective = args.join(" ").trim().to_string();
+    if objective.is_empty() {
+        emit_command_output(app, "Usage: `/objective <text>` or `/objective clear`.");
+        return Ok(CommandResult::Handled);
+    }
+    app.set_session_objective(Some(objective.clone()));
+    emit_command_output(
+        app,
+        format!(
+            "Session objective set:\n{}\n\nThis objective is now injected as system context for future turns.",
+            objective
+        ),
+    );
     Ok(CommandResult::Handled)
 }
 
@@ -10494,6 +10544,18 @@ mod tests {
     fn test_autocomplete_partial() {
         let results = autocomplete("/m");
         assert!(results.contains(&"/model"));
+    }
+
+    #[test]
+    fn test_objective_command_is_registered_and_completable() {
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/objective"));
+        let results = autocomplete("/obj");
+        assert!(results.contains(&"/objective"));
+    }
+
+    #[test]
+    fn test_goal_alias_maps_to_objective() {
+        assert_eq!(canonical_command("/goal"), "/objective");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `/objective` slash command (plus `/goal` alias)
- support show/set/clear objective semantics
- persist objective in App state and inject as synthetic system message for turn-level consistency
- clear objective on `/new` and `/reset`
- add tests for registration/alias and objective lifecycle

## Validation
- cargo fmt --all
- cargo test -p hermes-cli
