### PR TITLE
Fix TUI scroll and tool-output formatting; add tool-loop guard

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -1175,6 +1175,53 @@ fn governor_error_critical_rate() -> f64 {
         .unwrap_or(0.50)
 }
 
+fn governor_tool_loop_guard_enabled() -> bool {
+    std::env::var("HERMES_TOOL_LOOP_GUARD_ENABLED")
+        .map(|v| {
+            !matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "off"
+            )
+        })
+        .unwrap_or(true)
+}
+
+fn governor_tool_loop_guard_max_consecutive_error_turns() -> u32 {
+    std::env::var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(4)
+}
+
+fn governor_tool_loop_guard_min_failed_calls() -> u32 {
+    std::env::var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(1)
+}
+
+fn should_trip_tool_loop_guard(
+    consecutive_error_turns: u32,
+    turn_tool_count: usize,
+    turn_tool_error_count: u32,
+) -> bool {
+    if !governor_tool_loop_guard_enabled() {
+        return false;
+    }
+    if turn_tool_count == 0 {
+        return false;
+    }
+    if turn_tool_error_count < governor_tool_loop_guard_min_failed_calls() {
+        return false;
+    }
+    if turn_tool_error_count != turn_tool_count as u32 {
+        return false;
+    }
+    consecutive_error_turns >= governor_tool_loop_guard_max_consecutive_error_turns()
+}
+
 fn smart_routing_learning_enabled() -> bool {
     std::env::var("HERMES_SMART_ROUTING_LEARNING_ENABLED")
         .ok()
@@ -4303,6 +4350,50 @@ impl AgentLoop {
             if let Some(note) = lsp_note {
                 ctx.add_message(Message::system(note));
             }
+            if should_trip_tool_loop_guard(
+                governor_consecutive_error_turns,
+                tool_calls.len(),
+                turn_tool_error_count,
+            ) {
+                let guard_message = format!(
+                    "Tool-loop guard tripped after {} consecutive error turn(s); latest turn failed {}/{} tool call(s).",
+                    governor_consecutive_error_turns,
+                    turn_tool_error_count,
+                    tool_calls.len()
+                );
+                self.emit_status("lifecycle", &guard_message);
+                replay.record(
+                    "tool_loop_guard",
+                    serde_json::json!({
+                        "turn": total_turns,
+                        "consecutive_error_turns": governor_consecutive_error_turns,
+                        "failed_calls": turn_tool_error_count,
+                        "total_calls": tool_calls.len(),
+                    }),
+                );
+                if let Some(summary) = self
+                    .handle_tool_loop_guard_summary(
+                        &mut ctx,
+                        governor_consecutive_error_turns,
+                        turn_tool_error_count,
+                        tool_calls.len(),
+                    )
+                    .await?
+                {
+                    ctx.add_message(summary);
+                }
+                self.memory_on_session_end(ctx.get_messages());
+                return Ok(AgentResult {
+                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                    finished_naturally: false,
+                    total_turns,
+                    tool_errors,
+                    usage: accumulated_usage,
+                    interrupted: false,
+                    session_cost_usd: Some(session_cost_usd),
+                    session_started_hooks_fired,
+                });
+            }
             if !tool_calls.is_empty()
                 && tool_calls
                     .iter()
@@ -5264,6 +5355,64 @@ impl AgentLoop {
             if let Some(note) = lsp_note {
                 ctx.add_message(Message::system(note));
             }
+            if should_trip_tool_loop_guard(
+                governor_consecutive_error_turns,
+                tool_calls.len(),
+                turn_tool_error_count,
+            ) {
+                let guard_message = format!(
+                    "Tool-loop guard tripped after {} consecutive error turn(s); latest turn failed {}/{} tool call(s).",
+                    governor_consecutive_error_turns,
+                    turn_tool_error_count,
+                    tool_calls.len()
+                );
+                self.emit_status("lifecycle", &guard_message);
+                replay.record(
+                    "tool_loop_guard",
+                    serde_json::json!({
+                        "turn": total_turns,
+                        "consecutive_error_turns": governor_consecutive_error_turns,
+                        "failed_calls": turn_tool_error_count,
+                        "total_calls": tool_calls.len(),
+                    }),
+                );
+                if let Some(summary) = self
+                    .handle_tool_loop_guard_summary(
+                        &mut ctx,
+                        governor_consecutive_error_turns,
+                        turn_tool_error_count,
+                        tool_calls.len(),
+                    )
+                    .await?
+                {
+                    ctx.add_message(summary);
+                }
+                if stream_mute.swap(false, Ordering::AcqRel) {
+                    on_chunk(StreamChunk {
+                        delta: Some(hermes_core::StreamDelta {
+                            content: None,
+                            tool_calls: None,
+                            extra: Some(serde_json::json!({
+                                "control": "mute_post_response",
+                                "enabled": false
+                            })),
+                        }),
+                        finish_reason: None,
+                        usage: None,
+                    });
+                }
+                self.memory_on_session_end(ctx.get_messages());
+                return Ok(AgentResult {
+                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                    finished_naturally: false,
+                    total_turns,
+                    tool_errors,
+                    usage: accumulated_usage,
+                    interrupted: false,
+                    session_cost_usd: Some(session_cost_usd),
+                    session_started_hooks_fired,
+                });
+            }
             if !tool_calls.is_empty()
                 && tool_calls
                     .iter()
@@ -5774,6 +5923,33 @@ impl AgentLoop {
             "[SYSTEM] Maximum conversation turns reached. Please provide a brief summary of \
              what was accomplished and any remaining tasks.",
         ));
+        let (_, model_name) = self.extract_provider_and_model(self.config.model.as_str());
+        let response = self
+            .llm_provider
+            .chat_completion(
+                ctx.get_messages(),
+                &[],
+                self.config.max_tokens,
+                self.config.temperature,
+                Some(model_name),
+                self.extra_body_for_api_mode(&self.config.api_mode).as_ref(),
+            )
+            .await
+            .map_err(|e| AgentError::LlmApi(e.to_string()))?;
+        Ok(Some(response.message))
+    }
+
+    async fn handle_tool_loop_guard_summary(
+        &self,
+        ctx: &mut ContextManager,
+        consecutive_error_turns: u32,
+        failed_calls: u32,
+        total_calls: usize,
+    ) -> Result<Option<Message>, AgentError> {
+        ctx.add_message(Message::system(format!(
+            "[SYSTEM] Tool-loop guard triggered after {} consecutive error turn(s). Latest turn failed {}/{} tool call(s). Stop calling tools and provide a concise final response with what succeeded, what failed, and precise next manual step(s).",
+            consecutive_error_turns, failed_calls, total_calls
+        )));
         let (_, model_name) = self.extract_provider_and_model(self.config.model.as_str());
         let response = self
             .llm_provider
@@ -9638,6 +9814,29 @@ mod tests {
         assert!(gov.error_degraded);
         assert!(gov.max_tokens.unwrap_or(1200) < 1200);
         assert!(gov.tool_concurrency <= 2);
+    }
+
+    #[test]
+    fn test_tool_loop_guard_trips_on_consecutive_full_failure_turns() {
+        std::env::set_var("HERMES_TOOL_LOOP_GUARD_ENABLED", "1");
+        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS", "3");
+        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS", "1");
+        assert!(!should_trip_tool_loop_guard(2, 2, 2));
+        assert!(should_trip_tool_loop_guard(3, 2, 2));
+        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_ENABLED");
+        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS");
+        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS");
+    }
+
+    #[test]
+    fn test_tool_loop_guard_ignores_partial_success_turns() {
+        std::env::set_var("HERMES_TOOL_LOOP_GUARD_ENABLED", "1");
+        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS", "2");
+        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS", "1");
+        assert!(!should_trip_tool_loop_guard(4, 3, 2));
+        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_ENABLED");
+        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS");
+        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS");
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -1877,6 +1877,93 @@ fn render_assistant_markdown_lines(
     rendered
 }
 
+fn value_to_display_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.starts_with('{') || trimmed.starts_with('[') {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                    return serde_json::to_string_pretty(&parsed)
+                        .unwrap_or_else(|_| raw.to_string());
+                }
+            }
+            raw.to_string()
+        }
+        _ => serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()),
+    }
+}
+
+fn push_block(lines: &mut Vec<String>, header: &str, value: &serde_json::Value) {
+    let rendered = value_to_display_text(value);
+    if rendered.trim().is_empty() {
+        return;
+    }
+    lines.push(format!("[{header}]"));
+    for line in rendered.lines() {
+        lines.push(line.to_string());
+    }
+}
+
+fn format_tool_message_lines(content: &str) -> Vec<String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return vec![String::new()];
+    }
+
+    let parsed = match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(v) => v,
+        Err(_) => {
+            return content
+                .lines()
+                .map(std::string::ToString::to_string)
+                .collect();
+        }
+    };
+
+    if let Some(obj) = parsed.as_object() {
+        let mut lines: Vec<String> = Vec::new();
+
+        if let Some(w) = obj.get("_budget_warning").and_then(|v| v.as_str()) {
+            lines.push(format!("⚠ {}", w.trim()));
+        }
+
+        for key in ["result", "error", "stdout", "stderr", "message"] {
+            if let Some(value) = obj.get(key) {
+                push_block(&mut lines, key, value);
+            }
+        }
+
+        let mut extras = serde_json::Map::new();
+        for (k, v) in obj.iter() {
+            if k == "_budget_warning"
+                || k == "result"
+                || k == "error"
+                || k == "stdout"
+                || k == "stderr"
+                || k == "message"
+            {
+                continue;
+            }
+            extras.insert(k.clone(), v.clone());
+        }
+        if !extras.is_empty() {
+            push_block(&mut lines, "meta", &serde_json::Value::Object(extras));
+        }
+        if !lines.is_empty() {
+            return lines;
+        }
+    }
+
+    serde_json::to_string_pretty(&parsed)
+        .map(|s| s.lines().map(std::string::ToString::to_string).collect())
+        .unwrap_or_else(|_| {
+            content
+                .lines()
+                .map(std::string::ToString::to_string)
+                .collect()
+        })
+}
+
 fn append_transcript_message_lines(
     lines: &mut Vec<Line<'static>>,
     msg: &hermes_core::Message,
@@ -1929,7 +2016,7 @@ fn append_transcript_message_lines(
                 let expanded = state.expanded_tool_cards.contains(&card_key)
                     || state.expanded_tool_cards.contains("__all__")
                     || matches!(state.view_density, ViewDensity::Detailed);
-                let all_lines: Vec<&str> = content.lines().collect();
+                let all_lines = format_tool_message_lines(content);
                 let shown = if expanded { 32 } else { 5 };
                 lines.push(Line::from(vec![Span::styled(
                     format!(
@@ -2255,30 +2342,26 @@ fn render_messages(
         }
     }
     let lines = &state.transcript_cache.lines;
-
-    let max_hidden_from_bottom = lines.len().saturating_sub(viewport_rows);
+    let text = Text::from(lines.clone());
+    let total_visual_rows = approximate_visual_rows(lines, inner.width);
+    let max_hidden_from_bottom = total_visual_rows.saturating_sub(viewport_rows);
     let hidden_from_bottom = usize::from(state.scroll_offset).min(max_hidden_from_bottom);
-    let end = lines.len().saturating_sub(hidden_from_bottom);
-    let start = end.saturating_sub(viewport_rows);
-    let mut visible_lines: Vec<Line<'static>> = lines[start..end].to_vec();
-    if visible_lines.len() < viewport_rows {
-        let pad = viewport_rows - visible_lines.len();
-        let mut padded = Vec::with_capacity(viewport_rows);
-        padded.extend((0..pad).map(|_| Line::from(String::new())));
-        padded.extend(visible_lines);
-        visible_lines = padded;
+    if usize::from(state.scroll_offset) != hidden_from_bottom {
+        state.scroll_offset = hidden_from_bottom.min(u16::MAX as usize) as u16;
     }
+    let top_visual_row = total_visual_rows.saturating_sub(viewport_rows + hidden_from_bottom);
 
-    let paragraph = Paragraph::new(Text::from(visible_lines))
+    let paragraph = Paragraph::new(text)
         .block(block)
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((top_visual_row as u16, 0));
 
     frame.render_widget(Clear, area);
     frame.render_widget(paragraph, area);
 
-    if lines.len() > viewport_rows {
-        let mut scrollbar_state = ScrollbarState::new(lines.len())
-            .position(start)
+    if total_visual_rows > viewport_rows {
+        let mut scrollbar_state = ScrollbarState::new(total_visual_rows)
+            .position(top_visual_row)
             .viewport_content_length(viewport_rows);
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .track_symbol(Some("│"))
@@ -2297,6 +2380,18 @@ fn render_messages(
             );
         frame.render_stateful_widget(scrollbar, inner, &mut scrollbar_state);
     }
+}
+
+fn approximate_visual_rows(lines: &[Line<'static>], wrap_width: u16) -> usize {
+    let width = usize::from(wrap_width.max(1));
+    lines
+        .iter()
+        .map(|line| {
+            let chars = line.to_string().chars().count().max(1);
+            ((chars - 1) / width) + 1
+        })
+        .sum::<usize>()
+        .max(1)
 }
 
 /// Render slash-command completions as a popup over the conversation panel.
@@ -3879,6 +3974,25 @@ mod tests {
             Message::assistant("a"),
         ];
         assert_eq!(count_renderable_messages(&messages), 2);
+    }
+
+    #[test]
+    fn test_format_tool_message_lines_parses_json_payload() {
+        let payload = r#"{"result":"line1\nline2","_budget_warning":"[BUDGET WARNING: Iteration 40/50.]","error":"boom"}"#;
+        let lines = format_tool_message_lines(payload);
+        let joined = lines.join("\n");
+        assert!(joined.contains("⚠ [BUDGET WARNING"));
+        assert!(joined.contains("[result]"));
+        assert!(joined.contains("line1"));
+        assert!(joined.contains("[error]"));
+        assert!(joined.contains("boom"));
+    }
+
+    #[test]
+    fn test_approximate_visual_rows_wraps_long_lines() {
+        let lines = vec![Line::from("x".repeat(120))];
+        assert_eq!(approximate_visual_rows(&lines, 40), 3);
+        assert_eq!(approximate_visual_rows(&lines, 80), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- render tool messages as structured readable blocks instead of raw escaped JSON\n- make conversation scroll offset wrap-aware so long lines no longer break scrolling\n- add loop guard to stop repeated all-error tool-call turns (run + run_stream)\n\n## Validation\n- cargo fmt\n- cargo test -p hermes-cli\n- cargo test -p hermes-agent\n- cargo run -p hermes-cli --bin hermes-ultra -- --help