### PR TITLE
feat: implement intelligence tranche 1-8 end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ hermes-ultra mcp sentrux
 hermes-ultra mcp sentrux-status
 ```
 
+Key operator commands:
+
+```bash
+# Capability diagnostics for current or target model
+/model explain
+/model why-not --cap tools,reasoning --min-context 200000
+
+# Deterministic trace controls
+/raw trace status
+/raw trace verify
+/raw trace export 200
+
+# Runtime policy packs
+/policy list
+/policy strict
+/policy standard
+/policy dev
+```
+
 ## Local Backends
 
 `hermes-ultra setup` now includes local/self-host provider options with no mandatory API key:

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -15,6 +15,7 @@ use bytes::Bytes;
 use hermes_core::AgentError;
 use hermes_intelligence::model_metadata::{get_model_context_length, get_model_info};
 use hermes_intelligence::models_dev::default_client;
+use hermes_tools::ToolPolicyEngine;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -88,7 +89,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/rollback", "List rollback checkpoints"),
     (
         "/model",
-        "Show current model, set directly, or pick provider/model interactively (supports capability filters)",
+        "Show/switch models, or run capability diagnostics (`/model explain`, `why-not`, `--cap`)",
     ),
     ("/provider", "List configured providers and availability"),
     (
@@ -183,7 +184,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/policy",
-        "Policy lifecycle (needs HERMES_POLICY_ADMIN_TOKEN, same as HTTP X-Hermes-Policy-Admin)",
+        "Runtime policy profiles (`status|list|strict|standard|dev`) + live counters",
     ),
     ("/help", "Show help for available commands"),
     ("/quit", "Quit the application"),
@@ -3229,6 +3230,118 @@ fn model_meets_requirements(
     true
 }
 
+fn unmet_model_requirements(
+    capabilities: ResolvedModelCapabilities,
+    requirements: ModelCapabilityRequirements,
+) -> Vec<String> {
+    let mut missing = Vec::new();
+    if requirements.require_tools && !capabilities.supports_tools {
+        missing.push("tools".to_string());
+    }
+    if requirements.require_vision && !capabilities.supports_vision {
+        missing.push("vision".to_string());
+    }
+    if requirements.require_reasoning && !capabilities.supports_reasoning {
+        missing.push("reasoning".to_string());
+    }
+    if let Some(min_context) = requirements.effective_min_context() {
+        if capabilities.context_window < min_context {
+            missing.push(format!(
+                "context>={} (actual={})",
+                min_context, capabilities.context_window
+            ));
+        }
+    }
+    missing
+}
+
+async fn handle_model_explain_command(
+    app: &mut App,
+    args: &[&str],
+    strict_why_not: bool,
+) -> Result<CommandResult, AgentError> {
+    let (mut positional, requirements, provider_override) = parse_model_command_args(args)?;
+    if let Some(provider) = provider_override {
+        if positional.is_empty() {
+            positional.push(provider);
+        } else if let Some(first) = positional.first().cloned() {
+            let model_id = first
+                .split_once(':')
+                .map(|(_, rhs)| rhs.to_string())
+                .unwrap_or(first);
+            positional[0] = format!("{}:{}", provider, model_id.trim());
+        }
+    }
+    let target = if positional.is_empty() {
+        app.current_model.clone()
+    } else {
+        normalize_model_target(&app.current_model, &positional[0])?
+    };
+    let (guarded, remap_note) = guard_provider_model_selection(&target).await?;
+    let (provider, model_id) = split_provider_model(&guarded);
+    let client = default_client();
+    client.fetch(false).await;
+    let capabilities = resolve_model_capabilities(provider, model_id, client);
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Model capability report");
+    let _ = writeln!(out, "-----------------------");
+    let _ = writeln!(out, "target: {}", guarded);
+    let _ = writeln!(out, "provider: {}", provider.trim());
+    let _ = writeln!(out, "tools: {}", capabilities.supports_tools);
+    let _ = writeln!(out, "vision: {}", capabilities.supports_vision);
+    let _ = writeln!(out, "reasoning: {}", capabilities.supports_reasoning);
+    let _ = writeln!(out, "context_window: {}", capabilities.context_window);
+    if let Some(note) = remap_note.as_deref() {
+        let _ = writeln!(out, "catalog_guard: {}", note);
+    }
+
+    if !requirements.is_empty() {
+        let unmet = unmet_model_requirements(capabilities, requirements);
+        if unmet.is_empty() {
+            let _ = writeln!(out, "requirements: satisfied ({})", requirements.summary());
+        } else {
+            let _ = writeln!(out, "requirements: FAILED ({})", requirements.summary());
+            let _ = writeln!(out, "missing: {}", unmet.join(", "));
+            let catalog = provider_model_ids(provider).await;
+            let alternatives: Vec<String> = catalog
+                .into_iter()
+                .filter(|candidate| {
+                    model_meets_requirements(
+                        resolve_model_capabilities(provider, candidate, client),
+                        requirements,
+                    )
+                })
+                .take(8)
+                .collect();
+            if alternatives.is_empty() {
+                let _ = writeln!(out, "alternatives: none in provider catalog");
+            } else {
+                let _ = writeln!(
+                    out,
+                    "alternatives: {}",
+                    alternatives
+                        .iter()
+                        .map(|m| format!("{}:{}", provider, m))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            if strict_why_not {
+                return Err(AgentError::Config(out.trim_end().to_string()));
+            }
+        }
+    } else if strict_why_not {
+        let _ = writeln!(
+            out,
+            "why-not mode requires constraints. Example: `/model why-not --cap tools,reasoning --min-context 200000`"
+        );
+    }
+
+    emit_command_output(app, out.trim_end());
+    Ok(CommandResult::Handled)
+}
+
 fn parse_model_switch_request(args: &[&str], known_providers: &[&str]) -> ModelSwitchRequest {
     if args.is_empty() {
         return ModelSwitchRequest::PickProviderThenModel;
@@ -3429,6 +3542,18 @@ async fn pick_model_for_provider(
 }
 
 async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    if let Some(sub) = args.first().map(|v| v.trim()) {
+        if sub.eq_ignore_ascii_case("explain") {
+            return handle_model_explain_command(app, &args[1..], false).await;
+        }
+        if sub.eq_ignore_ascii_case("why-not")
+            || sub.eq_ignore_ascii_case("whynot")
+            || sub.eq_ignore_ascii_case("diagnose")
+        {
+            return handle_model_explain_command(app, &args[1..], true).await;
+        }
+    }
+
     let (mut positional, requirements, provider_override) = parse_model_command_args(args)?;
     if let Some(provider) = provider_override {
         if positional.is_empty() {
@@ -5442,6 +5567,97 @@ fn render_replay_trace_tail(path: &Path, limit: usize) -> Result<String, AgentEr
     Ok(out.trim_end().to_string())
 }
 
+fn replay_trace_integrity(path: &Path) -> Result<(usize, usize, usize), AgentError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        AgentError::Io(format!(
+            "Failed to read replay log {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    let mut entries = 0usize;
+    let mut parse_errors = 0usize;
+    let mut chain_breaks = 0usize;
+    let mut last_event_hash: Option<String> = None;
+    for line in raw.lines() {
+        let parsed: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => {
+                parse_errors = parse_errors.saturating_add(1);
+                continue;
+            }
+        };
+        entries = entries.saturating_add(1);
+        let prev_hash = parsed
+            .get("prev_hash")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let event_hash = parsed
+            .get("event_hash")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        if let (Some(last), Some(prev)) = (last_event_hash.as_ref(), prev_hash.as_ref()) {
+            if last != prev {
+                chain_breaks = chain_breaks.saturating_add(1);
+            }
+        }
+        if let Some(curr) = event_hash {
+            last_event_hash = Some(curr);
+        }
+    }
+    Ok((entries, parse_errors, chain_breaks))
+}
+
+fn export_replay_trace_json(
+    replay_path: &Path,
+    limit: usize,
+    output_path: &Path,
+) -> Result<usize, AgentError> {
+    let raw = std::fs::read_to_string(replay_path).map_err(|e| {
+        AgentError::Io(format!(
+            "Failed to read replay log {}: {}",
+            replay_path.display(),
+            e
+        ))
+    })?;
+    let rows: Vec<serde_json::Value> = raw
+        .lines()
+        .rev()
+        .take(limit.max(1))
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+
+    let payload = serde_json::json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "source_replay": replay_path.display().to_string(),
+        "rows": rows,
+    });
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            AgentError::Io(format!(
+                "Failed to create replay export directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+    std::fs::write(
+        output_path,
+        serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string()),
+    )
+    .map_err(|e| {
+        AgentError::Io(format!(
+            "Failed to write replay export {}: {}",
+            output_path.display(),
+            e
+        ))
+    })?;
+    Ok(payload["rows"].as_array().map(|arr| arr.len()).unwrap_or(0))
+}
+
 fn handle_raw_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     if args
         .first()
@@ -5454,7 +5670,7 @@ fn handle_raw_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Age
                 emit_command_output(
                     app,
                     format!(
-                        "Replay trace: {}{}\nSession: {}\nPath: {}\nUsage: /raw trace [on|off|toggle|status|tail [N]|path]",
+                        "Replay trace: {}{}\nSession: {}\nPath: {}\nUsage: /raw trace [on|off|toggle|status|tail [N]|verify|export [N] [PATH]|path]",
                         if replay_enabled_runtime() { "ON" } else { "OFF" },
                         if replay_path.exists() { "" } else { " (no log yet)" },
                         app.session_id,
@@ -5484,6 +5700,65 @@ fn handle_raw_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Age
                 let rendered = render_replay_trace_tail(&replay_path, limit)?;
                 emit_command_output(app, rendered);
             }
+            Some("verify") => {
+                if !replay_path.exists() {
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Replay log not found for current session yet: {}",
+                            replay_path.display()
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                let (entries, parse_errors, chain_breaks) = replay_trace_integrity(&replay_path)?;
+                let ok = parse_errors == 0 && chain_breaks == 0;
+                emit_command_output(
+                    app,
+                    format!(
+                        "Replay integrity: {}\nentries: {}\nparse_errors: {}\nchain_breaks: {}\npath: {}",
+                        if ok { "PASS" } else { "FAIL" },
+                        entries,
+                        parse_errors,
+                        chain_breaks,
+                        replay_path.display()
+                    ),
+                );
+            }
+            Some("export") => {
+                let limit = args
+                    .get(2)
+                    .and_then(|raw| raw.trim().parse::<usize>().ok())
+                    .unwrap_or(100)
+                    .clamp(1, 1000);
+                let output_path = args.get(3).map(PathBuf::from).unwrap_or_else(|| {
+                    hermes_config::hermes_home()
+                        .join("logs")
+                        .join("replay")
+                        .join("exports")
+                        .join(format!("{}-tail.json", app.session_id))
+                });
+                if !replay_path.exists() {
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Replay log not found for current session yet: {}",
+                            replay_path.display()
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                let written = export_replay_trace_json(&replay_path, limit, &output_path)?;
+                emit_command_output(
+                    app,
+                    format!(
+                        "Replay export written.\nrows: {}\nsource: {}\noutput: {}",
+                        written,
+                        replay_path.display(),
+                        output_path.display()
+                    ),
+                );
+            }
             Some("on") | Some("off") | Some("toggle") => {
                 let next = match sub.as_deref().unwrap_or("status") {
                     "on" => true,
@@ -5502,11 +5777,11 @@ fn handle_raw_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Age
             }
             Some("help") | Some("--help") | Some("-h") => emit_command_output(
                 app,
-                "Replay trace controls:\n  /raw trace status    Show enabled state + current log path\n  /raw trace on|off    Enable or disable deterministic replay trace logs\n  /raw trace toggle    Toggle replay trace logs\n  /raw trace tail [N]  Show latest trace events with lineage hashes\n  /raw trace path      Show trace log file for current session",
+                "Replay trace controls:\n  /raw trace status              Show enabled state + current log path\n  /raw trace on|off              Enable or disable deterministic replay trace logs\n  /raw trace toggle              Toggle replay trace logs\n  /raw trace tail [N]            Show latest trace events with lineage hashes\n  /raw trace verify              Validate replay hash-chain integrity\n  /raw trace export [N] [PATH]   Export tail events to JSON\n  /raw trace path                Show trace log file for current session",
             ),
             _ => emit_command_output(
                 app,
-                "Usage: /raw trace [on|off|toggle|status|tail [N]|path]",
+                "Usage: /raw trace [on|off|toggle|status|tail [N]|verify|export [N] [PATH]|path]",
             ),
         }
         return Ok(CommandResult::Handled);
@@ -5567,11 +5842,127 @@ fn handle_raw_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Age
     Ok(CommandResult::Handled)
 }
 
-fn handle_policy_command(app: &mut App, _args: &[&str]) -> Result<CommandResult, AgentError> {
-    emit_command_output(
-        app,
-        "The adaptive `/policy` CLI was removed — Hermes Python has no equivalent policy store.",
-    );
+#[derive(Debug, Clone, Copy)]
+struct PolicyProfile {
+    name: &'static str,
+    preset: &'static str,
+    mode: &'static str,
+    sandbox: &'static str,
+    description: &'static str,
+}
+
+const POLICY_PROFILES: &[PolicyProfile] = &[
+    PolicyProfile {
+        name: "strict",
+        preset: "strict",
+        mode: "enforce",
+        sandbox: "strict",
+        description: "maximum guardrails; strongest deny + sandbox posture",
+    },
+    PolicyProfile {
+        name: "standard",
+        preset: "balanced",
+        mode: "enforce",
+        sandbox: "balanced",
+        description: "default production posture with balanced safety and throughput",
+    },
+    PolicyProfile {
+        name: "dev",
+        preset: "dev",
+        mode: "audit",
+        sandbox: "dev",
+        description: "development posture with audit/simulate-friendly behavior",
+    },
+];
+
+fn resolve_policy_profile(input: &str) -> Option<PolicyProfile> {
+    let token = input.trim().to_ascii_lowercase();
+    POLICY_PROFILES.iter().copied().find(|profile| {
+        profile.name == token
+            || (token == "balanced" && profile.name == "standard")
+            || (token == "prod" && profile.name == "standard")
+    })
+}
+
+fn current_policy_profile_name() -> &'static str {
+    let preset = std::env::var("HERMES_TOOL_POLICY_PRESET")
+        .ok()
+        .unwrap_or_else(|| "balanced".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    match preset.as_str() {
+        "strict" => "strict",
+        "dev" => "dev",
+        _ => "standard",
+    }
+}
+
+fn apply_policy_profile(app: &mut App, profile: PolicyProfile) {
+    std::env::set_var("HERMES_TOOL_POLICY_PRESET", profile.preset);
+    std::env::set_var("HERMES_TOOL_POLICY_MODE", profile.mode);
+    std::env::set_var("HERMES_EXECUTION_SANDBOX_PROFILE", profile.sandbox);
+    app.tool_registry.set_policy(ToolPolicyEngine::from_env());
+}
+
+fn handle_policy_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    if args.is_empty() || args[0].eq_ignore_ascii_case("status") {
+        let counters = app.tool_registry.policy_counters();
+        emit_command_output(
+            app,
+            format!(
+                "Policy profile: {}\nPreset: {}\nMode: {}\nSandbox: {}\nCounters: allow={} deny={} audit_only={} simulate={} would_block={}\n\nUse `/policy list` or `/policy strict|standard|dev`.",
+                current_policy_profile_name(),
+                std::env::var("HERMES_TOOL_POLICY_PRESET").unwrap_or_else(|_| "balanced".into()),
+                std::env::var("HERMES_TOOL_POLICY_MODE").unwrap_or_else(|_| "enforce".into()),
+                std::env::var("HERMES_EXECUTION_SANDBOX_PROFILE")
+                    .unwrap_or_else(|_| "balanced".into()),
+                counters.allow,
+                counters.deny,
+                counters.audit_only,
+                counters.simulate,
+                counters.would_block
+            ),
+        );
+        return Ok(CommandResult::Handled);
+    }
+
+    if args[0].eq_ignore_ascii_case("list") {
+        let mut out = String::from("Policy profiles:\n");
+        for profile in POLICY_PROFILES {
+            let marker = if current_policy_profile_name() == profile.name {
+                "*"
+            } else {
+                " "
+            };
+            let _ = writeln!(
+                out,
+                "{} {:<9} preset={} mode={} sandbox={} — {}",
+                marker,
+                profile.name,
+                profile.preset,
+                profile.mode,
+                profile.sandbox,
+                profile.description
+            );
+        }
+        out.push_str("\nSelect with `/policy strict`, `/policy standard`, or `/policy dev`.");
+        emit_command_output(app, out.trim_end());
+        return Ok(CommandResult::Handled);
+    }
+
+    if let Some(profile) = resolve_policy_profile(args[0]) {
+        apply_policy_profile(app, profile);
+        emit_command_output(
+            app,
+            format!(
+                "Policy profile switched to `{}`.\nPreset={} Mode={} Sandbox={}",
+                profile.name, profile.preset, profile.mode, profile.sandbox
+            ),
+        );
+        return Ok(CommandResult::Handled);
+    }
+
+    emit_command_output(app, "Usage: /policy [status|list|strict|standard|dev]");
     Ok(CommandResult::Handled)
 }
 
@@ -5818,10 +6209,19 @@ fn background_status_rows() -> Vec<String> {
 fn handle_agents_command(app: &mut App) -> Result<CommandResult, AgentError> {
     let rows = background_status_rows();
     if rows.is_empty() {
-        emit_command_output(app, "No background jobs found.");
+        emit_command_output(
+            app,
+            "No background jobs found.\nAudit/repair queue manifests with `python3 scripts/audit_background_queue.py [--repair]`.",
+        );
     } else {
         let joined = rows.into_iter().take(20).collect::<Vec<_>>().join("\n");
-        emit_command_output(app, format!("Background jobs:\n{}", joined));
+        emit_command_output(
+            app,
+            format!(
+                "Background jobs:\n{}\n\nQueue audit: `python3 scripts/audit_background_queue.py`",
+                joined
+            ),
+        );
     }
     Ok(CommandResult::Handled)
 }
@@ -11329,10 +11729,69 @@ install_command: "uv pip install -r requirements.txt"
     }
 
     #[test]
+    fn unmet_model_requirements_lists_missing_constraints() {
+        let requirements = ModelCapabilityRequirements {
+            require_tools: true,
+            require_vision: true,
+            require_reasoning: true,
+            require_long_context: false,
+            min_context_window: Some(256_000),
+        };
+        let caps = ResolvedModelCapabilities {
+            supports_tools: true,
+            supports_vision: false,
+            supports_reasoning: false,
+            context_window: 128_000,
+        };
+        let missing = unmet_model_requirements(caps, requirements);
+        assert!(missing.iter().any(|m| m == "vision"));
+        assert!(missing.iter().any(|m| m == "reasoning"));
+        assert!(missing
+            .iter()
+            .any(|m| m.contains("context>=256000 (actual=128000)")));
+    }
+
+    #[test]
     fn parse_model_command_args_rejects_unknown_capability() {
         let err = parse_model_command_args(&["--cap", "telepathy"]).expect_err("expected error");
         let message = err.to_string().to_ascii_lowercase();
         assert!(message.contains("unknown model capability"));
+    }
+
+    #[test]
+    fn policy_profile_resolution_accepts_primary_aliases() {
+        assert_eq!(
+            resolve_policy_profile("strict").map(|p| p.name),
+            Some("strict")
+        );
+        assert_eq!(
+            resolve_policy_profile("standard").map(|p| p.name),
+            Some("standard")
+        );
+        assert_eq!(
+            resolve_policy_profile("balanced").map(|p| p.name),
+            Some("standard")
+        );
+        assert_eq!(resolve_policy_profile("dev").map(|p| p.name), Some("dev"));
+        assert!(resolve_policy_profile("unknown").is_none());
+    }
+
+    #[test]
+    fn replay_trace_integrity_detects_hash_break() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"seq":1,"event":"user","prev_hash":"seed","event_hash":"h1","payload":{"turn":1}}
+{"seq":2,"event":"assistant","prev_hash":"BROKEN","event_hash":"h2","payload":{"turn":1}}
+"#,
+        )
+        .expect("write replay");
+        let (entries, parse_errors, chain_breaks) =
+            replay_trace_integrity(&path).expect("integrity");
+        assert_eq!(entries, 2);
+        assert_eq!(parse_errors, 0);
+        assert_eq!(chain_breaks, 1);
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -1165,6 +1165,8 @@ pub fn render(frame: &mut Frame, app: &App, state: &mut TuiState, theme: &Theme)
 
 fn should_render_completions_popup(state: &TuiState) -> bool {
     state.mode != InputMode::Normal
+        && !state.processing
+        && state.modal.is_none()
         && state.input.starts_with('/')
         && !state.input.contains('\n')
         && !state.history_search_active
@@ -3317,6 +3319,29 @@ mod tests {
         state.refresh_completions();
         assert!(!should_render_completions_popup(&state));
         assert!(state.completions.is_empty());
+    }
+
+    #[test]
+    fn test_completion_popup_hidden_when_modal_or_processing_active() {
+        let mut state = TuiState::default();
+        state.input = "/model".to_string();
+        state.update_completions();
+        assert!(should_render_completions_popup(&state));
+
+        state.processing = true;
+        assert!(!should_render_completions_popup(&state));
+        state.processing = false;
+
+        state.modal = Some(PickerModal::new(
+            PickerKind::Personality,
+            "personality",
+            vec![PickerItem {
+                label: "default".to_string(),
+                detail: String::new(),
+                value: "default".to_string(),
+            }],
+        ));
+        assert!(!should_render_completions_popup(&state));
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/tts.rs
+++ b/crates/hermes-tools/src/backends/tts.rs
@@ -236,25 +236,19 @@ impl MultiTtsBackend {
         }
 
         let mut child = cmd.spawn().map_err(|e| {
-            ToolError::ExecutionFailed(format!(
-                "Failed to start piper binary '{}': {}",
-                binary, e
-            ))
+            ToolError::ExecutionFailed(format!("Failed to start piper binary '{}': {}", binary, e))
         })?;
 
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(text.as_bytes())
-                .await
-                .map_err(|e| ToolError::ExecutionFailed(format!("Failed writing to piper stdin: {}", e)))?;
-            stdin
-                .write_all(b"\n")
-                .await
-                .map_err(|e| ToolError::ExecutionFailed(format!("Failed finalizing piper stdin: {}", e)))?;
-            stdin
-                .shutdown()
-                .await
-                .map_err(|e| ToolError::ExecutionFailed(format!("Failed closing piper stdin: {}", e)))?;
+            stdin.write_all(text.as_bytes()).await.map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed writing to piper stdin: {}", e))
+            })?;
+            stdin.write_all(b"\n").await.map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed finalizing piper stdin: {}", e))
+            })?;
+            stdin.shutdown().await.map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed closing piper stdin: {}", e))
+            })?;
         }
 
         let output = child

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -35,8 +35,16 @@ fork-specific history.
   - Runs zero-copy policy hot-path benchmark test and captures ns/eval evidence
   - Emits JSON diagnostics under `.sync-reports/zero-copy-hotpath-<timestamp>.json`
 - `scripts/run-elite-sync-gate.py`
-  - Runs red-team + adapter chaos + zero-copy hot-path + differential parity + eval trend as one gate
+  - Runs red-team + adapter chaos + zero-copy hot-path + differential parity + eval trend + security gate v2 + performance autopilot as one gate
   - Emits JSON diagnostics under `.sync-reports/elite-sync-gate-<timestamp>.json`
+- `scripts/run-security-release-gate-v2.py`
+  - Runs release-time secret scan, SBOM generation (`cargo metadata`), provenance signature tests, and redaction regression tests
+  - Emits JSON diagnostics under `.sync-reports/security-release-gate-v2-<timestamp>.json`
+- `scripts/run-performance-autopilot.py`
+  - Runs hot-path + eval trend checks and emits deterministic tuning recommendations (`json` + `markdown`)
+- `scripts/audit_background_queue.py`
+  - Audits background job manifests for malformed JSON, stale running jobs, and duplicate active tasks
+  - Optional repair mode: `--repair`
 - `scripts/run-differential-parity-gate.py`
   - Compares local CLI command/action surface with `upstream/main`
   - Emits gate artifact under `.sync-reports/differential-parity-gate-<timestamp>.json`
@@ -47,7 +55,7 @@ fork-specific history.
   - Runs a unified intelligence loop across golden parity + eval trend + elite sync gates
   - Emits recommendations and intelligence index under `.sync-reports/self-evolution-loop-<timestamp>.json`
 - `scripts/run-nightly-elite-gate.sh`
-  - Nightly local validation gate (`cargo test -p hermes-cli` + deterministic replay suite)
+  - Nightly local validation gate (`cargo test -p hermes-cli` + deterministic replay + security gate v2 + performance autopilot + queue audit)
   - Auto-publishes run summary via `contextlattice -> github -> local` sink chain
 - `scripts/publish_automation_summary.py`
   - Publishes automation summaries with sink priority:

--- a/scripts/audit_background_queue.py
+++ b/scripts/audit_background_queue.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Audit and optionally repair Hermes background job queue manifests."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+ACTIVE_STATUSES = {"queued", "running"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--home", default="", help="Hermes home directory override")
+    parser.add_argument(
+        "--stale-running-seconds",
+        type=int,
+        default=1800,
+        help="Mark running jobs older than this threshold as stale",
+    )
+    parser.add_argument("--repair", action="store_true", help="Apply safe repairs")
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Optional report output path (defaults to .sync-reports/background-queue-audit-*.json)",
+    )
+    parser.add_argument("--json", action="store_true", help="Print report JSON")
+    return parser.parse_args()
+
+
+def resolve_home(args: argparse.Namespace) -> pathlib.Path:
+    if args.home:
+        return pathlib.Path(args.home).expanduser().resolve()
+    env_home = (pathlib.Path.home() / ".hermes-agent-ultra").resolve()
+    return env_home
+
+
+def parse_time(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def job_key(task: str) -> str:
+    return hashlib.sha256(task.strip().encode("utf-8")).hexdigest()[:16]
+
+
+def load_job(path: pathlib.Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return None, f"read_error: {exc}"
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            return None, "not_an_object"
+        return parsed, None
+    except Exception as exc:
+        return None, f"json_error: {exc}"
+
+
+def write_job(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def default_report_path(repo_root: pathlib.Path) -> pathlib.Path:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return repo_root / ".sync-reports" / f"background-queue-audit-{stamp}.json"
+
+
+def main() -> int:
+    args = parse_args()
+    home = resolve_home(args)
+    jobs_dir = home / "background_jobs"
+    repo_root = pathlib.Path.cwd()
+
+    findings: dict[str, Any] = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "home": str(home),
+        "jobs_dir": str(jobs_dir),
+        "repair": args.repair,
+        "totals": {
+            "files": 0,
+            "malformed": 0,
+            "stale_running": 0,
+            "duplicate_active": 0,
+            "repaired": 0,
+        },
+        "malformed": [],
+        "stale_running": [],
+        "duplicate_active": [],
+    }
+
+    if not jobs_dir.exists():
+        findings["note"] = "jobs directory not found"
+        findings["ok"] = True
+    else:
+        now = dt.datetime.now(dt.timezone.utc)
+        active_by_task: dict[str, list[tuple[pathlib.Path, dict[str, Any]]]] = {}
+        for path in sorted(jobs_dir.glob("*.json")):
+            findings["totals"]["files"] += 1
+            payload, err = load_job(path)
+            if err:
+                findings["totals"]["malformed"] += 1
+                findings["malformed"].append({"path": str(path), "error": err})
+                continue
+
+            status = str(payload.get("status", "")).strip().lower()
+            task = str(payload.get("task", "")).strip()
+            started_at = parse_time(payload.get("started_at"))
+
+            if status == "running" and started_at is not None:
+                age = (now - started_at).total_seconds()
+                if age > args.stale_running_seconds:
+                    findings["totals"]["stale_running"] += 1
+                    entry = {
+                        "path": str(path),
+                        "status": status,
+                        "age_seconds": int(age),
+                    }
+                    findings["stale_running"].append(entry)
+                    if args.repair:
+                        payload["status"] = "failed"
+                        payload["finished_at"] = now.isoformat()
+                        payload["error"] = f"queue_audit_repair: stale running job (> {args.stale_running_seconds}s)"
+                        write_job(path, payload)
+                        findings["totals"]["repaired"] += 1
+
+            if status in ACTIVE_STATUSES and task:
+                active_by_task.setdefault(job_key(task), []).append((path, payload))
+
+        for key, rows in active_by_task.items():
+            if len(rows) <= 1:
+                continue
+            rows.sort(key=lambda item: str(item[1].get("created_at", "")))
+            keep_path, _ = rows[0]
+            dup_paths = [str(path) for path, _ in rows[1:]]
+            findings["totals"]["duplicate_active"] += len(dup_paths)
+            findings["duplicate_active"].append(
+                {
+                    "task_key": key,
+                    "keep": str(keep_path),
+                    "duplicates": dup_paths,
+                }
+            )
+            if args.repair:
+                for dup_path, dup_payload in rows[1:]:
+                    dup_payload["status"] = "failed"
+                    dup_payload["finished_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+                    dup_payload["error"] = f"queue_audit_repair: duplicate active task of {keep_path.name}"
+                    write_job(dup_path, dup_payload)
+                    findings["totals"]["repaired"] += 1
+
+        findings["ok"] = (
+            findings["totals"]["malformed"] == 0
+            and findings["totals"]["stale_running"] == 0
+            and findings["totals"]["duplicate_active"] == 0
+        )
+
+    report_path = pathlib.Path(args.report).expanduser().resolve() if args.report else default_report_path(repo_root)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(findings, indent=2) + "\n", encoding="utf-8")
+    findings["report_path"] = str(report_path)
+
+    if args.json:
+        print(json.dumps(findings, indent=2))
+    else:
+        print(
+            "[background-queue-audit] "
+            f"{'PASS' if findings.get('ok') else 'WARN'} "
+            f"files={findings['totals']['files']} malformed={findings['totals']['malformed']} "
+            f"stale={findings['totals']['stale_running']} duplicates={findings['totals']['duplicate_active']} "
+            f"repaired={findings['totals']['repaired']}"
+        )
+        print(f"[background-queue-audit] Report: {report_path}")
+
+    return 0 if findings.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-elite-sync-gate.py
+++ b/scripts/run-elite-sync-gate.py
@@ -45,8 +45,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--release-security-cmd",
-        default="python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan.json",
+        default="python3 scripts/run-security-release-gate-v2.py --repo-root . --report .sync-reports/security-release-gate-v2.json",
         help="Release secret-scan gate command",
+    )
+    parser.add_argument(
+        "--performance-autopilot-cmd",
+        default="python3 scripts/run-performance-autopilot.py --repo-root . --strict",
+        help="Performance autopilot command",
     )
     parser.add_argument(
         "--chaos-baseline",
@@ -138,6 +143,7 @@ def main() -> int:
     parity_raw = run_shell(args.parity_diff_cmd, repo_root)
     eval_raw = run_shell(args.eval_trend_cmd, repo_root)
     release_security_raw = run_shell(args.release_security_cmd, repo_root)
+    perf_autopilot_raw = run_shell(args.performance_autopilot_cmd, repo_root)
 
     redteam = slim(redteam_raw)
     chaos = slim(chaos_raw)
@@ -145,6 +151,7 @@ def main() -> int:
     parity = slim(parity_raw)
     eval_trend = slim(eval_raw)
     release_security = slim(release_security_raw)
+    perf_autopilot = slim(perf_autopilot_raw)
     sections: dict[str, Any] = {
         "redteam": redteam,
         "chaos": chaos,
@@ -152,6 +159,7 @@ def main() -> int:
         "parity_differential": parity,
         "eval_trend": eval_trend,
         "release_security": release_security,
+        "performance_autopilot": perf_autopilot,
     }
 
     compare: dict[str, Any] | None = None

--- a/scripts/run-golden-parity-harness.py
+++ b/scripts/run-golden-parity-harness.py
@@ -19,10 +19,17 @@ TITLE_PREFIX = "[Parity] Golden Harness Drift"
 
 REQUIRED_TUI_TESTS = [
     "test_completion_popup_hidden_when_slash_deleted",
+    "test_completion_popup_hidden_when_modal_or_processing_active",
     "test_transcript_hides_system_messages",
     "test_stream_handle",
     "test_is_ctrl_c_detection",
 ]
+
+REQUIRED_COMMAND_CONTRACTS = {
+    "/model": ["capability", "explain"],
+    "/raw": ["trace", "deterministic"],
+    "/policy": ["profile"],
+}
 
 
 @dataclass
@@ -33,6 +40,7 @@ class HarnessReport:
     missing_commands: list[str]
     extra_commands: list[str]
     missing_tui_tests: list[str]
+    command_contract_failures: list[str]
     allow_missing_commands: int
     ok: bool
 
@@ -44,6 +52,7 @@ class HarnessReport:
             "missing_commands": self.missing_commands,
             "extra_commands": self.extra_commands,
             "missing_tui_tests": self.missing_tui_tests,
+            "command_contract_failures": self.command_contract_failures,
             "allow_missing_commands": self.allow_missing_commands,
             "ok": self.ok,
         }
@@ -87,6 +96,12 @@ def parse_local_slash_commands(commands_rs: pathlib.Path) -> set[str]:
     return {m.strip() for m in matches if m.strip().startswith("/")}
 
 
+def parse_local_command_descriptions(commands_rs: pathlib.Path) -> dict[str, str]:
+    raw = commands_rs.read_text(encoding="utf-8")
+    pairs = re.findall(r'\(\s*"(/[^"]+)"\s*,\s*"([^"]*)"\s*,?\s*\)', raw)
+    return {cmd.strip(): desc.strip() for cmd, desc in pairs if cmd.strip().startswith("/")}
+
+
 def parse_upstream_slash_commands(upstream_root: pathlib.Path) -> set[str]:
     sys.path.insert(0, str(upstream_root))
     try:
@@ -121,14 +136,29 @@ def load_allow_missing(args: argparse.Namespace, repo_root: pathlib.Path) -> int
 
 
 def build_report(repo_root: pathlib.Path, upstream_root: pathlib.Path, allow_missing: int) -> HarnessReport:
-    local = parse_local_slash_commands(repo_root / "crates/hermes-cli/src/commands.rs")
+    commands_rs = repo_root / "crates/hermes-cli/src/commands.rs"
+    local = parse_local_slash_commands(commands_rs)
+    local_desc = parse_local_command_descriptions(commands_rs)
     upstream = parse_upstream_slash_commands(upstream_root)
     missing = sorted(upstream - local)
     extra = sorted(local - upstream)
+    contract_failures: list[str] = []
+    for command, required_terms in REQUIRED_COMMAND_CONTRACTS.items():
+        desc = local_desc.get(command, "")
+        desc_lc = desc.lower()
+        missing_terms = [term for term in required_terms if term.lower() not in desc_lc]
+        if missing_terms:
+            contract_failures.append(
+                f"{command}: description missing required terms {missing_terms!r}"
+            )
 
     tui_tests = parse_tui_tests(repo_root / "crates/hermes-cli/src/tui.rs")
     missing_tui_tests = [name for name in REQUIRED_TUI_TESTS if name not in tui_tests]
-    ok = len(missing) <= allow_missing and not missing_tui_tests
+    ok = (
+        len(missing) <= allow_missing
+        and not missing_tui_tests
+        and not contract_failures
+    )
     return HarnessReport(
         generated_at=dt.datetime.now(dt.timezone.utc).isoformat(),
         repo_root=str(repo_root),
@@ -136,6 +166,7 @@ def build_report(repo_root: pathlib.Path, upstream_root: pathlib.Path, allow_mis
         missing_commands=missing,
         extra_commands=extra,
         missing_tui_tests=missing_tui_tests,
+        command_contract_failures=contract_failures,
         allow_missing_commands=allow_missing,
         ok=ok,
     )
@@ -179,6 +210,7 @@ def maybe_open_issue(repo_root: pathlib.Path, report: HarnessReport) -> None:
         "",
         f"- Missing upstream commands: `{len(report.missing_commands)}`",
         f"- Missing required TUI tests: `{len(report.missing_tui_tests)}`",
+        f"- Command contract failures: `{len(report.command_contract_failures)}`",
         "",
     ]
     if report.missing_commands:
@@ -188,6 +220,10 @@ def maybe_open_issue(repo_root: pathlib.Path, report: HarnessReport) -> None:
     if report.missing_tui_tests:
         summary_lines.append("Missing TUI tests:")
         summary_lines.extend([f"- `{name}`" for name in report.missing_tui_tests])
+        summary_lines.append("")
+    if report.command_contract_failures:
+        summary_lines.append("Command contract failures:")
+        summary_lines.extend([f"- {line}" for line in report.command_contract_failures[:50]])
         summary_lines.append("")
     body = "\n".join(summary_lines).strip()
 
@@ -248,7 +284,9 @@ def main() -> int:
         "[golden-parity] "
         f"{'PASSED' if report.ok else 'FAILED'} "
         f"(missing={len(report.missing_commands)} extra={len(report.extra_commands)} "
-        f"missing_tui_tests={len(report.missing_tui_tests)} allow_missing={allow_missing})"
+        f"missing_tui_tests={len(report.missing_tui_tests)} "
+        f"contract_failures={len(report.command_contract_failures)} "
+        f"allow_missing={allow_missing})"
     )
     print(f"[golden-parity] Report: {report_path}")
 

--- a/scripts/run-nightly-elite-gate.sh
+++ b/scripts/run-nightly-elite-gate.sh
@@ -107,6 +107,18 @@ run_gate() {
   echo "[elite-gate] running deterministic replay suite"
   "${REPO_ROOT}/scripts/run-deterministic-replay-suite.sh" || return $?
 
+  FAILED_STEP="security_release_gate_v2"
+  echo "[elite-gate] running security release gate v2"
+  python3 "${REPO_ROOT}/scripts/run-security-release-gate-v2.py" --repo-root "${REPO_ROOT}" || return $?
+
+  FAILED_STEP="performance_autopilot"
+  echo "[elite-gate] running performance autopilot"
+  python3 "${REPO_ROOT}/scripts/run-performance-autopilot.py" --repo-root "${REPO_ROOT}" || return $?
+
+  FAILED_STEP="background_queue_audit"
+  echo "[elite-gate] auditing background queue health"
+  python3 "${REPO_ROOT}/scripts/audit_background_queue.py" || return $?
+
   FAILED_STEP="write_summary"
   local head_sha
   head_sha="$(git rev-parse HEAD)"
@@ -119,7 +131,10 @@ run_gate() {
   "log_path": "${LOG_PATH}",
   "checks": [
     "cargo test -p hermes-cli",
-    "scripts/run-deterministic-replay-suite.sh"
+    "scripts/run-deterministic-replay-suite.sh",
+    "scripts/run-security-release-gate-v2.py",
+    "scripts/run-performance-autopilot.py",
+    "scripts/audit_background_queue.py"
   ]
 }
 EOF
@@ -148,7 +163,10 @@ if [[ "${RUN_RC}" -ne 0 ]]; then
   "exit_code": ${RUN_RC},
   "checks": [
     "cargo test -p hermes-cli",
-    "scripts/run-deterministic-replay-suite.sh"
+    "scripts/run-deterministic-replay-suite.sh",
+    "scripts/run-security-release-gate-v2.py",
+    "scripts/run-performance-autopilot.py",
+    "scripts/audit_background_queue.py"
   ]
 }
 EOF
@@ -164,6 +182,9 @@ Nightly elite gate completed.
 - checks:
   - \`cargo test -p hermes-cli\`
   - \`scripts/run-deterministic-replay-suite.sh\`
+  - \`scripts/run-security-release-gate-v2.py\`
+  - \`scripts/run-performance-autopilot.py\`
+  - \`scripts/audit_background_queue.py\`
 EOF
 
 cat > "${SUMMARY_META_PATH}" <<EOF
@@ -175,7 +196,10 @@ cat > "${SUMMARY_META_PATH}" <<EOF
   "failed_step": "${FAILED_STEP}",
   "checks": [
     "cargo test -p hermes-cli",
-    "scripts/run-deterministic-replay-suite.sh"
+    "scripts/run-deterministic-replay-suite.sh",
+    "scripts/run-security-release-gate-v2.py",
+    "scripts/run-performance-autopilot.py",
+    "scripts/audit_background_queue.py"
   ]
 }
 EOF

--- a/scripts/run-performance-autopilot.py
+++ b/scripts/run-performance-autopilot.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Run performance autopilot checks and emit actionable tuning recommendations."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument(
+        "--hotpath-cmd",
+        default="python3 scripts/run-zero-copy-hotpath-bench.py",
+        help="Hot-path benchmark command",
+    )
+    parser.add_argument(
+        "--eval-cmd",
+        default="python3 scripts/run-eval-trend-gate.py --allow-missing-baseline",
+        help="Eval trend command",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional JSON report path",
+    )
+    parser.add_argument(
+        "--output-md",
+        default="",
+        help="Optional markdown report path",
+    )
+    parser.add_argument(
+        "--apply-env",
+        default="",
+        help="Optional env file path to write recommended knobs",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when checks fail (default: advisory mode, always exits 0)",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON report")
+    return parser.parse_args()
+
+
+def run_shell(command: str, cwd: pathlib.Path) -> dict[str, Any]:
+    started = dt.datetime.now(dt.timezone.utc)
+    proc = subprocess.run(
+        ["bash", "-lc", command],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    finished = dt.datetime.now(dt.timezone.utc)
+    return {
+        "command": command,
+        "exit_code": proc.returncode,
+        "ok": proc.returncode == 0,
+        "started_at": started.isoformat(),
+        "finished_at": finished.isoformat(),
+        "duration_ms": int((finished - started).total_seconds() * 1000),
+        "stdout_tail": proc.stdout[-6000:],
+        "stderr_tail": proc.stderr[-6000:],
+    }
+
+
+def parse_hotpath_ns(stdout: str) -> int | None:
+    needle = "tool_policy_hot_path_ns_per_eval="
+    idx = stdout.rfind(needle)
+    if idx < 0:
+        return None
+    value = stdout[idx + len(needle):].splitlines()[0].strip()
+    if not value.isdigit():
+        return None
+    return int(value)
+
+
+def build_recommendations(hotpath: dict[str, Any], eval_gate: dict[str, Any]) -> list[dict[str, str]]:
+    recs: list[dict[str, str]] = []
+    ns = parse_hotpath_ns((hotpath.get("stdout_tail") or "") + "\n" + (hotpath.get("stderr_tail") or ""))
+
+    if not hotpath.get("ok"):
+        recs.append(
+            {
+                "id": "HOTPATH_FAIL",
+                "severity": "P0",
+                "title": "Hot-path benchmark failed",
+                "recommendation": "Run `cargo test -p hermes-tools tool_policy_hot_path_benchmark_report -- --nocapture` and resolve regressions before release.",
+            }
+        )
+    elif ns is not None and ns > 12000:
+        recs.append(
+            {
+                "id": "HOTPATH_SLOW",
+                "severity": "P1",
+                "title": "Tool policy hot-path latency above target",
+                "recommendation": "Keep `HERMES_TOOL_POLICY_PRESET=standard`, review deny-pattern complexity, and rerun zero-copy bench.",
+            }
+        )
+
+    if not eval_gate.get("ok"):
+        recs.append(
+            {
+                "id": "EVAL_TREND_FAIL",
+                "severity": "P0",
+                "title": "Eval trend gate failed",
+                "recommendation": "Run `python3 scripts/run-self-evolution-loop.py --json` and address top recommendation before promotion.",
+            }
+        )
+
+    if not recs:
+        recs.append(
+            {
+                "id": "PERF_STABLE",
+                "severity": "P3",
+                "title": "Performance checks stable",
+                "recommendation": "No immediate tuning required. Keep nightly elite gate cadence.",
+            }
+        )
+
+    return recs
+
+
+def default_paths(repo_root: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_dir = repo_root / ".sync-reports"
+    return (
+        out_dir / f"performance-autopilot-{stamp}.json",
+        out_dir / f"performance-autopilot-{stamp}.md",
+    )
+
+
+def write_markdown(path: pathlib.Path, report: dict[str, Any]) -> None:
+    lines = [
+        "# Performance Autopilot Report",
+        "",
+        f"- generated_at: `{report['generated_at']}`",
+        f"- ok: `{report['ok']}`",
+        "",
+        "## Sections",
+    ]
+    for name, section in report["sections"].items():
+        lines.append(
+            f"- `{name}`: {'PASS' if section.get('ok') else 'FAIL'} (exit={section.get('exit_code')})"
+        )
+    lines.extend(["", "## Recommendations"])
+    for rec in report["recommendations"]:
+        lines.append(
+            f"- **{rec['id']} ({rec['severity']})**: {rec['title']} — {rec['recommendation']}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
+
+
+def write_env(path: pathlib.Path, report: dict[str, Any]) -> None:
+    rec_ids = {rec["id"] for rec in report["recommendations"]}
+    lines = [f"# generated_at={report['generated_at']}"]
+    if "HOTPATH_SLOW" in rec_ids:
+        lines.extend(
+            [
+                "HERMES_TOOL_POLICY_PRESET=standard",
+                "HERMES_TOOL_POLICY_MODE=enforce",
+                "HERMES_MODEL_CATALOG_GUARD=1",
+            ]
+        )
+    if "EVAL_TREND_FAIL" in rec_ids:
+        lines.extend(
+            [
+                "HERMES_MODEL_AUTO_REMEDIATE=1",
+                "HERMES_REPLAY_ENABLED=1",
+            ]
+        )
+    if rec_ids == {"PERF_STABLE"}:
+        lines.append("HERMES_PERF_AUTOPILOT_STATUS=stable")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = pathlib.Path(args.repo_root).expanduser().resolve()
+    if not repo_root.exists():
+        raise SystemExit(f"repo root does not exist: {repo_root}")
+
+    default_json, default_md = default_paths(repo_root)
+    output_json = pathlib.Path(args.output_json).expanduser().resolve() if args.output_json else default_json
+    output_md = pathlib.Path(args.output_md).expanduser().resolve() if args.output_md else default_md
+
+    hotpath = run_shell(args.hotpath_cmd, repo_root)
+    eval_gate = run_shell(args.eval_cmd, repo_root)
+    recommendations = build_recommendations(hotpath, eval_gate)
+    ok = all(section.get("ok") for section in [hotpath, eval_gate])
+
+    report = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "repo_root": str(repo_root),
+        "ok": ok,
+        "sections": {
+            "hotpath": hotpath,
+            "eval_trend": eval_gate,
+        },
+        "recommendations": recommendations,
+        "report_json": str(output_json),
+        "report_markdown": str(output_md),
+    }
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    write_markdown(output_md, report)
+
+    if args.apply_env:
+        env_path = pathlib.Path(args.apply_env).expanduser().resolve()
+        write_env(env_path, report)
+        report["applied_env"] = str(env_path)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        status = "PASSED" if ok else "FAILED"
+        print(f"[performance-autopilot] {status}")
+        print(f"[performance-autopilot] JSON: {output_json}")
+        print(f"[performance-autopilot] Markdown: {output_md}")
+        if args.apply_env:
+            print(f"[performance-autopilot] Env recommendations: {report['applied_env']}")
+
+    if args.strict and not ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-security-release-gate-v2.py
+++ b/scripts/run-security-release-gate-v2.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Run release security gate v2: secret scan + SBOM + signature/redaction tests."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import shlex
+import subprocess
+import sys
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument(
+        "--secret-scan-cmd",
+        default="python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan.json",
+        help="Secret scan command",
+    )
+    parser.add_argument(
+        "--signature-tests-cmd",
+        default="cargo test -p hermes-cli provenance_verify_detects_ -- --nocapture",
+        help="Signature verification regression tests",
+    )
+    parser.add_argument(
+        "--redaction-tests-cmd",
+        default="cargo test -p hermes-gateway test_redact_pii -- --nocapture",
+        help="Redaction regression tests",
+    )
+    parser.add_argument(
+        "--sbom-output",
+        default=".sync-reports/release-sbom-metadata.json",
+        help="SBOM output path",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Gate report output path (defaults to .sync-reports/security-release-gate-v2-*.json)",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON report")
+    return parser.parse_args()
+
+
+def run_shell(command: str, cwd: pathlib.Path) -> dict[str, Any]:
+    started = dt.datetime.now(dt.timezone.utc)
+    proc = subprocess.run(
+        ["bash", "-lc", command],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    finished = dt.datetime.now(dt.timezone.utc)
+    return {
+        "command": command,
+        "exit_code": proc.returncode,
+        "ok": proc.returncode == 0,
+        "started_at": started.isoformat(),
+        "finished_at": finished.isoformat(),
+        "duration_ms": int((finished - started).total_seconds() * 1000),
+        "stdout_tail": proc.stdout[-6000:],
+        "stderr_tail": proc.stderr[-6000:],
+    }
+
+
+def default_report_path(repo_root: pathlib.Path) -> pathlib.Path:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return repo_root / ".sync-reports" / f"security-release-gate-v2-{stamp}.json"
+
+
+def generate_sbom(repo_root: pathlib.Path, output: pathlib.Path) -> dict[str, Any]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--locked"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    result: dict[str, Any] = {
+        "command": "cargo metadata --format-version 1 --locked",
+        "exit_code": proc.returncode,
+        "ok": proc.returncode == 0,
+        "output": str(output),
+        "stdout_tail": proc.stdout[-6000:],
+        "stderr_tail": proc.stderr[-6000:],
+    }
+    if proc.returncode != 0:
+        return result
+
+    try:
+        metadata = json.loads(proc.stdout)
+    except Exception as exc:
+        result["ok"] = False
+        result["error"] = f"failed to parse cargo metadata json: {exc}"
+        return result
+
+    packages = metadata.get("packages") or []
+    workspace_members = metadata.get("workspace_members") or []
+    nodes = (metadata.get("resolve") or {}).get("nodes") or []
+
+    summary = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "format": "cargo-metadata-v1",
+        "package_count": len(packages),
+        "workspace_member_count": len(workspace_members),
+        "resolve_node_count": len(nodes),
+        "packages": [
+            {
+                "name": pkg.get("name"),
+                "version": pkg.get("version"),
+                "id": pkg.get("id"),
+                "license": pkg.get("license"),
+                "repository": pkg.get("repository"),
+            }
+            for pkg in packages
+        ],
+    }
+    output.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    result["package_count"] = len(packages)
+    result["workspace_member_count"] = len(workspace_members)
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = pathlib.Path(args.repo_root).expanduser().resolve()
+    if not repo_root.exists():
+        raise SystemExit(f"repo root does not exist: {repo_root}")
+
+    sbom_output = pathlib.Path(args.sbom_output)
+    if not sbom_output.is_absolute():
+        sbom_output = repo_root / sbom_output
+
+    sections = {
+        "secret_scan": run_shell(args.secret_scan_cmd, repo_root),
+        "sbom": generate_sbom(repo_root, sbom_output),
+        "signature_tests": run_shell(args.signature_tests_cmd, repo_root),
+        "redaction_tests": run_shell(args.redaction_tests_cmd, repo_root),
+    }
+
+    ok = all(bool(section.get("ok")) for section in sections.values())
+    report_path = pathlib.Path(args.report).expanduser().resolve() if args.report else default_report_path(repo_root)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "repo_root": str(repo_root),
+        "ok": ok,
+        "summary": {
+            "passed_sections": sum(1 for s in sections.values() if s.get("ok")),
+            "failed_sections": sum(1 for s in sections.values() if not s.get("ok")),
+            "total_sections": len(sections),
+        },
+        "sections": sections,
+        "report_path": str(report_path),
+    }
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        status = "PASSED" if ok else "FAILED"
+        print(
+            f"[security-release-gate-v2] {status} "
+            f"(passed={report['summary']['passed_sections']}/{report['summary']['total_sections']})"
+        )
+        print(f"[security-release-gate-v2] SBOM: {sbom_output}")
+        print(f"[security-release-gate-v2] Report: {report_path}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- implement INTEL-01..08 tranche end-to-end
- add `/model explain|why-not`, `/raw trace verify|export`, and runtime `/policy` profile packs
- harden TUI completion popup render boundaries under modal/processing states
- add security release gate v2, performance autopilot runner, and background queue audit/repair utility
- wire new gates into elite sync and nightly elite gate flows
- expand golden parity harness with command-behavior contracts

## Validation
- `cargo test -p hermes-cli`
- `python3 -m py_compile scripts/run-golden-parity-harness.py scripts/run-security-release-gate-v2.py scripts/run-performance-autopilot.py scripts/audit_background_queue.py scripts/run-elite-sync-gate.py`
- `python3 scripts/run-golden-parity-harness.py --repo-root . --allow-missing 4`
- `python3 scripts/run-security-release-gate-v2.py --json`
- `python3 scripts/audit_background_queue.py --json`
- `python3 scripts/run-performance-autopilot.py --repo-root .`

Closes #150
Closes #151
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156
Closes #157
Closes #149
