### PR TITLE
Fix alpha_runtime flaky concurrency around HERMES_HOME

### DIFF
--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -368,6 +368,10 @@ fn ensure_alpha_dir() -> Result<(), AgentError> {
 fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), AgentError> {
     let serialized = serde_json::to_string_pretty(value)
         .map_err(|e| AgentError::Config(format!("serialize {} failed: {}", path.display(), e)))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AgentError::Io(format!("failed to create {}: {}", parent.display(), e)))?;
+    }
     std::fs::write(path, serialized)
         .map_err(|e| AgentError::Io(format!("write {} failed: {}", path.display(), e)))
 }
@@ -3082,47 +3086,80 @@ pub fn render_trading_alpha_board(report: &TradingAlphaReport) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock;
+    use std::ffi::OsString;
+    use std::path::Path;
+    use std::sync::MutexGuard;
     use tempfile::tempdir;
+
+    struct ScopedHermesHome {
+        previous: Option<OsString>,
+    }
+
+    impl ScopedHermesHome {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var_os("HERMES_HOME");
+            std::env::set_var("HERMES_HOME", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for ScopedHermesHome {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("HERMES_HOME", value),
+                None => std::env::remove_var("HERMES_HOME"),
+            }
+        }
+    }
+
+    fn hermes_home_lock() -> MutexGuard<'static, ()> {
+        test_env_lock::lock()
+    }
+
+    fn with_test_hermes_home<T>(f: impl FnOnce() -> T) -> T {
+        let _lock = hermes_home_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home = ScopedHermesHome::set(tmp.path());
+        f()
+    }
 
     #[test]
     fn objective_contract_roundtrip_and_counterfactual() {
-        let tmp = tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", tmp.path());
-        let contract = upsert_objective_contract(
-            "maximize reliability while keeping latency low and never skipping tests",
-            false,
-        )
-        .expect("upsert");
-        assert!(!contract.utility.terms.is_empty());
-        assert!(!contract.utility.hard_constraints.is_empty());
-        assert_eq!(contract.horizons.len(), 3);
-        let updated = append_counterfactual("if we defer tests", "risk rises").expect("append");
-        assert_eq!(updated.counterfactual_journal.len(), 1);
-        std::env::remove_var("HERMES_HOME");
+        with_test_hermes_home(|| {
+            let contract = upsert_objective_contract(
+                "maximize reliability while keeping latency low and never skipping tests",
+                false,
+            )
+            .expect("upsert");
+            assert!(!contract.utility.terms.is_empty());
+            assert!(!contract.utility.hard_constraints.is_empty());
+            assert_eq!(contract.horizons.len(), 3);
+            let updated = append_counterfactual("if we defer tests", "risk rises").expect("append");
+            assert_eq!(updated.counterfactual_journal.len(), 1);
+        });
     }
 
     #[test]
     fn bootstrap_writes_runtime_files() {
-        let tmp = tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", tmp.path());
-        let written = ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
-        assert!(!written.is_empty());
-        assert!(alpha_state_dir().join(LOOPS_FILE).exists());
-        assert!(alpha_state_dir().join(SUBAGENT_REGISTRY_FILE).exists());
-        assert!(alpha_state_dir().join(CONTEXTLATTICE_POLICY_FILE).exists());
-        std::env::remove_var("HERMES_HOME");
+        with_test_hermes_home(|| {
+            let written = ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+            assert!(!written.is_empty());
+            assert!(alpha_state_dir().join(LOOPS_FILE).exists());
+            assert!(alpha_state_dir().join(SUBAGENT_REGISTRY_FILE).exists());
+            assert!(alpha_state_dir().join(CONTEXTLATTICE_POLICY_FILE).exists());
+        });
     }
 
     #[test]
     fn queue_replay_is_deduplicated() {
-        let tmp = tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", tmp.path());
-        ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
-        enqueue_loop_event("loop-a", "tick", "same-payload").expect("event1");
-        enqueue_loop_event("loop-a", "tick", "same-payload").expect("event2");
-        let replayed = replay_loop_queue(10).expect("replay");
-        assert_eq!(replayed, 1);
-        std::env::remove_var("HERMES_HOME");
+        with_test_hermes_home(|| {
+            ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+            enqueue_loop_event("loop-a", "tick", "same-payload").expect("event1");
+            enqueue_loop_event("loop-a", "tick", "same-payload").expect("event2");
+            let replayed = replay_loop_queue(10).expect("replay");
+            assert_eq!(replayed, 1);
+        });
     }
 
     #[test]
