### PR TITLE
Parity catch-up: refresh queue/proof after upstream sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ Ultra uses controlled sync workflows, not blind merges.
 - `origin/main` at sync: `1861c5dcfb8cad8dcddb5f15c1a5a8c34c7f1ce2`
 - `upstream/main` at sync: `95f395027f72c69f06bddcecb08da53cfd10c440`
 - Pending commits captured in report: `1512`
-- Queue summary (`docs/parity/upstream-missing-queue.json`): pending `0`, ported `63`, superseded `1386`
+- Queue summary (`docs/parity/upstream-missing-queue.json`): pending `0`, ported `63`, superseded `1387`
 - Parity gates (`docs/parity/global-parity-proof.json`): release `pass`, ci `pass`
-- Workstream snapshot (`docs/parity/workstream-status.json`): `upstream/main` @ `a11aed1accc735ae0d7af80d626b33870d4b696c` (generated `2026-05-04T00:57:58-06:00`)
+- Workstream snapshot (`docs/parity/workstream-status.json`): `upstream/main` @ `8163d371922768c32f43eb6036d7d36e56775605` (generated `2026-05-04T01:23:44-06:00`)
 <!-- END:ULTRA_SYNC_STATUS -->
 
 Note: this repository intentionally tracks parity via queue/gate workflows because upstream and ultra history can diverge materially.

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-05-04T07:11:26.800104+00:00`_
+_Generated from source artifacts: `2026-05-04T07:38:03.927552+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `a11aed1accc735ae0d7af80d626b33870d4b696c`
-- Workstream snapshot generated: `2026-05-04T00:57:58-06:00`
+- Upstream target: `upstream/main` @ `8163d371922768c32f43eb6036d7d36e56775605`
+- Workstream snapshot generated: `2026-05-04T01:23:44-06:00`
 - Parity matrix generated: `2026-05-04T05:34:34.417292+00:00`
-- Queue snapshot generated: `2026-05-04T07:11:26.307978+00:00`
-- Proof snapshot generated: `2026-05-04T07:11:26.800104+00:00`
+- Queue snapshot generated: `2026-05-04T07:38:03.627513+00:00`
+- Proof snapshot generated: `2026-05-04T07:38:03.927552+00:00`
 
 ## Gate Status
 
@@ -21,10 +21,10 @@ _Generated from source artifacts: `2026-05-04T07:11:26.800104+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 1449 |
+| Total commits in queue | 1450 |
 | Pending | 0 |
 | Ported | 63 |
-| Superseded | 1386 |
+| Superseded | 1387 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -67,7 +67,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-05-04T07:19:17.288838+00:00",
+  "generated_at_utc": "2026-05-04T07:38:58.240185+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -98,18 +98,18 @@
   "queue_summary": {
     "by_disposition": {
       "ported": 63,
-      "superseded": 1386
+      "superseded": 1387
     },
     "by_target_ticket": {
       "20": 575,
-      "21": 49,
+      "21": 50,
       "22": 335,
       "23": 115,
       "24": 4,
       "25": 16,
       "26": 355
     },
-    "total_commits": 1449
+    "total_commits": 1450
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-04T07:19:17.288838+00:00`
+Generated: `2026-05-04T07:38:58.240185+00:00`
 
 ## Gate Status
 
@@ -38,10 +38,10 @@ Generated: `2026-05-04T07:19:17.288838+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `1449`.
+- Upstream missing commits tracked: `1450`.
 - By target ticket:
   - `#20`: `575`
-  - `#21`: `49`
+  - `#21`: `50`
   - `#22`: `335`
   - `#23`: `115`
   - `#24`: `4`

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -22113,9 +22113,23 @@
       "subject": "fix(cli): local backend CLI always uses launch directory, stops .env sync of TERMINAL_CWD (#19334)",
       "target_ticket": 22,
       "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "disposition": "superseded",
+      "files_sample": [
+        "optional-skills/creative/kanban-video-orchestrator/references/role-archetypes.md",
+        "optional-skills/creative/kanban-video-orchestrator/references/tool-matrix.md"
+      ],
+      "files_touched": 2,
+      "notes": "superseded: upstream optional-skills content doc references are outside Hermes Ultra runtime path; skill/tool parity is owned by Rust command + registry surfaces.",
+      "owner": "codex",
+      "sha": "8163d371922768c32f43eb6036d7d36e56775605",
+      "subject": "fix(skill): reference built-in video_analyze/vision_analyze tools in kanban-video-orchestrator (#19562)",
+      "target_ticket": 21,
+      "target_ticket_name": "GPAR-02 skills parity"
     }
   ],
-  "generated_at_utc": "2026-05-04T07:11:26.307978+00:00",
+  "generated_at_utc": "2026-05-04T07:38:03.627513+00:00",
   "refs": {
     "local_ref": "main",
     "range": "main..upstream/main",
@@ -22124,17 +22138,17 @@
   "summary": {
     "by_disposition": {
       "ported": 63,
-      "superseded": 1386
+      "superseded": 1387
     },
     "by_target_ticket": {
       "20": 575,
-      "21": 49,
+      "21": 50,
       "22": 335,
       "23": 115,
       "24": 4,
       "25": 16,
       "26": 355
     },
-    "total_commits": 1449
+    "total_commits": 1450
   }
 }

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,13 +1,13 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-05-04T07:11:26.307978+00:00`
+Generated: `2026-05-04T07:38:03.627513+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `1449`.
+- Range: `main..upstream/main`; total commits tracked: `1450`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
 | #20 | GPAR-01 tests+CI parity | 575 |
-| #21 | GPAR-02 skills parity | 49 |
+| #21 | GPAR-02 skills parity | 50 |
 | #22 | GPAR-03 UX parity | 335 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 115 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 4 |
@@ -17,7 +17,7 @@ Generated: `2026-05-04T07:11:26.307978+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | ported | 63 |
-| superseded | 1386 |
+| superseded | 1387 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-05-04T00:57:58-06:00",
-  "head_sha": "1d891b4f023d54305923ae32f899b04d9d5d03bf",
+  "generated_at_utc": "2026-05-04T01:23:44-06:00",
+  "head_sha": "db5de03da78453903b679e569742cf15a8f00327",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "a11aed1accc735ae0d7af80d626b33870d4b696c",
+  "upstream_sha": "8163d371922768c32f43eb6036d7d36e56775605",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `1d891b4f023d54305923ae32f899b04d9d5d03bf`
-- Upstream: `upstream/main` (`a11aed1accc735ae0d7af80d626b33870d4b696c`)
+- Local HEAD: `db5de03da78453903b679e569742cf15a8f00327`
+- Upstream: `upstream/main` (`8163d371922768c32f43eb6036d7d36e56775605`)
 
 | Workstream | Title | State |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- fetched upstream/main and regenerated parity queue
- resolved the single new pending item with explicit Rust-first supersede rationale
- refreshed parity artifacts and README sync status

## Validation
- python3 scripts/run-elite-sync-gate.py --repo-root . (pass 7/7)
