### PR TITLE
fix: tighten agent execution loop and textual tool-call coercion

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -234,6 +234,7 @@ const OBJECTIVE_DEEP_AUDIT_MIN_UNIQUE_COMMANDS: usize = 3;
 const OBJECTIVE_DEEP_AUDIT_MIN_WORKSTREAMS: usize = 3;
 const FINALIZER_EVIDENCE_MAX_RETRIES: u32 = 2;
 const FINALIZER_OUTPUT_QUALITY_MAX_RETRIES: u32 = 2;
+const FINALIZER_ACTION_EXECUTION_MAX_RETRIES: u32 = 2;
 
 // Python `AIAgent._MEMORY_REVIEW_PROMPT` / `_SKILL_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT` (v2026.4.13)
 const MEMORY_REVIEW_PROMPT: &str = "Review the conversation above and consider saving to memory if appropriate.\n\n\
@@ -4519,6 +4520,7 @@ impl AgentLoop {
         let mut objective_guard_retries: u32 = 0;
         let mut finalizer_evidence_retries: u32 = 0;
         let mut finalizer_output_quality_retries: u32 = 0;
+        let mut finalizer_action_execution_retries: u32 = 0;
         let governor_window_limit = governor_window_size();
 
         loop {
@@ -4960,8 +4962,32 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                if finalizer_action_execution_requires_retry(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    finalizer_action_execution_retries,
+                ) {
+                    finalizer_action_execution_retries =
+                        finalizer_action_execution_retries.saturating_add(1);
+                    self.emit_status(
+                        "lifecycle",
+                        "Detected intent narration without execution evidence; forcing action run.",
+                    );
+                    ctx.add_message(Message::system(
+                        "[SYSTEM] Execution contract: this request requires concrete execution now.\n\
+                         Requirements:\n\
+                         - run the relevant tool calls in this turn (do not only describe intent)\n\
+                         - if blocked, output `BLOCKED:` with exact command/tool error and next probe\n\
+                         - include at least one evidence line (`cmd=...` or `file=...`) in the final response.",
+                    ));
+                    ctx.add_message(Message::user(
+                        "Execute now. Do not narrate intent; return concrete evidence or explicit BLOCKED state.",
+                    ));
+                    continue;
+                }
                 finalizer_evidence_retries = 0;
                 finalizer_output_quality_retries = 0;
+                finalizer_action_execution_retries = 0;
                 let (objective_guard_active, requires_analytics, deep_audit_required) =
                     objective_guard_policy(ctx.get_messages());
                 if objective_guard_active {
@@ -5591,6 +5617,7 @@ impl AgentLoop {
         let mut objective_guard_retries: u32 = 0;
         let mut finalizer_evidence_retries: u32 = 0;
         let mut finalizer_output_quality_retries: u32 = 0;
+        let mut finalizer_action_execution_retries: u32 = 0;
         let governor_window_limit = governor_window_size();
 
         loop {
@@ -6102,8 +6129,32 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                if finalizer_action_execution_requires_retry(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    finalizer_action_execution_retries,
+                ) {
+                    finalizer_action_execution_retries =
+                        finalizer_action_execution_retries.saturating_add(1);
+                    self.emit_status(
+                        "lifecycle",
+                        "Detected intent narration without execution evidence; forcing action run.",
+                    );
+                    ctx.add_message(Message::system(
+                        "[SYSTEM] Execution contract: this request requires concrete execution now.\n\
+                         Requirements:\n\
+                         - run the relevant tool calls in this turn (do not only describe intent)\n\
+                         - if blocked, output `BLOCKED:` with exact command/tool error and next probe\n\
+                         - include at least one evidence line (`cmd=...` or `file=...`) in the final response.",
+                    ));
+                    ctx.add_message(Message::user(
+                        "Execute now. Do not narrate intent; return concrete evidence or explicit BLOCKED state.",
+                    ));
+                    continue;
+                }
                 finalizer_evidence_retries = 0;
                 finalizer_output_quality_retries = 0;
+                finalizer_action_execution_retries = 0;
                 let (objective_guard_active, requires_analytics, deep_audit_required) =
                     objective_guard_policy(ctx.get_messages());
                 if objective_guard_active {
@@ -8506,6 +8557,94 @@ fn finalizer_output_quality_requires_retry(assistant_text: &str, retry_count: u3
         }
     }
     false
+}
+
+fn assistant_response_has_execution_evidence(lower: &str) -> bool {
+    [
+        "file=",
+        "path=",
+        "cmd=",
+        "exists_now=",
+        "objective_state=",
+        "error:",
+        "blocked:",
+        "blocker:",
+        "run finished",
+        "tested",
+        "verified",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn detect_execution_required_intent(messages: &[Message]) -> bool {
+    let user = latest_user_content(messages)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if user.trim().is_empty() {
+        return false;
+    }
+    let objective = extract_session_objective(messages)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let combined = format!("{} {}", user, objective);
+    let action_terms = [
+        "proceed",
+        "implement",
+        "fix",
+        "debug",
+        "diagnose",
+        "run",
+        "test",
+        "patch",
+        "sync",
+        "rebuild",
+        "verify",
+        "connect",
+        "integrat",
+        "investigate",
+        "analyze",
+        "review",
+    ];
+    let has_action = action_terms.iter().any(|needle| combined.contains(needle));
+    let has_surface = combined.contains("repo")
+        || combined.contains("repository")
+        || combined.contains("codebase")
+        || combined.contains("contextlattice")
+        || combined.contains('/')
+        || combined.contains(".rs")
+        || combined.contains(".py")
+        || combined.contains("session");
+    has_action && has_surface
+}
+
+fn finalizer_action_execution_requires_retry(
+    messages: &[Message],
+    assistant_text: &str,
+    retry_count: u32,
+) -> bool {
+    if retry_count >= FINALIZER_ACTION_EXECUTION_MAX_RETRIES {
+        return false;
+    }
+    if !detect_execution_required_intent(messages) {
+        return false;
+    }
+    let lower = assistant_text.to_ascii_lowercase();
+    if assistant_response_has_execution_evidence(&lower) {
+        return false;
+    }
+    let deferral_markers = [
+        "i will",
+        "i'll",
+        "let me",
+        "i can",
+        "i'm going to",
+        "proceeding",
+        "next i",
+        "i should",
+        "i would",
+    ];
+    deferral_markers.iter().any(|needle| lower.contains(needle))
 }
 
 fn detect_contextlattice_connect_intent(messages: &[Message]) -> bool {
@@ -12832,6 +12971,35 @@ mod tests {
             - **Title:** Bayesian Learning for Dive State Prediction and Management";
         assert!(finalizer_output_quality_requires_retry(duplicated, 0));
         assert!(!finalizer_output_quality_requires_retry(duplicated, 2));
+    }
+
+    #[test]
+    fn test_finalizer_action_execution_retry_detects_intent_narration() {
+        let msgs = vec![Message::user(
+            "proceed with deep repo review for /tmp/app and implement patches",
+        )];
+        assert!(finalizer_action_execution_requires_retry(
+            &msgs,
+            "I will proceed now and report back shortly.",
+            0
+        ));
+        assert!(!finalizer_action_execution_requires_retry(
+            &msgs,
+            "I will proceed now and report back shortly.",
+            2
+        ));
+    }
+
+    #[test]
+    fn test_finalizer_action_execution_retry_skips_when_evidence_present() {
+        let msgs = vec![Message::user(
+            "proceed with deep repo review for /tmp/app and implement patches",
+        )];
+        assert!(!finalizer_action_execution_requires_retry(
+            &msgs,
+            "cmd=rg -n TODO src\nfile=/tmp/app/src/main.rs\nobjective_state=advancing",
+            0
+        ));
     }
 
     #[test]

--- a/crates/hermes-core/src/tool_call_parser.rs
+++ b/crates/hermes-core/src/tool_call_parser.rs
@@ -192,6 +192,9 @@ impl ToolCallParser for HermesToolCallParser {
             Regex::new(r#"(?s)<tool_call\s+name=['"]([^'"]+)['"]\s*>(.*?)</tool_call>"#).unwrap();
         let argument_re =
             Regex::new(r#"(?s)<argument\s+name=['"]([^'"]+)['"]\s*>(.*?)</argument>"#).unwrap();
+        let arguments_re = Regex::new(r#"(?s)<arguments>\s*(.*?)\s*</arguments>"#).unwrap();
+        let tool_use_re = Regex::new(r#"(?s)<tool_use>\s*(.*?)\s*</tool_use>"#).unwrap();
+        let tool_use_name_re = Regex::new(r#"(?s)<name>\s*([^<]+?)\s*</name>"#).unwrap();
 
         for fc_caps in func_calls_re.captures_iter(content) {
             let block = fc_caps.get(1).unwrap().as_str();
@@ -224,6 +227,27 @@ impl ToolCallParser for HermesToolCallParser {
                 let name = call_caps.get(1).unwrap().as_str().to_string();
                 let args_block = call_caps.get(2).unwrap().as_str();
                 let mut args = serde_json::Map::new();
+                if let Some(arguments_caps) = arguments_re.captures(args_block) {
+                    let raw_value = arguments_caps.get(1).unwrap().as_str().trim();
+                    let parsed_value = serde_json::from_str(raw_value)
+                        .unwrap_or_else(|_| serde_json::Value::String(raw_value.to_string()));
+                    let arguments = if let serde_json::Value::Object(map) = parsed_value {
+                        serde_json::Value::Object(map)
+                    } else {
+                        let mut fallback = serde_json::Map::new();
+                        fallback.insert("value".to_string(), parsed_value);
+                        serde_json::Value::Object(fallback)
+                    };
+                    calls.push(ToolCall {
+                        id: next_call_id(),
+                        function: FunctionCall {
+                            name,
+                            arguments: arguments.to_string(),
+                        },
+                        extra_content: None,
+                    });
+                    continue;
+                }
                 for arg_caps in argument_re.captures_iter(args_block) {
                     let arg_name = arg_caps.get(1).unwrap().as_str().to_string();
                     let raw_value = arg_caps.get(2).unwrap().as_str().trim();
@@ -236,6 +260,41 @@ impl ToolCallParser for HermesToolCallParser {
                     function: FunctionCall {
                         name,
                         arguments: serde_json::Value::Object(args).to_string(),
+                    },
+                    extra_content: None,
+                });
+            }
+        }
+
+        if calls.is_empty() {
+            for use_caps in tool_use_re.captures_iter(content) {
+                let block = use_caps.get(1).unwrap().as_str();
+                let Some(name_caps) = tool_use_name_re.captures(block) else {
+                    continue;
+                };
+                let name = name_caps.get(1).unwrap().as_str().trim().to_string();
+                if name.is_empty() {
+                    continue;
+                }
+                let arguments = if let Some(arguments_caps) = arguments_re.captures(block) {
+                    let raw = arguments_caps.get(1).unwrap().as_str().trim();
+                    let parsed_value = serde_json::from_str(raw)
+                        .unwrap_or_else(|_| serde_json::Value::String(raw.to_string()));
+                    if let serde_json::Value::Object(map) = parsed_value {
+                        serde_json::Value::Object(map)
+                    } else {
+                        let mut fallback = serde_json::Map::new();
+                        fallback.insert("value".to_string(), parsed_value);
+                        serde_json::Value::Object(fallback)
+                    }
+                } else {
+                    serde_json::Value::Object(serde_json::Map::new())
+                };
+                calls.push(ToolCall {
+                    id: next_call_id(),
+                    function: FunctionCall {
+                        name,
+                        arguments: arguments.to_string(),
                     },
                     extra_content: None,
                 });
@@ -305,6 +364,10 @@ pub fn separate_text_and_calls(content: &str) -> (String, Vec<ToolCall>) {
     let alt_tool_call_re =
         Regex::new(r#"(?s)<tool_call\s+name=['"][^'"]+['"]\s*>.*?</tool_call>"#).unwrap();
     result = alt_tool_call_re.replace_all(&result, "").to_string();
+
+    // Remove <tool_use>...</tool_use> blocks
+    let tool_use_re = Regex::new(r"(?s)<tool_use>\s*.*?\s*</tool_use>").unwrap();
+    result = tool_use_re.replace_all(&result, "").to_string();
 
     // Remove bare <tool_call>...</tool_call> blocks
     let bare_tool_call_re = Regex::new(r"(?s)<tool_call>\s*.*?\s*</tool_call>").unwrap();
@@ -474,6 +537,37 @@ Hello! Let me search for that.
     }
 
     #[test]
+    fn test_parse_tool_call_xml_arguments_payload_variant() {
+        let content = r#"
+<tool_call name="contextlattice_context_pack">
+<arguments>{"query":"repo state","max_items":20}</arguments>
+</tool_call>
+"#;
+        let calls = parse_tool_calls(content).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "contextlattice_context_pack");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["query"], "repo state");
+        assert_eq!(args["max_items"], 20);
+    }
+
+    #[test]
+    fn test_parse_tool_use_name_arguments_variant() {
+        let content = r#"
+<tool_use>
+<name>shell_exec</name>
+<arguments>{"cmd":"pwd","timeout_ms":10000}</arguments>
+</tool_use>
+"#;
+        let calls = parse_tool_calls(content).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "shell_exec");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["cmd"], "pwd");
+        assert_eq!(args["timeout_ms"], 10000);
+    }
+
+    #[test]
     fn test_parse_bare_tool_call_json_payload() {
         let content = r#"
 Proceeding.
@@ -526,6 +620,22 @@ Ready.
         let (text, calls) = separate_text_and_calls(content);
         assert_eq!(calls.len(), 1);
         assert_eq!(text.trim(), "Ready.");
+    }
+
+    #[test]
+    fn test_separate_text_and_calls_removes_tool_use_block() {
+        let content = r#"
+Proceeding now.
+<tool_use>
+<name>contextlattice_search</name>
+<arguments>{"query":"connectivity probe","limit":5}</arguments>
+</tool_use>
+"#;
+        let (text, calls) = separate_text_and_calls(content);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "contextlattice_search");
+        assert_eq!(text.trim(), "Proceeding now.");
+        assert!(!text.contains("<tool_use>"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse additional textual tool call formats (`<tool_use>`, `<arguments>`) so calls execute instead of rendering as plain text
- add a finalizer execution-contract retry when action-oriented tasks return intent narration without evidence
- add regression tests in `hermes-core` parser and `hermes-agent` finalizer guards

## Validation
- cargo test -p hermes-core tool_call_parser -- --nocapture
- cargo test -p hermes-agent finalizer_action_execution -- --nocapture
- cargo check -p hermes-agent
