### PR TITLE
Close surfaces 1-8 and envy 1-8 runtime gaps

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -7547,6 +7547,54 @@ fn detect_communication_intent(messages: &[Message]) -> bool {
     comm_terms.iter().any(|needle| text.contains(needle))
 }
 
+fn detect_tool_profile_escape_hatch(messages: &[Message]) -> bool {
+    let text = latest_user_content(messages)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let escape_terms = [
+        "allow all tools",
+        "disable narrowing",
+        "open tool profile",
+        "no tool filtering",
+        "bypass tool profile",
+    ];
+    escape_terms.iter().any(|needle| text.contains(needle))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RepoReviewToolProfileMode {
+    Off,
+    Balanced,
+    Focus,
+}
+
+impl RepoReviewToolProfileMode {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "off" | "open" => Some(Self::Off),
+            "balanced" | "default" => Some(Self::Balanced),
+            "focus" | "strict" => Some(Self::Focus),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Balanced => "balanced",
+            Self::Focus => "focus",
+        }
+    }
+}
+
+fn repo_review_tool_profile_mode() -> RepoReviewToolProfileMode {
+    std::env::var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE")
+        .ok()
+        .as_deref()
+        .and_then(RepoReviewToolProfileMode::parse)
+        .unwrap_or(RepoReviewToolProfileMode::Balanced)
+}
+
 fn exploratory_problem_solving_system_hint(messages: &[Message]) -> Option<String> {
     if !detect_repo_review_intent(messages) {
         return None;
@@ -7980,9 +8028,20 @@ fn apply_repo_review_tool_profile_narrowing(
     if !detect_repo_review_intent(messages) {
         return None;
     }
+    if detect_tool_profile_escape_hatch(messages) {
+        return Some(
+            "[SYSTEM] Repo-review tool profile narrowing bypassed by explicit operator escape hatch."
+                .to_string(),
+        );
+    }
+    let mode = repo_review_tool_profile_mode();
+    if mode == RepoReviewToolProfileMode::Off {
+        return None;
+    }
     let allow_messaging = detect_communication_intent(messages);
     let mut filtered_messaging = 0usize;
     let mut filtered_non_repo = 0usize;
+    let mut filtered_focus = 0usize;
     tool_calls.retain(|tc| {
         let mut should_filter = false;
         if is_messaging_tool_name(&tc.function.name) && !allow_messaging {
@@ -7994,19 +8053,31 @@ fn apply_repo_review_tool_profile_narrowing(
         {
             filtered_non_repo += 1;
             should_filter = true;
+        } else if mode == RepoReviewToolProfileMode::Focus
+            && !is_discovery_tool_name(&tc.function.name)
+            && !is_execution_tool_name(&tc.function.name)
+            && !is_housekeeping_tool_name(&tc.function.name)
+            && !tc
+                .function
+                .name
+                .to_ascii_lowercase()
+                .contains("contextlattice")
+        {
+            filtered_focus += 1;
+            should_filter = true;
         }
         if should_filter {
             return false;
         }
         true
     });
-    let filtered = filtered_messaging + filtered_non_repo;
+    let filtered = filtered_messaging + filtered_non_repo + filtered_focus;
     if filtered == 0 {
         return None;
     }
     Some(format!(
-        "[SYSTEM] Repo-review tool profile narrowed this turn: skipped {} low-signal call(s) (messaging={}, non-repo={}) to keep focus on code evidence. `todo` remains enabled for task organization. If notifications are required, request telegram/discord/slack explicitly.",
-        filtered, filtered_messaging, filtered_non_repo
+        "[SYSTEM] Repo-review tool profile narrowed this turn (mode={}): skipped {} low-signal call(s) (messaging={}, non-repo={}, focus={}) to keep focus on code evidence. `todo` remains enabled for task organization. If notifications are required, request telegram/discord/slack explicitly.",
+        mode.as_str(), filtered, filtered_messaging, filtered_non_repo, filtered_focus
     ))
 }
 
@@ -12470,6 +12541,44 @@ mod tests {
         assert!(note.is_some());
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "todo");
+    }
+
+    #[test]
+    fn test_repo_review_tool_profile_escape_hatch_disables_filtering() {
+        std::env::set_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE", "focus");
+        let msgs = vec![Message::user(
+            "review repo at /tmp/app and diagnose issue; allow all tools",
+        )];
+        let mut calls = vec![ToolCall {
+            id: "b".to_string(),
+            function: hermes_core::FunctionCall {
+                name: "telegram_send".to_string(),
+                arguments: r#"{"text":"status"}"#.to_string(),
+            },
+            extra_content: None,
+        }];
+        let note = apply_repo_review_tool_profile_narrowing(&mut calls, &msgs);
+        assert!(note.is_some());
+        assert_eq!(calls.len(), 1, "escape hatch should bypass filtering");
+        std::env::remove_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE");
+    }
+
+    #[test]
+    fn test_repo_review_tool_profile_off_mode_disables_filtering() {
+        std::env::set_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE", "off");
+        let msgs = vec![Message::user("review repo at /tmp/app and diagnose issue")];
+        let mut calls = vec![ToolCall {
+            id: "b".to_string(),
+            function: hermes_core::FunctionCall {
+                name: "telegram_send".to_string(),
+                arguments: r#"{"text":"status"}"#.to_string(),
+            },
+            extra_content: None,
+        }];
+        let note = apply_repo_review_tool_profile_narrowing(&mut calls, &msgs);
+        assert!(note.is_none());
+        assert_eq!(calls.len(), 1, "off mode should keep all calls");
+        std::env::remove_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE");
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -1055,6 +1055,42 @@ impl App {
         tracing::info!("Switched personality to: {}", name);
     }
 
+    /// Return the normalized runtime provider for the active model.
+    pub fn current_runtime_provider(&self) -> String {
+        let (provider_name, _) = resolve_provider_and_model(&self.config, &self.current_model);
+        normalize_runtime_provider_name(provider_name.as_str())
+    }
+
+    /// Refresh and verify runtime credentials for the active provider.
+    ///
+    /// This is the command-surface lifecycle helper used by `/auth`.
+    pub async fn verify_runtime_auth(&mut self, force_refresh: bool) -> Result<String, AgentError> {
+        let provider = self.current_runtime_provider();
+        let before_present = provider_api_key_from_env(&provider).is_some();
+        self.refresh_runtime_provider_credentials_if_needed(force_refresh)
+            .await;
+        let after = provider_api_key_from_env(&provider);
+        let after_present = after.is_some();
+        let status = if let Some(key) = after {
+            format!(
+                "present (masked={} chars)",
+                key.chars().count().max(1).saturating_sub(8).max(1)
+            )
+        } else {
+            "missing".to_string()
+        };
+        let refresh_mode = if force_refresh { "forced" } else { "passive" };
+        let changed = if before_present == after_present {
+            "unchanged"
+        } else {
+            "updated"
+        };
+        Ok(format!(
+            "Auth verify\nprovider: {}\nmode: {}\ncredential: {}\nstate: {}\nmodel: {}",
+            provider, refresh_mode, status, changed, self.current_model
+        ))
+    }
+
     /// Run the agent on the current message history.
     ///
     /// Sends all messages to the agent loop and appends the result.

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -131,12 +131,17 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/model",
         "Show/switch models, run capability diagnostics (`/model explain`, `why-not`, `--cap`), or configure failover (`/model failover`)",
     ),
+    (
+        "/auth",
+        "Auth lifecycle controls (`status|verify|refresh`) for active provider credentials",
+    ),
     ("/provider", "List configured providers and availability"),
     (
         "/personality",
         "Show current personality, list built-ins, or switch mode",
     ),
     ("/profile", "Show active profile and Hermes home path"),
+    ("/whoami", "Alias for /profile"),
     ("/fast", "Toggle fast-mode hints"),
     ("/skin", "Show available skin/theme options"),
     ("/skins", "Alias for /skin"),
@@ -184,7 +189,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/objective",
-        "Set/show objective contract + profile/policies (`status|plan|constraints|counterfactual|profile|context|simulator|ensemble|ledger|dag|eval|clear`)",
+        "Set/show objective contract + profile/policies (`status|verify|plan|constraints|counterfactual|profile|context|simulator|ensemble|ledger|dag|eval|clear`)",
     ),
     (
         "/claims",
@@ -220,7 +225,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/btw", "Run an ephemeral side-question"),
     (
         "/plan",
-        "Queue planning work or inspect planner queue status (`/plan caps ...` optional)",
+        "Queue planning work or inspect planner queue status (`/plan caps ...`, `/plan depth ...`)",
     ),
     ("/lsp", "Show code-index/LSP context status and controls"),
     ("/graph", "Show graph-memory and ContextLattice status"),
@@ -253,6 +258,14 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "Show build/parity/upstream snapshot and enabled Ultra features",
     ),
     ("/ops", "Operator control plane (status + quick controls)"),
+    (
+        "/telemetry",
+        "Live telemetry snapshot (`status|lane`) for runtime health and gate signals",
+    ),
+    (
+        "/runbook",
+        "Failure-first remediation runbooks (`list|show <name>`)",
+    ),
     (
         "/eval",
         "Run/show live session evaluation harness (`status|run|latest`)",
@@ -3014,8 +3027,10 @@ fn canonical_command(cmd: &str) -> &str {
         "/autocompress" => "/autocompact",
         "/skins" => "/skin",
         "/summary" => "/recap",
+        "/whoami" => "/profile",
         "/sb" => "/statusbar",
         "/pilot" => "/autopilot",
+        "/rb" => "/runbook",
         "/debug" => "/debug-dump",
         "/exit" => "/quit",
         other => other,
@@ -3058,7 +3073,8 @@ pub async fn handle_slash_command(
         "/history" => handle_history_command(app),
         "/recap" => handle_recap_command(app, args),
         "/context" => handle_context_command(app, args),
-        "/title" | "/branch" => handle_session_compat_command(app, canonical_command(cmd), args),
+        "/title" => handle_session_compat_command(app, canonical_command(cmd), args),
+        "/branch" => handle_branch_command(app, args),
         "/timetravel" => handle_timetravel_command(app, args),
         "/snapshot" => handle_snapshot_command(app, args),
         "/rollback" => handle_rollback_command(app, args),
@@ -3078,9 +3094,10 @@ pub async fn handle_slash_command(
         "/studio" => handle_studio_command(app, args).await,
         "/ask" => handle_interactive_question_command(app, args),
         "/model" => handle_model_command(app, args).await,
+        "/auth" => handle_auth_command(app, args).await,
         "/provider" => handle_provider_command(app).await,
         "/personality" => handle_personality_command(app, args),
-        "/profile" => handle_profile_command(app),
+        "/profile" | "/whoami" => handle_profile_command(app),
         "/fast" | "/skin" | "/voice" => {
             handle_runtime_ui_mode_command(app, canonical_command(cmd), args)
         }
@@ -3110,6 +3127,8 @@ pub async fn handle_slash_command(
         "/status" => handle_status_command(app),
         "/about" => handle_about_command(app),
         "/ops" => handle_ops_command(app, args).await,
+        "/telemetry" => handle_telemetry_command(app, args),
+        "/runbook" => handle_runbook_command(app, args),
         "/eval" => handle_ops_eval_command(app, args).await,
         "/autopilot" => handle_ops_autopilot_command(app, args).await,
         "/mission" => handle_mission_command(app, args).await,
@@ -5599,6 +5618,57 @@ fn summarize_route_health_state(path: &Path) -> String {
     )
 }
 
+fn summarize_route_health_details(path: &Path) -> Option<String> {
+    let report = read_json_file(path)?;
+    let entries = report.get("entries")?.as_array()?;
+    if entries.is_empty() {
+        return Some("route_health_trace=no_entries".to_string());
+    }
+    let mut ranked = entries
+        .iter()
+        .filter_map(|entry| {
+            let key = entry.get("key").and_then(|v| v.as_str())?;
+            let tier = entry
+                .get("tier")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let health = entry
+                .get("health_score")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let reasons = entry
+                .get("reasons")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            Some((key.to_string(), tier.to_string(), health, reasons))
+        })
+        .collect::<Vec<_>>();
+    if ranked.is_empty() {
+        return Some("route_health_trace=no_parseable_entries".to_string());
+    }
+    ranked.sort_by(|a, b| a.2.total_cmp(&b.2));
+    let hottest = ranked
+        .iter()
+        .take(3)
+        .map(|(key, tier, health, reasons)| {
+            let reason_text = if reasons.is_empty() {
+                "no_reasons".to_string()
+            } else {
+                reasons.join("|")
+            };
+            format!("{key} tier={tier} score={health:.2} reasons={reason_text}")
+        })
+        .collect::<Vec<_>>()
+        .join(" ; ");
+    Some(format!("route_health_trace={}", hottest))
+}
+
 fn handle_ops_budget_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     if args.is_empty() || args[0].eq_ignore_ascii_case("status") {
         let budget = RepoReviewBudgetRuntime::from_env();
@@ -5659,6 +5729,59 @@ fn handle_ops_budget_command(app: &mut App, args: &[&str]) -> Result<CommandResu
             );
         }
     }
+    Ok(CommandResult::Handled)
+}
+
+fn handle_ops_tool_profile_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let mode = std::env::var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "balanced".to_string());
+    if args.is_empty()
+        || args
+            .first()
+            .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "status" | "show"))
+    {
+        emit_command_output(
+            app,
+            format!(
+                "repo_review_tool_profile mode={}\nUse `/ops tool-profile [off|balanced|focus]`.\nEscape hatch: include `allow all tools` or `disable narrowing` in your request.",
+                mode
+            ),
+        );
+        return Ok(CommandResult::Handled);
+    }
+    if args[0].eq_ignore_ascii_case("list") {
+        emit_command_output(
+            app,
+            "Repo-review tool profile modes:\n- off: disable narrowing (open tool lane)\n- balanced: filter messaging/non-repo noise only\n- focus: balanced + stricter repo-first filtering",
+        );
+        return Ok(CommandResult::Handled);
+    }
+    if args[0].eq_ignore_ascii_case("clear") {
+        std::env::remove_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE");
+        emit_command_output(
+            app,
+            "Cleared repo-review tool profile override (default=balanced).",
+        );
+        return Ok(CommandResult::Handled);
+    }
+    let next = args[0].to_ascii_lowercase();
+    if !matches!(next.as_str(), "off" | "balanced" | "focus") {
+        emit_command_output(
+            app,
+            "Usage: /ops tool-profile [status|list|off|balanced|focus|clear]",
+        );
+        return Ok(CommandResult::Handled);
+    }
+    std::env::set_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE", next.as_str());
+    emit_command_output(
+        app,
+        format!("repo_review_tool_profile mode set to `{}`", next),
+    );
     Ok(CommandResult::Handled)
 }
 
