### PR TITLE
Relax guard policy, harden auth refresh, and support unlimited runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,19 @@ Skills commands support multi-registry search/install and local tap flows.
 ## Security Posture
 
 - Skill content security scanning blocks dangerous patterns and restricted URL targets
+- Skill guard modes: `strict` (default), `relaxed` (only blocks destructive `rm` ops), `off`
 - Policy-controlled tool execution modes: `off`, `audit`, `simulate`, `enforce`
+- Tool policy presets: `strict`, `balanced`, `dev`, `relaxed`
 - Sensitive field redaction in traces/log surfaces
 - Guardrails for path traversal, unsafe file ops, and runtime boundary violations
+
+Operator runtime overrides (env):
+
+- `HERMES_SKILL_GUARD_MODE=relaxed`
+- `HERMES_TOOL_POLICY_PRESET=relaxed`
+- `HERMES_MAX_TURNS_UNLIMITED=1` (or set `max_turns: 0` in config/profile)
+- `HERMES_FORCE_RUNTIME_AUTH_REFRESH=1`
+- `HERMES_AUTH_REFRESH_MAX_RETRIES=6`
 
 ## Upstream Sync and Parity Upkeep
 

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -580,6 +580,26 @@ fn default_max_turns() -> u32 {
     250
 }
 
