### PR TITLE
release: add contributor guidance and close partial surfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to Hermes Agent Ultra
+
+Hermes Agent Ultra is a Rust-first parity and reliability fork of `NousResearch/hermes-agent`. Contributions should preserve that contract: port upstream behavior intentionally, keep Ultra-only extensions explicit, and avoid placeholder runtime paths.
+
+## Getting Started
+
+```bash
+git clone https://github.com/sheawinkler/hermes-agent-ultra.git
+cd hermes-agent-ultra
+cargo build --workspace
+cargo test --workspace
+```
+
+Install the local CLI while testing end-to-end behavior:
+
+```bash
+cargo install --path crates/hermes-cli --force
+hermes --version
+hermes doctor --deep --snapshot
+```
+
+## Development Workflow
+
+- Branch from `main` and open a pull request for repository changes.
+- Keep PRs scoped to one feature, fix, parity port, or release-prep concern.
+- Follow existing Rust formatting and module layout before introducing new crates or top-level dependencies.
+- Use `tracing::{debug, info, warn, error}` for runtime logs; reserve direct stdout for user-facing CLI output.
+- Never commit secrets, provider keys, private prompts, or live operator traces.
+
+## Completeness Standard
+
+Do not submit stubs or partially implemented runtime behavior. If a feature cannot be completed in the PR, leave it out or guard it behind a documented, tested error path. Before requesting review, run:
+
+```bash
+bash scripts/check-runtime-placeholders.sh
+rg -n -i "not yet implemented|TODO: implement|unimplemented!\(|todo!\(|stub-only|placeholder" crates scripts
+```
+
+Legitimate future-work notes belong in docs or issues, not in callable runtime branches that pretend to work.
+
+## Required Checks
+
+Run the narrowest relevant tests while developing, then these release-grade checks before merge when the change affects runtime behavior:
+
+```bash
+cargo fmt --all --check
+bash scripts/clippy-warning-gate.sh --check
+bash scripts/check-runtime-placeholders.sh
+cargo test --workspace
+python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD
+python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main --local-ref HEAD
+```
+
+If your change touches parity governance artifacts, regenerate and commit the affected files under `docs/parity/`.
+
+## Parity Contributions
+
+For upstream parity ports, inspect the upstream source first, then implement the Rust equivalent in the relevant crate. Add or update tests and fixtures when behavior is comparable. Keep intentional divergence documented through the parity queue and surface-coverage allowlists rather than hiding it in code comments.
+
+## Release Contributions
+
+Release PRs should update release notes under `docs/releases/`, keep `Cargo.toml` workspace version accurate, pass the checks above, and tag only from a clean `main` after CI passes.

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ Ultra uses controlled sync workflows, not blind merges.
 
 Note: this repository intentionally tracks parity via queue/gate workflows because upstream and ultra history can diverge materially.
 
