### PR TITLE
packaging: refresh homebrew and nix metadata

### DIFF
--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -151,17 +151,17 @@
       "workstream": "WS8"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "flake.nix",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "c11ec82c548b768b38c34ef04a1935ca67d3da92",
-      "necessity": "necessary_review",
+      "local_blob": "b68760a0286865dd30f4867cc07e552d1f93b8f6",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "flake.nix",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "1c1d0b78922b62fddbb92e7820bb694b575d414a",
       "workstream": "WS8"
     },
@@ -301,17 +301,17 @@
       "workstream": "WS4"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "packaging/homebrew",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "packaging/homebrew/hermes-agent.rb",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "533aad39f5f5dbf15f083924c7ba542b3ce4d1e9",
-      "necessity": "necessary_review",
+      "local_blob": "806b717239ca094b6e2f0ec76bc3c5aa34af10db",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "packaging/homebrew/hermes-agent.rb",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "7c00fc6acf8f55d9b87108b61611f7164883e6c8",
       "workstream": "WS8"
     },
@@ -11236,31 +11236,31 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-26T18:23:37.696620+00:00",
+  "generated_at_utc": "2026-05-26T19:14:59.311747+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "4e95a8c754feb15aa2d067563db92932dc241312",
+    "local_sha": "90a97f2772c3284e8f166a80bf86a2c783574750",
     "upstream_ref": "upstream/main",
     "upstream_sha": "2517917de34eeb6a40f5a17a2e59d9746803dfa5"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 513,
-      "intentional_divergence": 31,
+      "functional": 511,
+      "intentional_divergence": 33,
       "policy_only": 204
     },
     "by_rust_requirement": {
-      "needs_rust_relevance_review": 7,
-      "not_required_for_runtime": 236,
+      "needs_rust_relevance_review": 5,
+      "not_required_for_runtime": 238,
       "rust_equivalent_or_contract_test_required": 385,
       "rust_native_runtime_parity_required_if_needed": 49,
       "rust_primary_ux_or_documented_divergence_required": 72
     },
     "by_status": {
-      "cleared_intentional_divergence": 31,
+      "cleared_intentional_divergence": 33,
       "cleared_non_runtime": 205,
-      "pending_review": 513
+      "pending_review": 511
     },
     "by_workstream": {
       "WS3": 49,
@@ -11269,10 +11269,10 @@
       "WS6": 386,
       "WS8": 12
     },
-    "cleared_intentional_divergence": 31,
+    "cleared_intentional_divergence": 33,
     "cleared_non_runtime": 205,
     "pending_classification": 0,
