### PR TITLE
Add persistent /kanban board command surface

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -37,6 +37,11 @@ use crate::alpha_runtime::{
     upsert_objective_contract, utility_terms_from_contract, ObjectiveLearningLedgerEntry,
 };
 use crate::app::{App, PetDock, PetSettings};
+use crate::kanban::{
+    add_task, archive_done, claim_task, create_or_select_board, ensure_board, find_task_mut,
+    lane_counts, load_store, maybe_checkpoint_to_contextlattice, move_task, save_store,
+    set_blocked, KanbanActionInput, KanbanBoard, KanbanLane, NewKanbanTaskInput,
+};
 use crate::model_switch::{curated_provider_slugs, normalize_provider_model, provider_model_ids};
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
 use hermes_config::{GatewayConfig, LlmProviderConfig};
@@ -146,7 +151,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/cron", "Show cron scheduler status"),
     ("/scheduler", "Alias for /background"),
     ("/agents", "Show active/background task state"),
-    ("/tasks", "Alias for /agents"),
+    ("/tasks", "Alias for /kanban"),
     ("/queue", "Queue a follow-up prompt"),
     ("/q", "Alias for /queue"),
     (
@@ -202,7 +207,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/insights", "Show local usage/session insights"),
     ("/stop", "Stop current agent execution"),
     ("/busy", "Busy/processing status compatibility surface"),
-    ("/kanban", "Task board compatibility surface"),
+    (
+        "/kanban",
+        "Task board controls (`status|boards|init|use|add|move|claim|block|done|archive-done|dispatch|sync`)",
+    ),
     ("/status", "Show session status (model, turns, token count)"),
     ("/agent", "Alias for /status"),
     (
@@ -2938,8 +2946,7 @@ fn canonical_command(cmd: &str) -> &str {
         "/skill" => "/skills",
         "/curator" => "/skills",
         "/agent" => "/status",
-        "/tasks" => "/agents",
-        "/kanban" => "/agents",
+        "/tasks" => "/kanban",
         "/busy" => "/status",
         "/topic" => "/title",
         "/scheduler" => "/background",
@@ -3026,6 +3033,7 @@ pub async fn handle_slash_command(
         "/reload" | "/reload-mcp" => handle_reload_command(app, canonical_command(cmd)),
         "/cron" => handle_cron_command(app),
         "/agents" => handle_agents_command(app),
+        "/kanban" => handle_kanban_command(app, args),
         "/plan" | "/lsp" | "/graph" | "/image" => {
             handle_capability_surface_command(app, canonical_command(cmd), args)
         }
@@ -6011,16 +6019,20 @@ async fn handle_browser_command(app: &mut App, args: &[&str]) -> Result<CommandR
     }
 }
 
-fn handle_background_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
-    if args.is_empty() {
-        emit_command_output(
-            app,
-            "Usage: /background <message>\nQueues a task to run in the background while you continue chatting.",
-        );
-        return Ok(CommandResult::Handled);
-    }
+struct QueuedBackgroundJob {
+    id: String,
+    task: String,
+    status_path: PathBuf,
+    log_path: PathBuf,
+}
 
-    let task = args.join(" ");
+fn queue_background_job(task: &str) -> Result<QueuedBackgroundJob, AgentError> {
+    let task = task.trim();
+    if task.is_empty() {
+        return Err(AgentError::Config(
+            "Background task cannot be empty.".to_string(),
+        ));
+    }
     let job_id = format!(
         "{}-{}",
         chrono::Utc::now().format("%Y%m%d%H%M%S"),
@@ -6054,19 +6066,34 @@ fn handle_background_command(app: &mut App, args: &[&str]) -> Result<CommandResu
     )
     .map_err(|e| AgentError::Io(format!("Failed to write background status: {}", e)))?;
 
-    schedule_background_job_execution(status_path.clone(), log_path.clone(), task.clone());
+    schedule_background_job_execution(status_path.clone(), log_path.clone(), task.to_string());
+    Ok(QueuedBackgroundJob {
+        id: status["id"].as_str().unwrap_or("unknown").to_string(),
+        task: task.to_string(),
+        status_path,
+        log_path,
+    })
+}
 
+fn handle_background_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    if args.is_empty() {
+        emit_command_output(
+            app,
+            "Usage: /background <message>\nQueues a task to run in the background while you continue chatting.",
+        );
+        return Ok(CommandResult::Handled);
+    }
+    let job = queue_background_job(&args.join(" "))?;
     emit_command_output(
         app,
         format!(
             "[Background task queued: \"{}\"]\nJob ID: {}\nStatus: {}\nLogs:   {}\nThis task runs in a detached `hermes chat --query ...` process.",
-            task,
-            status["id"].as_str().unwrap_or("unknown"),
-            status_path.display(),
-            log_path.display()
+            job.task,
+            job.id,
+            job.status_path.display(),
+            job.log_path.display()
         ),
     );
-
     Ok(CommandResult::Handled)
 }
 
@@ -7518,6 +7545,550 @@ fn handle_agents_command(app: &mut App) -> Result<CommandResult, AgentError> {
             ),
         );
     }
