### PR TITLE
feat: generalize objective controls + operator specialization

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -2610,6 +2610,73 @@ impl AgentLoop {
         hermes_home.join("auth").join("tokens.json")
     }
 
+    fn objective_runtime_ledger_path(&self) -> PathBuf {
+        let hermes_home = self
+            .config
+            .hermes_home
+            .as_deref()
+            .map(PathBuf::from)
+            .or_else(|| std::env::var("HERMES_HOME").ok().map(PathBuf::from))
+            .or_else(|| dirs::home_dir().map(|h| h.join(".hermes")))
+            .unwrap_or_else(|| PathBuf::from(".hermes"));
+        hermes_home
+            .join("alpha")
+            .join("objective_runtime_ledger.jsonl")
+    }
+
+    fn append_objective_runtime_ledger(
+        &self,
+        messages: &[Message],
+        assistant_text: &str,
+        total_turns: u32,
+    ) -> Result<(), AgentError> {
+        let Some(objective) = extract_session_objective(messages) else {
+            return Ok(());
+        };
+        if objective.trim().is_empty() {
+            return Ok(());
+        }
+        let objective_id = short_sha256_hex(&format!("objective:{}", objective))
+            .chars()
+            .take(12)
+            .collect::<String>();
+        let objective_state = extract_objective_state_marker(assistant_text);
+        let evidence_files = extract_marker_values(assistant_text, "path=", 12);
+        let evidence_commands = extract_marker_values(assistant_text, "cmd=", 12);
+        let decision = if objective_state == "advancing" {
+            "promote"
+        } else if objective_state == "regressing" {
+            "investigate"
+        } else if objective_state == "unproven" {
+            "collect-more-evidence"
+        } else {
+            "monitor"
+        };
+        let entry = serde_json::json!({
+            "recorded_at": Utc::now().to_rfc3339(),
+            "objective_id": format!("obj-{}", objective_id),
+            "objective_state": objective_state,
+            "decision": decision,
+            "turns": total_turns,
+            "evidence_files": evidence_files,
+            "evidence_commands": evidence_commands,
+        });
+        let path = self.objective_runtime_ledger_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                AgentError::Io(format!("create {} failed: {}", parent.display(), e))
+            })?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| AgentError::Io(format!("open {} failed: {}", path.display(), e)))?;
+        writeln!(file, "{}", entry)
+            .map_err(|e| AgentError::Io(format!("append {} failed: {}", path.display(), e)))?;
+        Ok(())
+    }
+
     fn resolve_runtime_command_args(
         &self,
         provider: Option<&str>,
@@ -4410,6 +4477,16 @@ impl AgentLoop {
                     }
                 }
                 tracing::debug!("No tool calls in response, finishing naturally");
+                if let Err(err) = self.append_objective_runtime_ledger(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    total_turns,
+                ) {
+                    self.emit_status(
+                        "lifecycle",
+                        &format!("Objective runtime ledger append skipped: {}", err),
+                    );
+                }
                 // Final memory sync
                 let (u, a) = extract_last_user_assistant(ctx.get_messages());
                 self.memory_sync(&u, &a, session_id);
@@ -5505,6 +5582,16 @@ impl AgentLoop {
                         ));
                         continue;
                     }
+                }
+                if let Err(err) = self.append_objective_runtime_ledger(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    total_turns,
+                ) {
+                    self.emit_status(
+                        "lifecycle",
+                        &format!("Objective runtime ledger append skipped: {}", err),
+                    );
                 }
                 let (u, a) = extract_last_user_assistant(ctx.get_messages());
                 self.memory_sync(&u, &a, session_id);
@@ -7767,6 +7854,62 @@ fn default_model_cost_per_million(model: &str) -> Option<(f64, f64)> {
         return Some((10.0, 40.0));
     }
     None
