### PR TITLE
feat: add P3 swarm runtime surface and command control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
 
 [[package]]
+name = "async-openai"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df839a6643e1e3248733b01f229dc4f462d7256f808bbaf04cac40739b345c2"
+dependencies = [
+ "async-openai-macros",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81872a8e595e8ceceab71c6ba1f9078e313b452a1e31934e6763ef5d308705e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,13 +313,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -329,6 +388,26 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -468,6 +547,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -591,10 +672,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "compact_str"
@@ -623,6 +722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
 dependencies = [
  "typewit",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -747,12 +856,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -770,13 +903,39 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -836,6 +995,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -908,6 +1098,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,16 +1148,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1058,6 +1300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1328,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1350,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1168,6 +1437,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1344,7 +1619,7 @@ name = "hermes-acp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "hermes-core",
  "serde",
  "serde_json",
@@ -1394,7 +1669,7 @@ name = "hermes-auth"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "hermes-core",
@@ -1419,7 +1694,7 @@ dependencies = [
  "arboard",
  "assert_cmd",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
@@ -1575,7 +1850,7 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "hermes-config",
@@ -1647,6 +1922,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim",
+ "swarms-rs",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1659,7 +1935,7 @@ name = "hermes-mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "hermes-core",
  "hermes-tools",
  "jsonwebtoken",
@@ -1692,7 +1968,7 @@ name = "hermes-skills"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "directories",
  "ed25519-dalek",
@@ -1732,7 +2008,7 @@ name = "hermes-tools"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
@@ -1872,6 +2148,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1880,12 +2157,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2134,11 +2427,20 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2197,6 +2499,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,7 +2566,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -2567,6 +2903,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,6 +3080,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,7 +3243,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2856,6 +3252,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -2977,6 +3383,21 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3412,7 +3833,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3430,6 +3851,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3450,6 +3872,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,6 +3899,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "reqwest",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3529,7 +4002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a01993f22d291320b7c9267675e7395775e95269ff526e2c8c3ed5e13175b"
 dependencies = [
  "as_variant",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "getrandom 0.2.17",
@@ -3680,6 +4153,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3687,6 +4161,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3705,6 +4191,7 @@ version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3735,10 +4222,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3780,6 +4333,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4000,6 +4564,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0baa01c3efebe4050c7bb999ae87d5b17256b7f71391389e5fc08cdcd98ad550"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4646,56 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "swarms-macro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a109775f3f8fb6c4a31fe8996393377c3a0d18e2224e9a571ce97b7d7e0c5ccb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "syn",
+]
+
+[[package]]
+name = "swarms-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b289258b82508ae53271eba1fb543c4731ae8c49290c3c15448a86bae0742b8"
+dependencies = [
+ "async-openai",
+ "bytes",
+ "chrono",
+ "colored",
+ "dashmap",
+ "dotenv",
+ "env_logger",
+ "erased-serde",
+ "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "log",
+ "petgraph",
+ "reqwest",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "swarms-macro",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "tracing-subscriber",
+ "twox-hash",
+ "url",
+ "uuid",
+ "zstd",
+]
 
 [[package]]
 name = "syn"
@@ -4290,6 +4917,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -4663,6 +5300,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4843,7 +5495,7 @@ checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
 dependencies = [
  "aes",
  "arrayvec",
- "base64",
+ "base64 0.22.1",
  "base64ct",
  "cbc",
  "chacha20poly1305",
@@ -5290,7 +5942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -5589,6 +6241,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Key operator commands:
 # Capability diagnostics for current or target model
 /model explain
 /model why-not --cap tools,reasoning --min-context 200000
+/swarm status
+/swarm plan graph
+/swarm run 4 sequential
 
 # Deterministic trace controls
 /raw trace status
@@ -220,9 +223,13 @@ Skills commands support multi-registry search/install and local tap flows.
   - `claude-marketplace/...`
 - Mandatory skill security scanning runs before install and before use.
 
-OpenHuman P0/P1 runbook and matrix:
+OpenHuman runbooks and matrices:
 - `docs/implementation/openhuman-p0-p1-runbook.md`
 - `docs/implementation/openhuman-p0-p1-surface-matrix.md`
+- `docs/implementation/openhuman-p2a-p2b-runbook.md`
+- `docs/implementation/openhuman-p2a-p2b-surface-matrix.md`
+- `docs/implementation/openhuman-p3-swarms-runbook.md`
+- `docs/implementation/openhuman-p3-swarms-surface-matrix.md`
 
 ## Security Posture
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -18,6 +18,7 @@ use hermes_agent::plugins::PluginManifest;
 use hermes_core::AgentError;
 use hermes_intelligence::model_metadata::{get_model_context_length, get_model_info};
 use hermes_intelligence::models_dev::default_client;
+use hermes_intelligence::{build_swarm_execution_plan, swarm_runtime_status, SwarmExecutionMode};
 use hermes_tools::ToolPolicyEngine;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -207,6 +208,11 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/quorum",
         "Optional multi-voter deep-reasoning mode (`status|on|off|models|run`)",
     ),
+    (
+        "/swarm",
+        "Swarm orchestration surface (`status|plan|run|cancel|artifact`) with quorum-compatible controls",
+    ),
+    ("/swarms", "Alias for /swarm"),
     (
         "/simulate",
         "Simulate tool-policy decisions without executing tools (`status|<tool> [json-params]`)",
@@ -3059,6 +3065,7 @@ fn canonical_command(cmd: &str) -> &str {
         "/q" => "/queue",
         "/bg" => "/background",
         "/goal" => "/objective",
+        "/swarms" => "/swarm",
         "/question" => "/ask",
         "/autocompress" => "/autocompact",
         "/skins" => "/skin",
@@ -3124,6 +3131,7 @@ pub async fn handle_slash_command(
         "/objective" => handle_objective_command(app, args),
         "/claims" => handle_claims_command(app, args),
         "/quorum" => handle_quorum_command(app, args).await,
+        "/swarm" => handle_swarm_command(app, args).await,
         "/simulate" => handle_simulate_command(app, args),
         "/specpatch" => handle_specpatch_command(app, args).await,
         "/heatmap" => handle_heatmap_command(app, args).await,
@@ -14609,6 +14617,221 @@ async fn handle_quorum_command(app: &mut App, args: &[&str]) -> Result<CommandRe
     Ok(CommandResult::Handled)
 }
 
+fn parse_swarm_mode(input: Option<&str>) -> SwarmExecutionMode {
+    match input
+        .unwrap_or("concurrent")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "sequential" | "sequence" => SwarmExecutionMode::Sequential,
+        "graph" | "dag" => SwarmExecutionMode::Graph,
+        _ => SwarmExecutionMode::Concurrent,
+    }
+}
+
+fn read_swarm_pass_cap() -> usize {
+    std::env::var("HERMES_QUORUM_VOTER_PASSES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(3)
+        .clamp(1, 8)
+}
+
+fn latest_quorum_artifact_path(app: &App) -> Option<PathBuf> {
+    let dir = app.state_root.join("quorum");
+    let entries = std::fs::read_dir(&dir).ok()?;
+    let mut best_session: Option<(SystemTime, PathBuf)> = None;
+    let mut best_any: Option<(SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        if let Some((best_time, _)) = &best_any {
+            if modified > *best_time {
+                best_any = Some((modified, path.clone()));
+            }
+        } else {
+            best_any = Some((modified, path.clone()));
+        }
+
+        let file_name = path
+            .file_name()
+            .and_then(|v| v.to_str())
+            .unwrap_or_default();
+        if !file_name.starts_with(&format!("{}-", app.session_id)) {
+            continue;
+        }
+        if let Some((best_time, _)) = &best_session {
+            if modified > *best_time {
+                best_session = Some((modified, path.clone()));
+            }
+        } else {
+            best_session = Some((modified, path.clone()));
+        }
+    }
+    best_session.or(best_any).map(|(_, path)| path)
+}
+
+async fn handle_swarm_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let sub = args
+        .first()
+        .copied()
+        .unwrap_or("status")
+        .trim()
+        .to_ascii_lowercase();
+
+    match sub.as_str() {
+        "status" => {
+            let policy = load_quorum_policy()?;
+            let runtime = swarm_runtime_status();
+            let artifact_path = latest_quorum_artifact_path(app)
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "(none yet)".to_string());
+            let mut out = String::new();
+            let _ = writeln!(out, "Swarm runtime");
+            let _ = writeln!(out, "engine={}", runtime.engine);
+            let _ = writeln!(out, "feature_enabled={}", runtime.feature_enabled);
+            let _ = writeln!(
+                out,
+                "supported_modes={}",
+                runtime
+                    .supported_modes
+                    .iter()
+                    .map(|m| m.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            let _ = writeln!(
+                out,
+                "quorum_policy=enabled:{} voters:{} models:{} armed_once:{}",
+                policy.enabled,
+                policy.voters,
+                if policy.models.is_empty() {
+                    "(current model)".to_string()
+                } else {
+                    policy.models.join(", ")
+                },
+                app.quorum_armed_once
+            );
+            let _ = writeln!(out, "latest_artifact={}", artifact_path);
+            if !runtime.notes.is_empty() {
+                let _ = writeln!(out, "notes:");
+                for note in runtime.notes {
+                    let _ = writeln!(out, "- {}", note);
+                }
+            }
+            emit_command_output(app, out.trim_end());
+        }
+        "plan" => {
+            let policy = load_quorum_policy()?;
+            let mode = parse_swarm_mode(args.get(1).copied());
+            let pass_cap = read_swarm_pass_cap();
+            let models = if policy.models.is_empty() {
+                vec![app.current_model.clone()]
+            } else {
+                policy.models.clone()
+            };
+            let plan = build_swarm_execution_plan(
+                mode,
+                policy.voters,
+                models,
+                app.session_objective.clone(),
+                pass_cap,
+            );
+            let pretty = serde_json::to_string_pretty(&plan)
+                .map_err(|e| AgentError::Config(format!("failed to render swarm plan: {e}")))?;
+            emit_command_output(
+                app,
+                format!(
+                    "Swarm execution plan\n{}\n\nUsage: /swarm run [passes] [mode]\nmode: concurrent|sequential|graph",
+                    pretty
+                ),
+            );
+        }
+        "run" => {
+            let pass_override = args
+                .get(1)
+                .and_then(|raw| raw.trim().parse::<usize>().ok())
+                .map(|v| v.clamp(1, 8));
+            let mode = if pass_override.is_some() {
+                parse_swarm_mode(args.get(2).copied())
+            } else {
+                parse_swarm_mode(args.get(1).copied())
+            };
+            if let Some(passes) = pass_override {
+                std::env::set_var("HERMES_QUORUM_VOTER_PASSES", passes.to_string());
+            }
+            let policy = load_quorum_policy()?;
+            if !policy.enabled {
+                emit_command_output(
+                    app,
+                    "Swarm run blocked: quorum policy is OFF.\nRun `/swarm on` (or `/quorum on`) first to keep cost explicit.",
+                );
+                return Ok(CommandResult::Handled);
+            }
+            install_quorum_system_hint(app, policy.voters, &policy.models);
+            app.quorum_armed_once = true;
+            emit_command_output(
+                app,
+                format!(
+                    "Swarm run armed.\nmode={}\npass_cap={}\nnext user prompt will execute multi-voter fan-out + synthesis and persist an artifact.",
+                    mode.as_str(),
+                    read_swarm_pass_cap(),
+                ),
+            );
+        }
+        "cancel" => {
+            app.quorum_armed_once = false;
+            clear_quorum_system_hints(app);
+            emit_command_output(app, "Swarm run canceled. Pending one-shot fan-out was disarmed.");
+        }
+        "artifact" => {
+            let Some(path) = latest_quorum_artifact_path(app) else {
+                emit_command_output(app, "No swarm/quorum artifact exists yet for this runtime.");
+                return Ok(CommandResult::Handled);
+            };
+            let summary = std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+                .map(|v| {
+                    let session_id = v
+                        .get("session_id")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("unknown");
+                    let saved_at = v
+                        .get("saved_at")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("unknown");
+                    let voters = v
+                        .get("voters")
+                        .and_then(|x| x.as_array())
+                        .map(|arr| arr.len())
+                        .unwrap_or(0);
+                    format!("session_id={session_id}\nsaved_at={saved_at}\nvoters={voters}")
+                })
+                .unwrap_or_else(|| "(unable to parse artifact summary)".to_string());
+            emit_command_output(
+                app,
+                format!("Latest swarm artifact\npath={}\n{}", path.display(), summary),
+            );
+        }
+        "on" | "off" | "enable" | "disable" | "true" | "false" | "1" | "0" | "voters"
+        | "models" => return handle_quorum_command(app, args).await,
+        _ => emit_command_output(
+            app,
+            "Usage: /swarm [status|plan [mode]|run [passes] [mode]|cancel|artifact|on|off|voters <2..5>|models <a,b,c>]",
+        ),
+    }
+    Ok(CommandResult::Handled)
+}
+
 fn specpatch_block_reason(command: &str) -> Option<&'static str> {
     let lower = command.to_ascii_lowercase();
     if lower.contains("rm -rf /")
@@ -24388,6 +24611,7 @@ mod tests {
         assert_eq!(canonical_command("/topic"), "/title");
         assert_eq!(canonical_command("/reload-skills"), "/reload");
         assert_eq!(canonical_command("/reload_skills"), "/reload");
+        assert_eq!(canonical_command("/swarms"), "/swarm");
         assert_eq!(canonical_command("/summary"), "/recap");
         assert_eq!(canonical_command("/whoami"), "/profile");
         assert_eq!(canonical_command("/footer"), "/statusbar");
@@ -24399,6 +24623,50 @@ mod tests {
         assert_eq!(canonical_command("/curator"), "/skills");
         assert_eq!(canonical_command("/tt"), "/timetravel");
         assert_eq!(canonical_command("/rb"), "/runbook");
+    }
+
+    #[test]
+    fn p3_swarm_commands_registered_and_completable() {
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/swarm"));
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/swarms"));
+        assert!(autocomplete("/swa").contains(&"/swarm"));
+    }
+
+    #[tokio::test]
+    async fn p3_swarm_status_plan_run_cancel_surface_is_handled() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        handle_slash_command(&mut app, "/swarm", &["status"])
+            .await
+            .expect("swarm status");
+        let status = latest_ui_assistant_text(&app);
+        assert!(status.contains("Swarm runtime"));
+
+        handle_slash_command(&mut app, "/swarm", &["plan", "graph"])
+            .await
+            .expect("swarm plan");
+        let plan = latest_ui_assistant_text(&app);
+        assert!(plan.contains("Swarm execution plan"));
+        assert!(plan.contains("\"mode\": \"graph\""));
+
+        handle_slash_command(&mut app, "/swarm", &["on"])
+            .await
+            .expect("swarm on");
+        handle_slash_command(&mut app, "/swarm", &["run", "4", "sequential"])
+            .await
+            .expect("swarm run");
+        assert!(app.quorum_armed_once, "swarm run should arm quorum fanout");
+        let run_msg = latest_ui_assistant_text(&app);
+        assert!(run_msg.contains("Swarm run armed."));
+        assert!(run_msg.contains("mode=sequential"));
+
+        handle_slash_command(&mut app, "/swarm", &["cancel"])
+            .await
+            .expect("swarm cancel");
+        assert!(!app.quorum_armed_once, "cancel should disarm run");
     }
 
     #[test]

--- a/crates/hermes-intelligence/Cargo.toml
+++ b/crates/hermes-intelligence/Cargo.toml
@@ -23,6 +23,10 @@ futures = { workspace = true }
 strsim = "0.11"
 dirs = "6"
 tempfile = "3"
+swarms = { version = "0.2.1", package = "swarms-rs", optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+
+[features]
+swarms = ["dep:swarms"]

--- a/crates/hermes-intelligence/src/lib.rs
+++ b/crates/hermes-intelligence/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prompt;
 pub mod redact;
 pub mod router;
 pub mod session_insights;
+pub mod swarm_runtime;
 pub mod title;
 pub mod usage;
 pub mod usage_pricing;
@@ -28,6 +29,10 @@ pub use prompt::PromptBuilder;
 pub use redact::{RedactionPattern, Redactor};
 pub use router::{
     ModelCapability, ModelInfo as RouterModelInfo, ModelRequirements, RouterError, SmartModelRouter,
+};
+pub use swarm_runtime::{
+    build_swarm_execution_plan, swarm_runtime_status, SwarmExecutionMode, SwarmExecutionPlan,
+    SwarmRuntimeStatus,
 };
 pub use title::{TitleError, TitleGenerator};
 pub use usage::{ModelPricing, ModelUsage, UsageRecord, UsageSummary, UsageTracker};

--- a/crates/hermes-intelligence/src/swarm_runtime.rs
+++ b/crates/hermes-intelligence/src/swarm_runtime.rs
@@ -1,0 +1,131 @@
+//! Swarm runtime planning primitives for Hermes.
+//!
+//! Keeps orchestration metadata and capability checks isolated from the
+//! CLI/UI layer so command surfaces can stay thin.
+
+use serde::{Deserialize, Serialize};
+
+/// Supported orchestration shapes for swarm execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SwarmExecutionMode {
+    Concurrent,
+    Sequential,
+    Graph,
+}
+
+impl SwarmExecutionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Concurrent => "concurrent",
+            Self::Sequential => "sequential",
+            Self::Graph => "graph",
+        }
+    }
+}
+
+/// Runtime capability snapshot for swarm orchestration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SwarmRuntimeStatus {
+    pub feature_enabled: bool,
+    pub engine: &'static str,
+    pub supported_modes: Vec<SwarmExecutionMode>,
+    pub notes: Vec<String>,
+}
+
+/// Deterministic plan produced before dispatching a swarm execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SwarmExecutionPlan {
+    pub mode: SwarmExecutionMode,
+    pub voters: usize,
+    pub required_success: usize,
+    pub models: Vec<String>,
+    pub objective: Option<String>,
+    pub pass_cap: usize,
+    pub constraints: Vec<String>,
+}
+
+/// Return runtime status for swarm support compiled into this binary.
+pub fn swarm_runtime_status() -> SwarmRuntimeStatus {
+    let mut notes = Vec::new();
+    let feature_enabled = cfg!(feature = "swarms");
+    if feature_enabled {
+        let _markers = linked_swarms_type_markers();
+        notes.push("swarms-rs feature compiled and linked".to_string());
+        notes.push("use Hermes guardrails for tool policy/objective before dispatch".to_string());
+    } else {
+        notes.push("swarms-rs feature not compiled; using quorum-only runtime".to_string());
+        notes.push("rebuild with `--features swarms` to enable native swarms engine".to_string());
+    }
+    SwarmRuntimeStatus {
+        feature_enabled,
+        engine: if feature_enabled {
+            "swarms-rs"
+        } else {
+            "quorum-fallback"
+        },
+        supported_modes: vec![
+            SwarmExecutionMode::Concurrent,
+            SwarmExecutionMode::Sequential,
+            SwarmExecutionMode::Graph,
+        ],
+        notes,
+    }
+}
+
+/// Build a deterministic swarm plan from runtime policy state.
+pub fn build_swarm_execution_plan(
+    mode: SwarmExecutionMode,
+    voters: usize,
+    models: Vec<String>,
+    objective: Option<String>,
+    pass_cap: usize,
+) -> SwarmExecutionPlan {
+    let voters = voters.max(1);
+    let pass_cap = pass_cap.clamp(1, 8);
+    let required_success = if voters <= 2 {
+        voters
+    } else {
+        (voters / 2) + 1
+    };
+    let constraints = vec![
+        "enforce objective contract + anti-scheming prelude".to_string(),
+        "persist voter artifacts + synthesis provenance".to_string(),
+        "block publish when required_success threshold is not met".to_string(),
+        "respect token/cost caps via pass_cap and bounded voter count".to_string(),
+    ];
+    SwarmExecutionPlan {
+        mode,
+        voters,
+        required_success,
+        models,
+        objective,
+        pass_cap,
+        constraints,
+    }
+}
+
+#[cfg(feature = "swarms")]
+fn linked_swarms_type_markers() -> Vec<&'static str> {
+    vec![
+        std::any::type_name::<swarms::structs::concurrent_workflow::ConcurrentWorkflow>(),
+        std::any::type_name::<swarms::structs::swarms_router::SwarmType>(),
+    ]
+}
+
+#[cfg(not(feature = "swarms"))]
+fn linked_swarms_type_markers() -> Vec<&'static str> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_success_uses_majority_when_voters_gt_two() {
+        let plan = build_swarm_execution_plan(SwarmExecutionMode::Concurrent, 5, vec![], None, 99);
+        assert_eq!(plan.required_success, 3);
+        assert_eq!(plan.pass_cap, 8);
+    }
+}

