### PR TITLE
feat(alpha): contextlattice-first intelligence 16+ controls

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -4038,6 +4038,11 @@ impl AgentLoop {
         if let Some(hint) = objective_mode_system_hint(ctx.get_messages()) {
             ctx.add_message(Message::system(hint));
         }
+        if let Some(hint) =
+            contextlattice_intelligence_system_hint(ctx.get_messages(), &tool_schemas)
+        {
+            ctx.add_message(Message::system(hint));
+        }
 
         let persist_user_idx = if self.config.persist_user_message.is_some() {
             ctx.get_messages()
@@ -5074,6 +5079,11 @@ impl AgentLoop {
             ctx.add_message(Message::system(hint));
         }
         if let Some(hint) = objective_mode_system_hint(ctx.get_messages()) {
+            ctx.add_message(Message::system(hint));
+        }
+        if let Some(hint) =
+            contextlattice_intelligence_system_hint(ctx.get_messages(), &tool_schemas)
+        {
             ctx.add_message(Message::system(hint));
         }
 
@@ -7839,6 +7849,42 @@ fn contextlattice_connect_system_hint(messages: &[Message]) -> Option<String> {
          (3) if needed call `contextlattice_context_pack` for broader grounding; \
          (4) call `contextlattice_write` to checkpoint what was verified. \
          Never use terminal command `contextlattice` for this workflow."
+            .to_string(),
+    )
+}
+
+fn contextlattice_intelligence_system_hint(
+    messages: &[Message],
+    tool_schemas: &[ToolSchema],
+) -> Option<String> {
+    let has_context_tools = tool_schemas.iter().any(|t| {
+        matches!(
+            t.name.as_str(),
+            "contextlattice_search"
+                | "contextlattice_context_pack"
+                | "contextlattice_write"
+                | "memory"
+        )
+    });
+    if !has_context_tools {
+        return None;
+    }
+
+    let objective_active = objective_guard_policy(messages).0;
+    let repo_intent = detect_repo_review_intent(messages);
+    let connect_intent = detect_contextlattice_connect_intent(messages);
+    if !(objective_active || repo_intent || connect_intent) {
+        return None;
+    }
+
+    Some(
+        "[SYSTEM] ContextLattice-first intelligence policy active.\n\
+         1) Start with scoped retrieval (`contextlattice_search`) using project + topic path.\n\
+         2) If scoped retrieval is empty/degraded, run one broader retrieval in the same project and compare.\n\
+         3) For broad or multi-file tasks, run `contextlattice_context_pack` before deep tool loops.\n\
+         4) During long execution, checkpoint durable progress with `contextlattice_write`.\n\
+         5) Before final answer, run one scoped readback and report contradictions as `unproven` rather than guessing.\n\
+         6) Copy numeric facts verbatim; do not normalize or round unless explicitly requested."
             .to_string(),
     )
 }
@@ -11779,6 +11825,38 @@ mod tests {
         assert!(hint.contains("contextlattice_search"));
         assert!(hint.contains("scripts/agent_orchestration.py"));
         assert!(hint.contains("Never use terminal command `contextlattice`"));
+    }
+
+    #[test]
+    fn test_contextlattice_intelligence_system_hint_requires_tools_and_intent() {
+        let msgs = vec![Message::user(
+            "perform deep repo audit and objective verification on /tmp/repo",
+        )];
+        let tools = vec![
+            ToolSchema::new("contextlattice_search", "search", JsonSchema::new("object")),
+            ToolSchema::new(
+                "contextlattice_context_pack",
+                "pack",
+                JsonSchema::new("object"),
+            ),
+        ];
+        let hint = contextlattice_intelligence_system_hint(&msgs, &tools).expect("expected hint");
+        assert!(hint.contains("ContextLattice-first intelligence policy active"));
+        assert!(hint.contains("scoped retrieval"));
+        assert!(hint.contains("Copy numeric facts verbatim"));
+    }
+
+    #[test]
+    fn test_contextlattice_intelligence_system_hint_skips_without_tools() {
+        let msgs = vec![Message::user(
+            "perform deep repo audit and objective verification on /tmp/repo",
+        )];
+        let tools = vec![ToolSchema::new(
+            "terminal",
+            "terminal",
+            JsonSchema::new("object"),
+        )];
+        assert!(contextlattice_intelligence_system_hint(&msgs, &tools).is_none());
     }
 
     #[test]

--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -216,6 +216,7 @@ pub struct SubagentRegistry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct ContextLatticePolicy {
     pub preflight_required: bool,
     pub auto_context_pack_on_mission_start: bool,
@@ -224,6 +225,60 @@ pub struct ContextLatticePolicy {
     pub readback_verification_required: bool,
     pub shared_topic_taxonomy: Vec<String>,
     pub conflict_resolution_mode: String,
+    pub include_grounding_required: bool,
+    pub include_retrieval_debug_for_execution: bool,
+    pub broaden_scope_on_zero_hits: bool,
+    pub scoped_recency_pass_before_finalize: bool,
+    pub contradiction_check_across_layers: bool,
+    pub numeric_fact_verbatim_copy: bool,
+    pub objective_analytics_writeback_required: bool,
+    pub preferred_retrieval_mode: String,
+    pub deep_retry_budget_secs: Vec<u64>,
+    pub regular_retry_budget_secs: Vec<u64>,
+    pub summary_sink_order: Vec<String>,
+    pub required_project_scoping: bool,
+    pub checkpoint_payload_requires_project_file_topic: bool,
+}
+
+impl Default for ContextLatticePolicy {
+    fn default() -> Self {
+        Self {
+            preflight_required: true,
+            auto_context_pack_on_mission_start: true,
+            degradation_aware_planning: true,
+            checkpoint_write_policy: vec![
+                "plan_started".to_string(),
+                "implementation_checkpoint".to_string(),
+                "verification_complete".to_string(),
+                "final_readback_verified".to_string(),
+            ],
+            readback_verification_required: true,
+            shared_topic_taxonomy: vec![
+                "runbooks/alpha".to_string(),
+                "runbooks/alpha/objective".to_string(),
+                "runbooks/alpha/loops".to_string(),
+                "runbooks/alpha/provider".to_string(),
+            ],
+            conflict_resolution_mode: "source_weight_then_recency".to_string(),
+            include_grounding_required: true,
+            include_retrieval_debug_for_execution: true,
+            broaden_scope_on_zero_hits: true,
+            scoped_recency_pass_before_finalize: true,
+            contradiction_check_across_layers: true,
+            numeric_fact_verbatim_copy: true,
+            objective_analytics_writeback_required: true,
+            preferred_retrieval_mode: "deep".to_string(),
+            deep_retry_budget_secs: vec![120, 180, 240],
+            regular_retry_budget_secs: vec![120, 180],
+            summary_sink_order: vec![
+                "contextlattice".to_string(),
+                "github".to_string(),
+                "local".to_string(),
+            ],
+            required_project_scoping: true,
+            checkpoint_payload_requires_project_file_topic: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -384,25 +439,7 @@ fn read_json_file<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, AgentE
 }
 
 fn default_contextlattice_policy() -> ContextLatticePolicy {
-    ContextLatticePolicy {
-        preflight_required: true,
-        auto_context_pack_on_mission_start: true,
-        degradation_aware_planning: true,
-        checkpoint_write_policy: vec![
-            "plan_started".to_string(),
-            "implementation_checkpoint".to_string(),
-            "verification_complete".to_string(),
-            "final_readback_verified".to_string(),
-        ],
-        readback_verification_required: true,
-        shared_topic_taxonomy: vec![
-            "runbooks/alpha".to_string(),
-            "runbooks/alpha/objective".to_string(),
-            "runbooks/alpha/loops".to_string(),
-            "runbooks/alpha/provider".to_string(),
-        ],
-        conflict_resolution_mode: "source_weight_then_recency".to_string(),
-    }
+    ContextLatticePolicy::default()
 }
 
 fn default_objective_profile() -> ObjectiveProfile {
@@ -1196,6 +1233,107 @@ pub fn load_contextlattice_policy() -> Result<ContextLatticePolicy, AgentError> 
     read_json_file(&contextlattice_policy_path())
 }
 
+pub fn set_contextlattice_policy(
+    policy: ContextLatticePolicy,
+) -> Result<ContextLatticePolicy, AgentError> {
+    ensure_alpha_runtime_bootstrap(false)?;
+    let mut updated = policy;
+    if updated.checkpoint_write_policy.is_empty() {
+        updated.checkpoint_write_policy = ContextLatticePolicy::default().checkpoint_write_policy;
+    }
+    if updated.shared_topic_taxonomy.is_empty() {
+        updated.shared_topic_taxonomy = ContextLatticePolicy::default().shared_topic_taxonomy;
+    }
+    if updated.deep_retry_budget_secs.is_empty() {
+        updated.deep_retry_budget_secs = ContextLatticePolicy::default().deep_retry_budget_secs;
+    }
+    if updated.regular_retry_budget_secs.is_empty() {
+        updated.regular_retry_budget_secs =
+            ContextLatticePolicy::default().regular_retry_budget_secs;
+    }
+    if updated.summary_sink_order.is_empty() {
+        updated.summary_sink_order = ContextLatticePolicy::default().summary_sink_order;
+    }
+    if updated.preferred_retrieval_mode.trim().is_empty() {
+        updated.preferred_retrieval_mode = ContextLatticePolicy::default().preferred_retrieval_mode;
+    } else {
+        let normalized = updated.preferred_retrieval_mode.trim().to_ascii_lowercase();
+        updated.preferred_retrieval_mode = match normalized.as_str() {
+            "fast" | "balanced" | "deep" => normalized,
+            _ => "deep".to_string(),
+        };
+    }
+    write_json_file(&contextlattice_policy_path(), &updated)?;
+    Ok(updated)
+}
+
+pub fn set_contextlattice_policy_mode(mode: &str) -> Result<ContextLatticePolicy, AgentError> {
+    let mut policy = load_contextlattice_policy()?;
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "max" | "strict" => {
+            policy.preflight_required = true;
+            policy.auto_context_pack_on_mission_start = true;
+            policy.degradation_aware_planning = true;
+            policy.readback_verification_required = true;
+            policy.include_grounding_required = true;
+            policy.include_retrieval_debug_for_execution = true;
+            policy.broaden_scope_on_zero_hits = true;
+            policy.scoped_recency_pass_before_finalize = true;
+            policy.contradiction_check_across_layers = true;
+            policy.numeric_fact_verbatim_copy = true;
+            policy.objective_analytics_writeback_required = true;
+            policy.required_project_scoping = true;
+            policy.checkpoint_payload_requires_project_file_topic = true;
+            policy.preferred_retrieval_mode = "deep".to_string();
+            policy.deep_retry_budget_secs = vec![120, 180, 240];
+            policy.regular_retry_budget_secs = vec![120, 180];
+        }
+        "balanced" => {
+            policy.preflight_required = true;
+            policy.auto_context_pack_on_mission_start = true;
+            policy.degradation_aware_planning = true;
+            policy.readback_verification_required = true;
+            policy.include_grounding_required = true;
+            policy.include_retrieval_debug_for_execution = true;
+            policy.broaden_scope_on_zero_hits = true;
+            policy.scoped_recency_pass_before_finalize = true;
+            policy.contradiction_check_across_layers = true;
+            policy.numeric_fact_verbatim_copy = true;
+            policy.objective_analytics_writeback_required = true;
+            policy.required_project_scoping = true;
+            policy.checkpoint_payload_requires_project_file_topic = true;
+            policy.preferred_retrieval_mode = "balanced".to_string();
+            policy.deep_retry_budget_secs = vec![90, 120, 180];
+            policy.regular_retry_budget_secs = vec![90, 120];
+        }
+        "speed" | "fast" => {
+            policy.preflight_required = true;
+            policy.auto_context_pack_on_mission_start = true;
+            policy.degradation_aware_planning = true;
+            policy.readback_verification_required = true;
+            policy.include_grounding_required = true;
+            policy.include_retrieval_debug_for_execution = false;
+            policy.broaden_scope_on_zero_hits = true;
+            policy.scoped_recency_pass_before_finalize = true;
+            policy.contradiction_check_across_layers = true;
+            policy.numeric_fact_verbatim_copy = true;
+            policy.objective_analytics_writeback_required = true;
+            policy.required_project_scoping = true;
+            policy.checkpoint_payload_requires_project_file_topic = true;
+            policy.preferred_retrieval_mode = "fast".to_string();
+            policy.deep_retry_budget_secs = vec![60, 90, 120];
+            policy.regular_retry_budget_secs = vec![60, 90];
+        }
+        _ => {
+            return Err(AgentError::Config(
+                "unknown contextlattice policy mode; expected one of: max|strict|balanced|fast|speed"
+                    .to_string(),
+            ));
+        }
+    }
+    set_contextlattice_policy(policy)
+}
+
 pub fn enqueue_loop_event(
     loop_id: &str,
     event_type: &str,
@@ -1602,11 +1740,32 @@ pub async fn render_mission_board(
     out.push_str(&format!("- {}\n", ctx_status.health_line));
     out.push_str(&format!("- {}\n", ctx_status.preflight_script_line));
     out.push_str(&format!(
-        "- policy: preflight={} context_pack_on_start={} degradation_aware={} readback_required={}\n\n",
+        "- policy: preflight={} context_pack_on_start={} degradation_aware={} readback_required={}\n",
         ctx_policy.preflight_required,
         ctx_policy.auto_context_pack_on_mission_start,
         ctx_policy.degradation_aware_planning,
         ctx_policy.readback_verification_required
+    ));
+    out.push_str(&format!(
+        "- retrieval: mode={} grounding_required={} retrieval_debug={} broaden_scope={} recency_pass={}\n",
+        ctx_policy.preferred_retrieval_mode,
+        ctx_policy.include_grounding_required,
+        ctx_policy.include_retrieval_debug_for_execution,
+        ctx_policy.broaden_scope_on_zero_hits,
+        ctx_policy.scoped_recency_pass_before_finalize
+    ));
+    out.push_str(&format!(
+        "- integrity: contradiction_check={} numeric_verbatim={} project_scoping={} checkpoint_payload_contract={}\n",
+        ctx_policy.contradiction_check_across_layers,
+        ctx_policy.numeric_fact_verbatim_copy,
+        ctx_policy.required_project_scoping,
+        ctx_policy.checkpoint_payload_requires_project_file_topic
+    ));
+    out.push_str(&format!(
+        "- retries: deep={:?} regular={:?} sinks={}\n\n",
+        ctx_policy.deep_retry_budget_secs,
+        ctx_policy.regular_retry_budget_secs,
+        ctx_policy.summary_sink_order.join(",")
     ));
 
     out.push_str("Objective Contract\n");
@@ -3298,6 +3457,29 @@ mod tests {
 
             let generalized = reset_objective_profile_generalized().expect("reset profile");
             assert_eq!(generalized.profile_id, "repo-general");
+        });
+    }
+
+    #[test]
+    fn contextlattice_policy_modes_roundtrip() {
+        with_test_hermes_home(|| {
+            ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+
+            let max = set_contextlattice_policy_mode("max").expect("max mode");
+            assert_eq!(max.preferred_retrieval_mode, "deep");
+            assert!(max.include_retrieval_debug_for_execution);
+            assert!(max.preflight_required);
+            assert_eq!(max.deep_retry_budget_secs, vec![120, 180, 240]);
+
+            let fast = set_contextlattice_policy_mode("fast").expect("fast mode");
+            assert_eq!(fast.preferred_retrieval_mode, "fast");
+            assert!(!fast.include_retrieval_debug_for_execution);
+            assert_eq!(fast.regular_retry_budget_secs, vec![60, 90]);
+
+            let loaded = load_contextlattice_policy().expect("load context policy");
+            assert_eq!(loaded.preferred_retrieval_mode, "fast");
+            assert!(loaded.required_project_scoping);
+            assert!(loaded.checkpoint_payload_requires_project_file_topic);
         });
     }
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -27,13 +27,14 @@ use crate::alpha_runtime::{
     append_counterfactual, append_objective_learning_entry, build_objective_dag_from_contract,
     clear_objective_contract, clear_objective_dag, clear_objective_learning_ledger,
     enqueue_loop_event, ensure_alpha_runtime_bootstrap, ensure_trading_runtime_bootstrap,
-    load_alpha_loops, load_claim_verifier_policy, load_last_trading_alpha_report,
-    load_objective_contract, load_objective_dag, load_objective_ensemble_policy,
-    load_objective_eval_trend, load_objective_learning_ledger, load_objective_profile,
-    load_objective_simulation_policy, load_quorum_policy, objective_profile_specialized_for,
-    recover_orphan_loop_events, refresh_trading_alpha_report, render_mission_board,
-    render_trading_alpha_board, replay_loop_queue, reset_objective_profile_generalized,
-    set_claim_verifier_enabled, set_objective_ensemble_mode, set_objective_profile,
+    load_alpha_loops, load_claim_verifier_policy, load_contextlattice_policy,
+    load_last_trading_alpha_report, load_objective_contract, load_objective_dag,
+    load_objective_ensemble_policy, load_objective_eval_trend, load_objective_learning_ledger,
+    load_objective_profile, load_objective_simulation_policy, load_quorum_policy,
+    objective_profile_specialized_for, recover_orphan_loop_events, refresh_trading_alpha_report,
+    render_mission_board, render_trading_alpha_board, replay_loop_queue,
+    reset_objective_profile_generalized, set_claim_verifier_enabled,
+    set_contextlattice_policy_mode, set_objective_ensemble_mode, set_objective_profile,
     set_objective_simulation_mode, set_quorum_policy, summarize_objective_contract,
     upsert_objective_contract, utility_terms_from_contract, ObjectiveLearningLedgerEntry,
 };
@@ -161,7 +162,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/objective",
-        "Set/show objective contract + profile/policies (`status|plan|constraints|counterfactual|profile|simulator|ensemble|ledger|dag|eval|clear`)",
+        "Set/show objective contract + profile/policies (`status|plan|constraints|counterfactual|profile|context|simulator|ensemble|ledger|dag|eval|clear`)",
     ),
     (
         "/claims",
@@ -8473,10 +8474,138 @@ fn handle_capability_surface_command(
 }
 
 fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
-    let objective_usage = "Usage: `/objective <text>` or `/objective status|plan|constraints|counterfactual <scenario> | <expected_delta>|profile [status|list|general|me|set <id>]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|dag [status|rebuild|clear]|eval [status|tail [n]]|clear`.";
+    let objective_usage = "Usage: `/objective <text>` or `/objective status|plan|constraints|counterfactual <scenario> | <expected_delta>|profile [status|list|general|me|set <id>]|context [status|list|max|balanced|fast]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|dag [status|rebuild|clear]|eval [status|tail [n]]|clear`.";
 
     if let Some(first) = args.first() {
         let cmd = first.trim().to_ascii_lowercase();
+        if cmd == "context" || cmd == "contextlattice" {
+            let sub = args
+                .get(1)
+                .map(|v| v.trim().to_ascii_lowercase())
+                .unwrap_or_else(|| "status".to_string());
+            match sub.as_str() {
+                "status" | "show" => {
+                    let p = load_contextlattice_policy()?;
+                    let mut out = String::new();
+                    out.push_str("ContextLattice policy\n");
+                    out.push_str("--------------------\n");
+                    let _ = writeln!(out, "mode_hint: {}", p.preferred_retrieval_mode);
+                    let _ = writeln!(out, "preflight_required: {}", p.preflight_required);
+                    let _ = writeln!(
+                        out,
+                        "auto_context_pack_on_mission_start: {}",
+                        p.auto_context_pack_on_mission_start
+                    );
+                    let _ = writeln!(
+                        out,
+                        "degradation_aware_planning: {}",
+                        p.degradation_aware_planning
+                    );
+                    let _ = writeln!(
+                        out,
+                        "include_grounding_required: {}",
+                        p.include_grounding_required
+                    );
+                    let _ = writeln!(
+                        out,
+                        "include_retrieval_debug_for_execution: {}",
+                        p.include_retrieval_debug_for_execution
+                    );
+                    let _ = writeln!(
+                        out,
+                        "broaden_scope_on_zero_hits: {}",
+                        p.broaden_scope_on_zero_hits
+                    );
+                    let _ = writeln!(
+                        out,
+                        "scoped_recency_pass_before_finalize: {}",
+                        p.scoped_recency_pass_before_finalize
+                    );
+                    let _ = writeln!(
+                        out,
+                        "objective_analytics_writeback_required: {}",
+                        p.objective_analytics_writeback_required
+                    );
+                    let _ = writeln!(
+                        out,
+                        "contradiction_check_across_layers: {}",
+                        p.contradiction_check_across_layers
+                    );
+                    let _ = writeln!(
+                        out,
+                        "numeric_fact_verbatim_copy: {}",
+                        p.numeric_fact_verbatim_copy
+                    );
+                    let _ = writeln!(
+                        out,
+                        "required_project_scoping: {}",
+                        p.required_project_scoping
+                    );
+                    let _ = writeln!(
+                        out,
+                        "checkpoint_payload_requires_project_file_topic: {}",
+                        p.checkpoint_payload_requires_project_file_topic
+                    );
+                    let _ = writeln!(
+                        out,
+                        "readback_verification_required: {}",
+                        p.readback_verification_required
+                    );
+                    let _ = writeln!(
+                        out,
+                        "conflict_resolution_mode: {}",
+                        p.conflict_resolution_mode
+                    );
+                    let _ = writeln!(
+                        out,
+                        "deep_retry_budget_secs: {:?}",
+                        p.deep_retry_budget_secs
+                    );
+                    let _ = writeln!(
+                        out,
+                        "regular_retry_budget_secs: {:?}",
+                        p.regular_retry_budget_secs
+                    );
+                    let _ = writeln!(
+                        out,
+                        "summary_sink_order: {}",
+                        p.summary_sink_order.join(",")
+                    );
+                    emit_command_output(app, out.trim_end());
+                    return Ok(CommandResult::Handled);
+                }
+                "list" => {
+                    emit_command_output(
+                        app,
+                        "ContextLattice policy presets:\n- max: full evidence + deep retrieval + strict recency/readback gates\n- balanced: full evidence with moderate deep/regular retry budgets\n- fast: grounded but lower retrieval-debug overhead for speed-sensitive loops",
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                "max" | "strict" | "balanced" | "fast" | "speed" => {
+                    let p = set_contextlattice_policy_mode(&sub)?;
+                    emit_command_output(
+                        app,
+                        format!(
+                            "ContextLattice policy updated.\nmode={} preflight={} retrieval_mode={} deep_retries={:?} regular_retries={:?}",
+                            sub,
+                            p.preflight_required,
+                            p.preferred_retrieval_mode,
+                            p.deep_retry_budget_secs,
+                            p.regular_retry_budget_secs
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+                _ => {
+                    emit_command_output(
+                        app,
+                        "Usage: /objective context [status|list|max|balanced|fast]",
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+            }
+        }
+
         if cmd == "profile" {
             let sub = args
                 .get(1)
@@ -8839,6 +8968,18 @@ fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                     out,
                     "\nObjective profile\n-----------------\nprofile_id: {}\noperator_hint: {}\nmemory_backend: {}\ndefault_shell: {}",
                     profile.profile_id, profile.operator_hint, profile.memory_backend, profile.default_shell
+                );
+            }
+            if let Ok(ctx_policy) = load_contextlattice_policy() {
+                let _ = writeln!(
+                    out,
+                    "\nContextLattice policy\n---------------------\nmode_hint: {}\npreflight_required: {}\nretrieval_debug: {}\nreadback_required: {}\ndeep_retries: {:?}\nregular_retries: {:?}",
+                    ctx_policy.preferred_retrieval_mode,
+                    ctx_policy.preflight_required,
+                    ctx_policy.include_retrieval_debug_for_execution,
+                    ctx_policy.readback_verification_required,
+                    ctx_policy.deep_retry_budget_secs,
+                    ctx_policy.regular_retry_budget_secs
                 );
             }
             if let Ok(sim) = load_objective_simulation_policy() {

--- a/docs/alpha/CONTEXTLATTICE_INTELLIGENCE_16_PLUS.md
+++ b/docs/alpha/CONTEXTLATTICE_INTELLIGENCE_16_PLUS.md
@@ -1,0 +1,43 @@
+# ContextLattice-First Intelligence 16+ (Implemented)
+
+This tranche reformulates the prior 16-item intelligence/performance set so memory and reasoning behavior is explicitly ContextLattice-first.
+
+## Elements
+1. Mandatory preflight handshake before deep execution.
+2. Scoped retrieval-first discipline for objective/repo workflows.
+3. Automatic broader same-project retrieval when scoped hits are empty/degraded.
+4. Context-pack requirement for broad or multi-file tasks.
+5. Grounding-required retrieval posture.
+6. Retrieval-debug-on-execution posture (mode-dependent).
+7. Lifecycle checkpoint policy for durable progress writes.
+8. Scoped readback verification before finalization.
+9. Contradiction check across evidence layers.
+10. Numeric-fact verbatim-copy integrity rule.
+11. Required project-scoping for memory operations.
+12. Structured checkpoint payload contract (`project/file/topic`).
+13. Explicit deep retry budget profile.
+14. Explicit regular retry budget profile.
+15. Objective analytics writeback requirement.
+16. Summary sink-order policy (`contextlattice -> github -> local`).
+17. ContextLattice telemetry folded into adaptive intelligence/performance autopilot.
+
+## Implementation Surfaces
+- `crates/hermes-cli/src/alpha_runtime.rs`
+  - Expanded `ContextLatticePolicy` surface and defaults.
+  - Added policy-mode setters (`max|balanced|fast`).
+- `crates/hermes-cli/src/commands.rs`
+  - Added `/objective context [status|list|max|balanced|fast]`.
+  - Included ContextLattice policy in objective status output.
+- `crates/hermes-agent/src/agent_loop.rs`
+  - Added ContextLattice-first intelligence system hint for objective/repo/connect intents when tools are available.
+- `scripts/run-performance-autopilot.py`
+  - Added ContextLattice preflight/telemetry section.
+  - Added ContextLattice-aware recommendations and adaptive-index penalties.
+
+## Operator Usage
+- Show current policy: `/objective context status`
+- List policy presets: `/objective context list`
+- Max intelligence mode: `/objective context max`
+- Balanced mode: `/objective context balanced`
+- Speed-focused mode: `/objective context fast`
+- Run adaptive loop: `/ops autopilot run` then `/ops autopilot recommend` or `/ops autopilot apply`

--- a/scripts/run-performance-autopilot.py
+++ b/scripts/run-performance-autopilot.py
@@ -31,6 +31,15 @@ def parse_args() -> argparse.Namespace:
         help="MCP stale-transport recovery regression command",
     )
     parser.add_argument(
+        "--contextlattice-cmd",
+        default=(
+            "python3 /Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py "
+            "preflight hermes-agent-ultra runbooks/alpha/objective "
+            "\"hermes-ultra contextlattice intelligence preflight\""
+        ),
+        help="ContextLattice preflight/intelligence telemetry command",
+    )
+    parser.add_argument(
         "--output-json",
         default="",
         help="Optional JSON report path",
@@ -54,7 +63,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run_shell(command: str, cwd: pathlib.Path) -> dict[str, Any]:
+def run_shell(command: str, cwd: pathlib.Path, max_tail: int = 6000) -> dict[str, Any]:
     started = dt.datetime.now(dt.timezone.utc)
     proc = subprocess.run(
         ["bash", "-lc", command],
@@ -71,8 +80,8 @@ def run_shell(command: str, cwd: pathlib.Path) -> dict[str, Any]:
         "started_at": started.isoformat(),
         "finished_at": finished.isoformat(),
         "duration_ms": int((finished - started).total_seconds() * 1000),
-        "stdout_tail": proc.stdout[-6000:],
-        "stderr_tail": proc.stderr[-6000:],
+        "stdout_tail": proc.stdout[-max_tail:],
+        "stderr_tail": proc.stderr[-max_tail:],
     }
 
 
@@ -87,11 +96,67 @@ def parse_hotpath_ns(stdout: str) -> int | None:
     return int(value)
 
 
+def parse_contextlattice_payload(section: dict[str, Any]) -> dict[str, Any] | None:
+    raw = (section.get("stdout_tail") or "").strip()
+    if not raw:
+        return None
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    blob = raw[start : end + 1]
+    try:
+        parsed = json.loads(blob)
+    except Exception:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def contextlattice_summary(payload: dict[str, Any] | None) -> dict[str, Any]:
+    summary = {
+        "healthy": False,
+        "warnings": 0,
+        "python_fallbacks": 0,
+        "route_owner_class": "",
+        "source_counts": {},
+        "queue_pending_total": 0,
+    }
+    if not payload:
+        return summary
+    health = payload.get("health") if isinstance(payload.get("health"), dict) else {}
+    summary["healthy"] = bool(health.get("ok"))
+    warnings = payload.get("warnings")
+    if isinstance(warnings, list):
+        summary["warnings"] = len(warnings)
+    retrieval = payload.get("context_pack", {}).get("retrieval")
+    if isinstance(retrieval, dict):
+        summary["route_owner_class"] = str(retrieval.get("route_owner_class") or "")
+        source_counts = retrieval.get("source_counts")
+        if isinstance(source_counts, dict):
+            summary["source_counts"] = source_counts
+        fallbacks = retrieval.get("fallback_counts")
+        if isinstance(fallbacks, dict):
+            summary["python_fallbacks"] = int(fallbacks.get("python_hot_path_total") or 0)
+    status = payload.get("status")
+    if isinstance(status, dict):
+        queue = status.get("queue")
+        if isinstance(queue, dict):
+            summary["queue_pending_total"] = int(queue.get("pendingTotal") or 0)
+    return summary
+
+
 def build_recommendations(
-    hotpath: dict[str, Any], eval_gate: dict[str, Any], mcp_gate: dict[str, Any]
+    hotpath: dict[str, Any],
+    eval_gate: dict[str, Any],
+    mcp_gate: dict[str, Any],
+    context_gate: dict[str, Any],
 ) -> list[dict[str, str]]:
     recs: list[dict[str, str]] = []
     ns = parse_hotpath_ns((hotpath.get("stdout_tail") or "") + "\n" + (hotpath.get("stderr_tail") or ""))
+    ctx_payload = parse_contextlattice_payload(context_gate)
+    ctx_summary = contextlattice_summary(ctx_payload)
 
     if not hotpath.get("ok"):
         recs.append(
@@ -129,6 +194,56 @@ def build_recommendations(
                 "severity": "P1",
                 "title": "MCP stale transport recovery regression",
                 "recommendation": "Run `cargo test -p hermes-mcp` and restore reconnect-on-stale behavior before promotion.",
+            }
+        )
+
+    if not context_gate.get("ok"):
+        recs.append(
+            {
+                "id": "CONTEXTLATTICE_PREFLIGHT_FAIL",
+                "severity": "P0",
+                "title": "ContextLattice preflight failed",
+                "recommendation": "Run `python3 /Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py preflight hermes-agent-ultra runbooks/alpha/objective` and resolve retrieval/service health before promotion.",
+            }
+        )
+    elif not ctx_summary["healthy"]:
+        recs.append(
+            {
+                "id": "CONTEXTLATTICE_UNHEALTHY",
+                "severity": "P1",
+                "title": "ContextLattice health is degraded",
+                "recommendation": "Use `/objective context max` and confirm orchestrator health/retrieval lanes before long-running objective loops.",
+            }
+        )
+    if ctx_summary["python_fallbacks"] > 0:
+        recs.append(
+            {
+                "id": "CONTEXTLATTICE_PYTHON_FALLBACK",
+                "severity": "P1",
+                "title": "ContextLattice retrieval fallback detected",
+                "recommendation": "Investigate non-native fallback causes and keep Go/Rust lanes hot to avoid degraded memory-intelligence behavior.",
+            }
+        )
+    if (
+        isinstance(ctx_summary["source_counts"], dict)
+        and not ctx_summary["source_counts"]
+        and int(ctx_summary["python_fallbacks"]) == 0
+    ):
+        recs.append(
+            {
+                "id": "CONTEXTLATTICE_ZERO_SOURCE_COVERAGE",
+                "severity": "P1",
+                "title": "ContextLattice source coverage is empty",
+                "recommendation": "Use broader same-project context-pack and ensure topic rollups/primary stores return at least one grounded hit.",
+            }
+        )
+    if int(ctx_summary["queue_pending_total"]) > 8:
+        recs.append(
+            {
+                "id": "CONTEXTLATTICE_QUEUE_PRESSURE",
+                "severity": "P2",
+                "title": "ContextLattice queue pressure elevated",
+                "recommendation": "Reduce write burst size or raise checkpoint spacing for long loops until pending queue normalizes.",
             }
         )
 
@@ -203,6 +318,22 @@ def write_env(path: pathlib.Path, report: dict[str, Any]) -> None:
                 "HERMES_REPLAY_ENABLED=1",
             ]
         )
+    if any(
+        key in rec_ids
+        for key in (
+            "CONTEXTLATTICE_PREFLIGHT_FAIL",
+            "CONTEXTLATTICE_UNHEALTHY",
+            "CONTEXTLATTICE_PYTHON_FALLBACK",
+            "CONTEXTLATTICE_ZERO_SOURCE_COVERAGE",
+        )
+    ):
+        lines.extend(
+            [
+                "HERMES_CONTEXTLATTICE_MODE=max",
+                "HERMES_CONTEXTLATTICE_RETRIEVAL_MODE=deep",
+                "HERMES_CONTEXTLATTICE_REQUIRE_READBACK=1",
+            ]
+        )
     if rec_ids == {"PERF_STABLE"}:
         lines.append("HERMES_PERF_AUTOPILOT_STATUS=stable")
     lines.append(f"HERMES_PERF_AUTOPILOT_PROFILE={report.get('profile_recommendation', 'balanced')}")
@@ -216,10 +347,14 @@ def write_env(path: pathlib.Path, report: dict[str, Any]) -> None:
 
 
 def compute_adaptive_indexes(
-    hotpath: dict[str, Any], eval_gate: dict[str, Any], mcp_gate: dict[str, Any], recommendations: list[dict[str, str]]
+    hotpath: dict[str, Any],
+    eval_gate: dict[str, Any],
+    mcp_gate: dict[str, Any],
+    context_gate: dict[str, Any],
+    recommendations: list[dict[str, str]],
 ) -> dict[str, Any]:
     ns = parse_hotpath_ns((hotpath.get("stdout_tail") or "") + "\n" + (hotpath.get("stderr_tail") or ""))
-    checks = [hotpath.get("ok"), eval_gate.get("ok"), mcp_gate.get("ok")]
+    checks = [hotpath.get("ok"), eval_gate.get("ok"), mcp_gate.get("ok"), context_gate.get("ok")]
     pass_count = sum(1 for ok in checks if ok)
     fail_count = len(checks) - pass_count
     base_performance = 100.0
@@ -231,6 +366,8 @@ def compute_adaptive_indexes(
         base_performance -= 35.0
     if not mcp_gate.get("ok"):
         base_performance -= 20.0
+    if not context_gate.get("ok"):
+        base_performance -= 25.0
     base_performance = max(0.0, min(100.0, base_performance))
 
     severity_weight = {"P0": 22.0, "P1": 12.0, "P2": 6.0, "P3": 2.0}
@@ -241,6 +378,20 @@ def compute_adaptive_indexes(
     base_intelligence = 100.0 - penalty
     if not eval_gate.get("ok"):
         base_intelligence -= 18.0
+    if not context_gate.get("ok"):
+        base_intelligence -= 20.0
+    ctx_payload = parse_contextlattice_payload(context_gate)
+    ctx_summary = contextlattice_summary(ctx_payload)
+    if ctx_summary["python_fallbacks"] > 0:
+        base_intelligence -= min(12.0, float(ctx_summary["python_fallbacks"]))
+    if (
+        isinstance(ctx_summary["source_counts"], dict)
+        and not ctx_summary["source_counts"]
+        and int(ctx_summary["python_fallbacks"]) == 0
+    ):
+        base_intelligence -= 10.0
+    if int(ctx_summary["queue_pending_total"]) > 8:
+        base_intelligence -= 8.0
     base_intelligence = max(0.0, min(100.0, base_intelligence))
 
     adaptive_index = round(base_performance * 0.55 + base_intelligence * 0.45, 2)
@@ -250,6 +401,8 @@ def compute_adaptive_indexes(
     if fail_count >= 2:
         profile = "safety"
     elif not eval_gate.get("ok"):
+        profile = "quality"
+    elif not context_gate.get("ok"):
         profile = "quality"
     elif not mcp_gate.get("ok"):
         profile = "reliability"
@@ -318,9 +471,16 @@ def main() -> int:
     hotpath = run_shell(args.hotpath_cmd, repo_root)
     eval_gate = run_shell(args.eval_cmd, repo_root)
     mcp_gate = run_shell(args.mcp_cmd, repo_root)
-    recommendations = build_recommendations(hotpath, eval_gate, mcp_gate)
-    ok = all(section.get("ok") for section in [hotpath, eval_gate, mcp_gate])
-    adaptive = compute_adaptive_indexes(hotpath, eval_gate, mcp_gate, recommendations)
+    context_gate = run_shell(args.contextlattice_cmd, repo_root, max_tail=240000)
+    recommendations = build_recommendations(hotpath, eval_gate, mcp_gate, context_gate)
+    ok = all(section.get("ok") for section in [hotpath, eval_gate, mcp_gate, context_gate])
+    adaptive = compute_adaptive_indexes(
+        hotpath,
+        eval_gate,
+        mcp_gate,
+        context_gate,
+        recommendations,
+    )
 
     report = {
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
@@ -330,6 +490,7 @@ def main() -> int:
             "hotpath": hotpath,
             "eval_trend": eval_gate,
             "mcp_stale_recovery": mcp_gate,
+            "contextlattice_preflight": context_gate,
         },
         "recommendations": recommendations,
         "performance_index": adaptive["performance_index"],


### PR DESCRIPTION
## Summary\n- expand ContextLattice policy into 16+ explicit intelligence controls\n- add /objective context control surface (status/list/max/balanced/fast)\n- inject ContextLattice-first system hint for objective/repo/connect intents\n- fold ContextLattice preflight telemetry into performance autopilot scoring and recommendations\n- add targeted tests and operator doc for this tranche\n\n## Validation\n- cargo test -p hermes-agent test_contextlattice_intelligence_system_hint -- --nocapture\n- cargo test -p hermes-cli contextlattice_policy_modes_roundtrip -- --nocapture\n- python3 scripts/run-performance-autopilot.py --repo-root . --hotpath-cmd "echo tool_policy_hot_path_ns_per_eval=8000" --eval-cmd "echo ok" --mcp-cmd "echo ok" --contextlattice-cmd "python3 /Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py preflight hermes-agent-ultra runbooks/alpha/objective \"autopilot context probe\"" --json