+fn unlimited_turns_enabled() -> bool {
+    std::env::var("HERMES_MAX_TURNS_UNLIMITED")
+        .ok()
+        .map(|raw| {
+            matches!(
+                raw.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn effective_max_turns(config_max_turns: u32) -> Option<u32> {
+    if unlimited_turns_enabled() || config_max_turns == 0 {
+        None
+    } else {
+        Some(config_max_turns)
+    }
+}
+
 fn default_model() -> String {
     "gpt-4o".to_string()
 }
@@ -4465,6 +4485,7 @@ impl AgentLoop {
             self.preflight_context_compress_with_status(&mut ctx);
         }
         let replay = ReplayRecorder::for_session(&self.config, session_id);
+        let max_turns_limit = effective_max_turns(self.config.max_turns);
         replay.record(
             "session_start",
             serde_json::json!({
@@ -4472,6 +4493,8 @@ impl AgentLoop {
                 "mode": "run",
                 "model": self.config.model,
                 "max_turns": self.config.max_turns,
+                "max_turns_effective": max_turns_limit,
+                "max_turns_unlimited": max_turns_limit.is_none(),
             }),
         );
 
@@ -4511,34 +4534,36 @@ impl AgentLoop {
                 ));
             }
 
-            if total_turns >= self.config.max_turns {
-                tracing::warn!(
-                    "Max turns ({}) exceeded, requesting final summary",
-                    self.config.max_turns
-                );
-                let summary_msg = self.handle_max_iterations(&mut ctx).await?;
-                if let Some(msg) = summary_msg {
-                    ctx.add_message(msg);
+            if let Some(max_turns) = max_turns_limit {
+                if total_turns >= max_turns {
+                    tracing::warn!(
+                        "Max turns ({}) exceeded, requesting final summary",
+                        max_turns
+                    );
+                    let summary_msg = self.handle_max_iterations(&mut ctx).await?;
+                    if let Some(msg) = summary_msg {
+                        ctx.add_message(msg);
+                    }
+                    self.memory_on_session_end(ctx.get_messages());
+                    replay.record(
+                        "session_end",
+                        serde_json::json!({
+                            "reason": "max_turns",
+                            "total_turns": total_turns,
+                            "session_cost_usd": session_cost_usd,
+                        }),
+                    );
+                    return Ok(AgentResult {
+                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        finished_naturally: false,
+                        total_turns,
+                        tool_errors,
+                        usage: accumulated_usage,
+                        interrupted: false,
+                        session_cost_usd: Some(session_cost_usd),
+                        session_started_hooks_fired,
+                    });
                 }
-                self.memory_on_session_end(ctx.get_messages());
-                replay.record(
-                    "session_end",
-                    serde_json::json!({
-                        "reason": "max_turns",
-                        "total_turns": total_turns,
-                        "session_cost_usd": session_cost_usd,
-                    }),
-                );
-                return Ok(AgentResult {
-                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
-                    finished_naturally: false,
-                    total_turns,
-                    tool_errors,
-                    usage: accumulated_usage,
-                    interrupted: false,
-                    session_cost_usd: Some(session_cost_usd),
-                    session_started_hooks_fired,
-                });
             }
 
             total_turns += 1;
@@ -5533,6 +5558,7 @@ impl AgentLoop {
             self.preflight_context_compress_with_status(&mut ctx);
         }
         let replay = ReplayRecorder::for_session(&self.config, session_id);
+        let max_turns_limit = effective_max_turns(self.config.max_turns);
         replay.record(
             "session_start",
             serde_json::json!({
@@ -5540,6 +5566,8 @@ impl AgentLoop {
                 "mode": "stream",
                 "model": self.config.model,
                 "max_turns": self.config.max_turns,
+                "max_turns_effective": max_turns_limit,
+                "max_turns_unlimited": max_turns_limit.is_none(),
             }),
         );
 
@@ -5578,34 +5606,36 @@ impl AgentLoop {
                 ));
             }
 
-            if total_turns >= self.config.max_turns {
-                tracing::warn!(
-                    "Max turns ({}) exceeded, requesting final summary",
-                    self.config.max_turns
-                );
-                let summary_msg = self.handle_max_iterations(&mut ctx).await?;
-                if let Some(msg) = summary_msg {
-                    ctx.add_message(msg);
+            if let Some(max_turns) = max_turns_limit {
+                if total_turns >= max_turns {
+                    tracing::warn!(
+                        "Max turns ({}) exceeded, requesting final summary",
+                        max_turns
+                    );
+                    let summary_msg = self.handle_max_iterations(&mut ctx).await?;
+                    if let Some(msg) = summary_msg {
+                        ctx.add_message(msg);
+                    }
+                    self.memory_on_session_end(ctx.get_messages());
+                    replay.record(
+                        "session_end",
+                        serde_json::json!({
+                            "reason": "max_turns",
+                            "total_turns": total_turns,
+                            "session_cost_usd": session_cost_usd,
+                        }),
+                    );
+                    return Ok(AgentResult {
+                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        finished_naturally: false,
+                        total_turns,
+                        tool_errors,
+                        usage: accumulated_usage,
+                        interrupted: false,
+                        session_cost_usd: Some(session_cost_usd),
+                        session_started_hooks_fired,
+                    });
                 }
-                self.memory_on_session_end(ctx.get_messages());
-                replay.record(
-                    "session_end",
-                    serde_json::json!({
-                        "reason": "max_turns",
-                        "total_turns": total_turns,
-                        "session_cost_usd": session_cost_usd,
-                    }),
-                );
-                return Ok(AgentResult {
-                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
-                    finished_naturally: false,
-                    total_turns,
-                    tool_errors,
-                    usage: accumulated_usage,
-                    interrupted: false,
-                    session_cost_usd: Some(session_cost_usd),
-                    session_started_hooks_fired,
-                });
             }
 
             total_turns += 1;
@@ -7503,7 +7533,11 @@ impl AgentLoop {
         cfg.skill_creation_nudge_interval = 0;
         cfg.max_concurrent_delegates = 0;
         cfg.quiet_mode = true;
-        cfg.max_turns = cfg.max_turns.min(16);
+        cfg.max_turns = if cfg.max_turns == 0 {
+            16
+        } else {
+            cfg.max_turns.min(16)
+        };
         let tools = self.tool_registry.clone();
         let provider = self.llm_provider.clone();
         let review_cb = self.callbacks.background_review_callback.clone();

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -381,6 +381,34 @@ impl App {
         true
     }
 
+    fn bool_env(key: &str) -> Option<bool> {
+        let raw = std::env::var(key).ok()?;
+        let normalized = raw.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        }
+    }
+
+    fn auth_refresh_retry_limit() -> usize {
+        std::env::var("HERMES_AUTH_REFRESH_MAX_RETRIES")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(3)
+    }
+
+    fn should_force_preflight_auth_refresh(provider: &str) -> bool {
+        if let Some(explicit) = Self::bool_env("HERMES_FORCE_RUNTIME_AUTH_REFRESH") {
+            return explicit;
+        }
+        matches!(
+            provider,
+            "nous" | "qwen-oauth" | "google-gemini-cli" | "gemini-cli" | "gemini-oauth"
+        )
+    }
+
     async fn refresh_runtime_provider_credentials_if_needed(&mut self, force_refresh: bool) {
         let (provider_name, _) = resolve_provider_and_model(&self.config, &self.current_model);
         let provider = normalize_runtime_provider_name(provider_name.as_str());
@@ -1209,8 +1237,16 @@ impl App {
             "runtime preflight + credential hydration",
             5,
         );
-        self.refresh_runtime_provider_credentials_if_needed(false)
+        let provider = self.current_runtime_provider();
+        let force_refresh = Self::should_force_preflight_auth_refresh(provider.as_str());
+        self.refresh_runtime_provider_credentials_if_needed(force_refresh)
             .await;
+        if force_refresh {
+            Self::emit_lifecycle_event(
+                &self.stream_handle_shared,
+                format!("preflight auth refresh forced for provider {}", provider),
+            );
+        }
         Self::emit_phase_event(
             &self.stream_handle_shared,
             "dispatch",
@@ -1219,7 +1255,8 @@ impl App {
         );
         self.interrupt_controller.clear_interrupt();
         let mut remediation_attempted = false;
-        let mut auth_refresh_attempted = false;
+        let mut auth_refresh_attempts = 0usize;
+        let auth_refresh_retry_limit = Self::auth_refresh_retry_limit();
         loop {
             Self::emit_lifecycle_event(
                 &self.stream_handle_shared,
@@ -1342,12 +1379,28 @@ impl App {
                     if let Some(handle) = &self.stream_handle {
                         handle.send_done();
                     }
-                    if !auth_refresh_attempted
-                        && Self::is_provider_auth_or_session_error(&e)
-                        && self.force_auth_refresh_after_error().await
-                    {
-                        auth_refresh_attempted = true;
-                        continue;
+                    if Self::is_provider_auth_or_session_error(&e) {
+                        if auth_refresh_attempts < auth_refresh_retry_limit {
+                            if self.force_auth_refresh_after_error().await {
+                                auth_refresh_attempts += 1;
+                                Self::emit_lifecycle_event(
+                                    &self.stream_handle_shared,
+                                    format!(
+                                        "auth refresh retry {}/{}",
+                                        auth_refresh_attempts, auth_refresh_retry_limit
+                                    ),
+                                );
+                                continue;
+                            }
+                        } else {
+                            Self::emit_lifecycle_event(
+                                &self.stream_handle_shared,
+                                format!(
+                                    "auth refresh retries exhausted ({})",
+                                    auth_refresh_retry_limit
+                                ),
+                            );
+                        }
                     }
                     if !remediation_attempted {
                         if let Some((next_model, notice)) =
@@ -1643,7 +1696,7 @@ impl App {
     async fn force_auth_refresh_after_error(&mut self) -> bool {
         let (provider_name, _) = resolve_provider_and_model(&self.config, &self.current_model);
         let provider = normalize_runtime_provider_name(provider_name.as_str());
-        let notice = match provider.as_str() {
+        let (notice, refreshed) = match provider.as_str() {
             "nous" => match resolve_nous_runtime_credentials(
                 true,
                 true,
@@ -1662,9 +1715,15 @@ impl App {
                     if changed {
                         self.switch_model(&self.current_model.clone());
                     }
-                    Some("Nous auth auto-refresh succeeded; retrying request.".to_string())
+                    (
+                        Some("Nous auth auto-refresh succeeded; retrying request.".to_string()),
+                        true,
+                    )
                 }
-                Err(err) => Some(format!("Nous auth auto-refresh failed: {}", err)),
+                Err(err) => (
+                    Some(format!("Nous auth auto-refresh failed: {}", err)),
+                    false,
+                ),
             },
             "qwen-oauth" => {
                 match resolve_qwen_runtime_credentials(
@@ -1686,9 +1745,17 @@ impl App {
                         if changed {
                             self.switch_model(&self.current_model.clone());
                         }
-                        Some("Qwen OAuth auto-refresh succeeded; retrying request.".to_string())
+                        (
+                            Some(
+                                "Qwen OAuth auto-refresh succeeded; retrying request.".to_string(),
+                            ),
+                            true,
+                        )
                     }
-                    Err(err) => Some(format!("Qwen OAuth auto-refresh failed: {}", err)),
+                    Err(err) => (
+                        Some(format!("Qwen OAuth auto-refresh failed: {}", err)),
+                        false,
+                    ),
                 }
             }
             "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => {
@@ -1702,12 +1769,21 @@ impl App {
                         if changed {
                             self.switch_model(&self.current_model.clone());
                         }
-                        Some("Gemini OAuth auto-refresh succeeded; retrying request.".to_string())
+                        (
+                            Some(
+                                "Gemini OAuth auto-refresh succeeded; retrying request."
+                                    .to_string(),
+                            ),
+                            true,
+                        )
                     }
-                    Err(err) => Some(format!("Gemini OAuth auto-refresh failed: {}", err)),
+                    Err(err) => (
+                        Some(format!("Gemini OAuth auto-refresh failed: {}", err)),
+                        false,
+                    ),
                 }
             }
-            _ => None,
+            _ => (None, false),
         };
 
         if let Some(text) = notice {
@@ -1717,9 +1793,8 @@ impl App {
             } else {
                 println!("{}", text);
             }
-            return true;
         }
-        false
+        refreshed
     }
 
     async fn model_auto_remediation_target(&self, err: &AgentError) -> Option<(String, String)> {

--- a/crates/hermes-skills/src/guard.rs
+++ b/crates/hermes-skills/src/guard.rs
@@ -127,6 +127,38 @@ static COMPILED_BLOCKED_URLS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         .collect()
 });
 
+static COMPILED_RELAXED_RM_BLOCKS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    [
+        // In relaxed mode we intentionally keep only destructive file-removal blocks.
+        r"(?i)(?:^|[\s;&|`])rm\s+",
+        r"(?i)\brm\s+-[^\n]*\b(?:r|f)\b",
+    ]
+    .iter()
+    .filter_map(|p| Regex::new(p).ok())
+    .collect()
+});
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillGuardMode {
+    Strict,
+    Relaxed,
+    Off,
+}
+
+impl SkillGuardMode {
+    fn from_env() -> Self {
+        let raw = std::env::var("HERMES_SKILL_GUARD_MODE")
+            .ok()
+            .or_else(|| std::env::var("HERMES_GUARD_MODE").ok())
+            .unwrap_or_else(|| "strict".to_string());
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "off" | "disabled" | "none" => Self::Off,
+            "relaxed" | "loose" | "permissive" => Self::Relaxed,
+            _ => Self::Strict,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SkillGuard
 // ---------------------------------------------------------------------------
@@ -206,14 +238,30 @@ impl SkillGuard {
     /// Unlike `validate_skill`, this does not enforce formatting/structure
     /// requirements and is safe to run against third-party skill bundles.
     pub fn scan_security_only(&self, skill: &Skill) -> Result<(), SkillError> {
-        // Check built-in dangerous patterns.
-        for (regex, reason) in COMPILED_DANGEROUS.iter() {
-            if regex.is_match(&skill.content) {
-                return Err(SkillError::GuardViolation(format!(
-                    "Blocked content: {}",
-                    reason
-                )));
+        let mode = SkillGuardMode::from_env();
+        match mode {
+            SkillGuardMode::Strict => {
+                // Check built-in dangerous patterns.
+                for (regex, reason) in COMPILED_DANGEROUS.iter() {
+                    if regex.is_match(&skill.content) {
+                        return Err(SkillError::GuardViolation(format!(
+                            "Blocked content: {}",
+                            reason
+                        )));
+                    }
+                }
             }
+            SkillGuardMode::Relaxed => {
+                // User-relaxed mode: only block destructive rm operations.
+                for regex in COMPILED_RELAXED_RM_BLOCKS.iter() {
+                    if regex.is_match(&skill.content) {
+                        return Err(SkillError::GuardViolation(
+                            "Blocked content: destructive rm operation detected".to_string(),
+                        ));
+                    }
+                }
+            }
+            SkillGuardMode::Off => {}
         }
 
         // Check custom blocked patterns.
@@ -228,8 +276,10 @@ impl SkillGuard {
             }
         }
 
-        // Validate any URLs found in the content.
-        self.validate_urls_in_content(&skill.content)?;
+        if mode == SkillGuardMode::Strict {
+            // Validate any URLs found in the content.
+            self.validate_urls_in_content(&skill.content)?;
+        }
 
         Ok(())
     }

--- a/crates/hermes-tools/src/tool_policy.rs
+++ b/crates/hermes-tools/src/tool_policy.rs
@@ -24,6 +24,7 @@ enum ToolPolicyPreset {
     Strict,
     Balanced,
     Dev,
+    Relaxed,
 }
 
 impl ToolPolicyPreset {
@@ -32,6 +33,7 @@ impl ToolPolicyPreset {
             "strict" => Some(Self::Strict),
             "balanced" => Some(Self::Balanced),
             "dev" => Some(Self::Dev),
+            "relaxed" | "loose" | "permissive" => Some(Self::Relaxed),
             _ => None,
         }
     }
@@ -228,6 +230,14 @@ impl ToolPolicyEngine {
                 denylist: HashSet::new(),
                 deny_param_patterns: compile_patterns(&default_deny_patterns()),
                 max_param_bytes: 512 * 1024,
+                sandbox_profile: ExecutionSandboxProfile::Dev,
+            },
+            ToolPolicyPreset::Relaxed => Self {
+                mode: ToolPolicyMode::Enforce,
+                allowlist: HashSet::new(),
+                denylist: HashSet::new(),
+                deny_param_patterns: compile_patterns(&default_relaxed_deny_patterns()),
+                max_param_bytes: 1024 * 1024,
                 sandbox_profile: ExecutionSandboxProfile::Dev,
             },
         }
@@ -523,6 +533,13 @@ fn default_deny_patterns() -> Vec<String> {
         r"(?i)aws_secret_access_key".to_string(),
         r"(?i)bearer\s+[a-z0-9\-_\.]{20,}".to_string(),
         r"(?i)api[_-]?key".to_string(),
+    ]
+}
+
+fn default_relaxed_deny_patterns() -> Vec<String> {
+    vec![
+        // Relaxed mode keeps only destructive remove-command blocking.
+        r"(?i)\brm\s+".to_string(),
     ]
 }
 
@@ -905,6 +922,20 @@ mod tests {
         );
         assert!(!decision.allow);
         assert_eq!(decision.code.as_deref(), Some("params_pattern_denied"));
+    }
+
+    #[test]
+    fn relaxed_preset_allows_api_key_strings_but_blocks_rm_commands() {
+        let relaxed = ToolPolicyEngine::from_preset(ToolPolicyPreset::Relaxed);
+        let allow = relaxed.evaluate(
+            "terminal",
+            &serde_json::json!({"cmd":"python3 - <<'PY'\nprint(\"api_key=abc123\")\nPY"}),
+        );
+        assert!(allow.allow, "relaxed mode should not block api_key tokens");
+
+        let deny = relaxed.evaluate("terminal", &serde_json::json!({"cmd":"rm -rf /tmp/demo"}));
+        assert!(!deny.allow, "relaxed mode should still block rm operations");
+        assert_eq!(deny.code.as_deref(), Some("params_pattern_denied"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add relaxed guard modes for skills and tool policy (rm-block only)\n- harden provider auth refresh with forced preflight hydration + retry budget\n- support unlimited run length via max_turns=0 or HERMES_MAX_TURNS_UNLIMITED=1\n- document runtime override envs in README\n\n## Validation\n- cargo test -p hermes-skills guard::tests --quiet\n- cargo test -p hermes-tools relaxed_preset_allows_api_key_strings_but_blocks_rm_commands --quiet\n- cargo test -p hermes-cli test_is_provider_auth_or_session_error_detects_auth_failures --quiet\n- cargo test -p hermes-agent max_turns --quiet\n- hermes-ultra auth verify nous\n- hermes-ultra chat probes with nous models (hermes-4-70b, deepseek-v4-pro, openai/gpt-5.5 tool-call)