### PR TITLE
Fix TUI chunk telemetry, wrap readability, and runtime prompt reformulation

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -31,7 +31,7 @@ use hermes_cron::cron_scheduler_for_data_dir;
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
 
-use crate::alpha_runtime::load_objective_contract;
+use crate::alpha_runtime::{load_objective_contract, objective_lifecycle_is_active};
 use crate::auth::{
     resolve_gemini_oauth_runtime_credentials, resolve_nous_runtime_credentials,
     resolve_qwen_runtime_credentials, DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
@@ -323,6 +323,7 @@ pub struct UiTranscriptMessage {
 
 impl App {
     const SESSION_OBJECTIVE_PREFIX: &'static str = "[SESSION_OBJECTIVE] ";
+    const RUNTIME_REFORMULATION_PREFIX: &'static str = "[HERMES_RUNTIME_REFORMULATION] ";
 
     fn ensure_session_stub_snapshot(&self) {
         if let Err(err) = self.persist_session_snapshot(None) {
@@ -633,6 +634,109 @@ impl App {
                 8,
             );
         }
+    }
+
+    fn runtime_prompt_reformulation_enabled() -> bool {
+        !matches!(
+            std::env::var("HERMES_RUNTIME_PROMPT_REFORMULATION")
+                .ok()
+                .as_deref()
+                .map(|v| v.trim().to_ascii_lowercase()),
+            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+        )
+    }
+
+    fn runtime_contradiction_self_check_enabled() -> bool {
+        !matches!(
+            std::env::var("HERMES_RUNTIME_CONTRADICTION_SELF_CHECK")
+                .ok()
+                .as_deref()
+                .map(|v| v.trim().to_ascii_lowercase()),
+            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+        )
+    }
+
+    fn current_tool_profile_mode() -> String {
+        std::env::var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE")
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "balanced".to_string())
+    }
+
+    fn build_runtime_reformulation_message(&self, latest_user_prompt: &str) -> Option<String> {
+        if !Self::runtime_prompt_reformulation_enabled() {
+            return None;
+        }
+        let prompt = latest_user_prompt.trim();
+        if prompt.is_empty() {
+            return None;
+        }
+        let tool_profile_mode = Self::current_tool_profile_mode();
+        let contradiction_check = Self::runtime_contradiction_self_check_enabled();
+        let context_topic = std::env::var("CONTEXTLATTICE_TOPIC_PATH")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "runbooks/hermes".to_string());
+
+        let objective_line = load_objective_contract()
+            .ok()
+            .flatten()
+            .filter(|contract| objective_lifecycle_is_active(&contract.lifecycle_status))
+            .map(|contract| {
+                format!(
+                    "objective(active): {} | behavior={} | text={}",
+                    contract.id,
+                    contract.behavior_mode.trim(),
+                    Self::preview_for_status(&contract.objective_text, 220)
+                )
+            })
+            .unwrap_or_else(|| "objective(active): none".to_string());
+
+        let contradiction_line = if contradiction_check {
+            "before final response: self-audit contradictions across tool outputs, runtime facts, and claims; unresolved items must be marked UNPROVEN/CONTRADICTORY."
+        } else {
+            "before final response: consistency self-audit optional (disabled by runtime toggle)."
+        };
+
+        let mut out = String::new();
+        out.push_str(Self::RUNTIME_REFORMULATION_PREFIX);
+        out.push_str(
+            "\nRuntime execution reformulation (internal):\n\
+             1) apply anti-scheming evidence-first discipline\n\
+             2) pull ContextLattice context first when relevant\n\
+             3) route tool usage intentionally and avoid repetitive low-signal loops\n",
+        );
+        out.push_str(&format!(
+            "tool-profile(mode): {}\ncontextlattice(topic): {}\n{}\n",
+            tool_profile_mode, context_topic, objective_line
+        ));
+        out.push_str(contradiction_line);
+        out.push_str("\nuser-request(original):\n");
+        out.push_str(prompt);
+        Some(out)
+    }
+
+    fn build_inference_messages(&self) -> (Vec<hermes_core::Message>, bool) {
+        let mut messages = self.messages.clone();
+        let Some(last_user_idx) = messages
+            .iter()
+            .rposition(|m| m.role == hermes_core::MessageRole::User)
+        else {
+            return (messages, false);
+        };
+        let user_prompt = messages[last_user_idx]
+            .content
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let Some(reformulation) = self.build_runtime_reformulation_message(&user_prompt) else {
+            return (messages, false);
+        };
+        messages.insert(last_user_idx, hermes_core::Message::system(reformulation));
+        (messages, true)
     }
 
     /// Create a new `App` from the parsed CLI arguments.
@@ -1130,7 +1234,13 @@ impl App {
                 "model inference + tool execution",
                 35,
             );
-            let messages = self.messages.clone();
+            let (messages, reformulated) = self.build_inference_messages();
+            if reformulated {
+                Self::emit_lifecycle_event(
+                    &self.stream_handle_shared,
+                    "runtime prompt reformulation injected (anti-scheming + context + tool routing + contradiction self-check)",
+                );
+            }
             let result = if self.config.streaming.enabled {
                 let stream_handle = self.stream_handle.clone();
                 let stream_cb: Option<Box<dyn Fn(hermes_core::StreamChunk) + Send + Sync>> =
@@ -2362,6 +2472,62 @@ mod tests {
         assert!(default_mouse_enabled());
 
         std::env::remove_var("HERMES_TUI_MOUSE");
+    }
+
+    #[test]
+    fn test_build_inference_messages_injects_runtime_reformulation() {
+        let _lock = env_test_lock();
+        let prev_home = std::env::var("HERMES_HOME").ok();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        std::env::set_var("HERMES_RUNTIME_PROMPT_REFORMULATION", "1");
+        std::env::set_var("HERMES_RUNTIME_CONTRADICTION_SELF_CHECK", "1");
+        std::env::set_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE", "focus");
+        std::env::set_var(
+            "CONTEXTLATTICE_TOPIC_PATH",
+            "runbooks/objective/test-objective",
+        );
+        let contract =
+            upsert_objective_contract("Grow SOL with controlled risk", true).expect("obj");
+
+        let mut app = build_minimal_test_app();
+        app.messages.push(hermes_core::Message::user(
+            "provide 3 more ideas with contextlattice being one",
+        ));
+        let (messages, injected) = app.build_inference_messages();
+        assert!(injected);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, hermes_core::MessageRole::System);
+        let injected_text = messages[0].content.as_deref().unwrap_or_default();
+        assert!(injected_text.contains(App::RUNTIME_REFORMULATION_PREFIX));
+        assert!(injected_text.contains("tool-profile(mode): focus"));
+        assert!(injected_text.contains("contextlattice(topic): runbooks/objective/test-objective"));
+        assert!(injected_text.contains(contract.id.as_str()));
+        assert!(injected_text.contains("UNPROVEN/CONTRADICTORY"));
+        assert_eq!(messages[1].role, hermes_core::MessageRole::User);
+
+        match prev_home {
+            Some(val) => std::env::set_var("HERMES_HOME", val),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        std::env::remove_var("HERMES_RUNTIME_PROMPT_REFORMULATION");
+        std::env::remove_var("HERMES_RUNTIME_CONTRADICTION_SELF_CHECK");
+        std::env::remove_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE");
+        std::env::remove_var("CONTEXTLATTICE_TOPIC_PATH");
+    }
+
+    #[test]
+    fn test_build_inference_messages_respects_reformulation_toggle_off() {
+        let _lock = env_test_lock();
+        std::env::set_var("HERMES_RUNTIME_PROMPT_REFORMULATION", "off");
+        let mut app = build_minimal_test_app();
+        app.messages
+            .push(hermes_core::Message::user("plain request"));
+        let (messages, injected) = app.build_inference_messages();
+        assert!(!injected);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, hermes_core::MessageRole::User);
+        std::env::remove_var("HERMES_RUNTIME_PROMPT_REFORMULATION");
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -3933,15 +3933,54 @@ fn hard_wrap_segments(text: &str, max_chars: usize) -> Vec<String> {
     if text.is_empty() {
         return vec![String::new()];
     }
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return vec![String::new()];
+    }
     let mut segments = Vec::new();
     let mut current = String::new();
-    let mut count = 0usize;
-    for ch in text.chars() {
-        current.push(ch);
-        count += 1;
-        if count >= width {
+    let mut current_len = 0usize;
+
+    for token in trimmed.split_whitespace() {
+        let token_len = token.chars().count();
+        if token_len > width {
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+                current_len = 0;
+            }
+            let mut chunk = String::new();
+            let mut chunk_len = 0usize;
+            for ch in token.chars() {
+                chunk.push(ch);
+                chunk_len += 1;
+                if chunk_len >= width {
+                    segments.push(std::mem::take(&mut chunk));
+                    chunk_len = 0;
+                }
+            }
+            if !chunk.is_empty() {
+                current = chunk;
+                current_len = chunk_len;
+            }
+            continue;
+        }
+
+        let needed = if current.is_empty() {
+            token_len
+        } else {
+            current_len + 1 + token_len
+        };
+        if needed <= width {
+            if !current.is_empty() {
+                current.push(' ');
+                current_len += 1;
+            }
+            current.push_str(token);
+            current_len += token_len;
+        } else {
             segments.push(std::mem::take(&mut current));
-            count = 0;
+            current.push_str(token);
+            current_len = token_len;
         }
     }
     if !current.is_empty() {
@@ -4584,6 +4623,32 @@ fn extract_file_like_hints(text: &str, limit: usize) -> Vec<String> {
     out
 }
 
+fn stream_chunk_has_progress(chunk: &StreamChunk) -> bool {
+    if let Some(delta) = chunk.delta.as_ref() {
+        let has_content = delta
+            .content
+            .as_ref()
+            .is_some_and(|text| !text.trim().is_empty());
+        let has_tool_calls = delta
+            .tool_calls
+            .as_ref()
+            .is_some_and(|calls| !calls.is_empty());
+        let has_extra_event = delta.extra.as_ref().is_some_and(|extra| match extra {
+            serde_json::Value::Null => false,
+            serde_json::Value::Object(map) => !map.is_empty(),
+            _ => true,
+        });
+        if has_content || has_tool_calls || has_extra_event {
+            return true;
+        }
+    }
+    chunk
+        .finish_reason
+        .as_ref()
+        .is_some_and(|reason| !reason.trim().is_empty())
+        || chunk.usage.is_some()
+}
+
 fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) -> bool {
     match event {
         Event::StreamDelta(delta) => {
@@ -4605,15 +4670,14 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
             true
         }
         Event::StreamChunk(chunk) => {
+            if stream_chunk_has_progress(&chunk) {
+                state.stream_chunk_count = state.stream_chunk_count.saturating_add(1);
+            }
             if let Some(delta) = chunk.delta {
-                let has_stream_payload =
-                    delta.content.as_ref().is_some_and(|text| !text.is_empty())
-                        || delta
-                            .tool_calls
-                            .as_ref()
-                            .is_some_and(|calls| !calls.is_empty());
-                if has_stream_payload {
-                    state.stream_chunk_count = state.stream_chunk_count.saturating_add(1);
+                if let Some(content) = delta.content.as_ref().filter(|text| !text.is_empty()) {
+                    state.stream_char_count = state
+                        .stream_char_count
+                        .saturating_add(content.chars().count());
                 }
                 if let Some(extra) = delta.extra.as_ref() {
                     if let Some(control) = extra.get("control").and_then(|v| v.as_str()) {
@@ -5759,6 +5823,52 @@ mod tests {
         assert_eq!(transcript_wrap_width(12), 12);
         assert_eq!(transcript_wrap_width(80), 80);
         assert_eq!(transcript_wrap_width(140), 80);
+    }
+
+    #[test]
+    fn test_hard_wrap_segments_prefers_word_boundaries() {
+        let wrapped = hard_wrap_segments("context lattice integration is core", 12);
+        assert_eq!(
+            wrapped,
+            vec![
+                "context".to_string(),
+                "lattice".to_string(),
+                "integration".to_string(),
+                "is core".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_hard_wrap_segments_splits_overlong_token() {
+        let wrapped = hard_wrap_segments("supercalifragilisticexpialidocious", 8);
+        assert_eq!(
+            wrapped,
+            vec![
+                "supercal".to_string(),
+                "ifragili".to_string(),
+                "sticexpi".to_string(),
+                "alidocio".to_string(),
+                "us".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_stream_chunk_has_progress_for_extra_only_events() {
+        let chunk = StreamChunk {
+            delta: Some(hermes_core::StreamDelta {
+                content: None,
+                tool_calls: None,
+                extra: Some(serde_json::json!({
+                    "ui_event": "lifecycle",
+                    "message": "dispatching request"
+                })),
+            }),
+            finish_reason: None,
+            usage: None,
+        };
+        assert!(stream_chunk_has_progress(&chunk));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix stream chunk/char accounting so live inference no longer reports zero chunks when progress arrives via extra events
- improve transcript wrapping to prefer word boundaries (with safe fallback splitting for overlong tokens)
- inject runtime prompt reformulation before inference with anti-scheming/context/tool-routing/contradiction self-audit directives
- add targeted regression tests for all new behavior

## Validation
- cargo fmt --all
- cargo test -p hermes-cli test_build_inference_messages_injects_runtime_reformulation -- --nocapture
- cargo test -p hermes-cli test_build_inference_messages_respects_reformulation_toggle_off -- --nocapture
- cargo test -p hermes-cli test_stream_chunk_has_progress_for_extra_only_events -- --nocapture
- cargo test -p hermes-cli test_hard_wrap_segments_prefers_word_boundaries -- --nocapture
- cargo test -p hermes-cli test_hard_wrap_segments_splits_overlong_token -- --nocapture
- interactive TUI smoke: verified chunk counter increments during live inference and wrap readability improved