+}
+
+fn extract_objective_state_marker(text: &str) -> String {
+    for line in text.lines() {
+        let lowered = line.trim().to_ascii_lowercase();
+        if let Some(rest) = lowered.split("objective_state=").nth(1) {
+            let token = rest
+                .trim_start()
+                .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
+                .next()
+                .unwrap_or("")
+                .trim_matches(|c: char| c == ')' || c == '.');
+            if !token.is_empty() {
+                return token.to_string();
+            }
+        }
+        if let Some(rest) = lowered.split("objective_state:").nth(1) {
+            let token = rest
+                .trim_start()
+                .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
+                .next()
+                .unwrap_or("")
+                .trim_matches(|c: char| c == ')' || c == '.');
+            if !token.is_empty() {
+                return token.to_string();
+            }
+        }
+    }
+    "unspecified".to_string()
+}
+
+fn extract_marker_values(text: &str, marker: &str, limit: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let Some(idx) = line.find(marker) else {
+            continue;
+        };
+        let rest = &line[idx + marker.len()..];
+        let value = rest
+            .split(|c: char| c.is_whitespace() || c == ')' || c == ',' || c == ';' || c == '|')
+            .next()
+            .unwrap_or("")
+            .trim();
+        if value.is_empty() {
+            continue;
+        }
+        let normalized = value.trim_matches(|c: char| c == '"' || c == '\'' || c == '`');
+        if normalized.is_empty() || out.iter().any(|v| v == normalized) {
+            continue;
+        }
+        out.push(normalized.to_string());
+        if out.len() >= limit {
+            break;
+        }
+    }
+    out
 }
 
 fn estimate_usage_cost_usd(usage: &UsageStats, model: &str, config: &AgentConfig) -> Option<f64> {
@@ -11696,5 +11839,25 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(coerced.tool_calls.as_ref().map(|v| v.len()), Some(1));
         assert_eq!(coerced.content.as_deref(), Some("Running tool."));
+    }
+
+    #[test]
+    fn test_extract_objective_state_marker_prefers_explicit_marker() {
+        let text = "ANALYTICS_VERIFIED:\n- objective_state=advancing metric=+0.12 SOL";
+        assert_eq!(extract_objective_state_marker(text), "advancing");
+        let colon_text = "ANALYTICS_VERIFIED:\n- objective_state: regressing metric=-0.30 SOL";
+        assert_eq!(extract_objective_state_marker(colon_text), "regressing");
+    }
+
+    #[test]
+    fn test_extract_marker_values_collects_unique_paths_and_cmds() {
+        let text = "PATCH_VERIFIED:\n- path=/tmp/a.rs exists_now=true\n- path=/tmp/a.rs exists_now=true\n- path=/tmp/b.rs exists_now=true\nDEEP_AUDIT_VERIFIED:\n- cmd=rg -n objective src\n- cmd=cargo test -p hermes-agent objective_guard";
+        let files = extract_marker_values(text, "path=", 8);
+        let cmds = extract_marker_values(text, "cmd=", 8);
+        assert_eq!(
+            files,
+            vec!["/tmp/a.rs".to_string(), "/tmp/b.rs".to_string()]
+        );
+        assert_eq!(cmds, vec!["rg".to_string(), "cargo".to_string()]);
     }
 }

--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -14,6 +14,10 @@ use crate::model_switch::{curated_provider_slugs, provider_model_ids};
 
 const ALPHA_STATE_DIR: &str = "alpha";
 const OBJECTIVE_CONTRACT_FILE: &str = "objective_contract.json";
+const OBJECTIVE_PROFILE_FILE: &str = "objective_profile.json";
+const OBJECTIVE_SIMULATION_POLICY_FILE: &str = "objective_simulation_policy.json";
+const OBJECTIVE_ENSEMBLE_POLICY_FILE: &str = "objective_ensemble_policy.json";
+const OBJECTIVE_LEARNING_LEDGER_FILE: &str = "objective_learning_ledger.json";
 const SUBAGENT_REGISTRY_FILE: &str = "subagents.json";
 const CONTEXTLATTICE_POLICY_FILE: &str = "contextlattice_policy.json";
 const LOOPS_FILE: &str = "loops.json";
