### PR TITLE
Close plugin surface parity gaps (interactive plugins + source discovery + dynamic CLI bridge)

### DIFF
--- a/crates/hermes-agent/src/plugins.rs
+++ b/crates/hermes-agent/src/plugins.rs
@@ -102,6 +102,30 @@ pub struct PluginManifest {
     pub dependencies: Vec<String>,
 }
 
+/// Plugin source used during discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginDiscoverySource {
+    User,
+    Project,
+}
+
+impl PluginDiscoverySource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PluginDiscoverySource::User => "user",
+            PluginDiscoverySource::Project => "project",
+        }
+    }
+}
+
+/// A discovered plugin bundle with source metadata.
+#[derive(Debug, Clone)]
+pub struct DiscoveredPlugin {
+    pub manifest: PluginManifest,
+    pub path: std::path::PathBuf,
+    pub source: PluginDiscoverySource,
+}
+
 // ---------------------------------------------------------------------------
 // PluginCliCommand
 // ---------------------------------------------------------------------------
@@ -310,94 +334,157 @@ impl PluginManager {
         disabled_list.iter().any(|d| d == name)
     }
 
-    /// Discover plugins in the given hermes directory by scanning for `plugin.yaml` files.
+    /// Discover plugins in the given Hermes directory by scanning `plugins/`.
+    ///
+    /// Backwards-compatible wrapper that preserves the historical return type
+    /// and only scans the user plugin directory.
     pub fn discover_plugins(hermes_dir: &Path) -> Vec<(PluginManifest, std::path::PathBuf)> {
-        let plugins_dir = hermes_dir.join("plugins");
+        Self::discover_plugins_with_options(hermes_dir, None, false)
+            .into_iter()
+            .map(|entry| (entry.manifest, entry.path))
+            .collect()
+    }
+
+    /// Discover plugins with explicit source controls.
+    ///
+    /// - Always scans user plugins at `<hermes_dir>/plugins`.
+    /// - Optionally scans project plugins at `<cwd>/.hermes/plugins` when
+    ///   `enable_project_plugins` is true.
+    pub fn discover_plugins_with_options(
+        hermes_dir: &Path,
+        cwd: Option<&Path>,
+        enable_project_plugins: bool,
+    ) -> Vec<DiscoveredPlugin> {
         let mut discovered = Vec::new();
+        let user_plugins_dir = hermes_dir.join("plugins");
+        scan_plugin_root(
+            &user_plugins_dir,
+            PluginDiscoverySource::User,
+            &mut discovered,
+        );
 
-        if !plugins_dir.exists() {
-            return discovered;
-        }
-
-        let Ok(entries) = std::fs::read_dir(&plugins_dir) else {
-            return discovered;
-        };
-
-        for entry in entries.filter_map(|e| e.ok()) {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-
-            let manifest_path = path.join("plugin.yaml");
-            if !manifest_path.exists() {
-                continue;
-            }
-
-            let disabled_marker = path.join(".disabled");
-            if disabled_marker.exists() {
-                tracing::debug!("Skipping disabled plugin: {}", path.display());
-                continue;
-            }
-
-            match std::fs::read_to_string(&manifest_path) {
-                Ok(content) => match serde_yaml::from_str::<PluginManifest>(&content) {
-                    Ok(mut manifest) => {
-                        // If the manifest doesn't explicitly declare a plugin kind,
-                        // detect Python memory-provider plugins and auto-coerce them
-                        // to `exclusive` so they can be routed away from generic
-                        // plugin loading.
-                        let explicit_kind = manifest
-                            .kind
-                            .as_deref()
-                            .map(str::trim)
-                            .filter(|s| !s.is_empty());
-                        if explicit_kind.is_none() {
-                            let init_file = path.join("__init__.py");
-                            if let Ok(source) = std::fs::read_to_string(&init_file) {
-                                let probe = if source.len() > 8192 {
-                                    &source[..8192]
-                                } else {
-                                    source.as_str()
-                                };
-                                if probe.contains("register_memory_provider")
-                                    || probe.contains("MemoryProvider")
-                                {
-                                    manifest.kind = Some("exclusive".to_string());
-                                    tracing::debug!(
-                                        "Plugin {} auto-coerced to kind=exclusive (memory provider heuristic)",
-                                        manifest.name
-                                    );
-                                }
-                            }
-                        }
-                        tracing::debug!(
-                            "Discovered plugin: {} v{} at {}",
-                            manifest.name,
-                            manifest.version,
-                            path.display()
-                        );
-                        discovered.push((manifest, path));
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to parse plugin.yaml at {}: {}",
-                            manifest_path.display(),
-                            e
-                        );
-                    }
-                },
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to read plugin.yaml at {}: {}",
-                        manifest_path.display(),
-                        e
-                    );
-                }
+        if enable_project_plugins {
+            if let Some(workdir) = cwd {
+                let project_plugins_dir = workdir.join(".hermes").join("plugins");
+                scan_plugin_root(
+                    &project_plugins_dir,
+                    PluginDiscoverySource::Project,
+                    &mut discovered,
+                );
             }
         }
 
         discovered
