### PR TITLE
Clear WS3 image generation contracts

### DIFF
--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -513,36 +513,6 @@
     {
       "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
       "classification": "functional",
-      "classification_path": "plugins/image_gen",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "c1a719f910221fe9d7c327c3f1e762818417fef9",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/image_gen/openai/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "448f5bc45af389fda842398c981cc4657de64699",
-      "workstream": "WS3"
-    },
-    {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/image_gen",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "ea8721075d0fad9e371f0e1e52cbcf6a6c799dc6",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/image_gen/xai/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "a8982393f7e4f5ad6af4e3ef2ee1893254fb9cff",
-      "workstream": "WS3"
-    },
-    {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
       "classification_path": "plugins/kanban",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "783e98f7ae15d2d62bebd5735d464a73652a52d0",
@@ -11236,33 +11206,33 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-26T21:11:15.674243+00:00",
+  "generated_at_utc": "2026-05-26T21:52:28.730255+00:00",
   "refs": {
-    "local_ref": "af1eb916b6f8e9bd0d045b49ce9c6220b07a2eb2",
-    "local_sha": "af1eb916b6f8e9bd0d045b49ce9c6220b07a2eb2",
+    "local_ref": "cd06292c54397a43f7720ec08392fdb2ae716fa9",
+    "local_sha": "cd06292c54397a43f7720ec08392fdb2ae716fa9",
     "upstream_ref": "upstream/main",
     "upstream_sha": "2517917de34eeb6a40f5a17a2e59d9746803dfa5"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 494,
+      "functional": 492,
       "intentional_divergence": 50,
       "policy_only": 204
     },
     "by_rust_requirement": {
       "not_required_for_runtime": 255,
       "rust_equivalent_or_contract_test_required": 389,
-      "rust_native_runtime_parity_required_if_needed": 33,
+      "rust_native_runtime_parity_required_if_needed": 31,
       "rust_primary_ux_or_documented_divergence_required": 72
     },
     "by_status": {
       "cleared_intentional_divergence": 50,
       "cleared_non_runtime": 205,
-      "pending_review": 494
+      "pending_review": 492
     },
     "by_workstream": {
-      "WS3": 45,
+      "WS3": 43,
       "WS4": 30,
       "WS5": 272,
       "WS6": 390,
@@ -11271,7 +11241,7 @@
     "cleared_intentional_divergence": 50,
     "cleared_non_runtime": 205,
     "pending_classification": 0,
-    "pending_review": 494,
-    "total_shared_different": 749
+    "pending_review": 492,
+    "total_shared_different": 747
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,12 +1,12 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-26T21:11:15.674243+00:00`
+Generated: `2026-05-26T21:52:28.730255+00:00`
 
 ## Summary
 
-- Total shared-different paths: `749`
+- Total shared-different paths: `747`
 - Pending classification: `0`
-- Pending functional review: `494`
+- Pending functional review: `492`
 - Cleared non-runtime: `205`
 - Cleared intentional divergence: `50`
 
@@ -16,13 +16,13 @@ Generated: `2026-05-26T21:11:15.674243+00:00`
 | --- | ---: |
 | `cleared_intentional_divergence` | 50 |
 | `cleared_non_runtime` | 205 |
-| `pending_review` | 494 |
+| `pending_review` | 492 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 45 |
+| `WS3` | 43 |
 | `WS4` | 30 |
 | `WS5` | 272 |
 | `WS6` | 390 |
@@ -56,7 +56,6 @@ Generated: `2026-05-26T21:11:15.674243+00:00`
 | `plugins/kanban` | 3 |
 | `ui-tui` | 3 |
 | `plugins/example-dashboard` | 2 |
-| `plugins/image_gen` | 2 |
 | `tests/honcho_plugin` | 2 |
 | `tests/skills` | 2 |
 | `tests/stress` | 2 |

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -33,6 +33,7 @@ from agent.image_gen_provider import (
     error_response,
     resolve_aspect_ratio,
     save_b64_image,
+    save_url_image,
     success_response,
 )
 
@@ -266,9 +267,21 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 )
             image_ref = str(saved_path)
         elif url:
-            # Defensive — gpt-image-2 returns b64 today, but fall back
-            # gracefully if the API ever changes.
-            image_ref = url
+            # Defensive — gpt-image-2 returns b64 today, but OpenAI's API
+            # has previously returned URLs.  Cache the bytes locally so the
+            # gateway never tries to fetch an ephemeral / signed URL after
+            # it expires — same rationale as the xAI provider (#26942).
+            try:
+                saved_path = save_url_image(url, prefix=f"openai_{tier_id}")
+            except Exception as exc:
+                logger.warning(
+                    "OpenAI image URL %s could not be cached (%s); falling back to bare URL.",
+                    url,
+                    exc,
+                )
+                image_ref = url
+            else:
+                image_ref = str(saved_path)
         else:
             return error_response(
                 error="OpenAI response contained neither b64_json nor URL",

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -29,9 +29,10 @@ from agent.image_gen_provider import (
     error_response,
     resolve_aspect_ratio,
     save_b64_image,
+    save_url_image,
     success_response,
 )
-from tools.xai_http import hermes_xai_user_agent
+from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -39,13 +40,16 @@ logger = logging.getLogger(__name__)
 # Model catalog
 # ---------------------------------------------------------------------------
 
-API_MODEL = "grok-imagine-image"
-
 _MODELS: Dict[str, Dict[str, Any]] = {
     "grok-imagine-image": {
         "display": "Grok Imagine Image",
         "speed": "~5-10s",
         "strengths": "Fast, high-quality",
+    },
+    "grok-imagine-image-quality": {
+        "display": "Grok Imagine Image (Quality)",
+        "speed": "~10-20s",
+        "strengths": "Higher fidelity / detail; slower than the standard model.",
     },
 }
 
@@ -127,7 +131,8 @@ class XAIImageGenProvider(ImageGenProvider):
         return "xAI (Grok)"
 
     def is_available(self) -> bool:
-        return bool(os.getenv("XAI_API_KEY"))
+        creds = resolve_xai_http_credentials()
+        return bool(creds.get("api_key"))
 
     def list_models(self) -> List[Dict[str, Any]]:
         return [
@@ -141,17 +146,16 @@ class XAIImageGenProvider(ImageGenProvider):
         ]
 
     def get_setup_schema(self) -> Dict[str, Any]:
+        # Auth resolution is delegated to the shared ``xai_grok`` post_setup
+        # hook (``hermes_cli/tools_config.py``); identical to the TTS / video
+        # gen entries so users see the same OAuth-or-API-key choice for every
+        # xAI service.
         return {
-            "name": "xAI (Grok)",
+            "name": "xAI Grok Imagine (image)",
             "badge": "paid",
-            "tag": "Native xAI image generation via grok-imagine-image",
-            "env_vars": [
-                {
-                    "key": "XAI_API_KEY",
-                    "prompt": "xAI API key",
-                    "url": "https://console.x.ai/",
-                },
-            ],
+            "tag": "grok-imagine-image — text-to-image; uses xAI Grok OAuth or XAI_API_KEY",
+            "env_vars": [],
+            "post_setup": "xai_grok",
         }
 
     def generate(
@@ -161,12 +165,14 @@ class XAIImageGenProvider(ImageGenProvider):
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Generate an image using xAI's grok-imagine-image."""
-        api_key = os.getenv("XAI_API_KEY", "").strip()
+        creds = resolve_xai_http_credentials()
+        api_key = str(creds.get("api_key") or "").strip()
+        provider_name = str(creds.get("provider") or "xai").strip() or "xai"
         if not api_key:
             return error_response(
-                error="XAI_API_KEY not set. Get one at https://console.x.ai/",
+                error="No xAI credentials found. Configure xAI OAuth in `hermes model` or set XAI_API_KEY.",
                 error_type="missing_api_key",
-                provider="xai",
+                provider=provider_name,
                 aspect_ratio=aspect_ratio,
             )
 
@@ -177,7 +183,7 @@ class XAIImageGenProvider(ImageGenProvider):
         xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
 
         payload: Dict[str, Any] = {
-            "model": API_MODEL,
+            "model": model_id,
             "prompt": prompt,
             "aspect_ratio": xai_ar,
             "resolution": xai_res,
@@ -189,7 +195,7 @@ class XAIImageGenProvider(ImageGenProvider):
             "User-Agent": hermes_xai_user_agent(),
         }
 
-        base_url = (os.getenv("XAI_BASE_URL") or "https://api.x.ai/v1").strip().rstrip("/")
+        base_url = str(creds.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
 
         try:
             response = requests.post(
@@ -210,7 +216,7 @@ class XAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error=f"xAI image generation failed ({status}): {err_msg}",
                 error_type="api_error",
-                provider="xai",
+                provider=provider_name,
                 model=model_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
@@ -219,7 +225,7 @@ class XAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error="xAI image generation timed out (120s)",
                 error_type="timeout",
-                provider="xai",
+                provider=provider_name,
                 model=model_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
@@ -228,7 +234,7 @@ class XAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error=f"xAI connection error: {exc}",
                 error_type="connection_error",
-                provider="xai",
+                provider=provider_name,
                 model=model_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
@@ -240,7 +246,7 @@ class XAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error=f"xAI returned invalid JSON: {exc}",
                 error_type="invalid_response",
-                provider="xai",
+                provider=provider_name,
                 model=model_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
@@ -252,7 +258,7 @@ class XAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error="xAI returned no image data",
                 error_type="empty_response",
-                provider="xai",
+                provider=provider_name,
                 model=model_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
@@ -276,7 +282,24 @@ class XAIImageGenProvider(ImageGenProvider):
                 )
             image_ref = str(saved_path)
         elif url:
-            image_ref = url
+            # xAI's grok-imagine-image returns ephemeral ``imgen.x.ai/xai-tmp-*``
+            # URLs that 404 within minutes — by the time Telegram's
+            # ``send_photo`` or any downstream consumer fetches them, the
+            # asset is gone (#26942).  Materialise the bytes locally at
+            # tool-completion time so the gateway has a stable file path to
+            # upload, mirroring the b64 branch above and the audio_cache
+            # pattern used by text_to_speech.
+            try:
+                saved_path = save_url_image(url, prefix=f"xai_{model_id}")
+            except Exception as exc:
+                logger.warning(
+                    "xAI image URL %s could not be cached (%s); falling back to bare URL.",
+                    url,
+                    exc,
+                )
+                image_ref = url
+            else:
+                image_ref = str(saved_path)
         else:
             return error_response(
                 error="xAI response contained neither b64_json nor URL",

--- a/tests/test_ws3_image_gen_contracts.py
+++ b/tests/test_ws3_image_gen_contracts.py
@@ -1,0 +1,205 @@
+"""WS3 image generation provider parity contracts.
+
+The Rust checkout does not include the upstream Python ``agent``/``tools``
+source modules these plugins import, so these tests load the plugin files with
+small local stubs and assert the shared-diff behavior directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _install_provider_stubs(monkeypatch, *, xai_creds: dict[str, str] | None = None) -> None:
+    agent_mod = types.ModuleType("agent")
+    image_provider_mod = types.ModuleType("agent.image_gen_provider")
+
+    class ImageGenProvider:
+        pass
+
+    def error_response(**kwargs):
+        return {"success": False, **kwargs}
+
+    def success_response(*, image, model, prompt, aspect_ratio, provider, extra=None):
+        result = {
+            "success": True,
+            "image": image,
+            "model": model,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": provider,
+        }
+        result.update(extra or {})
+        return result
+
+    def resolve_aspect_ratio(value):
+        return value if value in {"landscape", "portrait", "square"} else "square"
+
+    image_provider_mod.DEFAULT_ASPECT_RATIO = "square"
+    image_provider_mod.ImageGenProvider = ImageGenProvider
+    image_provider_mod.error_response = error_response
+    image_provider_mod.resolve_aspect_ratio = resolve_aspect_ratio
+    image_provider_mod.save_b64_image = lambda _b64, prefix: f"/cache/{prefix}.png"
+    image_provider_mod.save_url_image = lambda _url, prefix: f"/cache/{prefix}.png"
+    image_provider_mod.success_response = success_response
+
+    tools_mod = types.ModuleType("tools")
+    xai_http_mod = types.ModuleType("tools.xai_http")
+    xai_http_mod.hermes_xai_user_agent = lambda: "Hermes-Agent/test"
+    xai_http_mod.resolve_xai_http_credentials = lambda: dict(xai_creds or {})
+
+    monkeypatch.setitem(sys.modules, "agent", agent_mod)
+    monkeypatch.setitem(sys.modules, "agent.image_gen_provider", image_provider_mod)
+    monkeypatch.setitem(sys.modules, "tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "tools.xai_http", xai_http_mod)
+
+
+def _load_plugin(monkeypatch, name: str, rel_path: str, *, xai_creds=None):
+    _install_provider_stubs(monkeypatch, xai_creds=xai_creds)
+    module_name = f"_ws3_image_gen_{name}"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, REPO_ROOT / rel_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openai_url_response_is_materialized_before_return(monkeypatch):
+    plugin = _load_plugin(
+        monkeypatch,
+        "openai",
+        "plugins/image_gen/openai/__init__.py",
+    )
+
+    captured: dict[str, str] = {}
+
+    def save_url_image(url, *, prefix):
+        captured["url"] = url
+        captured["prefix"] = prefix
+        return "/cache/openai_url.png"
+
+    plugin.save_url_image = save_url_image
+
+    fake_client = SimpleNamespace(
+        images=SimpleNamespace(
+            generate=lambda **_kwargs: SimpleNamespace(
+                data=[SimpleNamespace(b64_json=None, url="https://example.com/signed.png")]
+            )
+        )
+    )
+    fake_openai = types.ModuleType("openai")
+    fake_openai.OpenAI = lambda: fake_client
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    result = plugin.OpenAIImageGenProvider().generate("draw a cacheable image")
+
+    assert result["success"] is True
+    assert result["image"] == "/cache/openai_url.png"
+    assert captured == {
+        "url": "https://example.com/signed.png",
+        "prefix": "openai_gpt-image-2-medium",
+    }
+
+
+def test_openai_url_cache_failure_falls_back_to_original_url(monkeypatch):
+    plugin = _load_plugin(
+        monkeypatch,
+        "openai_fallback",
+        "plugins/image_gen/openai/__init__.py",
+    )
+
+    def fail_cache(_url, *, prefix):
+        assert prefix == "openai_gpt-image-2-medium"
+        raise OSError("cache offline")
+
+    plugin.save_url_image = fail_cache
+
+    fake_client = SimpleNamespace(
+        images=SimpleNamespace(
+            generate=lambda **_kwargs: SimpleNamespace(
+                data=[SimpleNamespace(b64_json=None, url="https://example.com/signed.png")]
+            )
+        )
+    )
+    fake_openai = types.ModuleType("openai")
+    fake_openai.OpenAI = lambda: fake_client
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    result = plugin.OpenAIImageGenProvider().generate("draw a cacheable image")
+
+    assert result["success"] is True
+    assert result["image"] == "https://example.com/signed.png"
+
+
+def test_xai_uses_shared_credentials_schema_model_and_url_cache(monkeypatch):
+    plugin = _load_plugin(
+        monkeypatch,
+        "xai",
+        "plugins/image_gen/xai/__init__.py",
+        xai_creds={
+            "api_key": "oauth-token",
+            "provider": "xai-oauth",
+            "base_url": "https://api.x.ai/custom",
+        },
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.update({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return SimpleNamespace(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: {"data": [{"url": "https://imgen.x.ai/xai-tmp-result.png"}]},
+        )
+
+    plugin.requests.post = fake_post
+    plugin.save_url_image = lambda url, *, prefix: f"/cache/{prefix}.png"
+    monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-quality")
+
+    provider = plugin.XAIImageGenProvider()
+    schema = provider.get_setup_schema()
+    result = provider.generate("draw an OAuth-backed image", aspect_ratio="landscape")
+
+    assert provider.is_available() is True
+    assert schema["env_vars"] == []
+    assert schema["post_setup"] == "xai_grok"
+    assert "OAuth or XAI_API_KEY" in schema["tag"]
+    assert result["success"] is True
+    assert result["image"] == "/cache/xai_grok-imagine-image-quality.png"
+    assert result["model"] == "grok-imagine-image-quality"
+    assert captured["url"] == "https://api.x.ai/custom/images/generations"
+    assert captured["timeout"] == 120
+    assert captured["headers"]["Authorization"] == "Bearer oauth-token"
+    assert captured["headers"]["User-Agent"] == "Hermes-Agent/test"
+    assert captured["json"] == {
+        "model": "grok-imagine-image-quality",
+        "prompt": "draw an OAuth-backed image",
+        "aspect_ratio": "16:9",
+        "resolution": "1k",
+    }
+
+
+def test_xai_missing_credentials_points_to_shared_setup(monkeypatch):
+    plugin = _load_plugin(
+        monkeypatch,
+        "xai_missing",
+        "plugins/image_gen/xai/__init__.py",
+        xai_creds={},
+    )
+
+    result = plugin.XAIImageGenProvider().generate("draw something")
+
+    assert result["success"] is False
+    assert result["error_type"] == "missing_api_key"
+    assert "Configure xAI OAuth" in result["error"]


### PR DESCRIPTION
## Summary

- Ported upstream WS3 image generation provider fixes for OpenAI and xAI.
- OpenAI URL responses are now materialized through `save_url_image` before return, with fallback to the original URL if caching fails.
- xAI image generation now uses shared `resolve_xai_http_credentials`, exposes the shared `xai_grok` setup hook, supports `grok-imagine-image-quality`, sends the selected model ID, and materializes ephemeral xAI URLs.
- Added self-contained WS3 image_gen contract tests because this Rust checkout does not include the upstream Python `agent`/`tools` source modules needed by the older plugin tests.
- Regenerated the shared-diff backlog: `total_shared_different=747`, `pending_review=492`, `pending_classification=0`, `WS3=43`.

## Validation

- `python3 -m json.tool docs/parity/shared-diff-backlog.json >/dev/null`
- `python3 -m py_compile plugins/image_gen/openai/__init__.py plugins/image_gen/xai/__init__.py tests/test_ws3_image_gen_contracts.py`
- `pytest -q tests/test_ws3_image_gen_contracts.py` -> `4 passed`
- `python3 scripts/generate-shared-diff-backlog.py --local-ref "$TREE" --no-fetch`
- `git diff --check && git diff --cached --check`
- `CARGO_TARGET_DIR=target/ws3-image-gen-verify cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture` -> `4 passed`

Refs #304