@@ -73,6 +77,60 @@ pub struct ObjectiveContract {
     pub trading_sensitive: bool,
     #[serde(default)]
     pub counterfactual_journal: Vec<CounterfactualEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObjectiveProfile {
+    pub profile_id: String,
+    pub updated_at: String,
+    pub operator_hint: String,
+    pub default_shell: String,
+    pub memory_backend: String,
+    pub specialization_note: String,
+    #[serde(default)]
+    pub preferred_repos: Vec<String>,
+    #[serde(default)]
+    pub preferred_languages: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ObjectiveSimulationPolicy {
+    pub mode: String,
+    pub require_shadow_pass: bool,
+    pub min_shadow_samples: usize,
+    pub require_replay_validation: bool,
+    pub max_live_capital_fraction: f64,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObjectiveEnsemblePolicy {
+    pub mode: String,
+    pub arbitration: String,
+    pub min_voters: usize,
+    pub require_disagreement_explainer: bool,
+    pub allow_fast_path_single_model: bool,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObjectiveLearningLedgerEntry {
+    pub recorded_at: String,
+    pub objective_id: String,
+    pub objective_state: String,
+    pub decision: String,
+    #[serde(default)]
+    pub evidence_files: Vec<String>,
+    #[serde(default)]
+    pub evidence_commands: Vec<String>,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObjectiveLearningLedger {
+    pub updated_at: String,
+    #[serde(default)]
+    pub entries: Vec<ObjectiveLearningLedgerEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -192,6 +250,22 @@ fn objective_contract_path() -> PathBuf {
     alpha_state_dir().join(OBJECTIVE_CONTRACT_FILE)
 }
 
+fn objective_profile_path() -> PathBuf {
+    alpha_state_dir().join(OBJECTIVE_PROFILE_FILE)
+}
+
+fn objective_simulation_policy_path() -> PathBuf {
+    alpha_state_dir().join(OBJECTIVE_SIMULATION_POLICY_FILE)
+}
+
+fn objective_ensemble_policy_path() -> PathBuf {
+    alpha_state_dir().join(OBJECTIVE_ENSEMBLE_POLICY_FILE)
+}
+
+fn objective_learning_ledger_path() -> PathBuf {
+    alpha_state_dir().join(OBJECTIVE_LEARNING_LEDGER_FILE)
+}
+
 fn subagent_registry_path() -> PathBuf {
     alpha_state_dir().join(SUBAGENT_REGISTRY_FILE)
 }
@@ -251,6 +325,130 @@ fn default_contextlattice_policy() -> ContextLatticePolicy {
             "runbooks/alpha/provider".to_string(),
         ],
         conflict_resolution_mode: "source_weight_then_recency".to_string(),
+    }
+}
+
+fn default_objective_profile() -> ObjectiveProfile {
+    ObjectiveProfile {
+        profile_id: "repo-general".to_string(),
+        updated_at: now_rfc3339(),
+        operator_hint: "operator".to_string(),
+        default_shell: "auto".to_string(),
+        memory_backend: "contextlattice-preferred".to_string(),
+        specialization_note:
+            "Generalized repository profile: portable defaults with evidence-first execution."
+                .to_string(),
+        preferred_repos: vec![],
+        preferred_languages: vec!["rust".to_string(), "python".to_string(), "go".to_string()],
+    }
+}
+
+pub fn objective_profile_specialized_for(operator_hint: &str) -> ObjectiveProfile {
+    let normalized = operator_hint.trim().to_ascii_lowercase();
+    if normalized == "sheawinkler" {
+        return ObjectiveProfile {
+            profile_id: "sheawinkler".to_string(),
+            updated_at: now_rfc3339(),
+            operator_hint: "sheawinkler".to_string(),
+            default_shell: "zsh".to_string(),
+            memory_backend: "contextlattice-primary".to_string(),
+            specialization_note: "Specialized operator profile: ContextLattice-first, zsh-first, objective verification with deterministic evidence gates.".to_string(),
+            preferred_repos: vec![
+                "~/Documents/Projects/hermes-agent-ultra".to_string(),
+                "~/Documents/Projects/algotraderv2_rust".to_string(),
+                "~/Documents/Projects/fastapi-sidecar".to_string(),
+            ],
+            preferred_languages: vec![
+                "rust".to_string(),
+                "python".to_string(),
+                "go".to_string(),
+                "typescript".to_string(),
+            ],
+        };
+    }
+    ObjectiveProfile {
+        profile_id: "operator-custom".to_string(),
+        updated_at: now_rfc3339(),
+        operator_hint: operator_hint.trim().to_string(),
+        default_shell: "auto".to_string(),
+        memory_backend: "contextlattice-preferred".to_string(),
+        specialization_note: "Specialized operator profile generated from runtime command."
+            .to_string(),
+        preferred_repos: vec![],
+        preferred_languages: vec!["rust".to_string(), "python".to_string(), "go".to_string()],
+    }
+}
+
+fn default_objective_simulation_policy() -> ObjectiveSimulationPolicy {
+    ObjectiveSimulationPolicy {
+        mode: "balanced".to_string(),
+        require_shadow_pass: true,
+        min_shadow_samples: 5,
+        require_replay_validation: true,
+        max_live_capital_fraction: 0.25,
+        updated_at: now_rfc3339(),
+    }
+}
+
+fn simulation_policy_for_mode(mode: &str) -> ObjectiveSimulationPolicy {
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "strict" => ObjectiveSimulationPolicy {
+            mode: "strict".to_string(),
+            require_shadow_pass: true,
+            min_shadow_samples: 12,
+            require_replay_validation: true,
+            max_live_capital_fraction: 0.08,
+            updated_at: now_rfc3339(),
+        },
+        "aggressive" => ObjectiveSimulationPolicy {
+            mode: "aggressive".to_string(),
+            require_shadow_pass: false,
+            min_shadow_samples: 0,
+            require_replay_validation: false,
+            max_live_capital_fraction: 0.40,
+            updated_at: now_rfc3339(),
+        },
+        _ => default_objective_simulation_policy(),
+    }
+}
+
+fn default_objective_ensemble_policy() -> ObjectiveEnsemblePolicy {
+    ObjectiveEnsemblePolicy {
+        mode: "committee".to_string(),
+        arbitration: "weighted-confidence".to_string(),
+        min_voters: 2,
+        require_disagreement_explainer: true,
+        allow_fast_path_single_model: true,
+        updated_at: now_rfc3339(),
+    }
+}
+
+fn ensemble_policy_for_mode(mode: &str) -> ObjectiveEnsemblePolicy {
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "single" => ObjectiveEnsemblePolicy {
+            mode: "single".to_string(),
+            arbitration: "primary-model".to_string(),
+            min_voters: 1,
+            require_disagreement_explainer: false,
+            allow_fast_path_single_model: true,
+            updated_at: now_rfc3339(),
+        },
+        "debate" => ObjectiveEnsemblePolicy {
+            mode: "debate".to_string(),
+            arbitration: "disagreement-resolution".to_string(),
+            min_voters: 3,
+            require_disagreement_explainer: true,
+            allow_fast_path_single_model: false,
+            updated_at: now_rfc3339(),
+        },
+        _ => default_objective_ensemble_policy(),
+    }
+}
+
+fn default_objective_learning_ledger() -> ObjectiveLearningLedger {
+    ObjectiveLearningLedger {
+        updated_at: now_rfc3339(),
+        entries: vec![],
     }
 }
 
@@ -419,6 +617,30 @@ pub fn ensure_alpha_runtime_bootstrap(force: bool) -> Result<Vec<PathBuf>, Agent
             },
         )?;
         written.push(runtime_path);
