### PR TITLE
feat: trading mission runtime + autoresearch board

### DIFF
--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -1117,6 +1117,742 @@ pub fn utility_terms_from_contract() -> Result<HashMap<String, f64>, AgentError>
         .collect())
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TradingProjectSpec {
+    pub id: String,
+    pub path: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TradingRuntimeConfig {
+    pub updated_at: String,
+    pub target_wallet_sol: f64,
+    pub starting_wallet_sol: f64,
+    pub projects: Vec<TradingProjectSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct TradingProjectReport {
+    pub id: String,
+    pub path: String,
+    pub exists: bool,
+    pub run_context_files: usize,
+    pub latest_wallet_sol: f64,
+    pub latest_pnl_sol: f64,
+    pub drawdown_pct: f64,
+    pub volatility_score: f64,
+    pub slippage_bps: f64,
+    pub impact_bps: f64,
+    pub fee_drag_sol: f64,
+    pub funding_drag_sol: f64,
+    pub latency_p50_ms: f64,
+    pub latency_p95_ms: f64,
+    pub reject_rate: f64,
+    pub anomaly_score: f64,
+    pub incident_class: String,
+    pub regime: String,
+    pub objective_state: String,
+    pub patch_recommendations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct StrategyHypothesis {
+    pub id: String,
+    pub statement: String,
+    pub novelty_score: f64,
+    pub expected_gain_sol: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ExperimentSpec {
+    pub id: String,
+    pub hypothesis_id: String,
+    pub metric: String,
+    pub control: String,
+    pub treatment: String,
+    pub pass_criterion: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct TradingAlphaReport {
+    pub generated_at: String,
+    pub projects: Vec<TradingProjectReport>,
+    pub wallet_progress_pct: f64,
+    pub ruin_probability: f64,
+    pub volatility_sizing_factor: f64,
+    pub strategy_weights: HashMap<String, f64>,
+    pub pnl_decomposition: HashMap<String, f64>,
+    pub canary_recommendation: String,
+    pub postmortem: String,
+    pub hypotheses: Vec<StrategyHypothesis>,
+    pub experiments: Vec<ExperimentSpec>,
+    pub backtest_matrix: Vec<String>,
+    pub walkforward_checks: Vec<String>,
+    pub meta_ranking: Vec<String>,
+    pub promotion_candidate: String,
+}
+
+fn trading_state_dir() -> PathBuf {
+    alpha_state_dir().join("trading")
+}
+
+fn trading_config_path() -> PathBuf {
+    trading_state_dir().join("runtime_config.json")
+}
+
+fn trading_last_report_path() -> PathBuf {
+    trading_state_dir().join("last_report.json")
+}
+
+fn default_trading_projects() -> Vec<TradingProjectSpec> {
+    let mut projects = vec![
+        TradingProjectSpec {
+            id: "algotraderv2_rust".to_string(),
+            path: "~/Documents/Projects/algotraderv2_rust".to_string(),
+            enabled: true,
+        },
+        TradingProjectSpec {
+            id: "fastapi-sidecar".to_string(),
+            path: "~/Documents/Projects/fastapi-sidecar".to_string(),
+            enabled: true,
+        },
+        TradingProjectSpec {
+            id: "kraken-trader".to_string(),
+            path: "~/Documents/Projects/kraken-trader".to_string(),
+            enabled: true,
+        },
+    ];
+
+    if let Ok(raw) = std::env::var("HERMES_ALPHA_TRADING_PROJECTS") {
+        let custom = raw
+            .split(':')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .enumerate()
+            .map(|(idx, path)| TradingProjectSpec {
+                id: format!("project-{}", idx + 1),
+                path: path.to_string(),
+                enabled: true,
+            })
+            .collect::<Vec<_>>();
+        if !custom.is_empty() {
+            projects = custom;
+        }
+    }
+    projects
+}
+
+fn default_trading_runtime_config() -> TradingRuntimeConfig {
+    TradingRuntimeConfig {
+        updated_at: now_rfc3339(),
+        target_wallet_sol: 1000.0,
+        starting_wallet_sol: 0.2,
+        projects: default_trading_projects(),
+    }
+}
+
+fn expand_home(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            let mut p = PathBuf::from(home);
+            p.push(rest);
+            return p.to_string_lossy().to_string();
+        }
+    }
+    path.to_string()
+}
+
+pub fn ensure_trading_runtime_bootstrap(force: bool) -> Result<Vec<PathBuf>, AgentError> {
+    ensure_alpha_dir()?;
+    let dir = trading_state_dir();
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| AgentError::Io(format!("create {} failed: {}", dir.display(), e)))?;
+    let mut written = Vec::new();
+
+    let cfg = trading_config_path();
+    if force || !cfg.exists() {
+        write_json_file(&cfg, &default_trading_runtime_config())?;
+        written.push(cfg);
+    }
+
+    let report = trading_last_report_path();
+    if force || !report.exists() {
+        write_json_file(
+            &report,
+            &TradingAlphaReport {
+                generated_at: now_rfc3339(),
+                ..TradingAlphaReport::default()
+            },
+        )?;
+        written.push(report);
+    }
+    Ok(written)
+}
+
+pub fn load_trading_runtime_config() -> Result<TradingRuntimeConfig, AgentError> {
+    ensure_trading_runtime_bootstrap(false)?;
+    read_json_file(&trading_config_path())
+}
+
+fn discover_recent_json_files(root: &Path, limit: usize) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let logs = root.join("logs").join("run_context");
+    if !logs.exists() {
+        return out;
+    }
+    if let Ok(entries) = std::fs::read_dir(&logs) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("json") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort_by(|a, b| b.cmp(a));
+    out.truncate(limit.max(1));
+    out
+}
+
+fn find_numeric_hint(value: &Value, keys: &[&str]) -> Option<f64> {
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map {
+                let key = k.to_ascii_lowercase();
+                if keys.iter().any(|needle| key.contains(needle)) {
+                    if let Some(n) = v.as_f64() {
+                        return Some(n);
+                    }
+                    if let Some(n) = v.as_i64() {
+                        return Some(n as f64);
+                    }
+                    if let Some(n) = v.as_u64() {
+                        return Some(n as f64);
+                    }
+                }
+                if let Some(found) = find_numeric_hint(v, keys) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(arr) => arr.iter().find_map(|v| find_numeric_hint(v, keys)),
+        _ => None,
+    }
+}
+
+fn compute_regime(volatility: f64, pnl: f64, reject_rate: f64) -> String {
+    if reject_rate > 0.10 {
+        "execution-stressed".to_string()
+    } else if volatility > 1.2 {
+        if pnl >= 0.0 {
+            "high-vol-trending".to_string()
+        } else {
+            "high-vol-adverse".to_string()
+        }
+    } else if volatility < 0.35 {
+        "low-vol-range".to_string()
+    } else {
+        "neutral".to_string()
+    }
+}
+
+fn compute_incident_class(reject_rate: f64, latency_p95: f64, anomaly_score: f64) -> String {
+    if anomaly_score > 0.75 {
+        "critical-anomaly".to_string()
+    } else if reject_rate > 0.08 {
+        "order-reject-spike".to_string()
+    } else if latency_p95 > 1800.0 {
+        "latency-degradation".to_string()
+    } else {
+        "none".to_string()
+    }
+}
+
+fn analyze_project(spec: &TradingProjectSpec) -> TradingProjectReport {
+    let path = PathBuf::from(expand_home(&spec.path));
+    let exists = path.exists();
+    if !exists {
+        return TradingProjectReport {
+            id: spec.id.clone(),
+            path: path.display().to_string(),
+            exists: false,
+            objective_state: "unproven".to_string(),
+            incident_class: "missing-project-path".to_string(),
+            patch_recommendations: vec![
+                "verify project path and mount".to_string(),
+                "re-run /mission trading refresh".to_string(),
+            ],
+            ..TradingProjectReport::default()
+        };
+    }
+
+    let files = discover_recent_json_files(&path, 20);
+    let mut wallet_values = Vec::new();
+    let mut pnl_values = Vec::new();
+    let mut latency_values = Vec::new();
+    let mut reject_values = Vec::new();
+    let mut slip_values = Vec::new();
+    let mut fee_values = Vec::new();
+    let mut funding_values = Vec::new();
+    let mut impact_values = Vec::new();
+
+    for file in &files {
+        if let Ok(raw) = std::fs::read_to_string(file) {
+            if let Ok(v) = serde_json::from_str::<Value>(&raw) {
+                if let Some(n) = find_numeric_hint(
+                    &v,
+                    &[
+                        "wallet_sol",
+                        "wallet_balance_sol",
+                        "sol_balance",
+                        "sol_wallet",
+                    ],
+                ) {
+                    wallet_values.push(n);
+                }
+                if let Some(n) = find_numeric_hint(&v, &["pnl_sol", "profit_sol", "net_sol"]) {
+                    pnl_values.push(n);
+                }
+                if let Some(n) =
+                    find_numeric_hint(&v, &["latency_ms", "latency_p95_ms", "latency_p50_ms"])
+                {
+                    latency_values.push(n);
+                }
+                if let Some(n) = find_numeric_hint(&v, &["reject_rate", "rejects_pct", "reject"]) {
+                    reject_values.push(n);
+                }
+                if let Some(n) = find_numeric_hint(&v, &["slippage_bps", "slip_bps"]) {
+                    slip_values.push(n);
+                }
+                if let Some(n) = find_numeric_hint(&v, &["impact_bps", "price_impact_bps"]) {
+                    impact_values.push(n);
+                }
+                if let Some(n) = find_numeric_hint(&v, &["fee_sol", "fees_sol", "fee_drag_sol"]) {
+                    fee_values.push(n);
+                }
+                if let Some(n) = find_numeric_hint(&v, &["funding_sol", "funding_drag_sol"]) {
+                    funding_values.push(n);
+                }
+            }
+        }
+    }
+
+    let latest_wallet = wallet_values.first().copied().unwrap_or(0.0);
+    let latest_pnl = pnl_values.first().copied().unwrap_or(0.0);
+    let peak_wallet = wallet_values.iter().copied().fold(latest_wallet, f64::max);
+    let drawdown_pct = if peak_wallet > 0.0 {
+        ((peak_wallet - latest_wallet) / peak_wallet).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+
+    let mut volatility_score = 0.0f64;
+    if pnl_values.len() >= 2 {
+        let mean = pnl_values.iter().sum::<f64>() / (pnl_values.len() as f64);
+        let var = pnl_values
+            .iter()
+            .map(|v| {
+                let d = *v - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / (pnl_values.len() as f64);
+        volatility_score = var.sqrt().abs();
+    }
+
+    let latency_p95 = latency_values
+        .iter()
+        .copied()
+        .fold(0.0f64, f64::max)
+        .max(0.0);
+    let mut latency_sorted = latency_values.clone();
+    latency_sorted.sort_by(|a, b| a.total_cmp(b));
+    let latency_p50 = if latency_sorted.is_empty() {
+        0.0
+    } else {
+        latency_sorted[latency_sorted.len() / 2]
+    };
+    let reject_rate = reject_values
+        .first()
+        .copied()
+        .unwrap_or(0.0)
+        .clamp(0.0, 1.0);
+    let slippage_bps = slip_values.first().copied().unwrap_or(0.0).abs();
+    let impact_bps = impact_values.first().copied().unwrap_or(0.0).abs();
+    let fee_drag = fee_values.first().copied().unwrap_or(0.0).abs();
+    let funding_drag = funding_values.first().copied().unwrap_or(0.0).abs();
+
+    let anomaly_score = (drawdown_pct * 0.45
+        + reject_rate * 0.25
+        + (slippage_bps / 100.0).min(0.2)
+        + (latency_p95 / 4000.0).min(0.1))
+    .clamp(0.0, 1.0);
+
+    let regime = compute_regime(volatility_score, latest_pnl, reject_rate);
+    let incident = compute_incident_class(reject_rate, latency_p95, anomaly_score);
+    let objective_state = if latest_pnl > 0.0 && drawdown_pct < 0.2 {
+        "advancing".to_string()
+    } else if latest_pnl < 0.0 && drawdown_pct > 0.3 {
+        "regressing".to_string()
+    } else {
+        "flat".to_string()
+    };
+
+    let mut recommendations = Vec::new();
+    if slippage_bps > 50.0 {
+        recommendations.push("tighten max slippage + add venue spread gate".to_string());
+    }
+    if reject_rate > 0.06 {
+        recommendations.push("lower order aggressiveness and add retry backoff".to_string());
+    }
+    if drawdown_pct > 0.25 {
+        recommendations.push("activate drawdown circuit breaker and reduce size".to_string());
+    }
+    if recommendations.is_empty() {
+        recommendations.push("maintain current controls; continue telemetry burn-in".to_string());
+    }
+
+    TradingProjectReport {
+        id: spec.id.clone(),
+        path: path.display().to_string(),
+        exists: true,
+        run_context_files: files.len(),
+        latest_wallet_sol: latest_wallet,
+        latest_pnl_sol: latest_pnl,
+        drawdown_pct,
+        volatility_score,
+        slippage_bps,
+        impact_bps,
+        fee_drag_sol: fee_drag,
+        funding_drag_sol: funding_drag,
+        latency_p50_ms: latency_p50,
+        latency_p95_ms: latency_p95,
+        reject_rate,
+        anomaly_score,
+        incident_class: incident,
+        regime,
+        objective_state,
+        patch_recommendations: recommendations,
+    }
+}
+
+fn derive_hypotheses(report: &TradingAlphaReport) -> Vec<StrategyHypothesis> {
+    let mut out = Vec::new();
+    for project in &report.projects {
+        if project.slippage_bps > 30.0 {
+            out.push(StrategyHypothesis {
+                id: format!("hyp-{}-slippage", project.id),
+                statement: format!(
+                    "{}: routing/quote freshness is degrading; tighter slippage controls should improve expectancy",
+                    project.id
+                ),
+                novelty_score: (project.slippage_bps / 200.0).clamp(0.05, 1.0),
+                expected_gain_sol: (project.slippage_bps / 1000.0).clamp(0.001, 0.25),
+            });
+        }
+        if project.reject_rate > 0.04 {
+            out.push(StrategyHypothesis {
+                id: format!("hyp-{}-rejects", project.id),
+                statement: format!(
+                    "{}: reject spikes imply stale sizing/latency assumptions; adaptive order cadence may recover PnL",
+                    project.id
+                ),
+                novelty_score: (project.reject_rate * 8.0).clamp(0.05, 1.0),
+                expected_gain_sol: (project.reject_rate * 0.6).clamp(0.001, 0.25),
+            });
+        }
+        if project.drawdown_pct > 0.2 {
+            out.push(StrategyHypothesis {
+                id: format!("hyp-{}-drawdown", project.id),
+                statement: format!(
+                    "{}: drawdown profile suggests risk governor should step down exposure faster",
+                    project.id
+                ),
+                novelty_score: project.drawdown_pct.clamp(0.05, 1.0),
+                expected_gain_sol: (project.drawdown_pct * 0.4).clamp(0.001, 0.30),
+            });
+        }
+    }
+    out.sort_by(|a, b| b.novelty_score.total_cmp(&a.novelty_score));
+    out.dedup_by(|a, b| a.statement == b.statement);
+    out
+}
+
+fn compile_experiment_specs(hypotheses: &[StrategyHypothesis]) -> Vec<ExperimentSpec> {
+    hypotheses
+        .iter()
+        .enumerate()
+        .map(|(idx, h)| ExperimentSpec {
+            id: format!("exp-{}", idx + 1),
+            hypothesis_id: h.id.clone(),
+            metric: "net_pnl_after_costs_sol".to_string(),
+            control: "current_config".to_string(),
+            treatment: format!("treatment_from_{}", h.id),
+            pass_criterion: format!(
+                "delta_sol > {:.4}",
+                (h.expected_gain_sol * 0.35).max(0.0005)
+            ),
+        })
+        .collect()
+}
+
+fn build_backtest_matrix(specs: &[ExperimentSpec]) -> Vec<String> {
+    specs
+        .iter()
+        .map(|s| {
+            format!(
+                "{} | metric={} | control={} | treatment={} | pass={}",
+                s.id, s.metric, s.control, s.treatment, s.pass_criterion
+            )
+        })
+        .collect()
+}
+
+fn derive_walkforward_checks(projects: &[TradingProjectReport]) -> Vec<String> {
+    let mut checks = vec![
+        "walk-forward folds: train=30d validate=7d test=7d".to_string(),
+        "leakage gate: forbid label/source overlap across folds".to_string(),
+        "leakage gate: enforce timestamp monotonicity and no future joins".to_string(),
+    ];
+    for p in projects {
+        checks.push(format!(
+            "{}: run_context_audit files={} objective_state={}",
+            p.id, p.run_context_files, p.objective_state
+        ));
+    }
+    checks
+}
+
+fn rank_meta_strategies(projects: &[TradingProjectReport]) -> Vec<String> {
+    let mut rows: Vec<(String, f64)> = projects
+        .iter()
+        .map(|p| {
+            let score = p.latest_pnl_sol
+                - (p.drawdown_pct * 0.6)
+                - ((p.slippage_bps + p.impact_bps) / 10_000.0)
+                - (p.reject_rate * 0.4);
+            (p.id.clone(), score)
+        })
+        .collect();
+    rows.sort_by(|a, b| b.1.total_cmp(&a.1));
+    rows.into_iter()
+        .map(|(id, score)| format!("{} score={:.6}", id, score))
+        .collect()
+}
+
+fn compute_strategy_weights(projects: &[TradingProjectReport]) -> HashMap<String, f64> {
+    let mut weights = HashMap::new();
+    let mut raw = Vec::new();
+    for p in projects {
+        let score = (p.latest_pnl_sol + 0.25).max(0.01)
+            * (1.0 - p.drawdown_pct).max(0.1)
+            * (1.0 - p.reject_rate).max(0.1);
+        raw.push((p.id.clone(), score));
+    }
+    let total = raw.iter().map(|(_, v)| *v).sum::<f64>().max(1e-9);
+    for (id, score) in raw {
+        weights.insert(id, score / total);
+    }
+    weights
+}
+
+fn choose_promotion_candidate(meta: &[String]) -> String {
+    meta.first()
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or("none")
+        .to_string()
+}
+
+fn compute_postmortem(projects: &[TradingProjectReport]) -> String {
+    let mut lines = Vec::new();
+    lines.push("Postmortem packet".to_string());
+    for p in projects {
+        lines.push(format!(
+            "- {} state={} incident={} drawdown={:.2}% pnl={:.6} sol",
+            p.id,
+            p.objective_state,
+            p.incident_class,
+            p.drawdown_pct * 100.0,
+            p.latest_pnl_sol
+        ));
+        for r in p.patch_recommendations.iter().take(2) {
+            lines.push(format!("  remediation: {}", r));
+        }
+    }
+    lines.join("\n")
+}
+
+pub fn refresh_trading_alpha_report() -> Result<TradingAlphaReport, AgentError> {
+    ensure_trading_runtime_bootstrap(false)?;
+    let cfg = load_trading_runtime_config()?;
+    let projects = cfg
+        .projects
+        .iter()
+        .filter(|p| p.enabled)
+        .map(analyze_project)
+        .collect::<Vec<_>>();
+
+    let current_wallet = projects
+        .iter()
+        .map(|p| p.latest_wallet_sol)
+        .fold(0.0f64, f64::max);
+    let progress = if cfg.target_wallet_sol > cfg.starting_wallet_sol {
+        ((current_wallet - cfg.starting_wallet_sol)
+            / (cfg.target_wallet_sol - cfg.starting_wallet_sol))
+            .clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let worst_drawdown = projects
+        .iter()
+        .map(|p| p.drawdown_pct)
+        .fold(0.0f64, f64::max);
+    let ruin_probability = (worst_drawdown * 0.85 + (1.0 - progress) * 0.15).clamp(0.0, 1.0);
+    let avg_vol = if projects.is_empty() {
+        0.0
+    } else {
+        projects.iter().map(|p| p.volatility_score).sum::<f64>() / (projects.len() as f64)
+    };
+    let volatility_sizing_factor = (1.0 / (1.0 + avg_vol)).clamp(0.15, 1.25);
+
+    let strategy_weights = compute_strategy_weights(&projects);
+    let signal = projects
+        .iter()
+        .map(|p| p.latest_pnl_sol.max(0.0))
+        .sum::<f64>();
+    let execution_cost = projects
+        .iter()
+        .map(|p| (p.slippage_bps + p.impact_bps) / 10_000.0)
+        .sum::<f64>();
+    let fee_cost = projects
+        .iter()
+        .map(|p| p.fee_drag_sol + p.funding_drag_sol)
+        .sum::<f64>();
+    let mut pnl_decomposition = HashMap::new();
+    pnl_decomposition.insert("signal".to_string(), signal);
+    pnl_decomposition.insert("execution_cost".to_string(), -execution_cost);
+    pnl_decomposition.insert("fee_cost".to_string(), -fee_cost);
+
+    let canary_recommendation = if ruin_probability > 0.45 {
+        "rollback-to-shadow".to_string()
+    } else if progress > 0.55 && worst_drawdown < 0.15 {
+        "promote-canary".to_string()
+    } else {
+        "hold-canary".to_string()
+    };
+
+    let hypotheses = derive_hypotheses(&TradingAlphaReport {
+        projects: projects.clone(),
+        ..TradingAlphaReport::default()
+    });
+    let experiments = compile_experiment_specs(&hypotheses);
+    let backtest_matrix = build_backtest_matrix(&experiments);
+    let walkforward_checks = derive_walkforward_checks(&projects);
+    let meta_ranking = rank_meta_strategies(&projects);
+    let promotion_candidate = choose_promotion_candidate(&meta_ranking);
+    let postmortem = compute_postmortem(&projects);
+
+    let report = TradingAlphaReport {
+        generated_at: now_rfc3339(),
+        projects,
+        wallet_progress_pct: progress,
+        ruin_probability,
+        volatility_sizing_factor,
+        strategy_weights,
+        pnl_decomposition,
+        canary_recommendation,
+        postmortem,
+        hypotheses,
+        experiments,
+        backtest_matrix,
+        walkforward_checks,
+        meta_ranking,
+        promotion_candidate,
+    };
+
+    write_json_file(&trading_last_report_path(), &report)?;
+    Ok(report)
+}
+
+pub fn load_last_trading_alpha_report() -> Result<TradingAlphaReport, AgentError> {
+    ensure_trading_runtime_bootstrap(false)?;
+    read_json_file(&trading_last_report_path())
+}
+
+pub fn render_trading_alpha_board(report: &TradingAlphaReport) -> String {
+    let mut out = String::new();
+    out.push_str("Trading Private Mission Board\n");
+    out.push_str("----------------------------\n");
+    out.push_str(&format!("generated_at: {}\n", report.generated_at));
+    out.push_str(&format!(
+        "wallet_progress_pct: {:.2}%\nruin_probability: {:.4}\nvolatility_sizing_factor: {:.4}\ncanary_recommendation: {}\npromotion_candidate: {}\n\n",
+        report.wallet_progress_pct * 100.0,
+        report.ruin_probability,
+        report.volatility_sizing_factor,
+        report.canary_recommendation,
+        report.promotion_candidate
+    ));
+
+    out.push_str("Project telemetry\n");
+    for p in &report.projects {
+        out.push_str(&format!(
+            "- {} exists={} run_context_files={} wallet={:.6} pnl={:.6} drawdown={:.2}% reject_rate={:.2}% regime={} incident={} objective_state={}\n",
+            p.id,
+            p.exists,
+            p.run_context_files,
+            p.latest_wallet_sol,
+            p.latest_pnl_sol,
+            p.drawdown_pct * 100.0,
+            p.reject_rate * 100.0,
+            p.regime,
+            p.incident_class,
+            p.objective_state
+        ));
+    }
+    out.push('\n');
+
+    out.push_str("Strategy weights\n");
+    let mut weights = report
+        .strategy_weights
+        .iter()
+        .map(|(k, v)| (k.clone(), *v))
+        .collect::<Vec<_>>();
+    weights.sort_by(|a, b| b.1.total_cmp(&a.1));
+    for (id, w) in weights {
+        out.push_str(&format!("- {}: {:.4}\n", id, w));
+    }
+    out.push('\n');
+
+    out.push_str("Autoresearch\n");
+    out.push_str(&format!(
+        "- hypotheses={} experiments={} matrix_rows={}\n",
+        report.hypotheses.len(),
+        report.experiments.len(),
+        report.backtest_matrix.len()
+    ));
+    for h in report.hypotheses.iter().take(4) {
+        out.push_str(&format!(
+            "  - {} novelty={:.3} expected_gain_sol={:.4}\n",
+            h.id, h.novelty_score, h.expected_gain_sol
+        ));
+    }
+    out.push('\n');
+
+    out.push_str("Walk-forward + leakage defense\n");
+    for line in report.walkforward_checks.iter().take(6) {
+        out.push_str(&format!("- {}\n", line));
+    }
+    out.push('\n');
+    out.push_str("Meta ranking\n");
+    for line in report.meta_ranking.iter().take(6) {
+        out.push_str(&format!("- {}\n", line));
+    }
+    out.push('\n');
+    out.push_str(&report.postmortem);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1168,5 +1904,45 @@ mod tests {
         let level =
             recommend_reasoning_level_from_text("release-critical security objective for money");
         assert_eq!(level, "xhigh");
+    }
+
+    #[test]
+    fn trading_runtime_bootstrap_and_report_refresh_work() {
+        let tmp = tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        ensure_trading_runtime_bootstrap(true).expect("bootstrap trading");
+        let cfg = load_trading_runtime_config().expect("load trading config");
+        assert!(!cfg.projects.is_empty());
+        let report = refresh_trading_alpha_report().expect("refresh report");
+        assert!(!report.generated_at.is_empty());
+        let loaded = load_last_trading_alpha_report().expect("load report");
+        assert_eq!(loaded.generated_at, report.generated_at);
+        std::env::remove_var("HERMES_HOME");
+    }
+
+    #[test]
+    fn trading_board_render_contains_core_sections() {
+        let report = TradingAlphaReport {
+            generated_at: "2026-05-06T00:00:00Z".to_string(),
+            projects: vec![TradingProjectReport {
+                id: "proj-a".to_string(),
+                exists: true,
+                objective_state: "flat".to_string(),
+                incident_class: "none".to_string(),
+                ..TradingProjectReport::default()
+            }],
+            wallet_progress_pct: 0.1,
+            ruin_probability: 0.2,
+            volatility_sizing_factor: 0.8,
+            strategy_weights: HashMap::from([("proj-a".to_string(), 1.0)]),
+            canary_recommendation: "hold-canary".to_string(),
+            postmortem: "Postmortem packet".to_string(),
+            promotion_candidate: "proj-a".to_string(),
+            ..TradingAlphaReport::default()
+        };
+        let rendered = render_trading_alpha_board(&report);
+        assert!(rendered.contains("Trading Private Mission Board"));
+        assert!(rendered.contains("Strategy weights"));
+        assert!(rendered.contains("Autoresearch"));
     }
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -22,9 +22,11 @@ use sha2::{Digest, Sha256};
 
 use crate::alpha_runtime::{
     append_counterfactual, clear_objective_contract, enqueue_loop_event,
-    ensure_alpha_runtime_bootstrap, load_alpha_loops, load_objective_contract,
-    recover_orphan_loop_events, render_mission_board, replay_loop_queue,
-    summarize_objective_contract, upsert_objective_contract, utility_terms_from_contract,
+    ensure_alpha_runtime_bootstrap, ensure_trading_runtime_bootstrap, load_alpha_loops,
+    load_last_trading_alpha_report, load_objective_contract, recover_orphan_loop_events,
+    refresh_trading_alpha_report, render_mission_board, render_trading_alpha_board,
+    replay_loop_queue, summarize_objective_contract, upsert_objective_contract,
+    utility_terms_from_contract,
 };
 use crate::app::{App, PetDock, PetSettings};
 use crate::model_switch::{curated_provider_slugs, normalize_provider_model, provider_model_ids};
@@ -173,7 +175,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/ops", "Operator control plane (status + quick controls)"),
     (
         "/mission",
-        "Mission control board for continuous loops (`status|init|recover|replay|enqueue`)",
+        "Mission control board (`status|init|recover|replay|enqueue|trading ...`)",
     ),
     ("/dashboard", "Dashboard control (status|on|off|url)"),
     (
@@ -5184,8 +5186,12 @@ async fn handle_mission_command(app: &mut App, args: &[&str]) -> Result<CommandR
     match action.as_str() {
         "init" => {
             let written = ensure_alpha_runtime_bootstrap(true)?;
+            let trading_written = ensure_trading_runtime_bootstrap(true)?;
             let mut details = String::new();
             for path in written {
+                let _ = writeln!(details, "- {}", path.display());
+            }
+            for path in trading_written {
                 let _ = writeln!(details, "- {}", path.display());
             }
             emit_command_output(
@@ -5244,6 +5250,76 @@ async fn handle_mission_command(app: &mut App, args: &[&str]) -> Result<CommandR
             );
             Ok(CommandResult::Handled)
         }
+        "trading" => {
+            let sub = args
+                .get(1)
+                .copied()
+                .unwrap_or("status")
+                .to_ascii_lowercase();
+            match sub.as_str() {
+                "status" | "show" => {
+                    let report = load_last_trading_alpha_report()?;
+                    emit_command_output(app, render_trading_alpha_board(&report));
+                    Ok(CommandResult::Handled)
+                }
+                "refresh" | "run" | "scan" => {
+                    let report = refresh_trading_alpha_report()?;
+                    emit_command_output(app, render_trading_alpha_board(&report));
+                    Ok(CommandResult::Handled)
+                }
+                "postmortem" => {
+                    let report = load_last_trading_alpha_report()?;
+                    emit_command_output(
+                        app,
+                        format!("Trading postmortem\n\n{}", report.postmortem),
+                    );
+                    Ok(CommandResult::Handled)
+                }
+                "autoresearch" => {
+                    let report = load_last_trading_alpha_report()?;
+                    let mut out = String::new();
+                    out.push_str("Autoresearch artifacts\n");
+                    out.push_str("----------------------\n");
+                    out.push_str(&format!("hypotheses: {}\n", report.hypotheses.len()));
+                    for h in report.hypotheses.iter().take(12) {
+                        let _ = writeln!(
+                            out,
+                            "- {} novelty={:.3} expected_gain_sol={:.4} :: {}",
+                            h.id, h.novelty_score, h.expected_gain_sol, h.statement
+                        );
+                    }
+                    out.push_str("\nexperiments:\n");
+                    for e in report.experiments.iter().take(12) {
+                        let _ = writeln!(
+                            out,
+                            "- {} {} -> {} pass={}",
+                            e.id, e.control, e.treatment, e.pass_criterion
+                        );
+                    }
+                    out.push_str("\nbacktest_matrix:\n");
+                    for row in report.backtest_matrix.iter().take(20) {
+                        let _ = writeln!(out, "- {}", row);
+                    }
+                    out.push_str("\nwalkforward_checks:\n");
+                    for row in report.walkforward_checks.iter().take(20) {
+                        let _ = writeln!(out, "- {}", row);
+                    }
+                    out.push_str("\nmeta_ranking:\n");
+                    for row in report.meta_ranking.iter().take(20) {
+                        let _ = writeln!(out, "- {}", row);
+                    }
+                    emit_command_output(app, out.trim_end());
+                    Ok(CommandResult::Handled)
+                }
+                _ => {
+                    emit_command_output(
+                        app,
+                        "Usage: /mission trading [status|refresh|postmortem|autoresearch]",
+                    );
+                    Ok(CommandResult::Handled)
+                }
+            }
+        }
         "status" | "show" => {
             let loops = load_alpha_loops()?;
             let (queued, running, completed, failed) = background_job_counts();
@@ -5271,6 +5347,7 @@ async fn handle_mission_command(app: &mut App, args: &[&str]) -> Result<CommandR
             out.push_str("- /mission recover\n");
             out.push_str("- /mission replay [limit]\n");
             out.push_str("- /mission enqueue <loop-id> <event-type> <payload>\n");
+            out.push_str("- /mission trading [status|refresh|postmortem|autoresearch]\n");
             out.push_str("- /objective <text>\n");
             out.push_str("- /background <task>\n");
             emit_command_output(app, out.trim_end());
@@ -5279,7 +5356,7 @@ async fn handle_mission_command(app: &mut App, args: &[&str]) -> Result<CommandR
         _ => {
             emit_command_output(
                 app,
-                "Usage: /mission [status|init|recover|replay [limit]|enqueue <loop-id> <event-type> <payload>]",
+                "Usage: /mission [status|init|recover|replay [limit]|enqueue <loop-id> <event-type> <payload>|trading ...]",
             );
             Ok(CommandResult::Handled)
         }


### PR DESCRIPTION
## Summary
- add trading-private runtime config/report persistence under `~/.hermes-agent-ultra/alpha/trading`
- add project analytics extraction from `logs/run_context` + `logs/knob_tuner`
- add wallet growth KPI, drawdown/ruin metrics, volatility sizing factor, strategy weights, pnl decomposition
- add regime/incident classification, anomaly score, patch recommendations, postmortem packet
- add hypothesis/experiment/backtest/walkforward/meta-ranking/promotion candidate surfaces
- wire `/mission trading [status|refresh|postmortem|autoresearch]` and include trading bootstrap in `/mission init`

## Validation
- cargo fmt
- cargo test -p hermes-cli trading_runtime_bootstrap_and_report_refresh_work
- cargo test -p hermes-cli trading_board_render_contains_core_sections
- cargo test -p hermes-cli test_mission_command_is_registered_and_completable
- cargo check -p hermes-cli
