### PR TITLE
Implement items 1-12 deltas: OAuth self-heal, phase lane, objective autopin

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -31,6 +31,7 @@ use hermes_cron::cron_scheduler_for_data_dir;
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
 
+use crate::alpha_runtime::load_objective_contract;
 use crate::auth::{
     resolve_gemini_oauth_runtime_credentials, resolve_nous_runtime_credentials,
     resolve_qwen_runtime_credentials, DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
@@ -543,6 +544,97 @@ impl App {
         );
     }
 
+    fn emit_phase_event(
+        shared: &Arc<StdMutex<Option<StreamHandle>>>,
+        phase: &str,
+        label: &str,
+        progress_pct: u8,
+    ) {
+        let phase = phase.trim();
+        let label = App::preview_for_status(label, 220);
+        if phase.is_empty() || label.is_empty() {
+            return;
+        }
+        App::push_stream_extra_event(
+            shared,
+            serde_json::json!({
+                "ui_event": "phase",
+                "phase": phase,
+                "label": label,
+                "progress_pct": progress_pct.min(100),
+            }),
+        );
+    }
+
+    fn objective_context_autopin_enabled() -> bool {
+        !matches!(
+            std::env::var("HERMES_OBJECTIVE_CONTEXT_AUTOPIN")
+                .ok()
+                .as_deref()
+                .map(|v| v.trim().to_ascii_lowercase()),
+            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+        )
+    }
+
+    fn sanitize_topic_path_segment(raw: &str) -> String {
+        let mut out = String::with_capacity(raw.len());
+        for ch in raw.chars() {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '/') {
+                out.push(ch);
+            } else {
+                out.push('-');
+            }
+        }
+        out.trim_matches('-').to_string()
+    }
+
+    fn maybe_autopin_contextlattice_topic_from_objective(&self) {
+        if !Self::objective_context_autopin_enabled() {
+            return;
+        }
+        let Ok(Some(contract)) = load_objective_contract() else {
+            return;
+        };
+        let objective_id = Self::sanitize_topic_path_segment(contract.id.trim());
+        if objective_id.is_empty() {
+            return;
+        }
+        let target_topic = format!("runbooks/objective/{}", objective_id);
+        let current_topic = std::env::var("CONTEXTLATTICE_TOPIC_PATH")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let should_override = match current_topic.as_deref() {
+            None => true,
+            Some("runbooks/hermes") => true,
+            Some(existing)
+                if existing.eq_ignore_ascii_case(target_topic.as_str())
+                    || !existing
+                        .to_ascii_lowercase()
+                        .starts_with("runbooks/objective/") =>
+            {
+                false
+            }
+            Some(_) => true,
+        };
+        if should_override {
+            std::env::set_var("CONTEXTLATTICE_TOPIC_PATH", &target_topic);
+            Self::emit_lifecycle_event(
+                &self.stream_handle_shared,
+                format!(
+                    "ContextLattice objective autopin set topic_path={} (objective_id={})",
+                    target_topic, contract.id
+                ),
+            );
+            Self::emit_phase_event(
+                &self.stream_handle_shared,
+                "context",
+                "objective context autopin",
+                8,
+            );
+        }
+    }
+
     /// Create a new `App` from the parsed CLI arguments.
     ///
     /// This loads (or creates) the gateway configuration, builds a tool
