### PR TITLE
Add self-evolution loop runner and /ops evolve control plane

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -119,6 +119,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/queue", "Queue a follow-up prompt"),
     ("/q", "Alias for /queue"),
     (
+        "/evolve",
+        "Run or inspect the self-evolution intelligence loop",
+    ),
+    (
         "/objective",
         "Set/show/clear a durable session objective injected as system context",
     ),
@@ -2904,6 +2908,7 @@ pub async fn handle_slash_command(
         "/history" => handle_history_command(app),
         "/title" | "/branch" | "/snapshot" | "/rollback" | "/queue" | "/steer" | "/btw"
         | "/sethome" => handle_session_compat_command(app, canonical_command(cmd), args),
+        "/evolve" => handle_ops_evolve_command(app, args).await,
         "/objective" => handle_objective_command(app, args),
         "/model" => handle_model_command(app, args).await,
         "/provider" => handle_provider_command(app).await,
@@ -4389,6 +4394,61 @@ fn summarize_gate_report(path: &Path, key: &str) -> Option<String> {
     ))
 }
 
+fn summarize_self_evolution_report(path: &Path, key: &str) -> Option<String> {
+    let report = read_json_file(path)?;
+    let ok = report
+        .get("ok")
+        .and_then(|v| v.as_bool())
+        .map(|v| if v { "pass" } else { "fail" })
+        .unwrap_or("unknown");
+    let generated = report
+        .get("generated_at")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let idx = report
+        .get("summary")
+        .and_then(|s| s.get("intelligence_index"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let recs = report
+        .get("recommendations")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.len())
+        .unwrap_or(0);
+    Some(format!(
+        "{}={} idx={:.2} recs={} @ {} ({})",
+        key,
+        ok,
+        idx,
+        recs,
+        generated,
+        path.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.display().to_string())
+    ))
+}
+
+fn self_evolution_recommendations(path: &Path) -> Vec<String> {
+    let report = match read_json_file(path) {
+        Some(v) => v,
+        None => return Vec::new(),
+    };
+    let Some(items) = report.get("recommendations").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            let obj = item.as_object()?;
+            let id = obj.get("id").and_then(|v| v.as_str()).unwrap_or("UNKNOWN");
+            let sev = obj.get("severity").and_then(|v| v.as_str()).unwrap_or("PX");
+            let title = obj.get("title").and_then(|v| v.as_str()).unwrap_or("");
+            let cmd = obj.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            Some(format!("[{sev}] {id}: {title}\n  cmd: {cmd}"))
+        })
+        .collect()
+}
+
 fn dashboard_status_line_from_payload(payload: &serde_json::Value) -> String {
     let enabled = payload
         .get("enabled")
@@ -4624,6 +4684,91 @@ async fn handle_ops_gate_command(
     }
 }
 
+async fn handle_ops_evolve_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let sub = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .to_ascii_lowercase();
+    let Some(repo_root) = discover_repo_root_for_about() else {
+        emit_command_output(
+            app,
+            "Self-evolution controls are unavailable outside source checkout.",
+        );
+        return Ok(CommandResult::Handled);
+    };
+    let report_dir = repo_root.join(".sync-reports");
+    match sub.as_str() {
+        "status" => {
+            let summary = latest_json_report(&report_dir, "self-evolution-loop-")
+                .and_then(|p| summarize_self_evolution_report(&p, "self_evolution"))
+                .unwrap_or_else(|| "self_evolution=unknown (no reports yet)".to_string());
+            emit_command_output(
+                app,
+                format!(
+                    "{}\nRun `/ops evolve run` to execute the loop now.",
+                    summary
+                ),
+            );
+            Ok(CommandResult::Handled)
+        }
+        "run" => {
+            let cmd = if let Some(obj) = app.session_objective.as_deref() {
+                format!(
+                    "python3 scripts/run-self-evolution-loop.py --json --objective {}",
+                    shell_escape(obj)
+                )
+            } else {
+                "python3 scripts/run-self-evolution-loop.py --json".to_string()
+            };
+            let out = run_ops_shell_command(&cmd).await?;
+            emit_command_output(app, out);
+            Ok(CommandResult::Handled)
+        }
+        "recommend" | "recs" => {
+            let Some(path) = latest_json_report(&report_dir, "self-evolution-loop-") else {
+                emit_command_output(
+                    app,
+                    "No self-evolution reports found. Run `/ops evolve run` first.",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let recs = self_evolution_recommendations(&path);
+            if recs.is_empty() {
+                emit_command_output(
+                    app,
+                    format!(
+                        "No recommendations found in {}.",
+                        path.file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| path.display().to_string())
+                    ),
+                );
+            } else {
+                let file_label = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| path.display().to_string());
+                emit_command_output(
+                    app,
+                    format!(
+                        "Self-evolution recommendations ({file_label}):\n{}",
+                        recs.join("\n")
+                    ),
+                );
+            }
+            Ok(CommandResult::Handled)
+        }
+        _ => {
+            emit_command_output(app, "Usage: /ops evolve [status|run|recommend]");
+            Ok(CommandResult::Handled)
+        }
+    }
+}
+
 fn shell_escape(input: &str) -> String {
     let escaped = input.replace('\'', "'\"'\"'");
     format!("'{}'", escaped)
@@ -4659,7 +4804,10 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
             let slo = latest_json_report(&report_dir, "slo-auto-rollback-")
                 .and_then(|p| summarize_gate_report(&p, "slo"))
                 .unwrap_or_else(|| "slo=unknown".to_string());
-            format!("{eval}; {slo}")
+            let evolve = latest_json_report(&report_dir, "self-evolution-loop-")
+                .and_then(|p| summarize_self_evolution_report(&p, "evolve"))
+                .unwrap_or_else(|| "evolve=unknown".to_string());
+            format!("{eval}; {slo}; {evolve}")
         } else {
             "unavailable (non-source checkout)".to_string()
         };