+## Contributing
+
+Interested in helping? Start with [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, PR expectations, parity rules, and the no-stub completeness gate.
+
 ## Official References and Attribution
 
 Canonical/official upstream references:

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -1365,19 +1365,37 @@ fn should_trip_tool_loop_guard(
     turn_tool_count: usize,
     turn_tool_error_count: u32,
 ) -> bool {
-    if !governor_tool_loop_guard_enabled() {
+    should_trip_tool_loop_guard_with_config(
+        consecutive_error_turns,
+        turn_tool_count,
+        turn_tool_error_count,
+        governor_tool_loop_guard_enabled(),
+        governor_tool_loop_guard_max_consecutive_error_turns(),
+        governor_tool_loop_guard_min_failed_calls(),
+    )
+}
+
+fn should_trip_tool_loop_guard_with_config(
+    consecutive_error_turns: u32,
+    turn_tool_count: usize,
+    turn_tool_error_count: u32,
+    enabled: bool,
+    max_consecutive_error_turns: u32,
+    min_failed_calls: u32,
+) -> bool {
+    if !enabled {
         return false;
     }
     if turn_tool_count == 0 {
         return false;
     }
-    if turn_tool_error_count < governor_tool_loop_guard_min_failed_calls() {
+    if turn_tool_error_count < min_failed_calls {
         return false;
     }
     if turn_tool_error_count != turn_tool_count as u32 {
         return false;
     }
-    consecutive_error_turns >= governor_tool_loop_guard_max_consecutive_error_turns()
+    consecutive_error_turns >= max_consecutive_error_turns
 }
 
 fn looks_like_tool_error_output(output: &str) -> bool {
@@ -12751,25 +12769,20 @@ mod tests {
 
     #[test]
     fn test_tool_loop_guard_trips_on_consecutive_full_failure_turns() {
-        std::env::set_var("HERMES_TOOL_LOOP_GUARD_ENABLED", "1");
-        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS", "3");
-        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS", "1");
-        assert!(!should_trip_tool_loop_guard(2, 2, 2));
-        assert!(should_trip_tool_loop_guard(3, 2, 2));
-        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_ENABLED");
-        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS");
-        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS");
+        assert!(!should_trip_tool_loop_guard_with_config(
+            2, 2, 2, true, 3, 1
+        ));
+        assert!(should_trip_tool_loop_guard_with_config(3, 2, 2, true, 3, 1));
+        assert!(!should_trip_tool_loop_guard_with_config(
+            3, 2, 2, false, 3, 1
+        ));
     }
 
     #[test]
     fn test_tool_loop_guard_ignores_partial_success_turns() {
-        std::env::set_var("HERMES_TOOL_LOOP_GUARD_ENABLED", "1");
-        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS", "2");
-        std::env::set_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS", "1");
-        assert!(!should_trip_tool_loop_guard(4, 3, 2));
-        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_ENABLED");
-        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MAX_CONSEC_ERROR_TURNS");
-        std::env::remove_var("HERMES_TOOL_LOOP_GUARD_MIN_FAILED_CALLS");
+        assert!(!should_trip_tool_loop_guard_with_config(
+            4, 3, 2, true, 2, 1
+        ));
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4359,6 +4359,50 @@ mod tests {
     }
 
     #[test]
+    fn test_startup_model_env_sync_uses_config_provider_not_stale_env() {
+        let _guard = env_test_lock();
+        let keys = [
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+        ];
+        let previous: Vec<(&str, Option<String>)> = keys
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+        for key in keys {
+            std::env::remove_var(key);
+        }
+        std::env::set_var("HERMES_INFERENCE_PROVIDER", "openrouter");
+
+        let mut cfg = GatewayConfig::default();
+        cfg.model = Some("anthropic:claude-sonnet-4-6".to_string());
+        cfg.llm_providers
+            .insert("anthropic".to_string(), LlmProviderConfig::default());
+
+        let configured_model = cfg.model.as_deref().expect("model should be set");
+        let startup = resolve_startup_model(&cfg, configured_model);
+        sync_runtime_model_env(&cfg, &startup);
+
+        assert_eq!(startup, "anthropic:claude-sonnet-4-6");
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_PROVIDER").ok().as_deref(),
+            Some("anthropic")
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_MODEL").ok().as_deref(),
+            Some("anthropic:claude-sonnet-4-6")
+        );
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
     fn test_provider_api_key_from_env_supports_stepfun() {
         let hermes_var = "HERMES_STEPFUN_API_KEY";
         let stepfun_var = "STEPFUN_API_KEY";

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -1349,7 +1349,7 @@ fn resolve_resume_session_file(
                 }
             }
         }
-        // 2) newest canonical snapshot (may be startup stub)
+        // 2) newest canonical snapshot (may be startup empty snapshot)
         for (path, _) in &candidates {
             if let Some(summary) = session_file_summary(path) {
                 if summary.canonical {
@@ -7053,7 +7053,7 @@ async fn run_auth(
                     }
                     _ => {
                         println!(
-                            "OAuth flow is not implemented for provider '{}'; falling back to API key/manual token login.",
+                            "OAuth flow is unavailable for provider '{}'; falling back to API key/manual token login.",
                             provider
                         );
                         auth_type = "api_key".to_string();
@@ -15110,27 +15110,27 @@ max_turns: 50
     }
 
     #[test]
-    fn load_resume_payload_accepts_empty_messages_for_startup_stub() {
+    fn load_resume_payload_accepts_empty_messages_for_startup_snapshot() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cli = cli_for_temp_state_root(tmp.path());
         let sessions_dir = hermes_state_root(&cli).join("sessions");
         std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
-        let session_path = sessions_dir.join("stub-empty.json");
+        let session_path = sessions_dir.join("empty-messages.json");
         std::fs::write(
             &session_path,
             r#"{
   "session_info": {
-    "session_id": "stub-empty",
+    "session_id": "empty-messages",
     "model": "nous:nousresearch/hermes-4-70b"
   },
   "messages": []
 }"#,
         )
-        .expect("write stub session");
+        .expect("write empty session");
 
-        let payload = load_resume_payload(&cli, Some("stub-empty")).expect("load payload");
-        assert_eq!(payload.resolved_id, "stub-empty");
-        assert_eq!(payload.session_id, "stub-empty");
+        let payload = load_resume_payload(&cli, Some("empty-messages")).expect("load payload");
+        assert_eq!(payload.resolved_id, "empty-messages");
+        assert_eq!(payload.session_id, "empty-messages");
         assert_eq!(
             payload.model.as_deref(),
             Some("nous:nousresearch/hermes-4-70b")
@@ -15139,7 +15139,7 @@ max_turns: 50
     }
 
     #[test]
-    fn load_resume_payload_latest_prefers_nonempty_snapshot_over_newer_stub() {
+    fn load_resume_payload_latest_prefers_nonempty_snapshot_over_newer_empty_snapshot() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cli = cli_for_temp_state_root(tmp.path());
         let sessions_dir = hermes_state_root(&cli).join("sessions");
@@ -15155,15 +15155,15 @@ max_turns: 50
         )
         .expect("write non-empty session");
         std::thread::sleep(std::time::Duration::from_millis(20));
-        let stub = sessions_dir.join("startup-stub.json");
+        let empty_snapshot = sessions_dir.join("startup-empty.json");
         std::fs::write(
-            &stub,
+            &empty_snapshot,
             r#"{
-  "session_info": {"session_id":"startup-stub","model":"nous:openai/gpt-5.5"},
+  "session_info": {"session_id":"startup-empty","model":"nous:openai/gpt-5.5"},
   "messages":[]
 }"#,
         )
-        .expect("write stub session");
+        .expect("write empty session");
 
         let payload = load_resume_payload(&cli, None).expect("load payload");
         assert_eq!(payload.resolved_id, "history-real");
@@ -15172,7 +15172,7 @@ max_turns: 50
     }
 
     #[test]
-    fn load_resume_payload_latest_falls_back_to_legacy_nonempty_when_primary_stub_only() {
+    fn load_resume_payload_latest_falls_back_to_legacy_nonempty_when_primary_empty_only() {
         let _guard = env_lock();
         let prev_home = std::env::var("HOME").ok();
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -15196,13 +15196,13 @@ max_turns: 50
         let sessions_dir = hermes_state_root(&cli).join("sessions");
         std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
         std::fs::write(
-            sessions_dir.join("stub-only.json"),
+            sessions_dir.join("empty-only.json"),
             r#"{
-  "session_info": {"session_id":"stub-only","model":"nous:openai/gpt-5.5"},
+  "session_info": {"session_id":"empty-only","model":"nous:openai/gpt-5.5"},
   "messages":[]
 }"#,
         )
-        .expect("write primary stub");
+        .expect("write primary empty session");
 
         let payload = load_resume_payload(&cli, None).expect("load payload");
         assert_eq!(payload.resolved_id, "legacy-rich");

--- a/crates/hermes-eval/src/bin/hermes-bench.rs
+++ b/crates/hermes-eval/src/bin/hermes-bench.rs
@@ -38,7 +38,7 @@ struct Args {
     #[arg(long)]
     model: Option<String>,
 
-    /// Rollout backend (agent = real AgentLoop, noop = deterministic stub).
+    /// Rollout backend (agent = real AgentLoop, noop = deterministic no-agent rollout).
     #[arg(long, value_enum, default_value_t = RolloutKind::Agent)]
     rollout: RolloutKind,
 

--- a/crates/hermes-eval/src/tblite.rs
+++ b/crates/hermes-eval/src/tblite.rs
@@ -22,7 +22,7 @@ pub fn tblite_smoke_tasks() -> Vec<TaskSpec> {
         TaskSpec {
             task_id: "tblite_smoke_01".into(),
             category: Some("smoke".into()),
-            instruction: "TBLite smoke task 01: stub rollout only (no agent).".into(),
+            instruction: "TBLite smoke task 01: deterministic no-agent rollout.".into(),
             context: json!({
                 "benchmark": "openthoughts-tblite",
                 "smoke": true,
@@ -33,7 +33,7 @@ pub fn tblite_smoke_tasks() -> Vec<TaskSpec> {
         TaskSpec {
             task_id: "tblite_smoke_02".into(),
             category: Some("smoke".into()),
-            instruction: "TBLite smoke task 02: stub rollout only (no agent).".into(),
+            instruction: "TBLite smoke task 02: deterministic no-agent rollout.".into(),
             context: json!({
                 "benchmark": "openthoughts-tblite",
                 "smoke": true,
@@ -88,7 +88,7 @@ impl Verifier for SmokePassVerifier {
     }
 }
 
-/// Rollout stub: returns a JSON blob with the task id (no LLM, no tools).
+/// Deterministic rollout: returns a JSON blob with the task id (no LLM, no tools).
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NoopRollout;
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-23T12:15:37.854093+00:00",
+  "generated_at_utc": "2026-05-24T01:38:09.561885+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-05-23T12:15:37.854093+00:00`
+Generated: `2026-05-24T01:38:09.561885+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-23T12:15:38.842689+00:00",
+  "generated_at_utc": "2026-05-24T01:38:10.667647+00:00",
   "items": [
     {
       "errors": [],
@@ -92,7 +92,7 @@
       "errors": [],
       "id": "rust-cli-tui-primary-ux-surface",
       "last_reviewed": "2026-04-21",
-      "matched_files": 836,
+      "matched_files": 838,
       "matched_sample": [
         "ui-tui/.gitignore",
         "ui-tui/.prettierrc",
@@ -126,10 +126,10 @@
   "summary": {
     "errors": 0,
     "items": 5,
-    "local_paths": 3199,
+    "local_paths": 3253,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 3629,
+    "upstream_paths": 3641,
     "warnings": 0
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,25 +2,25 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 1.0,
+        "actual": 34.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "status": "pass"
       },
       {
-        "actual": 1.0,
+        "actual": 33.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "status": "pass"
       },
       {
-        "actual": 961.0,
+        "actual": 920.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "pass"
       },
       {
-        "actual": 556.0,
+        "actual": 581.0,
         "limit": 15,
         "metric": "max_shared_different",
         "status": "fail"
@@ -53,7 +53,7 @@
     "mode": "tree-drift",
     "pass": false
   },
-  "generated_at_utc": "2026-05-23T12:19:23.831961+00:00",
+  "generated_at_utc": "2026-05-24T01:38:11.929223+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -66,13 +66,13 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 1.0,
+    "max_commits_behind": 34.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 961.0,
+    "max_files_only_upstream": 920.0,
     "max_queue_pending_commits": 0.0,
-    "max_shared_different": 556.0,
+    "max_shared_different": 581.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 1.0,
+    "max_upstream_patch_missing": 33.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {
@@ -83,14 +83,18 @@
   },
   "queue_summary": {
     "by_disposition": {
-      "ported": 1
+      "ported": 6,
+      "superseded": 27
     },
     "by_target_ticket": {
-      "20": 1
+      "20": 9,
+      "22": 17,
+      "23": 2,
+      "26": 5
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 0,
-    "total_commits": 1
+    "total_commits": 33
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-23T12:19:23.831961+00:00`
+Generated: `2026-05-24T01:38:11.929223+00:00`
 
 ## Gate Status
 
@@ -13,10 +13,10 @@ Generated: `2026-05-23T12:19:23.831961+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 1.0 |
-| `max_upstream_patch_missing` | 1.0 |
-| `max_files_only_upstream` | 961.0 |
-| `max_shared_different` | 556.0 |
+| `max_commits_behind` | 34.0 |
+| `max_upstream_patch_missing` | 33.0 |
+| `max_files_only_upstream` | 920.0 |
+| `max_shared_different` | 581.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
@@ -38,7 +38,10 @@ Generated: `2026-05-23T12:19:23.831961+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `1`.
+- Upstream missing commits tracked: `33`.
 - By target ticket:
-  - `#20`: `1`
+  - `#20`: `9`
+  - `#22`: `17`
+  - `#23`: `2`
+  - `#26`: `5`
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-23T12:15:36.649752+00:00",
+  "generated_at_utc": "2026-05-24T01:38:08.130269+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "8300f1562a7bfec930ed597bd09ab8115d0ccfa3",
+    "local_sha": "6f87e0878bbe4c9bf087a41831d31f3797a01898",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "7f1b2b4569532d63a7f50e172963da0d4f3082f7",
+    "upstream_sha": "72ff3e909c73b625ee244ab5ea3d0608ee85dcf3",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 1,
-    "commits_ahead": 738,
-    "upstream_patch_missing": 1,
+    "commits_behind": 34,
+    "commits_ahead": 749,
+    "upstream_patch_missing": 33,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 635,
-    "files_only_upstream": 961,
-    "files_only_local": 531,
-    "files_shared_identical": 2112,
-    "files_shared_different": 556,
-    "tree_files_changed": 2049,
-    "tree_insertions": 548688,
-    "tree_deletions": 305020
+    "local_patch_unique": 645,
+    "files_only_upstream": 920,
+    "files_only_local": 532,
+    "files_shared_identical": 2140,
+    "files_shared_different": 581,
+    "tree_files_changed": 2034,
+    "tree_insertions": 540306,
+    "tree_deletions": 252550
   },
   "top_upstream_only": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 41
+      "count": 42
     },
     {
       "path": "gateway/platforms",
@@ -40,7 +40,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 34
+      "count": 35
     },
     {
       "path": "optional-skills/research",
@@ -48,19 +48,15 @@
     },
     {
       "path": "tests/gateway",
-      "count": 30
-    },
-    {
-      "path": "plugins/web",
-      "count": 25
+      "count": 31
     },
     {
       "path": "website/docs",
-      "count": 22
+      "count": 23
     },
     {
       "path": "tests/tools",
-      "count": 19
+      "count": 20
     },
     {
       "path": "tests/plugins",
@@ -71,11 +67,11 @@
       "count": 13
     },
     {
-      "path": "tools/environments",
-      "count": 12
+      "path": "ui-tui/src",
+      "count": 13
     },
     {
-      "path": "ui-tui/src",
+      "path": "tools/environments",
       "count": 12
     },
     {
@@ -95,16 +91,8 @@
       "count": 10
     },
     {
-      "path": "plugins/browser",
-      "count": 9
-    },
-    {
       "path": "hermes_cli/proxy",
       "count": 7
-    },
-    {
-      "path": "plugins/platforms",
-      "count": 6
     },
     {
       "path": "tests/cli",
@@ -127,10 +115,6 @@
       "count": 4
     },
     {
-      "path": "plugins/video_gen",
-      "count": 4
-    },
-    {
       "path": "website/i18n",
       "count": 4
     },
@@ -144,14 +128,6 @@
     },
     {
       "path": "optional-skills/blockchain",
-      "count": 2
-    },
-    {
-      "path": "plugins/image_gen",
-      "count": 2
-    },
-    {
-      "path": "plugins/model-providers",
       "count": 2
     },
     {
@@ -181,16 +157,40 @@
     {
       "path": ".env.example",
       "count": 1
+    },
+    {
+      "path": ".envrc",
+      "count": 1
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "count": 1
+    },
+    {
+      "path": ".github/dependabot.yml",
+      "count": 1
+    },
+    {
+      "path": ".mailmap",
+      "count": 1
+    },
+    {
+      "path": ".plans/openai-api-server.md",
+      "count": 1
+    },
+    {
+      "path": ".plans/streaming-support.md",
+      "count": 1
     }
   ],
   "top_shared_different": [
     {
       "path": "tests/gateway",
-      "count": 95
+      "count": 96
     },
     {
       "path": "website/docs",
-      "count": 78
+      "count": 80
     },
     {
       "path": "tests/tools",
@@ -198,31 +198,39 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 55
+      "count": 58
     },
     {
       "path": "ui-tui/src",
-      "count": 41
+      "count": 47
     },
     {
       "path": "tests/agent",
-      "count": 31
+      "count": 32
     },
     {
       "path": "tests/run_agent",
-      "count": 29
+      "count": 30
     },
     {
       "path": "ui-tui/packages",
-      "count": 15
+      "count": 17
     },
     {
       "path": "tests/cli",
-      "count": 12
+      "count": 13
+    },
+    {
+      "path": "plugins/google_meet",
+      "count": 9
     },
     {
       "path": "skills/creative",
       "count": 9
+    },
+    {
+      "path": "plugins/platforms",
+      "count": 8
     },
     {
       "path": "plugins/memory",
@@ -241,16 +249,8 @@
       "count": 7
     },
     {
-      "path": "plugins/google_meet",
-      "count": 6
-    },
-    {
-      "path": "plugins/platforms",
-      "count": 5
-    },
-    {
       "path": "tests/plugins",
-      "count": 5
+      "count": 6
     },
     {
       "path": "plugins/teams_pipeline",
@@ -321,6 +321,10 @@
       "count": 1
     },
     {
+      "path": "CONTRIBUTING.md",
+      "count": 1
+    },
+    {
       "path": "Dockerfile",
       "count": 1
     },
@@ -338,10 +342,6 @@
     },
     {
       "path": "docker/entrypoint.sh",
-      "count": 1
-    },
-    {
-      "path": "flake.nix",
       "count": 1
     }
   ],
@@ -514,7 +514,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 41
+      "count": 42
     },
     {
       "path": "gateway/platforms",
@@ -526,7 +526,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 34
+      "count": 35
     },
     {
       "path": "optional-skills/research",
@@ -534,19 +534,15 @@
     },
     {
       "path": "tests/gateway",
-      "count": 30
-    },
-    {
-      "path": "plugins/web",
-      "count": 25
+      "count": 31
     },
     {
       "path": "website/docs",
-      "count": 22
+      "count": 23
     },
     {
       "path": "tests/tools",
-      "count": 19
+      "count": 20
     },
     {
       "path": "tests/plugins",
@@ -557,11 +553,11 @@
       "count": 13
     },
     {
-      "path": "tools/environments",
-      "count": 12
+      "path": "ui-tui/src",
+      "count": 13
     },
     {
-      "path": "ui-tui/src",
+      "path": "tools/environments",
       "count": 12
     },
     {
@@ -581,16 +577,8 @@
       "count": 10
     },
     {
-      "path": "plugins/browser",
-      "count": 9
-    },
-    {
       "path": "hermes_cli/proxy",
       "count": 7
-    },
-    {
-      "path": "plugins/platforms",
-      "count": 6
     },
     {
       "path": "tests/cli",
@@ -613,10 +601,6 @@
       "count": 4
     },
     {
-      "path": "plugins/video_gen",
-      "count": 4
-    },
-    {
       "path": "website/i18n",
       "count": 4
     },
@@ -630,14 +614,6 @@
     },
     {
       "path": "optional-skills/blockchain",
-      "count": 2
-    },
-    {
-      "path": "plugins/image_gen",
-      "count": 2
-    },
-    {
-      "path": "plugins/model-providers",
       "count": 2
     },
     {
@@ -666,6 +642,30 @@
     },
     {
       "path": ".env.example",
+      "count": 1
+    },
+    {
+      "path": ".envrc",
+      "count": 1
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "count": 1
+    },
+    {
+      "path": ".github/dependabot.yml",
+      "count": 1
+    },
+    {
+      "path": ".mailmap",
+      "count": 1
+    },
+    {
+      "path": ".plans/openai-api-server.md",
+      "count": 1
+    },
+    {
+      "path": ".plans/streaming-support.md",
       "count": 1
     }
   ],
@@ -836,8 +836,8 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 185,
-      "shared_different": 331,
+      "upstream_only": 189,
+      "shared_different": 339,
       "local_only": 16,
       "risk": "high",
       "effort": "XL"
@@ -846,8 +846,8 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 342,
-      "shared_different": 11,
+      "upstream_only": 343,
+      "shared_different": 12,
       "local_only": 190,
       "risk": "medium",
       "effort": "L"
@@ -856,8 +856,8 @@
       "workstream": "WS5",
       "issue": 9,
       "name": "UX parity",
-      "upstream_only": 152,
-      "shared_different": 146,
+      "upstream_only": 153,
+      "shared_different": 156,
       "local_only": 67,
       "risk": "medium",
       "effort": "L"
@@ -866,9 +866,9 @@
       "workstream": "WS3",
       "issue": 7,
       "name": "Tools and adapters parity",
-      "upstream_only": 145,
-      "shared_different": 40,
-      "local_only": 96,
+      "upstream_only": 98,
+      "shared_different": 46,
+      "local_only": 97,
       "risk": "high",
       "effort": "L"
     },
@@ -904,12 +904,31 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 1,
+    "upstream_patch_missing": 33,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 635,
+    "local_patch_unique": 645,
     "local_patch_equivalent_to_upstream": 0,
     "upstream_patch_missing_sample": [
-      "7f1b2b4569532d63a7f50e172963da0d4f3082f7"
+      "c4b8f5efee8cdd3186e465d940bf0e8c98849346",
+      "cae7537359c0ba8fceedc0a6423a4d9f30972100",
+      "ad11327db0b570e72347eddca60b1d80abf0687b",
+      "026f64f8e07d8b5588f7e67b1b7fc3f60c5d99bc",
+      "e6ca730a2219c602284f9807d65497f8c697ce5e",
+      "874c2b1fe6ec185f9d1da17d31d2c7885d58c35c",
+      "4fea02cc16981dedb7878ce42e94c821d56d332f",
+      "cc61e3be49aa672d8d1ae75b8057a1b503251b7c",
+      "d1ad919a440948d73ad74a3b18d963a0763bb08e",
+      "521c870a05a928a6dcb8abde64859c5bc2a5e538",
+      "2a75bec6079be44212b91d0ec895e8c7e4e50161",
+      "0277194e3b31a72898962c528a5f75fde12cad72",
+      "35fdf111452933032d822ccab4d32166fc361a63",
+      "511b8e2325c621a30bc9a75f00762d820282e72f",
+      "b10f17bf1e9321c586cb3afb0d80ef5bd4ae34d6",
+      "6a8e131a0ab42e23fb8ad5e1e27ce2382f1d6a3b",
+      "3b096d6f6dbe8253aed46a2bc6b1304aaa9097d4",
+      "2c34a7da87d7c785f0f694bc2aceb1fd09d2516d",
+      "7de8cd4c5f67b5b17e64392fac5fdf1b3a986983",
+      "9451087aab30f5f28d3828ce867dd7e902d788a1"
     ],
     "upstream_patch_represented_sample": [],
     "local_patch_unique_sample": [
@@ -936,7 +955,7 @@
     ],
     "local_patch_equivalent_sample": [],
     "intentional_divergence_items": 5,
-    "intentional_divergence_covered_files": 428
+    "intentional_divergence_covered_files": 440
   },
   "intentional_divergence": [
     {
@@ -1010,7 +1029,7 @@
       "status": "approved",
       "workstream": "WS5",
       "summary": "Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported.",
-      "matched_files": 302,
+      "matched_files": 314,
       "matched_sample": [
         "ui-tui/README.md",
         "ui-tui/babel.compiler.config.cjs",
@@ -1023,6 +1042,7 @@
         "ui-tui/packages/hermes-ink/src/ink/components/App.tsx",
         "ui-tui/packages/hermes-ink/src/ink/components/CursorAdvanceContext.ts",
         "ui-tui/packages/hermes-ink/src/ink/components/Link.tsx",
+        "ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx",
         "ui-tui/packages/hermes-ink/src/ink/hooks/use-cursor-advance.ts",
         "ui-tui/packages/hermes-ink/src/ink/hyperlinkHover.ts",
         "ui-tui/packages/hermes-ink/src/ink/ink-cursor-advance.test.ts",
@@ -1030,8 +1050,7 @@
         "ui-tui/packages/hermes-ink/src/ink/ink.tsx",
         "ui-tui/packages/hermes-ink/src/ink/log-update.test.ts",
         "ui-tui/packages/hermes-ink/src/ink/log-update.ts",
-        "ui-tui/packages/hermes-ink/src/ink/root.ts",
-        "ui-tui/packages/hermes-ink/src/ink/termio/dec.ts"
+        "ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts"
       ]
     }
   ]

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,67 +1,61 @@
 # Parity Matrix
 
-Generated: `2026-05-23T12:15:36.649752+00:00`
+Generated: `2026-05-24T01:38:08.130269+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`8300f1562a7bfec930ed597bd09ab8115d0ccfa3`)
-- Upstream ref: `upstream/main` (`7f1b2b4569532d63a7f50e172963da0d4f3082f7`)
+- Local ref: `HEAD` (`6f87e0878bbe4c9bf087a41831d31f3797a01898`)
+- Upstream ref: `upstream/main` (`72ff3e909c73b625ee244ab5ea3d0608ee85dcf3`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 1 |
-| Commits ahead local (`local` ancestry only) | 738 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 1 |
+| Commits behind local (`upstream` ancestry only) | 34 |
+| Commits ahead local (`local` ancestry only) | 749 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 33 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 0 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 635 |
-| Files only in upstream tree | 961 |
-| Files only in local tree | 531 |
-| Shared files identical content | 2112 |
-| Shared files different content | 556 |
-| Total files changed (`local` vs `upstream`) | 2049 |
-| Insertions (`local` vs `upstream`) | 548688 |
-| Deletions (`local` vs `upstream`) | 305020 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 645 |
+| Files only in upstream tree | 920 |
+| Files only in local tree | 532 |
+| Shared files identical content | 2140 |
+| Shared files different content | 581 |
+| Total files changed (`local` vs `upstream`) | 2034 |
+| Insertions (`local` vs `upstream`) | 540306 |
+| Deletions (`local` vs `upstream`) | 252550 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
 | `web/src` | 87 |
-| `tests/hermes_cli` | 41 |
+| `tests/hermes_cli` | 42 |
 | `gateway/platforms` | 40 |
 | `skills/creative` | 36 |
-| `tests/agent` | 34 |
+| `tests/agent` | 35 |
 | `optional-skills/research` | 33 |
-| `tests/gateway` | 30 |
-| `plugins/web` | 25 |
-| `website/docs` | 22 |
-| `tests/tools` | 19 |
+| `tests/gateway` | 31 |
+| `website/docs` | 23 |
+| `tests/tools` | 20 |
 | `tests/plugins` | 14 |
 | `.github/workflows` | 13 |
+| `ui-tui/src` | 13 |
 | `tools/environments` | 12 |
-| `ui-tui/src` | 12 |
 | `agent/lsp` | 11 |
 | `agent/transports` | 11 |
 | `web/public` | 11 |
 | `tests/run_agent` | 10 |
-| `plugins/browser` | 9 |
 | `hermes_cli/proxy` | 7 |
-| `plugins/platforms` | 6 |
 | `tests/cli` | 6 |
 | `tools/computer_use` | 6 |
 | `ui-tui/packages` | 6 |
 | `scripts/whatsapp-bridge` | 5 |
 | `.github/ISSUE_TEMPLATE` | 4 |
-| `plugins/video_gen` | 4 |
 | `website/i18n` | 4 |
 | `.github/actions` | 2 |
 | `agent/secret_sources` | 2 |
 | `optional-skills/blockchain` | 2 |
-| `plugins/image_gen` | 2 |
-| `plugins/model-providers` | 2 |
 | `skills/autonomous-ai-agents` | 2 |
 | `tests/acp` | 2 |
 | `tests/hermes_state` | 2 |
@@ -69,28 +63,34 @@ Generated: `2026-05-23T12:15:36.649752+00:00`
 | `tools/neutts_samples` | 2 |
 | `.dockerignore` | 1 |
 | `.env.example` | 1 |
+| `.envrc` | 1 |
+| `.github/PULL_REQUEST_TEMPLATE.md` | 1 |
+| `.github/dependabot.yml` | 1 |
+| `.mailmap` | 1 |
+| `.plans/openai-api-server.md` | 1 |
+| `.plans/streaming-support.md` | 1 |
 
 ## Top 40 shared-different buckets
 
 | Bucket | Files |
 | --- | ---: |
-| `tests/gateway` | 95 |
-| `website/docs` | 78 |
+| `tests/gateway` | 96 |
+| `website/docs` | 80 |
 | `tests/tools` | 67 |
-| `tests/hermes_cli` | 55 |
-| `ui-tui/src` | 41 |
-| `tests/agent` | 31 |
-| `tests/run_agent` | 29 |
-| `ui-tui/packages` | 15 |
-| `tests/cli` | 12 |
+| `tests/hermes_cli` | 58 |
+| `ui-tui/src` | 47 |
+| `tests/agent` | 32 |
+| `tests/run_agent` | 30 |
+| `ui-tui/packages` | 17 |
+| `tests/cli` | 13 |
+| `plugins/google_meet` | 9 |
 | `skills/creative` | 9 |
+| `plugins/platforms` | 8 |
 | `plugins/memory` | 7 |
 | `plugins/model-providers` | 7 |
 | `skills/productivity` | 7 |
 | `tests/acp` | 7 |
-| `plugins/google_meet` | 6 |
-| `plugins/platforms` | 5 |
-| `tests/plugins` | 5 |
+| `tests/plugins` | 6 |
 | `plugins/teams_pipeline` | 4 |
 | `tests/cron` | 4 |
 | `tests/providers` | 4 |
@@ -108,12 +108,12 @@ Generated: `2026-05-23T12:15:36.649752+00:00`
 | `.github/workflows` | 1 |
 | `.gitignore` | 1 |
 | `AGENTS.md` | 1 |
+| `CONTRIBUTING.md` | 1 |
 | `Dockerfile` | 1 |
 | `LICENSE` | 1 |
 | `README.md` | 1 |
 | `docker-compose.yml` | 1 |
 | `docker/entrypoint.sh` | 1 |
-| `flake.nix` | 1 |
 
 ## Top 40 local-only buckets
 
@@ -164,20 +164,20 @@ Generated: `2026-05-23T12:15:36.649752+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 185 | 331 | high | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 342 | 11 | medium | L |
-| `WS5` | #9 | UX parity | 152 | 146 | medium | L |
-| `WS3` | #7 | Tools and adapters parity | 145 | 40 | high | L |
+| `WS6` | #10 | Tests and CI parity | 189 | 339 | high | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 343 | 12 | medium | L |
+| `WS5` | #9 | UX parity | 153 | 156 | medium | L |
+| `WS3` | #7 | Tools and adapters parity | 98 | 46 | high | L |
 | `WS4` | #8 | Skills parity | 74 | 28 | medium | L |
 | `WS2` | #6 | Core runtime parity | 63 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `1`
+- Upstream missing by patch-id: `33`
 - Upstream represented by patch-id: `0`
-- Local unique by patch-id: `635`
-- Intentional divergence tracked items: `5` (covered files: `428`)
+- Local unique by patch-id: `645`
+- Intentional divergence tracked items: `5` (covered files: `440`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -188,7 +188,7 @@ Generated: `2026-05-23T12:15:36.649752+00:00`
 | `ultra-webhook-queue-backends` | approved | WS7 | 4 | Preserve webhook-driven sync queue worker architecture with sqlite, SQS, and Kafka support. |
 | `ultra-launchd-webhook-lifecycle` | approved | WS7 | 4 | Preserve launchd-based interactive dev lifecycle management for webhook listener and worker. |
 | `rust-skills-catalog-governance` | approved | WS4 | 116 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
-| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 302 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
+| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 314 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
 
 
 ## Notes
@@ -196,4 +196,4 @@ Generated: `2026-05-23T12:15:36.649752+00:00`
 - Data is computed directly from git refs in this repository.
 - Tree-level parity classification does not require a merge-base.
 - Commit representation/missing uses patch-id equivalence from `git cherry`.
-- Default behavior fetches latest upstream refs (`git fetch upstream --prune`).
+- Default behavior fetches the configured upstream branch into `upstream/main`.

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -519,6 +519,30 @@
     "11e6dd3c606e": {
       "disposition": "superseded",
       "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
+    },
+    "7a4dc8e8d610": {
+      "disposition": "superseded",
+      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
+    },
+    "e42fcc562596": {
+      "disposition": "ported",
+      "notes": "Rust startup model resolution now pins provider selection to config-derived provider:model state and overwrites stale HERMES_INFERENCE_PROVIDER handoff env during runtime sync; CLI --provider remains the per-invocation override."
+    },
+    "b10f17bf1e93": {
+      "disposition": "ported",
+      "notes": "Imported ntfy as a platform plugin under plugins/platforms/ntfy with standalone send, env enablement, identity hardening, and local plugin regression tests."
+    },
+    "6a8e131a0ab4": {
+      "disposition": "ported",
+      "notes": "Hermes Ultra uses the upstream platform-plugin ntfy shape rather than a bundled core adapter; tests/gateway/test_ntfy_plugin.py covers plugin registration and standalone delivery."
+    },
+    "3b096d6f6dbe": {
+      "disposition": "ported",
+      "notes": "Ntfy robustness and docs are represented by plugins/platforms/ntfy, tests/gateway/test_ntfy_plugin.py, website ntfy messaging docs, sidebars, and environment-variable reference entries."
+    },
+    "7de8cd4c5f67": {
+      "disposition": "ported",
+      "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync."
     }
   },
   "subject_patterns": [

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -17,6 +17,13 @@
       "ticket": 25
     },
     {
+      "path": "CONTRIBUTING.md",
+      "classification": "policy_only",
+      "rationale": "Contributor process guidance and release policy; no runtime behavior.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "Dockerfile",
       "classification": "functional",
       "rationale": "Container build/runtime path impacts deployment behavior and should be tracked for parity deltas.",

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-23T12:15:37.805540+00:00",
+  "generated_at_utc": "2026-05-24T01:38:09.507781+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-05-23T12:15:37.805540+00:00`
+Generated: `2026-05-24T01:38:09.507781+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -2,7 +2,7 @@
   "commits": [
     {
       "classification_rule": "sha_override",
-      "disposition": "superseded",
+      "disposition": "ported",
       "files_sample": [
         ".dockerignore",
         ".env.example",
@@ -25,961 +25,19 @@
         ".github/workflows/nix-lockfile-fix.yml",
         ".github/workflows/nix.yml"
       ],
-      "files_touched": 3640,
-      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": false,
-        "superseded_by_guard": false
-      },
-      "sha": "11e6dd3c606e102cf7f9070a561abdd9312182c6",
-      "subject": "chore(release): add AUTHOR_MAP entry for egilewski (PR #30432) (#30833)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "hermes_cli/web_server.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "09f85f2cf79362a2f7963754b49a44cb3d234176",
-      "subject": "fix(plugins): apply truthy env semantics to project-plugin gate (#29156)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/hermes_cli/test_project_plugin_rce_bypass.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "da636e982b1c6536fc499ab2cebd5bd78677014a",
-      "subject": "test(plugins): regression coverage for project-plugin RCE chain (#29156)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "hermes_cli/web_server.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "8bf99227f0b107a58a03d48a520d596b609e5f54",
-      "subject": "fix(plugins): block plugin-api path traversal + project RCE (#29156)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "website/docs/reference/environment-variables.md"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "6a2df9f451a2ef5f5059466eefb2ccf111c4885d",
-      "subject": "docs(env): clarify HERMES_ENABLE_PROJECT_PLUGINS contract (#29156)",
-      "target_ticket": 22,
-      "target_ticket_name": "GPAR-03 UX parity"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/acp/test_server.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "3127a41cb19f520dbeea93f21d29957fe0d11cde",
-      "subject": "test(acp): pin parse_model_input in slash-command tests",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/pairing.py",
-        "tests/gateway/test_pairing.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "52a368fa722f91337786739181eb653f779d4b86",
-      "subject": "fix(gateway): preserve WhatsApp pairing approvals across JID/LID alias flips",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/agent/test_context_compressor.py",
-        "tests/conftest.py",
-        "tests/gateway/test_runner_startup_failures.py",
-        "tests/tools/test_tirith_security.py",
-        "tests/tools/test_voice_mode.py"
-      ],
-      "files_touched": 5,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "71291d83cd2d659c4e8314b3d5613f524f718769",
-      "subject": "test: keep tirith checks hermetic",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "plugins/model-providers/opencode-zen/__init__.py",
-        "tests/plugins/model_providers/test_opencode_go_profile.py"
-      ],
-      "files_touched": 2,
-      "notes": "Rust GenericProvider now maps OpenCode Go reasoning controls by model: Kimi K2 and DeepSeek thinking models receive provider-native thinking/reasoning_effort fields while non-target models drop unsupported controls.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": false,
-        "superseded_by_guard": false
-      },
-      "sha": "3589960e03d0429f485f43ee9b6fbe0f33bdc9ac",
-      "subject": "fix(provider): expose OpenCode Go reasoning controls",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "plugins/model-providers/opencode-zen/__init__.py",
-        "tests/plugins/model_providers/test_opencode_go_profile.py"
-      ],
-      "files_touched": 2,
-      "notes": "Rust reasoning configuration now preserves raw opencode-go effort levels for runtime model-specific mapping, including Kimi xhigh/max to high and minimal omission.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": false,
-        "superseded_by_guard": false
-      },
-      "sha": "70aaa774be92d8c9ffb6b9745f5c47bb69b8198c",
-      "subject": "fix(opencode-go): emit Kimi reasoning_effort, match KimiProfile shape",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "agent/chat_completion_helpers.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "b2e6fdd3bfacae3ad54efb463260a8ed3578f3f7",
-      "subject": "fix(agent): log warning when fallback model normalization fails instead of silently swallowing",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "infographic/aux-picker-parity/infographic.png",
-        "infographic/bitwarden-secrets-manager/infographic.png",
-        "infographic/bitwarden-secrets-manager/prompts/infographic.md",
-        "infographic/bitwarden-secrets-manager/structured-content.md",
-        "infographic/minimax-oauth-token-refresh/infographic.png",
-        "infographic/pr-14157-control-plane-write-deny/infographic.png",
-        "infographic/pr-17659-read-deny-credentials/infographic.png",
-        "infographic/pr-27612-nous-url-allowlist/infographic.png",
-        "infographic/pr-30591-discord-plugin-migration/infographic.png",
-        "infographic/pr-6656-skill-hub-safety-audit/infographic.png",
-        "infographic/pr-8056-hash-pairing-codes/infographic.png",
-        "infographic/pr-8306-hmac-bypass/infographic.png",
-        "infographic/pr27784-anthropic-refactor/infographic.png",
-        "infographic/pr27784-anthropic-refactor/prompts/infographic.md",
-        "infographic/pr27784-anthropic-refactor/structured-content.md",
-        "infographic/pr30609-termux-cold-start/infographic.png",
-        "infographic/skill-scanner-no-ghost-skills/infographic.png"
-      ],
-      "files_touched": 17,
-      "notes": "Removed the tracked infographic/ asset tree and added infographic/ to .gitignore so generated PR infographics stay in PR bodies rather than the repository.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": false,
-        "superseded_by_guard": false
-      },
-      "sha": "5772e638c9babef4d365e9e9ebb68cb9ff554c7f",
-      "subject": "chore: drop in-repo infographic/ directory; keep PR-body URLs only (#30854)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/hermes_cli/test_kanban_notify.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "99671a86347769240ca6f4c17e059b7366bba64d",
-      "subject": "test(kanban): allow tmp_path artifacts past media-delivery validator",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/run.py",
-        "tests/gateway/test_session_model_override_routing.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "d21ac579e99f5561de724f13500b930bb28848d7",
-      "subject": "fix(gateway): honor key_env in auth-failure fallback resolution",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/run.py",
-        "tests/gateway/test_runtime_config_env_expansion.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "2362cc4688364ca8d03924ab1f64e9bb2f5f0cb3",
-      "subject": "fix(gateway): enforce env variable template expansion on runtime config loaders",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/run.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "66d81f9e14281f1f67f8f259a3a8cbae5c9d75df",
-      "subject": "fix(gateway): don't swallow expansion errors in runtime config helper",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/platforms/qqbot/adapter.py",
-        "tests/gateway/test_qqbot.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "bbd77d165cd603759f183e620c1e626580e31135",
-      "subject": "fix(qqbot): add INTERACTION intent and expose video/file cached paths",
-      "target_ticket": 23,
-      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/platforms/qqbot/adapter.py",
-        "tests/gateway/test_qqbot.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "a54f5afc7086ffe14bc5a46d1e56e835c61092e4",
-      "subject": "fix(qqbot): handle op 7/9 and expand fatal close code set",
-      "target_ticket": 23,
-      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/platforms/qqbot/adapter.py",
-        "tests/gateway/test_qqbot.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "0e7448d63abd6864fa7ed4c6b20030890abf813e",
-      "subject": "fix(qqbot): use original attachment filename for cached files",
-      "target_ticket": 23,
-      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/platforms/qqbot/adapter.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "60b0a0e00671f8bb809b57cf73fbf90a07803ec4",
-      "subject": "fix(qqbot): fix SILK magic byte detection slice length",
-      "target_ticket": 23,
-      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "hermes_cli/gateway_windows.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "b183be95a28bd8a6447ec4ffa99d030186e37afc",
-      "subject": "fix(gateway-windows): atomic write for .cmd and startup launcher scripts",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "agent/agent_runtime_helpers.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "53cb6d32be17b6a873614a5d7cca821b6ae8319e",
-      "subject": "fix(agent): use atomic_json_write for request debug dumps instead of bare write_text",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "agent/agent_runtime_helpers.py",
-        "tests/run_agent/test_create_openai_client_reuse.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "e2a7d73a66a8aa75e78002fbde53b41b774f8f9b",
-      "subject": "fix(force_close_tcp_sockets): shutdown only, do not release FD (#29507)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "agent/chat_completion_helpers.py",
-        "run_agent.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "30c22f1158c001cf35ce4a2cb5d2dc188fe43066",
-      "subject": "fix(api-call): defer client.close() to owning worker thread on interrupt (#29507)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/run_agent/test_tls_fd_recycle_corruption.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "5b6f0b695b8182ebd8860ca9fb45bf8661be2ec3",
-      "subject": "test(tls-fd-recycle): pin shutdown-only + thread-aware close contract (#29507)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/hermes_cli/test_kanban_notify.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "db489a315f21c139219b9e2d457a7b7b62fdec7c",
-      "subject": "fix(tests): allowlist tmp_path for kanban_notify artifact delivery (#30852)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tools/skills_guard.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "0f8215f6333b5ac6f3961cada5903ab36b18756a",
-      "subject": "fix(security): correct verdict logic and enforce --force limitation in skills_guard",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/tools/test_skills_guard.py",
-        "tools/skills_guard.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "789043b691ff1283a0d79fd7e1190a082ccfc04e",
-      "subject": "fix(security): update tests for verdict and --force changes",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/tools/test_skills_guard.py",
-        "tools/skills_guard.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "6942b1836e95621eea7bf9dd54085e5849819ad4",
-      "subject": "fix(skills_guard): explain why --force is rejected on dangerous verdicts",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "hermes_cli/main.py",
-        "hermes_cli/portal_cli.py",
-        "hermes_cli/setup.py",
-        "hermes_cli/tools_config.py"
-      ],
-      "files_touched": 4,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "b4cf5b65dd1cfa676f5d6077699dba06d38e606e",
-      "subject": "feat(portal): one-shot setup, status CLI, and Nous-included markers (#30860)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/platforms/webhook.py",
-        "tests/gateway/test_webhook_dynamic_routes.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "61ac1187240cfaf38167d50b87b5c6b77de29504",
-      "subject": "fix(webhook): enforce INSECURE_NO_AUTH safety rail on dynamic route reloads",
-      "target_ticket": 23,
-      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/gateway/test_fast_command.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "4b6d68bd645fee8be171b4c7ee1e2a3ea680b456",
-      "subject": "test(fast-command): stub _load_gateway_runtime_config too",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "gateway/platforms/telegram.py",
-        "gateway/run.py",
-        "tests/gateway/test_telegram_status_update.py"
-      ],
-      "files_touched": 3,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "9acf949e3498e84e9f997cbe332b885d938918c1",
-      "subject": "feat(telegram): edit status messages in place instead of appending (#30864)",
-      "target_ticket": 23,
-      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "website/docs/getting-started/quickstart.md",
-        "website/docs/reference/cli-commands.md",
-        "website/docs/user-guide/features/browser.md",
-        "website/docs/user-guide/features/image-generation.md",
-        "website/docs/user-guide/features/tool-gateway.md",
-        "website/docs/user-guide/features/tts.md",
-        "website/docs/user-guide/features/web-search.md"
-      ],
-      "files_touched": 7,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "f3fb7899d0a4ddc1db72e97ba9f6f4b81c198e30",
-      "subject": "docs: surface 'hermes setup --portal' and 'hermes portal' across user-facing pages (#30869)",
-      "target_ticket": 22,
-      "target_ticket_name": "GPAR-03 UX parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "website/docs/getting-started/installation.md",
-        "website/docs/integrations/providers.md",
-        "website/docs/user-guide/configuring-models.md",
-        "website/docs/user-guide/features/api-server.md",
-        "website/docs/user-guide/features/batch-processing.md",
-        "website/docs/user-guide/features/fallback-providers.md",
-        "website/docs/user-guide/features/voice-mode.md",
-        "website/docs/user-guide/windows-native.md"
-      ],
-      "files_touched": 8,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "64b3eb0dd70bdbace7d61db1c0050611800b9a64",
-      "subject": "docs: surface Nous Portal on pages where it solves a real problem the page describes (#30874)",
-      "target_ticket": 22,
-      "target_ticket_name": "GPAR-03 UX parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "run_agent.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "8b3cb930c9d06053b8fa9f07fd36c25e1796381d",
-      "subject": "fix(xai-oauth): honor [WKE=unauthenticated:...] disambiguator in entitlement classifier (#29344)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_only_python_test_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/run_agent/test_codex_xai_oauth_recovery.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": true,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": true
-      },
-      "sha": "b5ea6a5c80075737165f7a2b474886811a675310",
-      "subject": "test(xai-oauth): regression coverage for the bad-credentials disambiguator (#29344)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "agent/agent_runtime_helpers.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "cc93053b42ea98713cf46192ec340682a3728862",
-      "subject": "fix(xai-oauth): apply WKE disambiguator to recovery-path catch-all (#29344)",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "rust_primary_surface_guard",
-      "disposition": "superseded",
-      "files_sample": [
-        "tests/tools/test_memory_tool.py",
-        "tools/memory_tool.py"
-      ],
-      "files_touched": 2,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "6855d177531f9abfbb00d0da1f2db6ff91bdb872",
-      "subject": "fix(memory): guard against external drift in MEMORY.md/USER.md (#26045) (#30877)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "tests/tools/test_approval.py",
-        "tools/approval.py"
-      ],
-      "files_touched": 2,
-      "notes": "Rust terminal approval path denies confirmation-required commands without consent and now pins the same no-retry/no-rephrase/no-same-outcome 'Silence is not consent' contract in crates/hermes-tools/src/tools/terminal.rs.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "7f1b2b4569532d63a7f50e172963da0d4f3082f7",
-      "subject": "fix(approval): pin 'silence is not consent' contract on timeout/deny (#24912) (#30879)",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "cli.py",
-        "gateway/run.py",
-        "hermes_cli/fallback_cmd.py",
-        "hermes_cli/fallback_config.py",
-        "hermes_cli/oneshot.py",
-        "tests/cli/test_cli_init.py",
-        "tests/gateway/test_auth_fallback.py",
-        "tests/hermes_cli/test_fallback_cmd.py"
-      ],
-      "files_touched": 8,
-      "notes": "Rust config loading now normalizes Python-style fallback_providers plus legacy fallback_model into a merged fallback_models chain, preserves fallback provider metadata in llm_providers, and forwards that chain into AgentConfig unless HERMES_FALLBACK_MODEL(S) overrides it.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "7245bc77eb3b92b311c622806821375709bbe4d2",
-      "subject": "fix(fallback): merge fallback_providers with legacy fallback_model configurations",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "README.md",
-        "README.zh-CN.md"
-      ],
-      "files_touched": 2,
-      "notes": "README.md and local Chinese README now include the upstream Nous Portal setup/status section adapted to hermes-agent-ultra command names.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": false,
-        "superseded_by_guard": false
-      },
-      "sha": "e97a4c8f379530b556eee9cffb608b2016d87708",
-      "subject": "docs(readme): add Nous Portal section between Getting Started and CLI/Messaging reference (#30941)",
-      "target_ticket": 25,
-      "target_ticket_name": "GPAR-06 packaging/docs/install parity"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "hermes_cli/kanban_db.py",
-        "tests/hermes_cli/test_kanban_db.py"
-      ],
-      "files_touched": 2,
-      "notes": "Rust kanban store loading now refuses malformed or semantically empty existing boards.json state, preserves the original bytes, and writes a same-directory boards.json.corrupt.<timestamp> backup before returning an error.",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "39fe4ecee3d0876ca16a4a031349140733264302",
-      "subject": "fix(kanban): refuse corrupt db auto-init",
-      "target_ticket": 20,
-      "target_ticket_name": "GPAR-01 tests+CI parity"
-    },
-    {
-      "classification_rule": "prior_state",
-      "disposition": "superseded",
-      "files_sample": [
-        "scripts/release.py"
-      ],
-      "files_touched": 1,
-      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
-      "owner": "",
-      "rust_only_guard": {
-        "allow_python_test_surfaces": false,
-        "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
-        "superseded_by_guard": false
-      },
-      "sha": "4f835f7e43f9c6c1b90a50951b6ed94b653efa60",
-      "subject": "chore(release): map NickLarcombe author email for #30707 salvage",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
-    },
-    {
-      "classification_rule": "sha_override",
-      "disposition": "ported",
-      "files_sample": [
-        "hermes_cli/kanban_db.py"
-      ],
-      "files_touched": 1,
+      "files_touched": 3630,
       "notes": "Rust corrupt-store backup derives the backup filename from the canonical store basename and writes only within the original store parent directory, matching the upstream path-injection hardening intent.",
       "owner": "",
       "rust_only_guard": {
         "allow_python_test_surfaces": false,
         "python_test_only_commit": false,
-        "rust_primary_surface_only_commit": true,
+        "rust_primary_surface_only_commit": false,
         "superseded_by_guard": false
       },
       "sha": "c4b8f5efee8cdd3186e465d940bf0e8c98849346",
       "subject": "fix(kanban): harden corrupt-db backup against CodeQL path-injection findings",
-      "target_ticket": 26,
-      "target_ticket_name": "GPAR-07 upstream queue backfill"
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
       "classification_rule": "sha_override",
@@ -1002,7 +60,7 @@
       "target_ticket_name": "GPAR-07 upstream queue backfill"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "hermes_cli/kanban_db.py",
@@ -1025,7 +83,7 @@
       "target_ticket_name": "GPAR-03 UX parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "ui-tui/src/__tests__/textInputBurstInput.test.ts",
@@ -1046,7 +104,7 @@
       "target_ticket_name": "GPAR-03 UX parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "ui-tui/src/__tests__/gatewayClient.test.ts",
@@ -1069,7 +127,7 @@
       "target_ticket_name": "GPAR-03 UX parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "ui-tui/src/__tests__/createGatewayEventHandler.test.ts",
@@ -1088,9 +146,626 @@
       "subject": "fix(tui): ignore late thinking deltas after completion (#31055)",
       "target_ticket": 22,
       "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts",
+        "ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts",
+        "ui-tui/src/hooks/useVirtualHistory.ts"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "4fea02cc16981dedb7878ce42e94c821d56d332f",
+      "subject": "fix(tui): refresh virtual transcript on viewport resize",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "cc61e3be49aa672d8d1ae75b8057a1b503251b7c",
+      "subject": "test(tui): isolate viewport-height remount regression",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/src/hooks/useVirtualHistory.ts"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "d1ad919a440948d73ad74a3b18d963a0763bb08e",
+      "subject": "test(tui): clarify virtual history resize snapshot",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "521c870a05a928a6dcb8abde64859c5bc2a5e538",
+      "subject": "docs(tui): clarify scrollbox subscription signals",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts",
+        "ui-tui/src/hooks/useVirtualHistory.ts"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "2a75bec6079be44212b91d0ec895e8c7e4e50161",
+      "subject": "fix(tui): recompute virtual tail after width resize",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/packages/hermes-ink/src/ink/log-update.test.ts",
+        "ui-tui/packages/hermes-ink/src/ink/log-update.ts",
+        "ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts",
+        "ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts",
+        "ui-tui/src/app/useMainApp.ts",
+        "ui-tui/src/lib/inputMetrics.ts"
+      ],
+      "files_touched": 6,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "0277194e3b31a72898962c528a5f75fde12cad72",
+      "subject": "fix(tui): preserve transcript tail across resizes",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/src/banner.ts",
+        "ui-tui/src/components/appLayout.tsx",
+        "ui-tui/src/components/branding.tsx"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "35fdf111452933032d822ccab4d32166fc361a63",
+      "subject": "feat(tui): responsive banner tiers",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "ui-tui/src/app/useMainApp.ts"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "511b8e2325c621a30bc9a75f00762d820282e72f",
+      "subject": "fix(tui): re-check sticky inside resize debounce + document remount",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "agent/prompt_builder.py",
+        "cron/scheduler.py",
+        "gateway/channel_directory.py",
+        "gateway/config.py",
+        "gateway/platforms/ntfy.py",
+        "gateway/run.py",
+        "hermes_cli/status.py",
+        "tests/gateway/test_ntfy.py",
+        "tools/send_message_tool.py",
+        "toolsets.py"
+      ],
+      "files_touched": 10,
+      "notes": "Imported ntfy as a platform plugin under plugins/platforms/ntfy with standalone send, env enablement, identity hardening, and local plugin regression tests.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "b10f17bf1e9321c586cb3afb0d80ef5bd4ae34d6",
+      "subject": "feat(ntfy): add ntfy platform adapter with atomic reconnect, identity fix, and 81 tests",
+      "target_ticket": 23,
+      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "agent/prompt_builder.py",
+        "cron/scheduler.py",
+        "gateway/channel_directory.py",
+        "gateway/config.py",
+        "gateway/run.py",
+        "hermes_cli/status.py",
+        "plugins/platforms/ntfy/__init__.py",
+        "plugins/platforms/ntfy/adapter.py",
+        "plugins/platforms/ntfy/plugin.yaml",
+        "tests/gateway/test_ntfy_plugin.py",
+        "tools/send_message_tool.py",
+        "toolsets.py"
+      ],
+      "files_touched": 12,
+      "notes": "Hermes Ultra uses the upstream platform-plugin ntfy shape rather than a bundled core adapter; tests/gateway/test_ntfy_plugin.py covers plugin registration and standalone delivery.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "6a8e131a0ab42e23fb8ad5e1e27ce2382f1d6a3b",
+      "subject": "refactor(ntfy): convert built-in adapter to platform plugin",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "plugins/platforms/ntfy/adapter.py",
+        "tests/gateway/test_ntfy_plugin.py",
+        "website/docs/reference/environment-variables.md",
+        "website/docs/user-guide/messaging/index.md",
+        "website/docs/user-guide/messaging/ntfy.md",
+        "website/sidebars.ts"
+      ],
+      "files_touched": 6,
+      "notes": "Ntfy robustness and docs are represented by plugins/platforms/ntfy, tests/gateway/test_ntfy_plugin.py, website ntfy messaging docs, sidebars, and environment-variable reference entries.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "3b096d6f6dbe8253aed46a2bc6b1304aaa9097d4",
+      "subject": "ntfy: tighten robustness, dedupe auth/truncation, add docs",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/main.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "2c34a7da87d7c785f0f694bc2aceb1fd09d2516d",
+      "subject": "fix(cli): prevent temp directory leak on ZIP update failure",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "tui_gateway/server.py",
+        "ui-tui/src/app/interfaces.ts",
+        "ui-tui/src/app/slash/commands/session.ts",
+        "ui-tui/src/app/useMainApp.ts"
+      ],
+      "files_touched": 4,
+      "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "7de8cd4c5f67b5b17e64392fac5fdf1b3a986983",
+      "subject": "fix(tui): clear TTS env var on voice off, and add TTS indicator to status bar",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "gateway/platforms/telegram.py",
+        "tests/gateway/test_telegram_group_gating.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "9451087aab30f5f28d3828ce867dd7e902d788a1",
+      "subject": "fix(telegram): preserve observed group slash commands",
+      "target_ticket": 23,
+      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "scripts/release.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "87111c7bfe111443ff6032686229c3f393891a2c",
+      "subject": "chore: map Glucksberg noreply email in AUTHOR_MAP",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "website/docs/user-guide/messaging/simplex.md"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "514a4eff36a02976580965b26088e2366734da35",
+      "subject": "docs(simplex): remove broken Docker install command (#26974) (#26975)",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/env_loader.py",
+        "tests/hermes_cli/test_env_loader.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "75643a615405def3e73201e5b07fc7860343a2f6",
+      "subject": "fix(env): strip null bytes from .env before python-dotenv loads",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "agent/agent_init.py",
+        "agent/context_compressor.py",
+        "agent/context_engine.py",
+        "tests/agent/test_last_total_tokens.py",
+        "tests/run_agent/test_plugin_context_engine_init.py"
+      ],
+      "files_touched": 5,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "8b2adead78c25142f98da7d7163e7fe5e24e09b2",
+      "subject": "fix(compressor): ABC compliance \u2014 total_tokens, api_mode, logger consistency",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "agent/agent_runtime_helpers.py",
+        "agent/chat_completion_helpers.py",
+        "agent/conversation_loop.py",
+        "agent/model_metadata.py",
+        "agent/tool_executor.py"
+      ],
+      "files_touched": 5,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "dcbcdd6526dc2ebf290dbffabede77967b6eaf6f",
+      "subject": "fix(compressor): propagate api_mode and fix root logger calls",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "agent/agent_init.py",
+        "agent/conversation_compression.py",
+        "cli.py",
+        "gateway/session_context.py",
+        "tests/cli/test_branch_command.py",
+        "tests/cli/test_cli_init.py",
+        "tests/cli/test_cli_new_session.py"
+      ],
+      "files_touched": 7,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "86871ee25aacac6da29a79105cebaeff76499d12",
+      "subject": "fix(cli): synchronize HERMES_SESSION_ID across environment and contextvar during session switches",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/commands.py",
+        "hermes_cli/main.py",
+        "hermes_cli/skills_hub.py",
+        "tests/tools/test_skills_ast_audit.py",
+        "tools/skills_ast_audit.py"
+      ],
+      "files_touched": 5,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "7255050c99ef0bd9ba54a00dbf760ed79baed75a",
+      "subject": "feat(skills): add opt-in AST deep diagnostics",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/main.py",
+        "hermes_cli/skills_hub.py",
+        "tests/tools/test_skills_ast_audit.py",
+        "tools/skills_ast_audit.py"
+      ],
+      "files_touched": 4,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "4254f7dd17e06e8cd976d93fe17ead0363b10c3b",
+      "subject": "refactor(skills): slim AST diagnostic to single entry point",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/auth.py",
+        "tests/hermes_cli/test_auth_qwen_provider.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "e8fa415a9e29ce7667d131335d2a614e5a41290b",
+      "subject": "fix(cli): validate runtime token refresh capability in Qwen auth status",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "agent/auxiliary_client.py",
+        "gateway/run.py",
+        "hermes_cli/main.py",
+        "hermes_cli/plugins.py",
+        "tests/agent/test_auxiliary_config_bridge.py",
+        "tests/hermes_cli/test_plugin_auxiliary_tasks.py"
+      ],
+      "files_touched": 6,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "e752c9454e3a4aa136f6150307adc0c0c39404d4",
+      "subject": "feat(plugins): add register_auxiliary_task() to PluginContext API",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "superseded",
+      "files_sample": [
+        "scripts/release.py"
+      ],
+      "files_touched": 1,
+      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "7a4dc8e8d6100e0e135299106b5c7b023f4ea13f",
+      "subject": "chore: map edison@mcclean.codes for PR #29817 salvage",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "cli-config.yaml.example",
+        "gateway/run.py",
+        "hermes_cli/_parser.py",
+        "hermes_cli/oneshot.py",
+        "tests/gateway/test_auth_fallback.py",
+        "website/docs/developer-guide/adding-providers.md",
+        "website/docs/developer-guide/model-provider-plugin.md",
+        "website/docs/guides/minimax-oauth.md",
+        "website/docs/guides/xai-grok-oauth.md",
+        "website/docs/reference/cli-commands.md",
+        "website/docs/reference/environment-variables.md"
+      ],
+      "files_touched": 11,
+      "notes": "Rust startup model resolution now pins provider selection to config-derived provider:model state and overwrites stale HERMES_INFERENCE_PROVIDER handoff env during runtime sync; CLI --provider remains the per-invocation override.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "e42fcc562596cf9d0f2708184fa3f990ce31047e",
+      "subject": "fix(provider): make config.yaml model.provider the single source of truth (#31222)",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "website/docs/integrations/providers.md"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "72ff3e909c73b625ee244ab5ea3d0608ee85dcf3",
+      "subject": "docs(providers): rewrite Nous Portal section as primary recommended path (#31230)",
+      "target_ticket": 22,
+      "target_ticket_name": "GPAR-03 UX parity"
     }
   ],
-  "generated_at_utc": "2026-05-23T20:31:09.608543+00:00",
+  "generated_at_utc": "2026-05-24T01:38:11.866517+00:00",
   "refs": {
     "local_ref": "HEAD",
     "range": "HEAD..upstream/main",
@@ -1098,18 +773,17 @@
   },
   "summary": {
     "by_disposition": {
-      "ported": 8,
-      "superseded": 42
+      "ported": 6,
+      "superseded": 27
     },
     "by_target_ticket": {
-      "20": 21,
-      "22": 7,
-      "23": 6,
-      "25": 1,
-      "26": 15
+      "20": 9,
+      "22": 17,
+      "23": 2,
+      "26": 5
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 0,
-    "total_commits": 50
+    "total_commits": 33
   }
 }

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,21 +1,20 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-05-23T20:31:09.608543+00:00`
+Generated: `2026-05-24T01:38:11.866517+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `50`.
+- Range: `HEAD..upstream/main`; total commits tracked: `33`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 21 |
-| #22 | GPAR-03 UX parity | 7 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 6 |
-| #25 | GPAR-06 packaging/docs/install parity | 1 |
-| #26 | GPAR-07 upstream queue backfill | 15 |
+| #20 | GPAR-01 tests+CI parity | 9 |
+| #22 | GPAR-03 UX parity | 17 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 2 |
+| #26 | GPAR-07 upstream queue backfill | 5 |
 
 | Disposition | Commit Count |
 | --- | ---: |
-| ported | 8 |
-| superseded | 42 |
+| ported | 6 |
+| superseded | 27 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-05-23T05:56:16-06:00",
-  "head_sha": "8300f1562a7bfec930ed597bd09ab8115d0ccfa3",
+  "generated_at_utc": "2026-05-23T19:07:51-06:00",
+  "head_sha": "6f87e0878bbe4c9bf087a41831d31f3797a01898",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "7f1b2b4569532d63a7f50e172963da0d4f3082f7",
+  "upstream_sha": "72ff3e909c73b625ee244ab5ea3d0608ee85dcf3",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `8300f1562a7bfec930ed597bd09ab8115d0ccfa3`
-- Upstream: `upstream/main` (`7f1b2b4569532d63a7f50e172963da0d4f3082f7`)
+- Local HEAD: `6f87e0878bbe4c9bf087a41831d31f3797a01898`
+- Upstream: `upstream/main` (`72ff3e909c73b625ee244ab5ea3d0608ee85dcf3`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/plugins/google_meet/__init__.py
+++ b/plugins/google_meet/__init__.py
@@ -1,13 +1,9 @@
 """google_meet plugin — let the agent join a Meet call, transcribe it, follow up.
 
-v1: transcribe-only. Spawns a headless Chromium via Playwright, joins the Meet
-URL, enables live captions, scrapes them into a transcript file. The agent then
-has the transcript in its workspace and can do whatever followup work it needs
-using its regular tools.
-
-v2 (not in this PR): realtime duplex audio so the agent can speak in the
-meeting, via OpenAI Realtime / Gemini Live + BlackHole / PulseAudio null-sink.
-``meet_say`` exists as a stub today so the tool surface is stable.
+Transcribe mode spawns a headless Chromium via Playwright, joins the Meet URL,
+enables live captions, and writes them into a transcript file. Realtime mode
+also lets the agent queue speech with ``meet_say``; the bot consumes that queue
+through the OpenAI Realtime speaker bridge and an OS audio sink.
 
 Explicit-by-design: only joins ``https://meet.google.com/`` URLs explicitly
 passed in. No calendar scanning, no auto-dial, no consent announcement.

--- a/plugins/google_meet/_hermes_home.py
+++ b/plugins/google_meet/_hermes_home.py
@@ -1,0 +1,18 @@
+"""Hermes home resolution for the Google Meet plugin.
+
+This plugin can be imported in the Rust-first Ultra tree where the upstream
+Python ``hermes_constants`` module is intentionally not vendored.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_hermes_home() -> Path:
+    """Return the active Hermes home directory."""
+    override = os.environ.get("HERMES_HOME", "").strip()
+    if override:
+        return Path(override)
+    return Path.home() / ".hermes"

--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from hermes_constants import get_hermes_home
+from plugins.google_meet._hermes_home import get_hermes_home
 
 from plugins.google_meet import process_manager as pm
 from plugins.google_meet.meet_bot import _is_safe_meet_url

--- a/plugins/google_meet/node/registry.py
+++ b/plugins/google_meet/node/registry.py
@@ -24,7 +24,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from hermes_constants import get_hermes_home
+from plugins.google_meet._hermes_home import get_hermes_home
 
 
 def _default_path() -> Path:

--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -30,7 +30,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import get_hermes_home
+from plugins.google_meet._hermes_home import get_hermes_home
 from plugins.google_meet.node import protocol as _proto
 
 
@@ -125,7 +125,7 @@ class NodeServer:
                 kwargs = {
                     k: payload[k]
                     for k in ("url", "guest_name", "duration", "headed",
-                              "auth_state", "session_id", "out_dir")
+                              "auth_state", "session_id", "out_dir", "mode")
                     if k in payload
                 }
                 if "url" not in kwargs:
@@ -143,13 +143,40 @@ class NodeServer:
                 result = pm.transcript(last=last)
                 return _proto.make_response(req_id, result)
             if t == "say":
-                # v2 wiring: enqueue into say_queue.jsonl inside the
-                # active meeting's out_dir when present. The bot-side
-                # consumer is v3+ (for v1 this is a stub returning ok).
                 text = payload.get("text", "")
+                if not str(text).strip():
+                    return _proto.make_response(
+                        req_id,
+                        {
+                            "ok": False,
+                            "enqueued": False,
+                            "reason": "text is required",
+                        },
+                    )
                 active = pm._read_active()  # type: ignore[attr-defined]
+                if not active:
+                    return _proto.make_response(
+                        req_id,
+                        {
+                            "ok": False,
+                            "enqueued": False,
+                            "reason": "no active meeting",
+                        },
+                    )
+                if active.get("mode") != "realtime":
+                    return _proto.make_response(
+                        req_id,
+                        {
+                            "ok": False,
+                            "enqueued": False,
+                            "reason": (
+                                "active meeting is in transcribe mode; pass "
+                                "mode='realtime' to meet_join to enable speech"
+                            ),
+                        },
+                    )
                 enqueued = False
-                if active and active.get("out_dir"):
+                if active.get("out_dir"):
                     queue = Path(active["out_dir"]) / "say_queue.jsonl"
                     try:
                         queue.parent.mkdir(parents=True, exist_ok=True)
@@ -160,7 +187,12 @@ class NodeServer:
                         enqueued = False
                 return _proto.make_response(
                     req_id,
-                    {"ok": True, "enqueued": enqueued, "text": text},
+                    {
+                        "ok": enqueued,
+                        "enqueued": enqueued,
+                        "text": text,
+                        "reason": None if enqueued else "failed to write say queue",
+                    },
                 )
         except Exception as exc:  # noqa: BLE001 — surface any pm crash to client
             return _proto.make_error(req_id, f"{type(exc).__name__}: {exc}")

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -20,7 +20,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import get_hermes_home
+from plugins.google_meet._hermes_home import get_hermes_home
 
 # File + directory layout (under $HERMES_HOME):
 #

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -3139,10 +3139,25 @@ async def _standalone_send(
     resource-name character set before substitution into the REST URL so
     a tampered value cannot path-traverse or query-inject.
 
-    ``media_files`` and ``force_document`` are accepted for signature
-    parity but are not implemented for the standalone path; messages with
-    attachments send as text-only.  The live adapter handles attachments.
+    Standalone mode sends text-only messages. Attachment requests are rejected
+    explicitly so callers do not mistake a text-only fallback for successful
+    media delivery. The live adapter handles attachments.
     """
+    if media_files:
+        return {
+            "error": (
+                "Google Chat standalone send supports text only; run the live "
+                "gateway adapter for attachment delivery"
+            )
+        }
+    if force_document:
+        return {
+            "error": (
+                "Google Chat standalone send does not support force_document; "
+                "run the live gateway adapter for document delivery"
+            )
+        }
+
     if not chat_id:
         return {"error": "Google Chat standalone send: chat_id (space resource) is required"}
     if not _GCHAT_CHAT_ID_RE.match(chat_id):

--- a/plugins/platforms/ntfy/__init__.py
+++ b/plugins/platforms/ntfy/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -1,0 +1,582 @@
+"""ntfy platform adapter (Hermes plugin).
+
+Subscribes to a topic on ntfy.sh or any self-hosted ntfy server via
+HTTP streaming (``/json`` endpoint with ``poll=false``) and publishes
+replies via HTTP POST. No external SDK - only httpx, which is already
+a Hermes dependency.
+
+This adapter ships as a Hermes platform plugin under
+``plugins/platforms/ntfy/``. The Hermes plugin loader scans the
+directory at startup, calls :func:`register`, and the platform becomes
+available to ``gateway/run.py`` and ``tools/send_message_tool`` through
+the registry - no edits to core files required.
+
+Configuration in config.yaml::
+
+    platforms:
+      ntfy:
+        enabled: true
+        extra:
+          server: "https://ntfy.sh"       # or self-hosted URL
+          topic: "hermes-in"              # subscribe topic (incoming)
+          publish_topic: "hermes-out"     # optional - defaults to topic
+          token: "..."                    # optional Bearer / Basic auth token
+          markdown: true                  # optional - enable markdown (default: false)
+
+Environment variables (all read at adapter construct time, env wins over
+config.yaml ``extra``):
+
+    NTFY_TOPIC                 Topic to subscribe to (required)
+    NTFY_SERVER_URL            Server URL (default: https://ntfy.sh)
+    NTFY_TOKEN                 Bearer token or 'user:pass' for Basic auth
+    NTFY_PUBLISH_TOPIC         Reply topic (defaults to NTFY_TOPIC)
+    NTFY_MARKDOWN              "true"/"1"/"yes" enables X-Markdown header
+    NTFY_ALLOWED_USERS         Allowlist (treated by gateway as user IDs;
+                               on ntfy these are topic names)
+    NTFY_ALLOW_ALL_USERS       Allow any topic - dev only
+    NTFY_HOME_CHANNEL          Default topic for cron / notification delivery
+    NTFY_HOME_CHANNEL_NAME     Human label for the home channel
+
+Identity model: ntfy has no native authenticated user identity. The
+``title`` field is publisher-controlled and is NOT used for
+authorization. Each topic is treated as a single trusted channel -
+``user_id`` is fixed to the topic name. Use a private topic protected
+by a read token for any real trust boundary.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+try:
+    import httpx
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _FatalStreamError(Exception):
+    """Raised when a stream error is unrecoverable (e.g. 401, 404)."""
+
+
+DEFAULT_SERVER = "https://ntfy.sh"
+MAX_MESSAGE_LENGTH = 4096  # ntfy message body limit
+DEDUP_WINDOW_SECONDS = 300
+DEDUP_MAX_SIZE = 1000
+RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+STREAM_TIMEOUT_SECONDS = 90  # ntfy keepalive default is 55s; give margin
+
+
+def _build_auth_header(token: str) -> Dict[str, str]:
+    """Build an ``Authorization`` header from an ntfy token.
+
+    Shared by :class:`NtfyAdapter._auth_headers` and :func:`_standalone_send`
+    so both paths follow the same auth shape and whitespace-stripping rules.
+
+    Tokens are stripped of surrounding whitespace - pasted tokens often
+    carry trailing newlines that would otherwise render the header
+    malformed (``Authorization: Bearer foo\\n``).  ``user:pass`` tokens
+    become Basic auth; anything else is treated as a Bearer token.
+    Returns ``{}`` when no token is configured.
+    """
+    if not token:
+        return {}
+    token = token.strip()
+    if not token:
+        return {}
+    if ":" in token:
+        import base64
+        encoded = base64.b64encode(token.encode()).decode()
+        return {"Authorization": f"Basic {encoded}"}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _truncate_body(message: str, *, context: str) -> bytes:
+    """Apply the ntfy 4096-char limit, logging a warning on truncation.
+
+    ``context`` is included in the log message so adapter and standalone
+    truncations can be told apart in logs.
+    """
+    if len(message) > MAX_MESSAGE_LENGTH:
+        logger.warning(
+            "%s: truncating message from %d to %d chars (ntfy limit)",
+            context, len(message), MAX_MESSAGE_LENGTH,
+        )
+    return message[:MAX_MESSAGE_LENGTH].encode("utf-8")
+
+
+def check_requirements() -> bool:
+    """Check whether the ntfy adapter is installable and minimally configured.
+
+    Reads ``NTFY_TOPIC`` directly to avoid the cost of a full
+    ``load_gateway_config()`` (which also writes to ``os.environ``) on
+    every pre-flight check.
+    """
+    if not HTTPX_AVAILABLE:
+        return False
+    topic = os.getenv("NTFY_TOPIC", "").strip()
+    return bool(topic)
+
+
+def validate_config(config) -> bool:
+    """Validate that the configured ntfy platform has a topic set."""
+    extra = getattr(config, "extra", {}) or {}
+    topic = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+    return bool(topic)
+
+
+def is_connected(config) -> bool:
+    """Check whether ntfy is configured (env or config.yaml)."""
+    extra = getattr(config, "extra", {}) or {}
+    topic = os.getenv("NTFY_TOPIC") or extra.get("topic", "")
+    return bool(topic)
+
+
+class NtfyAdapter(BasePlatformAdapter):
+    """ntfy adapter.
+
+    Subscribes to a topic via HTTP streaming (``/json`` endpoint) and
+    publishes replies via HTTP POST. No external SDK - only httpx.
+    """
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        platform = Platform("ntfy")
+        super().__init__(config=config, platform=platform)
+
+        extra = config.extra or {}
+        self._server: str = (
+            extra.get("server")
+            or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+        ).rstrip("/")
+        self._topic: str = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+        self._publish_topic: str = (
+            extra.get("publish_topic")
+            or os.getenv("NTFY_PUBLISH_TOPIC", "")
+            or self._topic
+        )
+        self._token: str = extra.get("token") or os.getenv("NTFY_TOKEN", "")
+
+        self._stream_task: Optional[asyncio.Task] = None
+        self._http_client: Optional["httpx.AsyncClient"] = None
+
+        # Message deduplication: msg_id -> timestamp
+        self._seen_messages: Dict[str, float] = {}
+
+    # -- Connection lifecycle -----------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to ntfy by starting the streaming subscription task."""
+        if not HTTPX_AVAILABLE:
+            logger.warning("[%s] httpx not installed. Run: pip install httpx", self.name)
+            return False
+        if not self._topic:
+            logger.warning("[%s] NTFY_TOPIC not configured", self.name)
+            return False
+
+        try:
+            self._http_client = httpx.AsyncClient(timeout=None)
+            self._stream_task = asyncio.create_task(self._run_stream())
+            self._mark_connected()
+            logger.info("[%s] Connected - subscribing to %s/%s", self.name, self._server, self._topic)
+            return True
+        except Exception as e:
+            logger.error("[%s] Failed to connect: %s", self.name, e)
+            return False
+
+    async def _run_stream(self) -> None:
+        """Subscribe to the ntfy topic with automatic reconnection."""
+        backoff_idx = 0
+        stream_start: float = 0.0
+        url = f"{self._server}/{self._topic}/json"
+        headers = self._auth_headers()
+
+        while self._running:
+            try:
+                logger.debug("[%s] Opening stream to %s", self.name, url)
+                stream_start = time.monotonic()
+                await self._consume_stream(url, headers)
+            except asyncio.CancelledError:
+                return
+            except _FatalStreamError:
+                self._running = False
+                return
+            except Exception as e:
+                if not self._running:
+                    return
+                logger.warning("[%s] Stream error: %s", self.name, e)
+
+            if not self._running:
+                return
+
+            # Reset backoff if stream stayed alive for at least 60s
+            if time.monotonic() - stream_start >= 60.0:
+                backoff_idx = 0
+            delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
+            logger.info("[%s] Reconnecting in %ds...", self.name, delay)
+            await asyncio.sleep(delay)
+            backoff_idx += 1
+
+    async def _consume_stream(self, url: str, headers: Dict[str, str]) -> None:
+        """Open an HTTP streaming connection and dispatch events."""
+        # poll=false keeps a persistent streaming connection alive with keepalive events
+        params = {"poll": "false"}
+        async with self._http_client.stream(
+            "GET",
+            url,
+            headers=headers,
+            params=params,
+            timeout=httpx.Timeout(connect=15.0, read=STREAM_TIMEOUT_SECONDS, write=15.0, pool=15.0),
+        ) as response:
+            if response.status_code == 401:
+                logger.error(
+                    "[%s] Authentication failed (401) - stopping reconnect loop. Check NTFY_TOKEN.",
+                    self.name,
+                )
+                self._set_fatal_error(
+                    "ntfy_unauthorized",
+                    "ntfy server rejected auth (401). Check NTFY_TOKEN.",
+                    retryable=False,
+                )
+                raise _FatalStreamError("401 Unauthorized")
+            if response.status_code == 404:
+                logger.error(
+                    "[%s] Topic not found (404): %s - stopping reconnect loop.",
+                    self.name, self._topic,
+                )
+                self._set_fatal_error(
+                    "ntfy_topic_not_found",
+                    f"ntfy topic '{self._topic}' returned 404. Check NTFY_TOPIC.",
+                    retryable=False,
+                )
+                raise _FatalStreamError("404 Not Found")
+            response.raise_for_status()
+
+            async for line in response.aiter_lines():
+                if not self._running:
+                    return
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("event") == "message":
+                    await self._on_message(event)
+
+    async def disconnect(self) -> None:
+        """Disconnect from ntfy."""
+        self._running = False
+        self._mark_disconnected()
+
+        if self._stream_task:
+            self._stream_task.cancel()
+            try:
+                await self._stream_task
+            except asyncio.CancelledError:
+                pass
+            self._stream_task = None
+
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+
+        self._seen_messages.clear()
+        logger.info("[%s] Disconnected", self.name)
+
+    # -- Inbound message processing -----------------------------------------
+
+    async def _on_message(self, event: Dict[str, Any]) -> None:
+        """Process an incoming ntfy message event."""
+        msg_id = event.get("id") or uuid.uuid4().hex
+        if self._is_duplicate(msg_id):
+            logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
+            return
+
+        text = (event.get("message") or "").strip()
+        if not text:
+            logger.debug("[%s] Empty message body, skipping", self.name)
+            return
+
+        topic = event.get("topic") or self._topic
+        # ntfy has no native authenticated user identity. The title field is
+        # publisher-controlled and must NOT be used for authorization - any
+        # publisher who knows the topic can set title to an allowed username.
+        # Treat ntfy as a single trusted channel; user_id is fixed to the
+        # topic name. NTFY_ALLOWED_USERS is only a real trust boundary when
+        # the topic itself is protected by a read token.
+        user_id = topic
+        user_name = topic
+
+        source = self.build_source(
+            chat_id=topic,
+            chat_name=topic,
+            chat_type="dm",
+            user_id=user_id,
+            user_name=user_name,
+        )
+
+        unix_ts = event.get("time")
+        try:
+            timestamp = (
+                datetime.fromtimestamp(int(unix_ts), tz=timezone.utc)
+                if unix_ts else datetime.now(tz=timezone.utc)
+            )
+        except (ValueError, OSError, TypeError):
+            timestamp = datetime.now(tz=timezone.utc)
+
+        message_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=msg_id,
+            raw_message=event,
+            timestamp=timestamp,
+        )
+
+        logger.debug("[%s] Message on topic %s: %s", self.name, topic, text[:80])
+        await self.handle_message(message_event)
+
+    # -- Deduplication ------------------------------------------------------
+
+    def _is_duplicate(self, msg_id: str) -> bool:
+        """Return True if this message ID was already seen within the dedup window."""
+        now = time.time()
+        if len(self._seen_messages) > DEDUP_MAX_SIZE:
+            cutoff = now - DEDUP_WINDOW_SECONDS
+            self._seen_messages = {k: v for k, v in self._seen_messages.items() if v > cutoff}
+
+        if msg_id in self._seen_messages:
+            return True
+        self._seen_messages[msg_id] = now
+        return False
+
+    # -- Outbound messaging -------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Publish a message to the configured publish topic."""
+        metadata = metadata or {}
+        publish_topic = metadata.get("publish_topic") or self._publish_topic or chat_id
+
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+
+        url = f"{self._server}/{publish_topic}"
+        markdown_enabled = (self.config.extra or {}).get("markdown", False)
+        headers = {**self._auth_headers(), "Content-Type": "text/plain; charset=utf-8"}
+        if markdown_enabled:
+            headers["X-Markdown"] = "true"
+
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            logger.warning(
+                "[%s] Message truncated from %d to %d chars (ntfy limit)",
+                self.name, len(content), self.MAX_MESSAGE_LENGTH,
+            )
+        body = content[:self.MAX_MESSAGE_LENGTH]
+
+        try:
+            resp = await self._http_client.post(
+                url, content=body.encode("utf-8"), headers=headers, timeout=15.0,
+            )
+            if resp.status_code < 300:
+                try:
+                    data = resp.json()
+                    returned_id = data.get("id") or uuid.uuid4().hex[:12]
+                except Exception:
+                    returned_id = uuid.uuid4().hex[:12]
+                return SendResult(success=True, message_id=returned_id)
+            body_text = resp.text
+            logger.warning("[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body_text[:200])
+            return SendResult(success=False, error=f"HTTP {resp.status_code}: {body_text[:200]}")
+        except httpx.TimeoutException:
+            return SendResult(success=False, error="Timeout publishing to ntfy")
+        except Exception as e:
+            logger.error("[%s] Send error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """ntfy does not support typing indicators."""
+        pass
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return basic info about an ntfy topic."""
+        return {"name": chat_id, "type": "dm"}
+
+    # -- Helpers ------------------------------------------------------------
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Build Authorization header if a token is configured."""
+        return _build_auth_header(self._token)
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def _env_enablement() -> dict | None:
+    """Seed ``PlatformConfig.extra`` from env vars during gateway config load.
+
+    Called by the platform registry's env-enablement hook BEFORE adapter
+    construction, so ``gateway status`` and ``get_connected_platforms()``
+    reflect env-only configuration without instantiating the HTTP client.
+    Returns ``None`` when ntfy isn't minimally configured; the caller skips
+    auto-enabling.
+
+    The special ``home_channel`` key in the returned dict is handled by the
+    core hook - it becomes a proper ``HomeChannel`` dataclass on the
+    ``PlatformConfig`` rather than being merged into ``extra``.
+    """
+    topic = os.getenv("NTFY_TOPIC", "").strip()
+    if not topic:
+        return None
+    seed: dict = {
+        "topic": topic,
+        "server": os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER).rstrip("/"),
+    }
+    publish_topic = os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
+    if publish_topic:
+        seed["publish_topic"] = publish_topic
+    token = os.getenv("NTFY_TOKEN", "").strip()
+    if token:
+        seed["token"] = token
+    markdown = os.getenv("NTFY_MARKDOWN", "").strip().lower()
+    if markdown:
+        seed["markdown"] = markdown in ("1", "true", "yes")
+    home = os.getenv("NTFY_HOME_CHANNEL", "").strip() or topic
+    if home:
+        seed["home_channel"] = {
+            "chat_id": home,
+            "name": os.getenv("NTFY_HOME_CHANNEL_NAME", home),
+        }
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Out-of-process publish for cron / send_message_tool fallbacks.
+
+    Used by ``tools/send_message_tool._send_via_adapter`` and the cron
+    scheduler when the gateway runner is not in this process (e.g.
+    ``hermes cron`` running standalone). Without this hook,
+    ``deliver=ntfy`` cron jobs fail with ``No live adapter for platform``.
+
+    ``thread_id`` and ``media_files`` are accepted for signature parity
+    only - ntfy has no thread or attachment primitive. Markdown is
+    honored if ``NTFY_MARKDOWN`` is set OR ``pconfig.extra["markdown"]``
+    is True.
+    """
+    if not HTTPX_AVAILABLE:
+        return {"error": "ntfy standalone send: httpx not installed"}
+
+    extra = getattr(pconfig, "extra", {}) or {}
+    server = (
+        extra.get("server")
+        or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+    ).rstrip("/")
+    publish_topic = (
+        chat_id
+        or extra.get("publish_topic")
+        or os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
+        or extra.get("topic")
+        or os.getenv("NTFY_TOPIC", "").strip()
+    )
+    if not publish_topic:
+        return {"error": "ntfy standalone send: NTFY_TOPIC not configured"}
+
+    token = extra.get("token") or os.getenv("NTFY_TOKEN", "")
+    markdown_env = os.getenv("NTFY_MARKDOWN", "").strip().lower()
+    markdown_enabled = bool(extra.get("markdown")) or markdown_env in ("1", "true", "yes")
+
+    headers = {"Content-Type": "text/plain; charset=utf-8", **_build_auth_header(token)}
+    if markdown_enabled:
+        headers["X-Markdown"] = "true"
+
+    body = _truncate_body(message, context="ntfy standalone")
+
+    url = f"{server}/{publish_topic}"
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(url, content=body, headers=headers)
+        if resp.status_code >= 300:
+            return {"error": f"ntfy HTTP {resp.status_code}: {resp.text[:200]}"}
+        try:
+            data = resp.json()
+            msg_id = data.get("id") or uuid.uuid4().hex[:12]
+        except Exception:
+            msg_id = uuid.uuid4().hex[:12]
+        return {"success": True, "platform": "ntfy", "chat_id": publish_topic, "message_id": msg_id}
+    except Exception as e:
+        return {"error": f"ntfy standalone send failed: {e}"}
+
+
+def register(ctx) -> None:
+    """Plugin entry point - called by the Hermes plugin system at startup."""
+    ctx.register_platform(
+        name="ntfy",
+        label="ntfy",
+        adapter_factory=lambda cfg: NtfyAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["NTFY_TOPIC"],
+        install_hint="pip install httpx   # already a Hermes dependency",
+        # Env-driven auto-configuration: seeds PlatformConfig.extra so
+        # env-only setups show up in `hermes gateway status` without
+        # instantiating the HTTP client.
+        env_enablement_fn=_env_enablement,
+        # Cron home-channel delivery support - `deliver=ntfy` cron jobs
+        # route to NTFY_HOME_CHANNEL when set.
+        cron_deliver_env_var="NTFY_HOME_CHANNEL",
+        # Out-of-process cron delivery. Without this hook, deliver=ntfy
+        # cron jobs fail with "No live adapter" when cron runs separately
+        # from the gateway.
+        standalone_sender_fn=_standalone_send,
+        # Auth env vars for _is_user_authorized() integration.
+        allowed_users_env="NTFY_ALLOWED_USERS",
+        allow_all_env="NTFY_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="ntfy",
+        # ntfy publishers have no persistent identity - topic names are
+        # the only identifier, no phone numbers / emails to redact.
+        pii_safe=True,
+        allow_update_command=True,
+        platform_hint=(
+            "You are communicating via ntfy push notifications. "
+            "Use plain text by default - ntfy supports optional markdown "
+            "(set markdown: true in config or NTFY_MARKDOWN=true). "
+            "Keep responses concise; ntfy is a push notification service "
+            "with a 4096-character per-message limit."
+        ),
+    )

--- a/plugins/platforms/ntfy/plugin.yaml
+++ b/plugins/platforms/ntfy/plugin.yaml
@@ -1,0 +1,56 @@
+name: ntfy-platform
+label: ntfy
+kind: platform
+version: 1.0.0
+description: >
+  ntfy push-notification gateway adapter for Hermes Agent.
+  Subscribes to a topic on ntfy.sh or any self-hosted ntfy server via
+  HTTP streaming, and publishes replies via HTTP POST. Lightweight -
+  no external SDK, only httpx (already a Hermes dependency).
+
+  ntfy has no native user-identity primitive; the adapter treats each
+  topic as a single trusted channel and never derives user identity
+  from publisher-controlled fields. Use a private topic + read token
+  for any real trust boundary.
+author: sprmn24
+# ``requires_env`` and ``optional_env`` entries are surfaced in the
+# ``hermes config`` UI via the platform-plugin env var injector in
+# ``hermes_cli/config.py``.
+requires_env:
+  - name: NTFY_TOPIC
+    description: "Topic name to subscribe to (e.g. hermes-in)"
+    prompt: "ntfy subscribe topic"
+    password: false
+optional_env:
+  - name: NTFY_SERVER_URL
+    description: "ntfy server URL (default: https://ntfy.sh)"
+    prompt: "ntfy server URL"
+    password: false
+  - name: NTFY_TOKEN
+    description: "Bearer token or 'user:pass' for Basic auth (optional)"
+    prompt: "ntfy auth token (or empty)"
+    password: true
+  - name: NTFY_PUBLISH_TOPIC
+    description: "Topic to publish replies to (defaults to NTFY_TOPIC)"
+    prompt: "ntfy publish topic (or empty)"
+    password: false
+  - name: NTFY_MARKDOWN
+    description: "Send replies with X-Markdown: true header (true/false, default: false)"
+    prompt: "Enable markdown formatting? (true/false)"
+    password: false
+  - name: NTFY_ALLOWED_USERS
+    description: "Comma-separated topic names allowed (allowlist)"
+    prompt: "Allowed topic names (comma-separated)"
+    password: false
+  - name: NTFY_ALLOW_ALL_USERS
+    description: "Allow any topic to talk to the bot (dev only - disables allowlist)"
+    prompt: "Allow all topics? (true/false)"
+    password: false
+  - name: NTFY_HOME_CHANNEL
+    description: "Default topic for cron / notification delivery"
+    prompt: "Home channel topic (or empty)"
+    password: false
+  - name: NTFY_HOME_CHANNEL_NAME
+    description: "Human label for the home channel (defaults to the topic name)"
+    prompt: "Home channel display name (or empty)"
+    password: false

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -512,11 +512,25 @@ async def _standalone_send(
     env var.  ``chat_id`` is validated to match the documented Bot
     Framework ID character set so it cannot escape the URL path.
 
-    ``media_files`` and ``force_document`` are accepted for signature
-    parity but not implemented for the standalone path; messages with
-    attachments will send as text-only.  The live adapter handles
-    attachments via the SDK.
+    Standalone mode sends text-only activities. Attachment requests are
+    rejected explicitly so callers do not mistake a text-only fallback for
+    successful media delivery. The live adapter handles attachments via the SDK.
     """
+    if media_files:
+        return {
+            "error": (
+                "Teams standalone send supports text only; run the live "
+                "gateway adapter for attachment delivery"
+            )
+        }
+    if force_document:
+        return {
+            "error": (
+                "Teams standalone send does not support force_document; run "
+                "the live gateway adapter for document delivery"
+            )
+        }
+
     extra = getattr(pconfig, "extra", {}) or {}
     client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
     client_secret = os.getenv("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2801,6 +2801,40 @@ class TestGoogleChatStandaloneSend:
         assert kwargs["json"] == {"text": "hello cron"}
 
     @pytest.mark.asyncio
+    async def test_standalone_send_rejects_media_files_before_credentials(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", raising=False)
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _gc_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "spaces/AAAA-BBBB",
+            "hi",
+            media_files=["/tmp/report.pdf"],
+        )
+
+        assert "error" in result
+        assert "text only" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_force_document_before_credentials(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", raising=False)
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _gc_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "spaces/AAAA-BBBB",
+            "hi",
+            force_document=True,
+        )
+
+        assert "error" in result
+        assert "force_document" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
     async def test_standalone_send_returns_error_on_invalid_chat_id(self, monkeypatch):
         monkeypatch.delenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", raising=False)
         result = await _gc_mod._standalone_send(

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -1,0 +1,212 @@
+"""Regression coverage for the ntfy platform plugin port."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+
+class Platform(str):
+    _cache: dict[str, "Platform"] = {}
+
+    def __new__(cls, value: str):
+        if value in cls._cache:
+            return cls._cache[value]
+        obj = str.__new__(cls, value)
+        cls._cache[value] = obj
+        return obj
+
+    @property
+    def value(self) -> str:
+        return str(self)
+
+
+@dataclass
+class PlatformConfig:
+    enabled: bool = True
+    extra: dict | None = None
+
+
+class MessageType:
+    TEXT = "text"
+
+
+@dataclass
+class MessageEvent:
+    text: str
+    message_type: str
+    source: dict
+    message_id: str
+    raw_message: dict
+    timestamp: object
+
+
+@dataclass
+class SendResult:
+    success: bool
+    message_id: str | None = None
+    error: str | None = None
+
+
+class BasePlatformAdapter:
+    def __init__(self, *, config: PlatformConfig, platform: Platform):
+        self.config = config
+        self.platform = platform
+        self.name = platform.value
+        self._running = False
+
+    def _mark_connected(self) -> None:
+        self._running = True
+
+    def _mark_disconnected(self) -> None:
+        self._running = False
+
+    def _set_fatal_error(self, *_args, **_kwargs) -> None:
+        pass
+
+    def build_source(self, **kwargs) -> dict:
+        return kwargs
+
+    async def handle_message(self, event: MessageEvent) -> None:
+        self.last_event = event
+
+
+def _install_gateway_stubs() -> None:
+    gateway_pkg = sys.modules.setdefault("gateway", types.ModuleType("gateway"))
+    gateway_pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "gateway")]
+
+    config_mod = types.ModuleType("gateway.config")
+    config_mod.Platform = Platform
+    config_mod.PlatformConfig = PlatformConfig
+    sys.modules["gateway.config"] = config_mod
+
+    platforms_pkg = sys.modules.setdefault("gateway.platforms", types.ModuleType("gateway.platforms"))
+    platforms_pkg.__path__ = []
+    base_mod = types.ModuleType("gateway.platforms.base")
+    base_mod.BasePlatformAdapter = BasePlatformAdapter
+    base_mod.MessageEvent = MessageEvent
+    base_mod.MessageType = MessageType
+    base_mod.SendResult = SendResult
+    sys.modules["gateway.platforms.base"] = base_mod
+
+
+_install_gateway_stubs()
+_ntfy = load_plugin_adapter("ntfy")
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_auth_header_strips_token_and_supports_basic_auth():
+    assert _ntfy._build_auth_header(" token\n") == {"Authorization": "Bearer token"}
+    assert _ntfy._build_auth_header("user:pass")["Authorization"].startswith("Basic ")
+    assert _ntfy._build_auth_header(" \n") == {}
+
+
+def test_env_enablement_seeds_topic_publish_auth_markdown_and_home(monkeypatch):
+    monkeypatch.setenv("NTFY_TOPIC", "inbox")
+    monkeypatch.setenv("NTFY_SERVER_URL", "https://ntfy.example/")
+    monkeypatch.setenv("NTFY_PUBLISH_TOPIC", "outbox")
+    monkeypatch.setenv("NTFY_TOKEN", "secret")
+    monkeypatch.setenv("NTFY_MARKDOWN", "yes")
+    monkeypatch.setenv("NTFY_HOME_CHANNEL", "home")
+    monkeypatch.setenv("NTFY_HOME_CHANNEL_NAME", "Home")
+
+    seed = _ntfy._env_enablement()
+
+    assert seed == {
+        "topic": "inbox",
+        "server": "https://ntfy.example",
+        "publish_topic": "outbox",
+        "token": "secret",
+        "markdown": True,
+        "home_channel": {"chat_id": "home", "name": "Home"},
+    }
+
+
+def test_on_message_uses_topic_identity_not_spoofable_title():
+    adapter = _ntfy.NtfyAdapter(PlatformConfig(extra={"topic": "trusted-topic"}))
+    adapter.handle_message = AsyncMock()
+
+    _run(adapter._on_message({
+        "id": "msg-1",
+        "topic": "trusted-topic",
+        "title": "admin",
+        "message": "hello",
+        "time": 1710000000,
+    }))
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source["user_id"] == "trusted-topic"
+    assert event.source["user_name"] == "trusted-topic"
+    assert event.source["user_id"] != "admin"
+
+
+def test_standalone_send_truncates_and_uses_shared_auth(monkeypatch):
+    posted: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "ok"
+
+        def json(self):
+            return {"id": "ntfy-id"}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, content, headers):
+            posted["url"] = url
+            posted["content"] = content
+            posted["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.setattr(_ntfy, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(_ntfy.httpx, "AsyncClient", FakeClient)
+
+    result = _run(_ntfy._standalone_send(
+        SimpleNamespace(extra={
+            "server": "https://ntfy.example/",
+            "topic": "default-topic",
+            "token": " user:pass\n",
+            "markdown": True,
+        }),
+        "",
+        "x" * (_ntfy.MAX_MESSAGE_LENGTH + 20),
+    ))
+
+    assert result == {"success": True, "platform": "ntfy", "chat_id": "default-topic", "message_id": "ntfy-id"}
+    assert posted["url"] == "https://ntfy.example/default-topic"
+    assert len(posted["content"]) == _ntfy.MAX_MESSAGE_LENGTH
+    assert posted["headers"]["Authorization"].startswith("Basic ")
+    assert posted["headers"]["X-Markdown"] == "true"
+
+
+def test_register_exposes_plugin_contract():
+    calls = []
+    ctx = SimpleNamespace(register_platform=lambda **kwargs: calls.append(kwargs))
+
+    _ntfy.register(ctx)
+
+    registration = calls[0]
+    assert registration["name"] == "ntfy"
+    assert registration["env_enablement_fn"] is _ntfy._env_enablement
+    assert registration["standalone_sender_fn"] is _ntfy._standalone_send
+    assert registration["cron_deliver_env_var"] == "NTFY_HOME_CHANNEL"
+    assert registration["max_message_length"] == _ntfy.MAX_MESSAGE_LENGTH
+    assert registration["pii_safe"] is True

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -796,6 +796,42 @@ class TestTeamsStandaloneSend:
         assert activity_kwargs["json"]["type"] == "message"
 
     @pytest.mark.asyncio
+    async def test_standalone_send_rejects_media_files_before_http(self, monkeypatch):
+        for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+            monkeypatch.delenv(var, raising=False)
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hi",
+            media_files=["/tmp/report.pdf"],
+        )
+
+        assert "error" in result
+        assert "text only" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_force_document_before_http(self, monkeypatch):
+        for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+            monkeypatch.delenv(var, raising=False)
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hi",
+            force_document=True,
+        )
+
+        assert "error" in result
+        assert "force_document" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
     async def test_standalone_send_returns_error_when_unconfigured(self, monkeypatch):
         for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
             monkeypatch.delenv(var, raising=False)

--- a/tests/plugins/test_google_meet_node.py
+++ b/tests/plugins/test_google_meet_node.py
@@ -317,6 +317,7 @@ def test_server_handle_request_start_bot_dispatches(tmp_path, monkeypatch):
         "url": "https://meet.google.com/abc-defg-hij",
         "guest_name": "Bot",
         "duration": "30m",
+        "mode": "realtime",
     })
     resp = asyncio.run(s._handle_request(req))
     assert resp["type"] == "response"
@@ -324,6 +325,7 @@ def test_server_handle_request_start_bot_dispatches(tmp_path, monkeypatch):
     assert captured["url"] == "https://meet.google.com/abc-defg-hij"
     assert captured["guest_name"] == "Bot"
     assert captured["duration"] == "30m"
+    assert captured["mode"] == "realtime"
 
 
 def test_server_handle_request_start_bot_missing_url(tmp_path):
@@ -389,7 +391,12 @@ def test_server_handle_request_say_enqueues_when_active(tmp_path, monkeypatch):
     out = tmp_path / "meet-out"
     out.mkdir()
     monkeypatch.setattr(pm, "_read_active",
-                        lambda: {"pid": 1, "meeting_id": "m", "out_dir": str(out)})
+                        lambda: {
+                            "pid": 1,
+                            "meeting_id": "m",
+                            "mode": "realtime",
+                            "out_dir": str(out),
+                        })
 
     s = NodeServer(token_path=tmp_path / "t.json")
     tok = s.ensure_token()
@@ -403,7 +410,7 @@ def test_server_handle_request_say_enqueues_when_active(tmp_path, monkeypatch):
     assert json.loads(q[0])["text"] == "hello"
 
 
-def test_server_handle_request_say_without_active_still_ok(tmp_path, monkeypatch):
+def test_server_handle_request_say_without_active_returns_error(tmp_path, monkeypatch):
     from plugins.google_meet.node.server import NodeServer
     from plugins.google_meet.node import protocol
     from plugins.google_meet import process_manager as pm
@@ -415,8 +422,35 @@ def test_server_handle_request_say_without_active_still_ok(tmp_path, monkeypatch
     req = protocol.make_request("say", tok, {"text": "hi"})
     resp = asyncio.run(s._handle_request(req))
     assert resp["type"] == "response"
-    assert resp["payload"]["ok"] is True
+    assert resp["payload"]["ok"] is False
     assert resp["payload"]["enqueued"] is False
+    assert "no active meeting" in resp["payload"]["reason"]
+
+
+def test_server_handle_request_say_requires_realtime_mode(tmp_path, monkeypatch):
+    from plugins.google_meet.node.server import NodeServer
+    from plugins.google_meet.node import protocol
+    from plugins.google_meet import process_manager as pm
+
+    out = tmp_path / "meet-out"
+    out.mkdir()
+    monkeypatch.setattr(pm, "_read_active",
+                        lambda: {
+                            "pid": 1,
+                            "meeting_id": "m",
+                            "mode": "transcribe",
+                            "out_dir": str(out),
+                        })
+
+    s = NodeServer(token_path=tmp_path / "t.json")
+    tok = s.ensure_token()
+    req = protocol.make_request("say", tok, {"text": "hi"})
+    resp = asyncio.run(s._handle_request(req))
+    assert resp["type"] == "response"
+    assert resp["payload"]["ok"] is False
+    assert resp["payload"]["enqueued"] is False
+    assert "mode='realtime'" in resp["payload"]["reason"]
+    assert not (out / "say_queue.jsonl").exists()
 
 
 def test_server_handle_request_wraps_pm_exceptions(tmp_path, monkeypatch):
@@ -471,9 +505,26 @@ def _install_fake_ws(monkeypatch, reply_builder):
         fake_ws_holder["kwargs"] = kwargs
         return ws
 
-    # Patch the concrete import site inside client._rpc
-    import websockets.sync.client as wsc  # type: ignore
-    monkeypatch.setattr(wsc, "connect", _connect)
+    # Patch the concrete import site inside client._rpc without requiring the
+    # optional websockets dependency to be installed in the test environment.
+    try:
+        import websockets.sync.client as wsc  # type: ignore
+    except ImportError:
+        import sys
+        import types
+
+        ws_pkg = types.ModuleType("websockets")
+        sync_pkg = types.ModuleType("websockets.sync")
+        wsc = types.ModuleType("websockets.sync.client")
+        ws_pkg.__path__ = []  # type: ignore[attr-defined]
+        sync_pkg.__path__ = []  # type: ignore[attr-defined]
+        ws_pkg.sync = sync_pkg  # type: ignore[attr-defined]
+        sync_pkg.client = wsc  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "websockets", ws_pkg)
+        monkeypatch.setitem(sys.modules, "websockets.sync", sync_pkg)
+        monkeypatch.setitem(sys.modules, "websockets.sync.client", wsc)
+
+    monkeypatch.setattr(wsc, "connect", _connect, raising=False)
     return fake_ws_holder
 
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -285,6 +285,8 @@ describe('createSlashHandler', () => {
       expect(ctx.transcript.sys).toHaveBeenCalledWith('Voice TTS enabled.')
     })
     expect(ctx.voice.setVoiceRecordKey).not.toHaveBeenCalled()
+    expect(ctx.voice.setVoiceTts).toHaveBeenCalledWith(true)
+    expect(ctx.voice.setVoiceEnabled).toHaveBeenCalledWith(true)
   })
 
   it('cycles details mode and persists it', async () => {
@@ -764,7 +766,8 @@ const buildTranscript = () => ({
 
 const buildVoice = () => ({
   setVoiceEnabled: vi.fn(),
-  setVoiceRecordKey: vi.fn()
+  setVoiceRecordKey: vi.fn(),
+  setVoiceTts: vi.fn()
 })
 
 interface Ctx {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -216,6 +216,7 @@ export interface InputHandlerContext {
     setProcessing: StateSetter<boolean>
     setRecording: StateSetter<boolean>
     setVoiceEnabled: StateSetter<boolean>
+    setVoiceTts: StateSetter<boolean>
   }
   wheelStep: number
 }
@@ -254,6 +255,7 @@ export interface GatewayEventHandlerContext {
     setProcessing: StateSetter<boolean>
     setRecording: StateSetter<boolean>
     setVoiceEnabled: StateSetter<boolean>
+    setVoiceTts: StateSetter<boolean>
   }
 }
 
@@ -295,6 +297,7 @@ export interface SlashHandlerContext {
   voice: {
     setVoiceEnabled: StateSetter<boolean>
     setVoiceRecordKey: (v: ParsedVoiceRecordKey) => void
+    setVoiceTts: StateSetter<boolean>
   }
 }
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -233,6 +233,7 @@ export const sessionCommands: SlashCommand[] = [
       ctx.gateway.rpc<VoiceToggleResponse>('voice.toggle', { action }).then(
         ctx.guarded<VoiceToggleResponse>(r => {
           ctx.voice.setVoiceEnabled(!!r.enabled)
+          ctx.voice.setVoiceTts(!!r.tts)
 
           // Render the configured record key (config.yaml ``voice.record_key``)
           // instead of hardcoded "Ctrl+B" — the gateway response carries the

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -102,6 +102,7 @@ export function useMainApp(gw: GatewayClient) {
   const [stickyPrompt, setStickyPrompt] = useState('')
   const [catalog, setCatalog] = useState<null | SlashCatalog>(null)
   const [voiceEnabled, setVoiceEnabled] = useState(false)
+  const [voiceTts, setVoiceTts] = useState(false)
   const [voiceRecording, setVoiceRecording] = useState(false)
   const [voiceProcessing, setVoiceProcessing] = useState(false)
   const [voiceRecordKey, setVoiceRecordKey] = useState<ParsedVoiceRecordKey>(DEFAULT_VOICE_RECORD_KEY)
@@ -550,7 +551,8 @@ export function useMainApp(gw: GatewayClient) {
       recording: voiceRecording,
       setProcessing: setVoiceProcessing,
       setRecording: setVoiceRecording,
-      setVoiceEnabled
+      setVoiceEnabled,
+      setVoiceTts
     },
     wheelStep: WHEEL_SCROLL_STEP
   })
@@ -574,7 +576,8 @@ export function useMainApp(gw: GatewayClient) {
         voice: {
           setProcessing: setVoiceProcessing,
           setRecording: setVoiceRecording,
-          setVoiceEnabled
+          setVoiceEnabled,
+          setVoiceTts
         }
       }),
     [
@@ -590,6 +593,7 @@ export function useMainApp(gw: GatewayClient) {
       setVoiceEnabled,
       setVoiceProcessing,
       setVoiceRecording,
+      setVoiceTts,
       stdout,
       submitRef,
       sys
@@ -651,7 +655,7 @@ export function useMainApp(gw: GatewayClient) {
         },
         slashFlightRef,
         transcript: { page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
-        voice: { setVoiceEnabled, setVoiceRecordKey }
+        voice: { setVoiceEnabled, setVoiceRecordKey, setVoiceTts }
       }),
     [
       catalog,
@@ -667,6 +671,7 @@ export function useMainApp(gw: GatewayClient) {
       selection,
       send,
       session,
+      setVoiceTts,
       sys
     ]
   )
@@ -821,7 +826,7 @@ export function useMainApp(gw: GatewayClient) {
       turnStartedAt: ui.sid ? turnStartedAt : null,
       // CLI parity: the classic prompt_toolkit status bar shows a red dot
       // on REC (cli.py:_get_voice_status_fragments line 2344).
-      voiceLabel: voiceRecording ? '● REC' : voiceProcessing ? '◉ STT' : `voice ${voiceEnabled ? 'on' : 'off'}`
+      voiceLabel: voiceRecording ? '● REC' : voiceProcessing ? '◉ STT' : `voice ${voiceEnabled ? 'on' : 'off'}${voiceTts ? ' [tts]' : ''}`
     }),
     [
       cwd,
@@ -833,7 +838,8 @@ export function useMainApp(gw: GatewayClient) {
       ui,
       voiceEnabled,
       voiceProcessing,
-      voiceRecording
+      voiceRecording,
+      voiceTts
     ]
   )
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -443,6 +443,24 @@ Only used when the [`teams_pipeline` plugin](/docs/user-guide/messaging/msgraph-
 | `TEAMS_CHANNEL_ID` | Target channel ID (paired with `TEAMS_TEAM_ID`). |
 | `TEAMS_CHAT_ID` | Target 1:1 or group chat ID (alternative to team+channel for `graph` mode). |
 
+### ntfy (push notifications)
+
+[ntfy](https://ntfy.sh/) is a lightweight HTTP-based push notification service. Subscribe to a topic from the [ntfy mobile app](https://ntfy.sh/docs/subscribe/phone/), publish to that topic to talk to the agent.
+
+| Variable | Description |
+|----------|-------------|
+| `NTFY_TOPIC` | Topic to subscribe to (incoming messages). Required. |
+| `NTFY_SERVER_URL` | Server URL (default: `https://ntfy.sh`). Point at a self-hosted ntfy for privacy. |
+| `NTFY_TOKEN` | Optional auth token. Bearer token (e.g. `tk_xyz`) or `user:pass` for Basic auth. |
+| `NTFY_PUBLISH_TOPIC` | Topic for outgoing replies (defaults to `NTFY_TOPIC`). |
+| `NTFY_MARKDOWN` | Set `true` to send replies with `X-Markdown: true` header. Default: `false`. |
+| `NTFY_ALLOWED_USERS` | Allowlist (treated as user IDs; on ntfy these are topic names). Typically set to the same value as `NTFY_TOPIC`. |
+| `NTFY_ALLOW_ALL_USERS` | Dev-only escape hatch - only safe on access-controlled private topics. Default: `false`. |
+| `NTFY_HOME_CHANNEL` | Default delivery target for cron jobs with `deliver: ntfy`. |
+| `NTFY_HOME_CHANNEL_NAME` | Human label for the home channel (defaults to the topic name). |
+
+See [the ntfy messaging guide](/docs/user-guide/messaging/ntfy), especially the identity model section, before deploying with untrusted topics.
+
 ### Advanced Messaging Tuning
 
 Advanced per-platform knobs for throttling the outbound message batcher. Most users never need to touch these; defaults are set to respect each platform's rate limits without feeling sluggish.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, ntfy, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/docs/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/docs/guides/use-voice-mode-with-hermes).
 
@@ -34,6 +34,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | QQ | ✅ | ✅ | ✅ | — | — | ✅ | — |
 | Yuanbao | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
 | Microsoft Teams | — | ✅ | — | ✅ | — | ✅ | — |
+| ntfy | — | — | — | — | — | — | — |
 
 **Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.
 

--- a/website/docs/user-guide/messaging/ntfy.md
+++ b/website/docs/user-guide/messaging/ntfy.md
@@ -1,0 +1,155 @@
+# ntfy
+
+[ntfy](https://ntfy.sh/) is a simple HTTP-based pub-sub notification service. It works with the free public server at `ntfy.sh` or any self-hosted instance, and supports any client that can make HTTP requests — phones, browsers, scripts, watches.
+
+ntfy makes a great lightweight push channel for Hermes: subscribe to a topic from the [ntfy mobile app](https://ntfy.sh/docs/subscribe/phone/), send messages to the topic to talk to the agent, get the response back on your phone.
+
+## Prerequisites
+
+- A topic name (any unique string — `hermes-myname-2026` works fine)
+- The [ntfy mobile app](https://ntfy.sh/docs/subscribe/phone/) installed and subscribed to that topic
+- Optional: a self-hosted ntfy server, or an `ntfy.sh` account token for private/reserved topics
+
+That's it. No SDK, no daemon, no Node.js. The adapter uses `httpx` which is already a Hermes dependency.
+
+## Configure Hermes
+
+### Via setup wizard
+
+```bash
+hermes setup gateway
+```
+
+Select **ntfy** and follow the prompts.
+
+### Via environment variables
+
+Add these to `~/.hermes/.env`:
+
+```
+NTFY_TOPIC=hermes-myname-2026
+NTFY_ALLOWED_USERS=hermes-myname-2026
+NTFY_HOME_CHANNEL=hermes-myname-2026
+```
+
+| Variable | Required | Description |
+|---|---|---|
+| `NTFY_TOPIC` | Yes | Topic to subscribe to (incoming messages) |
+| `NTFY_SERVER_URL` | Optional | Server URL (default: `https://ntfy.sh`) — point to a self-hosted ntfy for privacy |
+| `NTFY_TOKEN` | Optional | Bearer token (e.g. `tk_xyz`) or `user:pass` for Basic auth |
+| `NTFY_PUBLISH_TOPIC` | Optional | Different topic for outgoing replies (defaults to `NTFY_TOPIC`) |
+| `NTFY_MARKDOWN` | Optional | Set `true` to send replies with `X-Markdown: true` header |
+| `NTFY_ALLOWED_USERS` | Recommended | Comma-separated topic names allowed (treated as user IDs; see below) |
+| `NTFY_ALLOW_ALL_USERS` | Optional | Set `true` to allow every publisher — only safe for private topics with read tokens |
+| `NTFY_HOME_CHANNEL` | Optional | Default topic for cron / notification delivery |
+| `NTFY_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
+
+## Identity model — read this before deploying
+
+ntfy has no native authenticated user identity. The `title` field on a published message is **publisher-controlled** and can be anything the sender wants. The Hermes adapter does NOT use `title` for authorization — it would let any publisher who knows the topic spoof an allowed user.
+
+Instead, **the topic name itself is the identity**. Every message published to the topic is treated as coming from the same logical user (the topic). `NTFY_ALLOWED_USERS` is therefore typically just the topic name itself — a single-entry allowlist that gates the whole channel.
+
+This means **anyone who knows the topic can talk to the agent**. To make that a real trust boundary:
+
+- **Self-host ntfy** and lock the topic down with [Access Control](https://docs.ntfy.sh/config/#access-control). Only authorized clients with the read/write token can publish.
+- Or **use a private topic on ntfy.sh** ([reserved topics](https://docs.ntfy.sh/publish/#reserved-topics) require an account) and protect it with a `NTFY_TOKEN`.
+- Or **pick a long, unguessable topic name** (`hermes-7d4f9c8b-2026`) and treat it as the shared secret. This is the lightest setup but the topic name leaks via any logs or screenshots.
+
+In all cases, do not put sensitive data through ntfy unless the underlying topic is access-controlled.
+
+## Quick start — talk to your agent from your phone
+
+1. Pick a topic name: `hermes-myname-2026`
+2. On your phone: install the [ntfy app](https://ntfy.sh/docs/subscribe/phone/), tap **+**, enter `hermes-myname-2026`
+3. On the host:
+   ```bash
+   echo 'NTFY_TOPIC=hermes-myname-2026' >> ~/.hermes/.env
+   echo 'NTFY_ALLOWED_USERS=hermes-myname-2026' >> ~/.hermes/.env
+   hermes gateway restart
+   ```
+4. From the ntfy app, send a message to the topic. The agent's reply lands as a push notification.
+
+## Using ntfy with cron jobs
+
+Once `NTFY_HOME_CHANNEL` is set, cron jobs can deliver to ntfy:
+
+```python
+cronjob(
+    action="create",
+    schedule="every 1h",
+    deliver="ntfy",          # uses NTFY_HOME_CHANNEL
+    prompt="Check for alerts and summarise."
+)
+```
+
+Or target a specific topic explicitly:
+
+```python
+send_message(target="ntfy:alerts-channel", message="Done!")
+```
+
+This works even when the cron runs out-of-process from the gateway — the plugin registers a `standalone_sender_fn` that opens its own HTTP connection.
+
+## Self-hosting ntfy
+
+If you want full control:
+
+```bash
+# Docker
+docker run -p 80:80 -it binwiederhier/ntfy serve
+
+# Native
+go install heckel.io/ntfy/v2@latest
+ntfy serve
+```
+
+Then point Hermes at it:
+
+```
+NTFY_SERVER_URL=https://ntfy.mydomain.com
+NTFY_TOPIC=hermes
+NTFY_TOKEN=tk_abc123  # if you've set up access control
+```
+
+Self-hosting gives you topic access control, message persistence policies, attachments, and emoji tags. See the [ntfy server docs](https://docs.ntfy.sh/install/).
+
+## Markdown formatting
+
+ntfy clients render markdown when the publisher sets the `X-Markdown: true` header. To enable for outgoing Hermes replies:
+
+```
+NTFY_MARKDOWN=true
+```
+
+Or in `config.yaml`:
+
+```yaml
+platforms:
+  ntfy:
+    extra:
+      markdown: true
+```
+
+The mobile app supports a subset of CommonMark — bold, italic, lists, links, fenced code blocks. See [ntfy's markdown docs](https://docs.ntfy.sh/publish/#markdown-formatting) for the exact set.
+
+## Outgoing-only setup (notifications without inbound)
+
+If you only want Hermes to *push* notifications to ntfy (cron summaries, alerts) and never accept messages back, set both `NTFY_TOPIC` and `NTFY_PUBLISH_TOPIC` to the same value and skip `NTFY_ALLOWED_USERS` entirely. With no allowlist, the agent never responds to inbound messages — your phone gets the pushes, but the conversation is one-way.
+
+## Limits
+
+- **Message size**: ntfy caps message bodies at 4096 chars. Hermes truncates with a warning when this is exceeded.
+- **No typing indicators**: the protocol doesn't expose one; `send_typing` is a no-op.
+- **No threads or attachments**: ntfy is plain push notifications. Long replies stay in the message body, no thread fanout.
+- **No native user identity**: see the identity-model section above.
+
+## Troubleshooting
+
+**Auth failure / 401** — `NTFY_TOKEN` is wrong, or the token doesn't have publish/subscribe rights on this topic. The adapter halts its reconnect loop on 401 and the gateway runtime status will show `fatal: ntfy_unauthorized`. Fix the token and restart the gateway.
+
+**Topic not found / 404** — `NTFY_TOPIC` doesn't exist on the configured server. For ntfy.sh, topics are auto-created on first publish, so a 404 means you're pointed at a self-hosted server that doesn't have the topic provisioned. The adapter halts its reconnect loop with `fatal: ntfy_topic_not_found`.
+
+**Connected but no messages** — Check that `NTFY_ALLOWED_USERS` includes the topic name itself. With ntfy's identity model, the topic IS the user; leaving the allowlist empty rejects everything.
+
+**Reconnects every 60s** — The stream keepalive default is 55s; ntfy may have intermittent network issues. The adapter applies exponential backoff (2 → 5 → 10 → 30 → 60s) and resets to 0 once a stream stays alive ≥60s.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -141,6 +141,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/messaging/teams',
         'user-guide/messaging/teams-meetings',
         'user-guide/messaging/msgraph-webhook',
+        'user-guide/messaging/ntfy',
         'user-guide/messaging/open-webui',
         'user-guide/messaging/webhooks',
       ],


### PR DESCRIPTION
## Summary
- Add contributor guidance with setup, completeness, checks, parity, and release rules.
- Replace stub/partial runtime surfaces with explicit behavior or deterministic terminology.
- Harden Google Meet realtime speech queue behavior and standalone Teams/Google Chat unsupported attachment handling.
- Add upstream ntfy plugin surface to keep surface coverage current.
- Remove a Rust test env race in the tool-loop guard.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `bash scripts/check-runtime-placeholders.sh`
- `python3 -m py_compile plugins/google_meet/__init__.py plugins/google_meet/_hermes_home.py plugins/google_meet/cli.py plugins/google_meet/process_manager.py plugins/google_meet/node/registry.py plugins/google_meet/node/server.py plugins/platforms/teams/adapter.py plugins/platforms/google_chat/adapter.py plugins/platforms/ntfy/__init__.py plugins/platforms/ntfy/adapter.py`
- `pytest tests/plugins/test_google_meet_node.py -q`
- `cargo test -p hermes-agent test_tool_loop_guard -- --nocapture`
- `bash scripts/clippy-warning-gate.sh --check`
- `cargo test --workspace`
- `cargo test -p hermes-parity-tests`
- `cargo test -p hermes-parity-tests --test cli_command_contract`
- `cargo test -p hermes-parity-tests --test global_parity_governance`
- `python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main --local-ref HEAD`

## Notes
- Python gateway adapter test classes for Teams/Google Chat are not locally collectible in this Rust-first tree because the upstream Python `gateway.config` package is intentionally not vendored; their changed behavior is covered by py_compile and code inspection here, while repo CI remains Rust/parity focused.