@@ -5765,6 +5888,9 @@ async fn handle_qos_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                 learning_path.display()
             );
             let _ = writeln!(out, "  {} ({})", health_summary, health_path.display());
+            if let Some(trace) = summarize_route_health_details(&health_path) {
+                let _ = writeln!(out, "  {}", trace);
+            }
             let _ = writeln!(
                 out,
                 "  route_autotune_state={} ({})",
@@ -6352,6 +6478,10 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
             .filter(|v| !v.trim().is_empty())
             .unwrap_or_else(|| "balanced".to_string());
         let repo_review_budget = RepoReviewBudgetRuntime::from_env();
+        let tool_profile_mode = std::env::var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "balanced".to_string());
 
         let out = format!(
             "Operator Control Plane\n\
@@ -6372,7 +6502,9 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
              Policy/Gates:\n\
                tool_policy:  mode={} preset={}\n\
                autopilot:    mode={} profile={}\n\
+               tool_profile: {}\n\
                repo_budget:  profile={} repeat={} low_signal={} keep_repeat={} keep_low_signal={} min_signal={:.2}\n\
+               task_depth:   {}\n\
                policy_counts allow={} deny={} audit_only={} simulate={} would_block={}\n\
                skills_tier:  {} (bypass={})\n\
                {}\n\
@@ -6389,6 +6521,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                /ops verbose\n\
                /ops dashboard [status|on|off|url] [host] [port]\n\
                /ops skills-tier [status|trusted|balanced|open]\n\
+               /ops tool-profile [status|list|off|balanced|focus]\n\
                /ops budget [status|list|balanced|aggressive|relaxed|off|clear]\n\
                /ops evolve [status|run|recommend]\n\
                /ops eval [status|run|latest]\n\
@@ -6406,12 +6539,14 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
             policy_preset,
             autopilot_mode,
             autopilot_profile,
+            tool_profile_mode,
             repo_review_budget.profile.as_str(),
             repo_review_budget.repeat_threshold,
             repo_review_budget.low_signal_threshold,
             repo_review_budget.keep_repeat,
             repo_review_budget.keep_low_signal,
             repo_review_budget.min_signal_score,
+            task_depth_runtime_summary(),
             counters.allow,
             counters.deny,
             counters.audit_only,
@@ -6447,6 +6582,7 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                  - /ops statusbar\n\
                  - /ops dashboard [status|on|off|url] [host] [port]\n\
                  - /ops skills-tier [status|trusted|balanced|open]\n\
+                 - /ops tool-profile [status|list|off|balanced|focus]\n\
                  - /ops budget [status|list|balanced|aggressive|relaxed|off|clear]\n\
                  - /ops evolve [status|run|recommend]\n\
                  - /ops eval [status|run|latest]\n\
@@ -6468,6 +6604,9 @@ async fn handle_ops_command(app: &mut App, args: &[&str]) -> Result<CommandResul
         "statusbar" => handle_statusbar_command(app),
         "dashboard" => handle_dashboard_command(app, &args[1..]).await,
         "skills-tier" => handle_ops_skills_tier_command(app, &args[1..]),
+        "tool-profile" | "toolprofile" | "tool_profile" => {
+            handle_ops_tool_profile_command(app, &args[1..])
+        }
         "budget" => handle_ops_budget_command(app, &args[1..]),
         "evolve" => handle_ops_evolve_command(app, &args[1..]).await,
         "eval" => handle_ops_eval_command(app, &args[1..]).await,
@@ -6882,6 +7021,181 @@ fn enumerate_saved_sessions(sessions_dir: &Path) -> Vec<(String, PathBuf, System
     entries
 }
 
+#[derive(Debug, Clone)]
+struct SnapshotIntegrity {
+    valid: bool,
+    reason: Option<String>,
+    session_id: Option<String>,
+    message_count: usize,
+}
+
+fn inspect_snapshot_integrity(path: &Path) -> SnapshotIntegrity {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(body) => body,
+        Err(err) => {
+            return SnapshotIntegrity {
+                valid: false,
+                reason: Some(format!("read_failed: {}", err)),
+                session_id: None,
+                message_count: 0,
+            };
+        }
+    };
+    let data: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(err) => {
+            return SnapshotIntegrity {
+                valid: false,
+                reason: Some(format!("json_invalid: {}", err)),
+                session_id: None,
+                message_count: 0,
+            };
+        }
+    };
+    let messages = match data.get("messages").and_then(|m| m.as_array()) {
+        Some(arr) => arr,
+        None => {
+            return SnapshotIntegrity {
+                valid: false,
+                reason: Some("missing_messages_array".to_string()),
+                session_id: data
+                    .get("session_info")
+                    .and_then(|v| v.get("session_id"))
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.to_string()),
+                message_count: 0,
+            };
+        }
+    };
+    SnapshotIntegrity {
+        valid: true,
+        reason: None,
+        session_id: data
+            .get("session_info")
+            .and_then(|v| v.get("session_id"))
+            .and_then(|v| v.as_str())
+            .map(|v| v.to_string()),
+        message_count: messages.len(),
+    }
+}
+
+fn resolve_saved_session_entry<'a>(
+    entries: &'a [(String, PathBuf, SystemTime)],
+    requested: &str,
+) -> Result<&'a (String, PathBuf, SystemTime), String> {
+    if let Some(entry) = entries
+        .iter()
+        .find(|(name, _, _)| name.eq_ignore_ascii_case(requested))
+    {
+        return Ok(entry);
+    }
+
+    let prefix_matches: Vec<&(String, PathBuf, SystemTime)> = entries
+        .iter()
+        .filter(|(name, _, _)| name.starts_with(requested))
+        .collect();
+    match prefix_matches.as_slice() {
+        [entry] => Ok(*entry),
+        [] => Err(format!("not_found: {}", requested)),
+        many => Err(format!(
+            "ambiguous: {}",
+            many.iter()
+                .map(|entry| format!("`{}`", entry.0))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn message_from_snapshot_entry(entry: &serde_json::Value) -> hermes_core::Message {
+    let role_str = entry.get("role").and_then(|r| r.as_str()).unwrap_or("User");
+    let content_str = entry.get("content").and_then(|c| c.as_str()).unwrap_or("");
+    match role_str {
+        "Assistant" => hermes_core::Message::assistant(content_str),
+        "System" => hermes_core::Message::system(content_str),
+        "Tool" => hermes_core::Message::assistant(content_str),
+        _ => hermes_core::Message::user(content_str),
+    }
+}
+
+fn load_messages_from_snapshot(path: &Path) -> Result<Vec<hermes_core::Message>, AgentError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| AgentError::Io(format!("Failed to read session: {}", e)))?;
+    let data: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| AgentError::Config(format!("Failed to parse session: {}", e)))?;
+    let messages = data
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .ok_or_else(|| AgentError::Config("Session file has no messages array.".to_string()))?;
+    Ok(messages.iter().map(message_from_snapshot_entry).collect())
+}
+
+fn message_signature(message: &hermes_core::Message) -> String {
+    let role = match message.role {
+        hermes_core::MessageRole::System => "system",
+        hermes_core::MessageRole::User => "user",
+        hermes_core::MessageRole::Assistant => "assistant",
+        hermes_core::MessageRole::Tool => "tool",
+    };
+    format!(
+        "{}|{}",
+        role,
+        message.content.as_deref().unwrap_or_default()
+    )
+}
+
+fn summarize_branch_diff(
+    left_name: &str,
+    left_messages: &[hermes_core::Message],
+    right_name: &str,
+    right_messages: &[hermes_core::Message],
+) -> String {
+    let left_set: HashSet<String> = left_messages.iter().map(message_signature).collect();
+    let right_set: HashSet<String> = right_messages.iter().map(message_signature).collect();
+    let only_left = left_set.difference(&right_set).count();
+    let only_right = right_set.difference(&left_set).count();
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "Branch diff: `{}` vs `{}`",
+        left_name.trim(),
+        right_name.trim()
+    );
+    let _ = writeln!(
+        out,
+        "  messages: {} vs {}",
+        left_messages.len(),
+        right_messages.len()
+    );
+    let _ = writeln!(out, "  unique_to_{}: {}", left_name.trim(), only_left);
+    let _ = writeln!(out, "  unique_to_{}: {}", right_name.trim(), only_right);
+    let left_last = left_messages
+        .iter()
+        .rev()
+        .find(|m| m.role == hermes_core::MessageRole::Assistant)
+        .and_then(|m| m.content.as_deref())
+        .unwrap_or("");
+    let right_last = right_messages
+        .iter()
+        .rev()
+        .find(|m| m.role == hermes_core::MessageRole::Assistant)
+        .and_then(|m| m.content.as_deref())
+        .unwrap_or("");
+    let _ = writeln!(
+        out,
+        "  last_assistant_{}: {}",
+        left_name.trim(),
+        truncate_chars(left_last, 120)
+    );
+    let _ = writeln!(
+        out,
+        "  last_assistant_{}: {}",
+        right_name.trim(),
+        truncate_chars(right_last, 120)
+    );
+    out.trim_end().to_string()
+}
+
 fn load_session_from_path(
     app: &mut App,
     session_name: &str,
@@ -6901,14 +7215,7 @@ fn load_session_from_path(
     app.messages.clear();
     app.ui_messages.clear();
     for msg in messages {
-        let role_str = msg.get("role").and_then(|r| r.as_str()).unwrap_or("User");
-        let content_str = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
-        let message = match role_str {
-            "Assistant" => hermes_core::Message::assistant(content_str),
-            "System" => hermes_core::Message::system(content_str),
-            _ => hermes_core::Message::user(content_str),
-        };
-        app.messages.push(message);
+        app.messages.push(message_from_snapshot_entry(msg));
     }
 
     let session_info = data.get("session_info");
@@ -6975,10 +7282,23 @@ fn handle_load_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Ag
         } else {
             let mut out = String::from("Saved sessions:\n");
             for (idx, (name, _, _)) in entries.iter().enumerate() {
-                if idx == 0 {
-                    out.push_str(&format!("- `{}` (latest)\n", name));
+                let integrity = inspect_snapshot_integrity(&entries[idx].1);
+                let marker = if integrity.valid { "✓" } else { "⚠" };
+                let detail = if integrity.valid {
+                    format!(
+                        "session_id={} messages={}",
+                        integrity.session_id.unwrap_or_else(|| "?".to_string()),
+                        integrity.message_count
+                    )
                 } else {
-                    out.push_str(&format!("- `{}`\n", name));
+                    integrity
+                        .reason
+                        .unwrap_or_else(|| "invalid snapshot".to_string())
+                };
+                if idx == 0 {
+                    out.push_str(&format!("- {} `{}` (latest) — {}\n", marker, name, detail));
+                } else {
+                    out.push_str(&format!("- {} `{}` — {}\n", marker, name, detail));
                 }
             }
             out.push_str("\nUsage: `/load <session-name>` or `/resume [session-name]`");
@@ -7012,24 +7332,39 @@ fn handle_resume_command(app: &mut App, args: &[&str]) -> Result<CommandResult, 
     }
 
     if args.is_empty() {
-        let (name, path, _) = &entries[0];
-        return load_session_from_path(app, name, path, true);
+        if let Some((name, path, _)) = entries
+            .iter()
+            .find(|(_, path, _)| inspect_snapshot_integrity(path).valid)
+        {
+            return load_session_from_path(app, name, path, true);
+        }
+        emit_command_output(
+            app,
+            "No valid saved sessions found (all snapshots are malformed). Use `/sessions` to inspect and `/save` to create a fresh checkpoint.",
+        );
+        return Ok(CommandResult::Handled);
     }
 
     let requested = args[0];
-    if let Some((name, path, _)) = entries
-        .iter()
-        .find(|(name, _, _)| name.eq_ignore_ascii_case(requested))
-    {
-        return load_session_from_path(app, name, path, true);
-    }
-
-    let prefix_matches: Vec<&(String, PathBuf, SystemTime)> = entries
-        .iter()
-        .filter(|(name, _, _)| name.starts_with(requested))
-        .collect();
-    match prefix_matches.as_slice() {
-        [] => {
+    match resolve_saved_session_entry(&entries, requested) {
+        Ok((name, path, _)) => {
+            let integrity = inspect_snapshot_integrity(path);
+            if !integrity.valid {
+                emit_command_output(
+                    app,
+                    format!(
+                        "Session '{}' is present but invalid: {}.\nUse `/sessions` to inspect snapshot health.",
+                        requested,
+                        integrity
+                            .reason
+                            .unwrap_or_else(|| "malformed session snapshot".to_string())
+                    ),
+                );
+                return Ok(CommandResult::Handled);
+            }
+            load_session_from_path(app, name, path, true)
+        }
+        Err(err) if err.starts_with("not_found:") => {
             emit_command_output(
                 app,
                 format!(
@@ -7039,18 +7374,13 @@ fn handle_resume_command(app: &mut App, args: &[&str]) -> Result<CommandResult, 
             );
             Ok(CommandResult::Handled)
         }
-        [entry] => load_session_from_path(app, &entry.0, &entry.1, true),
-        many => {
-            let names = many
-                .iter()
-                .map(|entry| format!("`{}`", entry.0))
-                .collect::<Vec<_>>()
-                .join(", ");
+        Err(err) => {
             emit_command_output(
                 app,
                 format!(
                     "Session name '{}' is ambiguous. Matches: {}",
-                    requested, names
+                    requested,
+                    err.trim_start_matches("ambiguous: ")
                 ),
             );
             Ok(CommandResult::Handled)
@@ -7061,6 +7391,57 @@ fn handle_resume_command(app: &mut App, args: &[&str]) -> Result<CommandResult, 
 fn handle_sessions_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     if args.is_empty() {
         return handle_load_command(app, args);
+    }
+    let action = args[0].to_ascii_lowercase();
+    if action == "doctor" || action == "verify" {
+        let sessions_dir = hermes_config::hermes_home().join("sessions");
+        let entries = enumerate_saved_sessions(&sessions_dir);
+        if entries.is_empty() {
+            emit_command_output(app, "No saved sessions found.");
+            return Ok(CommandResult::Handled);
+        }
+        let mut invalid = Vec::new();
+        let mut by_session_id: HashMap<String, Vec<String>> = HashMap::new();
+        for (name, path, _) in entries {
+            let integrity = inspect_snapshot_integrity(&path);
+            if integrity.valid {
+                if let Some(id) = integrity.session_id {
+                    by_session_id.entry(id).or_default().push(name);
+                }
+            } else {
+                invalid.push((
+                    name,
+                    integrity
+                        .reason
+                        .unwrap_or_else(|| "invalid snapshot".to_string()),
+                ));
+            }
+        }
+        let split = by_session_id
+            .iter()
+            .filter(|(_, names)| names.len() > 1)
+            .map(|(session_id, names)| format!("{} => {}", session_id, names.join(", ")))
+            .collect::<Vec<_>>();
+        let mut out = String::new();
+        out.push_str("Session snapshot doctor\n");
+        out.push_str("-----------------------\n");
+        let _ = writeln!(out, "invalid_snapshots={}", invalid.len());
+        let _ = writeln!(out, "split_session_ids={}", split.len());
+        if !invalid.is_empty() {
+            out.push_str("invalid_details:\n");
+            for (name, reason) in invalid.into_iter().take(20) {
+                let _ = writeln!(out, "- {}: {}", name, reason);
+            }
+        }
+        if !split.is_empty() {
+            out.push_str("split_details:\n");
+            for row in split.into_iter().take(20) {
+                let _ = writeln!(out, "- {}", row);
+            }
+        }
+        out.push_str("Recommendation: `/save` now to create a fresh canonical checkpoint.");
+        emit_command_output(app, out.trim_end());
+        return Ok(CommandResult::Handled);
     }
     handle_resume_command(app, args)
 }
@@ -8678,6 +9059,176 @@ async fn handle_provider_command(app: &mut App) -> Result<CommandResult, AgentEr
     Ok(CommandResult::Handled)
 }
 
+async fn handle_auth_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let action = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .to_ascii_lowercase();
+    match action.as_str() {
+        "status" => {
+            let provider = app.current_runtime_provider();
+            let credential_present = crate::app::provider_api_key_from_env(&provider).is_some();
+            let state = if credential_present {
+                "present"
+            } else {
+                "missing"
+            };
+            emit_command_output(
+                app,
+                format!(
+                    "Auth status\nprovider: {}\nmodel: {}\ncredential: {}\nnext: `/auth verify` (passive refresh check) or `/auth refresh` (forced token refresh)",
+                    provider, app.current_model, state
+                ),
+            );
+        }
+        "verify" => {
+            let summary = app.verify_runtime_auth(false).await?;
+            emit_command_output(
+                app,
+                format!(
+                    "{}\nnext: if provider rejects again, run `/auth refresh` then retry.",
+                    summary
+                ),
+            );
+        }
+        "refresh" | "force" => {
+            let summary = app.verify_runtime_auth(true).await?;
+            emit_command_output(
+                app,
+                format!(
+                    "{}\nforced refresh complete; retry your request now.",
+                    summary
+                ),
+            );
+        }
+        _ => emit_command_output(
+            app,
+            "Usage: /auth [status|verify|refresh]\n- status: show active provider auth state\n- verify: passive credential hydration + verification\n- refresh: force OAuth/session token refresh",
+        ),
+    }
+    Ok(CommandResult::Handled)
+}
+
+fn handle_telemetry_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let action = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .to_ascii_lowercase();
+    let provider = app
+        .current_model
+        .split_once(':')
+        .map(|(p, _)| p.to_string())
+        .unwrap_or_else(|| "openai".to_string());
+    let provider_health = provider_health_snapshot(&provider);
+    let session = app.session_info();
+    let mut out = String::new();
+    let _ = writeln!(out, "Telemetry snapshot");
+    let _ = writeln!(out, "session: {}", session.session_id);
+    let _ = writeln!(out, "model: {}", app.current_model);
+    let _ = writeln!(out, "messages: {}", session.message_count);
+    let _ = writeln!(out, "provider health: {}", provider_health);
+
+    if let Some(repo_root) = detect_repo_root_from_cwd() {
+        let report_dir = repo_root.join(".sync-reports");
+        let eval = latest_json_report(&report_dir, "eval-trend-gate-")
+            .and_then(|p| summarize_gate_report(&p, "eval"))
+            .unwrap_or_else(|| "eval=unknown".to_string());
+        let autopilot = latest_json_report(&report_dir, "performance-autopilot-")
+            .and_then(|p| summarize_performance_autopilot_report(&p, "autopilot"))
+            .unwrap_or_else(|| "autopilot=unknown".to_string());
+        let replay = latest_json_report(&report_dir, "deterministic-replay-")
+            .and_then(|p| summarize_gate_report(&p, "replay"))
+            .unwrap_or_else(|| "replay=unknown".to_string());
+        let _ = writeln!(out, "gates: {}; {}; {}", eval, autopilot, replay);
+    }
+
+    if action == "lane" {
+        let _ = writeln!(
+            out,
+            "lane hints:\n- Ctrl+L toggle activity lane\n- Ctrl+O switch lane mode (live/cockpit)\n- Ctrl+G force transcript refresh + jump latest"
+        );
+    } else if action != "status" {
+        emit_command_output(
+            app,
+            "Usage: /telemetry [status|lane]\n- status: session/provider + gate snapshots\n- lane: status plus TUI activity-lane controls",
+        );
+        return Ok(CommandResult::Handled);
+    }
+
+    emit_command_output(app, out.trim_end());
+    Ok(CommandResult::Handled)
+}
+
+fn handle_runbook_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let action = args.first().copied().unwrap_or("list").to_ascii_lowercase();
+    if action == "list" || action == "status" {
+        emit_command_output(
+            app,
+            "Runbooks\n- auth-refresh: provider auth/session rejected\n- model-not-found: catalog drift / unknown model\n- contextlattice-connect: local memory integration bootstrap\n- tool-policy-deny: blocked by policy or sandbox profile\n- stream-finalization: stream done but transcript not finalized\n\nUse `/runbook show <name>`.",
+        );
+        return Ok(CommandResult::Handled);
+    }
+    if action == "show" {
+        let Some(name) = args.get(1).map(|v| v.to_ascii_lowercase()) else {
+            emit_command_output(app, "Usage: /runbook show <name>");
+            return Ok(CommandResult::Handled);
+        };
+        let body = match name.as_str() {
+            "auth-refresh" => {
+                "Runbook: auth-refresh\n1) `/auth status`\n2) `/auth refresh`\n3) retry prompt\n4) if still failing, run `/model` and confirm provider/model pair is valid for your account."
+            }
+            "model-not-found" => {
+                "Runbook: model-not-found\n1) `/model` and select a valid catalog model\n2) retry request\n3) if provider alias was stale, run `/auth verify` and re-check."
+            }
+            "contextlattice-connect" => {
+                "Runbook: contextlattice-connect\n1) ensure contextlattice tools are registered via `/tools`\n2) ask agent to run `contextlattice_search` first (not shell command `contextlattice`)\n3) checkpoint verified integration via `contextlattice_write`."
+            }
+            "tool-policy-deny" => {
+                "Runbook: tool-policy-deny\n1) inspect denial reason in tool card `[remediation]` section\n2) remove secret-like args from inline command payload\n3) retry with safer params or approved tool route (`/tools`)."
+            }
+            "stream-finalization" => {
+                "Runbook: stream-finalization\n1) wait for final transcript writeback (status shows `Finalizing response…`)\n2) avoid submitting a new prompt until finalization completes\n3) if UI appears stale, use Ctrl+G to refresh and jump latest."
+            }
+            _ => {
+                emit_command_output(
+                    app,
+                    format!(
+                        "Unknown runbook `{}`. Use `/runbook list` for available entries.",
+                        name
+                    ),
+                );
+                return Ok(CommandResult::Handled);
+            }
+        };
+        emit_command_output(app, body);
+        return Ok(CommandResult::Handled);
+    }
+    emit_command_output(app, "Usage: /runbook [list|show <name>]");
+    Ok(CommandResult::Handled)
+}
+
+fn provider_health_snapshot(provider: &str) -> &'static str {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "nous" | "google-gemini-cli" | "gemini-cli" | "gemini-oauth" | "qwen-oauth" => {
+            "oauth-capable"
+        }
+        "openai" | "anthropic" | "openrouter" => "api-key/session",
+        _ => "unknown",
+    }
+}
+
+fn detect_repo_root_from_cwd() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    for candidate in cwd.ancestors() {
+        if candidate.join(".git").exists() {
+            return Some(candidate.to_path_buf());
+        }
+    }
+    None
+}
+
 fn handle_profile_command(app: &mut App) -> Result<CommandResult, AgentError> {
     let home = hermes_config::hermes_home();
     let selected = app.config.profile.current.as_deref().unwrap_or("default");
@@ -9777,6 +10328,112 @@ fn plan_capability_preflight(app: &App, task: &str) -> (Option<String>, bool) {
     (Some(message), allowed)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskDepthProfile {
+    Shallow,
+    Balanced,
+    Deep,
+    Max,
+}
+
+impl TaskDepthProfile {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "shallow" | "fast" => Some(Self::Shallow),
+            "balanced" | "default" => Some(Self::Balanced),
+            "deep" | "thorough" => Some(Self::Deep),
+            "max" | "exhaustive" => Some(Self::Max),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Shallow => "shallow",
+            Self::Balanced => "balanced",
+            Self::Deep => "deep",
+            Self::Max => "max",
+        }
+    }
+}
+
+fn set_env_var_u64(key: &str, value: u64) {
+    std::env::set_var(key, value.to_string());
+}
+
+fn set_env_var_f64(key: &str, value: f64) {
+    std::env::set_var(key, format!("{value:.2}"));
+}
+
+fn apply_task_depth_profile(profile: TaskDepthProfile) {
+    std::env::set_var("HERMES_TASK_DEPTH_PROFILE", profile.as_str());
+    match profile {
+        TaskDepthProfile::Shallow => {
+            set_env_var_u64("HERMES_MAX_ITERATIONS", 18);
+            set_env_var_u64("HERMES_TOOL_CALL_MAX_CONCURRENCY", 10);
+            set_env_var_u64("HERMES_MAX_DELEGATE_DEPTH", 1);
+            set_env_var_u64("HERMES_PERF_GOV_WINDOW", 6);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_WARN_MS", 2800.0);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_CRITICAL_MS", 5200.0);
+            std::env::set_var("HERMES_REPO_REVIEW_BUDGET_PROFILE", "aggressive");
+        }
+        TaskDepthProfile::Balanced => {
+            set_env_var_u64("HERMES_MAX_ITERATIONS", 50);
+            set_env_var_u64("HERMES_TOOL_CALL_MAX_CONCURRENCY", 8);
+            set_env_var_u64("HERMES_MAX_DELEGATE_DEPTH", 2);
+            set_env_var_u64("HERMES_PERF_GOV_WINDOW", 8);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_WARN_MS", 3500.0);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_CRITICAL_MS", 6500.0);
+            std::env::set_var("HERMES_REPO_REVIEW_BUDGET_PROFILE", "balanced");
+        }
+        TaskDepthProfile::Deep => {
+            set_env_var_u64("HERMES_MAX_ITERATIONS", 120);
+            set_env_var_u64("HERMES_TOOL_CALL_MAX_CONCURRENCY", 6);
+            set_env_var_u64("HERMES_MAX_DELEGATE_DEPTH", 3);
+            set_env_var_u64("HERMES_PERF_GOV_WINDOW", 10);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_WARN_MS", 4800.0);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_CRITICAL_MS", 9000.0);
+            std::env::set_var("HERMES_REPO_REVIEW_BUDGET_PROFILE", "relaxed");
+        }
+        TaskDepthProfile::Max => {
+            set_env_var_u64("HERMES_MAX_ITERATIONS", 250);
+            set_env_var_u64("HERMES_TOOL_CALL_MAX_CONCURRENCY", 5);
+            set_env_var_u64("HERMES_MAX_DELEGATE_DEPTH", 4);
+            set_env_var_u64("HERMES_PERF_GOV_WINDOW", 12);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_WARN_MS", 6500.0);
+            set_env_var_f64("HERMES_PERF_GOV_LATENCY_CRITICAL_MS", 12000.0);
+            std::env::set_var("HERMES_REPO_REVIEW_BUDGET_PROFILE", "off");
+        }
+    }
+}
+
+fn current_task_depth_profile() -> TaskDepthProfile {
+    std::env::var("HERMES_TASK_DEPTH_PROFILE")
+        .ok()
+        .as_deref()
+        .and_then(TaskDepthProfile::parse)
+        .unwrap_or(TaskDepthProfile::Balanced)
+}
+
+fn task_depth_runtime_summary() -> String {
+    let profile = current_task_depth_profile();
+    let max_iters = std::env::var("HERMES_MAX_ITERATIONS").unwrap_or_else(|_| "50".to_string());
+    let tool_concurrency =
+        std::env::var("HERMES_TOOL_CALL_MAX_CONCURRENCY").unwrap_or_else(|_| "8".to_string());
+    let delegate_depth =
+        std::env::var("HERMES_MAX_DELEGATE_DEPTH").unwrap_or_else(|_| "2".to_string());
+    let repo_budget = std::env::var("HERMES_REPO_REVIEW_BUDGET_PROFILE")
+        .unwrap_or_else(|_| "balanced".to_string());
+    format!(
+        "task_depth profile={} max_iterations={} tool_concurrency={} max_delegate_depth={} repo_budget_profile={}",
+        profile.as_str(),
+        max_iters,
+        tool_concurrency,
+        delegate_depth,
+        repo_budget
+    )
+}
+
 fn handle_plan_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     if args.is_empty()
         || args