@@ -3134,16 +3171,15 @@ mod tests {
 
     #[test]
     fn trading_runtime_bootstrap_and_report_refresh_work() {
-        let tmp = tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", tmp.path());
-        ensure_trading_runtime_bootstrap(true).expect("bootstrap trading");
-        let cfg = load_trading_runtime_config().expect("load trading config");
-        assert!(!cfg.projects.is_empty());
-        let report = refresh_trading_alpha_report().expect("refresh report");
-        assert!(!report.generated_at.is_empty());
-        let loaded = load_last_trading_alpha_report().expect("load report");
-        assert_eq!(loaded.generated_at, report.generated_at);
-        std::env::remove_var("HERMES_HOME");
+        with_test_hermes_home(|| {
+            ensure_trading_runtime_bootstrap(true).expect("bootstrap trading");
+            let cfg = load_trading_runtime_config().expect("load trading config");
+            assert!(!cfg.projects.is_empty());
+            let report = refresh_trading_alpha_report().expect("refresh report");
+            assert!(!report.generated_at.is_empty());
+            let loaded = load_last_trading_alpha_report().expect("load report");
+            assert_eq!(loaded.generated_at, report.generated_at);
+        });
     }
 
     #[test]
@@ -3228,79 +3264,78 @@ mod tests {
 
     #[test]
     fn objective_profile_and_policy_planes_roundtrip() {
-        let tmp = tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", tmp.path());
-        ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+        with_test_hermes_home(|| {
+            ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
 
-        let profile = objective_profile_specialized_for("sheawinkler");
-        let profile = set_objective_profile(profile).expect("set profile");
-        assert_eq!(profile.profile_id, "sheawinkler");
-        assert_eq!(profile.default_shell, "zsh");
-        let loaded_profile = load_objective_profile().expect("load profile");
-        assert_eq!(loaded_profile.profile_id, "sheawinkler");
+            let profile = objective_profile_specialized_for("sheawinkler");
+            let profile = set_objective_profile(profile).expect("set profile");
+            assert_eq!(profile.profile_id, "sheawinkler");
+            assert_eq!(profile.default_shell, "zsh");
+            let loaded_profile = load_objective_profile().expect("load profile");
+            assert_eq!(loaded_profile.profile_id, "sheawinkler");
 
-        let sim = set_objective_simulation_mode("strict").expect("strict sim");
-        assert_eq!(sim.mode, "strict");
-        assert!(sim.require_shadow_pass);
-        assert!(sim.require_replay_validation);
-        let ensemble = set_objective_ensemble_mode("debate").expect("debate ensemble");
-        assert_eq!(ensemble.mode, "debate");
-        assert!(ensemble.require_disagreement_explainer);
-        assert!(!ensemble.allow_fast_path_single_model);
+            let sim = set_objective_simulation_mode("strict").expect("strict sim");
+            assert_eq!(sim.mode, "strict");
+            assert!(sim.require_shadow_pass);
+            assert!(sim.require_replay_validation);
+            let ensemble = set_objective_ensemble_mode("debate").expect("debate ensemble");
+            assert_eq!(ensemble.mode, "debate");
+            assert!(ensemble.require_disagreement_explainer);
+            assert!(!ensemble.allow_fast_path_single_model);
 
-        let ledger = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
-            recorded_at: String::new(),
-            objective_id: "obj-demo".to_string(),
-            objective_state: "advancing".to_string(),
-            decision: "promote".to_string(),
-            evidence_files: vec!["src/lib.rs".to_string()],
-            evidence_commands: vec!["cargo test".to_string()],
-            notes: "test-entry".to_string(),
-        })
-        .expect("append ledger");
-        assert_eq!(ledger.entries.len(), 1);
-        assert_eq!(ledger.entries[0].objective_id, "obj-demo");
+            let ledger = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
+                recorded_at: String::new(),
+                objective_id: "obj-demo".to_string(),
+                objective_state: "advancing".to_string(),
+                decision: "promote".to_string(),
+                evidence_files: vec!["src/lib.rs".to_string()],
+                evidence_commands: vec!["cargo test".to_string()],
+                notes: "test-entry".to_string(),
+            })
+            .expect("append ledger");
+            assert_eq!(ledger.entries.len(), 1);
+            assert_eq!(ledger.entries[0].objective_id, "obj-demo");
 
-        let generalized = reset_objective_profile_generalized().expect("reset profile");
-        assert_eq!(generalized.profile_id, "repo-general");
-        std::env::remove_var("HERMES_HOME");
+            let generalized = reset_objective_profile_generalized().expect("reset profile");
+            assert_eq!(generalized.profile_id, "repo-general");
+        });
     }
 
     #[test]
     fn objective_dag_claim_quorum_and_eval_surfaces_roundtrip() {
-        let tmp = tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", tmp.path());
-        ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
-        upsert_objective_contract("improve objective with verified rollout", false).expect("obj");
+        with_test_hermes_home(|| {
+            ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+            upsert_objective_contract("improve objective with verified rollout", false)
+                .expect("obj");
 
-        let dag = build_objective_dag_from_contract().expect("build dag");
-        assert_eq!(dag.objective_id.starts_with("obj-"), true);
-        assert!(dag.nodes.len() >= 4);
-        let loaded_dag = load_objective_dag().expect("load dag");
-        assert_eq!(loaded_dag.nodes.len(), dag.nodes.len());
+            let dag = build_objective_dag_from_contract().expect("build dag");
+            assert_eq!(dag.objective_id.starts_with("obj-"), true);
+            assert!(dag.nodes.len() >= 4);
+            let loaded_dag = load_objective_dag().expect("load dag");
+            assert_eq!(loaded_dag.nodes.len(), dag.nodes.len());
 
-        let claim = set_claim_verifier_enabled(false).expect("claim off");
-        assert!(!claim.enabled);
-        let claim = set_claim_verifier_enabled(true).expect("claim on");
-        assert!(claim.enabled);
+            let claim = set_claim_verifier_enabled(false).expect("claim off");
+            assert!(!claim.enabled);
+            let claim = set_claim_verifier_enabled(true).expect("claim on");
+            assert!(claim.enabled);
 
-        let quorum = set_quorum_policy(
-            true,
-            Some(3),
-            Some(vec!["nous:nousresearch/hermes-4-70b".to_string()]),
-        )
-        .expect("quorum");
-        assert!(quorum.enabled);
-        assert_eq!(quorum.voters, 3);
-        assert_eq!(quorum.models.len(), 1);
+            let quorum = set_quorum_policy(
+                true,
+                Some(3),
+                Some(vec!["nous:nousresearch/hermes-4-70b".to_string()]),
+            )
+            .expect("quorum");
+            assert!(quorum.enabled);
+            assert_eq!(quorum.voters, 3);
+            assert_eq!(quorum.models.len(), 1);
 
-        let trend = append_objective_eval_sample("obj-demo", "advancing", "test sample")
-            .expect("append eval");
-        assert_eq!(trend.samples.len(), 1);
-        assert!(trend.samples[0].score > 0.9);
+            let trend = append_objective_eval_sample("obj-demo", "advancing", "test sample")
+                .expect("append eval");
+            assert_eq!(trend.samples.len(), 1);
+            assert!(trend.samples[0].score > 0.9);
 
-        let cleared = clear_objective_dag().expect("clear dag");
-        assert!(cleared.nodes.is_empty());
-        std::env::remove_var("HERMES_HOME");
+            let cleared = clear_objective_dag().expect("clear dag");
+            assert!(cleared.nodes.is_empty());
+        });
     }
 }

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -1489,15 +1489,12 @@ fn apply_cli_runtime_overrides(config: &mut GatewayConfig, cli: &Cli) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock;
     use hermes_config::LlmProviderConfig;
     use std::collections::HashMap;
