### PR TITLE
Parity tranche 1-36: provider/profile/install/tui ports

### DIFF
--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -292,6 +292,9 @@ pub enum CliCommand {
         /// Skip alias creation during profile create.
         #[arg(long = "no-alias")]
         no_alias: bool,
+        /// Do not carry skill overrides from cloned source profiles.
+        #[arg(long = "no-skills")]
+        no_skills: bool,
     },
 
     /// Authentication management.

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -262,6 +262,10 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/save", "Save current session to disk"),
     ("/load", "Load a saved session"),
     ("/resume", "Resume the most recent or named saved session"),
+    (
+        "/sessions",
+        "Browse saved sessions, or resume one by name (`/sessions [name]`)",
+    ),
     ("/background", "Run a task in the background"),
     ("/bg", "Alias for /background"),
     ("/mouse", "Toggle mouse interactions in the TUI"),
@@ -3096,6 +3100,7 @@ pub async fn handle_slash_command(
         "/save" => handle_save_command(app, args),
         "/load" => handle_load_command(app, args),
         "/resume" => handle_resume_command(app, args),
+        "/sessions" => handle_sessions_command(app, args),
         "/background" => handle_background_command(app, args),
         "/mouse" => handle_mouse_command(app, args),
         "/verbose" => handle_verbose_command(app),
@@ -6251,6 +6256,13 @@ fn handle_resume_command(app: &mut App, args: &[&str]) -> Result<CommandResult, 
             Ok(CommandResult::Handled)
         }
     }