@@ -961,8 +1053,21 @@ impl App {
     /// Checks the interrupt controller before running and clears it after.
     async fn run_agent(&mut self) -> Result<(), AgentError> {
         let run_started_at = Instant::now();
+        self.maybe_autopin_contextlattice_topic_from_objective();
+        Self::emit_phase_event(
+            &self.stream_handle_shared,
+            "preflight",
+            "runtime preflight + credential hydration",
+            5,
+        );
         self.refresh_runtime_provider_credentials_if_needed(false)
             .await;
+        Self::emit_phase_event(
+            &self.stream_handle_shared,
+            "dispatch",
+            "dispatching model request",
+            15,
+        );
         self.interrupt_controller.clear_interrupt();
         let mut remediation_attempted = false;
         let mut auth_refresh_attempted = false;
@@ -974,6 +1079,12 @@ impl App {
                     self.current_model,
                     self.messages.len()
                 ),
+            );
+            Self::emit_phase_event(
+                &self.stream_handle_shared,
+                "inference",
+                "model inference + tool execution",
+                35,
             );
             let messages = self.messages.clone();
             let result = if self.config.streaming.enabled {
@@ -1008,6 +1119,12 @@ impl App {
                             run_started_at.elapsed().as_secs_f64(),
                             result.total_turns
                         ),
+                    );
+                    Self::emit_phase_event(
+                        &self.stream_handle_shared,
+                        "finalize",
+                        "transcript finalization + persistence",
+                        100,
                     );
                     if let Some(handle) = &self.stream_handle {
                         handle.send_done();
@@ -1059,6 +1176,12 @@ impl App {
                             run_started_at.elapsed().as_secs_f64(),
                             e
                         ),
+                    );
+                    Self::emit_phase_event(
+                        &self.stream_handle_shared,
+                        "recovery",
+                        "error handling + remediation",
+                        60,
                     );
                     if let Some(handle) = &self.stream_handle {
                         handle.send_done();
@@ -1530,6 +1653,7 @@ fn apply_cli_runtime_overrides(config: &mut GatewayConfig, cli: &Cli) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alpha_runtime::upsert_objective_contract;
     use crate::test_env_lock;
     use hermes_config::LlmProviderConfig;
     use std::collections::HashMap;
@@ -2221,6 +2345,70 @@ mod tests {
                 .unwrap_or_default()
                 .starts_with("[SESSION_OBJECTIVE] ")
         }));