+    Ok(CommandResult::Handled)
+}
+
+fn render_kanban_status(board: &KanbanBoard) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        &mut out,
+        "Kanban board: {} ({})",
+        board.name.trim(),
+        board.id.trim()
+    );
+    if let Some(project_path) = board.project_path.as_deref() {
+        let _ = writeln!(&mut out, "Project: {}", project_path);
+    }
+    let counts = lane_counts(board);
+    let total: usize = counts.iter().map(|(_, count)| *count).sum();
+    let _ = writeln!(
+        &mut out,
+        "Tasks: {} (archived done: {})",
+        total,
+        board.archived.len()
+    );
+    for (lane, count) in counts {
+        let _ = writeln!(&mut out, "  {:>7}: {}", lane.as_str(), count);
+    }
+    if board.tasks.is_empty() {
+        let _ = writeln!(&mut out, "\nNo active tasks. Use `/kanban add <title>`.");
+        return out.trim_end().to_string();
+    }
+
+    let mut tasks = board.tasks.clone();
+    tasks.sort_by(|a, b| {
+        a.lane
+            .as_str()
+            .cmp(b.lane.as_str())
+            .then_with(|| a.priority.cmp(&b.priority))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    let _ = writeln!(&mut out, "\nActive tasks (top 20):");
+    for task in tasks.into_iter().take(20) {
+        let assignee = task.assignee.unwrap_or_else(|| "-".to_string());
+        let blocked = task
+            .blocked_reason
+            .as_deref()
+            .map(|reason| format!(" blocked={reason}"))
+            .unwrap_or_default();
+        let bg = task
+            .background_job_id
+            .as_deref()
+            .map(|job_id| format!(" job={job_id}"))
+            .unwrap_or_default();
+        let _ = writeln!(
+            &mut out,
+            "- {} [{}] p{} @{} {}{}{}",
+            task.id,
+            task.lane.as_str(),
+            task.priority,
+            assignee,
+            task.title,
+            blocked,
+            bg
+        );
+    }
+    out.trim_end().to_string()
+}
+
+fn parse_kanban_add(args: &[&str]) -> Result<NewKanbanTaskInput, AgentError> {
+    if args.is_empty() {
+        return Err(AgentError::Config(
+            "Usage: /kanban add <title> [--lane <todo|doing|blocked|done>] [--priority <1..5>] [--assignee <name>] [--depends K-0001,K-0002] [--desc <text>]".to_string(),
+        ));
+    }
+    let mut lane = KanbanLane::Todo;
+    let mut priority: u8 = 3;
+    let mut assignee: Option<String> = None;
+    let mut depends_on: Vec<String> = Vec::new();
+    let mut description: Option<String> = None;
+    let mut title_parts: Vec<String> = Vec::new();
+
+    let mut idx = 0usize;
+    while idx < args.len() {
+        let token = args[idx];
+        if token == "--lane" {
+            idx = idx.saturating_add(1);
+            let Some(raw) = args.get(idx) else {
+                return Err(AgentError::Config("Missing value for --lane".to_string()));
+            };
+            lane = KanbanLane::parse(raw).ok_or_else(|| {
+                AgentError::Config(format!(
+                    "Invalid lane `{raw}`. Use: todo|doing|blocked|done."
+                ))
+            })?;
+        } else if token == "--priority" || token == "-p" {
+            idx = idx.saturating_add(1);
+            let Some(raw) = args.get(idx) else {
+                return Err(AgentError::Config(
+                    "Missing value for --priority".to_string(),
+                ));
+            };
+            priority = raw.parse::<u8>().map_err(|_| {
+                AgentError::Config(format!("Invalid priority `{raw}`. Expected integer 1..5."))
+            })?;
+            if !(1..=5).contains(&priority) {
+                return Err(AgentError::Config(format!(
+                    "Invalid priority `{priority}`. Expected 1..5."
+                )));
+            }
+        } else if token == "--assignee" || token == "-a" {
+            idx = idx.saturating_add(1);
+            assignee = args.get(idx).map(|s| s.to_string());
+        } else if token == "--depends" || token == "--deps" {
+            idx = idx.saturating_add(1);
+            if let Some(raw) = args.get(idx) {
+                depends_on = raw
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToString::to_string)
+                    .collect();
+            }
+        } else if token == "--desc" || token == "--description" {
+            idx = idx.saturating_add(1);
+            description = args.get(idx).map(|s| s.to_string());
+        } else {
+            title_parts.push(token.to_string());
+        }
+        idx = idx.saturating_add(1);
+    }
+    let title = title_parts.join(" ").trim().to_string();
+    if title.is_empty() {
+        return Err(AgentError::Config(
+            "Usage: /kanban add <title> [flags...]".to_string(),
+        ));
+    }
+    Ok(NewKanbanTaskInput {
+        title,
+        lane,
+        priority,
+        assignee,
+        description,
+        depends_on,
+    })
+}
+
+fn handle_kanban_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let action = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .to_ascii_lowercase();
+    let mut store = load_store()?;
+
+    match action.as_str() {
+        "status" | "show" => {
+            let requested = args.get(1).copied();
+            let board = ensure_board(&mut store, requested);
+            emit_command_output(app, render_kanban_status(board));
+        }
+        "boards" | "list" => {
+            let mut out = String::from("Kanban boards:\n");
+            for board in &store.boards {
+                let marker = if board.id == store.current_board_id {
+                    "*"
+                } else {
+                    " "
+                };
+                let project = board.project_path.as_deref().unwrap_or("-");
+                let _ = writeln!(
+                    &mut out,
+                    "{} {} ({}) project={}",
+                    marker, board.name, board.id, project
+                );
+            }
+            emit_command_output(app, out.trim_end());
+        }
+        "init" => {
+            let Some(name) = args.get(1).copied() else {
+                emit_command_output(
+                    app,
+                    "Usage: /kanban init <board-name> [project-path]\nExample: /kanban init alpha ~/Documents/Projects/hermes-agent-ultra",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let project_path = args.get(2).map(|s| s.to_string());
+            let (board_name, board_id, board_snapshot) = {
+                let board = create_or_select_board(&mut store, name, project_path);
+                (board.name.clone(), board.id.clone(), board.clone())
+            };
+            save_store(&store)?;
+            let checkpoint = maybe_checkpoint_to_contextlattice(
+                &board_snapshot,
+                KanbanActionInput {
+                    action: "init".to_string(),
+                    task_id: None,
+                    lane: None,
+                    summary: format!("board={board_name} board_id={board_id}"),
+                },
+            );
+            emit_command_output(
+                app,
+                format!(
+                    "Board selected: {} ({})\n{}",
+                    board_name, board_id, checkpoint.detail
+                ),
+            );
+        }
+        "use" | "select" => {
+            let Some(name_or_id) = args.get(1).copied() else {
+                emit_command_output(app, "Usage: /kanban use <board-id-or-name>");
+                return Ok(CommandResult::Handled);
+            };
+            let (board_name, board_id) = {
+                let board = ensure_board(&mut store, Some(name_or_id));
+                (board.name.clone(), board.id.clone())
+            };
+            save_store(&store)?;
+            emit_command_output(app, format!("Using board: {} ({})", board_name, board_id));
+        }
+        "add" => {
+            let input = parse_kanban_add(args.get(1..).unwrap_or_default())?;
+            let (task_id, task_lane, task_priority, task_title, board_snapshot) = {
+                let board = ensure_board(&mut store, None);
+                let task = add_task(board, input);
+                (
+                    task.id.clone(),
+                    task.lane,
+                    task.priority,
+                    task.title.clone(),
+                    board.clone(),
+                )
+            };
+            save_store(&store)?;
+            let checkpoint = maybe_checkpoint_to_contextlattice(
+                &board_snapshot,
+                KanbanActionInput {
+                    action: "add".to_string(),
+                    task_id: Some(task_id.clone()),
+                    lane: Some(task_lane),
+                    summary: task_title.clone(),
+                },
+            );
+            emit_command_output(
+                app,
+                format!(
+                    "Added task {} [{}] p{}: {}\n{}",
+                    task_id,
+                    task_lane.as_str(),
+                    task_priority,
+                    task_title,
+                    checkpoint.detail
+                ),
+            );
+        }
+        "move" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                emit_command_output(
+                    app,
+                    "Usage: /kanban move <task-id|title> <todo|doing|blocked|done> [summary]",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let Some(raw_lane) = args.get(2).copied() else {
+                emit_command_output(
+                    app,
+                    "Usage: /kanban move <task-id|title> <todo|doing|blocked|done> [summary]",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let Some(lane) = KanbanLane::parse(raw_lane) else {
+                emit_command_output(
+                    app,
+                    format!("Invalid lane `{raw_lane}`. Use: todo|doing|blocked|done."),
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let summary = args.get(3..).unwrap_or_default().join(" ");
+            let maybe_update = {
+                let board = ensure_board(&mut store, None);
+                let task_meta = if let Some(task) = find_task_mut(board, task_ref) {
+                    move_task(
+                        task,
+                        lane,
+                        (!summary.trim().is_empty()).then_some(summary.clone()),
+                    );
+                    Some((task.id.clone(), task.title.clone()))
+                } else {
+                    None
+                };
+                task_meta.map(|(task_id, title)| (task_id, title, board.clone()))
+            };
+            if let Some((task_id, title, board_snapshot)) = maybe_update {
+                save_store(&store)?;
+                let checkpoint = maybe_checkpoint_to_contextlattice(
+                    &board_snapshot,
+                    KanbanActionInput {
+                        action: "move".to_string(),
+                        task_id: Some(task_id.clone()),
+                        lane: Some(lane),
+                        summary: format!("{title} {}", summary.trim()).trim().to_string(),
+                    },
+                );
+                emit_command_output(
+                    app,
+                    format!(
+                        "Moved {} -> {}\n{}",
+                        task_id,
+                        lane.as_str(),
+                        checkpoint.detail
+                    ),
+                );
+            } else {
+                emit_command_output(app, format!("Task not found: {task_ref}"));
+            }
+        }
+        "claim" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                emit_command_output(app, "Usage: /kanban claim <task-id|title> [assignee]");
+                return Ok(CommandResult::Handled);
+            };
+            let assignee = args.get(2).map(|s| s.to_string());
+            let maybe_update = {
+                let board = ensure_board(&mut store, None);
+                let task_meta = if let Some(task) = find_task_mut(board, task_ref) {
+                    claim_task(task, assignee.clone());
+                    Some((task.id.clone(), task.lane))
+                } else {
+                    None
+                };
+                task_meta.map(|(task_id, lane)| (task_id, lane, board.clone()))
+            };
+            if let Some((task_id, lane, board_snapshot)) = maybe_update {
+                save_store(&store)?;
+                let checkpoint = maybe_checkpoint_to_contextlattice(
+                    &board_snapshot,
+                    KanbanActionInput {
+                        action: "claim".to_string(),
+                        task_id: Some(task_id.clone()),
+                        lane: Some(lane),
+                        summary: format!(
+                            "assignee={}",
+                            assignee.unwrap_or_else(|| "-".to_string())
+                        ),
+                    },
+                );
+                emit_command_output(
+                    app,
+                    format!("Claimed {} ({})\n{}", task_id, task_ref, checkpoint.detail),
+                );
+            } else {
+                emit_command_output(app, format!("Task not found: {task_ref}"));
+            }
+        }
+        "block" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                emit_command_output(app, "Usage: /kanban block <task-id|title> <reason>");
+                return Ok(CommandResult::Handled);
+            };
+            let reason = args
+                .get(2..)
+                .unwrap_or_default()
+                .join(" ")
+                .trim()
+                .to_string();
+            if reason.is_empty() {
+                emit_command_output(app, "Usage: /kanban block <task-id|title> <reason>");
+                return Ok(CommandResult::Handled);
+            }
+            let maybe_update = {
+                let board = ensure_board(&mut store, None);
+                let task_id = if let Some(task) = find_task_mut(board, task_ref) {
+                    set_blocked(task, Some(reason.clone()));
+                    Some(task.id.clone())
+                } else {
+                    None
+                };
+                task_id.map(|task_id| (task_id, board.clone()))
+            };
+            if let Some((task_id, board_snapshot)) = maybe_update {
+                save_store(&store)?;
+                let checkpoint = maybe_checkpoint_to_contextlattice(
+                    &board_snapshot,
+                    KanbanActionInput {
+                        action: "block".to_string(),
+                        task_id: Some(task_id.clone()),
+                        lane: Some(KanbanLane::Blocked),
+                        summary: reason,
+                    },
+                );
+                emit_command_output(app, format!("Blocked {}\n{}", task_id, checkpoint.detail));
+            } else {
+                emit_command_output(app, format!("Task not found: {task_ref}"));
+            }
+        }
+        "done" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                emit_command_output(app, "Usage: /kanban done <task-id|title> [summary]");
+                return Ok(CommandResult::Handled);
+            };
+            let summary = args.get(2..).unwrap_or_default().join(" ");
+            let maybe_update = {
+                let board = ensure_board(&mut store, None);
+                let task_id = if let Some(task) = find_task_mut(board, task_ref) {
+                    move_task(
+                        task,
+                        KanbanLane::Done,
+                        (!summary.trim().is_empty()).then_some(summary.clone()),
+                    );
+                    Some(task.id.clone())
+                } else {
+                    None
+                };
+                task_id.map(|task_id| (task_id, board.clone()))
+            };
+            if let Some((task_id, board_snapshot)) = maybe_update {
+                save_store(&store)?;
+                let checkpoint = maybe_checkpoint_to_contextlattice(
+                    &board_snapshot,
+                    KanbanActionInput {
+                        action: "done".to_string(),
+                        task_id: Some(task_id.clone()),
+                        lane: Some(KanbanLane::Done),
+                        summary,
+                    },
+                );
+                emit_command_output(
+                    app,
+                    format!("Marked done: {}\n{}", task_id, checkpoint.detail),
+                );
+            } else {
+                emit_command_output(app, format!("Task not found: {task_ref}"));
+            }
+        }
+        "archive-done" | "archive" => {
+            let (archived, board_snapshot) = {
+                let board = ensure_board(&mut store, None);
+                let archived = archive_done(board);
+                (archived, board.clone())
+            };
+            save_store(&store)?;
+            let checkpoint = maybe_checkpoint_to_contextlattice(
+                &board_snapshot,
+                KanbanActionInput {
+                    action: "archive_done".to_string(),
+                    task_id: None,
+                    lane: Some(KanbanLane::Done),
+                    summary: format!("archived_count={archived}"),
+                },
+            );
+            emit_command_output(
+                app,
+                format!("Archived {} done task(s).\n{}", archived, checkpoint.detail),
+            );
+        }
+        "dispatch" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                emit_command_output(
+                    app,
+                    "Usage: /kanban dispatch <task-id|title> [background-task-override]",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let override_msg = args.get(2..).unwrap_or_default().join(" ");
+            let dispatch_result = {
+                let board = ensure_board(&mut store, None);
+                if let Some(task) = find_task_mut(board, task_ref) {
+                    let task_message = if override_msg.trim().is_empty() {
+                        let mut prompt = format!("Execute Kanban task {}: {}", task.id, task.title);
+                        if let Some(desc) = task.description.as_deref() {
+                            let _ = write!(&mut prompt, "\nDetails: {}", desc.trim());
+                        }
+                        if !task.depends_on.is_empty() {
+                            let _ = write!(
+                                &mut prompt,
+                                "\nDependencies: {}",
+                                task.depends_on.join(", ")
+                            );
+                        }
+                        prompt
+                    } else {
+                        override_msg.clone()
+                    };
+                    let job = queue_background_job(&task_message)?;
+                    task.background_job_id = Some(job.id.clone());
+                    move_task(task, KanbanLane::Doing, None);
+                    Some((task.id.clone(), job, task_message, board.clone()))
+                } else {
+                    None
+                }
+            };
+            if let Some((task_id, job, task_message, board_snapshot)) = dispatch_result {
+                save_store(&store)?;
+                let checkpoint = maybe_checkpoint_to_contextlattice(
+                    &board_snapshot,
+                    KanbanActionInput {
+                        action: "dispatch".to_string(),
+                        task_id: Some(task_id.clone()),
+                        lane: Some(KanbanLane::Doing),
+                        summary: format!("job_id={} task={}", job.id, task_message),
+                    },
+                );
+                emit_command_output(
+                    app,
+                    format!(
+                        "Dispatched {} as background job {}\nStatus: {}\nLogs:   {}\n{}",
+                        task_id,
+                        job.id,
+                        job.status_path.display(),
+                        job.log_path.display(),
+                        checkpoint.detail
+                    ),
+                );
+            } else {
+                emit_command_output(app, format!("Task not found: {task_ref}"));
+            }
+        }
+        "sync" => {
+            let board_snapshot = {
+                let board = ensure_board(&mut store, None);
+                board.clone()
+            };
+            let checkpoint = maybe_checkpoint_to_contextlattice(
+                &board_snapshot,
+                KanbanActionInput {
+                    action: "sync".to_string(),
+                    task_id: None,
+                    lane: None,
+                    summary: format!(
+                        "manual sync tasks={} archived={}",
+                        board_snapshot.tasks.len(),
+                        board_snapshot.archived.len()
+                    ),
+                },
+            );
+            emit_command_output(app, checkpoint.detail);
+        }
+        "help" => {
+            emit_command_output(
+                app,
+                "Kanban commands:\n  /kanban status [board]\n  /kanban boards\n  /kanban init <name> [project-path]\n  /kanban use <name-or-id>\n  /kanban add <title> [--lane <todo|doing|blocked|done>] [--priority <1..5>] [--assignee <name>] [--depends K-0001,K-0002] [--desc <text>]\n  /kanban move <task-id|title> <todo|doing|blocked|done> [summary]\n  /kanban claim <task-id|title> [assignee]\n  /kanban block <task-id|title> <reason>\n  /kanban done <task-id|title> [summary]\n  /kanban archive-done\n  /kanban dispatch <task-id|title> [background-task-override]\n  /kanban sync",
+            );
+        }
+        _ => emit_command_output(app, "Unknown /kanban action. Use `/kanban help`."),
+    }
+
     Ok(CommandResult::Handled)
 }
 
