### PR TITLE
Clear WS3 example dashboard contracts

### DIFF
--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -331,32 +331,32 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/example-dashboard",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/example-dashboard/dashboard/manifest.json",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "95fce2f100f4e7333dacd226cb1cb6bcc2cdc42e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/example-dashboard/dashboard/manifest.json",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "68a2e9b895c140c15384d53d01d024a4cccd5cde",
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/example-dashboard",
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "plugins/example-dashboard/dashboard/plugin_api.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "20aed76e26feefc5cf05cda23170afbb359b6645",
-      "necessity": "necessary_review",
+      "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "plugins/example-dashboard/dashboard/plugin_api.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 304,
       "upstream_blob": "3e850298a0941de07828af07afc46b191a5fe549",
       "workstream": "WS3"
     },
@@ -11206,30 +11206,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-26T21:52:28.730255+00:00",
+  "generated_at_utc": "2026-05-26T22:32:03.267229+00:00",
   "refs": {
-    "local_ref": "cd06292c54397a43f7720ec08392fdb2ae716fa9",
-    "local_sha": "cd06292c54397a43f7720ec08392fdb2ae716fa9",
+    "local_ref": "84ff493c17917948eca679ea0d57b9f3c1d97182",
+    "local_sha": "84ff493c17917948eca679ea0d57b9f3c1d97182",
     "upstream_ref": "upstream/main",
     "upstream_sha": "2517917de34eeb6a40f5a17a2e59d9746803dfa5"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 492,
-      "intentional_divergence": 50,
-      "policy_only": 204
+      "functional": 490,
+      "intentional_divergence": 51,
+      "policy_only": 205
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 255,
+      "not_required_for_runtime": 257,
       "rust_equivalent_or_contract_test_required": 389,
-      "rust_native_runtime_parity_required_if_needed": 31,
+      "rust_native_runtime_parity_required_if_needed": 29,
       "rust_primary_ux_or_documented_divergence_required": 72
     },
     "by_status": {
-      "cleared_intentional_divergence": 50,
-      "cleared_non_runtime": 205,
-      "pending_review": 492
+      "cleared_intentional_divergence": 51,
+      "cleared_non_runtime": 206,
+      "pending_review": 490
     },
     "by_workstream": {
       "WS3": 43,
@@ -11238,10 +11238,10 @@
       "WS6": 390,
       "WS8": 12
     },
-    "cleared_intentional_divergence": 50,
-    "cleared_non_runtime": 205,
+    "cleared_intentional_divergence": 51,
+    "cleared_non_runtime": 206,
     "pending_classification": 0,
-    "pending_review": 492,
+    "pending_review": 490,
     "total_shared_different": 747
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-26T21:52:28.730255+00:00`
+Generated: `2026-05-26T22:32:03.267229+00:00`
 
 ## Summary
 
 - Total shared-different paths: `747`
 - Pending classification: `0`
-- Pending functional review: `492`
-- Cleared non-runtime: `205`
-- Cleared intentional divergence: `50`
+- Pending functional review: `490`
+- Cleared non-runtime: `206`
+- Cleared intentional divergence: `51`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 50 |
-| `cleared_non_runtime` | 205 |
-| `pending_review` | 492 |
+| `cleared_intentional_divergence` | 51 |
+| `cleared_non_runtime` | 206 |
+| `pending_review` | 490 |
 
 ## Workstream Counts
 
@@ -55,7 +55,6 @@ Generated: `2026-05-26T21:52:28.730255+00:00`
 | `tests/providers` | 4 |
 | `plugins/kanban` | 3 |
 | `ui-tui` | 3 |
-| `plugins/example-dashboard` | 2 |
 | `tests/honcho_plugin` | 2 |
 | `tests/skills` | 2 |
 | `tests/stress` | 2 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -416,6 +416,20 @@
       "ticket": 25
     },
     {
+      "path": "plugins/example-dashboard/dashboard/manifest.json",
+      "classification": "intentional_divergence",
+      "rationale": "Local example dashboard intentionally advertises the sessions:top slot so the bundled SDK demo exercises page-scoped slot injection; contract tests verify the manifest and dist bundle stay aligned.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
+      "path": "plugins/example-dashboard/dashboard/plugin_api.py",
+      "classification": "policy_only",
+      "rationale": "The shared diff is module docstring wording only; the /hello route behavior remains unchanged and is covered by the example dashboard contract test.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
       "path": "skills/devops",
       "classification": "intentional_divergence",
       "rationale": "Skill catalog content is curated locally while runtime skill contracts remain tracked separately.",

--- a/tests/test_ws3_example_dashboard_contracts.py
+++ b/tests/test_ws3_example_dashboard_contracts.py
@@ -1,0 +1,57 @@
+"""WS3 example dashboard plugin divergence contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "example-dashboard" / "dashboard"
+
+
+def test_example_dashboard_manifest_matches_local_slot_demo() -> None:
+    manifest = json.loads((PLUGIN_ROOT / "manifest.json").read_text())
+    bundle = (PLUGIN_ROOT / "dist" / "index.js").read_text()
+
+    assert manifest["description"] == "Example dashboard plugin — demonstrates the plugin SDK"
+    assert manifest["slots"] == ["sessions:top"]
+    assert manifest["entry"] == "dist/index.js"
+    assert 'registerSlot("example", "sessions:top", SessionsTopBanner)' in bundle
+    assert "window.__HERMES_PLUGIN_SDK__" in bundle
+
+
+def test_example_dashboard_hello_route_remains_stable(monkeypatch) -> None:
+    class APIRouter:
+        def __init__(self) -> None:
+            self.routes = []
+
+        def get(self, path):
+            def decorator(func):
+                self.routes.append((path, func))
+                return func
+
+            return decorator
+
+    fastapi = types.ModuleType("fastapi")
+    fastapi.APIRouter = APIRouter
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi)
+
+    spec = importlib.util.spec_from_file_location(
+        "_ws3_example_dashboard_api",
+        PLUGIN_ROOT / "plugin_api.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "_ws3_example_dashboard_api", module)
+    spec.loader.exec_module(module)
+
+    assert module.router.routes[0][0] == "/hello"
+    assert asyncio.run(module.hello()) == {
+        "message": "Hello from the example plugin!",
+        "plugin": "example",
+        "version": "1.0.0",
+    }


### PR DESCRIPTION
## Summary
- classify the shared example-dashboard manifest diff as intentional divergence because the local demo intentionally advertises `sessions:top`
- classify the example-dashboard API diff as policy-only docstring wording while keeping `/hello` behavior unchanged
- add WS3 contract coverage for manifest/bundle slot alignment and the `/hello` route payload

## Backlog
- total_shared_different: 747
- pending_review: 490
- pending_classification: 0
- cleared_non_runtime: 206
- cleared_intentional_divergence: 51

## Verification
- `python3 -m json.tool docs/parity/shared-different-classification.json >/dev/null`
- `python3 -m py_compile plugins/example-dashboard/dashboard/plugin_api.py tests/test_ws3_example_dashboard_contracts.py`
- `pytest -q tests/test_ws3_example_dashboard_contracts.py`
- `git diff --check && git diff --cached --check`
- `TREE=$(git write-tree) && python3 scripts/generate-shared-diff-backlog.py --local-ref "$TREE" --no-fetch`
- `TREE=$(git write-tree) && python3 scripts/generate-shared-diff-backlog.py --local-ref "$TREE" --no-fetch && CARGO_TARGET_DIR=target/ws3-example-dashboard-verify cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture`

Refs #304