+    }
+
+    #[test]
+    fn test_objective_context_autopin_sets_topic_for_default_path() {
+        let _guard = env_test_lock();
+        let prev_home = std::env::var("HERMES_HOME").ok();
+        let prev_topic = std::env::var("CONTEXTLATTICE_TOPIC_PATH").ok();
+        let prev_toggle = std::env::var("HERMES_OBJECTIVE_CONTEXT_AUTOPIN").ok();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        std::env::set_var("CONTEXTLATTICE_TOPIC_PATH", "runbooks/hermes");
+        std::env::set_var("HERMES_OBJECTIVE_CONTEXT_AUTOPIN", "1");
+
+        let contract = upsert_objective_contract("grow wallet safely", true).expect("objective");
+        let app = build_minimal_test_app();
+        app.maybe_autopin_contextlattice_topic_from_objective();
+        let expected = format!("runbooks/objective/{}", contract.id);
+        assert_eq!(
+            std::env::var("CONTEXTLATTICE_TOPIC_PATH").ok().as_deref(),
+            Some(expected.as_str())
+        );
+
+        match prev_toggle {
+            Some(v) => std::env::set_var("HERMES_OBJECTIVE_CONTEXT_AUTOPIN", v),
+            None => std::env::remove_var("HERMES_OBJECTIVE_CONTEXT_AUTOPIN"),
+        }
+        match prev_topic {
+            Some(v) => std::env::set_var("CONTEXTLATTICE_TOPIC_PATH", v),
+            None => std::env::remove_var("CONTEXTLATTICE_TOPIC_PATH"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HERMES_HOME", v),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+    }
+
+    #[test]
+    fn test_objective_context_autopin_respects_custom_topic_pin() {
+        let _guard = env_test_lock();
+        let prev_home = std::env::var("HERMES_HOME").ok();
+        let prev_topic = std::env::var("CONTEXTLATTICE_TOPIC_PATH").ok();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        std::env::set_var("CONTEXTLATTICE_TOPIC_PATH", "runbooks/custom/keep-me");
+
+        let _contract =
+            upsert_objective_contract("objective override regression test", false).expect("obj");
+        let app = build_minimal_test_app();
+        app.maybe_autopin_contextlattice_topic_from_objective();
+        assert_eq!(
+            std::env::var("CONTEXTLATTICE_TOPIC_PATH").ok().as_deref(),
+            Some("runbooks/custom/keep-me")
+        );
+
+        match prev_topic {
+            Some(v) => std::env::set_var("CONTEXTLATTICE_TOPIC_PATH", v),
+            None => std::env::remove_var("CONTEXTLATTICE_TOPIC_PATH"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HERMES_HOME", v),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
     }
 }
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -5598,6 +5598,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
              \n\
              Quick actions:\n\
                /ops model [provider|provider:model]\n\
+               /ops mode [status|list|strict|standard|dev]\n\
                /ops personality [list|name]\n\
                /ops mouse [on|off|toggle]\n\
                /ops yolo\n\
@@ -5645,6 +5646,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                 "Operator control plane commands:\n\
                  - /ops status\n\
                  - /ops model [provider|provider:model]\n\
+                 - /ops mode [status|list|strict|standard|dev]\n\
                  - /ops personality [list|name]\n\
                  - /ops mouse [on|off|toggle]\n\
                  - /ops yolo\n\
@@ -5662,6 +5664,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
             Ok(CommandResult::Handled)
         }
         "model" => handle_model_command(app, &args[1..]).await,
+        "mode" => handle_policy_command(app, &args[1..]),
         "personality" => handle_personality_command(app, &args[1..]),
         "mouse" => handle_mouse_command(app, &args[1..]),
         "yolo" => handle_yolo_command(app),

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -110,35 +110,93 @@ fn auth_error_message(err: &AgentError) -> Option<String> {
     }
 }
 
-fn oneshot_should_auto_verify_nous(
-    err: &AgentError,
-    provider_override: Option<&str>,
-    model_override: Option<&str>,
-) -> bool {
-    let Some(message) = auth_error_message(err) else {
-        return false;
-    };
-
-    let is_auth_like = message.contains("401")
+fn oneshot_auth_is_refreshable(message: &str) -> bool {
+    message.contains("401")
+        || message.contains("403")
         || message.contains("unauthorized")
         || message.contains("invalid token")
         || message.contains("token expired")
-        || message.contains("authentication failed");
-    if !is_auth_like {
-        return false;
+        || message.contains("authentication failed")
+        || message.contains("invalid_grant")
+        || message.contains("expired")
+}
+
+fn infer_oauth_provider_from_error_message(message: &str) -> Option<String> {
+    if message.contains("portal.nousresearch.com")
+        || message.contains("inference-api.nousresearch.com")
+        || message.contains(" provider nous")
+        || message.contains("nous:")
+    {
+        return Some("nous".to_string());
+    }
+    if message.contains("console.anthropic.com")
+        || message.contains("claude.ai")
+        || message.contains("anthropic")
+    {
+        return Some("anthropic".to_string());
+    }
+    if message.contains("chat.qwen.ai") || message.contains("dashscope") || message.contains("qwen")
+    {
+        return Some("qwen-oauth".to_string());
+    }
+    if message.contains("oauth2.googleapis.com")
+        || message.contains("googleapis.com")
+        || message.contains("gemini")
+        || message.contains("google")
+    {
+        return Some("google-gemini-cli".to_string());
+    }
+    if message.contains("auth.openai.com")
+        || message.contains("chatgpt.com")
+        || message.contains("openai")
+        || message.contains("codex")
+    {
+        if message.contains("codex") || message.contains("chatgpt.com") {
+            return Some("openai-codex".to_string());
+        }
+        return Some("openai".to_string());
+    }
+    None
+}
+
+fn oneshot_auto_verify_oauth_provider(
+    err: &AgentError,
+    provider_override: Option<&str>,
+    model_override: Option<&str>,
+) -> Option<String> {
+    let Some(message) = auth_error_message(err) else {
+        return None;
+    };
+
+    if !oneshot_auth_is_refreshable(&message) {
+        return None;
     }
 
-    let provider_is_nous = provider_override
-        .map(str::trim)
-        .is_some_and(|p| p.eq_ignore_ascii_case("nous"));
-    let model_is_nous = model_override
-        .map(str::trim)
-        .is_some_and(|m| m.to_ascii_lowercase().starts_with("nous:"));
-    let message_is_nous = message.contains("nous")
-        || message.contains("portal.nousresearch.com")
-        || message.contains("inference-api.nousresearch.com");
+    let mut candidates: Vec<String> = Vec::new();
+    if let Some(raw_provider) = provider_override.map(str::trim).filter(|v| !v.is_empty()) {
+        candidates.push(normalize_auth_provider(raw_provider));
+    }
+    if let Some(raw_model_provider) = model_override
+        .and_then(|m| m.split_once(':').map(|(provider, _)| provider.trim()))
+        .filter(|v| !v.is_empty())
+    {
+        candidates.push(normalize_auth_provider(raw_model_provider));
+    }
+    if let Some(from_message) = infer_oauth_provider_from_error_message(&message) {
+        candidates.push(from_message);
+    }
 
-    provider_is_nous || model_is_nous || message_is_nous
+    let mut seen = HashSet::new();
+    for candidate in candidates {
+        let normalized = normalize_auth_provider(&candidate);
+        if !seen.insert(normalized.clone()) {
+            continue;
+        }
+        if provider_supports_oauth(&normalized) {
+            return Some(normalized);
+        }
+    }
+    None
 }
 
 #[tokio::main]
@@ -198,18 +256,19 @@ async fn main() {
         )
         .await;
         if let Err(err) = &result {
-            if oneshot_should_auto_verify_nous(
+            if let Some(provider) = oneshot_auto_verify_oauth_provider(
                 err,
                 global_provider_override.as_deref(),
                 global_model_override.as_deref(),
             ) {
                 eprintln!(
-                    "Detected Nous auth failure in one-shot mode; running `hermes-ultra auth verify nous` and retrying once..."
+                    "Detected OAuth auth failure for provider '{}' in one-shot mode; running `hermes-ultra auth verify {}` and retrying once...",
+                    provider, provider
                 );
                 if let Err(verify_err) = run_auth(
                     cli.clone(),
                     Some("verify".to_string()),
-                    Some("nous".to_string()),
+                    Some(provider.clone()),
                     None,
                     None,
                     None,
@@ -219,8 +278,8 @@ async fn main() {
                 .await
                 {
                     eprintln!(
-                        "Warning: automatic `auth verify nous` failed: {}",
-                        verify_err
+                        "Warning: automatic `auth verify {}` failed: {}",
+                        provider, verify_err
                     );
                 }
                 result = hermes_cli::commands::handle_cli_chat(
@@ -12931,40 +12990,133 @@ mod tests {
     }
 
     #[test]
-    fn oneshot_auto_verify_nous_detects_nous_401_errors() {
+    fn oneshot_auto_verify_provider_detects_nous_401_errors() {
         let err = AgentError::LlmApi(
             "API error 401 Unauthorized: https://portal.nousresearch.com".to_string(),
         );
-        assert!(oneshot_should_auto_verify_nous(
-            &err,
-            Some("nous"),
-            Some("nous:openai/gpt-5.5")
-        ));
-        assert!(oneshot_should_auto_verify_nous(
-            &err,
-            None,
-            Some("nous:moonshotai/kimi-k2.6")
-        ));
-        assert!(oneshot_should_auto_verify_nous(&err, None, None));
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&err, Some("nous"), Some("nous:openai/gpt-5.5")),
+            Some("nous".to_string())
+        );
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&err, None, Some("nous:moonshotai/kimi-k2.6")),
+            Some("nous".to_string())
+        );
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&err, None, None),
+            Some("nous".to_string())
+        );
     }
 
     #[test]
-    fn oneshot_auto_verify_nous_ignores_non_nous_or_non_auth_errors() {
+    fn oneshot_auto_verify_provider_supports_core_oauth_providers() {
+        let openai = AgentError::LlmApi("API error 401 Unauthorized: auth.openai.com".to_string());
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&openai, Some("openai"), Some("openai:gpt-5.5")),
+            Some("openai".to_string())
+        );
+        let codex = AgentError::LlmApi("API error 401 Unauthorized: chatgpt.com codex".to_string());
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&codex, None, Some("openai-codex:codex-mini")),
+            Some("openai-codex".to_string())
+        );
+        let anthropic = AgentError::LlmApi(
+            "API error 401 Unauthorized: console.anthropic.com token expired".to_string(),
+        );
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&anthropic, Some("claude"), None),
+            Some("anthropic".to_string())
+        );
+        let gemini = AgentError::LlmApi(
+            "API error 401 Unauthorized: oauth2.googleapis.com invalid_grant".to_string(),
+        );
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&gemini, Some("gemini-cli"), None),
+            Some("google-gemini-cli".to_string())
+        );
+        let qwen = AgentError::LlmApi(
+            "API error 401 Unauthorized: chat.qwen.ai token expired".to_string(),
+        );
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(&qwen, Some("qwen-cli"), None),
+            Some("qwen-oauth".to_string())
+        );
+    }
+
+    #[test]
+    fn oneshot_auto_verify_provider_ignores_non_oauth_or_non_auth_errors() {
         let not_auth = AgentError::LlmApi("API error 404 Not Found".to_string());
-        assert!(!oneshot_should_auto_verify_nous(
-            &not_auth,
-            Some("nous"),
-            Some("nous:openai/gpt-5.5")
-        ));
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(
+                &not_auth,
+                Some("nous"),
+                Some("nous:openai/gpt-5.5")
+            ),
+            None
+        );
 
         let other_provider = AgentError::LlmApi(
             "API error 401 Unauthorized: provider openrouter token expired".to_string(),
         );