-    "pending_review": 513,
+    "pending_review": 511,
     "total_shared_different": 749
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-26T18:23:37.696620+00:00`
+Generated: `2026-05-26T19:14:59.311747+00:00`
 
 ## Summary
 
 - Total shared-different paths: `749`
 - Pending classification: `0`
-- Pending functional review: `513`
+- Pending functional review: `511`
 - Cleared non-runtime: `205`
-- Cleared intentional divergence: `31`
+- Cleared intentional divergence: `33`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 31 |
+| `cleared_intentional_divergence` | 33 |
 | `cleared_non_runtime` | 205 |
-| `pending_review` | 513 |
+| `pending_review` | 511 |
 
 ## Workstream Counts
 
@@ -67,8 +67,6 @@ Generated: `2026-05-26T18:23:37.696620+00:00`
 | `README.md` | 1 |
 | `docker-compose.yml` | 1 |
 | `docker/entrypoint.sh` | 1 |
-| `flake.nix` | 1 |
-| `packaging/homebrew` | 1 |
 | `plugins/disk-cleanup` | 1 |
 | `plugins/hermes-achievements` | 1 |
 | `plugins/video_gen` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -60,13 +60,6 @@
     },
     {
       "path": "flake.nix",
-      "classification": "functional",
-      "rationale": "Nix packaging/install behavior affects reproducible environment parity.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "flake.nix",
       "classification": "intentional_divergence",
       "rationale": "Nix packaging intentionally builds the Rust workspace with the Hermes Ultra release version rather than upstream's Python flake-parts packaging stack.",
       "owner": "sheawinkler",

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -66,6 +66,20 @@
       "ticket": 25
     },
     {
+      "path": "flake.nix",
+      "classification": "intentional_divergence",
+      "rationale": "Nix packaging intentionally builds the Rust workspace with the Hermes Ultra release version rather than upstream's Python flake-parts packaging stack.",
+      "owner": "sheawinkler",
+      "ticket": 305
+    },
+    {
+      "path": "packaging/homebrew/hermes-agent.rb",
+      "classification": "intentional_divergence",
+      "rationale": "Homebrew packaging uses Hermes Ultra's checksummed Rust release artifacts instead of upstream's Python virtualenv formula.",
+      "owner": "sheawinkler",
+      "ticket": 305
+    },
+    {
       "path": "packaging/homebrew",
       "classification": "functional",
       "rationale": "Distribution packaging path impacts install parity for Homebrew users.",

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       in {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "hermes-agent";
-          version = "0.1.0";
+          version = "0.14.2";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
 

--- a/packaging/homebrew/hermes-agent.rb
+++ b/packaging/homebrew/hermes-agent.rb
@@ -1,42 +1,35 @@
 class HermesAgentUltra < Formula
-  desc "Hermes Agent Ultra: autonomous AI agent with memory, tools, and gateway adapters"
+  desc "Hermes Agent Ultra autonomous AI agent"
   homepage "https://github.com/sheawinkler/hermes-agent-ultra"
-  # Update URL and sha256 for each release
-  url "https://github.com/sheawinkler/hermes-agent-ultra/archive/refs/tags/v0.1.0.tar.gz"
-  sha256 "REPLACE_WITH_ACTUAL_SHA256"
+  version "0.14.2"
   license "MIT"
-  head "https://github.com/sheawinkler/hermes-agent-ultra.git", branch: "main"
 
-  depends_on "rust" => :build
-  depends_on "pkg-config" => :build
-  depends_on "openssl"
-  depends_on "sqlite"
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/sheawinkler/hermes-agent-ultra/releases/download/v0.14.2/hermes-macos-aarch64.tar.gz"
+      sha256 "71ab5172a0ba2672bd66ab4742c73b99649adaeba131df29a6a08987059953c8"
+    else
+      url "https://github.com/sheawinkler/hermes-agent-ultra/releases/download/v0.14.2/hermes-macos-x86_64.tar.gz"
+      sha256 "ae8472ad3a724de13897ed2a9ec808024a0b732353fcf28b45ecdf1ab821f4e8"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/sheawinkler/hermes-agent-ultra/releases/download/v0.14.2/hermes-linux-aarch64.tar.gz"
+      sha256 "75a5b2751c38b131b3c244504ec69c37e2a7799259cee26bb6e13e695dcf0529"
+    else
+      url "https://github.com/sheawinkler/hermes-agent-ultra/releases/download/v0.14.2/hermes-linux-x86_64.tar.gz"
+      sha256 "f22d6fb401c0a1ef75a4cd873079063a5f9e2d83679716c4ac911c2db11fd30d"
+    end
+  end
 
   def install
-    system "cargo", "install", "--path", "crates/hermes-cli", "--locked", "--root", prefix, "--bins"
-  end
-
-  def post_install
-    (var/"hermes").mkpath
-  end
-
-  def caveats
-    <<~EOS
-      Hermes Agent Ultra has been installed.
-
-      Set your API key before running:
-        export HERMES_OPENAI_API_KEY="sk-..."
-
-      Data is stored in:
-        #{var}/hermes
-
-      Get started:
-        hermes-ultra --help
-        hermes-ultra
-    EOS
+    bin.install "hermes" => "hermes-agent-ultra"
+    bin.install_symlink "hermes-agent-ultra" => "hermes"
   end
 
   test do
-    assert_match "hermes-agent-ultra", shell_output("#{bin}/hermes-agent-ultra --version")
+    system "#{bin}/hermes-agent-ultra", "--version"
   end
 end

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import re
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_homebrew_formula_tracks_workspace_release_version():
+    cargo = tomllib.loads((REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+    version = cargo["workspace"]["package"]["version"]
+    formula = (REPO_ROOT / "packaging/homebrew/hermes-agent.rb").read_text(
+        encoding="utf-8"
+    )
+
+    assert f'version "{version}"' in formula
+    assert f"/releases/download/v{version}/" in formula
+    assert "REPLACE_WITH_ACTUAL_SHA256" not in formula
+    assert "v0.1.0" not in formula
+
+
+def test_homebrew_formula_has_platform_specific_checksummed_assets():
+    formula = (REPO_ROOT / "packaging/homebrew/hermes-agent.rb").read_text(
+        encoding="utf-8"
+    )
+
+    for asset in [
+        "hermes-macos-aarch64.tar.gz",
+        "hermes-macos-x86_64.tar.gz",
+        "hermes-linux-aarch64.tar.gz",
+        "hermes-linux-x86_64.tar.gz",
+    ]:
+        assert asset in formula
+
+    shas = re.findall(r'sha256 "([0-9a-f]{64})"', formula)
+    assert len(shas) == 4

--- a/tests/test_nix_packaging.py
+++ b/tests/test_nix_packaging.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_flake_tracks_workspace_release_version():
+    cargo = tomllib.loads((REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+    version = cargo["workspace"]["package"]["version"]
+    flake = (REPO_ROOT / "flake.nix").read_text(encoding="utf-8")
+
+    assert f'version = "{version}";' in flake
+    assert 'version = "0.1.0";' not in flake


### PR DESCRIPTION
## Summary
- Replace stale Homebrew formula (`v0.1.0`, placeholder sha) with the checksummed v0.14.2 release formula asset.
- Update `flake.nix` package version from `0.1.0` to workspace release `0.14.2`.
- Add regression tests so Homebrew/Nix packaging metadata tracks workspace release version and real checksummed artifacts.
- Mark Homebrew and Nix packaging as approved Hermes Ultra Rust packaging divergences from upstream Python packaging.
- Refresh `docs/parity/shared-diff-backlog.*`.

## Backlog Effect
- `pending_review`: `513 -> 511`
- `needs_rust_relevance_review`: `7 -> 5`
- Cleared WS8 items: `packaging/homebrew/hermes-agent.rb`, `flake.nix`
- Remaining WS8 review items: `Dockerfile`, `docker-compose.yml`, `docker/entrypoint.sh`, `scripts/install.sh`, `README.md`

## Validation
- `pytest -q tests/test_homebrew_formula.py tests/test_nix_packaging.py tests/test_generate_shared_diff_backlog.py tests/test_upstream_surface_coverage_gate.py tests/test_generate_upstream_patch_queue.py`
- `ruby -c packaging/homebrew/hermes-agent.rb`
- `bash -n scripts/install.sh`
- `sh -n docker/entrypoint.sh`
- `git diff --check`