@@ -4697,6 +4845,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                /ops verbose\n\
                /ops dashboard [status|on|off|url] [host] [port]\n\
                /ops skills-tier [status|trusted|balanced|open]\n\
+               /ops evolve [status|run|recommend]\n\
                /ops gate [status|eval|elite|slo]\n\
                /ops help",
             app.session_id,
@@ -4740,6 +4889,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                  - /ops statusbar\n\
                  - /ops dashboard [status|on|off|url] [host] [port]\n\
                  - /ops skills-tier [status|trusted|balanced|open]\n\
+                 - /ops evolve [status|run|recommend]\n\
                  - /ops gate [status|eval|elite|slo]",
             );
             Ok(CommandResult::Handled)
@@ -4754,6 +4904,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
         "statusbar" => handle_statusbar_command(app),
         "dashboard" => handle_dashboard_command(app, &args[1..]).await,
         "skills-tier" => handle_ops_skills_tier_command(app, &args[1..]),
+        "evolve" => handle_ops_evolve_command(app, &args[1..]).await,
         "gate" => handle_ops_gate_command(app, &args[1..]).await,
         other => {
             emit_command_output(
@@ -10556,6 +10707,56 @@ mod tests {
     #[test]
     fn test_goal_alias_maps_to_objective() {
         assert_eq!(canonical_command("/goal"), "/objective");
+    }
+
+    #[test]
+    fn test_autocomplete_includes_evolve() {
+        let results = autocomplete("/evo");
+        assert!(results.contains(&"/evolve"));
+    }
+
+    #[test]
+    fn summarize_self_evolution_report_formats_fields() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("self-evolution-loop-test.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "ok": false,
+  "generated_at": "2026-05-02T00:00:00Z",
+  "summary": { "intelligence_index": 66.67 },
+  "recommendations": [{"id":"PARITY_DRIFT"}]
+}"#,
+        )
+        .expect("write report");
+        let line = summarize_self_evolution_report(&path, "self_evolution").expect("summary");
+        assert!(line.contains("self_evolution=fail"));
+        assert!(line.contains("idx=66.67"));
+        assert!(line.contains("recs=1"));
+    }
+
+    #[test]
+    fn self_evolution_recommendations_extracts_lines() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("self-evolution-loop-test.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "recommendations": [
+    {
+      "id": "EVAL_REGRESSION",
+      "severity": "P0",
+      "title": "Recover eval trend before promotion",
+      "command": "python3 scripts/run-eval-trend-gate.py --json"
+    }
+  ]
+}"#,
+        )
+        .expect("write report");
+        let lines = self_evolution_recommendations(&path);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("EVAL_REGRESSION"));
+        assert!(lines[0].contains("python3 scripts/run-eval-trend-gate.py --json"));
     }
 
     #[test]

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -43,6 +43,9 @@ fork-specific history.
 - `scripts/run-eval-trend-gate.py`
   - Compares eval run baselines and enforces regression thresholds
   - Emits gate artifact under `.sync-reports/eval-trend-gate-<timestamp>.json`
+- `scripts/run-self-evolution-loop.py`
+  - Runs a unified intelligence loop across golden parity + eval trend + elite sync gates
+  - Emits recommendations and intelligence index under `.sync-reports/self-evolution-loop-<timestamp>.json`
 - `scripts/compare-adapter-chaos-reports.py`
   - Compares chaos reports and fails on attempts/fallback/outcome regressions
 - `scripts/generate-readme-sync-status.py`
