### PR TITLE
Fix Nous auth auto-recovery and relax tool strictness

### DIFF
--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -700,8 +700,8 @@ fn default_subagent_registry() -> SubagentRegistry {
                 ],
                 escalation_target: "coder".to_string(),
                 budget: SubagentBudgetPolicy {
-                    max_turns: 24,
-                    max_tool_calls: 72,
+                    max_turns: 64,
+                    max_tool_calls: 180,
                     max_tokens: 250_000,
                 },
             },
@@ -715,8 +715,8 @@ fn default_subagent_registry() -> SubagentRegistry {
                 ],
                 escalation_target: "release-manager".to_string(),
                 budget: SubagentBudgetPolicy {
-                    max_turns: 48,
-                    max_tool_calls: 120,
+                    max_turns: 96,
+                    max_tool_calls: 320,
                     max_tokens: 350_000,
                 },
             },
@@ -730,8 +730,8 @@ fn default_subagent_registry() -> SubagentRegistry {
                 ],
                 escalation_target: "operator".to_string(),
                 budget: SubagentBudgetPolicy {
-                    max_turns: 20,
-                    max_tool_calls: 50,
+                    max_turns: 48,
+                    max_tool_calls: 180,
                     max_tokens: 180_000,
                 },
             },
@@ -1390,7 +1390,35 @@ pub fn append_objective_eval_sample(
 
 pub fn load_subagent_registry() -> Result<SubagentRegistry, AgentError> {
     ensure_alpha_runtime_bootstrap(false)?;
-    read_json_file(&subagent_registry_path())
+    let path = subagent_registry_path();
+    let mut registry = read_json_file::<SubagentRegistry>(&path)?;
+    let mut changed = false;
+    for profile in registry.profiles.iter_mut() {
+        let role = profile.role.trim().to_ascii_lowercase();
+        let (min_turns, min_tool_calls, min_tokens) = match role.as_str() {
+            "research" => (64u32, 180u32, 250_000u32),
+            "coder" => (96u32, 320u32, 350_000u32),
+            "release-manager" => (48u32, 180u32, 180_000u32),
+            _ => (48u32, 120u32, 180_000u32),
+        };
+        if profile.budget.max_turns < min_turns {
+            profile.budget.max_turns = min_turns;
+            changed = true;
+        }
+        if profile.budget.max_tool_calls < min_tool_calls {
+            profile.budget.max_tool_calls = min_tool_calls;
+            changed = true;
+        }
+        if profile.budget.max_tokens < min_tokens {
+            profile.budget.max_tokens = min_tokens;
+            changed = true;
+        }
+    }
+    if changed {
+        registry.updated_at = now_rfc3339();
+        write_json_file(&path, &registry)?;
+    }
+    Ok(registry)
 }
 
 pub fn load_contextlattice_policy() -> Result<ContextLatticePolicy, AgentError> {
@@ -3525,6 +3553,28 @@ mod tests {
             assert!(alpha_state_dir().join(LOOPS_FILE).exists());
             assert!(alpha_state_dir().join(SUBAGENT_REGISTRY_FILE).exists());
             assert!(alpha_state_dir().join(CONTEXTLATTICE_POLICY_FILE).exists());
+        });
+    }
+
+    #[test]
+    fn load_subagent_registry_normalizes_legacy_low_budgets() {
+        with_test_hermes_home(|| {
+            ensure_alpha_runtime_bootstrap(true).expect("bootstrap");
+            let path = alpha_state_dir().join(SUBAGENT_REGISTRY_FILE);
+            let mut registry: SubagentRegistry = read_json_file(&path).expect("read registry");
+            for profile in registry.profiles.iter_mut() {
+                profile.budget.max_turns = 1;
+                profile.budget.max_tool_calls = 1;
+                profile.budget.max_tokens = 1;
+            }
+            write_json_file(&path, &registry).expect("write legacy budgets");
+
+            let normalized = load_subagent_registry().expect("load normalized registry");
+            for profile in normalized.profiles {
+                assert!(profile.budget.max_turns >= 48);
+                assert!(profile.budget.max_tool_calls >= 120);
+                assert!(profile.budget.max_tokens >= 180_000);
+            }
         });
     }
 

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -35,8 +35,9 @@ use crate::alpha_runtime::{
     load_objective_contract, load_quorum_policy, objective_lifecycle_is_active, QuorumPolicy,
 };
 use crate::auth::{
-    resolve_gemini_oauth_runtime_credentials, resolve_nous_runtime_credentials,
-    resolve_qwen_runtime_credentials, DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
+    login_nous_device_code, resolve_gemini_oauth_runtime_credentials,
+    resolve_nous_runtime_credentials, resolve_qwen_runtime_credentials, save_nous_auth_state,
+    NousDeviceCodeOptions, DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
     NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 };
 use crate::cli::Cli;
