### PR TITLE
feat: show contextlattice connection status in activity lane

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::{Instant, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -567,6 +567,103 @@ impl App {
             provider,
             "nous" | "qwen-oauth" | "google-gemini-cli" | "gemini-cli" | "gemini-oauth"
         )
+    }
+
+    fn contextlattice_ui_status_enabled() -> bool {
+        !matches!(
+            std::env::var("HERMES_CONTEXTLATTICE_UI_STATUS")
+                .ok()
+                .as_deref()
+                .map(|v| v.trim().to_ascii_lowercase()),
+            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+        )
+    }
+
+    fn contextlattice_orchestrator_url() -> String {
+        std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
+            .ok()
+            .or_else(|| std::env::var("MEMMCP_ORCHESTRATOR_URL").ok())
+            .map(|v| v.trim().trim_end_matches('/').to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "http://127.0.0.1:8075".to_string())
+    }
+
+    async fn emit_contextlattice_connectivity_status(&self) {
+        if !Self::contextlattice_ui_status_enabled() {
+            return;
+        }
+        let base = Self::contextlattice_orchestrator_url();
+        let url = format!("{}/status", base);
+        let topic = std::env::var("CONTEXTLATTICE_TOPIC_PATH")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "runbooks/hermes".to_string());
+        Self::emit_lifecycle_event(
+            &self.stream_handle_shared,
+            format!("contextlattice preflight ping {} (topic={})", base, topic),
+        );
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(3))
+            .build()
+        {
+            Ok(c) => c,
+            Err(err) => {
+                Self::emit_lifecycle_event(
+                    &self.stream_handle_shared,
+                    format!("contextlattice client init failed: {}", err),
+                );
+                return;
+            }
+        };
+        match client.get(&url).send().await {
+            Ok(resp) => {
+                let status_code = resp.status();
+                if status_code.is_success() {
+                    let parsed = resp.json::<serde_json::Value>().await.ok();
+                    let service = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("service").and_then(|s| s.as_str()))
+                        .unwrap_or("unknown");
+                    let ok_flag = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("ok").and_then(|s| s.as_bool()))
+                        .unwrap_or(true);
+                    let detail = if ok_flag { "connected" } else { "degraded" };
+                    Self::emit_lifecycle_event(
+                        &self.stream_handle_shared,
+                        format!(
+                            "contextlattice {} (service={} status={} endpoint={})",
+                            detail, service, status_code, base
+                        ),
+                    );
+                    Self::emit_phase_event(
+                        &self.stream_handle_shared,
+                        "context",
+                        if ok_flag {
+                            "contextlattice connected"
+                        } else {
+                            "contextlattice degraded"
+                        },
+                        12,
+                    );
+                } else {
+                    Self::emit_lifecycle_event(
+                        &self.stream_handle_shared,
+                        format!(
+                            "contextlattice status endpoint returned {} ({})",
+                            status_code, url
+                        ),
+                    );
+                }
+            }
+            Err(err) => {
+                Self::emit_lifecycle_event(
+                    &self.stream_handle_shared,
+                    format!("contextlattice preflight failed: {} ({})", err, url),
+                );
+            }
+        }
     }
 
     fn auto_nous_reauth_enabled() -> bool {
@@ -2216,6 +2313,7 @@ impl App {
             "runtime preflight + credential hydration",
             5,
         );
+        self.emit_contextlattice_connectivity_status().await;
         let provider = self.current_runtime_provider();
         let force_refresh = Self::should_force_preflight_auth_refresh(provider.as_str());
         self.refresh_runtime_provider_credentials_if_needed(force_refresh)
@@ -3787,6 +3885,32 @@ mod tests {
         assert!(default_mouse_enabled());
 
         std::env::remove_var("HERMES_TUI_MOUSE");
+    }
+
+    #[test]
+    fn test_contextlattice_orchestrator_url_prefers_contextlattice_env_then_memmcp() {
+        let _lock = env_test_lock();
+        std::env::remove_var("CONTEXTLATTICE_ORCHESTRATOR_URL");
+        std::env::remove_var("MEMMCP_ORCHESTRATOR_URL");
+        assert_eq!(
+            App::contextlattice_orchestrator_url(),
+            "http://127.0.0.1:8075"
+        );
+
+        std::env::set_var("MEMMCP_ORCHESTRATOR_URL", "http://127.0.0.1:9999/");
+        assert_eq!(
+            App::contextlattice_orchestrator_url(),
+            "http://127.0.0.1:9999"
+        );
+
+        std::env::set_var("CONTEXTLATTICE_ORCHESTRATOR_URL", "http://127.0.0.1:7777/");
+        assert_eq!(
+            App::contextlattice_orchestrator_url(),
+            "http://127.0.0.1:7777"
+        );
+
+        std::env::remove_var("CONTEXTLATTICE_ORCHESTRATOR_URL");
+        std::env::remove_var("MEMMCP_ORCHESTRATOR_URL");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add explicit ContextLattice connectivity signal during runtime preflight
- emit lifecycle + phase events showing endpoint, topic, and connected/degraded state
- include env precedence for orchestrator URL (CONTEXTLATTICE_ORCHESTRATOR_URL -> MEMMCP_ORCHESTRATOR_URL -> localhost)
- add test coverage for orchestrator URL precedence

## Validation
- cargo fmt --all
- cargo test -p hermes-cli test_contextlattice_orchestrator_url_prefers_contextlattice_env_then_memmcp -- --nocapture
- cargo test -p hermes-cli test_build_inference_messages_injects_runtime_reformulation -- --nocapture
- hermes-ultra auth verify nous