### PR TITLE
parity: clear ws8 container installer contracts

### DIFF
--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -76,17 +76,17 @@
       "workstream": "WS8"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "Dockerfile",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d235ffc6c3cd7f6f2f83f02acdeab56c018b3527",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "Dockerfile",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "be4e8848bb5aad2a79bb69473dcef6548aa7b8b0",
       "workstream": "WS8"
     },
@@ -106,47 +106,47 @@
       "workstream": "WS8"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b9b04b6f90c65d38f26372e845141dd7f43574cf",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "README.md",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "9b14816429447b48b6fc415566ee78ca7f7a15c2",
       "workstream": "WS8"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "docker-compose.yml",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "40ca57e0489a48e669d6d46997964c71de115c4a",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "docker-compose.yml",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "513cb8e18e8a1d382f8ffa206394a5c8c1909013",
       "workstream": "WS8"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "docker/entrypoint.sh",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "7fe71f70b8657255cb595b82b6b8d8cac930eb80",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "docker/entrypoint.sh",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "9e735fe561bd72e9e5d51bb70082f7bdd8567260",
       "workstream": "WS8"
     },
@@ -1051,17 +1051,17 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "scripts/install.sh",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "4017c58d19389e34d37988993e59594fc4c8e829",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "scripts/install.sh",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
       "upstream_blob": "71902f55866f5c50e17d4fc412b9fdf1d52903f2",
       "workstream": "WS8"
     },
@@ -11236,31 +11236,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-26T19:14:59.311747+00:00",
+  "generated_at_utc": "2026-05-26T19:46:47.988306+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "90a97f2772c3284e8f166a80bf86a2c783574750",
+    "local_sha": "d4e0bf7710ef5ce34c144870a532e3a8b2632719",
     "upstream_ref": "upstream/main",
     "upstream_sha": "2517917de34eeb6a40f5a17a2e59d9746803dfa5"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 511,
-      "intentional_divergence": 33,
+      "functional": 506,
+      "intentional_divergence": 38,
       "policy_only": 204
     },
     "by_rust_requirement": {
-      "needs_rust_relevance_review": 5,
-      "not_required_for_runtime": 238,
+      "not_required_for_runtime": 243,
       "rust_equivalent_or_contract_test_required": 385,
       "rust_native_runtime_parity_required_if_needed": 49,
       "rust_primary_ux_or_documented_divergence_required": 72
     },
     "by_status": {
-      "cleared_intentional_divergence": 33,
+      "cleared_intentional_divergence": 38,
       "cleared_non_runtime": 205,
-      "pending_review": 511
+      "pending_review": 506
     },
     "by_workstream": {
       "WS3": 49,
@@ -11269,10 +11268,10 @@
       "WS6": 386,
       "WS8": 12
     },
-    "cleared_intentional_divergence": 33,
+    "cleared_intentional_divergence": 38,
     "cleared_non_runtime": 205,
     "pending_classification": 0,