@@ -428,6 +429,60 @@ impl App {
         )
     }
 
+    fn auto_nous_reauth_enabled() -> bool {
+        !matches!(
+            std::env::var("HERMES_AUTO_NOUS_REAUTH")
+                .ok()
+                .as_deref()
+                .map(|v| v.trim().to_ascii_lowercase()),
+            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+        )
+    }
+
+    fn auth_error_requires_nous_login(err: &AgentError) -> bool {
+        let text = err.to_string().to_ascii_lowercase();
+        text.contains("not logged into nous portal")
+            || text.contains("re-run `hermes auth nous`")
+            || text.contains("stored nous auth state is invalid")
+            || text.contains("missing refresh token")
+            || text.contains("invalid nous refresh response")
+    }
+
+    async fn attempt_interactive_nous_login(&mut self, reason: &str) -> bool {
+        if !Self::auto_nous_reauth_enabled() {
+            return false;
+        }
+        Self::emit_lifecycle_event(
+            &self.stream_handle_shared,
+            format!("Nous OAuth re-auth required ({reason}); launching portal login flow"),
+        );
+        match login_nous_device_code(NousDeviceCodeOptions::default()).await {
+            Ok(state) => match save_nous_auth_state(&state) {
+                Ok(path) => {
+                    Self::emit_lifecycle_event(
+                        &self.stream_handle_shared,
+                        format!("Nous OAuth state refreshed: {}", path.display()),
+                    );
+                    true
+                }
+                Err(err) => {
+                    Self::emit_lifecycle_event(
+                        &self.stream_handle_shared,
+                        format!("Nous OAuth state save failed: {}", err),
+                    );
+                    false
+                }
+            },
+            Err(err) => {
+                Self::emit_lifecycle_event(
+                    &self.stream_handle_shared,
+                    format!("Nous OAuth interactive login failed: {}", err),
+                );
+                false
+            }
+        }
+    }
+
     async fn refresh_runtime_provider_credentials_if_needed(&mut self, force_refresh: bool) {
         let (provider_name, _) = resolve_provider_and_model(&self.config, &self.current_model);
         let provider = normalize_runtime_provider_name(provider_name.as_str());
@@ -454,10 +509,44 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    Self::emit_lifecycle_event(
-                        &self.stream_handle_shared,
-                        format!("warning: Nous credential refresh skipped ({e})"),
-                    );
+                    if Self::auth_error_requires_nous_login(&e)
+                        && self
+                            .attempt_interactive_nous_login("credential missing or invalid")
+                            .await
+                    {
+                        match resolve_nous_runtime_credentials(
+                            true,
+                            true,
+                            NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+                            DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
+                        )
+                        .await
+                        {
+                            Ok(creds) => {
+                                rotated |= Self::set_env_if_changed("NOUS_API_KEY", &creds.api_key);
+                                if !creds.base_url.trim().is_empty() {
+                                    rotated |= Self::set_env_if_changed(
+                                        "NOUS_INFERENCE_BASE_URL",
+                                        &creds.base_url,
+                                    );
+                                }
+                                if rotated {
+                                    note = Some("refreshed Nous runtime credential".to_string());
+                                }
+                            }
+                            Err(err) => {
+                                Self::emit_lifecycle_event(
+                                    &self.stream_handle_shared,
+                                    format!("warning: Nous credential refresh skipped ({err})"),
+                                );
+                            }
+                        }
+                    } else {
+                        Self::emit_lifecycle_event(
+                            &self.stream_handle_shared,
+                            format!("warning: Nous credential refresh skipped ({e})"),
+                        );
+                    }
                 }
             },
             "qwen-oauth" => match resolve_qwen_runtime_credentials(
@@ -754,7 +843,9 @@ impl App {
              1) apply anti-scheming evidence-first discipline\n\
              2) pull ContextLattice context first when relevant\n\
              3) route tool usage intentionally and avoid repetitive low-signal loops\n\