+    }
+
+    /// Discover plugins using runtime defaults.
+    ///
+    /// Project-local plugins are included when
+    /// `HERMES_ENABLE_PROJECT_PLUGINS` is enabled.
+    pub fn discover_plugins_runtime_default(hermes_dir: &Path) -> Vec<DiscoveredPlugin> {
+        let enable_project_plugins = std::env::var("HERMES_ENABLE_PROJECT_PLUGINS")
+            .ok()
+            .is_some_and(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            });
+        let cwd = std::env::current_dir().ok();
+        Self::discover_plugins_with_options(hermes_dir, cwd.as_deref(), enable_project_plugins)
+    }
+}
+
+fn scan_plugin_root(
+    plugins_dir: &Path,
+    source: PluginDiscoverySource,
+    discovered: &mut Vec<DiscoveredPlugin>,
+) {
+    if !plugins_dir.exists() {
+        return;
+    }
+
+    let Ok(entries) = std::fs::read_dir(plugins_dir) else {
+        return;
+    };
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let manifest_path = path.join("plugin.yaml");
+        if !manifest_path.exists() {
+            continue;
+        }
+
+        let disabled_marker = path.join(".disabled");
+        if disabled_marker.exists() {
+            tracing::debug!("Skipping disabled plugin: {}", path.display());
+            continue;
+        }
+
+        match std::fs::read_to_string(&manifest_path) {
+            Ok(content) => match serde_yaml::from_str::<PluginManifest>(&content) {
+                Ok(mut manifest) => {
+                    // If the manifest doesn't explicitly declare a plugin kind,
+                    // detect Python memory-provider plugins and auto-coerce them
+                    // to `exclusive` so they can be routed away from generic
+                    // plugin loading.
+                    let explicit_kind = manifest
+                        .kind
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty());
+                    if explicit_kind.is_none() {
+                        let init_file = path.join("__init__.py");
+                        if let Ok(source_text) = std::fs::read_to_string(&init_file) {
+                            let probe = if source_text.len() > 8192 {
+                                &source_text[..8192]
+                            } else {
+                                source_text.as_str()
+                            };
+                            if probe.contains("register_memory_provider")
+                                || probe.contains("MemoryProvider")
+                            {
+                                manifest.kind = Some("exclusive".to_string());
+                                tracing::debug!(
+                                    "Plugin {} auto-coerced to kind=exclusive (memory provider heuristic)",
+                                    manifest.name
+                                );
+                            }
+                        }
+                    }
+                    tracing::debug!(
+                        "Discovered plugin: {} v{} at {} (source={})",
+                        manifest.name,
+                        manifest.version,
+                        path.display(),
+                        source.as_str()
+                    );
+                    discovered.push(DiscoveredPlugin {
+                        manifest,
+                        path,
+                        source,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse plugin.yaml at {}: {}",
+                        manifest_path.display(),
+                        e
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to read plugin.yaml at {}: {}",
+                    manifest_path.display(),
+                    e
+                );
+            }
+        }
     }
 }
 
@@ -577,5 +664,74 @@ dependencies:
         let discovered = PluginManager::discover_plugins(tmp.path());
         assert_eq!(discovered.len(), 1);
         assert_eq!(discovered[0].0.kind.as_deref(), Some("standalone"));
+    }
+
+    #[test]
+    fn test_discover_plugins_with_options_includes_project_when_enabled() {
+        let home = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+
+        let user_plugin = home.path().join("plugins").join("user_bundle");
+        std::fs::create_dir_all(&user_plugin).unwrap();
+        std::fs::write(
+            user_plugin.join("plugin.yaml"),
+            "name: user_bundle\nversion: \"0.1.0\"\ndescription: User plugin\n",
+        )
+        .unwrap();
+
+        let project_plugin = cwd
+            .path()
+            .join(".hermes")
+            .join("plugins")
+            .join("project_bundle");
+        std::fs::create_dir_all(&project_plugin).unwrap();
+        std::fs::write(
+            project_plugin.join("plugin.yaml"),
+            "name: project_bundle\nversion: \"0.1.0\"\ndescription: Project plugin\n",
+        )
+        .unwrap();
+
+        let discovered =
+            PluginManager::discover_plugins_with_options(home.path(), Some(cwd.path()), true);
+        assert_eq!(discovered.len(), 2);
+        assert!(discovered
+            .iter()
+            .any(|d| d.manifest.name == "user_bundle" && d.source == PluginDiscoverySource::User));
+        assert!(discovered
+            .iter()
+            .any(|d| d.manifest.name == "project_bundle"
+                && d.source == PluginDiscoverySource::Project));
+    }
+
+    #[test]
+    fn test_discover_plugins_with_options_excludes_project_when_disabled() {
+        let home = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+
+        let user_plugin = home.path().join("plugins").join("user_bundle");
+        std::fs::create_dir_all(&user_plugin).unwrap();
+        std::fs::write(
+            user_plugin.join("plugin.yaml"),
+            "name: user_bundle\nversion: \"0.1.0\"\ndescription: User plugin\n",
+        )
+        .unwrap();
+
+        let project_plugin = cwd
+            .path()
+            .join(".hermes")
+            .join("plugins")
+            .join("project_bundle");
+        std::fs::create_dir_all(&project_plugin).unwrap();
+        std::fs::write(
+            project_plugin.join("plugin.yaml"),
+            "name: project_bundle\nversion: \"0.1.0\"\ndescription: Project plugin\n",
+        )
+        .unwrap();
+
+        let discovered =
+            PluginManager::discover_plugins_with_options(home.path(), Some(cwd.path()), false);
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].manifest.name, "user_bundle");
+        assert_eq!(discovered[0].source, PluginDiscoverySource::User);
     }
 }