-        assert!(!oneshot_should_auto_verify_nous(
-            &other_provider,
-            Some("openrouter"),
-            Some("openrouter:openai/gpt-4o")
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(
+                &other_provider,
+                Some("openrouter"),
+                Some("openrouter:openai/gpt-4o")
+            ),
+            None
+        );
+
+        let missing_signal = AgentError::LlmApi("API error 500 Internal Server Error".to_string());
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(
+                &missing_signal,
+                Some("openai"),
+                Some("openai:gpt-5.5")
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn oneshot_auth_is_refreshable_detects_auth_signals() {
+        assert!(oneshot_auth_is_refreshable(
+            "api error 401 unauthorized token expired"
         ));
+        assert!(oneshot_auth_is_refreshable("invalid_grant"));
+        assert!(!oneshot_auth_is_refreshable("api error 404 not found"));
+    }
+
+    #[test]
+    fn infer_oauth_provider_from_error_message_maps_known_hosts() {
+        assert_eq!(
+            infer_oauth_provider_from_error_message("portal.nousresearch.com unauthorized"),
+            Some("nous".to_string())
+        );
+        assert_eq!(
+            infer_oauth_provider_from_error_message("auth.openai.com unauthorized"),
+            Some("openai".to_string())
+        );
+        assert_eq!(
+            infer_oauth_provider_from_error_message("chatgpt.com codex token expired"),
+            Some("openai-codex".to_string())
+        );
+        assert_eq!(
+            infer_oauth_provider_from_error_message("console.anthropic.com invalid token"),
+            Some("anthropic".to_string())
+        );
+        assert_eq!(
+            infer_oauth_provider_from_error_message("oauth2.googleapis.com invalid_grant"),
+            Some("google-gemini-cli".to_string())
+        );
+        assert_eq!(
+            infer_oauth_provider_from_error_message("chat.qwen.ai invalid token"),
+            Some("qwen-oauth".to_string())
+        );
+        assert_eq!(
+            infer_oauth_provider_from_error_message("openrouter.ai unauthorized"),
+            None
+        );
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -461,6 +461,12 @@ pub struct TuiState {
     stream_char_count: usize,
     /// Whether first response token has been observed in this cycle.
     saw_first_token: bool,
+    /// Current structured phase name for active processing cycle.
+    processing_phase: String,
+    /// Current structured phase label for active processing cycle.
+    processing_phase_label: String,
+    /// Current structured phase progress percentage (0..=100).
+    processing_phase_progress: u8,
     /// Whether the current cycle used fallback/remediation paths.
     processing_degraded: bool,
     /// Degraded lifecycle notes captured during current cycle.
@@ -549,6 +555,9 @@ impl Default for TuiState {
             stream_chunk_count: 0,
             stream_char_count: 0,
             saw_first_token: false,
+            processing_phase: String::new(),
+            processing_phase_label: String::new(),
+            processing_phase_progress: 0,
             processing_degraded: false,
             degraded_notes: Vec::new(),
         }
@@ -624,6 +633,9 @@ impl TuiState {
         self.stream_needs_break = false;
         self.active_tools.clear();
         self.live_thinking.clear();
+        self.processing_phase = "preflight".to_string();
+        self.processing_phase_label = "preparing request".to_string();
+        self.processing_phase_progress = 0;
         self.push_activity(format!("⟳ dispatching request to {model}"));
     }
 
@@ -656,6 +668,9 @@ impl TuiState {
         self.stream_chunk_count = 0;
         self.stream_char_count = 0;
         self.saw_first_token = false;
+        self.processing_phase.clear();
+        self.processing_phase_label.clear();
+        self.processing_phase_progress = 0;
         self.processing_degraded = false;
         self.degraded_notes.clear();
         self.jump_to_latest();
@@ -682,9 +697,18 @@ impl TuiState {
         } else {
             format!("{} active tool(s)", self.active_tools.len())
         };
+        let phase_state = if self.processing_phase_label.is_empty() {
+            "phase: n/a".to_string()
+        } else {
+            format!(
+                "phase: {} ({}%)",
+                truncate_chars(&self.processing_phase_label, 64),
+                self.processing_phase_progress
+            )
+        };
         self.push_activity(format!(
-            "… working {:.1}s • {} chunks • {} chars • {}",
-            elapsed, self.stream_chunk_count, self.stream_char_count, tool_state
+            "… working {:.1}s • {} chunks • {} chars • {} • {}",
+            elapsed, self.stream_chunk_count, self.stream_char_count, tool_state, phase_state
         ));
         self.last_progress_pulse_at = Some(now);
     }
@@ -699,6 +723,9 @@ impl TuiState {
         if !self.processing {
             return "idle";
         }
+        if !self.processing_phase_label.is_empty() {
+            return "phase-driven";
+        }
         if !self.saw_first_token {
             if self.active_tools.is_empty() {
                 "awaiting first token"
@@ -710,6 +737,35 @@ impl TuiState {
         } else {
             "running tools + streaming"
         }
+    }
+
+    fn update_processing_phase(&mut self, phase: &str, label: &str, progress_pct: Option<u8>) {
+        if !self.processing {
+            return;
+        }
+        let phase = phase.trim().to_ascii_lowercase();
+        let label = label.trim();
+        if phase.is_empty() && label.is_empty() && progress_pct.is_none() {
+            return;
+        }
+        if !phase.is_empty() {
+            self.processing_phase = phase;
+        }
+        if !label.is_empty() {
+            self.processing_phase_label = truncate_chars(label, 120);
+        }
+        if let Some(progress) = progress_pct {
+            self.processing_phase_progress = progress.min(100);
+        }
+        let activity_label = if self.processing_phase_label.is_empty() {
+            self.processing_phase.as_str()
+        } else {
+            self.processing_phase_label.as_str()
+        };
+        self.push_activity(format!(
+            "◈ phase {}% • {}",
+            self.processing_phase_progress, activity_label
+        ));
     }
 
     fn refresh_sticky_prompt(&mut self, app: &App) {
@@ -1572,10 +1628,19 @@ fn render_live_details(
         ]));
         rows.push(Line::from(vec![Span::styled(
             format!(
-                " [{}] chunks:{} chars:{}",
+                " [{}] chunks:{} chars:{} phase:{}% {}",
                 animated_processing_bar(state.spinner_frame, 18),
                 state.stream_chunk_count,
-                state.stream_char_count
+                state.stream_char_count,
+                state.processing_phase_progress,
+                truncate_chars(
+                    if state.processing_phase_label.is_empty() {
+                        state.processing_phase.as_str()
+                    } else {
+                        state.processing_phase_label.as_str()
+                    },
+                    38
+                )
             ),
             Style::default().fg(colors.accent).bg(colors.background),
         )]));
@@ -4174,6 +4239,19 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
                                     state.push_activity(format!("[{}] {}", event_type, message));
                                 }
                             }
+                            "phase" => {
+                                let phase = extra
+                                    .get("phase")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("phase");
+                                let label =
+                                    extra.get("label").and_then(|v| v.as_str()).unwrap_or("");
+                                let progress_pct = extra
+                                    .get("progress_pct")
+                                    .and_then(|v| v.as_u64())
+                                    .and_then(|v| u8::try_from(v).ok());
+                                state.update_processing_phase(phase, label, progress_pct);
+                            }
                             "lifecycle" => {
                                 let message = extra
                                     .get("message")
@@ -4871,13 +4949,28 @@ mod tests {
         let mut state = TuiState::default();
         assert_eq!(state.processing_stage_label(), "idle");
         state.begin_processing_cycle("nous:test-model");
-        assert_eq!(state.processing_stage_label(), "awaiting first token");
+        assert_eq!(state.processing_stage_label(), "phase-driven");
+        state.processing_phase_label.clear();
         state.active_tools.push("terminal".to_string());
         assert_eq!(state.processing_stage_label(), "running tools (pre-token)");
         state.saw_first_token = true;
         assert_eq!(state.processing_stage_label(), "running tools + streaming");
         state.active_tools.clear();
         assert_eq!(state.processing_stage_label(), "streaming response");
+    }
+
+    #[test]
+    fn test_phase_updates_set_progress_and_activity() {
+        let mut state = TuiState::default();
+        state.begin_processing_cycle("nous:test-model");
+        state.update_processing_phase("retrieval", "collecting evidence", Some(42));
+        assert_eq!(state.processing_phase, "retrieval");
+        assert_eq!(state.processing_phase_label, "collecting evidence");
+        assert_eq!(state.processing_phase_progress, 42);
+        assert!(state
+            .recent_activity
+            .last()
+            .is_some_and(|line| line.contains("phase 42%")));
     }
 
     #[test]

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -343,8 +343,26 @@ fn with_login_profile_sources(command: &str) -> String {
         let zsh_command = shell_single_quote(&format!(
             "[ -f \"$HOME/.zshenv\" ] && . \"$HOME/.zshenv\"; [ -f \"$HOME/.zprofile\" ] && . \"$HOME/.zprofile\"; [ -f \"$HOME/.zshrc\" ] && . \"$HOME/.zshrc\"; [ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; {command}"
         ));
+        let preferred_shell = std::env::var("SHELL")
+            .ok()
+            .and_then(|raw| {
+                std::path::Path::new(raw.trim())
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(|name| name.to_ascii_lowercase())
+            })
+            .filter(|name| matches!(name.as_str(), "bash" | "zsh"));
+        let preferred_branch = match preferred_shell.as_deref() {
+            Some("zsh") => {
+                format!("if command -v zsh >/dev/null 2>&1; then exec zsh -lc {zsh_command}; fi; ")
+            }
+            Some("bash") => format!(
+                "if command -v bash >/dev/null 2>&1; then exec bash -lc {bash_command}; fi; "
+            ),
+            _ => String::new(),
+        };
         format!(
-            "if command -v bash >/dev/null 2>&1; then exec bash -lc {bash_command}; \
+            "{preferred_branch}if command -v bash >/dev/null 2>&1; then exec bash -lc {bash_command}; \
 elif command -v zsh >/dev/null 2>&1; then exec zsh -lc {zsh_command}; \
 else printf '%s\n' \"Hermes could not find bash or zsh in PATH. Run 'exec zsh -l' or set your default shell where env vars are available.\" >&2; exit 127; fi"
         )
@@ -1088,6 +1106,21 @@ mod tests {
         assert!(wrapped.contains("exec zsh -lc"));
         assert!(wrapped.contains(". \"$HOME/.zshrc\""));
         assert!(wrapped.contains("echo hi"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_with_login_profile_sources_prefers_user_shell_when_supported() {
+        let _shell = EnvGuard::set("SHELL", "/bin/zsh");
+        let wrapped = with_login_profile_sources("echo hi");
+        let preferred = "if command -v zsh >/dev/null 2>&1; then exec zsh -lc";
+        let fallback = "if command -v bash >/dev/null 2>&1; then exec bash -lc";
+        let preferred_idx = wrapped.find(preferred).expect("preferred zsh branch");
+        let fallback_idx = wrapped.find(fallback).expect("fallback bash branch");
+        assert!(
+            preferred_idx < fallback_idx,
+            "preferred shell branch should come before fallback"
+        );
     }
 
     #[cfg(not(unix))]

--- a/docs/implementation/items-1-12-parity-plan-2026-05-10.md
+++ b/docs/implementation/items-1-12-parity-plan-2026-05-10.md
@@ -1,0 +1,99 @@
+# Hermes Agent Ultra: Items 1-12 Surgical Plan + Implementation Notes (2026-05-10)
+
+Scope: complete coverage for the 12 previously proposed upgrades while reusing existing Rust-first surfaces and minimizing net-new code.
+
+## 1) Universal OAuth self-heal loop
+Implementation:
+- Generalized one-shot auth auto-repair from Nous-only to provider-aware OAuth verification.
+- Added provider inference from overrides/model prefix/error host patterns.
+- Auto-runs `auth verify <provider>` and retries once for OAuth-capable providers.
+Files:
+- `crates/hermes-cli/src/main.rs`
+
+## 2) Adaptive tool-budget governor
+Status:
+- Already implemented.
+Evidence surfaces:
+- `crates/hermes-agent/src/agent_loop.rs` (`governor_*`, tool-loop guard, discovery-budget policy).
+
+## 3) Agent live reasoning lane phases/progress
+Implementation:
+- Added structured phase events (`ui_event=phase`) with progress percentages.
+- Wired App runtime to emit `preflight`, `dispatch`, `inference`, `recovery`, `finalize` phases.
+- TUI now tracks/render phase name + progress in Activity Lane and heartbeat pulses.
+Files:
+- `crates/hermes-cli/src/app.rs`
+- `crates/hermes-cli/src/tui.rs`
+
+## 4) Deterministic replay + diff runner
+Status:
+- Already implemented.
+Evidence surfaces:
+- `/raw trace ...` and `/studio replay status|verify|diff ...`
+- `crates/hermes-cli/src/commands.rs`
+
+## 5) Skills risk firewall v2
+Status:
+- Already implemented.
+Evidence surfaces:
+- skill bundle security scanning, plugin security checks, credential guard paths in:
+- `crates/hermes-cli/src/commands.rs`
+- `crates/hermes-tools/src/tools/*`
+
+## 6) Auto shell/env resolver
+Implementation delta:
+- Preserved existing bash/zsh fallback but now prefers the user's current `$SHELL` when supported (`bash`/`zsh`) before fallback sequence.
+Files:
+- `crates/hermes-environments/src/local.rs`
+
+## 7) ContextLattice objective autopin
+Implementation:
+- Added objective-driven ContextLattice topic autopin.
+- When an objective contract exists and topic path is unset/default (or prior objective autopin), runtime pins `CONTEXTLATTICE_TOPIC_PATH=runbooks/objective/<objective_id>`.
+- Emits lifecycle + phase note for operator visibility.
+Files:
+- `crates/hermes-cli/src/app.rs`
+
+## 8) Provider capability guardrails
+Status:
+- Already implemented.
+Evidence surfaces:
+- `/model explain`, `/model why-not`, capability filtering and incompatibility reporting.
+- `crates/hermes-cli/src/commands.rs`
+- `crates/hermes-cli/src/alpha_runtime.rs`
+
+## 9) Session resilience upgrade
+Status:
+- Already implemented.
+Evidence surfaces:
+- session persistence/snapshots/resume surfaces and guardrails.
+- `crates/hermes-cli/src/app.rs`, `crates/hermes-cli/src/main.rs`
+
+## 10) Upstream parity watchdog
+Status:
+- Already implemented.
+Evidence surfaces:
+- parity reports and drift gates in scripts/docs:
+- `scripts/run-differential-parity-gate.py`
+- `scripts/upstream_webhook_sync.py`
+- `docs/upstream-webhook-sync.md`
+
+## 11) Cost/latency autopilot
+Status:
+- Already implemented.
+Evidence surfaces:
+- autopilot profiles + reporting + recommendation/apply flows:
+- `scripts/run-performance-autopilot.py`
+- `crates/hermes-cli/src/commands.rs`
+
+## 12) Operator-mode toggles
+Implementation delta:
+- Added `/ops mode ...` alias routing to policy profiles (`strict|standard|dev`) to make operator flow explicit inside `/ops`.
+Files:
+- `crates/hermes-cli/src/commands.rs`
+
+## Test strategy for this tranche
+- Unit tests for OAuth inference and one-shot auto-verify provider mapping.
+- Unit tests for TUI phase state/progress behavior.
+- Unit tests for shell preference order in login wrapper.
+- Existing regression suites for replay/policy/objective/model capabilities remain authoritative.


### PR DESCRIPTION
## Summary
Implements the missing deltas for the 1-12 upgrade set while reusing existing surfaces.

### Added
- Universal one-shot OAuth self-heal across OAuth-capable providers.
- Structured phase/progress events into Activity Lane.
- Objective-driven ContextLattice topic autopin.
- /ops mode alias to policy profiles.
- Shell resolver now prefers user default shell (bash/zsh) before fallback.
- Plan artifact mapping items 1-12 status + evidence.

### Validation
- cargo fmt --all
- cargo test -p hermes-cli oneshot_auto_verify_provider -- --nocapture
- cargo test -p hermes-cli phase_updates_set_progress_and_activity -- --nocapture
- cargo test -p hermes-cli objective_context_autopin -- --nocapture
- cargo test -p hermes-environments test_with_login_profile_sources -- --nocapture