-             4) match requested output shape exactly (count/format), with no template placeholders or duplicate list items\n",
+             4) match requested output shape exactly (count/format), with no template placeholders or duplicate list items\n\
+             5) for open-ended missions, execute at least one concrete action before returning status text\n\
+             6) maintain iterative objective momentum: gather evidence, test, refine, then continue with next high-value action\n",
         );
         out.push_str(&format!(
             "tool-profile(mode): {}\ncontextlattice(topic): {}\n{}\n",
@@ -2428,10 +2519,52 @@ impl App {
                         true,
                     )
                 }
-                Err(err) => (
-                    Some(format!("Nous auth auto-refresh failed: {}", err)),
-                    false,
-                ),
+                Err(err) => {
+                    if Self::auth_error_requires_nous_login(&err)
+                        && self
+                            .attempt_interactive_nous_login("runtime auth refresh failed")
+                            .await
+                    {
+                        match resolve_nous_runtime_credentials(
+                            true,
+                            true,
+                            NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+                            DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
+                        )
+                        .await
+                        {
+                            Ok(creds) => {
+                                let mut changed = false;
+                                changed |= Self::set_env_if_changed("NOUS_API_KEY", &creds.api_key);
+                                if !creds.base_url.trim().is_empty() {
+                                    changed |= Self::set_env_if_changed(
+                                        "NOUS_INFERENCE_BASE_URL",
+                                        &creds.base_url,
+                                    );
+                                }
+                                if changed {
+                                    self.switch_model(&self.current_model.clone());
+                                }
+                                (
+                                    Some(
+                                        "Nous auth re-login succeeded; retrying request."
+                                            .to_string(),
+                                    ),
+                                    true,
+                                )
+                            }
+                            Err(retry_err) => (
+                                Some(format!("Nous auth auto-refresh failed: {}", retry_err)),
+                                false,
+                            ),
+                        }
+                    } else {
+                        (
+                            Some(format!("Nous auth auto-refresh failed: {}", err)),
+                            false,
+                        )
+                    }
+                }
             },
             "qwen-oauth" => {
                 match resolve_qwen_runtime_credentials(
@@ -3474,6 +3607,8 @@ mod tests {
         assert!(injected_text.contains("contextlattice(topic): runbooks/objective/test-objective"));
         assert!(injected_text.contains(contract.id.as_str()));
         assert!(injected_text.contains("UNPROVEN/CONTRADICTORY"));
+        assert!(injected_text.contains("execute at least one concrete action"));
+        assert!(injected_text.contains("iterative objective momentum"));
         assert_eq!(messages[1].role, hermes_core::MessageRole::User);
 
         match prev_home {
@@ -3570,6 +3705,26 @@ mod tests {
         assert!(App::is_provider_auth_or_session_error(&err));
         let non_auth = AgentError::LlmApi("API error 404 Not Found: model missing".to_string());
         assert!(!App::is_provider_auth_or_session_error(&non_auth));
+    }
+
+    #[test]
+    fn test_auth_error_requires_nous_login_detects_missing_login_shape() {
+        let err = AgentError::AuthFailed(
+            "Hermes is not logged into Nous Portal. Run `hermes auth nous`.".to_string(),
+        );
+        assert!(App::auth_error_requires_nous_login(&err));
+        let unrelated = AgentError::AuthFailed("rate limited".to_string());
+        assert!(!App::auth_error_requires_nous_login(&unrelated));
+    }
+
+    #[test]
+    fn test_auto_nous_reauth_toggle_defaults_on() {
+        let _guard = env_test_lock();
+        std::env::remove_var("HERMES_AUTO_NOUS_REAUTH");
+        assert!(App::auto_nous_reauth_enabled());
+        std::env::set_var("HERMES_AUTO_NOUS_REAUTH", "0");
+        assert!(!App::auto_nous_reauth_enabled());
+        std::env::remove_var("HERMES_AUTO_NOUS_REAUTH");
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -7397,7 +7397,7 @@ async fn handle_ops_cockpit_command(
         "policy: profile={} mode={} preset={} sandbox={} skills_tier={}",
         current_policy_profile_name(),
         std::env::var("HERMES_TOOL_POLICY_MODE").unwrap_or_else(|_| "enforce".into()),
-        std::env::var("HERMES_TOOL_POLICY_PRESET").unwrap_or_else(|_| "balanced".into()),
+        std::env::var("HERMES_TOOL_POLICY_PRESET").unwrap_or_else(|_| "relaxed".into()),
         std::env::var("HERMES_EXECUTION_SANDBOX_PROFILE").unwrap_or_else(|_| "balanced".into()),
         std::env::var("HERMES_SKILLS_EXECUTION_TIER").unwrap_or_else(|_| "balanced".into())
     );

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -313,6 +313,49 @@ async fn main() {
                     global_allow_tools_override,
                 )
                 .await;
+                if provider == "nous" {
+                    if let Err(retry_err) = &result {
+                        if oneshot_auto_verify_oauth_provider(
+                            retry_err,
+                            Some(provider.as_str()),
+                            global_model_override.as_deref(),
+                        )
+                        .as_deref()
+                            == Some("nous")
+                        {
+                            eprintln!(
+                                "Nous OAuth still invalid; launching `hermes-ultra auth login nous` and retrying once..."
+                            );
+                            if let Err(login_err) = run_auth(
+                                cli.clone(),
+                                Some("login".to_string()),
+                                Some("nous".to_string()),
+                                None,
+                                None,
+                                None,
+                                None,
+                                false,
+                            )
+                            .await
+                            {
+                                eprintln!(
+                                    "Warning: automatic `auth login nous` failed: {}",
+                                    login_err
+                                );
+                            } else {
+                                result = hermes_cli::commands::handle_cli_chat(
+                                    Some(cli.oneshot.clone().unwrap_or_default()),
+                                    None,
+                                    false,
+                                    global_model_override.clone(),
+                                    global_provider_override.clone(),
+                                    global_allow_tools_override,
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                }
             }
         }
         if let Err(e) = result {
@@ -9795,7 +9838,7 @@ fn build_elite_doctor_diagnostics(cli: &Cli) -> serde_json::Value {
     let policy_preset = std::env::var("HERMES_TOOL_POLICY_PRESET")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "balanced".to_string());
+        .unwrap_or_else(|| "relaxed".to_string());
 
     let elite_gate_script = std::env::var("HERMES_ELITE_GATE_CMD")
         .ok()
@@ -11982,7 +12025,7 @@ async fn run_status(cli: Cli) -> Result<(), AgentError> {
     let policy_preset = std::env::var("HERMES_TOOL_POLICY_PRESET")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "balanced".to_string());
+        .unwrap_or_else(|| "relaxed".to_string());
     let policy_counters_path = default_tool_policy_counters_path();
     let policy_counters = load_tool_policy_counters(&policy_counters_path).unwrap_or_default();
     println!(

--- a/crates/hermes-tools/src/tool_policy.rs
+++ b/crates/hermes-tools/src/tool_policy.rs
@@ -133,7 +133,7 @@ impl ToolPolicyEngine {
             .ok()
             .as_deref()
             .and_then(ToolPolicyPreset::parse)
-            .unwrap_or(ToolPolicyPreset::Balanced);
+            .unwrap_or(ToolPolicyPreset::Relaxed);
         let mut policy = Self::from_preset(preset);
 
         if let Ok(path) = std::env::var("HERMES_TOOL_POLICY_FILE") {
@@ -1138,6 +1138,46 @@ mod tests {
         match sandbox_orig {
             Some(v) => std::env::set_var("HERMES_EXECUTION_SANDBOX_PROFILE", v),
             None => std::env::remove_var("HERMES_EXECUTION_SANDBOX_PROFILE"),
+        }
+    }
+
+    #[test]
+    fn policy_from_env_defaults_to_relaxed_when_unset() {
+        let mode_orig = std::env::var("HERMES_TOOL_POLICY_MODE").ok();
+        let preset_orig = std::env::var("HERMES_TOOL_POLICY_PRESET").ok();
+        let patterns_orig = std::env::var("HERMES_TOOL_POLICY_DENY_PARAM_PATTERNS").ok();
+
+        std::env::remove_var("HERMES_TOOL_POLICY_MODE");
+        std::env::remove_var("HERMES_TOOL_POLICY_PRESET");
+        std::env::remove_var("HERMES_TOOL_POLICY_DENY_PARAM_PATTERNS");
+
+        let policy = ToolPolicyEngine::from_env();
+        let api_key_decision = policy.evaluate(
+            "terminal",
+            &serde_json::json!({"cmd":"echo api_key=abc123 && echo done"}),
+        );
+        assert!(
+            api_key_decision.allow,
+            "default relaxed preset should not block api_key-like strings"
+        );
+        let rm_decision =
+            policy.evaluate("terminal", &serde_json::json!({"cmd":"rm -rf /tmp/demo"}));
+        assert!(
+            !rm_decision.allow,
+            "default relaxed preset should still block destructive rm commands"
+        );
+
+        match mode_orig {
+            Some(v) => std::env::set_var("HERMES_TOOL_POLICY_MODE", v),
+            None => std::env::remove_var("HERMES_TOOL_POLICY_MODE"),
+        }
+        match preset_orig {
+            Some(v) => std::env::set_var("HERMES_TOOL_POLICY_PRESET", v),
+            None => std::env::remove_var("HERMES_TOOL_POLICY_PRESET"),
+        }
+        match patterns_orig {
+            Some(v) => std::env::set_var("HERMES_TOOL_POLICY_DENY_PARAM_PATTERNS", v),
+            None => std::env::remove_var("HERMES_TOOL_POLICY_DENY_PARAM_PATTERNS"),
         }
     }
 


### PR DESCRIPTION
## Summary\n- add automatic Nous re-login fallback when runtime auth state is missing/invalid\n- add one-shot Nous OAuth auto-login retry when verify+retry still fails\n- switch default tool policy preset to relaxed (still blocks destructive rm patterns)\n- raise and auto-normalize subagent tool/turn budgets for deep objective runs\n- strengthen runtime reformulation to enforce action-first objective momentum\n\n## Validation\n- cargo test -p hermes-tools policy_from_env_defaults_to_relaxed_when_unset -- --nocapture\n- cargo test -p hermes-cli test_auth_error_requires_nous_login_detects_missing_login_shape -- --nocapture\n- cargo test -p hermes-cli test_auto_nous_reauth_toggle_defaults_on -- --nocapture\n- cargo test -p hermes-cli test_build_inference_messages_injects_runtime_reformulation -- --nocapture\n- cargo test -p hermes-cli load_subagent_registry_normalizes_legacy_low_budgets -- --nocapture\n- hermes-ultra auth verify nous\n- hermes-ultra -m nous:nousresearch/hermes-4-70b -z "Reply with exactly: 1"\n- hermes-ultra doctor | rg "tool-policy mode/preset"\n