@@ -14256,6 +14827,46 @@ mod tests {
     }
 
     #[test]
+    fn test_kanban_command_is_registered_and_completable() {
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/kanban"));
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/tasks"));
+        let results = autocomplete("/kan");
+        assert!(results.contains(&"/kanban"));
+    }
+
+    #[test]
+    fn test_parse_kanban_add_defaults() {
+        let input = parse_kanban_add(&["Ship", "kanban"]).expect("parse");
+        assert_eq!(input.title, "Ship kanban");
+        assert_eq!(input.lane, KanbanLane::Todo);
+        assert_eq!(input.priority, 3);
+    }
+
+    #[test]
+    fn test_parse_kanban_add_flags() {
+        let input = parse_kanban_add(&[
+            "Task",
+            "--lane",
+            "doing",
+            "--priority",
+            "2",
+            "--assignee",
+            "runner",
+            "--depends",
+            "K-0001,K-0002",
+            "--desc",
+            "note",
+        ])
+        .expect("parse");
+        assert_eq!(input.title, "Task");
+        assert_eq!(input.lane, KanbanLane::Doing);
+        assert_eq!(input.priority, 2);
+        assert_eq!(input.assignee.as_deref(), Some("runner"));
+        assert_eq!(input.depends_on, vec!["K-0001", "K-0002"]);
+        assert_eq!(input.description.as_deref(), Some("note"));
+    }
+
+    #[test]
     fn test_goal_alias_maps_to_objective() {
         assert_eq!(canonical_command("/goal"), "/objective");
     }