-    use std::sync::{Mutex, OnceLock};
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("env test lock")
+        test_env_lock::lock()
     }
 
     fn build_minimal_test_app() -> App {

--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -3034,13 +3034,7 @@ pub async fn logout(provider: &str) -> Result<String, AgentError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static OPENAI_ENV_LOCK: Mutex<()> = Mutex::new(());
-    static ANTHROPIC_ENV_LOCK: Mutex<()> = Mutex::new(());
-    static NOUS_ENV_LOCK: Mutex<()> = Mutex::new(());
-    static QWEN_ENV_LOCK: Mutex<()> = Mutex::new(());
-    static GEMINI_ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::test_env_lock;
 
     #[test]
     fn nous_runtime_api_key_prefers_agent_key() {
@@ -3119,7 +3113,7 @@ mod tests {
 
     #[test]
     fn discover_existing_openai_oauth_reads_env_path() {
-        let _guard = OPENAI_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let auth_path = tmp.path().join("codex-auth.json");
         let exp = Utc::now().timestamp() + 3600;
@@ -3166,7 +3160,7 @@ mod tests {
 
     #[test]
     fn discover_existing_openai_codex_oauth_reads_env_path() {
-        let _guard = OPENAI_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let auth_path = tmp.path().join("codex-auth.json");
         let exp = Utc::now().timestamp() + 3600;
@@ -3209,7 +3203,7 @@ mod tests {
 
     #[test]
     fn discover_existing_anthropic_oauth_reads_claude_credentials_file() {
-        let _guard = ANTHROPIC_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let cred_path = tmp.path().join(".credentials.json");
         let expires_at = Utc::now().timestamp_millis() + 3600_000;
@@ -3243,7 +3237,7 @@ mod tests {
 
     #[test]
     fn discover_existing_nous_oauth_reads_auth_store_provider_state() {
-        let _guard = NOUS_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let auth_store = tmp.path().join("auth.json");
         let raw = serde_json::json!({
@@ -3288,7 +3282,7 @@ mod tests {
 
     #[test]
     fn read_provider_auth_state_falls_back_to_global_store_when_primary_missing_provider() {
-        let _guard = NOUS_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let prev_home = std::env::var("HOME").ok();
         let prev_hermes_home = std::env::var("HERMES_HOME").ok();
@@ -3389,7 +3383,7 @@ mod tests {
 
     #[test]
     fn gemini_state_read_write_roundtrip() {
-        let _guard = GEMINI_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let auth_path = tmp.path().join("google_oauth.json");
         std::env::set_var(
@@ -3420,7 +3414,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_qwen_runtime_credentials_reads_qwen_cli_auth_file() {
-        let _guard = QWEN_ENV_LOCK.lock().expect("lock");
+        let _guard = test_env_lock::lock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let auth_path = tmp.path().join("oauth_creds.json");
         let expiry_date = Utc::now().timestamp_millis() + 5 * 60 * 1000;

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -14190,16 +14190,12 @@ pub fn handle_cli_version() -> Result<(), hermes_core::AgentError> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, OnceLock};
-
     use super::*;
+    use crate::test_env_lock;
     use tempfile::tempdir;
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("env test lock")
+        test_env_lock::lock()
     }
 
     #[test]

--- a/crates/hermes-cli/src/lib.rs
+++ b/crates/hermes-cli/src/lib.rs
@@ -42,6 +42,9 @@ pub mod tui;
 pub mod update;
 pub mod webhook_delivery;
 
+#[cfg(test)]
+pub(crate) mod test_env_lock;
+
 // Re-export primary types
 pub use app::App;
 pub use checklist::{

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -799,8 +799,8 @@ pub async fn provider_catalog_entries(
 
 #[cfg(test)]
 mod tests {
+    use crate::test_env_lock;
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use hermes_intelligence::models_dev::ModelsDevClient;
@@ -814,10 +814,7 @@ mod tests {
     };
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("env lock poisoned")
+        test_env_lock::lock()
     }
 
     fn cache_path(label: &str) -> PathBuf {

--- a/crates/hermes-cli/src/test_env_lock.rs
+++ b/crates/hermes-cli/src/test_env_lock.rs
@@ -1,0 +1,8 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+pub(crate) fn lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}


### PR DESCRIPTION
## Summary
- add a crate-wide test env lock shared across hermes-cli test modules
- wrap alpha_runtime env-mutating tests with scoped HERMES_HOME guard + shared lock
- make JSON writes ensure parent directory exists before write

## Verification
- cargo test -p hermes-cli alpha_runtime::tests -- --test-threads=16 (3x, all pass)
- cargo test -p hermes-cli alpha_runtime::tests::objective_dag_claim_quorum_and_eval_surfaces_roundtrip -- --test-threads=16

## Note
- full 
running 288 tests
test alpha_runtime::tests::repo_drift_marks_missing_project ... ok
test alpha_runtime::tests::risk_governor_hard_stop_triggers_on_high_ruin ... ok
test alpha_runtime::tests::reasoning_policy_recommends_xhigh_for_risky_terms ... ok
test app::tests::test_allow_no_api_key_for_local_backends_and_private_base_urls ... ok
test app::tests::test_apply_cli_runtime_overrides_applies_provider_to_prefixed_model ... ok
test app::tests::test_apply_cli_runtime_overrides_applies_provider_to_bare_model ... ok
test alpha_runtime::tests::trading_board_render_contains_core_sections ... ok
test alpha_runtime::tests::env_provenance_detects_conflicts ... ok
test app::tests::test_default_mouse_enabled_respects_env_override ... ok
test app::tests::test_default_rtk_raw_mode_respects_env_override ... ok
test app::tests::test_build_agent_config_infers_provider_for_bare_model ... ok
test app::tests::test_build_agent_config_forwards_provider_extra_body ... ok
test app::tests::test_is_model_not_found_error_detects_provider_404_shape ... ok
test app::tests::test_build_agent_config_maps_runtime_provider_api_key_env ... ok
test app::tests::test_is_provider_auth_or_session_error_detects_auth_failures ... ok
test app::tests::test_is_model_not_found_error_ignores_non_catalog_errors ... ok
test app::tests::test_normalize_runtime_provider_name_covers_aliases ... ok
test alpha_runtime::tests::bootstrap_writes_runtime_files ... ok
test alpha_runtime::tests::objective_contract_roundtrip_and_counterfactual ... ok
test app::tests::test_pet_settings_normalization_clamps_and_rewrites_invalid_values ... ok
test app::tests::test_provider_api_key_from_env_supports_anthropic_aliases ... ok
test app::tests::test_provider_api_key_from_env_supports_extended_registry ... ok
test app::tests::test_provider_api_key_from_env_supports_google_gemini_cli ... ok
test app::tests::test_provider_api_key_from_env_supports_openai_codex ... ok
test app::tests::test_provider_api_key_from_env_supports_qwen_oauth ... ok
test app::tests::test_provider_api_key_from_env_supports_stepfun ... ok
test app::tests::test_resolve_provider_and_model_uses_single_provider_fallback ... ok
test app::tests::test_resolve_startup_model_prefers_provider_runtime_model_for_provider_slug ... ok
test app::tests::test_session_info_serialization ... ok
test alpha_runtime::tests::objective_dag_claim_quorum_and_eval_surfaces_roundtrip ... ok
test app::tests::test_sync_runtime_model_env_sets_model_and_provider_values ... ok
test auth::tests::clear_provider_auth_state_is_noop_when_missing ... ok
test alpha_runtime::tests::objective_profile_and_policy_planes_roundtrip ... ok
test alpha_runtime::tests::queue_replay_is_deduplicated ... ok
test app::tests::test_set_session_objective_injects_replaces_and_clears_system_message ... ok
test alpha_runtime::tests::trading_runtime_bootstrap_and_report_refresh_work ... ok
test auth::tests::gemini_access_token_is_expiring_honors_skew ... ok
test app::tests::test_load_pet_settings_uses_persisted_file_if_present ... ok
test auth::tests::gemini_packed_refresh_roundtrip ... ok
test auth::tests::nous_agent_key_usable_requires_future_expiry ... ok
test auth::tests::nous_runtime_api_key_prefers_agent_key ... ok
test auth::tests::nous_timestamp_is_expiring_treats_missing_as_expiring ... ok
test auth::tests::qwen_access_token_is_expiring_honors_skew ... ok
test app::tests::test_new_session_persists_startup_stub_snapshot ... ok
test app::tests::test_persist_session_snapshot_prunes_old_files_by_count_limit ... ok
test checklist::tests::sanitize_display_text_flattens_multiline_labels ... ok
test checklist::tests::test_checklist_result_default ... ok
test checklist::tests::test_curses_select_empty_items ... ok
test checklist::tests::test_numbered_fallback_empty_items ... ok
test claw_migrate::tests::test_find_openclaw_dir_explicit ... ok
test claw_migrate::tests::test_find_openclaw_dir_none ... ok
test claw_migrate::tests::test_merge_env_files ... ok
test claw_migrate::tests::test_migration_dry_run ... ok
test claw_migrate::tests::test_migration_no_source ... ok
test claw_migrate::tests::test_migration_status_eq ... ok
test cli::tests::cli_effective_command_default ... ok
test cli::tests::cli_parse_config_dir ... ok
test cli::tests::cli_parse_config_set ... ok
test cli::tests::cli_parse_default ... ok
test cli::tests::cli_parse_doctor ... ok
test cli::tests::cli_parse_doctor_with_flags ... ok
test cli::tests::cli_parse_elite_check ... ok
test cli::tests::cli_parse_incident_pack ... ok
test cli::tests::cli_parse_logs_default ... ok
test cli::tests::cli_parse_logs_with_count ... ok
test cli::tests::cli_parse_model ... ok
test cli::tests::cli_parse_model_flag ... ok
test cli::tests::cli_parse_profile ... ok
test cli::tests::cli_parse_profile_create ... ok
test cli::tests::cli_parse_provider_and_oneshot_flags ... ok
test cli::tests::cli_parse_resume_latest_default ... ok
test cli::tests::cli_parse_resume_specific_session ... ok
test cli::tests::cli_parse_rotate_provenance_key ... ok
test cli::tests::cli_parse_route_autotune_apply ... ok
test cli::tests::cli_parse_route_health_show ... ok
test cli::tests::cli_parse_route_learning_reset ... ok
test cli::tests::cli_parse_secrets_set ... ok
test cli::tests::cli_parse_status ... ok
test cli::tests::cli_parse_update_with_check_flag ... ok
test cli::tests::cli_parse_verbose ... ok
test cli::tests::cli_parse_verify_provenance ... ok
test app::tests::test_persist_session_snapshot_respects_app_state_root ... ok
test app::tests::test_persist_session_snapshot_writes_default_session_file ... ok
test commands::tests::effective_skill_taps_merges_defaults_custom_and_subscriptions ... ok
test auth::tests::discover_existing_anthropic_oauth_reads_claude_credentials_file ... ok
test commands::tests::ensure_safe_relative_path_rejects_traversal ... ok
test auth::tests::discover_existing_nous_oauth_reads_auth_store_provider_state ... ok
test commands::tests::format_personality_catalog_renders_multiline_entries ... ok
test auth::tests::discover_existing_openai_codex_oauth_reads_env_path ... ok
test commands::tests::mask_secret_value_hides_payload ... ok
test commands::tests::model_meets_requirements_checks_tools_vision_reasoning_and_context ... ok
test auth::tests::discover_existing_openai_oauth_reads_env_path ... ok
test commands::tests::normalize_model_target_keeps_explicit_provider_model ... ok
test commands::tests::normalize_model_target_uses_current_provider_for_bare_model ... ok
test commands::tests::normalize_repo_relative_path_handles_absolute_and_relative ... ok
test commands::tests::format_personality_catalog_includes_current_and_usage_hint ... ok
test auth::tests::gemini_state_read_write_roundtrip ... ok
test commands::tests::extract_marker_paths_captures_path_and_file_tokens ... ok
test commands::tests::parse_explicit_github_skill_owner_repo_path ... ok
test commands::tests::parse_model_command_args_extracts_provider_override ... ok
test commands::tests::parse_bootstrap_command_accepts_allowlisted_and_relative_execs ... ok
test commands::tests::parse_bootstrap_command_rejects_shell_operators ... ok
test auth::tests::read_provider_auth_state_falls_back_to_global_store_when_primary_missing_provider ... ok
test commands::tests::parse_model_command_args_extracts_capability_flags ... ok
test commands::tests::parse_model_command_args_rejects_unknown_capability ... ok
test commands::tests::parse_model_command_args_supports_boolean_capability_switches ... ok
test commands::tests::parse_model_switch_request_accepts_direct_provider_model ... ok
test auth::tests::resolve_qwen_runtime_credentials_reads_qwen_cli_auth_file ... ok
test commands::tests::parse_model_switch_request_picks_provider_when_empty ... ok
test commands::tests::parse_model_switch_request_uses_provider_picker_for_provider_arg ... ok
test commands::tests::parse_model_switch_request_keeps_bare_model_as_direct ... ok
test commands::tests::parse_pet_dock_accepts_left_or_right ... ok
test commands::tests::parse_pet_species_and_mood_validate_catalog_entries ... ok
test commands::tests::parse_reasoning_effort_accepts_levels_and_auto_clear ... ok
test commands::tests::parse_toggle_arg_supports_status_and_explicit_values ... ok
test commands::tests::parse_skill_name_and_version_handles_repo_plus_skill ... ok
test commands::tests::parse_skill_tap_spec_parses_github_url_with_override ... ok
test commands::tests::parse_skill_tap_spec_parses_tree_url ... ok
test commands::tests::policy_profile_resolution_accepts_primary_aliases ... ok
test commands::tests::parse_skill_bootstrap_plan_extracts_supported_frontmatter_fields ... ok
test commands::tests::registry_prefixed_install_identifiers_override_github_slug_parse ... ok
test commands::tests::registry_prefixed_install_identifiers_override_github_slug_parse_pretext ... ok
test commands::tests::alpha_loop_defaults_are_written_and_loadable ... ok
test commands::tests::replay_trace_integrity_detects_hash_break ... ok
test commands::tests::resolve_catalog_model_candidate_prefers_suffix_match ... ok
test commands::tests::apply_cli_chat_runtime_env_sets_provider_model ... ok
test commands::tests::read_skill_taps_accepts_upstream_object_shape ... ok
test commands::tests::resolve_cli_chat_provider_model_applies_provider_override ... ok
test commands::tests::guard_provider_model_selection_soft_accepts_unlisted_codex_models ... ok
test commands::tests::query_mode_tools_enabled_defaults_on_for_query_mode ... ok
test commands::tests::read_skill_subscriptions_accepts_array_and_object_shapes ... ok
test commands::tests::query_mode_tools_enabled_respects_disable_env_and_flag_override ... ok
test commands::tests::secret_stdout_gate_defaults_false ... ok
test commands::tests::resolve_cli_chat_provider_model_prefers_model_override_with_provider_prefix ... ok
test commands::tests::secret_stdout_gate_accepts_truthy_values ... ok
test commands::tests::sanitize_skill_install_name_normalizes_path_tail ... ok
test commands::tests::resolve_cli_chat_provider_model_uses_inference_model_env_when_no_flag_override ... ok
test commands::tests::resolve_cli_chat_provider_model_defaults_to_config_when_no_overrides ... ok
test commands::tests::query_mode_tools_enabled_respects_legacy_allow_env ... ok
test commands::tests::set_provider_reasoning_effort_sets_gemini_thinking_level ... ok
test commands::tests::skills_action_blocked_by_tier_enforces_expected_matrix ... ok
test commands::tests::sort_registry_skill_records_uses_router_priority_tie_break ... ok
test commands::tests::set_provider_reasoning_effort_updates_and_clears_extra_body ... ok
test commands::tests::specpatch_block_reason_flags_destructive_patterns ... ok
test commands::tests::self_evolution_recommendations_extracts_lines ... ok
test commands::tests::subscription_source_to_tap_filters_registry_prefixes_and_non_github_schemes ... ok
test commands::tests::test_acp_history_to_messages_flattens_assistant_parts_to_text ... ok
test commands::tests::test_acp_history_to_messages_preserves_multimodal_user_content_marker ... ok
test commands::tests::test_autocomplete_empty ... ok
test commands::tests::test_autocomplete_no_match ... ok
test commands::tests::test_autoresearch_default_skill_tap_present_in_merged_list ... ok
test commands::tests::test_command_result_equality ... ok
test commands::tests::test_browser_command_is_registered_and_completable ... ok
test commands::tests::test_autocomplete_partial ... ok
test commands::tests::test_debug_alias_maps_to_debug_dump ... ok
test commands::tests::test_default_skill_tap_present_in_merged_list ... ok
test commands::tests::test_goal_alias_maps_to_objective ... ok
test commands::tests::test_autocomplete_includes_raw_controls ... ok
test commands::tests::test_help_for_unknown_command ... ok
test commands::tests::test_help_for_known_command ... ok
test commands::tests::test_autocomplete_ops_control_plane ... ok
test commands::tests::summarize_self_evolution_report_formats_fields ... ok
test commands::tests::test_autocomplete_exact ... ok
test commands::tests::test_mattpocock_default_skill_tap_present_in_merged_list ... ok
test commands::tests::test_merged_skill_taps_deduplicates_default ... ok
test commands::tests::test_pet_command_is_registered_and_completable ... ok
test commands::tests::test_nous_official_default_skill_taps_present_in_merged_list ... ok
test commands::tests::test_objective_command_is_registered_and_completable ... ok
test commands::tests::test_skins_alias_maps_to_skin ... ok
test commands::tests::test_upstream_compat_aliases_are_mapped ... ok
test commands::tests::unmet_model_requirements_lists_missing_constraints ... ok
test commands::tests::test_mission_command_is_registered_and_completable ... ok
test commands::tests::test_official_skill_path_candidates_cover_skills_and_optional ... ok
test commands::tests::test_autocomplete_fuzzy_prefers_close_matches ... ok
test commands::tests::test_autocomplete_matches_description_terms ... ok
test commands::tests::test_autocomplete_includes_evolve ... ok
test config_env::tests::hydrate_env_never_overwrites_existing_values ... ok
test commands::tests::write_skill_taps_writes_canonical_object_shape ... ok
test lumio::tests::test_error_page ... ok
test commands::tests::test_resume_command_is_registered_and_completable ... ok
test config_env::tests::hydrate_env_sets_platform_and_top_level_vars ... ok
test lumio::tests::test_parse_query ... ok
test lumio::tests::test_parse_query_empty ... ok
test lumio::tests::test_parse_query_encoded ... ok
test lumio::tests::test_rand_u128_not_zero ... ok
test model_switch::tests::deepseek_curated_models_include_v4_variants ... ok
test lumio::tests::test_success_page_with_username ... ok
test lumio::tests::test_success_page_without_username ... ok
test lumio::tests::test_topup_hint ... ok
test model_switch::tests::openrouter_curated_models_include_gpt55_variants ... ok
test model_switch::tests::local_backend_curated_models_include_ollama_llamacpp_and_vllm ... ok
test model_switch::tests::merge_is_models_dev_first_with_case_insensitive_dedup ... ok
test model_switch::tests::merge_returns_curated_when_models_dev_empty ... ok
test model_switch::tests::preferred_provider_set_excludes_openrouter_and_nous ... ok
test lumio::tests::test_save_and_load_token ... ok
test commands::tests::test_mcp_sentrux_setup_syncs_json_and_yaml ... ok
test model_switch::tests::provider_catalog_entries_uses_global_client_shape ... ok
test pairing_store::tests::test_approve_nonexistent_fails ... ok
test model_switch::tests::signed_provider_catalog_cache_detects_tamper ... ok
test pairing_store::tests::test_approve_pending_device ... ok
test model_switch::tests::local_provider_catalog_returns_curated_without_network_dependency ... ok
test model_switch::tests::preferred_provider_falls_back_to_curated_when_models_dev_has_no_provider_data ... ok
test model_switch::tests::openrouter_never_merges_models_dev_entries ... ok
test pairing_store::tests::test_generate_shared_secret_length ... ok
test platform_toolsets::tests::normalize_platform_aliases ... ok
test pairing_store::tests::test_roundtrip_empty ... ok
test pairing_store::tests::test_revoke_device ... ok
test pairing_store::tests::test_clear_pending ... ok
test model_switch::tests::nous_provider_uses_curated_plus_openrouter_agentic_catalog ... ok
test model_switch::tests::preferred_provider_merges_models_dev_with_curated ... ok
test providers::tests::known_provider_registry_has_no_duplicates ... ok
test providers::tests::known_provider_registry_covers_upstream_snapshot_required_ids ... ok
test providers::tests::oauth_capable_provider_registry_matches_upstream_snapshot ... ok
test providers::tests::provider_capability_registry_marks_nous_as_oauth_and_managed_tools ... ok
test providers::tests::provider_capability_registry_marks_models_dev_merged_providers ... ok
test providers::tests::local_backends_are_known_and_not_oauth ... ok
test runtime_tool_wiring::tests::stdio_clarify_backend_uses_auto_answer_in_non_interactive_mode ... ok
test commands::tests::test_mcp_sentrux_remove_syncs_json_and_yaml ... ok
test skin_engine::tests::canonical_skin_aliases_resolve ... ok
test skin_engine::tests::resolve_theme_uses_new_builtins ... ok
test theme::tests::test_default_theme ... ok
test model_switch::tests::provider_catalog_entries_truncates_but_keeps_total ... ok
test theme::tests::test_light_theme ... ok
test model_switch::tests::signed_provider_catalog_cache_round_trip_verifies ... FAILED
test theme::tests::test_load_theme_missing_file ... ok
test theme::tests::test_parse_color_hex ... ok
test theme::tests::test_parse_color_indexed ... ok
test theme::tests::test_parse_color_named ... ok
test theme::tests::test_parse_hex ... ok
test theme::tests::test_resolved_styles ... ok
test theme::tests::test_status_bar_color_fields_respect_overrides ... ok
test theme::tests::test_status_bar_color_fields_set_for_default_theme ... ok
test theme::tests::test_style_def_to_style ... ok
test theme::tests::test_theme_serialization ... ok
test theme::tests::test_ultra_variants_have_distinct_names ... ok
test theme::tests::test_ultra_neon_theme ... ok
test tool_preview::tests::process_preview_includes_action_session_data_timeout ... ok
test tool_preview::tests::process_preview_uses_pid_alias ... ok
test tool_preview::tests::rl_preview_and_fallback_preview_work ... ok
test tool_preview::tests::emoji_map_covers_process_and_todo ... ok
test tool_preview::tests::todo_and_message_preview_are_descriptive ... ok
test tui::tests::test_animated_processing_bar_width_and_motion ... ok
test tui::tests::test_append_message_renderer_matches_full_builder ... ok
test tui::tests::test_append_live_thinking_is_capped ... ok
test tui::tests::test_activity_ring_buffer_caps_size ... ok
test tui::tests::test_approximate_visual_rows_wraps_long_lines ... ok
test tui::tests::test_completion_popup_hidden_when_modal_or_processing_active ... ok
test tui::tests::test_completion_popup_hidden_when_slash_deleted ... ok
test tui::tests::test_default_language_sanitizer_strips_non_ascii ... ok
test tui::tests::test_count_renderable_messages_ignores_system ... ok
test tui::tests::test_event_debug ... ok
test tui::tests::test_find_anchor_line_index_falls_back_to_global_search ... ok
test tui::tests::test_format_tool_message_lines_parses_json_payload ... ok
test tui::tests::test_find_anchor_line_index_prefers_near_expected_window ... ok
test tui::tests::test_insert_newline_at_cursor_updates_input_and_cursor ... ok
test tui::tests::test_input_mode_display ... ok
test tui::tests::test_is_ctrl_c_detection ... ok
test tui::tests::test_open_skin_modal_populates_builtin_skin_items ... ok
test tui::tests::test_parse_interactive_question_request_multiline_syntax ... ok
test tui::tests::test_parse_interactive_question_request_requires_two_options ... ok
test tui::tests::test_parse_interactive_question_request_pipe_syntax ... ok
test tui::tests::test_pet_frame_token_hidden_when_disabled ... ok
test tui::tests::test_pet_frame_token_returns_species_specific_frame ... ok
test tui::tests::test_processing_stage_labels ... ok
test tui::tests::test_processing_cycle_tracks_and_resets_stats ... ok
test tui::tests::test_render_assistant_markdown_lines_enforces_default_language_gate ... ok
test tui::tests::test_progress_pulse_emits_activity_row ... ok
test tui::tests::test_spinner_char ... ok
test tui::tests::test_status_message_style_critical_for_error ... ok
test tui::tests::test_status_message_style_warn_for_warning ... ok
test tui::tests::test_stream_handle ... ok
test tui::tests::test_submit_shortcut_rejects_multiline_slash_commands ... ok
test tui::tests::test_submit_shortcuts_are_detected ... ok
test tui::tests::test_submit_shortcuts_exclude_newline_shortcuts ... ok
test tui::tests::test_tool_output_section ... ok
test tui::tests::test_transcript_fingerprint_tracks_toolcard_expand_state ... ok
test tui::tests::test_transcript_placeholder_shows_when_empty ... ok
test tui::tests::test_transcript_hides_system_messages ... ok
test tui::tests::test_tui_state_default ... ok
test tui::tests::test_transcript_wrap_width_caps_at_80 ... ok
test tui::tests::test_tui_state_completions_update ... ok
test platform_toolsets::tests::tools_config_disabled_removes_even_if_platform_enables ... ok
test platform_toolsets::tests::config_override_is_used_when_present ... ok
test platform_toolsets::tests::tools_config_enabled_adds_tools_outside_platform_toolset ... ok
test platform_toolsets::tests::platform_defaults_resolve_preset ... ok
test runtime_tool_wiring::tests::gateway_messaging_backend_sends_real_message ... ok
test runtime_tool_wiring::tests::cron_scheduler_backend_handles_create_and_list ... ok
test terminal_backend::tests::backend_from_default_config_executes_local_command ... ok

failures:

---- model_switch::tests::signed_provider_catalog_cache_round_trip_verifies stdout ----

thread 'model_switch::tests::signed_provider_catalog_cache_round_trip_verifies' (76210951) panicked at crates/hermes-cli/src/model_switch.rs:1056:60:
load cache
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    model_switch::tests::signed_provider_catalog_cache_round_trip_verifies

test result: FAILED. 287 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 40.19s currently has an unrelated existing failure in  (assertion mismatch on curated model list), outside this fix scope.