### PR TITLE
Fix tool-enabled swarm provider fallback

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -948,6 +948,12 @@ fn is_tool_payload_validation_error(err: &str) -> bool {
     (lower.contains("invalid input") && lower.contains("function"))
         || lower.contains("provider returned error")
             && (lower.contains("request is not valid") || lower.contains("check the model name"))
+        || (lower.contains("no choices in response") || lower.contains("empty choices array"))
+            && (lower.contains("request is not valid")
+                || lower.contains("valid payload")
+                || lower.contains("provider returned error")
+                || lower.contains("tool"))
+        || lower.contains("unprocessable entity") && lower.contains("valid payload")
         || lower.contains("tools") && lower.contains("invalid")
 }
 
@@ -3736,24 +3742,11 @@ impl AgentLoop {
             .filter(|s| !s.is_empty())
             .map(str::to_string);
         let active_provider = route_provider_hint.unwrap_or(inferred_provider);
-        let forced_tool_model = if tool_schemas.is_empty() {
-            None
-        } else {
-            preferred_tool_payload_fallback_model(active_provider.as_str(), model_name)
-                .filter(|candidate| !candidate.eq_ignore_ascii_case(model_name))
-        };
-        if let Some(ref fallback_model) = forced_tool_model {
-            self.emit_status(
-                "lifecycle",
-                &format!(
-                    "Routing tool-enabled turn via {}:{} (requested model '{}' does not accept current tool schema).",
-                    active_provider, fallback_model, model_name
-                ),
-            );
-        }
-        let effective_model_name = forced_tool_model
-            .clone()
-            .unwrap_or_else(|| model_name.to_string());
+        // Always try the requested model first. Some providers only reveal tool
+        // schema limitations at request time, so proactive substitution hides
+        // the real model behavior and makes quorum voters appear to "succeed"
+        // on a different backend.
+        let effective_model_name = model_name.to_string();
         if let Some(rt) = route {
             if let Some(ref label) = rt.route_label {
                 tracing::debug!(%label, model = %rt.model, ?rt.signature, "smart model route");
@@ -9124,6 +9117,11 @@ mod tests {
         assert!(is_tool_payload_validation_error(strict_shape));
         let provider_generic = "API error 400 Bad Request: This request is not valid. Check the model name and other parameters. Additional info: Provider returned error";
         assert!(is_tool_payload_validation_error(provider_generic));
+        let no_choices_provider_shape = "No choices in response (status=400; message=This request is not valid. Check the model name and other parameters. Additional info: Provider returned error)";
+        assert!(is_tool_payload_validation_error(no_choices_provider_shape));
+        let unprocessable_payload =
+            "API error 422 Unprocessable Entity: Check that you're sending a valid payload";
+        assert!(is_tool_payload_validation_error(unprocessable_payload));
         assert!(!is_tool_payload_validation_error(
             "API error 400 Bad Request: max_tokens must be positive"
         ));

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -1954,11 +1954,19 @@ fn parse_openai_response(json: &Value) -> Result<LlmResponse, AgentError> {
     let choices = json
         .get("choices")
         .and_then(|c| c.as_array())
-        .ok_or_else(|| AgentError::LlmApi("No choices in response".to_string()))?;
+        .ok_or_else(|| {
+            AgentError::LlmApi(format!(
+                "No choices in response ({})",
+                summarize_openai_response_shape(json)
+            ))
+        })?;
 
-    let choice = choices
-        .first()
-        .ok_or_else(|| AgentError::LlmApi("Empty choices array".to_string()))?;
+    let choice = choices.first().ok_or_else(|| {
+        AgentError::LlmApi(format!(
+            "Empty choices array ({})",
+            summarize_openai_response_shape(json)
+        ))
+    })?;
 
     let message_obj = choice
         .get("message")
@@ -2050,6 +2058,44 @@ fn parse_openai_response(json: &Value) -> Result<LlmResponse, AgentError> {
         model,
         finish_reason,
     })
+}
+
+fn summarize_openai_response_shape(json: &Value) -> String {
+    fn truncate_chars(value: &str, max_chars: usize) -> String {
+        if value.chars().count() <= max_chars {
+            return value.to_string();
+        }
+        let mut out = value
+            .chars()
+            .take(max_chars.saturating_sub(1))
+            .collect::<String>();
+        out.push('…');
+        out
+    }
+
+    let mut parts = Vec::new();
+    if let Some(status) = json.get("status").and_then(|v| v.as_i64()) {
+        parts.push(format!("status={status}"));
+    }
+    if let Some(message) = json.get("message").and_then(|v| v.as_str()) {
+        parts.push(format!("message={}", truncate_chars(message, 240)));
+    }
+    if let Some(error) = json.get("error") {
+        let error_text = error
+            .get("message")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| error.to_string());
+        parts.push(format!("error={}", truncate_chars(&error_text, 240)));
+    }
+    if parts.is_empty() {
+        let keys = json
+            .as_object()
+            .map(|obj| obj.keys().cloned().collect::<Vec<_>>().join(","))
+            .unwrap_or_else(|| json.to_string());
+        parts.push(format!("keys={}", truncate_chars(&keys, 240)));
+    }
+    parts.join("; ")
 }
 
 #[cfg(test)]
@@ -2166,6 +2212,29 @@ mod tests {
         assert_eq!(resp.message.content.as_deref(), Some("Hello!"));
         assert_eq!(resp.finish_reason.as_deref(), Some("stop"));
         assert_eq!(resp.usage.as_ref().unwrap().total_tokens, 15);
+    }
+
+    #[test]
+    fn test_parse_openai_response_no_choices_includes_provider_context() {
+        let json = serde_json::json!({
+            "status": 400,
+            "message": "This request is not valid. Check the model name and other parameters. Additional info: Provider returned error",
+        });
+        let err = parse_openai_response(&json).unwrap_err().to_string();
+        assert!(err.contains("No choices in response"));
+        assert!(err.contains("status=400"));
+        assert!(err.contains("Provider returned error"));
+    }
+
+    #[test]
+    fn test_parse_openai_response_empty_choices_includes_error_context() {
+        let json = serde_json::json!({
+            "choices": [],
+            "error": {"message": "Check that you're sending a valid payload."},
+        });
+        let err = parse_openai_response(&json).unwrap_err().to_string();
+        assert!(err.contains("Empty choices array"));
+        assert!(err.contains("valid payload"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2518,41 +2518,45 @@ impl App {
                             break;
                         }
                         Err(err) => {
+                            if Self::is_provider_tool_payload_error(&err)
+                                && Self::quorum_toolless_provider_fallback_enabled()
+                                && voter_tools_enabled
+                                && !toolless_fallback_used
+                            {
+                                toolless_fallback_used = true;
+                                pass_errors.push(format!(
+                                    "pass {}: provider rejected tool schema on requested model; retried this voter pass without tool schemas",
+                                    pass_idx + 1
+                                ));
+                                Self::emit_lifecycle_event(
+                                    &self.stream_handle_shared,
+                                    format!(
+                                        "quorum voter {}/{} provider rejected tool schema; retrying this voter pass without tool schemas",
+                                        display_index,
+                                        voter_models.len()
+                                    ),
+                                );
+                                match self
+                                    .run_messages_with_current_agent_tools(
+                                        pass_messages.clone(),
+                                        false,
+                                        false,
+                                    )
+                                    .await
+                                {
+                                    Ok(result) => {
+                                        maybe_result = Some(result);
+                                        break;
+                                    }
+                                    Err(fallback_err) => {
+                                        last_err = Some(fallback_err);
+                                        break;
+                                    }
+                                }
+                            }
                             if Self::is_provider_auth_or_session_error(&err)
                                 && attempts < max_attempts
                             {
-                                if Self::quorum_toolless_provider_fallback_enabled()
-                                    && voter_tools_enabled
-                                    && !toolless_fallback_used
-                                    && attempts >= 2
-                                {
-                                    toolless_fallback_used = true;
-                                    Self::emit_lifecycle_event(
-                                        &self.stream_handle_shared,
-                                        format!(
-                                            "quorum voter {}/{} provider rejected tool-enabled request; retrying pass without tool schemas",
-                                            display_index,
-                                            voter_models.len()
-                                        ),
-                                    );
-                                    match self
-                                        .run_messages_with_current_agent_tools(
-                                            pass_messages.clone(),
-                                            false,
-                                            false,
-                                        )
-                                        .await
-                                    {
-                                        Ok(result) => {
-                                            maybe_result = Some(result);
-                                            break;
-                                        }
-                                        Err(fallback_err) => {
-                                            last_err = Some(fallback_err);
-                                            break;
-                                        }
-                                    }
-                                }
                                 let refreshed = self.force_auth_refresh_after_error().await;
                                 if refreshed {
                                     continue;
@@ -2605,8 +2609,12 @@ impl App {
 
             if !combined_output.trim().is_empty() {
                 let output = Self::truncate_for_quorum(&combined_output, output_char_cap);
+                let degraded = Self::quorum_output_is_degraded_non_answer(&output);
                 let status = if output.trim().is_empty() {
                     "empty"
+                } else if degraded {
+                    pass_errors.push("voter returned degraded non-answer".to_string());
+                    "degraded"
                 } else {
                     succeeded += 1;
                     "ok"
@@ -3258,7 +3266,46 @@ impl App {
             || message.contains("expired")
             || message.contains("authentication")
             || message.contains("session expired")
-            || message.contains("provider rejected")
+    }
+
+    fn is_provider_tool_payload_error(err: &AgentError) -> bool {
+        let message = match err {
+            AgentError::LlmApi(msg)
+            | AgentError::Config(msg)
+            | AgentError::ToolExecution(msg)
+            | AgentError::Gateway(msg)
+            | AgentError::AuthFailed(msg) => msg.to_ascii_lowercase(),
+            _ => return false,
+        };
+        let provider_payload_rejected = message.contains("provider returned error")
+            && (message.contains("request is not valid")
+                || message.contains("valid payload")
+                || message.contains("check the model name"));
+        let openai_shape_rejected = (message.contains("no choices in response")
+            || message.contains("empty choices array"))
+            && (message.contains("request is not valid")
+                || message.contains("valid payload")
+                || message.contains("provider returned error")
+                || message.contains("tool"));
+        let explicit_tool_schema_rejected =
+            message.contains("tool") && (message.contains("invalid") || message.contains("schema"));
+        let strict_function_shape =
+            message.contains("invalid input") && message.contains("function");
+        provider_payload_rejected
+            || openai_shape_rejected
+            || explicit_tool_schema_rejected
+            || strict_function_shape
+            || (message.contains("422") && message.contains("valid payload"))
+    }
+
+    fn quorum_output_is_degraded_non_answer(output: &str) -> bool {
+        let lower = output.to_ascii_lowercase();
+        lower.contains("objective delivery compromised")
+            || lower.contains("reverting to hermes")
+            || lower.contains("safe-mode response")
+            || lower.contains("safe mode response")
+            || (lower.contains("i do not have") && lower.contains("tools"))
+            || (lower.contains("cannot access") && lower.contains("tools"))
     }
 
     async fn force_auth_refresh_after_error(&mut self) -> bool {
@@ -4575,6 +4622,42 @@ mod tests {
         assert!(App::is_provider_auth_or_session_error(&err));
         let non_auth = AgentError::LlmApi("API error 404 Not Found: model missing".to_string());
         assert!(!App::is_provider_auth_or_session_error(&non_auth));
+        let provider_payload = AgentError::LlmApi(
+            "API error 400 Bad Request: This request is not valid. Additional info: Provider returned error"
+                .to_string(),
+        );
+        assert!(!App::is_provider_auth_or_session_error(&provider_payload));
+    }
+
+    #[test]
+    fn test_is_provider_tool_payload_error_detects_schema_rejections() {
+        let generic_provider = AgentError::LlmApi(
+            "API error 400 Bad Request: This request is not valid. Check the model name and other parameters. Additional info: Provider returned error"
+                .to_string(),
+        );
+        assert!(App::is_provider_tool_payload_error(&generic_provider));
+        let no_choices = AgentError::LlmApi(
+            "No choices in response (status=400; message=This request is not valid. Additional info: Provider returned error)"
+                .to_string(),
+        );
+        assert!(App::is_provider_tool_payload_error(&no_choices));
+        let invalid_tool = AgentError::LlmApi("tools schema is invalid".to_string());
+        assert!(App::is_provider_tool_payload_error(&invalid_tool));
+        let rate_limit = AgentError::LlmApi("HTTP 429 Too Many Requests".to_string());
+        assert!(!App::is_provider_tool_payload_error(&rate_limit));
+    }
+
+    #[test]
+    fn test_quorum_output_is_degraded_non_answer() {
+        assert!(App::quorum_output_is_degraded_non_answer(
+            "Objective delivery compromised; reverting to Hermes base model"
+        ));
+        assert!(App::quorum_output_is_degraded_non_answer(
+            "I do not have access to tools in this environment"
+        ));
+        assert!(!App::quorum_output_is_degraded_non_answer(
+            "Strategy table: edge hypothesis, required data, implementation delta"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- try requested quorum/swarm voter models with tool schemas before any fallback
- add provider response-shape diagnostics for no-choices/empty-choices payloads
- separate provider auth errors from tool-schema payload errors and mark degraded non-answer voters as non-success

## Tests
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-agent openai_response -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-agent tool_payload_validation_error_detector -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli provider_tool_payload -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli quorum_output_is_degraded -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli provider_auth_or_session_error -- --nocapture