@@ -9785,7 +10442,7 @@ fn handle_plan_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Ag
     {
         emit_command_output(
             app,
-            "Planner controls:\n  /plan <task>          Queue a planning/research task in background\n  /plan status          Show queue health + active steering\n  /plan list            Show queue health + active steering\n  /plan clear           Clear queued/running status records\n  /plan caps [mode]     Optional capability router (`off|advisory|enforce`)",
+            "Planner controls:\n  /plan <task>          Queue a planning/research task in background\n  /plan status          Show queue health + active steering\n  /plan list            Show queue health + active steering\n  /plan clear           Clear queued/running status records\n  /plan caps [mode]     Optional capability router (`off|advisory|enforce`)\n  /plan depth [profile] Task-depth governor (`status|list|shallow|balanced|deep|max|clear`)",
         );
         return Ok(CommandResult::Handled);
     }
@@ -9820,6 +10477,58 @@ fn handle_plan_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Ag
         }
         return Ok(CommandResult::Handled);
     }
+    if sub == "depth" {
+        let next = args
+            .get(1)
+            .copied()
+            .unwrap_or("status")
+            .to_ascii_lowercase();
+        match next.as_str() {
+            "status" | "show" => emit_command_output(app, task_depth_runtime_summary()),
+            "list" => emit_command_output(
+                app,
+                "Task depth profiles:\n- shallow: quickest turn cadence; strict exploration trim\n- balanced: default profile for most sessions\n- deep: larger turn budget + lower concurrency for heavier analysis\n- max: exhaustive mode for very complex objective work\nUse `/plan depth <profile>` to apply.",
+            ),
+            "clear" => {
+                std::env::remove_var("HERMES_TASK_DEPTH_PROFILE");
+                for key in [
+                    "HERMES_MAX_ITERATIONS",
+                    "HERMES_TOOL_CALL_MAX_CONCURRENCY",
+                    "HERMES_MAX_DELEGATE_DEPTH",
+                    "HERMES_PERF_GOV_WINDOW",
+                    "HERMES_PERF_GOV_LATENCY_WARN_MS",
+                    "HERMES_PERF_GOV_LATENCY_CRITICAL_MS",
+                    "HERMES_REPO_REVIEW_BUDGET_PROFILE",
+                ] {
+                    std::env::remove_var(key);
+                }
+                apply_task_depth_profile(TaskDepthProfile::Balanced);
+                emit_command_output(
+                    app,
+                    format!("Task depth reset to defaults.\n{}", task_depth_runtime_summary()),
+                );
+            }
+            _ => {
+                let Some(profile) = TaskDepthProfile::parse(&next) else {
+                    emit_command_output(
+                        app,
+                        "Usage: /plan depth [status|list|shallow|balanced|deep|max|clear]",
+                    );
+                    return Ok(CommandResult::Handled);
+                };
+                apply_task_depth_profile(profile);
+                emit_command_output(
+                    app,
+                    format!(
+                        "Task depth profile set to `{}`.\n{}",
+                        profile.as_str(),
+                        task_depth_runtime_summary()
+                    ),
+                );
+            }
+        }
+        return Ok(CommandResult::Handled);
+    }
     if sub == "status" || sub == "list" {
         let (queued, running, completed, failed) = background_job_counts();
         let mut out = String::new();
@@ -9844,6 +10553,7 @@ fn handle_plan_command(app: &mut App, args: &[&str]) -> Result<CommandResult, Ag
             "  capability_router={}",
             plan_capability_mode().as_str()
         );