--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -442,7 +442,7 @@ pub enum CliCommand {
 
     /// Plugin management.
     Plugins {
-        /// Action: install/update/remove/list/enable/disable
+        /// Action: install/update/remove/list/enable/disable/inspect
         action: Option<String>,
         /// Plugin name.
         name: Option<String>,
@@ -599,6 +599,13 @@ pub enum CliCommand {
         #[arg(short, long)]
         model: Option<String>,
     },
+
+    /// Plugin-provided external command surface (dynamic dispatch).
+    ///
+    /// Used to mirror upstream behavior where active plugins can contribute
+    /// top-level CLI commands (for example, memory-provider command shims).
+    #[command(external_subcommand)]
+    PluginExternal(Vec<String>),
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use hermes_agent::plugins::PluginManifest;
 use hermes_core::AgentError;
 use hermes_intelligence::model_metadata::{get_model_context_length, get_model_info};
 use hermes_intelligence::models_dev::default_client;
@@ -6978,42 +6979,23 @@ fn handle_toolsets_command(app: &mut App) -> Result<CommandResult, AgentError> {
 }
 
 fn handle_plugins_command(app: &mut App) -> Result<CommandResult, AgentError> {
-    let plugins_dir = hermes_config::hermes_home().join("plugins");
-    if !plugins_dir.exists() {
+    let rows = discover_plugin_surface(true);
+    if rows.is_empty() {
+        let plugins_dir = hermes_config::hermes_home().join("plugins");
         emit_command_output(
             app,
             format!(
-                "Plugin directory not found yet: {}\nUse `hermes plugins install ...` to add plugin bundles.",
+                "No plugin bundles discovered.\nUser plugin dir: {}\nInstall with `hermes plugins install <owner/repo>`.",
                 plugins_dir.display()
             ),
-        );
-        return Ok(CommandResult::Handled);
-    }
-    let mut plugin_names = Vec::new();
-    if let Ok(read_dir) = std::fs::read_dir(&plugins_dir) {
-        for entry in read_dir.flatten() {
-            if entry.path().is_dir() {
-                plugin_names.push(entry.file_name().to_string_lossy().to_string());
-            }
-        }
-    }
-    plugin_names.sort();
-    if plugin_names.is_empty() {
-        emit_command_output(
-            app,
-            format!("No installed plugin bundles in {}.", plugins_dir.display()),
         );
     } else {
         emit_command_output(
             app,
             format!(
-                "Installed plugin bundles ({}):\n{}",
-                plugin_names.len(),
-                plugin_names
-                    .iter()
-                    .map(|n| format!("  - {}", n))
-                    .collect::<Vec<_>>()
-                    .join("\n")
+                "Plugin surface ({} entries):\n{}",
+                rows.len(),
+                render_plugin_surface_table(&rows)
             ),
         );
     }
@@ -9218,6 +9200,571 @@ pub async fn handle_cli_skills(
 }
 
 // ---------------------------------------------------------------------------
+// Plugin discovery / surface rendering
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum PluginSurfaceSource {
+    User,
+    Project,
+    Entrypoint,
+}
+
+impl PluginSurfaceSource {
+    fn label(&self) -> &'static str {
+        match self {
+            PluginSurfaceSource::User => "user",
+            PluginSurfaceSource::Project => "project",
+            PluginSurfaceSource::Entrypoint => "entrypoint",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PluginSurfaceEntry {
+    name: String,
+    version: String,
+    description: String,
+    kind: Option<String>,
+    source: PluginSurfaceSource,
+    path: Option<PathBuf>,
+    enabled: bool,
+    entrypoint_value: Option<String>,
+    entrypoint_dist: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PythonEntrypointPayload {
+    #[serde(default)]
+    entries: Vec<PythonEntrypointItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PythonEntrypointItem {
+    name: String,
+    value: String,
+    #[serde(default)]
+    dist: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PythonPluginCommandPayload {
+    #[serde(default)]
+    commands: Vec<PythonPluginCommandItem>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct PythonPluginCommandItem {
+    name: String,
+    #[serde(default)]
+    help: String,
+}
+
+fn coerce_memory_provider_kind(path: &Path, kind: Option<String>) -> Option<String> {
+    let explicit_kind = kind
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string);
+    if explicit_kind.is_some() {
+        return explicit_kind;
+    }
+    let init_file = path.join("__init__.py");
+    let Ok(source) = std::fs::read_to_string(&init_file) else {
+        return None;
+    };
+    let probe = if source.len() > 8192 {
+        &source[..8192]
+    } else {
+        source.as_str()
+    };
+    if probe.contains("register_memory_provider") || probe.contains("MemoryProvider") {
+        Some("exclusive".to_string())
+    } else {
+        None
+    }
+}
+
+fn scan_plugin_manifest_root(root: &Path, source: PluginSurfaceSource) -> Vec<PluginSurfaceEntry> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return out;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let manifest_path = path.join("plugin.yaml");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&manifest_path) {
+            Ok(content) => content,
+            Err(_) => continue,
+        };
+        let manifest: PluginManifest = match serde_yaml::from_str(&content) {
+            Ok(manifest) => manifest,
+            Err(_) => continue,
+        };
+        let disabled_marker = path.join(".disabled");
+        out.push(PluginSurfaceEntry {
+            name: manifest.name.clone(),
+            version: manifest.version.clone(),
+            description: manifest.description.clone(),
+            kind: coerce_memory_provider_kind(&path, manifest.kind.clone()),
+            source,
+            path: Some(path),
+            enabled: !disabled_marker.exists(),
+            entrypoint_value: None,
+            entrypoint_dist: None,
+        });
+    }
+    out
+}
+
+fn discover_python_entrypoint_plugins() -> Vec<PluginSurfaceEntry> {
+    let script = r#"
+import json
+from importlib import metadata
+
+def _entry_points():
+    eps = metadata.entry_points()
+    if hasattr(eps, "select"):
+        return list(eps.select(group="hermes_agent.plugins"))
+    if isinstance(eps, dict):
+        return list(eps.get("hermes_agent.plugins", []))
+    return [ep for ep in eps if getattr(ep, "group", "") == "hermes_agent.plugins"]
+
+rows = []
+try:
+    for ep in _entry_points():
+        dist = None
+        try:
+            if getattr(ep, "dist", None):
+                dist = ep.dist.name
+        except Exception:
+            dist = None
+        rows.append({
+            "name": str(getattr(ep, "name", "") or ""),
+            "value": str(getattr(ep, "value", "") or ""),
+            "dist": dist,
+        })
+except Exception:
+    rows = []
+print(json.dumps({"entries": rows}))
+"#;
+
+    let output = std::process::Command::new("python3")
+        .args(["-c", script])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let payload: PythonEntrypointPayload = match serde_json::from_slice(&output.stdout) {
+        Ok(payload) => payload,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for item in payload.entries {
+        let name = item.name.trim().to_string();
+        if name.is_empty() {
+            continue;
+        }
+        out.push(PluginSurfaceEntry {
+            name,
+            version: "entrypoint".to_string(),
+            description: String::new(),
+            kind: None,
+            source: PluginSurfaceSource::Entrypoint,
+            path: None,
+            enabled: true,
+            entrypoint_value: Some(item.value),
+            entrypoint_dist: item.dist,
+        });
+    }
+    out
+}
+
+fn discover_plugin_surface(include_entrypoints: bool) -> Vec<PluginSurfaceEntry> {
+    let mut rows = Vec::new();
+    let user_root = hermes_config::hermes_home().join("plugins");
+    rows.extend(scan_plugin_manifest_root(
+        &user_root,
+        PluginSurfaceSource::User,
+    ));
+
+    if hermes_config::env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS") {
+        if let Ok(cwd) = std::env::current_dir() {
+            let project_root = cwd.join(".hermes").join("plugins");
+            rows.extend(scan_plugin_manifest_root(
+                &project_root,
+                PluginSurfaceSource::Project,
+            ));
+        }
+    }
+
+    if include_entrypoints {
+        rows.extend(discover_python_entrypoint_plugins());
+    }
+
+    rows.sort_by(|a, b| {
+        a.source.cmp(&b.source).then_with(|| {
+            a.name
+                .to_ascii_lowercase()
+                .cmp(&b.name.to_ascii_lowercase())
+        })
+    });
+    rows
+}
+
+fn resolve_local_plugin_path_by_name(name: &str) -> Option<PathBuf> {
+    discover_plugin_surface(false)
+        .into_iter()
+        .filter_map(|row| {
+            if row.name.eq_ignore_ascii_case(name) {
+                row.path
+            } else {
+                None
+            }
+        })
+        .next()
+}
+
+fn render_plugin_surface_table(rows: &[PluginSurfaceEntry]) -> String {
+    if rows.is_empty() {
+        return "  (no plugins discovered)".to_string();
+    }
+    let mut out = String::new();
+    for row in rows {
+        let status = if row.enabled { "enabled" } else { "disabled" };
+        let mut meta_parts = vec![format!("source={}", row.source.label())];
+        if let Some(kind) = row.kind.as_deref().filter(|k| !k.trim().is_empty()) {
+            meta_parts.push(format!("kind={}", kind));
+        }
+        if let Some(dist) = row
+            .entrypoint_dist
+            .as_deref()
+            .filter(|d| !d.trim().is_empty())
+        {
+            meta_parts.push(format!("dist={}", dist));
+        }
+        if let Some(value) = row
+            .entrypoint_value
+            .as_deref()
+            .filter(|v| !v.trim().is_empty())
+        {
+            meta_parts.push(format!("entry={}", value));
+        }
+        let path = row
+            .path
+            .as_deref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let version = if row.version.trim().is_empty() {
+            "unknown".to_string()
+        } else {
+            row.version.clone()
+        };
+        let description = row.description.trim();
+        let _ = writeln!(
+            out,
+            "  • {} v{} [{}; {}; path={}]",
+            row.name,
+            version,
+            status,
+            meta_parts.join(", "),
+            path
+        );
+        if !description.is_empty() {
+            let _ = writeln!(out, "    {}", description);
+        }
+    }
+    out.trim_end().to_string()
+}
+
+fn set_plugin_enabled(path: &Path, enable: bool) -> Result<(), AgentError> {
+    let marker = path.join(".disabled");
+    if enable {
+        if marker.exists() {
+            std::fs::remove_file(&marker)
+                .map_err(|e| AgentError::Io(format!("Failed to enable plugin: {}", e)))?;
+        }
+    } else {
+        std::fs::write(&marker, "")
+            .map_err(|e| AgentError::Io(format!("Failed to disable plugin: {}", e)))?;
+    }
+    Ok(())
+}
+
+fn parse_selection_indices(raw: &str, max: usize) -> Vec<usize> {
+    let mut out = Vec::new();
+    for token in raw.split(|c: char| c == ',' || c.is_ascii_whitespace()) {
+        let trimmed = token.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(idx) = trimmed.parse::<usize>() else {
+            continue;
+        };
+        if idx == 0 || idx > max {
+            continue;
+        }
+        out.push(idx - 1);
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn run_plugins_interactive_toggle() -> Result<(), AgentError> {
+    let mut rows: Vec<PluginSurfaceEntry> = discover_plugin_surface(false)
+        .into_iter()
+        .filter(|row| row.path.is_some())
+        .collect();
+    if rows.is_empty() {
+        println!("No plugin bundles discovered.");
+        println!("Install one with: hermes plugins install <owner/repo>  (or a trusted git URL)");
+        return Ok(());
+    }
+
+    rows.sort_by(|a, b| {
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+    });
+
+    println!("Plugin toggle UI (interactive)");
+    println!("------------------------------");
+    println!("Source roots:");
+    println!(
+        "  - user:    {}",
+        hermes_config::hermes_home().join("plugins").display()
+    );
+    if hermes_config::env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS") {
+        if let Ok(cwd) = std::env::current_dir() {
+            println!(
+                "  - project: {}",
+                cwd.join(".hermes").join("plugins").display()
+            );
+        }
+    } else {
+        println!("  - project: disabled (set HERMES_ENABLE_PROJECT_PLUGINS=true)");
+    }
+    println!();
+
+    let mut provider_indices = Vec::new();
+    println!("General Plugins");
+    for (idx, row) in rows.iter().enumerate() {
+        let is_provider = row.kind.as_deref() == Some("exclusive");
+        if is_provider {
+            provider_indices.push(idx);
+            continue;
+        }
+        let mark = if row.enabled { "✓" } else { " " };
+        println!(
+            "  {:>2}. [{}] {} (source={})",
+            idx + 1,
+            mark,
+            row.name,
+            row.source.label()
+        );
+    }
+
+    if !provider_indices.is_empty() {
+        println!();
+        println!("Provider Plugins (single-select recommended)");
+        for idx in &provider_indices {
+            let row = &rows[*idx];
+            let mark = if row.enabled { "✓" } else { " " };
+            println!(
+                "  {:>2}. [{}] {} (source={}, kind={})",
+                idx + 1,
+                mark,
+                row.name,
+                row.source.label(),
+                row.kind.clone().unwrap_or_else(|| "provider".to_string())
+            );
+        }
+    }
+
+    use std::io::Write as _;
+    print!("\nToggle plugin numbers (comma/space separated, Enter to skip): ");
+    let _ = std::io::stdout().flush();
+    let mut toggle_buf = String::new();
+    std::io::stdin()
+        .read_line(&mut toggle_buf)
+        .map_err(|e| AgentError::Io(format!("Failed to read selection: {}", e)))?;
+    let toggle_indices = parse_selection_indices(&toggle_buf, rows.len());
+    for idx in toggle_indices {
+        if let Some(path) = rows[idx].path.as_deref() {
+            let target = !rows[idx].enabled;
+            set_plugin_enabled(path, target)?;
+            rows[idx].enabled = target;
+        }
+    }
+
+    if !provider_indices.is_empty() {
+        print!("Activate exactly one provider plugin number (Enter to keep current): ");
+        let _ = std::io::stdout().flush();
+        let mut provider_buf = String::new();
+        std::io::stdin()
+            .read_line(&mut provider_buf)
+            .map_err(|e| AgentError::Io(format!("Failed to read provider selection: {}", e)))?;
+        let selected = parse_selection_indices(&provider_buf, rows.len());
+        if let Some(selected_idx) = selected.first().copied() {
+            if provider_indices.contains(&selected_idx) {
+                for idx in provider_indices {
+                    if let Some(path) = rows[idx].path.as_deref() {
+                        let should_enable = idx == selected_idx;
+                        set_plugin_enabled(path, should_enable)?;
+                        rows[idx].enabled = should_enable;
+                    }
+                }
+            } else {
+                println!(
+                    "Selection {} is not a provider plugin row; keeping provider state unchanged.",
+                    selected_idx + 1
+                );
+            }
+        }
+    }
+
+    println!("\nUpdated plugin state:");
+    println!("{}", render_plugin_surface_table(&rows));
+    Ok(())
+}
+
+fn discover_python_plugin_cli_commands() -> Vec<PythonPluginCommandItem> {
+    let script = r#"
+import json
+rows = []
+try:
+    from plugins.memory import discover_plugin_cli_commands
+    for cmd in (discover_plugin_cli_commands() or []):
+        name = str(cmd.get("name", "") or "").strip()
+        if not name:
+            continue
+        help_text = str(cmd.get("help") or cmd.get("description") or "")
+        rows.append({"name": name, "help": help_text})
+except Exception:
+    rows = []
+print(json.dumps({"commands": rows}))
+"#;
+    let output = std::process::Command::new("python3")
+        .args(["-c", script])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let payload: PythonPluginCommandPayload = match serde_json::from_slice(&output.stdout) {
+        Ok(payload) => payload,
+        Err(_) => return Vec::new(),
+    };
+    let mut rows = payload.commands;
+    rows.sort_by(|a, b| a.name.cmp(&b.name));
+    rows.dedup_by(|a, b| a.name == b.name);
+    rows
+}
+
+pub async fn handle_cli_external_plugin_subcommand(raw: Vec<String>) -> Result<(), AgentError> {
+    if raw.is_empty() {
+        return Err(AgentError::Config(
+            "Unknown command. Run `hermes --help` for available commands.".to_string(),
+        ));
+    }
+    let command_name = raw[0].trim().to_string();
+    let command_args: Vec<String> = raw[1..].to_vec();
+    let available = discover_python_plugin_cli_commands();
+    if !available.iter().any(|row| row.name == command_name) {
+        let catalog = if available.is_empty() {
+            "none discovered".to_string()
+        } else {
+            available
+                .iter()
+                .map(|row| {
+                    if row.help.trim().is_empty() {
+                        format!("  - {}", row.name)
+                    } else {
+                        format!("  - {}: {}", row.name, row.help.trim())
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        return Err(AgentError::Config(format!(
+            "Unknown command '{}'. Run `hermes --help` for core commands.\nDiscovered plugin commands:\n{}",
+            command_name, catalog
+        )));
+    }
+
+    let args_json = serde_json::to_string(&command_args)
+        .map_err(|e| AgentError::Config(format!("Failed to serialize plugin CLI args: {}", e)))?;
+    let script = r#"
+import argparse
+import json
+import sys
+
+try:
+    from plugins.memory import discover_plugin_cli_commands
+except Exception as exc:
+    print(f"Plugin CLI bridge unavailable: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+name = sys.argv[1]
+argv = json.loads(sys.argv[2])
+
+for item in (discover_plugin_cli_commands() or []):
+    if str(item.get("name", "")).strip() != name:
+        continue
+    setup = item.get("setup_fn")
+    if not callable(setup):
+        print(f"Plugin command '{name}' is missing setup_fn", file=sys.stderr)
+        sys.exit(2)
+    parser = argparse.ArgumentParser(prog=name)
+    setup(parser)
+    ns = parser.parse_args(argv)
+    handler = item.get("handler_fn")
+    if callable(handler):
+        handler(ns)
+        sys.exit(0)
+    if hasattr(ns, "func") and callable(getattr(ns, "func")):
+        ns.func(ns)
+        sys.exit(0)
+    parser.print_help()
+    sys.exit(0)
+
+print(f"Unknown plugin command: {name}", file=sys.stderr)
+sys.exit(3)
+"#;
+
+    let output = tokio::process::Command::new("python3")
+        .args(["-c", script, &command_name, &args_json])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .await
+        .map_err(|e| AgentError::Io(format!("Failed to execute plugin command: {}", e)))?;
+    if !output.success() {
+        return Err(AgentError::Config(format!(
+            "Plugin command '{}' failed with exit code {:?}.",
+            command_name,
+            output.code()
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Plugin security (remote Git installs)
 // ---------------------------------------------------------------------------
 
@@ -9395,42 +9942,24 @@ pub async fn handle_cli_plugins(
 ) -> Result<(), hermes_core::AgentError> {
     let plugins_dir = hermes_config::hermes_home().join("plugins");
 
-    match action.as_deref().unwrap_or("list") {
-        "list" => {
-            if !plugins_dir.exists() {
-                println!("No plugins directory found at {}", plugins_dir.display());
-                return Ok(());
-            }
-            let mut count = 0u32;
-            println!("Installed plugins ({}):", plugins_dir.display());
-            if let Ok(entries) = std::fs::read_dir(&plugins_dir) {
-                for entry in entries.filter_map(|e| e.ok()) {
-                    let path = entry.path();
-                    let manifest = path.join("plugin.yaml");
-                    if path.is_dir() && manifest.exists() {
-                        let dir_name = path.file_name().unwrap_or_default().to_string_lossy();
-                        let disabled_marker = path.join(".disabled");
-                        let status = if disabled_marker.exists() {
-                            "disabled"
-                        } else {
-                            "enabled"
-                        };
-                        println!("  • {} [{}]", dir_name, status);
-                        count += 1;
-                    }
-                }
-            }
-            if count == 0 {
-                println!("  (no plugins installed)");
-            }
+    match action.as_deref() {
+        None => {
+            run_plugins_interactive_toggle()?;
         }
-        "enable" => {
+        Some("list") => {
+            let rows = discover_plugin_surface(true);
+            println!("Plugin surface ({} entries):", rows.len());
+            println!("{}", render_plugin_surface_table(&rows));
+        }
+        Some("enable") => {
             let plugin_name = name.ok_or_else(|| {
                 hermes_core::AgentError::Config(
                     "Missing plugin name. Usage: hermes plugins enable <name>".into(),
                 )
             })?;
-            let disabled_marker = plugins_dir.join(&plugin_name).join(".disabled");
+            let target = resolve_local_plugin_path_by_name(&plugin_name)
+                .unwrap_or_else(|| plugins_dir.join(&plugin_name));
+            let disabled_marker = target.join(".disabled");
             if disabled_marker.exists() {
                 std::fs::remove_file(&disabled_marker).map_err(|e| {
                     hermes_core::AgentError::Io(format!("Failed to enable plugin: {}", e))
@@ -9443,13 +9972,14 @@ pub async fn handle_cli_plugins(
                 );
             }
         }
-        "disable" => {
+        Some("disable") => {
             let plugin_name = name.ok_or_else(|| {
                 hermes_core::AgentError::Config(
                     "Missing plugin name. Usage: hermes plugins disable <name>".into(),
                 )
             })?;
-            let plugin_dir = plugins_dir.join(&plugin_name);
+            let plugin_dir = resolve_local_plugin_path_by_name(&plugin_name)
+                .unwrap_or_else(|| plugins_dir.join(&plugin_name));
             if !plugin_dir.exists() {
                 println!("Plugin '{}' not found.", plugin_name);
                 return Ok(());
@@ -9460,7 +9990,7 @@ pub async fn handle_cli_plugins(
             })?;
             println!("Plugin '{}' disabled.", plugin_name);
         }
-        "install" => {
+        Some("install") => {
             let plugin_name = name.ok_or_else(|| {
                 hermes_core::AgentError::Config(
                     "Missing plugin name. Usage: hermes plugins install <name|url>".into(),
@@ -9790,13 +10320,14 @@ pub async fn handle_cli_plugins(
                 }
             }
         }
-        "remove" | "uninstall" => {
+        Some("remove") | Some("uninstall") => {
             let plugin_name = name.ok_or_else(|| {
                 hermes_core::AgentError::Config(
                     "Missing plugin name. Usage: hermes plugins remove <name>".into(),
                 )
             })?;
-            let target = plugins_dir.join(&plugin_name);
+            let target = resolve_local_plugin_path_by_name(&plugin_name)
+                .unwrap_or_else(|| plugins_dir.join(&plugin_name));
             if target.exists() {
                 std::fs::remove_dir_all(&target).map_err(|e| {
                     hermes_core::AgentError::Io(format!("Failed to remove plugin: {}", e))
@@ -9806,7 +10337,7 @@ pub async fn handle_cli_plugins(
                 println!("Plugin '{}' not found.", plugin_name);
             }
         }
-        "update" => {
+        Some("update") => {
             let plugin_name = name.as_deref();
             let mut checked = 0u32;
             let mut updated = 0u32;
@@ -9922,14 +10453,62 @@ pub async fn handle_cli_plugins(
                 println!("Checked {} plugin(s); updated {}.", checked, updated);
             }
         }
-        "inspect" | "info" => {
+        Some("inspect") | Some("info") => {
             let plugin_name = name.ok_or_else(|| {
                 hermes_core::AgentError::Config(
                     "Missing plugin name. Usage: hermes plugins inspect <name>".into(),
                 )
             })?;
-            let target = plugins_dir.join(&plugin_name);
+            let surface_rows = discover_plugin_surface(true);
+            if let Some(row) = surface_rows
+                .iter()
+                .find(|row| row.name.eq_ignore_ascii_case(&plugin_name))
+            {
+                println!("Plugin: {}", row.name);
+                println!("Source: {}", row.source.label());
+                println!(
+                    "Status: {}",
+                    if row.enabled { "enabled" } else { "disabled" }
+                );
+                let version = if row.version.trim().is_empty() {
+                    "unknown"
+                } else {
+                    row.version.as_str()
+                };
+                println!("Version: {}", version);
+                if let Some(kind) = row.kind.as_deref().filter(|k| !k.trim().is_empty()) {
+                    println!("Kind: {}", kind);
+                }
+                if let Some(path) = row.path.as_deref() {
+                    println!("Path: {}", path.display());
+                }
+                if let Some(value) = row
+                    .entrypoint_value
+                    .as_deref()
+                    .filter(|v| !v.trim().is_empty())
+                {
+                    println!("Entrypoint: {}", value);
+                }
+                if let Some(dist) = row
+                    .entrypoint_dist
+                    .as_deref()
+                    .filter(|d| !d.trim().is_empty())
+                {
+                    println!("Distribution: {}", dist);
+                }
+                if !row.description.trim().is_empty() {
+                    println!("Description: {}", row.description.trim());
+                }
+            }
+            let target = resolve_local_plugin_path_by_name(&plugin_name)
+                .unwrap_or_else(|| plugins_dir.join(&plugin_name));
             if !target.exists() {
+                if surface_rows
+                    .iter()
+                    .any(|row| row.name.eq_ignore_ascii_case(&plugin_name))
+                {
+                    return Ok(());
+                }
                 println!("Plugin '{}' not found.", plugin_name);
                 return Ok(());
             }
@@ -9947,7 +10526,7 @@ pub async fn handle_cli_plugins(
                 println!("Plugin '{}' has no plugin.yaml manifest.", plugin_name);
             }
         }
-        other => {
+        Some(other) => {
             println!("Plugins action '{}' is not recognized.", other);
             println!("Available: list, install, remove, enable, disable, update, inspect");
         }

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -439,6 +439,9 @@ async fn main() {
         CliCommand::Completion { shell } => run_completion(shell),
         CliCommand::Uninstall { yes } => run_uninstall(yes).await,
         CliCommand::Lumio { action, model } => run_lumio(action, model).await,
+        CliCommand::PluginExternal(raw) => {
+            hermes_cli::commands::handle_cli_external_plugin_subcommand(raw).await
+        }
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
## Summary
- add source-aware plugin discovery surface in Rust CLI: user + opt-in project (`HERMES_ENABLE_PROJECT_PLUGINS`) + Python entrypoint visibility
- make `hermes plugins` (no action) interactive toggle UI (general + provider-style single-select behavior)
- upgrade `/plugins` slash output to show full plugin surface/status/source
- add dynamic external subcommand bridge for plugin-provided commands via Python `discover_plugin_cli_commands()`
- add `inspect` to plugin action help + richer inspect output for entrypoint/file plugins
- add hermes-agent plugin discovery tests for project source include/exclude

## Validation
- `cargo fmt`
- `cargo check -p hermes-cli`
- `cargo test -p hermes-agent test_discover_plugins_with_options -- --nocapture`
- `cargo test -p hermes-agent test_discover_plugins -- --nocapture`
- `cargo test -p hermes-cli cli_parse_ -- --nocapture`
- runtime smoke (local):
  - `cargo run -q -p hermes-cli --bin hermes-agent-ultra -- plugins list`
  - `cargo run -q -p hermes-cli --bin hermes-agent-ultra -- plugins`
  - `cargo run -q -p hermes-cli --bin hermes-agent-ultra -- plugins inspect <name>`