+    }
+
+    let profile_path = objective_profile_path();
+    if force || !profile_path.exists() {
+        write_json_file(&profile_path, &default_objective_profile())?;
+        written.push(profile_path);
+    }
+
+    let sim_policy_path = objective_simulation_policy_path();
+    if force || !sim_policy_path.exists() {
+        write_json_file(&sim_policy_path, &default_objective_simulation_policy())?;
+        written.push(sim_policy_path);
+    }
+
+    let ensemble_policy_path = objective_ensemble_policy_path();
+    if force || !ensemble_policy_path.exists() {
+        write_json_file(&ensemble_policy_path, &default_objective_ensemble_policy())?;
+        written.push(ensemble_policy_path);
+    }
+
+    let learning_ledger_path = objective_learning_ledger_path();
+    if force || !learning_ledger_path.exists() {
+        write_json_file(&learning_ledger_path, &default_objective_learning_ledger())?;
+        written.push(learning_ledger_path);
     }
 
     Ok(written)
@@ -613,6 +835,76 @@ pub fn append_counterfactual(
     contract.updated_at = now_rfc3339();
     write_json_file(&objective_contract_path(), &contract)?;
     Ok(contract)
+}
+
+pub fn load_objective_profile() -> Result<ObjectiveProfile, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    read_json_file(&objective_profile_path())
+}
+
+pub fn set_objective_profile(profile: ObjectiveProfile) -> Result<ObjectiveProfile, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    let mut updated = profile;
+    updated.updated_at = now_rfc3339();
+    write_json_file(&objective_profile_path(), &updated)?;
+    Ok(updated)
+}
+
+pub fn reset_objective_profile_generalized() -> Result<ObjectiveProfile, AgentError> {
+    set_objective_profile(default_objective_profile())
+}
+
+pub fn load_objective_simulation_policy() -> Result<ObjectiveSimulationPolicy, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    read_json_file(&objective_simulation_policy_path())
+}
+
+pub fn set_objective_simulation_mode(mode: &str) -> Result<ObjectiveSimulationPolicy, AgentError> {
+    let policy = simulation_policy_for_mode(mode);
+    ensure_alpha_runtime_bootstrap(false)?;
+    write_json_file(&objective_simulation_policy_path(), &policy)?;
+    Ok(policy)
+}
+
+pub fn load_objective_ensemble_policy() -> Result<ObjectiveEnsemblePolicy, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    read_json_file(&objective_ensemble_policy_path())
+}
+
+pub fn set_objective_ensemble_mode(mode: &str) -> Result<ObjectiveEnsemblePolicy, AgentError> {
+    let policy = ensemble_policy_for_mode(mode);
+    ensure_alpha_runtime_bootstrap(false)?;
+    write_json_file(&objective_ensemble_policy_path(), &policy)?;
+    Ok(policy)
+}
+
+pub fn load_objective_learning_ledger() -> Result<ObjectiveLearningLedger, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    read_json_file(&objective_learning_ledger_path())
+}
+
+pub fn append_objective_learning_entry(
+    mut entry: ObjectiveLearningLedgerEntry,
+) -> Result<ObjectiveLearningLedger, AgentError> {
+    let mut ledger = load_objective_learning_ledger()?;
+    if entry.recorded_at.trim().is_empty() {
+        entry.recorded_at = now_rfc3339();
+    }
+    ledger.entries.push(entry);
+    if ledger.entries.len() > 512 {
+        let drain = ledger.entries.len().saturating_sub(512);
+        ledger.entries.drain(0..drain);
+    }
+    ledger.updated_at = now_rfc3339();
+    write_json_file(&objective_learning_ledger_path(), &ledger)?;
+    Ok(ledger)
+}
+
+pub fn clear_objective_learning_ledger() -> Result<ObjectiveLearningLedger, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    let ledger = default_objective_learning_ledger();
+    write_json_file(&objective_learning_ledger_path(), &ledger)?;
+    Ok(ledger)
 }
 
 pub fn load_subagent_registry() -> Result<SubagentRegistry, AgentError> {
@@ -2657,5 +2949,45 @@ mod tests {
         };
         let drift = collect_repo_drift(&spec, &TradingDriftBaseline::default());
         assert_eq!(drift.drift_state, "missing-project");
+    }
+
+    #[test]
+    fn objective_profile_and_policy_planes_roundtrip() {
+        let tmp = tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+
+        let profile = objective_profile_specialized_for("sheawinkler");
+        let profile = set_objective_profile(profile).expect("set profile");
+        assert_eq!(profile.profile_id, "sheawinkler");
+        assert_eq!(profile.default_shell, "zsh");
+        let loaded_profile = load_objective_profile().expect("load profile");
+        assert_eq!(loaded_profile.profile_id, "sheawinkler");
+
+        let sim = set_objective_simulation_mode("strict").expect("strict sim");
+        assert_eq!(sim.mode, "strict");
+        assert!(sim.require_shadow_pass);
+        assert!(sim.require_replay_validation);
+        let ensemble = set_objective_ensemble_mode("debate").expect("debate ensemble");
+        assert_eq!(ensemble.mode, "debate");
+        assert!(ensemble.require_disagreement_explainer);
+        assert!(!ensemble.allow_fast_path_single_model);
+
+        let ledger = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
+            recorded_at: String::new(),
+            objective_id: "obj-demo".to_string(),
+            objective_state: "advancing".to_string(),
+            decision: "promote".to_string(),
+            evidence_files: vec!["src/lib.rs".to_string()],
+            evidence_commands: vec!["cargo test".to_string()],
+            notes: "test-entry".to_string(),
+        })
+        .expect("append ledger");
+        assert_eq!(ledger.entries.len(), 1);
+        assert_eq!(ledger.entries[0].objective_id, "obj-demo");
+
+        let generalized = reset_objective_profile_generalized().expect("reset profile");
+        assert_eq!(generalized.profile_id, "repo-general");
+        std::env::remove_var("HERMES_HOME");
     }
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -23,12 +23,16 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::alpha_runtime::{
-    append_counterfactual, clear_objective_contract, enqueue_loop_event,
-    ensure_alpha_runtime_bootstrap, ensure_trading_runtime_bootstrap, load_alpha_loops,
-    load_last_trading_alpha_report, load_objective_contract, recover_orphan_loop_events,
-    refresh_trading_alpha_report, render_mission_board, render_trading_alpha_board,
-    replay_loop_queue, summarize_objective_contract, upsert_objective_contract,
-    utility_terms_from_contract,
+    append_counterfactual, append_objective_learning_entry, clear_objective_contract,
+    clear_objective_learning_ledger, enqueue_loop_event, ensure_alpha_runtime_bootstrap,
+    ensure_trading_runtime_bootstrap, load_alpha_loops, load_last_trading_alpha_report,
+    load_objective_contract, load_objective_ensemble_policy, load_objective_learning_ledger,
+    load_objective_profile, load_objective_simulation_policy, objective_profile_specialized_for,
+    recover_orphan_loop_events, refresh_trading_alpha_report, render_mission_board,
+    render_trading_alpha_board, replay_loop_queue, reset_objective_profile_generalized,
+    set_objective_ensemble_mode, set_objective_profile, set_objective_simulation_mode,
+    summarize_objective_contract, upsert_objective_contract, utility_terms_from_contract,
+    ObjectiveLearningLedgerEntry,
 };
 use crate::app::{App, PetDock, PetSettings};
 use crate::model_switch::{curated_provider_slugs, normalize_provider_model, provider_model_ids};