@@ -61,6 +64,7 @@ bash scripts/sync-upstream.sh --redteam-cmd "python3 scripts/run-redteam-gate.py
 python3 scripts/run-adapter-chaos-harness.py --repo-root .
 python3 scripts/run-zero-copy-hotpath-bench.py --repo-root .
 python3 scripts/run-elite-sync-gate.py --repo-root .
+python3 scripts/run-self-evolution-loop.py --repo-root . --json
 python3 scripts/generate-parity-dashboard.py --repo-root .
 python3 scripts/generate-readme-sync-status.py --repo-root .
 bash scripts/sync-upstream.sh --elite-gate

--- a/scripts/run-self-evolution-loop.py
+++ b/scripts/run-self-evolution-loop.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Run an integrated self-evolution loop and emit actionable recommendations."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument(
+        "--objective",
+        default="",
+        help="Optional objective text included in the loop report",
+    )
+    parser.add_argument(
+        "--golden-cmd",
+        default="python3 scripts/run-golden-parity-harness.py --auto-issue",
+        help="Golden parity harness command",
+    )
+    parser.add_argument(
+        "--eval-cmd",
+        default="python3 scripts/run-eval-trend-gate.py --allow-missing-baseline --json",
+        help="Eval trend gate command",
+    )
+    parser.add_argument(
+        "--elite-cmd",
+        default="python3 scripts/run-elite-sync-gate.py --json",
+        help="Consolidated elite gate command",
+    )
+    parser.add_argument(
+        "--skip-golden",
+        action="store_true",
+        help="Skip golden parity harness run",
+    )
+    parser.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip eval trend gate run",
+    )
+    parser.add_argument(
+        "--skip-elite",
+        action="store_true",
+        help="Skip elite sync gate run",
+    )
+    parser.add_argument(
+        "--report-path",
+        default="",
+        help="Optional explicit report path",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON report")
+    return parser.parse_args()
+
+
+def default_report_path(repo_root: pathlib.Path) -> pathlib.Path:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return repo_root / ".sync-reports" / f"self-evolution-loop-{stamp}.json"
+
+
+def run_shell(command: str, cwd: pathlib.Path) -> dict[str, Any]:
+    started = time.time()
+    proc = subprocess.run(
+        ["bash", "-lc", command],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed_ms = int((time.time() - started) * 1000)
+    return {
+        "command": command,
+        "exit_code": proc.returncode,
+        "ok": proc.returncode == 0,
+        "elapsed_ms": elapsed_ms,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def extract_report_path(output: str) -> str | None:
+    patterns = [
+        r"\[[^\]]+\]\s*Report:\s*(.+)",
+        r"report=(\S+)",
+        r'"report_path"\s*:\s*"([^"]+)"',
+    ]
+    for line in output.splitlines():
+        for pattern in patterns:
+            match = re.search(pattern, line)
+            if match:
+                return match.group(1).strip()
+    return None
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any] | None:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def slim(raw: dict[str, Any], repo_root: pathlib.Path) -> dict[str, Any]:
+    output = (raw.get("stdout") or "") + "\n" + (raw.get("stderr") or "")
+    report_path_raw = extract_report_path(output)
+    report_path = ""
+    report_payload: dict[str, Any] | None = None
+    if report_path_raw:
+        candidate = pathlib.Path(report_path_raw).expanduser()
+        if not candidate.is_absolute():
+            candidate = (repo_root / candidate).resolve()
+        report_path = str(candidate)
+        if candidate.exists():
+            report_payload = read_json(candidate)
+    return {
+        "command": raw.get("command"),
+        "exit_code": raw.get("exit_code"),
+        "ok": bool(raw.get("ok")),
+        "elapsed_ms": raw.get("elapsed_ms"),
+        "stdout_tail": (raw.get("stdout") or "")[-4000:],
+        "stderr_tail": (raw.get("stderr") or "")[-4000:],
+        "report_path": report_path,
+        "report_ok": (
+            report_payload.get("ok")
+            if isinstance(report_payload, dict)
+            and isinstance(report_payload.get("ok"), bool)
+            else None
+        ),
+        "report_excerpt": (
+            {
+                key: report_payload.get(key)
+                for key in (
+                    "summary",
+                    "missing_commands",
+                    "missing_tui_tests",
+                    "drift",
+                    "sections",
+                )
+                if report_payload and key in report_payload
+            }
+            if isinstance(report_payload, dict)
+            else None
+        ),
+    }
+
+
+def recommendation(
+    rec_id: str,
+    severity: str,
+    title: str,
+    reason: str,
+    command: str,
+) -> dict[str, str]:
+    return {
+        "id": rec_id,
+        "severity": severity,
+        "title": title,
+        "reason": reason,
+        "command": command,
+    }
+
+
+def build_recommendations(
+    objective: str,
+    sections: dict[str, dict[str, Any]],
+) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    objective_hint = (
+        f" Objective: {objective.strip()}."
+        if objective and objective.strip()
+        else ""
+    )
+
+    golden = sections.get("golden_parity")
+    if golden and not golden.get("ok", False):
+        out.append(
+            recommendation(
+                "PARITY_DRIFT",
+                "P0",
+                "Resolve command/TUI parity drift before feature work",
+                "Golden parity harness failed; upstream command surface or required TUI contracts drifted."
+                + objective_hint,
+                "python3 scripts/run-golden-parity-harness.py --auto-issue",
+            )
+        )
+
+    eval_trend = sections.get("eval_trend")
+    if eval_trend and not eval_trend.get("ok", False):
+        out.append(
+            recommendation(
+                "EVAL_REGRESSION",
+                "P0",
+                "Recover eval trend before promotion",
+                "Eval trend gate failed; current behavior regressed against baseline."
+                + objective_hint,
+                "hermes route-autotune plan --apply --json && python3 scripts/run-eval-trend-gate.py --json",
+            )
+        )
+
+    elite = sections.get("elite_sync")
+    if elite and not elite.get("ok", False):
+        out.append(
+            recommendation(
+                "ELITE_GATE_FAIL",
+                "P0",
+                "Hold release and remediate elite gate failures",
+                "Consolidated elite gate failed; one or more hardening/performance/parity sections failed."
+                + objective_hint,
+                "python3 scripts/run-elite-sync-gate.py --json",
+            )
+        )
+
+    if not out:
+        out.append(
+            recommendation(
+                "PROMOTE_BASELINE",
+                "P2",
+                "Promote current state as next baseline",
+                "All enabled sections passed; safe to store this run as a quality baseline."
+                + objective_hint,
+                "python3 scripts/generate-global-parity-proof.py --repo-root .",
+            )
+        )
+    return out
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = pathlib.Path(args.repo_root).expanduser().resolve()
+    if not repo_root.exists():
+        raise SystemExit(f"repo root does not exist: {repo_root}")
+
+    report_path = (
+        pathlib.Path(args.report_path).expanduser().resolve()
+        if args.report_path
+        else default_report_path(repo_root)
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    sections: dict[str, dict[str, Any]] = {}
+    if not args.skip_golden:
+        sections["golden_parity"] = slim(run_shell(args.golden_cmd, repo_root), repo_root)
+    if not args.skip_eval:
+        sections["eval_trend"] = slim(run_shell(args.eval_cmd, repo_root), repo_root)
+    if not args.skip_elite:
+        sections["elite_sync"] = slim(run_shell(args.elite_cmd, repo_root), repo_root)
+
+    total = len(sections)
+    passed = sum(1 for section in sections.values() if section.get("ok"))
+    ok = all(section.get("ok") for section in sections.values()) if sections else True
+    recommendations = build_recommendations(args.objective, sections)
+
+    report = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "repo_root": str(repo_root),
+        "objective": args.objective.strip(),
+        "ok": ok,
+        "summary": {
+            "total_sections": total,
+            "passed_sections": passed,
+            "failed_sections": max(total - passed, 0),
+            "intelligence_index": round((passed / total) * 100.0, 2) if total else 100.0,
+        },
+        "sections": sections,
+        "recommendations": recommendations,
+    }
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    report["report_path"] = str(report_path)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        status = "PASSED" if report["ok"] else "FAILED"
+        summary = report["summary"]
+        print(
+            f"[self-evolution-loop] {status} "
+            f"(passed={summary['passed_sections']}/{summary['total_sections']} "
+            f"index={summary['intelligence_index']})"
+        )
+        print(f"[self-evolution-loop] Report: {report_path}")
+        if recommendations:
+            print("[self-evolution-loop] Recommendations:")
+            for rec in recommendations:
+                print(f"- [{rec['severity']}] {rec['title']} :: {rec['command']}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `scripts/run-self-evolution-loop.py` as an integrated intelligence loop runner
- add `/evolve` slash command and `/ops evolve [status|run|recommend]`
- summarize latest self-evolution report in `/ops status`
- add report parsing helpers and tests
- update upstream sync docs with self-evolution loop usage

Closes #145.

## Validation
- python3 -m py_compile scripts/run-self-evolution-loop.py
- python3 scripts/run-self-evolution-loop.py --repo-root . --json
- cargo fmt --all
- cargo test -p hermes-cli