+}
+
+fn handle_sessions_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    if args.is_empty() {
+        return handle_load_command(app, args);
+    }
+    handle_resume_command(app, args)
 }
 
 fn persist_browser_cdp_url(url: Option<&str>) -> Result<(), AgentError> {
@@ -16885,6 +16897,13 @@ mod tests {
         assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/resume"));
         let results = autocomplete("/res");
         assert!(results.contains(&"/resume"));
+    }
+
+    #[test]
+    fn test_sessions_command_is_registered_and_completable() {
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/sessions"));
+        let results = autocomplete("/sess");
+        assert!(results.contains(&"/sessions"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -269,6 +269,7 @@ async fn main() {
             clone_all,
             clone_from,
             no_alias,
+            no_skills,
         } => {
             run_profile(
                 cli,
@@ -284,6 +285,7 @@ async fn main() {
                 clone_all,
                 clone_from,
                 no_alias,
+                no_skills,
             )
             .await
         }
@@ -12211,6 +12213,29 @@ fn save_profile_yaml(path: &Path, value: &serde_yaml::Value) -> Result<(), Agent
         .map_err(|e| AgentError::Io(format!("write {}: {}", path.display(), e)))
 }
 
+fn validate_profile_name(name: &str) -> Result<String, AgentError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(AgentError::Config("profile name cannot be empty".into()));
+    }
+    if trimmed == "." || trimmed == ".." || trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(AgentError::Config(format!(
+            "invalid profile name '{}': path separators are not allowed",
+            trimmed
+        )));
+    }
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        return Err(AgentError::Config(format!(
+            "invalid profile name '{}': use letters, numbers, '-', '_' or '.'",
+            trimmed
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_profile(
     cli: Cli,
@@ -12226,6 +12251,7 @@ async fn run_profile(
     clone_all: bool,
     clone_from: Option<String>,
     no_alias: bool,
+    no_skills: bool,
 ) -> Result<(), AgentError> {
     let config_dir = cli
         .config_dir
@@ -12319,10 +12345,7 @@ async fn run_profile(
                     "Missing profile name. Usage: hermes profile create <name>".into(),
                 )
             })?;
-            let profile_name = profile_name.trim().to_string();
-            if profile_name.is_empty() {
-                return Err(AgentError::Config("profile create: empty name".into()));
-            }
+            let profile_name = validate_profile_name(&profile_name)?;
 
             std::fs::create_dir_all(&profiles_dir)
                 .map_err(|e| AgentError::Io(format!("Failed to create profiles dir: {}", e)))?;
@@ -12380,6 +12403,13 @@ async fn run_profile(
                         }
                     }
                 }
+            }
+
+            if no_skills {
+                let skills_key = serde_yaml::Value::String("skills".to_string());
+                let overrides_key = serde_yaml::Value::String("skill_overrides".to_string());
+                out_map.remove(&skills_key);
+                out_map.remove(&overrides_key);
             }
 
             out_map
@@ -12527,6 +12557,7 @@ async fn run_profile(
             let new_name = secondary.ok_or_else(|| {
                 AgentError::Config("profile rename usage: hermes profile rename <old> <new>".into())
             })?;
+            let new_name = validate_profile_name(&new_name)?;
             let old_resolved = resolve_profile_name(&old_requested, &aliases);
             let old_path =
                 resolve_profile_yaml_path(&profiles_dir, &old_resolved).ok_or_else(|| {
@@ -12607,21 +12638,33 @@ async fn run_profile(
                 )));
             }
             let mut value = load_profile_yaml(&source_path)?;
-            let target_name = import_name.unwrap_or_else(|| {
+            let target_name_raw = import_name.unwrap_or_else(|| {
                 source_path
                     .file_stem()
                     .unwrap_or_default()
                     .to_string_lossy()
                     .into_owned()
             });
+            let target_name = validate_profile_name(&target_name_raw)?;
             std::fs::create_dir_all(&profiles_dir)
                 .map_err(|e| AgentError::Io(format!("mkdir {}: {}", profiles_dir.display(), e)))?;
             let target_path = profiles_dir.join(format!("{}.yaml", target_name));
-            if target_path.exists() && !yes {
-                return Err(AgentError::Config(format!(
-                    "Target profile exists at {} (re-run with -y to overwrite)",
-                    target_path.display()
-                )));
+            if target_path.exists() {
+                let metadata = std::fs::metadata(&target_path).map_err(|e| {
+                    AgentError::Io(format!("stat {}: {}", target_path.display(), e))
+                })?;
+                if metadata.is_dir() {
+                    return Err(AgentError::Config(format!(
+                        "Refusing to import profile: target path is a directory ({})",
+                        target_path.display()
+                    )));
+                }
+                if !yes {
+                    return Err(AgentError::Config(format!(
+                        "Target profile exists at {} (re-run with -y to overwrite)",
+                        target_path.display()
+                    )));
+                }
             }
             if let Some(map) = value.as_mapping_mut() {
                 map.insert(
@@ -12629,7 +12672,26 @@ async fn run_profile(
                     serde_yaml::Value::String(target_name.clone()),
                 );
             }
-            save_profile_yaml(&target_path, &value)?;
+            let staged_path = profiles_dir.join(format!(
+                ".{}.import-{}.yaml.tmp",
+                target_name,
+                uuid::Uuid::new_v4()
+            ));
+            save_profile_yaml(&staged_path, &value)?;
+            if target_path.exists() {
+                std::fs::remove_file(&target_path).map_err(|e| {
+                    AgentError::Io(format!("remove {}: {}", target_path.display(), e))
+                })?;
+            }
+            if let Err(err) = std::fs::rename(&staged_path, &target_path) {
+                let _ = std::fs::remove_file(&staged_path);
+                return Err(AgentError::Io(format!(
+                    "rename {} -> {}: {}",
+                    staged_path.display(),
+                    target_path.display(),
+                    err
+                )));
+            }
             if !no_alias {
                 if let Some(alias) = alias_name
                     .or(secondary)
@@ -13289,6 +13351,128 @@ mod tests {
         assert!(raw.contains("HERMES_AUTH_DEFAULT_PROVIDER=nous"));
         assert!(raw.contains("NOUS_API_KEY=tok"));
         assert!(!raw.contains("HERMES_AUTH_DEFAULT_PROVIDER=openai"));
+    }
+
+    #[tokio::test]
+    async fn profile_create_no_skills_strips_cloned_skill_overrides() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cli = cli_for_temp_state_root(tmp.path());
+        let profiles_dir = tmp.path().join("profiles");
+        std::fs::create_dir_all(&profiles_dir).expect("create profiles dir");
+
+        let source_profile = profiles_dir.join("source.yaml");
+        std::fs::write(
+            &source_profile,
+            r#"
+name: source
+model: openai:gpt-4o
+personality: technical
+max_turns: 50
+skills:
+  enabled:
+    - contextlattice-agent-contract
+  disabled:
+    - noisy-skill
+"#,
+        )
+        .expect("write source profile");
+        write_active_profile_name(&profiles_dir, "source").expect("set active profile");
+
+        run_profile(
+            cli,
+            Some("create".to_string()),
+            Some("target".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            true,
+            true,
+            Some("source".to_string()),
+            true,
+            true,
+        )
+        .await
+        .expect("create profile");
+
+        let target_profile = profiles_dir.join("target.yaml");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            &std::fs::read_to_string(&target_profile).expect("read target profile"),
+        )
+        .expect("parse target profile");
+        let map = parsed.as_mapping().expect("mapping profile");
+        let skills_key = serde_yaml::Value::String("skills".to_string());
+        assert!(
+            !map.contains_key(&skills_key),
+            "skills key should be stripped"
+        );
+    }
+
+    #[test]
+    fn validate_profile_name_rejects_paths() {
+        let err = validate_profile_name("../danger").expect_err("should reject traversal");
+        assert!(
+            err.to_string().contains("path separators"),
+            "unexpected error: {err}"
+        );
+        let err = validate_profile_name("alpha beta").expect_err("should reject spaces");
+        assert!(
+            err.to_string().contains("letters, numbers"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            validate_profile_name("prod-profile_1.2").expect("valid"),
+            "prod-profile_1.2"
+        );
+    }
+
+    #[tokio::test]
+    async fn profile_import_refuses_directory_clobber_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cli = cli_for_temp_state_root(tmp.path());
+        let profiles_dir = tmp.path().join("profiles");
+        std::fs::create_dir_all(&profiles_dir).expect("create profiles dir");
+
+        let source_profile = tmp.path().join("source.yaml");
+        std::fs::write(
+            &source_profile,
+            r#"
+name: source
+model: openai:gpt-4o
+personality: default
+max_turns: 50
+"#,
+        )
+        .expect("write source profile");
+
+        let clobber_target_dir = profiles_dir.join("target.yaml");
+        std::fs::create_dir_all(&clobber_target_dir).expect("create clobber directory");
+
+        let err = run_profile(
+            cli,
+            Some("import".to_string()),
+            Some(source_profile.to_string_lossy().into_owned()),
+            None,
+            None,
+            Some("target".to_string()),
+            None,
+            false,
+            true,
+            false,
+            false,
+            None,
+            true,
+            false,
+        )
+        .await
+        .expect_err("directory clobber should be rejected");
+
+        assert!(
+            err.to_string().contains("target path is a directory"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -11,7 +11,7 @@ use rand::RngCore;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::providers::provider_capability_for;
+use crate::providers::{canonical_provider_id, provider_capability_for};
 const NOUS_DEFAULT_INFERENCE_BASE_URL: &str = "https://inference-api.nousresearch.com/v1";
 const PROVIDER_CATALOG_CACHE_VERSION: u32 = 1;
 const OLLAMA_LOCAL_DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
@@ -454,7 +454,7 @@ pub fn merge_with_models_dev(models_dev: &[String], curated: &[&str]) -> Vec<Str
 }
 
 pub fn provider_curated_models(provider: &str) -> &'static [&'static str] {
-    let normalized = provider.trim().to_ascii_lowercase();
+    let normalized = canonical_provider_id(provider);
     for (slug, models) in CURATED_PROVIDER_MODELS {
         if slug.eq_ignore_ascii_case(&normalized) {
             return models;
@@ -683,11 +683,11 @@ pub async fn provider_model_ids_with_client(
     provider: &str,
     client: &ModelsDevClient,
 ) -> Vec<String> {
-    let curated = provider_curated_models(provider);
+    let normalized = canonical_provider_id(provider);
+    let curated = provider_curated_models(&normalized);
     if curated.is_empty() {
         return Vec::new();
     }
-    let normalized = provider.trim().to_ascii_lowercase();
     if let Some(cached) = load_provider_catalog_cache(&normalized) {
         if !cached.is_empty() {
             return cached;
@@ -882,6 +882,22 @@ mod tests {
     }
 
     #[test]
+    fn provider_curated_models_accepts_aliases() {
+        assert_eq!(
+            provider_curated_models("ollama"),
+            provider_curated_models("ollama-local")
+        );
+        assert_eq!(
+            provider_curated_models("llama.cpp"),
+            provider_curated_models("llama-cpp")
+        );
+        assert_eq!(
+            provider_curated_models("llvm"),
+            provider_curated_models("vllm")
+        );
+    }
+
+    #[test]
     fn openrouter_curated_models_include_gpt55_variants() {
         let models = provider_curated_models("openrouter");
         assert!(models.contains(&"openai/gpt-5.5"));
@@ -970,6 +986,14 @@ mod tests {
                 "missing model {model}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn provider_model_ids_normalizes_provider_aliases() {
+        let client = seeded_client(json!({}));
+        let aliased = provider_model_ids_with_client("ollama", &client).await;
+        let canonical = provider_model_ids_with_client("ollama-local", &client).await;
+        assert_eq!(aliased, canonical);
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -84,8 +84,32 @@ pub fn oauth_capable_providers() -> Vec<&'static str> {
     OAUTH_CAPABLE_PROVIDERS.to_vec()
 }
 
-pub fn provider_capability_for(provider: &str) -> Option<ProviderCapability> {
+pub fn canonical_provider_id(provider: &str) -> String {
     let normalized = provider.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "codex" => "openai-codex".to_string(),
+        "claude" | "claude-code" => "anthropic".to_string(),
+        "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
+        "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "step" | "step-plan" => "stepfun".to_string(),
+        "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
+        "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
+        "minimax-cn" => "minimax".to_string(),
+        "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
+        "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
+        "go" => "opencode-go".to_string(),
+        "ollama" => "ollama-local".to_string(),
+        "llama.cpp" | "llamacpp" => "llama-cpp".to_string(),
+        "ollvm" | "llvm" => "vllm".to_string(),
+        "mlx-lm" | "apple-mlx" => "mlx".to_string(),
+        "ane" | "apple-neural-engine" | "neural-engine" => "apple-ane".to_string(),
+        "text-generation-inference" => "tgi".to_string(),
+        _ => normalized,
+    }
+}
+
+pub fn provider_capability_for(provider: &str) -> Option<ProviderCapability> {
+    let normalized = canonical_provider_id(provider);
     if normalized.is_empty() {
         return None;
     }
@@ -109,7 +133,7 @@ mod tests {
     use serde::Deserialize;
 
     use super::{
-        known_providers, oauth_capable_providers, provider_capability_for,
+        canonical_provider_id, known_providers, oauth_capable_providers, provider_capability_for,
         MODELS_DEV_MERGED_PROVIDERS,
     };
 
@@ -233,5 +257,14 @@ mod tests {
                 "{provider} should not require models.dev merge"
             );
         }
+    }
+
+    #[test]
+    fn canonical_provider_id_normalizes_common_aliases() {
+        assert_eq!(canonical_provider_id("moonshot"), "kimi");
+        assert_eq!(canonical_provider_id("gemini-cli"), "google-gemini-cli");
+        assert_eq!(canonical_provider_id("ollama"), "ollama-local");
+        assert_eq!(canonical_provider_id("llama.cpp"), "llama-cpp");
+        assert_eq!(canonical_provider_id("llvm"), "vllm");
     }
 }

--- a/docs/parity/batch-triage-log.md
+++ b/docs/parity/batch-triage-log.md
@@ -1,5 +1,7 @@
 # Batch Triage Log
 
+- 2026-05-09: closed upstream tranche items 1-36 with Rust parity dispositions and targeted ports (`docs/parity/tranche-items-1-36-2026-05-09.md`).
+
 ## 2026-04-21 batch-01 (50 commits)
 - Scope: first 50 `pending` entries in `docs/parity/upstream-missing-queue.json` at triage time.
 - SHA range (ordered): `21d80ca68346` -> `f81395975025`.

--- a/docs/parity/tranche-items-1-36-2026-05-09.md
+++ b/docs/parity/tranche-items-1-36-2026-05-09.md
@@ -1,0 +1,106 @@
+# Upstream Parity Tranche: Items 1-36 (2026-05-09)
+
+This tranche maps the first 36 pending upstream commits from `main..upstream/main` to Hermes Ultra Rust outcomes.
+
+## Scope
+
+- Upstream range source: `git cherry -v main upstream/main`
+- Target window: first 36 commits in that range
+- Goal: implement actionable parity in Rust and explicitly close non-actionable metadata/docs-only commits
+
+## Disposition Summary
+
+- `ported_now`: 4
+- `already_covered`: 7
+- `docs_or_metadata_only`: 21
+- `superseded_by_rust_architecture`: 4
+
+## Item-by-Item Disposition
+
+1. `d8cc85dcdccf` review(stt-xai): address cetej's nits  
+   Disposition: `superseded_by_rust_architecture` (bulk upstream snapshot/review commit across Python/web/docs surfaces).
+2. `3d90292eda55` fix: normalize provider in list_provider_models to support aliases  
+   Disposition: `ported_now` via provider alias canonicalization for model catalog resolution in Rust.
+3. `77f99c4ff445` chore(release): AUTHOR_MAP  
+   Disposition: `docs_or_metadata_only`.
+4. `8b1ff55f5382` fix(wecom): strip @mention prefix in group chats  
+   Disposition: `already_covered` in Rust WeCom callback adapter mention-strip path + tests.
+5. `85cc12e2bd55` chore(release): AUTHOR_MAP  
+   Disposition: `docs_or_metadata_only`.
+6. `92e4bbc201e6` docs Docker guide update  
+   Disposition: `docs_or_metadata_only`.
+7. `fa47cbd45671` chore(release): AUTHOR_MAP  
+   Disposition: `docs_or_metadata_only`.
+8. `156b3583206d` docs(cron): runtime resolution note  
+   Disposition: `docs_or_metadata_only`.
+9. `48dc8ef1d158` docs(cron): default model/provider clarification  
+   Disposition: `docs_or_metadata_only`.
+10. `e8cba18f77c2` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+11. `15efb410d035` fix(nix): writable working dir  
+    Disposition: `superseded_by_rust_architecture` (no equivalent Nix module path in this repo).
+12. `5e76c650bbae` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+13. `22afa066f838` fix(cron): guard non-dict run_conversation result  
+    Disposition: `superseded_by_rust_architecture` (Rust cron runner path does not deserialize Python dict payloads).
+14. `1c532278ae70` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+15. `738d0900fddd` anthropic auxiliary transport refactor  
+    Disposition: `superseded_by_rust_architecture`.
+16. `f4612785a485` anthropic adapter refactor  
+    Disposition: `superseded_by_rust_architecture`.
+17. `43de1ca8c287` anthropic shim removal/flush guard  
+    Disposition: `superseded_by_rust_architecture`.
+18. `36adcebe6ca8` docs rename API call function  
+    Disposition: `docs_or_metadata_only`.
+19. `f77da7de42a1` docs rename API call function  
+    Disposition: `docs_or_metadata_only`.
+20. `48923e5a3d8f` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+21. `d7452af257b9` fix(pairing): null user_name in list display  
+    Disposition: `already_covered` via optional-name fallback in Rust pairing output.
+22. `b5ec6e8df79f` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+23. `1df0c812c43a` feat(skills): MiniMax-AI/cli default tap  
+    Disposition: `already_covered` (`DEFAULT_SKILL_TAPS` already includes `https://github.com/MiniMax-AI/cli::skill`).
+24. `c80cc8557ed0` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+25. `a5b0c7e2ec07` fix(config): preserve list-format models in custom_providers normalize  
+    Disposition: `already_covered`/N/A for Rust typed provider config model field (string-based provider model selection path).
+26. `33773ed5c6da` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+27. `5d0947434864` fix(tools): enforce ACP transport overrides in delegate_task children  
+    Disposition: `already_covered` by Rust in-process delegation that reuses parent runtime/tool registry wiring.
+28. `911f57ad979d` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+29. `be99feff1f42` fix(image-gen): force-refresh plugin providers in long sessions  
+    Disposition: `already_covered`/N/A (Rust image generation backend does not rely on mutable Python plugin provider cache).
+30. `8f50f2834a0d` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+31. `9dba75bc3862` fix(feishu): leading newlines on stream edits  
+    Disposition: `already_covered` via message normalization trim path + tests.
+32. `08cb345e242e` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+33. `51c1d2de16bc` fix(profiles): stage imports to prevent clobbering  
+    Disposition: `ported_now` in Rust profile import flow.
+34. `4c02e4597ec9` fix(status): catch OSError in `os.kill(pid,0)` on Windows  
+    Disposition: `already_covered` in Rust with platform-gated PID liveness implementation.
+35. `dab36d9511ce` chore(release): AUTHOR_MAP  
+    Disposition: `docs_or_metadata_only`.
+36. `7ca2f70055d9` docs: Atropos/wandb links  
+    Disposition: `docs_or_metadata_only`.
+
+## Rust Ports in This Tranche
+
+- Provider alias normalization for model catalog/listing:
+  - `crates/hermes-cli/src/providers.rs`
+  - `crates/hermes-cli/src/model_switch.rs`
+- Profile import hardening (staged writes + clobber guard + profile name validation):
+  - `crates/hermes-cli/src/main.rs`
+
+## Extra in-flight hardening carried forward
+
+- Added `/sessions` slash command bridge in interactive command router.
+- Added `profile create --no-skills`.
+- Sanitized post-install Python environment during installer checks/setup.
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -237,19 +237,30 @@ prompt_yes_no() {
 
 run_post_install_flow() {
   local bin_path="$1"
+  local -a clean_python_env=(
+    env
+    -u PYTHONHOME
+    -u PYTHONPATH
+    -u PYTHONSTARTUP
+    -u VIRTUAL_ENV
+    -u CONDA_PREFIX
+    -u CONDA_DEFAULT_ENV
+    -u PIP_REQUIRE_VIRTUALENV
+    -u PYTHONUSERBASE
+  )
 
   echo
   echo "Running post-install verification..."
-  "${bin_path}" doctor || true
+  "${clean_python_env[@]}" "${bin_path}" doctor || true
 
   echo
   echo "Current auth/platform status:"
-  "${bin_path}" auth status || true
+  "${clean_python_env[@]}" "${bin_path}" auth status || true
 
   if [[ -t 0 ]]; then
     echo
     if prompt_yes_no "Run interactive setup now?" "yes"; then
-      "${bin_path}" setup || true
+      "${clean_python_env[@]}" "${bin_path}" setup || true
     else
       echo "Skipped setup. Run this anytime:"
       echo "  ${bin_path} setup"


### PR DESCRIPTION
## Summary
- port upstream item #2 parity: provider alias normalization in Rust model catalog resolution
- port upstream item #33 parity: staged profile import + clobber hardening + profile name validation
- add slash  command alias + autocomplete coverage
- harden installer post-install flow with sanitized Python env
- document tranche 1-36 dispositions in parity docs

## Validation
- cargo fmt --all
- targeted hermes-cli tests:
  - canonical_provider_id_normalizes_common_aliases
  - provider_curated_models_accepts_aliases
  - provider_model_ids_normalizes_provider_aliases
  - profile_create_no_skills_strips_cloned_skill_overrides
  - validate_profile_name_rejects_paths
  - profile_import_refuses_directory_clobber_target
  - test_sessions_command_is_registered_and_completable