@@ -149,7 +153,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/objective",
-        "Set/show/clear objective contract (`status|plan|constraints|counterfactual|clear`)",
+        "Set/show objective contract + profile/policies (`status|plan|constraints|counterfactual|profile|simulator|ensemble|ledger|clear`)",
     ),
     ("/goal", "Alias for /objective"),
     (
@@ -7447,10 +7451,245 @@ fn handle_capability_surface_command(
 }
 
 fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
-    let objective_usage = "Usage: `/objective <text>` or `/objective status|plan|constraints|counterfactual <scenario> | <expected_delta>|clear`.";
+    let objective_usage = "Usage: `/objective <text>` or `/objective status|plan|constraints|counterfactual <scenario> | <expected_delta>|profile [status|list|general|me|set <id>]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|clear`.";
 
     if let Some(first) = args.first() {
         let cmd = first.trim().to_ascii_lowercase();
+        if cmd == "profile" {
+            let sub = args
+                .get(1)
+                .map(|v| v.trim().to_ascii_lowercase())
+                .unwrap_or_else(|| "status".to_string());
+            match sub.as_str() {
+                "status" | "show" => {
+                    let p = load_objective_profile()?;
+                    let mut out = String::new();
+                    out.push_str("Objective profile\n");
+                    out.push_str("-----------------\n");
+                    let _ = writeln!(out, "profile_id: {}", p.profile_id);
+                    let _ = writeln!(out, "operator_hint: {}", p.operator_hint);
+                    let _ = writeln!(out, "default_shell: {}", p.default_shell);
+                    let _ = writeln!(out, "memory_backend: {}", p.memory_backend);
+                    let _ = writeln!(out, "specialization_note: {}", p.specialization_note);
+                    if !p.preferred_repos.is_empty() {
+                        out.push_str("preferred_repos:\n");
+                        for repo in p.preferred_repos {
+                            let _ = writeln!(out, "- {}", repo);
+                        }
+                    }
+                    if !p.preferred_languages.is_empty() {
+                        out.push_str("preferred_languages:\n");
+                        for lang in p.preferred_languages {
+                            let _ = writeln!(out, "- {}", lang);
+                        }
+                    }
+                    emit_command_output(app, out.trim_end());
+                    return Ok(CommandResult::Handled);
+                }
+                "list" => {
+                    emit_command_output(
+                        app,
+                        "Objective profile presets:\n- repo-general: generalized defaults for any operator/repo\n- sheawinkler: specialized ContextLattice+zsh profile\n- operator-custom: generated when using `/objective profile set <name>`",
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                "general" | "repo-general" | "reset" => {
+                    let profile = reset_objective_profile_generalized()?;
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Objective profile reset to generalized defaults.\nprofile_id={} memory_backend={} shell={}",
+                            profile.profile_id, profile.memory_backend, profile.default_shell
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                "me" | "sheawinkler" => {
+                    let profile = set_objective_profile(objective_profile_specialized_for(
+                        std::env::var("USER")
+                            .unwrap_or_else(|_| "sheawinkler".to_string())
+                            .as_str(),
+                    ))?;
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Objective profile specialized for operator.\nprofile_id={} memory_backend={} shell={}",
+                            profile.profile_id, profile.memory_backend, profile.default_shell
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                "set" => {
+                    let Some(name) = args.get(2) else {
+                        emit_command_output(
+                            app,
+                            "Usage: /objective profile set <name> (or use /objective profile me|general)",
+                        );
+                        return Ok(CommandResult::Handled);
+                    };
+                    let profile = set_objective_profile(objective_profile_specialized_for(name))?;
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Objective profile set.\nprofile_id={} operator_hint={} shell={} memory_backend={}",
+                            profile.profile_id,
+                            profile.operator_hint,
+                            profile.default_shell,
+                            profile.memory_backend
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                _ => {
+                    emit_command_output(
+                        app,
+                        "Usage: /objective profile [status|list|general|me|set <id>]",
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+            }
+        }
+
+        if cmd == "simulator" || cmd == "simulation" {
+            let sub = args
+                .get(1)
+                .map(|v| v.trim().to_ascii_lowercase())
+                .unwrap_or_else(|| "status".to_string());
+            if sub == "status" || sub == "show" {
+                let p = load_objective_simulation_policy()?;
+                emit_command_output(
+                    app,
+                    format!(
+                        "Objective simulation policy\nmode={}\nrequire_shadow_pass={}\nmin_shadow_samples={}\nrequire_replay_validation={}\nmax_live_capital_fraction={:.4}\nupdated_at={}",
+                        p.mode,
+                        p.require_shadow_pass,
+                        p.min_shadow_samples,
+                        p.require_replay_validation,
+                        p.max_live_capital_fraction,
+                        p.updated_at
+                    ),
+                );
+                return Ok(CommandResult::Handled);
+            }
+            if !matches!(sub.as_str(), "balanced" | "strict" | "aggressive") {
+                emit_command_output(
+                    app,
+                    "Usage: /objective simulator [status|balanced|strict|aggressive]",
+                );
+                return Ok(CommandResult::Handled);
+            }
+            let p = set_objective_simulation_mode(&sub)?;
+            emit_command_output(
+                app,
+                format!(
+                    "Objective simulation policy updated.\nmode={} shadow_pass={} replay_validation={} max_live_capital_fraction={:.4}",
+                    p.mode,
+                    p.require_shadow_pass,
+                    p.require_replay_validation,
+                    p.max_live_capital_fraction
+                ),
+            );
+            return Ok(CommandResult::Handled);
+        }
+
+        if cmd == "ensemble" {
+            let sub = args
+                .get(1)
+                .map(|v| v.trim().to_ascii_lowercase())
+                .unwrap_or_else(|| "status".to_string());
+            if sub == "status" || sub == "show" {
+                let p = load_objective_ensemble_policy()?;
+                emit_command_output(
+                    app,
+                    format!(
+                        "Objective ensemble policy\nmode={}\narbitration={}\nmin_voters={}\nrequire_disagreement_explainer={}\nallow_fast_path_single_model={}\nupdated_at={}",
+                        p.mode,
+                        p.arbitration,
+                        p.min_voters,
+                        p.require_disagreement_explainer,
+                        p.allow_fast_path_single_model,
+                        p.updated_at
+                    ),
+                );
+                return Ok(CommandResult::Handled);
+            }
+            if !matches!(sub.as_str(), "committee" | "single" | "debate") {
+                emit_command_output(
+                    app,
+                    "Usage: /objective ensemble [status|committee|single|debate]",
+                );
+                return Ok(CommandResult::Handled);
+            }
+            let p = set_objective_ensemble_mode(&sub)?;
+            emit_command_output(
+                app,
+                format!(
+                    "Objective ensemble policy updated.\nmode={} arbitration={} min_voters={} disagreement_explainer={}",
+                    p.mode, p.arbitration, p.min_voters, p.require_disagreement_explainer
+                ),
+            );
+            return Ok(CommandResult::Handled);
+        }
+
+        if cmd == "ledger" {
+            let sub = args
+                .get(1)
+                .map(|v| v.trim().to_ascii_lowercase())
+                .unwrap_or_else(|| "status".to_string());
+            if sub == "clear" {
+                clear_objective_learning_ledger()?;
+                emit_command_output(app, "Objective learning ledger cleared.");
+                return Ok(CommandResult::Handled);
+            }
+            let ledger = load_objective_learning_ledger()?;
+            if sub == "status" || sub == "show" {
+                let last = ledger
+                    .entries
+                    .last()
+                    .map(|v| format!("{} {} {}", v.recorded_at, v.objective_state, v.decision))
+                    .unwrap_or_else(|| "none".to_string());
+                emit_command_output(
+                    app,
+                    format!(
+                        "Objective learning ledger\nentries={}\nupdated_at={}\nlast_entry={}",
+                        ledger.entries.len(),
+                        ledger.updated_at,
+                        last
+                    ),
+                );
+                return Ok(CommandResult::Handled);
+            }
+            if sub == "tail" {
+                let n = args
+                    .get(2)
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(8)
+                    .clamp(1, 64);
+                let mut out = String::new();
+                out.push_str("Objective learning ledger tail\n");
+                out.push_str("-----------------------------\n");
+                let start = ledger.entries.len().saturating_sub(n);
+                for row in &ledger.entries[start..] {
+                    let _ = writeln!(
+                        out,
+                        "- {} id={} state={} decision={} notes={}",
+                        row.recorded_at,
+                        row.objective_id,
+                        row.objective_state,
+                        row.decision,
+                        row.notes
+                    );
+                }
+                if ledger.entries.is_empty() {
+                    out.push_str("(empty)\n");
+                }
+                emit_command_output(app, out.trim_end());
+                return Ok(CommandResult::Handled);
+            }
+            emit_command_output(app, "Usage: /objective ledger [status|tail [n]|clear]");
+            return Ok(CommandResult::Handled);
+        }
+
         if cmd == "status" || cmd == "show" {
             let mut out = String::new();
             match app.session_objective.as_deref() {
@@ -7467,6 +7706,27 @@ fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                 let _ = writeln!(out, "{}", summarize_objective_contract(&contract));
             } else {
                 let _ = writeln!(out, "\nNo persisted objective contract yet.");
+            }
+            if let Ok(profile) = load_objective_profile() {
+                let _ = writeln!(
+                    out,
+                    "\nObjective profile\n-----------------\nprofile_id: {}\noperator_hint: {}\nmemory_backend: {}\ndefault_shell: {}",
+                    profile.profile_id, profile.operator_hint, profile.memory_backend, profile.default_shell
+                );
+            }
+            if let Ok(sim) = load_objective_simulation_policy() {
+                let _ = writeln!(
+                    out,
+                    "\nSimulation policy\n-----------------\nmode: {} (shadow_pass={} replay_validation={} cap={:.4})",
+                    sim.mode, sim.require_shadow_pass, sim.require_replay_validation, sim.max_live_capital_fraction
+                );
+            }
+            if let Ok(ensemble) = load_objective_ensemble_policy() {
+                let _ = writeln!(
+                    out,
+                    "\nEnsemble policy\n---------------\nmode: {} (arbitration={} min_voters={})",
+                    ensemble.mode, ensemble.arbitration, ensemble.min_voters
+                );
             }
             emit_command_output(app, out.trim_end());
             return Ok(CommandResult::Handled);
@@ -7570,8 +7830,20 @@ fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResul
         || first.eq_ignore_ascii_case("none")
         || first.eq_ignore_ascii_case("reset")
     {
+        let previous_id = load_objective_contract()?
+            .map(|c| c.id)
+            .unwrap_or_else(|| "none".to_string());
         app.set_session_objective(None);
         clear_objective_contract()?;
+        let _ = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
+            recorded_at: String::new(),
+            objective_id: previous_id,
+            objective_state: "cleared".to_string(),
+            decision: "objective_clear".to_string(),
+            evidence_files: vec![],
+            evidence_commands: vec!["/objective clear".to_string()],
+            notes: "Objective contract cleared by operator command.".to_string(),
+        });
         emit_command_output(app, "Session objective cleared.");
         return Ok(CommandResult::Handled);
     }
@@ -7589,6 +7861,19 @@ fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResul
     .any(|needle| objective_lc.contains(needle));
     let contract = upsert_objective_contract(&objective, trading_sensitive)?;
     app.set_session_objective(Some(objective.clone()));
+    let _ = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
+        recorded_at: String::new(),
+        objective_id: contract.id.clone(),
+        objective_state: "configured".to_string(),
+        decision: "objective_set".to_string(),
+        evidence_files: vec!["alpha/objective_contract.json".to_string()],
+        evidence_commands: vec!["/objective <text>".to_string()],
+        notes: if trading_sensitive {
+            "Trading-sensitive objective configured.".to_string()
+        } else {
+            "General objective configured.".to_string()
+        },
+    });
     emit_command_output(
         app,
         format!(


### PR DESCRIPTION
## Summary
- add persisted objective profile/simulation/ensemble/learning-ledger state planes
- add `/objective profile|simulator|ensemble|ledger` subcommands with generalized defaults and operator specialization path
- append objective runtime ledger entries at natural agent-loop completion with objective_state/evidence markers

## Verification
- `cargo check -p hermes-cli -p hermes-agent`
- `cargo test -p hermes-cli objective_profile_and_policy_planes_roundtrip -- --nocapture`
- `cargo test -p hermes-agent test_extract_objective_state_marker_prefers_explicit_marker -- --nocapture`
- `cargo test -p hermes-agent test_extract_marker_values_collects_unique_paths_and_cmds -- --nocapture`
- `cargo test -p hermes-cli test_objective_command_is_registered_and_completable -- --nocapture`