@@ -14299,7 +14910,8 @@ mod tests {
         assert_eq!(canonical_command("/reload_skills"), "/reload");
         assert_eq!(canonical_command("/footer"), "/statusbar");
         assert_eq!(canonical_command("/indicator"), "/statusbar");
-        assert_eq!(canonical_command("/kanban"), "/agents");
+        assert_eq!(canonical_command("/tasks"), "/kanban");
+        assert_eq!(canonical_command("/kanban"), "/kanban");
         assert_eq!(canonical_command("/busy"), "/status");
         assert_eq!(canonical_command("/bg"), "/background");
         assert_eq!(canonical_command("/curator"), "/skills");

--- a/crates/hermes-cli/src/kanban.rs
+++ b/crates/hermes-cli/src/kanban.rs
@@ -1,0 +1,620 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use chrono::Utc;
+use hermes_core::AgentError;
+use serde::{Deserialize, Serialize};
+
+const KANBAN_STATE_DIR: &str = "alpha/kanban";
+const KANBAN_STORE_FILE: &str = "boards.json";
+const KANBAN_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_BOARD_ID: &str = "main";
+const CONTEXTLATTICE_DEFAULT_SCRIPT: &str =
+    "/Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KanbanLane {
+    Todo,
+    Doing,
+    Blocked,
+    Done,
+}
+
+impl KanbanLane {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "todo" | "backlog" | "to-do" => Some(Self::Todo),
+            "doing" | "in-progress" | "inprogress" | "running" => Some(Self::Doing),
+            "blocked" | "stalled" => Some(Self::Blocked),
+            "done" | "completed" => Some(Self::Done),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Todo => "todo",
+            Self::Doing => "doing",
+            Self::Blocked => "blocked",
+            Self::Done => "done",
+        }
+    }
+
+    pub fn all() -> [Self; 4] {
+        [Self::Todo, Self::Doing, Self::Blocked, Self::Done]
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KanbanTask {
+    pub id: String,
+    pub title: String,
+    pub lane: KanbanLane,
+    pub priority: u8,
+    pub assignee: Option<String>,
+    pub description: Option<String>,
+    pub depends_on: Vec<String>,
+    pub blocked_reason: Option<String>,
+    pub background_job_id: Option<String>,
+    pub run_summary: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KanbanBoard {
+    pub id: String,
+    pub name: String,
+    pub project_path: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub next_task_seq: u64,
+    pub tasks: Vec<KanbanTask>,
+    pub archived: Vec<KanbanTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KanbanStore {
+    pub schema_version: u32,
+    pub current_board_id: String,
+    pub boards: Vec<KanbanBoard>,
+}
+
+#[derive(Debug, Clone)]
+pub struct KanbanActionInput {
+    pub action: String,
+    pub task_id: Option<String>,
+    pub lane: Option<KanbanLane>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct KanbanCheckpointResult {
+    pub attempted: bool,
+    pub succeeded: bool,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewKanbanTaskInput {
+    pub title: String,
+    pub lane: KanbanLane,
+    pub priority: u8,
+    pub assignee: Option<String>,
+    pub description: Option<String>,
+    pub depends_on: Vec<String>,
+}
+
+impl Default for KanbanStore {
+    fn default() -> Self {
+        let now = now_rfc3339();
+        Self {
+            schema_version: KANBAN_SCHEMA_VERSION,
+            current_board_id: DEFAULT_BOARD_ID.to_string(),
+            boards: vec![KanbanBoard {
+                id: DEFAULT_BOARD_ID.to_string(),
+                name: "Main".to_string(),
+                project_path: None,
+                created_at: now.clone(),
+                updated_at: now,
+                next_task_seq: 1,
+                tasks: Vec::new(),
+                archived: Vec::new(),
+            }],
+        }
+    }
+}
+
+pub fn kanban_store_path() -> PathBuf {
+    hermes_config::hermes_home()
+        .join(KANBAN_STATE_DIR)
+        .join(KANBAN_STORE_FILE)
+}
+
+pub fn load_store() -> Result<KanbanStore, AgentError> {
+    let path = kanban_store_path();
+    if !path.exists() {
+        let store = KanbanStore::default();
+        save_store(&store)?;
+        return Ok(store);
+    }
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| AgentError::Io(format!("read {} failed: {}", path.display(), e)))?;
+    let mut store = serde_json::from_str::<KanbanStore>(&raw)
+        .map_err(|e| AgentError::Config(format!("parse {} failed: {}", path.display(), e)))?;
+    normalize_store(&mut store);
+    Ok(store)
+}
+
+pub fn save_store(store: &KanbanStore) -> Result<PathBuf, AgentError> {
+    let path = kanban_store_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AgentError::Io(format!("failed to create {}: {}", parent.display(), e)))?;
+    }
+    let serialized = serde_json::to_string_pretty(store)
+        .map_err(|e| AgentError::Config(format!("serialize kanban store failed: {}", e)))?;
+    std::fs::write(&path, serialized)
+        .map_err(|e| AgentError::Io(format!("write {} failed: {}", path.display(), e)))?;
+    Ok(path)
+}
+
+pub fn ensure_board<'a>(
+    store: &'a mut KanbanStore,
+    requested: Option<&str>,
+) -> &'a mut KanbanBoard {
+    if store.boards.is_empty() {
+        *store = KanbanStore::default();
+    }
+    if let Some(raw) = requested {
+        if let Some(idx) = store.boards.iter().position(|board| board.id == raw) {
+            store.current_board_id = raw.to_string();
+            return &mut store.boards[idx];
+        }
+        if let Some(idx) = store
+            .boards
+            .iter()
+            .position(|board| board.name.eq_ignore_ascii_case(raw))
+        {
+            store.current_board_id = store.boards[idx].id.clone();
+            return &mut store.boards[idx];
+        }
+    }
+    if let Some(idx) = store
+        .boards
+        .iter()
+        .position(|board| board.id == store.current_board_id)
+    {
+        return &mut store.boards[idx];
+    }
+    store.current_board_id = store.boards[0].id.clone();
+    &mut store.boards[0]
+}
+
+pub fn create_or_select_board<'a>(
+    store: &'a mut KanbanStore,
+    name: &str,
+    project_path: Option<String>,
+) -> &'a mut KanbanBoard {
+    if let Some(idx) = store
+        .boards
+        .iter()
+        .position(|board| board.name.eq_ignore_ascii_case(name))
+    {
+        store.current_board_id = store.boards[idx].id.clone();
+        if project_path.is_some() && store.boards[idx].project_path.is_none() {
+            store.boards[idx].project_path = project_path;
+            store.boards[idx].updated_at = now_rfc3339();
+        }
+        return &mut store.boards[idx];
+    }
+    let now = now_rfc3339();
+    let board_id = slugify_board_id(name);
+    let unique = unique_board_id(store, &board_id);
+    store.boards.push(KanbanBoard {
+        id: unique.clone(),
+        name: name.trim().to_string(),
+        project_path,
+        created_at: now.clone(),
+        updated_at: now,
+        next_task_seq: 1,
+        tasks: Vec::new(),
+        archived: Vec::new(),
+    });
+    store.current_board_id = unique.clone();
+    let idx = store
+        .boards
+        .iter()
+        .position(|board| board.id == unique)
+        .unwrap_or(0);
+    &mut store.boards[idx]
+}
+
+pub fn add_task(board: &mut KanbanBoard, input: NewKanbanTaskInput) -> KanbanTask {
+    let now = now_rfc3339();
+    let id = format!("K-{:04}", board.next_task_seq.max(1));
+    board.next_task_seq = board.next_task_seq.saturating_add(1);
+    let task = KanbanTask {
+        id,
+        title: input.title.trim().to_string(),
+        lane: input.lane,
+        priority: input.priority.clamp(1, 5),
+        assignee: normalize_optional(input.assignee),
+        description: normalize_optional(input.description),
+        depends_on: dedupe_strings(input.depends_on),
+        blocked_reason: None,
+        background_job_id: None,
+        run_summary: None,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        started_at: (input.lane == KanbanLane::Doing).then_some(now.clone()),
+        completed_at: (input.lane == KanbanLane::Done).then_some(now),
+    };
+    board.updated_at = now_rfc3339();
+    board.tasks.push(task.clone());
+    task
+}
+
+pub fn find_task_mut<'a>(
+    board: &'a mut KanbanBoard,
+    id_or_title: &str,
+) -> Option<&'a mut KanbanTask> {
+    let needle = id_or_title.trim();
+    if needle.is_empty() {
+        return None;
+    }
+    if let Some(idx) = board
+        .tasks
+        .iter()
+        .position(|task| task.id.eq_ignore_ascii_case(needle))
+    {
+        return board.tasks.get_mut(idx);
+    }
+    board
+        .tasks
+        .iter_mut()
+        .find(|task| task.title.eq_ignore_ascii_case(needle))
+}
+
+pub fn move_task(task: &mut KanbanTask, lane: KanbanLane, note: Option<String>) {
+    let now = now_rfc3339();
+    task.lane = lane;
+    task.updated_at = now.clone();
+    if lane == KanbanLane::Doing && task.started_at.is_none() {
+        task.started_at = Some(now.clone());
+    }
+    if lane == KanbanLane::Done {
+        task.completed_at = Some(now.clone());
+        if let Some(note) = normalize_optional(note) {
+            task.run_summary = Some(note);
+        }
+    } else {
+        task.completed_at = None;
+    }
+    if lane != KanbanLane::Blocked {
+        task.blocked_reason = None;
+    }
+}
+
+pub fn set_blocked(task: &mut KanbanTask, reason: Option<String>) {
+    task.lane = KanbanLane::Blocked;
+    task.blocked_reason = normalize_optional(reason);
+    task.updated_at = now_rfc3339();
+}
+
+pub fn claim_task(task: &mut KanbanTask, assignee: Option<String>) {
+    task.assignee = normalize_optional(assignee);
+    if task.lane == KanbanLane::Todo {
+        task.lane = KanbanLane::Doing;
+        task.started_at = Some(now_rfc3339());
+    }
+    task.updated_at = now_rfc3339();
+}
+
+pub fn archive_done(board: &mut KanbanBoard) -> usize {
+    let mut moved = Vec::new();
+    board.tasks.retain(|task| {
+        let done = task.lane == KanbanLane::Done;
+        if done {
+            moved.push(task.clone());
+        }
+        !done
+    });
+    let count = moved.len();
+    board.archived.extend(moved);
+    if count > 0 {
+        board.updated_at = now_rfc3339();
+    }
+    count
+}
+
+pub fn lane_counts(board: &KanbanBoard) -> Vec<(KanbanLane, usize)> {
+    let mut rows = Vec::new();
+    for lane in KanbanLane::all() {
+        rows.push((lane, board.tasks.iter().filter(|t| t.lane == lane).count()));
+    }
+    rows
+}
+
+pub fn maybe_checkpoint_to_contextlattice(
+    board: &KanbanBoard,
+    payload: KanbanActionInput,
+) -> KanbanCheckpointResult {
+    if !kanban_contextlattice_sync_enabled() {
+        return KanbanCheckpointResult {
+            attempted: false,
+            succeeded: false,
+            detail: "ContextLattice sync disabled via HERMES_KANBAN_CONTEXTLATTICE_SYNC."
+                .to_string(),
+        };
+    }
+    let Some(script_path) = contextlattice_script_path() else {
+        return KanbanCheckpointResult {
+            attempted: false,
+            succeeded: false,
+            detail: "ContextLattice orchestration script not found; skipped checkpoint."
+                .to_string(),
+        };
+    };
+
+    let mut content = format!(
+        "kanban_action={} board_id={} board_name={} summary={}",
+        payload.action,
+        board.id,
+        board.name,
+        payload.summary.replace('\n', " ")
+    );
+    if let Some(task_id) = payload.task_id {
+        content.push_str(&format!(" task_id={task_id}"));
+    }
+    if let Some(lane) = payload.lane {
+        content.push_str(&format!(" lane={}", lane.as_str()));
+    }
+
+    let topic_path = format!("runbooks/kanban/{}", board.id);
+    let output = Command::new("python3")
+        .arg(&script_path)
+        .arg("write")
+        .arg("hermes-agent-ultra")
+        .arg(&topic_path)
+        .arg(content)
+        .env(
+            "MEMMCP_ORCHESTRATOR_URL",
+            std::env::var("MEMMCP_ORCHESTRATOR_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string()),
+        )
+        .env(
+            "CONTEXTLATTICE_ORCHESTRATOR_URL",
+            std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string()),
+        )
+        .env(
+            "CONTEXTLATTICE_AGENT_ID",
+            std::env::var("CONTEXTLATTICE_AGENT_ID").unwrap_or_else(|_| "codex_gpt5".to_string()),
+        )
+        .env(
+            "MEMMCP_AGENT_ID",
+            std::env::var("MEMMCP_AGENT_ID").unwrap_or_else(|_| "codex_gpt5".to_string()),
+        )
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => KanbanCheckpointResult {
+            attempted: true,
+            succeeded: true,
+            detail: format!("ContextLattice checkpointed to topic `{topic_path}`."),
+        },
+        Ok(out) => KanbanCheckpointResult {
+            attempted: true,
+            succeeded: false,
+            detail: format!(
+                "ContextLattice checkpoint failed (exit={}): {}",
+                out.status.code().unwrap_or(-1),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        },
+        Err(err) => KanbanCheckpointResult {
+            attempted: true,
+            succeeded: false,
+            detail: format!("ContextLattice checkpoint error: {err}"),
+        },
+    }
+}
+
+fn normalize_store(store: &mut KanbanStore) {
+    if store.schema_version == 0 {
+        store.schema_version = KANBAN_SCHEMA_VERSION;
+    }
+    if store.boards.is_empty() {
+        *store = KanbanStore::default();
+        return;
+    }
+    if !store
+        .boards
+        .iter()
+        .any(|board| board.id == store.current_board_id)
+    {
+        store.current_board_id = store.boards[0].id.clone();
+    }
+}
+
+fn unique_board_id(store: &KanbanStore, base: &str) -> String {
+    let clean = if base.is_empty() {
+        DEFAULT_BOARD_ID.to_string()
+    } else {
+        base.to_string()
+    };
+    if !store.boards.iter().any(|board| board.id == clean) {
+        return clean;
+    }
+    for idx in 2..10_000 {
+        let candidate = format!("{clean}-{idx}");
+        if !store.boards.iter().any(|board| board.id == candidate) {
+            return candidate;
+        }
+    }
+    format!("{}-{}", clean, uuid::Uuid::new_v4().simple())
+}
+
+fn slugify_board_id(raw: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = false;
+    for ch in raw.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn dedupe_strings(values: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for v in values {
+        let normalized = v.trim().to_string();
+        if normalized.is_empty() {
+            continue;
+        }
+        if out
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(&normalized))
+        {
+            continue;
+        }
+        out.push(normalized);
+    }
+    out
+}
+
+fn normalize_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn kanban_contextlattice_sync_enabled() -> bool {
+    std::env::var("HERMES_KANBAN_CONTEXTLATTICE_SYNC")
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(true)
+}
+
+fn contextlattice_script_path() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Ok(path) = std::env::var("HERMES_KANBAN_CONTEXTLATTICE_SCRIPT") {
+        candidates.push(PathBuf::from(path));
+    }
+    candidates.push(PathBuf::from(CONTEXTLATTICE_DEFAULT_SCRIPT));
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd.join("scripts/agent_orchestration.py"));
+    }
+    for candidate in candidates {
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env_lock;
+
+    fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        test_env_lock::lock()
+    }
+
+    fn with_temp_home<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("HERMES_HOME");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        let result = f();
+        match prev {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        result
+    }
+
+    #[test]
+    fn load_store_bootstraps_default_board() {
+        with_temp_home(|| {
+            let store = load_store().expect("load");
+            assert_eq!(store.current_board_id, "main");
+            assert_eq!(store.boards.len(), 1);
+            assert_eq!(store.boards[0].name, "Main");
+        });
+    }
+
+    #[test]
+    fn add_move_and_archive_flow_works() {
+        with_temp_home(|| {
+            let mut store = load_store().expect("load");
+            let board = ensure_board(&mut store, None);
+            let task = add_task(
+                board,
+                NewKanbanTaskInput {
+                    title: "Ship kanban".to_string(),
+                    lane: KanbanLane::Todo,
+                    priority: 2,
+                    assignee: None,
+                    description: None,
+                    depends_on: vec![],
+                },
+            );
+            assert_eq!(task.id, "K-0001");
+            let task = find_task_mut(board, "K-0001").expect("task");
+            claim_task(task, Some("worker-a".to_string()));
+            assert_eq!(task.lane, KanbanLane::Doing);
+            move_task(task, KanbanLane::Done, Some("verified".to_string()));
+            assert_eq!(task.lane, KanbanLane::Done);
+            assert!(task.completed_at.is_some());
+            let moved = archive_done(board);
+            assert_eq!(moved, 1);
+            assert_eq!(board.tasks.len(), 0);
+            assert_eq!(board.archived.len(), 1);
+            save_store(&store).expect("save");
+        });
+    }
+
+    #[test]
+    fn contextlattice_checkpoint_disabled_path() {
+        with_temp_home(|| {
+            std::env::set_var("HERMES_KANBAN_CONTEXTLATTICE_SYNC", "0");
+            let board = KanbanBoard {
+                id: "main".to_string(),
+                name: "Main".to_string(),
+                project_path: None,
+                created_at: now_rfc3339(),
+                updated_at: now_rfc3339(),
+                next_task_seq: 1,
+                tasks: vec![],
+                archived: vec![],
+            };
+            let res = maybe_checkpoint_to_contextlattice(
+                &board,
+                KanbanActionInput {
+                    action: "add".to_string(),
+                    task_id: Some("K-0001".to_string()),
+                    lane: Some(KanbanLane::Todo),
+                    summary: "test".to_string(),
+                },
+            );
+            assert!(!res.attempted);
+            std::env::remove_var("HERMES_KANBAN_CONTEXTLATTICE_SYNC");
+        });
+    }
+}

--- a/crates/hermes-cli/src/lib.rs
+++ b/crates/hermes-cli/src/lib.rs
@@ -23,6 +23,7 @@ pub mod copilot_auth;
 pub mod doctor;
 pub mod env_loader;
 pub mod gateway_cmd;
+pub mod kanban;
 pub mod lumio;
 pub mod mcp_config;
 pub mod model_switch;


### PR DESCRIPTION
## Summary\n- add new kanban module with persisted board/task state under ~/.hermes-agent-ultra/alpha/kanban\n- wire real /kanban command flow (status/boards/init/use/add/move/claim/block/done/archive/dispatch/sync)\n- route /tasks alias to /kanban and reuse background queue helper for kanban dispatch\n- checkpoint kanban actions into ContextLattice topic path runbooks/kanban/<board_id>\n\n## Validation\n- cargo check -p hermes-cli\n- cargo test -p hermes-cli kanban -- --nocapture\n- cargo test -p hermes-cli test_upstream_compat_aliases_are_mapped -- --nocapture