-    "pending_review": 511,
+    "pending_review": 506,
     "total_shared_different": 749
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-26T19:14:59.311747+00:00`
+Generated: `2026-05-26T19:46:47.988306+00:00`
 
 ## Summary
 
 - Total shared-different paths: `749`
 - Pending classification: `0`
-- Pending functional review: `511`
+- Pending functional review: `506`
 - Cleared non-runtime: `205`
-- Cleared intentional divergence: `33`
+- Cleared intentional divergence: `38`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 33 |
+| `cleared_intentional_divergence` | 38 |
 | `cleared_non_runtime` | 205 |
-| `pending_review` | 511 |
+| `pending_review` | 506 |
 
 ## Workstream Counts
 
@@ -63,11 +63,6 @@ Generated: `2026-05-26T19:14:59.311747+00:00`
 | `tests/honcho_plugin` | 2 |
 | `tests/skills` | 2 |
 | `tests/stress` | 2 |
-| `Dockerfile` | 1 |
-| `README.md` | 1 |
-| `docker-compose.yml` | 1 |
-| `docker/entrypoint.sh` | 1 |
 | `plugins/disk-cleanup` | 1 |
 | `plugins/hermes-achievements` | 1 |
 | `plugins/video_gen` | 1 |
-| `scripts/install.sh` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -25,10 +25,10 @@
     },
     {
       "path": "Dockerfile",
-      "classification": "functional",
-      "rationale": "Container build/runtime path impacts deployment behavior and should be tracked for parity deltas.",
+      "classification": "intentional_divergence",
+      "rationale": "Hermes Agent Ultra intentionally ships a Rust multi-stage container with tini/gosu and /data state instead of upstream's Python uv+s6-overlay image; Rust-native container contracts cover the retained runtime behavior.",
       "owner": "sheawinkler",
-      "ticket": 25
+      "ticket": 305
     },
     {
       "path": "LICENSE",
@@ -39,24 +39,24 @@
     },
     {
       "path": "README.md",
-      "classification": "functional",
-      "rationale": "Installation and operational guidance influences real-world runtime setup outcomes.",
+      "classification": "intentional_divergence",
+      "rationale": "README.md intentionally describes Ultra's Rust-first runtime, release installer, and parity workflow rather than upstream's Python product positioning; install/readme contracts cover the actionable setup guidance.",
       "owner": "sheawinkler",
-      "ticket": 25
+      "ticket": 305
     },
     {
       "path": "docker-compose.yml",
-      "classification": "functional",
-      "rationale": "Container orchestration defaults affect gateway/runtime launch semantics and service wiring.",
+      "classification": "intentional_divergence",
+      "rationale": "Compose defaults intentionally target the Ultra Rust image, /data volume, and hermes-agent-ultra naming while preserving localhost dashboard and UID/GID runtime controls.",
       "owner": "sheawinkler",
-      "ticket": 25
+      "ticket": 305
     },
     {
       "path": "docker/entrypoint.sh",
-      "classification": "functional",
-      "rationale": "Container bootstrap and runtime environment export behavior affect parity at startup.",
+      "classification": "intentional_divergence",
+      "rationale": "The entrypoint intentionally implements the Rust image's direct tini/gosu startup path instead of upstream's s6 stage2 hook; entrypoint contracts cover home setup, UID/GID remap, and privilege drop.",
       "owner": "sheawinkler",
-      "ticket": 25
+      "ticket": 305
     },
     {
       "path": "flake.nix",
@@ -102,10 +102,10 @@
     },
     {
       "path": "scripts/install.sh",
-      "classification": "functional",
-      "rationale": "Installer behavior directly affects setup parity and bootstrap capabilities.",
+      "classification": "intentional_divergence",
+      "rationale": "Installer intentionally downloads or builds Hermes Agent Ultra Rust release binaries instead of cloning upstream's Python/uv environment; installer contracts cover release assets, symlinks, PATH guard, Termux pathing, and post-install probes.",
       "owner": "sheawinkler",
-      "ticket": 25
+      "ticket": 305
     },
     {
       "path": "tests",

--- a/tests/test_docker_compose_contract.py
+++ b/tests/test_docker_compose_contract.py
@@ -1,0 +1,27 @@
+"""Contracts for the Ultra docker-compose defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+
+def test_compose_uses_ultra_image_and_data_volume() -> None:
+    text = COMPOSE.read_text()
+
+    assert "image: hermes-agent-ultra" in text
+    assert "container_name: hermes-agent-ultra" in text
+    assert "- ~/.hermes-agent-ultra:/data" in text
+    assert "HERMES_UID=${HERMES_UID:-10000}" in text
+    assert "HERMES_GID=${HERMES_GID:-10000}" in text
+
+
+def test_compose_keeps_dashboard_localhost_by_default() -> None:
+    text = COMPOSE.read_text()
+
+    assert 'command: ["dashboard", "--host", "127.0.0.1", "--no-open"]' in text
+    assert "# - API_SERVER_HOST=0.0.0.0" in text
+    assert "# - API_SERVER_KEY=${API_SERVER_KEY}" in text

--- a/tests/test_docker_entrypoint_contract.py
+++ b/tests/test_docker_entrypoint_contract.py
@@ -1,0 +1,29 @@
+"""Contracts for docker/entrypoint.sh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+
+
+def test_entrypoint_prepares_hermes_home() -> None:
+    text = ENTRYPOINT.read_text()
+
+    assert "set -eu" in text
+    assert 'APP_HOME="${HERMES_HOME:-/data}"' in text
+    assert 'mkdir -p "${APP_HOME}"' in text
+
+
+def test_entrypoint_remaps_hermes_user_when_root() -> None:
+    text = ENTRYPOINT.read_text()
+
+    assert 'if [ "$(id -u)" = "0" ]; then' in text
+    assert 'TARGET_UID="${HERMES_UID:-10000}"' in text
+    assert 'TARGET_GID="${HERMES_GID:-${TARGET_UID}}"' in text
+    assert 'groupmod -o -g "${TARGET_GID}" hermes' in text
+    assert 'usermod -o -u "${TARGET_UID}" -g "${TARGET_GID}" hermes' in text
+    assert 'exec gosu "${actual_uid}:${actual_gid}" "$@"' in text
+    assert 'exec "$@"' in text

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -1,8 +1,9 @@
-"""Regression tests for install.sh Python environment sanitization.
+"""Contracts for the Rust release installer environment behavior.
 
-When install.sh is launched from another Python-driven tool session, inherited
-PYTHONPATH/PYTHONHOME can shadow the freshly installed checkout. The installer
-must sanitize those vars both during installation and at runtime launch.
+Hermes Agent Ultra installs a release binary, not an editable Python checkout.
+The only Python-environment interaction left is post-install binary probing,
+which must run with inherited Python vars cleared so host tooling cannot shadow
+runtime diagnostics.
 """
 
 from pathlib import Path
@@ -12,19 +13,28 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
-def test_install_script_unsets_pythonpath_and_pythonhome_early() -> None:
+def test_post_install_flow_clears_python_environment_for_binary_probes() -> None:
     text = INSTALL_SH.read_text()
 
-    # During install, inherited Python env must be sanitized before pip/venv use.
-    assert 'unset PYTHONPATH' in text
-    assert 'unset PYTHONHOME' in text
+    for var in (
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "VIRTUAL_ENV",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
+        "PIP_REQUIRE_VIRTUALENV",
+        "PYTHONUSERBASE",
+    ):
+        assert f"-u {var}" in text
 
 
-def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
+def test_installer_uses_binary_symlinks_not_python_launcher_wrapper() -> None:
     text = INSTALL_SH.read_text()
 
-    # Wrapper should clear env and forward args untouched to the venv entrypoint.
-    assert 'cat > "$command_link_dir/hermes" <<EOF' in text
-    assert 'unset PYTHONPATH' in text
-    assert 'unset PYTHONHOME' in text
-    assert 'exec "$HERMES_BIN" "\\$@"' in text
+    assert 'install -m 0755 "${SOURCE_BIN}" "${INSTALL_DIR}/${CANONICAL_BIN_NAME}"' in text
+    assert 'ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${PRIMARY_BIN_NAME}"' in text
+    assert 'ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${LEGACY_BIN_NAME}"' in text
+    assert 'cat > "$command_link_dir/hermes" <<EOF' not in text
+    assert "pip install" not in text
+    assert "uv pip install" not in text

--- a/tests/test_install_sh_termux_network_prereqs.py
+++ b/tests/test_install_sh_termux_network_prereqs.py
@@ -1,4 +1,4 @@
-"""Regression tests for Termux network prerequisite handling in install.sh."""
+"""Termux contracts for the Rust release installer."""
 
 from pathlib import Path
 
@@ -7,16 +7,20 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
-def test_termux_pkg_list_includes_network_basics() -> None:
+def test_termux_installs_into_prefix_bin() -> None:
     text = INSTALL_SH.read_text()
-    assert "local termux_pkgs=(clang rust make pkg-config libffi openssl ca-certificates curl)" in text
+
+    assert "is_termux()" in text
+    assert '[[ -n "${TERMUX_VERSION:-}" ]]' in text
+    assert '[[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]' in text
+    assert 'INSTALL_DIR="${PREFIX}/bin"' in text
 
 
-def test_install_script_has_connectivity_probe_and_termux_guidance() -> None:
+def test_installer_requires_release_download_tools_only() -> None:
     text = INSTALL_SH.read_text()
-    assert "check_network_prerequisites()" in text
-    assert "https://pypi.org/simple/" in text
-    assert "https://duckduckgo.com/" in text
-    assert "termux-change-repo" in text
-    assert "pkg install -y ca-certificates curl && pkg update" in text
-    assert "check_network_prerequisites" in text
+
+    assert "need_cmd curl" in text
+    assert "need_cmd tar" in text
+    assert "need_cmd install" in text
+    assert "pkg install" not in text
+    assert "pip install" not in text

--- a/tests/test_readme_install_contract.py
+++ b/tests/test_readme_install_contract.py
@@ -1,0 +1,40 @@
+"""README contracts for install and Rust-primary positioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def test_readme_points_to_ultra_installer() -> None:
+    text = README.read_text()
+
+    assert (
+        "https://raw.githubusercontent.com/sheawinkler/hermes-agent-ultra/main/scripts/install.sh"
+        in text
+    )
+    assert "cargo install --git https://github.com/sheawinkler/hermes-agent-ultra" in text
+
+
+def test_readme_documents_rust_primary_runtime() -> None:
+    text = README.read_text()
+
+    assert "Rust-first autonomous agent runtime" in text
+    assert "Fully Rust-native core runtime" in text
+    assert "Rust-only implementation strategy" in text
+
+
+def test_readme_quick_start_uses_ultra_commands() -> None:
+    text = README.read_text()
+
+    for command in (
+        "hermes-ultra setup",
+        "hermes-ultra",
+        'hermes-ultra chat --query "summarize this repository"',
+        "hermes-ultra gateway --live",
+        "hermes-ultra doctor --deep --snapshot --bundle",
+    ):
+        assert command in text

--- a/tests/test_termux_all_extra_compat.py
+++ b/tests/test_termux_all_extra_compat.py
@@ -1,4 +1,4 @@
-"""Regression coverage for the Termux broad install profile."""
+"""Regression coverage for Termux in the Rust release installer."""
 
 from pathlib import Path
 
@@ -8,16 +8,15 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
-def test_pyproject_defines_termux_all_without_known_blockers() -> None:
-    text = PYPROJECT.read_text()
-    assert "termux-all = [" in text
-    assert '"hermes-agent[termux]"' in text
-    assert '"hermes-agent[matrix]"' not in text.split("termux-all = [", 1)[1].split("]", 1)[0]
-    assert '"hermes-agent[voice]"' not in text.split("termux-all = [", 1)[1].split("]", 1)[0]
+def test_rust_repo_does_not_require_python_termux_extra_profile() -> None:
+    assert not PYPROJECT.exists()
+    assert "termux-all" not in INSTALL_SH.read_text()
 
 
-def test_install_script_prefers_termux_all_then_fallbacks() -> None:
+def test_install_script_uses_release_assets_for_termux_targets() -> None:
     text = INSTALL_SH.read_text()
-    assert "pip install -e '.[termux-all]' -c constraints-termux.txt" in text
-    assert "Termux broad profile (.[termux-all]) failed, trying baseline Termux profile..." in text
-    assert "Termux baseline profile (.[termux]) failed, trying base install..." in text
+    assert "detect_target()" in text
+    assert 'Linux) os="linux" ;;' in text
+    assert 'arm64|aarch64) arch="aarch64" ;;' in text
+    assert 'ASSET_CANDIDATES=("${RELEASE_BIN_BASENAME}-${TARGET}.tar.gz")' in text
+    assert '"${RELEASE_BIN_BASENAME}-linux-arm64.tar.gz"' in text

--- a/tests/tools/test_dockerfile_node_modules_perms.py
+++ b/tests/tools/test_dockerfile_node_modules_perms.py
@@ -1,11 +1,8 @@
-"""contract test: dockerfile chowns runtime node_modules trees to hermes
+"""Contract tests for Rust-native Docker runtime ownership.
 
-regression guard for #18800. the container drops privileges to the hermes
-user (uid 10000) in entrypoint.sh, then the TUI launcher's
-_tui_need_npm_install() trips on every startup (see the
-npm_config_install_links=false comment in the Dockerfile) and runs
-`npm install` in /opt/hermes/ui-tui. that install fails with EACCES unless
-the runtime node_modules trees are owned by hermes.
+Upstream's Python image owns Python and Node runtime trees. Hermes Agent Ultra
+ships a Rust binary image instead, so the durable contract is ownership of the
+mounted data directory plus a root-to-hermes privilege drop through gosu.
 """
 from __future__ import annotations
 
@@ -13,27 +10,23 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
 
 
-def test_dockerfile_chowns_runtime_node_modules_to_hermes_user() -> None:
+def test_dockerfile_chowns_data_volume_to_hermes_user() -> None:
     text = DOCKERFILE.read_text()
 
-    chown_lines = [
-        line for line in text.splitlines()
-        if "chown" in line and "hermes:hermes" in line
-    ]
-    assert chown_lines, (
-        "Dockerfile must contain a chown -R hermes:hermes for the runtime "
-        "node_modules trees; see #18800"
-    )
+    assert "groupadd -g 10000 hermes" in text
+    assert "useradd -u 10000 -g 10000" in text
+    assert "mkdir -p /data" in text
+    assert "chown -R 10000:10000 /data" in text
 
-    chown_block = "\n".join(chown_lines)
 
-    # both runtime-mutable trees must be passed to the chown command.
-    # /opt/hermes/web is intentionally excluded: it is build-time only,
-    # because HERMES_WEB_DIST points at hermes_cli/web_dist for runtime.
-    for required_path in ("/opt/hermes/ui-tui", "/opt/hermes/node_modules"):
-        assert required_path in chown_block, (
-            f"{required_path} must be passed to a chown -R hermes:hermes "
-            f"command in the Dockerfile (see #18800)"
-        )
+def test_entrypoint_drops_root_to_selected_uid_gid() -> None:
+    dockerfile_text = DOCKERFILE.read_text()
+    entrypoint_text = ENTRYPOINT.read_text()
+
+    assert "gosu" in dockerfile_text
+    assert "TARGET_UID=\"${HERMES_UID:-10000}\"" in entrypoint_text
+    assert "TARGET_GID=\"${HERMES_GID:-${TARGET_UID}}\"" in entrypoint_text
+    assert "exec gosu \"${actual_uid}:${actual_gid}\" \"$@\"" in entrypoint_text

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -1,6 +1,6 @@
 """Contract tests for the container Dockerfile.
 
-These tests assert invariants about how the Dockerfile composes its runtime —
+These tests assert invariants about how the Dockerfile composes its runtime -
 they deliberately avoid snapshotting specific package versions, line numbers,
 or exact flag choices.  What they DO assert is that the Dockerfile maintains
 the properties required for correct production behaviour:
@@ -10,6 +10,8 @@ the properties required for correct production behaviour:
   instead of accumulating as zombies (#15012).
 - Signal forwarding runs through the init so ``docker stop`` triggers
   hermes's own graceful-shutdown path.
+- The container builds and ships the Rust CLI binary directly.  Ultra does
+  not vendor upstream's Python/uv/s6 image stack.
 """
 
 from __future__ import annotations
@@ -105,42 +107,31 @@ def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
     )
 
 
-def test_dockerfile_installs_tui_dependencies(dockerfile_text):
-    # The TUI workspace manifests must be present so ``npm install`` can
-    # resolve dependencies. The bundled ``hermes-ink`` workspace package is
-    # now COPIED into the image as a whole tree (not just its lockfile)
-    # because it's referenced as a ``file:`` workspace dependency from
-    # ``ui-tui/package.json`` — copying the tree avoids npm stopping at a
-    # bare ``package.json`` shell.
-    assert "ui-tui/package.json" in dockerfile_text
-    assert "ui-tui/package-lock.json" in dockerfile_text
-    assert "ui-tui/packages/hermes-ink/" in dockerfile_text
+def test_dockerfile_builds_rust_workspace_binary(dockerfile_text):
+    assert "FROM rust:" in dockerfile_text
+    assert "COPY Cargo.toml Cargo.lock ./" in dockerfile_text
+    assert "COPY crates crates" in dockerfile_text
     assert any(
-        "ui-tui" in step and "npm" in step and (" install" in step or " ci" in step)
+        "cargo build --release" in step and "telegram,discord,slack" in step
         for step in _run_steps(dockerfile_text)
     )
 
 
-def test_dockerfile_builds_tui_assets(dockerfile_text):
-    assert any(
-        "ui-tui" in step and "npm" in step and "run build" in step
-        for step in _run_steps(dockerfile_text)
+def test_dockerfile_runtime_installs_rust_binary(dockerfile_text):
+    assert (
+        "COPY --from=builder /app/target/release/hermes /usr/local/bin/hermes"
+        in dockerfile_text
     )
+    assert "uv sync" not in dockerfile_text
+    assert "pyproject.toml" not in dockerfile_text
+    assert ".venv" not in dockerfile_text
 
 
-def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
-    # ``hermes-ink`` is a bundled workspace package referenced from
-    # ``ui-tui/package.json`` via ``file:`` — not pulled from the npm
-    # registry. The contract this test pins is just that the image
-    # actually carries the package source so ``await import('@hermes/ink')``
-    # can resolve at runtime; the previous, much pickier assertion (manual
-    # ``rm -rf`` + ``npm install --omit=dev --prefix node_modules/@hermes/ink``)
-    # baked in implementation details of an older materialisation flow that
-    # was simplified once npm workspaces handled the resolution natively.
-    assert "ui-tui/packages/hermes-ink/" in dockerfile_text, (
-        "Dockerfile must COPY the bundled hermes-ink workspace package "
-        "so ``await import('@hermes/ink')`` resolves at runtime."
-    )
+def test_dockerfile_uses_ultra_data_home(dockerfile_text):
+    assert "ENV HERMES_HOME=/data" in dockerfile_text
+    assert 'VOLUME ["/data"]' in dockerfile_text
+    assert "useradd -u 10000" in dockerfile_text
+    assert "hermes" in dockerfile_text
 
 
 def test_dockerignore_excludes_nested_dependency_dirs():


### PR DESCRIPTION
## Summary
- clear the five remaining WS8 infra/setup shared-different paths as Rust-native intentional divergences tied to #305
- replace stale upstream Python Docker/installer assertions with contracts for Ultra's Rust image, compose defaults, entrypoint, README install path, and release-asset installer
- regenerate the shared-diff backlog snapshot

## Backlog effect
- pending_review: 511 -> 506
- cleared_intentional_divergence: 33 -> 38
- remaining WS8 pending functional review: 0

## Validation
- `pytest -q tests/tools/test_dockerfile_pid1_reaping.py tests/tools/test_dockerfile_node_modules_perms.py tests/test_docker_compose_contract.py tests/test_docker_entrypoint_contract.py tests/test_readme_install_contract.py tests/test_install_sh_pythonpath_sanitization.py tests/test_install_sh_termux_network_prereqs.py tests/test_termux_all_extra_compat.py tests/test_generate_shared_diff_backlog.py` -> 22 passed, 1 skipped
- `python3 scripts/generate-shared-diff-backlog.py --local-ref HEAD --no-fetch`
- `python3 -m json.tool docs/parity/shared-different-classification.json >/dev/null`
- `bash -n scripts/install.sh`
- `sh -n docker/entrypoint.sh`
- `git diff --check`
- `CARGO_TARGET_DIR=target/ws8-verify cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture` -> 4 passed

## Post-merge baseline
- PR #307 merged as `d4e0bf7710ef5ce34c144870a532e3a8b2632719`
- post-merge main CI run `26470568391` completed success