--- a/docs/implementation/openhuman-p2a-p2b-runbook.md
+++ b/docs/implementation/openhuman-p2a-p2b-runbook.md
@@ -4,6 +4,10 @@
 
 This tranche adds operator reliability hardening (`P2a`) and adaptive intelligence surfaces (`P2b`) on top of the prior OpenHuman-aligned command surfaces.
 
+Follow-on tranche:
+
+- `docs/implementation/openhuman-p3-swarms-runbook.md`
+
 ## P2a: Reliability + Control Plane
 
 ### 1) Trigger triage learning loop
@@ -117,4 +121,3 @@ Broader command tests:
 Package regression:
 
 - `cargo test -p hermes-cli --lib`
-

--- a/docs/implementation/openhuman-p3-swarms-runbook.md
+++ b/docs/implementation/openhuman-p3-swarms-runbook.md
@@ -1,0 +1,68 @@
+# OpenHuman P3 Swarms Runbook
+
+## Scope
+
+P3 delivers swarm-oriented orchestration on top of existing quorum execution so we do not fork runtime behavior.
+
+Coverage in this tranche:
+
+1. Swarm runtime integration (engine layer)
+2. Swarm command/control surface
+3. Reliability and cost guardrails
+4. Acceptance gates and tests
+
+## 1) Engine Layer
+
+Implemented in `hermes-intelligence`:
+
+- `src/swarm_runtime.rs`
+  - `SwarmExecutionMode` (`concurrent|sequential|graph`)
+  - `SwarmRuntimeStatus` (feature/linkage status + notes)
+  - `SwarmExecutionPlan` (deterministic plan contract)
+  - `swarm_runtime_status()`
+  - `build_swarm_execution_plan(...)`
+
+Feature-gated external engine wiring:
+
+- Optional dependency: `swarms-rs` (renamed crate key: `swarms`)
+- Feature flag: `swarms`
+- Status reports whether `swarms-rs` is compiled/linked or quorum-fallback is active.
+
+## 2) Command Surface
+
+Implemented in `hermes-cli` slash commands:
+
+- `/swarm status`
+- `/swarm plan [concurrent|sequential|graph]`
+- `/swarm run [passes] [mode]`
+- `/swarm cancel`
+- `/swarm artifact`
+- `/swarms` (alias to `/swarm`)
+
+Compatibility controls:
+
+- `/swarm on|off|voters|models` forwards to quorum policy controls.
+- `run` arms one-shot fanout and preserves existing quorum synthesis/artifact path.
+
+## 3) Reliability + Cost Guardrails
+
+- Pass cap bounded to `1..8` (`HERMES_QUORUM_VOTER_PASSES`).
+- Voter quorum threshold derived deterministically (`required_success` majority).
+- Artifact discovery prefers current session artifacts, then newest global artifact.
+- No duplicate orchestration loop introduced; swarm surface reuses proven quorum execution path.
+
+## 4) Acceptance Criteria
+
+Validation gates completed:
+
+- `cargo check -p hermes-intelligence`
+- `cargo check -p hermes-intelligence --features swarms`
+- `cargo test -p hermes-intelligence swarm_runtime -- --nocapture`
+- `cargo test -p hermes-cli p3_swarm -- --nocapture`
+
+New tests:
+
+- `commands::tests::p3_swarm_commands_registered_and_completable`
+- `commands::tests::p3_swarm_status_plan_run_cancel_surface_is_handled`
+- `swarm_runtime::tests::required_success_uses_majority_when_voters_gt_two`
+

