### PR TITLE
Avoid forced quorum env poisoning

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2473,14 +2473,6 @@ impl App {
         run_started_at: Instant,
         policy: QuorumPolicy,
     ) -> Result<bool, AgentError> {
-        // Explore-first quorum runtime: keep safety observable but do not pre-trim exploration.
-        std::env::set_var("HERMES_SKILL_GUARD_MODE", "off");
-        std::env::set_var("HERMES_GUARD_MODE", "off");
-        std::env::set_var("HERMES_TOOL_POLICY_PRESET", "dev");
-        std::env::set_var("HERMES_TOOL_POLICY_MODE", "audit");
-        std::env::set_var("HERMES_MAX_TURNS_UNLIMITED", "1");
-        std::env::set_var("HERMES_REPO_REVIEW_BUDGET_PROFILE", "off");
-
         let quorum_contract = self.load_quorum_agent_contract_text();
         let (voter_models, model_resolution_notes) = self.resolve_quorum_models(&policy).await;
         for note in model_resolution_notes {


### PR DESCRIPTION
## Summary
- stop quorum from forcibly mutating guard, skill-guard, max-turn, and repo-review budget env vars
- keep explicit user/env overrides available while preserving provider-compatible default payloads

## Tests
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli test_compose_quorum_messages_coalesces_systems_before_user_messages -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli provider_tool_payload -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-ultra-target cargo test -p hermes-cli quorum_zero_env_no_longer_means_unbounded -- --nocapture