### PR TITLE
Preserve versioned Nous swarm model IDs

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -1458,6 +1458,18 @@ impl App {
         }
     }
 
+    fn looks_like_version_pinned_model(model_id: &str) -> bool {
+        let tail = model_id
+            .trim()
+            .rsplit('/')
+            .next()
+            .unwrap_or(model_id)
+            .to_ascii_lowercase();
+        tail.as_bytes()
+            .windows(8)
+            .any(|window| window.iter().all(|byte| byte.is_ascii_digit()))
+    }
+
     fn resolve_quorum_catalog_candidate(
         requested_model: &str,
         catalog: &[String],
@@ -1482,6 +1494,9 @@ impl App {
             lower.ends_with(&slash_suffix) || lower == requested_lc
         }) {
             return Some(hit.clone());
+        }
+        if Self::looks_like_version_pinned_model(requested_trimmed) {
+            return None;
         }
         Self::rank_catalog_candidates(requested_trimmed, catalog, 1)
             .into_iter()
@@ -1590,6 +1605,11 @@ impl App {
                             normalized, final_target
                         ));
                     }
+                } else if Self::looks_like_version_pinned_model(model_id) {
+                    notes.push(format!(
+                        "quorum model preserved despite catalog miss: {}",
+                        normalized
+                    ));
                 } else if let Some(fallback) = catalog.first() {
                     let ranked = Self::rank_catalog_candidates(model_id, &catalog, 3);
                     final_target = format!("{}:{}", provider, fallback.trim());
@@ -4712,6 +4732,36 @@ mod tests {
         ];
         let resolved = App::resolve_quorum_catalog_candidate("qwen3.6-max", &catalog);
         assert_eq!(resolved.as_deref(), Some("qwen/qwen3.6-max-preview"));
+    }
+
+    #[test]
+    fn test_resolve_quorum_catalog_candidate_preserves_version_pinned_miss() {
+        let catalog = vec![
+            "openai/gpt-5.5-pro".to_string(),
+            "anthropic/claude-opus-4.7".to_string(),
+            "qwen/qwen3.6-max-preview".to_string(),
+        ];
+
+        let gpt = App::resolve_quorum_catalog_candidate("openai/gpt-5.5-pro-20260423", &catalog);
+        let claude = App::resolve_quorum_catalog_candidate(
+            "anthropic/claude-4.7-opus-fast-20260512",
+            &catalog,
+        );
+        let qwen =
+            App::resolve_quorum_catalog_candidate("qwen/qwen3.6-max-preview-20260420", &catalog);
+
+        assert!(
+            gpt.is_none(),
+            "version-pinned GPT ID should not fuzzy-remap"
+        );
+        assert!(
+            claude.is_none(),
+            "version-pinned Claude ID should not fuzzy-remap"
+        );
+        assert!(
+            qwen.is_none(),
+            "version-pinned Qwen ID should not fuzzy-remap"
+        );
     }
 
     #[test]

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 
 use crate::providers::{canonical_provider_id, provider_capability_for};
 const NOUS_DEFAULT_INFERENCE_BASE_URL: &str = "https://inference-api.nousresearch.com/v1";
-const PROVIDER_CATALOG_CACHE_VERSION: u32 = 1;
+const PROVIDER_CATALOG_CACHE_VERSION: u32 = 2;
 const OLLAMA_LOCAL_DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
 const LLAMA_CPP_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080/v1";
 const VLLM_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
@@ -37,9 +37,12 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
     (
         "nous",
         &[
+            "openai/gpt-5.5-pro-20260423",
             "openai/gpt-5.5-pro",
             "openai/gpt-5.5",
+            "anthropic/claude-4.7-opus-fast-20260512",
             "anthropic/claude-opus-4.7",
+            "qwen/qwen3.6-max-preview-20260420",
             "qwen/qwen3.6-max-preview",
             "deepseek/deepseek-v4-pro",
             "moonshotai/kimi-k2.6",
@@ -1126,9 +1129,12 @@ mod tests {
         let out = provider_model_ids_with_client("nous", &client).await;
         assert!(
             out.starts_with(&[
+                "openai/gpt-5.5-pro-20260423".to_string(),
                 "openai/gpt-5.5-pro".to_string(),
                 "openai/gpt-5.5".to_string(),
+                "anthropic/claude-4.7-opus-fast-20260512".to_string(),
                 "anthropic/claude-opus-4.7".to_string(),
+                "qwen/qwen3.6-max-preview-20260420".to_string(),
                 "qwen/qwen3.6-max-preview".to_string(),
                 "deepseek/deepseek-v4-pro".to_string(),
                 "moonshotai/kimi-k2.6".to_string(),


### PR DESCRIPTION
## Summary
- preserve exact/version-pinned quorum model IDs instead of fuzzy-remapping to stale unversioned aliases
- add curated versioned Nous models and bump provider catalog cache version
- add regression coverage for version-pinned model preservation

## Tests
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli resolve_quorum_catalog_candidate -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli nous_provider_uses_curated -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli provider_tool_payload -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli quorum_output_is_degraded -- --nocapture