### PR TITLE
release: fix cyclonedx sbom generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Generate SBOM (CycloneDX)
         run: |
           cargo install cargo-cyclonedx --locked
-          cargo cyclonedx --workspace --format json --output-file release-sbom.cdx.json
+          cargo cyclonedx --manifest-path crates/hermes-cli/Cargo.toml --format json --override-filename release-sbom
+          cp crates/hermes-cli/release-sbom.json release-sbom.cdx.json
+          test -s release-sbom.cdx.json
       - name: Upload security gate artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Fixes the v0.13.0 Release workflow SBOM step for cargo-cyclonedx v0.5.9. The CLI does not support `--workspace` or `--output-file`; it writes the crate SBOM to `crates/hermes-cli/release-sbom.json`, then the workflow copies it to the uploaded artifact path.\n\nLocal verification:\n- cargo cyclonedx --manifest-path crates/hermes-cli/Cargo.toml --format json --override-filename release-sbom\n- cp crates/hermes-cli/release-sbom.json release-sbom.cdx.json\n- test -s release-sbom.cdx.json\n- parsed JSON reports CycloneDX 1.3