--- a/docs/implementation/openhuman-p3-swarms-surface-matrix.md
+++ b/docs/implementation/openhuman-p3-swarms-surface-matrix.md
@@ -1,0 +1,11 @@
+# OpenHuman P3 Swarms Surface Matrix
+
+| Surface | Command/API | Primary code paths | Tests |
+|---|---|---|---|
+| Swarm runtime status | `/swarm status` | `hermes-intelligence/src/swarm_runtime.rs`, `handle_swarm_command` | `p3_swarm_status_plan_run_cancel_surface_is_handled` |
+| Deterministic swarm plan | `/swarm plan [mode]` | `build_swarm_execution_plan`, `parse_swarm_mode`, `read_swarm_pass_cap` | `p3_swarm_status_plan_run_cancel_surface_is_handled`, `required_success_uses_majority_when_voters_gt_two` |
+| One-shot swarm execution arm | `/swarm run [passes] [mode]` | `handle_swarm_command` + quorum arming (`app.quorum_armed_once`) | `p3_swarm_status_plan_run_cancel_surface_is_handled` |
+| Cancel/disarm path | `/swarm cancel` | `handle_swarm_command`, `clear_quorum_system_hints` | `p3_swarm_status_plan_run_cancel_surface_is_handled` |
+| Artifact introspection | `/swarm artifact` | `latest_quorum_artifact_path`, artifact summary readback | command handler coverage in `--lib` suite |
+| Compatibility aliasing | `/swarms` -> `/swarm` | `canonical_command` mapping | `test_upstream_compat_aliases_are_mapped`, `p3_swarm_commands_registered_and_completable` |
+


### PR DESCRIPTION
## Summary
- add hermes-intelligence swarm runtime module with feature-aware swarms status and deterministic execution plan contract
- add /swarm command surface (status, plan, run, cancel, artifact) with quorum-compatible controls and /swarms alias
- add OpenHuman P3 runbook + surface matrix and README operator command updates

## Validation
- cargo fmt
- cargo test -p hermes-intelligence swarm_runtime -- --nocapture
- cargo test -p hermes-cli p3_swarm -- --nocapture
- cargo check -p hermes-intelligence
- cargo check -p hermes-intelligence --features swarms