### PR TITLE
release: publish checksummed homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,4 +175,4 @@ jobs:
             dist/*.zip.pem
             dist/security/release-sbom.cdx.json
             scripts/install.sh
-            Formula/hermes.rb
+            Formula/hermes-agent-ultra.rb

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -6,6 +6,15 @@ REPO="https://github.com/sheawinkler/hermes-agent-ultra"
 FORMULA_DIR="Formula"
 FORMULA_FILE="${FORMULA_DIR}/hermes-agent-ultra.rb"
 
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+MACOS_AARCH64_SHA="$(sha256_file dist/hermes-macos-aarch64.tar.gz)"
+MACOS_X86_64_SHA="$(sha256_file dist/hermes-macos-x86_64.tar.gz)"
+LINUX_AARCH64_SHA="$(sha256_file dist/hermes-linux-aarch64.tar.gz)"
+LINUX_X86_64_SHA="$(sha256_file dist/hermes-linux-x86_64.tar.gz)"
+
 mkdir -p "${FORMULA_DIR}"
 
 cat > "${FORMULA_FILE}" <<EOF
@@ -18,20 +27,20 @@ class HermesAgentUltra < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "${REPO}/releases/download/${VERSION}/hermes-macos-aarch64.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "${MACOS_AARCH64_SHA}"
     else
       url "${REPO}/releases/download/${VERSION}/hermes-macos-x86_64.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "${MACOS_X86_64_SHA}"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "${REPO}/releases/download/${VERSION}/hermes-linux-aarch64.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "${LINUX_AARCH64_SHA}"
     else
       url "${REPO}/releases/download/${VERSION}/hermes-linux-x86_64.tar.gz"
-      sha256 "REPLACE_WITH_SHA256"
+      sha256 "${LINUX_X86_64_SHA}"
     end
   end
 


### PR DESCRIPTION
Fixes the Release workflow's Homebrew formula asset. The generator writes `Formula/hermes-agent-ultra.rb`, not `Formula/hermes.rb`, and now fills SHA256 values from the built release artifacts instead of placeholders.\n\nLocal verification:\n- bash scripts/generate-homebrew-formula.sh v0.13.0 with dummy dist artifacts\n- ruby -c Formula/hermes-agent-ultra.rb\n- verified generated formula contains no `REPLACE_WITH` placeholders