+        let _ = writeln!(out, "  {}", task_depth_runtime_summary());
         emit_command_output(app, out.trim_end());
         return Ok(CommandResult::Handled);
     }
@@ -10244,7 +10954,7 @@ fn handle_image_command(app: &mut App, args: &[&str]) -> Result<CommandResult, A
 }
 
 fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
-    let objective_usage = "Usage: `/objective <text>` or `/objective status|plan|constraints|counterfactual <scenario> | <expected_delta>|profile [status|list|general|me|set <id>]|context [status|list|max|balanced|fast]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|dag [status|rebuild|clear]|eval [status|tail [n]]|clear`.";
+    let objective_usage = "Usage: `/objective <text>` or `/objective status|verify|plan|constraints|counterfactual <scenario> | <expected_delta>|profile [status|list|general|me|set <id>]|context [status|list|max|balanced|fast]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|dag [status|rebuild|clear]|eval [status|tail [n]]|clear`.";
 
     if let Some(first) = args.first() {
         let cmd = first.trim().to_ascii_lowercase();
@@ -10713,6 +11423,107 @@ fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                     trend.updated_at
                 ),
             );
+            return Ok(CommandResult::Handled);
+        }
+
+        if cmd == "verify" {
+            let Some(contract) = load_objective_contract()? else {
+                emit_command_output(
+                    app,
+                    "No objective contract. Set one with `/objective <text>` before verify.",
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let trend = load_objective_eval_trend()?;
+            let ledger = load_objective_learning_ledger()?;
+            let latest = trend.samples.last().map(|s| s.score).unwrap_or(0.0);
+            let prev = if trend.samples.len() >= 2 {
+                trend
+                    .samples
+                    .get(trend.samples.len().saturating_sub(2))
+                    .map(|s| s.score)
+                    .unwrap_or(latest)
+            } else {
+                latest
+            };
+            let delta = latest - prev;
+            let avg = if trend.samples.is_empty() {
+                0.0
+            } else {
+                trend.samples.iter().map(|s| s.score).sum::<f64>() / trend.samples.len() as f64
+            };
+            let ledger_tail = ledger.entries.last();
+            let last_ledger_state = ledger_tail
+                .map(|entry| entry.objective_state.as_str())
+                .unwrap_or("unknown");
+            let has_contract = !contract.id.trim().is_empty();
+            let outcome = if !has_contract {
+                "unproven"
+            } else if latest >= 0.75 && delta >= -0.01 {
+                "advancing"
+            } else if latest <= 0.35 || delta < -0.05 {
+                "regressing"
+            } else if trend.samples.len() < 2 {
+                "unproven"
+            } else {
+                "flat"
+            };
+            let mut evidence_files: Vec<String> = Vec::new();
+            let mut verified_existing = 0usize;
+            if let Some(last_assistant) = app
+                .messages
+                .iter()
+                .rev()
+                .find(|m| m.role == hermes_core::MessageRole::Assistant)
+                .and_then(|m| m.content.as_deref())
+            {
+                if let Ok(path_re) = Regex::new(r"path=([^\s]+)") {
+                    for cap in path_re.captures_iter(last_assistant) {
+                        if let Some(path) = cap.get(1).map(|m| m.as_str().trim()) {
+                            if path.is_empty() {
+                                continue;
+                            }
+                            if !evidence_files.iter().any(|v| v == path) {
+                                let exists = Path::new(path).exists();
+                                if exists {
+                                    verified_existing += 1;
+                                }
+                                evidence_files.push(path.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+            let mut out = String::new();
+            out.push_str("Objective outcome verifier\n");
+            out.push_str("-------------------------\n");
+            let _ = writeln!(out, "objective_id={}", contract.id);
+            let _ = writeln!(out, "objective_state={}", outcome);
+            let _ = writeln!(out, "latest_score={:.3}", latest);
+            let _ = writeln!(out, "delta_vs_prev={:+.3}", delta);
+            let _ = writeln!(out, "avg_score={:.3}", avg);
+            let _ = writeln!(out, "trend_samples={}", trend.samples.len());
+            let _ = writeln!(out, "ledger_entries={}", ledger.entries.len());
+            let _ = writeln!(out, "ledger_last_state={}", last_ledger_state);
+            let _ = writeln!(out, "verified_files_present={}", verified_existing);
+            let _ = writeln!(out, "verified_files_total={}", evidence_files.len());
+            if evidence_files.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "note=no PATCH_VERIFIED path markers found in last assistant turn; file verification is unproven."
+                );
+            } else {
+                out.push_str("verified_paths:\n");
+                for path in evidence_files.iter().take(12) {
+                    let _ = writeln!(
+                        out,
+                        "- {} exists_now={}",
+                        path,
+                        yes_no(Path::new(path).exists())
+                    );
+                }
+            }
+            emit_command_output(app, out.trim_end());
             return Ok(CommandResult::Handled);
         }
 
@@ -11884,7 +12695,7 @@ fn handle_timetravel_command(app: &mut App, args: &[&str]) -> Result<CommandResu
         "undo" => handle_rollback_command(app, args),
         "branch" | "fork" => {
             let label = args.get(1).copied().unwrap_or("timetravel");
-            handle_session_compat_command(app, "/branch", &[label])
+            handle_branch_command(app, &[label])
         }
         other => {
             if other.parse::<usize>().is_ok() {
@@ -12276,6 +13087,261 @@ fn handle_sethome_command(app: &mut App, args: &[&str]) -> Result<CommandResult,
     Ok(CommandResult::Handled)
 }
 
+fn branch_checkpoint_name(session_id: &str, label: Option<&str>) -> String {
+    let requested = label.unwrap_or("branch").trim();
+    let sanitized = requested
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    format!(
+        "branch-{}-{}",
+        &session_id[..8.min(session_id.len())],
+        if sanitized.is_empty() {
+            "checkpoint"
+        } else {
+            sanitized.as_str()
+        }
+    )
+}
+
+fn handle_branch_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let sessions_dir = hermes_config::hermes_home().join("sessions");
+    let entries = enumerate_saved_sessions(&sessions_dir);
+    let action = args
+        .first()
+        .map(|v| v.to_ascii_lowercase())
+        .unwrap_or_else(|| "save".to_string());
+
+    match action.as_str() {
+        "help" => {
+            emit_command_output(
+                app,
+                "Usage: /branch [label]\n\
+                       /branch list\n\
+                       /branch diff <left> [right]\n\
+                       /branch merge <source> [target]\n\
+                 Notes:\n\
+                 - save: creates a branch checkpoint snapshot\n\
+                 - diff: compares message footprints between snapshots\n\
+                 - merge: appends unique messages from source into target/current session",
+            );
+            return Ok(CommandResult::Handled);
+        }
+        "list" | "ls" | "show" => {
+            if entries.is_empty() {
+                emit_command_output(app, "No snapshots found. Use `/branch <label>` first.");
+                return Ok(CommandResult::Handled);
+            }
+            let mut out = String::from("Branch checkpoints:\n");
+            let mut shown = 0usize;
+            for (name, path, _) in entries.iter() {
+                if !name.starts_with("branch-") {
+                    continue;
+                }
+                let integrity = inspect_snapshot_integrity(path);
+                let marker = if integrity.valid { "✓" } else { "⚠" };
+                let detail = if integrity.valid {
+                    format!("messages={}", integrity.message_count)
+                } else {
+                    integrity
+                        .reason
+                        .unwrap_or_else(|| "invalid snapshot".to_string())
+                };
+                let _ = writeln!(out, "  - {} `{}` ({})", marker, name, detail);
+                shown += 1;
+                if shown >= 25 {
+                    break;
+                }
+            }
+            if shown == 0 {
+                out.push_str("  (no branch-* checkpoints found)\n");
+            }
+            out.push_str(
+                "\nUse `/branch diff <left> [right]` or `/branch merge <source> [target]`.",
+            );
+            emit_command_output(app, out.trim_end());
+            return Ok(CommandResult::Handled);
+        }
+        "diff" => {
+            let Some(left_name) = args.get(1).copied() else {
+                emit_command_output(app, "Usage: /branch diff <left> [right]");
+                return Ok(CommandResult::Handled);
+            };
+            let right_name = args.get(2).copied().unwrap_or("latest");
+            let left_entry = match resolve_saved_session_entry(&entries, left_name) {
+                Ok(entry) => entry,
+                Err(err) if err.starts_with("not_found:") => {
+                    emit_command_output(app, format!("Snapshot '{}' not found.", left_name));
+                    return Ok(CommandResult::Handled);
+                }
+                Err(err) => {
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Snapshot '{}' is ambiguous. Matches: {}",
+                            left_name,
+                            err.trim_start_matches("ambiguous: ")
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+            };
+            let right_entry = if right_name.eq_ignore_ascii_case("latest") {
+                match entries.first() {
+                    Some(entry) => entry,
+                    None => {
+                        emit_command_output(app, "No snapshots found.");
+                        return Ok(CommandResult::Handled);
+                    }
+                }
+            } else {
+                match resolve_saved_session_entry(&entries, right_name) {
+                    Ok(entry) => entry,
+                    Err(err) if err.starts_with("not_found:") => {
+                        emit_command_output(app, format!("Snapshot '{}' not found.", right_name));
+                        return Ok(CommandResult::Handled);
+                    }
+                    Err(err) => {
+                        emit_command_output(
+                            app,
+                            format!(
+                                "Snapshot '{}' is ambiguous. Matches: {}",
+                                right_name,
+                                err.trim_start_matches("ambiguous: ")
+                            ),
+                        );
+                        return Ok(CommandResult::Handled);
+                    }
+                }
+            };
+            let left_messages = load_messages_from_snapshot(&left_entry.1)?;
+            let right_messages = load_messages_from_snapshot(&right_entry.1)?;
+            emit_command_output(
+                app,
+                summarize_branch_diff(
+                    &left_entry.0,
+                    &left_messages,
+                    &right_entry.0,
+                    &right_messages,
+                ),
+            );
+            return Ok(CommandResult::Handled);
+        }
+        "merge" => {
+            let Some(source_name) = args.get(1).copied() else {
+                emit_command_output(app, "Usage: /branch merge <source> [target]");
+                return Ok(CommandResult::Handled);
+            };
+            let source_entry = match resolve_saved_session_entry(&entries, source_name) {
+                Ok(entry) => entry,
+                Err(err) if err.starts_with("not_found:") => {
+                    emit_command_output(app, format!("Snapshot '{}' not found.", source_name));
+                    return Ok(CommandResult::Handled);
+                }
+                Err(err) => {
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Snapshot '{}' is ambiguous. Matches: {}",
+                            source_name,
+                            err.trim_start_matches("ambiguous: ")
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+            };
+
+            let mut target_label = "current".to_string();
+            let mut merged_messages = app.messages.clone();
+            if let Some(target_name) = args.get(2).copied() {
+                let target_entry = match resolve_saved_session_entry(&entries, target_name) {
+                    Ok(entry) => entry,
+                    Err(err) if err.starts_with("not_found:") => {
+                        emit_command_output(app, format!("Snapshot '{}' not found.", target_name));
+                        return Ok(CommandResult::Handled);
+                    }
+                    Err(err) => {
+                        emit_command_output(
+                            app,
+                            format!(
+                                "Snapshot '{}' is ambiguous. Matches: {}",
+                                target_name,
+                                err.trim_start_matches("ambiguous: ")
+                            ),
+                        );
+                        return Ok(CommandResult::Handled);
+                    }
+                };
+                target_label = target_entry.0.clone();
+                merged_messages = load_messages_from_snapshot(&target_entry.1)?;
+            }
+
+            let source_messages = load_messages_from_snapshot(&source_entry.1)?;
+            let mut seen: HashSet<String> = merged_messages.iter().map(message_signature).collect();
+            let mut appended = 0usize;
+            for msg in source_messages {
+                let sig = message_signature(&msg);
+                if seen.insert(sig) {
+                    merged_messages.push(msg);
+                    appended += 1;
+                }
+            }
+            let merged_total = merged_messages.len();
+            app.messages = merged_messages;
+            app.ui_messages
+                .retain(|msg| msg.insert_at <= app.messages.len());
+            let stem = branch_checkpoint_name(
+                &app.session_id,
+                Some(&format!("merge-{}-into-{}", source_entry.0, target_label)),
+            );
+            let path = app.persist_session_snapshot(Some(&stem))?;
+            emit_command_output(
+                app,
+                format!(
+                    "Branch merge complete.\n  source: {}\n  target: {}\n  appended_unique_messages: {}\n  merged_total_messages: {}\n  snapshot: {}",
+                    source_entry.0,
+                    target_label,
+                    appended,
+                    merged_total,
+                    path.display()
+                ),
+            );
+            return Ok(CommandResult::Handled);
+        }
+        _ => {}
+    }
+
+    let label = if args.is_empty() {
+        None
+    } else {
+        Some(args.join(" "))
+    };
+    let stem = branch_checkpoint_name(&app.session_id, label.as_deref());
+    match app.persist_session_snapshot(Some(&stem)) {
+        Ok(path) => emit_command_output(
+            app,
+            format!(
+                "Branch checkpoint saved: {}\nContinue in current session or run `/resume {}`.",
+                path.display(),
+                stem
+            ),
+        ),
+        Err(err) => emit_command_output(
+            app,
+            format!("Branch marker requested, but snapshot failed: {}", err),
+        ),
+    }
+    Ok(CommandResult::Handled)
+}
+
 fn handle_session_compat_command(
     app: &mut App,
     cmd: &str,
@@ -12290,42 +13356,7 @@ fn handle_session_compat_command(
                 format!("Session title marker set to: {}", arg_joined.trim())
             }
         }
-        "/branch" => {
-            let label = if arg_joined.trim().is_empty() {
-                "branch".to_string()
-            } else {
-                arg_joined.trim().to_string()
-            };
-            let sanitized = label
-                .chars()
-                .map(|c| {
-                    if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                        c
-                    } else {
-                        '-'
-                    }
-                })
-                .collect::<String>()
-                .trim_matches('-')
-                .to_string();
-            let stem = format!(
-                "branch-{}-{}",
-                &app.session_id[..8.min(app.session_id.len())],
-                if sanitized.is_empty() {
-                    "checkpoint"
-                } else {
-                    sanitized.as_str()
-                }
-            );
-            match app.persist_session_snapshot(Some(&stem)) {
-                Ok(path) => format!(
-                    "Branch checkpoint saved: {}\nContinue in current session or run `/resume {}`.",
-                    path.display(),
-                    stem
-                ),
-                Err(err) => format!("Branch marker requested, but snapshot failed: {}", err),
-            }
-        }
+        "/branch" => "Use `/branch` (native) for list/diff/merge/save controls.".to_string(),
         _ => "Compatibility command acknowledged.".to_string(),
     };
     emit_command_output(app, msg);
@@ -18500,6 +19531,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn slash_auth_status_command_is_handled() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        let result = handle_slash_command(&mut app, "/auth", &["status"])
+            .await
+            .expect("auth status");
+        assert_eq!(result, CommandResult::Handled);
+        let output = latest_ui_assistant_text(&app);
+        assert!(output.contains("Auth status"));
+    }
+
+    #[tokio::test]
+    async fn slash_runbook_and_telemetry_commands_are_handled() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        let runbook = handle_slash_command(&mut app, "/runbook", &["list"])
+            .await
+            .expect("runbook list");
+        assert_eq!(runbook, CommandResult::Handled);
+        assert!(latest_ui_assistant_text(&app).contains("Runbooks"));
+
+        let telemetry = handle_slash_command(&mut app, "/telemetry", &["status"])
+            .await
+            .expect("telemetry status");
+        assert_eq!(telemetry, CommandResult::Handled);
+        assert!(latest_ui_assistant_text(&app).contains("Telemetry snapshot"));
+    }
+
+    #[tokio::test]
     async fn promoted_sethome_command_sets_status_and_clears_marker() {
         let _guard = env_test_lock();
         let tmp = tempdir().expect("tempdir");
@@ -18820,6 +19886,14 @@ mod tests {
     }
 
     #[test]
+    fn test_whoami_alias_maps_to_profile() {
+        assert_eq!(canonical_command("/whoami"), "/profile");
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/whoami"));
+        let results = autocomplete("/who");
+        assert!(results.contains(&"/whoami"));
+    }
+
+    #[test]
     fn test_resume_command_is_registered_and_completable() {
         assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/resume"));
         let results = autocomplete("/res");
@@ -18879,6 +19953,7 @@ mod tests {
         assert_eq!(canonical_command("/reload-skills"), "/reload");
         assert_eq!(canonical_command("/reload_skills"), "/reload");
         assert_eq!(canonical_command("/summary"), "/recap");
+        assert_eq!(canonical_command("/whoami"), "/profile");
         assert_eq!(canonical_command("/footer"), "/statusbar");
         assert_eq!(canonical_command("/indicator"), "/statusbar");
         assert_eq!(canonical_command("/tasks"), "/kanban");
@@ -18887,6 +19962,7 @@ mod tests {
         assert_eq!(canonical_command("/bg"), "/background");
         assert_eq!(canonical_command("/curator"), "/skills");
         assert_eq!(canonical_command("/tt"), "/timetravel");
+        assert_eq!(canonical_command("/rb"), "/runbook");
     }
 
     #[test]
@@ -18909,13 +19985,52 @@ mod tests {
     }
 
     #[test]
+    fn task_depth_profile_application_sets_expected_env() {
+        let _guard = env_test_lock();
+        apply_task_depth_profile(TaskDepthProfile::Max);
+        assert_eq!(
+            std::env::var("HERMES_TASK_DEPTH_PROFILE").ok().as_deref(),
+            Some("max")
+        );
+        assert_eq!(
+            std::env::var("HERMES_MAX_ITERATIONS").ok().as_deref(),
+            Some("250")
+        );
+        assert_eq!(
+            std::env::var("HERMES_REPO_REVIEW_BUDGET_PROFILE")
+                .ok()
+                .as_deref(),
+            Some("off")
+        );
+
+        apply_task_depth_profile(TaskDepthProfile::Balanced);
+        assert_eq!(
+            std::env::var("HERMES_TASK_DEPTH_PROFILE").ok().as_deref(),
+            Some("balanced")
+        );
+        assert_eq!(
+            std::env::var("HERMES_MAX_ITERATIONS").ok().as_deref(),
+            Some("50")
+        );
+    }
+
+    #[test]
     fn test_recap_and_context_commands_are_registered() {
         assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/recap"));
         assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/context"));
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/auth"));
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/telemetry"));
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/runbook"));
         let recap = autocomplete("/rec");
         assert!(recap.contains(&"/recap"));
         let context = autocomplete("/cont");
         assert!(context.contains(&"/context"));
+        let auth = autocomplete("/au");
+        assert!(auth.contains(&"/auth"));
+        let telemetry = autocomplete("/tele");
+        assert!(telemetry.contains(&"/telemetry"));
+        let runbook = autocomplete("/runb");
+        assert!(runbook.contains(&"/runbook"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -31,7 +31,7 @@ use ratatui::widgets::{
 use ratatui::Frame;
 use tokio::sync::mpsc;
 use tui_textarea::{CursorMove, TextArea};
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use hermes_auth::FileTokenStore;
 use hermes_core::{AgentError, AgentResult, Message, StreamChunk};
@@ -437,6 +437,10 @@ pub struct TuiState {
     pub live_thinking: String,
     /// Last known token usage (prompt, completion, total).
     pub last_usage: Option<(u64, u64, u64)>,
+    /// Last total-token value emitted into activity lane.
+    last_usage_total_emitted: Option<u64>,
+    /// Monotonic sequence for activity-timeline rows.
+    timeline_seq: u64,
     /// Sticky prompt hint shown while scrolling history.
     pub sticky_prompt: String,
     /// Number of queued/running background jobs.
@@ -479,6 +483,8 @@ pub struct TuiState {
     processing_degraded: bool,
     /// Degraded lifecycle notes captured during current cycle.
     degraded_notes: Vec<String>,
+    /// Stream finished, waiting for `AgentRunComplete` to commit transcript.
+    awaiting_run_complete: bool,
 }
 
 /// A section of tool output that can be folded/expanded.
@@ -548,6 +554,8 @@ impl Default for TuiState {
             active_tools: Vec::new(),
             live_thinking: String::new(),
             last_usage: None,
+            last_usage_total_emitted: None,
+            timeline_seq: 0,
             sticky_prompt: String::new(),
             background_jobs_running: 0,
             activity_lane_open: true,
@@ -569,6 +577,7 @@ impl Default for TuiState {
             processing_phase_progress: 0,
             processing_degraded: false,
             degraded_notes: Vec::new(),
+            awaiting_run_complete: false,
         }
     }
 }
@@ -596,7 +605,9 @@ impl TuiState {
         if trimmed.is_empty() {
             return;
         }
-        self.recent_activity.push(trimmed);
+        self.timeline_seq = self.timeline_seq.saturating_add(1);
+        self.recent_activity
+            .push(format!("{:02}. {}", self.timeline_seq, trimmed));
         const MAX_EVENTS: usize = 16;
         if self.recent_activity.len() > MAX_EVENTS {
             let remove = self.recent_activity.len() - MAX_EVENTS;
@@ -630,6 +641,7 @@ impl TuiState {
 
     fn begin_processing_cycle(&mut self, model: &str) {
         self.processing = true;
+        self.awaiting_run_complete = true;
         self.processing_started_at = Some(Instant::now());
         self.last_progress_pulse_at = None;
         self.stream_chunk_count = 0;
@@ -641,6 +653,8 @@ impl TuiState {
         self.stream_muted = false;
         self.stream_needs_break = false;
         self.active_tools.clear();
+        self.last_usage_total_emitted = None;
+        self.timeline_seq = 0;
         self.live_thinking.clear();
         self.processing_phase = "preflight".to_string();
         self.processing_phase_label = "preparing request".to_string();
@@ -682,6 +696,7 @@ impl TuiState {
         self.processing_phase_progress = 0;
         self.processing_degraded = false;
         self.degraded_notes.clear();
+        self.awaiting_run_complete = false;
         self.jump_to_latest();
     }
 
@@ -2211,6 +2226,16 @@ fn looks_like_internal_scaffold_line(line: &str) -> bool {
         || lowered.contains("</arguments>")
         || lowered.contains("<name>")
         || lowered.contains("</name>")
+        || lowered.contains("<argument name=")
+        || lowered.contains("</argument>")
+        || lowered.contains("&lt;tool_use")
+        || lowered.contains("&lt;/tool_use")
+        || lowered.contains("&lt;tool_call")
+        || lowered.contains("&lt;/tool_call")
+        || lowered.contains("\\u003ctool_use")
+        || lowered.contains("\\u003c/tool_use")
+        || lowered.contains("\\u003ctool_call")
+        || lowered.contains("\\u003c/tool_call")
         || lowered.contains("invoke_result")
         || lowered.contains("invokn_result")
         || lowered.contains("to=functions.")
@@ -2264,6 +2289,23 @@ fn sanitize_line_to_default_language_ascii(line: &str, compact_ws: bool) -> Opti
         body.trim_end().to_string()
     };
     if body.trim().is_empty() {
+        return None;
+    }
+    let ascii_letters = body.chars().filter(|c| c.is_ascii_alphabetic()).count();
+    let ascii_graphics = body.chars().filter(|c| c.is_ascii_graphic()).count();
+    if ascii_graphics > 0 && ascii_letters == 0 {
+        let symbolic_ratio = body.chars().filter(|c| !c.is_ascii_alphanumeric()).count() as f64
+            / ascii_graphics as f64;
+        if symbolic_ratio > 0.85 {
+            return None;
+        }
+    }
+    let lower = body.to_ascii_lowercase();
+    if lower.contains("<tool_call")
+        || lower.contains("</tool_call")
+        || lower.contains("<tool_use>")
+        || lower.contains("</tool_use>")
+    {
         return None;
     }
     Some(format!("{leading}{body}"))
@@ -2594,6 +2636,12 @@ fn format_tool_message_lines(content: &str) -> Vec<String> {
                 push_block(&mut lines, key, value);
             }
         }
+        if let Some(remediation) = tool_policy_remediation_from_payload(obj) {
+            lines.push("[remediation]".to_string());
+            for row in remediation {
+                lines.push(format!("- {}", row));
+            }
+        }
 
         let mut extras = serde_json::Map::new();
         for (k, v) in obj.iter() {
@@ -2624,6 +2672,69 @@ fn format_tool_message_lines(content: &str) -> Vec<String> {
                 .map(std::string::ToString::to_string)
                 .collect()
         })
+}
+
+fn tool_policy_remediation_from_payload(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Option<Vec<String>> {
+    let code = obj
+        .get("policy")
+        .and_then(|p| p.get("code"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let error_text = obj
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let blocked = error_text.contains("blocked by tool policy")
+        || error_text.contains("denied by security policy")
+        || !code.is_empty();
+    if !blocked {
+        return None;
+    }
+
+    let mut rows = Vec::new();
+    match code.as_str() {
+        "params_pattern_denied" => {
+            rows.push(
+                "Remove secret-like parameter names from tool args; pass secrets via local env/vault.".to_string(),
+            );
+            rows.push(
+                "Retry with sanitized args that reference variable names, not credential material."
+                    .to_string(),
+            );
+        }
+        "params_too_large" => {
+            rows.push(
+                "Reduce payload size and pass only minimal fields required by the tool."
+                    .to_string(),
+            );
+        }
+        "tool_denylisted" | "tool_not_allowlisted" => {
+            rows.push(
+                "Switch to an approved tool surface (`/tools`) for this operation.".to_string(),
+            );
+        }
+        "sandbox_profile_violation" => {
+            rows.push(
+                "Command matched sandbox denial pattern; use a safer equivalent command path."
+                    .to_string(),
+            );
+            rows.push(
+                "If necessary, change runtime sandbox policy explicitly before retrying."
+                    .to_string(),
+            );
+        }
+        _ => {
+            rows.push(
+                "Review policy decision details in `/ops status` and retry with safer parameters."
+                    .to_string(),
+            );
+        }
+    }
+    Some(rows)
 }
 
 fn append_transcript_message_lines(
@@ -3078,8 +3189,8 @@ fn approximate_visual_rows(lines: &[Line<'static>], wrap_width: u16) -> usize {
     lines
         .iter()
         .map(|line| {
-            let chars = line.to_string().chars().count().max(1);
-            ((chars - 1) / width) + 1
+            let display_width = UnicodeWidthStr::width(line.to_string().as_str()).max(1);
+            ((display_width - 1) / width) + 1
         })
         .sum::<usize>()
         .max(1)
@@ -4280,6 +4391,39 @@ fn handle_agent_run_complete(
     state.stream_muted = false;
     state.stream_needs_break = false;
     state.active_tools.clear();
+    state.awaiting_run_complete = false;
+}
+
+fn extract_file_like_hints(text: &str, limit: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    for token in text.split_whitespace() {
+        if out.len() >= limit {
+            break;
+        }
+        let cleaned = token
+            .trim_matches(|c: char| {
+                c == '"' || c == '\'' || c == ',' || c == ';' || c == ')' || c == '('
+            })
+            .to_string();
+        if cleaned.len() < 4 {
+            continue;
+        }
+        let looks_like_path = cleaned.contains('/')
+            || cleaned.ends_with(".rs")
+            || cleaned.ends_with(".py")
+            || cleaned.ends_with(".toml")
+            || cleaned.ends_with(".md")
+            || cleaned.ends_with(".json")
+            || cleaned.ends_with(".yaml")
+            || cleaned.ends_with(".yml");
+        if !looks_like_path {
+            continue;
+        }
+        if !out.iter().any(|v| v == &cleaned) {
+            out.push(cleaned);
+        }
+    }
+    out
 }
 
 fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) -> bool {
@@ -4348,6 +4492,10 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
                                 } else {
                                     state.push_activity(format!("▶ {} {}", tool, args_preview));
                                 }
+                                state.push_activity(format!(
+                                    "Δtools active={}",
+                                    state.active_tools.len()
+                                ));
                             }
                             "tool_complete" => {
                                 let tool = extra
@@ -4370,6 +4518,13 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
                                     state.push_activity(format!("✓ {}", tool));
                                 } else {
                                     state.push_activity(format!("✓ {} {}", tool, result_preview));
+                                    let file_hints = extract_file_like_hints(result_preview, 3);
+                                    if !file_hints.is_empty() {
+                                        state.push_activity(format!(
+                                            "Δfiles {}",
+                                            file_hints.join(", ")
+                                        ));
+                                    }
                                 }
                             }
                             "status" => {
@@ -4454,6 +4609,9 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
                                 .unwrap_or_default();
                             state.push_activity(format!("↧ first token in {}ms", first_token_ms));
                         }
+                        if state.auto_follow_transcript {
+                            state.scroll_offset = 0;
+                        }
                     }
                 }
             }
@@ -4463,16 +4621,35 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
                     usage.completion_tokens,
                     usage.total_tokens,
                 ));
+                let previous = state.last_usage_total_emitted.unwrap_or(0);
+                if usage.total_tokens >= previous.saturating_add(64)
+                    || state.last_usage_total_emitted.is_none()
+                {
+                    let delta_total = usage.total_tokens.saturating_sub(previous);
+                    state.push_activity(format!(
+                        "Δtokens p={} c={} t={} (+{})",
+                        usage.prompt_tokens,
+                        usage.completion_tokens,
+                        usage.total_tokens,
+                        delta_total
+                    ));
+                    state.last_usage_total_emitted = Some(usage.total_tokens);
+                }
             }
             true
         }
         Event::AgentDone => {
-            state.finish_processing_cycle("✔ completed in");
-            state.stream_buffer.clear();
-            state.stream_muted = false;
-            state.stream_needs_break = false;
-            state.active_tools.clear();
-            state.status_message.clear();
+            if state.awaiting_run_complete {
+                state.push_activity("finalizing transcript writeback…".to_string());
+                state.status_message = "Finalizing response…".to_string();
+            } else {
+                state.finish_processing_cycle("✔ completed in");
+                state.stream_buffer.clear();
+                state.stream_muted = false;
+                state.stream_needs_break = false;
+                state.active_tools.clear();
+                state.status_message.clear();
+            }
             true
         }
         Event::AgentRunComplete {
@@ -5341,6 +5518,18 @@ mod tests {
     }
 
     #[test]
+    fn test_format_tool_message_lines_adds_policy_remediation_block() {
+        let payload = r#"{
+  "error":"Blocked by tool policy: tool params matched deny pattern '(?i)api[_-]?key'",
+  "policy":{"code":"params_pattern_denied","mode":"enforce"}
+}"#;
+        let lines = format_tool_message_lines(payload);
+        let joined = lines.join("\n");
+        assert!(joined.contains("[remediation]"));
+        assert!(joined.contains("Remove secret-like parameter names"));
+    }
+
+    #[test]
     fn test_approximate_visual_rows_wraps_long_lines() {
         let lines = vec![Line::from("x".repeat(120))];
         assert_eq!(approximate_visual_rows(&lines, 40), 3);
@@ -5454,6 +5643,12 @@ mod tests {
     #[test]
     fn test_scaffold_detector_matches_embedded_tool_tags() {
         let line = "random prefix <tool_use><name>terminal</name></tool_use> suffix";
+        assert!(looks_like_internal_scaffold_line(line));
+    }
+
+    #[test]
+    fn test_scaffold_detector_matches_escaped_tool_tags() {
+        let line = "noise \\u003ctool_use\\u003e <argument name=\"skill\">x</argument>";
         assert!(looks_like_internal_scaffold_line(line));
     }
 

--- a/docs/implementation/surfaces-envy-1-8-2026-05-11.md
+++ b/docs/implementation/surfaces-envy-1-8-2026-05-11.md
@@ -1,0 +1,43 @@
+# Missing Surfaces 1-8 + Envy Features 1-8 (2026-05-11)
+
+Scope: complete the remaining high-signal UX/runtime deltas without duplicating previously landed parity work.
+
+## Surgical Plan
+
+1. Missing Surface 1: eliminate stream-finalization race so completed runs do not appear one turn late.
+2. Missing Surface 2: suppress leaked internal scaffold/tool markup in rendered transcript.
+3. Missing Surface 3: add first-class auth lifecycle slash surface for active provider runtime credentials.
+4. Missing Surface 4: add fast telemetry slash surface for lane/runtime/gate status from the active session.
+5. Missing Surface 5: add failure-first runbooks as slash surface to reduce operator recovery latency.
+6. Missing Surface 6: harden session snapshot integrity flows (`/sessions doctor`, resume validity checks).
+7. Missing Surface 7: add task-depth controls so long/complex tasks are explicit and tunable at runtime.
+8. Missing Surface 8: add objective verification output that includes concrete file existence verification signals.
+
+9. Envy Feature 1: operator control for repo-review tool profile mode (`off|balanced|focus`).
+10. Envy Feature 2: explicit operator escape hatch for tool-profile narrowing in active requests.
+11. Envy Feature 3: richer activity-lane telemetry with delta markers (`Δtokens`, `Δtools`, `Δfiles`).
+12. Envy Feature 4: policy-deny remediation hints inline in tool cards.
+13. Envy Feature 5: broaden slash alias ergonomics (`/whoami`, `/rb`) and reduce compatibility friction.
+14. Envy Feature 6: branch checkpoint ergonomics (`/branch list|diff|merge`) for session forking workflows.
+15. Envy Feature 7: route-health detail surfacing inside `/qos` and `/ops` output paths.
+16. Envy Feature 8: objective verify mode (`/objective verify`) with trend+ledger+artifact presence summary.
+
+## Implementation Notes (No Duplicate Work)
+
+- Reused and extended existing command framework, activity lane, and objective ledger/trend infrastructure.
+- Avoided re-adding already shipped parity surfaces (capability router, mission/autopilot, context governance).
+- Added only missing operational glue and hardening behavior on top of existing Rust-native architecture.
+
+## Verification
+
+- Rust tests (targeted):
+  - `/auth`, `/runbook`, `/telemetry` command handler coverage
+  - scaffold suppression + tool policy remediation rendering tests
+  - repo-review tool-profile mode/escape-hatch tests
+  - command-registry compatibility tests
+- UI-TUI test: `externalLink` helper suite
+- Interactive PTY smoke test against real `hermes-agent-ultra` binary:
+  - `/auth status`
+  - `/runbook list`
+  - `/telemetry lane`
+  - live prompt execution path with real auth failure surfaced in transcript

--- a/ui-tui/scripts/build.mjs
+++ b/ui-tui/scripts/build.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Bundles src/entry.tsx into a single self-contained dist/entry.js.
+// No runtime node_modules needed.
+import { build } from 'esbuild'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '..')
+const out = resolve(root, 'dist/entry.js')
+
+// `react-devtools-core` is only imported when DEV=true at runtime (Ink dev
+// mode). Stub it out so the bundle doesn't carry the dep.
+const stubDevtools = {
+  name: 'stub-react-devtools-core',
+  setup(b) {
+    b.onResolve({ filter: /^react-devtools-core$/ }, args => ({
+      path: args.path,
+      namespace: 'stub-devtools'
+    }))
+    b.onLoad({ filter: /.*/, namespace: 'stub-devtools' }, () => ({
+      contents: 'export default { initialize() {}, connectToDevTools() {} }',
+      loader: 'js'
+    }))
+  }
+}
+
+await build({
+  entryPoints: [resolve(root, 'src/entry.tsx')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node20',
+  outfile: out,
+  jsx: 'automatic',
+  jsxImportSource: 'react',
+  // Skip the prebuilt @hermes/ink bundle — esbuild's __esm helper doesn't
+  // await nested async init, which breaks lazy-initialized exports like
+  // `render`. Bundling from source sidesteps that.
+  alias: { '@hermes/ink': resolve(root, 'packages/hermes-ink/src/entry-exports.ts') },
+  plugins: [stubDevtools],
+  // Some transitive deps use CommonJS `require(...)` at runtime. ESM bundles
+  // don't get a `require` binding automatically, so we inject one.
+  banner: {
+    js: "import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);"
+  },
+  logLevel: 'info'
+})
+
+// esbuild preserves the shebang from src/entry.tsx into the bundle, but Nix's
+// patchShebangs phase mangles `/usr/bin/env -S node --foo --bar` (it strips
+// the `node` token, leaving a broken interpreter). The hermes_cli launcher
+// always invokes this file as `node dist/entry.js` anyway, so the shebang is
+// redundant — strip it.
+const body = readFileSync(out, 'utf8')
+if (body.startsWith('#!')) {
+  writeFileSync(out, body.slice(body.indexOf('\n') + 1))
+}
+
+console.log(`built ${out}`)

--- a/ui-tui/src/__tests__/externalLink.test.ts
+++ b/ui-tui/src/__tests__/externalLink.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  __resetLinkTitleCache,
+  fetchLinkTitle,
+  hostPathLabel,
+  isTitleFetchable,
+  normalizeExternalUrl,
+  urlSlugTitleLabel
+} from '../lib/externalLink.js'
+
+afterEach(() => {
+  __resetLinkTitleCache()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('external link helpers', () => {
+  it('formats URL fallbacks as host + path', () => {
+    expect(
+      hostPathLabel(
+        'https://www.getyourguide.com/culebra-island-l145468/from-fajardo-full-day-cordillera-islands-catamaran-tour-t19894/'
+      )
+    ).toBe('getyourguide.com/culebra-island-l145468/from-fajardo-full-day-cordillera-islands-catamaran-tour-t19894')
+  })
+
+  it('derives readable title fallbacks from URL slugs', () => {
+    expect(
+      urlSlugTitleLabel('https://www.getyourguide.com/fajardo-l882/from-fajardo-icacos-island-full-day-catamaran-trip-t19891/')
+    ).toBe('From Fajardo Icacos Island Full Day Catamaran Trip')
+  })
+
+  it('normalizes scheme-less links', () => {
+    expect(normalizeExternalUrl(' expedia.com/things-to-do/puerto-rico-el-yunque ')).toBe(
+      'https://expedia.com/things-to-do/puerto-rico-el-yunque'
+    )
+  })
+
+  it('filters out local/non-http targets for title fetches', () => {
+    expect(isTitleFetchable('https://www.expedia.com/things-to-do/foo')).toBe(true)
+    expect(isTitleFetchable('http://localhost:5174')).toBe(false)
+    expect(isTitleFetchable('file:///tmp/demo.html')).toBe(false)
+    expect(isTitleFetchable('mailto:hello@example.com')).toBe(false)
+  })
+
+  it('blocks private, link-local, and intranet hosts', () => {
+    expect(isTitleFetchable('http://10.0.0.12/path')).toBe(false)
+    expect(isTitleFetchable('http://172.22.5.4/path')).toBe(false)
+    expect(isTitleFetchable('http://192.168.1.22/path')).toBe(false)
+    expect(isTitleFetchable('http://169.254.169.254/latest/meta-data')).toBe(false)
+    expect(isTitleFetchable('http://[fd00::1]/')).toBe(false)
+    expect(isTitleFetchable('http://[fe80::1]/')).toBe(false)
+    expect(isTitleFetchable('http://printer.local/status')).toBe(false)
+    expect(isTitleFetchable('http://intranet/status')).toBe(false)
+    expect(isTitleFetchable('https://8.8.8.8/status')).toBe(true)
+  })
+
+  it('deduplicates in-flight title fetches and caches results', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>El Yunque Tour Water Slide, Rope Swing & Pickup</title></head></html>', {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const url = 'https://www.expedia.com/things-to-do/puerto-rico-el-yunque-rainforest-adventure.a46272756.activity-details'
+    const [first, second] = await Promise.all([fetchLinkTitle(url), fetchLinkTitle(url)])
+
+    expect(first).toBe('El Yunque Tour Water Slide, Rope Swing & Pickup')
+    expect(second).toBe('El Yunque Tour Water Slide, Rope Swing & Pickup')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const third = await fetchLinkTitle(url)
+
+    expect(third).toBe('El Yunque Tour Water Slide, Rope Swing & Pickup')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares cache across protocol/www URL variants', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>Shared Canonical Title</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = 'https://www.getyourguide.com/san-juan-puerto-rico-l355/sunset-tours-tc306/'
+    const second = 'http://getyourguide.com/san-juan-puerto-rico-l355/sunset-tours-tc306/'
+
+    const [a, b] = await Promise.all([fetchLinkTitle(first), fetchLinkTitle(second)])
+
+    expect(a).toBe('Shared Canonical Title')
+    expect(b).toBe('Shared Canonical Title')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores error-like fetched titles', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>Just a moment...</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const url = 'https://www.getyourguide.com/culebra-island-l145468/from-fajardo-full-day-cordillera-islands-catamaran-tour-t19894/'
+
+    await expect(fetchLinkTitle(url)).resolves.toBe('')
+  })
+
+  it('decodes HTML entities in fetched titles', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><head><title>AT&amp;T &#39;Deals&#39;</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchLinkTitle('https://example.com/offers')).resolves.toBe("AT&T 'Deals'")
+  })
+
+  it('skips network fetch for non-fetchable targets', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchLinkTitle('http://localhost:3000/path')).resolves.toBe('')
+    await expect(fetchLinkTitle('mailto:hello@example.com')).resolves.toBe('')
+    await expect(fetchLinkTitle('file:///tmp/demo.html')).resolves.toBe('')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/ui-tui/src/lib/externalLink.ts
+++ b/ui-tui/src/lib/externalLink.ts
@@ -1,0 +1,429 @@
+import { isIP } from 'node:net'
+
+import { useEffect, useMemo, useState } from 'react'
+
+const titleCache = new Map<string, string>()
+const titleInflight = new Map<string, Promise<string>>()
+const titleSubs = new Map<string, Set<(value: string) => void>>()
+
+const TITLE_CACHE_LIMIT = 500
+const TITLE_MAX_LENGTH = 240
+const TITLE_BYTE_BUDGET = 96 * 1024
+const TITLE_TIMEOUT_MS = 5000
+
+const TITLE_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
+
+const TITLE_ERROR_RE =
+  /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|request blocked|too many requests)\b/i
+
+const DOMAIN_RE = /^(?:www\.)?[a-z0-9](?:[a-z0-9-]*\.)+[a-z]{2,}(?::\d+)?(?:[/?#][^\s]*)?$/i
+const SKIP_PROTO_RE = /^(?:file|data|mailto|javascript|blob|chrome|about|hermes):/i
+const LOCAL_HOSTNAME_RE = /^(?:localhost|localhost\.localdomain)$/i
+const LOCAL_HOST_SUFFIXES = ['.corp', '.home', '.internal', '.lan', '.local', '.localdomain']
+
+const HTML_ENTITIES: Record<string, string> = {
+  '#39': "'",
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  nbsp: ' ',
+  quot: '"'
+}
+
+export function normalizeExternalUrl(value: string): string {
+  const trimmed = value.trim()
+
+  if (!trimmed || /^https?:\/\//i.test(trimmed)) {
+    return trimmed
+  }
+
+  return DOMAIN_RE.test(trimmed) ? `https://${trimmed}` : trimmed
+}
+
+function parseUrl(value: string): null | URL {
+  try {
+    return new URL(normalizeExternalUrl(value))
+  } catch {
+    return null
+  }
+}
+
+function titleCacheKey(value: string): string {
+  const url = parseUrl(value)
+
+  if (!url) {
+    return normalizeExternalUrl(value)
+  }
+
+  const host = url.hostname.replace(/^www\./i, '').toLowerCase()
+  const pathname = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '') || '/'
+
+  return `${host}${pathname}${url.search || ''}`
+}
+
+function cacheTitle(key: string, title: string): void {
+  if (titleCache.size >= TITLE_CACHE_LIMIT) {
+    titleCache.delete(titleCache.keys().next().value as string)
+  }
+
+  titleCache.set(key, title)
+}
+
+export function hostPathLabel(value: string): string {
+  const url = parseUrl(value)
+
+  if (!url) {
+    return value
+  }
+
+  const host = url.hostname.replace(/^www\./, '')
+  const path = url.pathname && url.pathname !== '/' ? url.pathname.replace(/\/$/, '') : ''
+
+  return `${host}${path}`
+}
+
+function cleanSlug(segment: string): string {
+  try {
+    return decodeURIComponent(segment)
+      .replace(/\.a\d+\..*$/i, '')
+      .replace(/\.(?:html?|php|aspx?)$/i, '')
+      .replace(/(?:[-_.](?:[a-z]{1,3}\d{2,}|i\d{2,}))+$/i, '')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  } catch {
+    return ''
+  }
+}
+
+export function urlSlugTitleLabel(value: string): string {
+  const url = parseUrl(value)
+
+  for (const segment of url?.pathname.split('/').filter(Boolean).reverse() ?? []) {
+    const cleaned = cleanSlug(segment)
+
+    if (!cleaned || !/[a-z]/i.test(cleaned)) {
+      continue
+    }
+
+    if (/^(?:[a-z]{1,3}\d+|\d+)$/i.test(cleaned.replace(/\s+/g, ''))) {
+      continue
+    }
+
+    const titled = cleaned.replace(/\b[a-z]/g, c => c.toUpperCase())
+
+    if (titled.length >= 4) {
+      return titled
+    }
+  }
+
+  return hostPathLabel(value)
+}
+
+function parseIpv4Octets(value: string): null | [number, number, number, number] {
+  const parts = value.split('.')
+
+  if (parts.length !== 4) {
+    return null
+  }
+
+  const octets: number[] = []
+
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) {
+      return null
+    }
+
+    const next = Number(part)
+
+    if (!Number.isInteger(next) || next < 0 || next > 255) {
+      return null
+    }
+
+    octets.push(next)
+  }
+
+  return [octets[0]!, octets[1]!, octets[2]!, octets[3]!]
+}
+
+function isPrivateIpv4(value: string): boolean {
+  const octets = parseIpv4Octets(value)
+
+  if (!octets) {
+    return false
+  }
+
+  const [a, b] = octets
+
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    a === 255 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19))
+  )
+}
+
+function isPrivateIpv6(value: string): boolean {
+  const normalized = value.toLowerCase()
+
+  if (normalized === '::' || normalized === '::1') {
+    return true
+  }
+
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) {
+    return true
+  }
+
+  if (normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')) {
+    return true
+  }
+
+  if (normalized.startsWith('::ffff:')) {
+    return isPrivateIpv4(normalized.slice('::ffff:'.length))
+  }
+
+  return false
+}
+
+function normalizeHostname(value: string): string {
+  const withoutBrackets = value.replace(/^\[/, '').replace(/\]$/, '')
+  const withoutZoneId = withoutBrackets.split('%', 1)[0]!
+
+  return withoutZoneId.replace(/\.$/, '').toLowerCase()
+}
+
+function isPrivateOrLocalHost(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname)
+
+  if (!normalized) {
+    return true
+  }
+
+  if (LOCAL_HOSTNAME_RE.test(normalized)) {
+    return true
+  }
+
+  if (LOCAL_HOST_SUFFIXES.some(suffix => normalized.endsWith(suffix))) {
+    return true
+  }
+
+  const ipVersion = isIP(normalized)
+
+  if (ipVersion === 4) {
+    return isPrivateIpv4(normalized)
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6(normalized)
+  }
+
+  // Single-label hostnames are usually LAN names or enterprise intranet aliases.
+  return !normalized.includes('.')
+}
+
+export function isTitleFetchable(value: string): boolean {
+  if (!value || SKIP_PROTO_RE.test(value)) {
+    return false
+  }
+
+  const url = parseUrl(value)
+
+  return Boolean(url && /^https?:$/.test(url.protocol) && !isPrivateOrLocalHost(url.hostname))
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&(amp|lt|gt|quot|apos|nbsp|#39);/gi, (_match, key: string) => HTML_ENTITIES[key.toLowerCase()] ?? '')
+    .replace(/&#x([0-9a-f]+);/gi, (_match, hex: string) => String.fromCodePoint(parseInt(hex, 16) || 32))
+    .replace(/&#(\d+);/g, (_match, decimal: string) => String.fromCodePoint(parseInt(decimal, 10) || 32))
+}
+
+function parseHtmlTitle(html: string): string {
+  const raw = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]
+
+  return raw ? decodeHtmlEntities(raw).replace(/\s+/g, ' ').trim() : ''
+}
+
+async function readResponseSnippet(response: Response): Promise<string> {
+  const reader = response.body?.getReader()
+
+  if (!reader) {
+    return (await response.text()).slice(0, TITLE_BYTE_BUDGET)
+  }
+
+  const chunks: Uint8Array[] = []
+  let done = false
+  let bytes = 0
+
+  try {
+    while (bytes < TITLE_BYTE_BUDGET) {
+      const chunk = await reader.read()
+
+      if (chunk.done) {
+        done = true
+
+        break
+      }
+
+      const value = chunk.value
+
+      if (!value?.length) {
+        continue
+      }
+
+      const remaining = TITLE_BYTE_BUDGET - bytes
+      const next = value.length > remaining ? value.subarray(0, remaining) : value
+
+      chunks.push(next)
+      bytes += next.length
+
+      if (next.length < value.length) {
+        break
+      }
+    }
+  } catch {
+    return ''
+  } finally {
+    if (!done) {
+      try {
+        await reader.cancel()
+      } catch {
+        // Ignore stream teardown failures.
+      }
+    }
+  }
+
+  if (!chunks.length) {
+    return ''
+  }
+
+  const joined = new Uint8Array(bytes)
+  let offset = 0
+
+  for (const chunk of chunks) {
+    joined.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return new TextDecoder().decode(joined)
+}
+
+function usableTitle(value: string): string {
+  const clean = value.replace(/\s+/g, ' ').trim()
+
+  return clean && !TITLE_ERROR_RE.test(clean) ? clean : ''
+}
+
+async function fetchHtmlTitle(normalizedUrl: string): Promise<string> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TITLE_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(normalizedUrl, {
+      headers: {
+        Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
+        'Accept-Language': 'en-US,en;q=0.7',
+        'User-Agent': TITLE_USER_AGENT
+      },
+      redirect: 'follow',
+      signal: controller.signal
+    })
+
+    if (!response.ok) {
+      return ''
+    }
+
+    const contentType = response.headers.get('content-type')
+
+    if (contentType && !/(?:html|xml|text\/html)/i.test(contentType)) {
+      return ''
+    }
+
+    const html = await readResponseSnippet(response)
+
+    return parseHtmlTitle(html).slice(0, TITLE_MAX_LENGTH)
+  } catch {
+    return ''
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function fetchLinkTitle(url: string): Promise<string> {
+  const normalizedUrl = normalizeExternalUrl(url)
+  const key = titleCacheKey(normalizedUrl)
+
+  if (!isTitleFetchable(normalizedUrl)) {
+    return Promise.resolve('')
+  }
+
+  if (titleCache.has(key)) {
+    return Promise.resolve(titleCache.get(key) ?? '')
+  }
+
+  const pending = titleInflight.get(key)
+
+  if (pending) {
+    return pending
+  }
+
+  const promise = fetchHtmlTitle(normalizedUrl)
+    .then(usableTitle)
+    .catch(() => '')
+    .then(clean => {
+      cacheTitle(key, clean)
+      titleSubs.get(key)?.forEach(sub => sub(clean))
+
+      return clean
+    })
+    .finally(() => {
+      titleInflight.delete(key)
+    })
+
+  titleInflight.set(key, promise)
+
+  return promise
+}
+
+export function useLinkTitle(url?: null | string): string {
+  const normalizedUrl = useMemo(() => (url ? normalizeExternalUrl(url) : ''), [url])
+  const key = useMemo(() => (normalizedUrl ? titleCacheKey(normalizedUrl) : ''), [normalizedUrl])
+  const [title, setTitle] = useState(() => (key ? (titleCache.get(key) ?? '') : ''))
+
+  useEffect(() => {
+    setTitle(key ? (titleCache.get(key) ?? '') : '')
+
+    if (!key || !isTitleFetchable(normalizedUrl)) {
+      return
+    }
+
+    const subs = titleSubs.get(key) ?? new Set<(value: string) => void>()
+
+    subs.add(setTitle)
+    titleSubs.set(key, subs)
+    void fetchLinkTitle(normalizedUrl)
+
+    return () => {
+      subs.delete(setTitle)
+
+      if (!subs.size) {
+        titleSubs.delete(key)
+      }
+    }
+  }, [key, normalizedUrl])
+
+  return title
+}
+
+export function __resetLinkTitleCache(): void {
+  titleCache.clear()
+  titleInflight.clear()
+  titleSubs.clear()
+}


### PR DESCRIPTION
## Summary\n- close missing runtime surfaces with first-class slash controls (, , )\n- harden TUI stream finalization, scaffold suppression, and policy remediation rendering\n- add repo-review tool-profile operator controls and objective/session verification ergonomics\n- add UI-TUI external-link normalization + safe title-fetch helper with tests\n- record surgical 1-8 closure plan/proof doc\n\n## Validation\n- cargo fmt\n- cargo test -p hermes-cli slash_auth_status_command_is_handled -- --nocapture\n- cargo test -p hermes-cli slash_runbook_and_telemetry_commands_are_handled -- --nocapture\n- cargo test -p hermes-cli test_scaffold_detector_matches_escaped_tool_tags -- --nocapture\n- cargo test -p hermes-cli test_format_tool_message_lines_adds_policy_remediation_block -- --nocapture\n- cargo test -p hermes-cli test_upstream_compat_aliases_are_mapped -- --nocapture\n- cargo test -p hermes-cli test_recap_and_context_commands_are_registered -- --nocapture\n- cargo test -p hermes-agent test_repo_review_tool_profile_escape_hatch_disables_filtering -- --nocapture\n- cargo test -p hermes-agent test_repo_review_tool_profile_off_mode_disables_filtering -- --nocapture\n- cd ui-tui && npm test -- --run src/__tests__/externalLink.test.ts\n- interactive PTY smoke on real  for , , , and live prompt/error surface\n