### PR TITLE
Port WS3 OpenViking provider parity

### DIFF
--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -635,21 +635,6 @@
       "classification": "functional",
       "classification_path": "plugins/memory",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "620780008663127d0decacf1d3c3ba362b43334f",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/memory/openviking/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "42925fa74aa04f4fe9a708e397990e871065a0e6",
-      "workstream": "WS3"
-    },
-    {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
-      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f0cbfd60276da4cfedb104ab63ab94d883491359",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -11206,33 +11191,33 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-26T23:17:01.839534+00:00",
+  "generated_at_utc": "2026-05-27T00:01:19.627095+00:00",
   "refs": {
-    "local_ref": "fed4108bb2a084ff5ea8fd505a8b725170ef0742",
-    "local_sha": "fed4108bb2a084ff5ea8fd505a8b725170ef0742",
+    "local_ref": "b8f762423bc679f8830a0b611fb98519a472a758",
+    "local_sha": "b8f762423bc679f8830a0b611fb98519a472a758",
     "upstream_ref": "upstream/main",
     "upstream_sha": "2517917de34eeb6a40f5a17a2e59d9746803dfa5"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 481,
+      "functional": 480,
       "intentional_divergence": 55,
       "policy_only": 210
     },
     "by_rust_requirement": {
       "not_required_for_runtime": 266,
       "rust_equivalent_or_contract_test_required": 389,
-      "rust_native_runtime_parity_required_if_needed": 20,
+      "rust_native_runtime_parity_required_if_needed": 19,
       "rust_primary_ux_or_documented_divergence_required": 72
     },
     "by_status": {
       "cleared_intentional_divergence": 55,
       "cleared_non_runtime": 211,
-      "pending_review": 481
+      "pending_review": 480
     },
     "by_workstream": {
-      "WS3": 43,
+      "WS3": 42,
       "WS4": 30,
       "WS5": 272,
       "WS6": 390,
@@ -11241,7 +11226,7 @@
     "cleared_intentional_divergence": 55,
     "cleared_non_runtime": 211,
     "pending_classification": 0,
-    "pending_review": 481,
-    "total_shared_different": 747
+    "pending_review": 480,
+    "total_shared_different": 746
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,12 +1,12 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-26T23:17:01.839534+00:00`
+Generated: `2026-05-27T00:01:19.627095+00:00`
 
 ## Summary
 
-- Total shared-different paths: `747`
+- Total shared-different paths: `746`
 - Pending classification: `0`
-- Pending functional review: `481`
+- Pending functional review: `480`
 - Cleared non-runtime: `211`
 - Cleared intentional divergence: `55`
 
@@ -16,13 +16,13 @@ Generated: `2026-05-26T23:17:01.839534+00:00`
 | --- | ---: |
 | `cleared_intentional_divergence` | 55 |
 | `cleared_non_runtime` | 211 |
-| `pending_review` | 481 |
+| `pending_review` | 480 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 43 |
+| `WS3` | 42 |
 | `WS4` | 30 |
 | `WS5` | 272 |
 | `WS6` | 390 |
@@ -47,9 +47,9 @@ Generated: `2026-05-26T23:17:01.839534+00:00`
 | `tests/cli` | 17 |
 | `ui-tui/packages` | 17 |
 | `plugins/platforms` | 9 |
-| `plugins/memory` | 7 |
 | `tests/acp` | 7 |
 | `tests/plugins` | 7 |
+| `plugins/memory` | 6 |
 | `tests/cron` | 6 |
 | `tests/providers` | 4 |
 | `plugins/kanban` | 3 |

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -47,6 +47,25 @@ _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 
+# Maps the viking_remember `category` enum to a viking:// subdirectory.
+# Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
+_CATEGORY_SUBDIR_MAP = {
+    "preference": "preferences",
+    "entity": "entities",
+    "event": "events",
+    "case": "cases",
+    "pattern": "patterns",
+}
+_DEFAULT_MEMORY_SUBDIR = "preferences"
+
+# Maps the built-in memory tool's `target` ("user" vs "memory") to a subdir
+# for on_memory_write mirroring. User profile facts → preferences; agent
+# notes / observations → patterns. Anything unknown falls back to the default.
+_MEMORY_WRITE_TARGET_SUBDIR_MAP = {
+    "user": "preferences",
+    "memory": "patterns",
+}
+
 
 # ---------------------------------------------------------------------------
 # Process-level atexit safety net — ensures pending sessions are committed
@@ -336,10 +355,17 @@ ADD_RESOURCE_SCHEMA = {
 
 def _zip_directory(dir_path: Path) -> Path:
     """Create a temporary zip file containing a directory tree."""
+    root = dir_path.resolve()
     zip_path = Path(tempfile.gettempdir()) / f"openviking_upload_{uuid.uuid4().hex}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         for file_path in dir_path.rglob("*"):
+            if file_path.is_symlink():
+                continue
             if file_path.is_file():
+                try:
+                    file_path.resolve().relative_to(root)
+                except ValueError:
+                    continue
                 arcname = str(file_path.relative_to(dir_path)).replace("\\", "/")
                 zipf.write(file_path, arcname=arcname)
     return zip_path
@@ -350,7 +376,7 @@ def _is_windows_absolute_path(value: str) -> bool:
         len(value) >= 3
         and value[0].isalpha()
         and value[1] == ":"
-        and value[2] in ("/", "\\")
+        and value[2] in {"/", "\\"}
     )
 
 
@@ -374,7 +400,7 @@ def _is_local_path_reference(value: str) -> bool:
 
 def _path_from_file_uri(uri: str) -> Path | str:
     parsed = urlparse(uri)
-    if parsed.netloc not in ("", "localhost"):
+    if parsed.netloc not in {"", "localhost"}:
         return f"Unsupported non-local file URI: {uri}"
     return Path(url2pathname(parsed.path)).expanduser()
 
@@ -600,10 +626,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.warning("OpenViking session commit failed: %s", e)
 
-    def on_memory_write(self, action: str, target: str, content: str) -> None:
-        """Mirror built-in memory writes to OpenViking as explicit memories."""
+    def _build_memory_uri(self, subdir: str) -> str:
+        """Build a viking:// memory URI under the configured user/subdir."""
+        slug = uuid.uuid4().hex[:12]
+        return f"viking://user/{self._user}/memories/{subdir}/mem_{slug}.md"
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory writes to OpenViking via content/write."""
         if not self._client or action != "add" or not content:
             return
+
+        subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
+        uri = self._build_memory_uri(subdir)
 
         def _write():
             try:
@@ -611,13 +651,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     self._endpoint, self._api_key,
                     account=self._account, user=self._user, agent=self._agent,
                 )
-                # Add as a user message with memory context so the commit
-                # picks it up as an explicit memory during extraction
-                client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-                    "role": "user",
-                    "parts": [
-                        {"type": "text", "text": f"[Memory note — {target}] {content}"},
-                    ],
+                client.post("/api/v1/content/write", {
+                    "uri": uri,
+                    "content": content,
+                    "mode": "create",
                 })
             except Exception as e:
                 logger.debug("OpenViking memory mirror failed: %s", e)
@@ -748,7 +785,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         level = args.get("level", "overview")
 
-        summary_level = level in ("abstract", "overview")
+        summary_level = level in {"abstract", "overview"}
         # OpenViking expects directory URIs for pseudo summary files
         # (e.g. viking://user/hermes/.overview.md).
         resolved_uri = self._normalize_summary_uri(uri) if summary_level else uri
@@ -825,7 +862,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         result = self._unwrap_result(resp)
 
         # Format list/tree results for readability
-        if action in ("list", "tree"):
+        if action in {"list", "tree"}:
             raw_entries = result
             if isinstance(result, dict):
                 raw_entries = result.get("entries") or result.get("items") or result.get("children") or []
@@ -851,24 +888,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not content:
             return tool_error("content is required")
 
-        # Store as a session message that will be extracted during commit.
-        # The category hint helps OpenViking's extraction classify correctly.
         category = args.get("category", "")
-        text = f"[Remember] {content}"
-        if category:
-            text = f"[Remember — {category}] {content}"
+        subdir = _CATEGORY_SUBDIR_MAP.get(category, _DEFAULT_MEMORY_SUBDIR)
+        uri = self._build_memory_uri(subdir)
 
-        self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
-            "role": "user",
-            "parts": [
-                {"type": "text", "text": text},
-            ],
-        })
-
-        return json.dumps({
-            "status": "stored",
-            "message": "Memory recorded. Will be extracted and indexed on session commit.",
-        })
+        # Write directly via content/write API.
+        # This creates the file, stores the content, and queues vector indexing
+        # in a single call — no dependency on session commit / VLM extraction.
+        try:
+            result = self._client.post("/api/v1/content/write", {
+                "uri": uri,
+                "content": content,
+                "mode": "create",
+            })
+            written = result.get("result", {}).get("written_bytes", 0)
+            return json.dumps({
+                "status": "stored",
+                "message": f"Memory stored ({written}b) and queued for vector indexing.",
+            })
+        except Exception as e:
+            logger.error("OpenViking content/write failed: %s", e)
+            return tool_error(f"Failed to store memory: {e}")
 
     def _tool_add_resource(self, args: dict) -> str:
         url = args.get("url", "")
@@ -880,7 +920,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         payload: Dict[str, Any] = {}
         for key in ("reason", "to", "parent", "instruction", "wait", "timeout"):
-            if key in args and args[key] not in (None, ""):
+            if key in args and args[key] not in {None, ""}:
                 payload[key] = args[key]
 
         parsed_url = urlparse(url)

--- a/tests/plugins/memory/test_openviking_ultra_contracts.py
+++ b/tests/plugins/memory/test_openviking_ultra_contracts.py
@@ -1,0 +1,153 @@
+import importlib.util
+import json
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPENVIKING_MODULE = REPO_ROOT / "plugins" / "memory" / "openviking" / "__init__.py"
+
+
+def load_openviking_module(monkeypatch):
+    """Load the provider file directly; this checkout has pyc-only support modules."""
+    agent_pkg = types.ModuleType("agent")
+    agent_pkg.__path__ = []
+    memory_provider = types.ModuleType("agent.memory_provider")
+
+    class MemoryProvider:
+        pass
+
+    memory_provider.MemoryProvider = MemoryProvider
+
+    tools_pkg = types.ModuleType("tools")
+    tools_pkg.__path__ = []
+    registry = types.ModuleType("tools.registry")
+    registry.tool_error = lambda message: json.dumps({"error": message})
+
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.memory_provider", memory_provider)
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.registry", registry)
+
+    module_name = "_openviking_contract_test"
+    spec = importlib.util.spec_from_file_location(module_name, OPENVIKING_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeClient:
+    def __init__(self, response=None):
+        self.response = response or {"result": {"written_bytes": 0}}
+        self.posts = []
+
+    def post(self, path, payload=None, **kwargs):
+        self.posts.append((path, payload or {}, kwargs))
+        return self.response
+
+
+def test_viking_remember_writes_direct_content_file(monkeypatch):
+    module = load_openviking_module(monkeypatch)
+    monkeypatch.setattr(
+        module.uuid,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex="abc123def4567890"),
+    )
+
+    provider = module.OpenVikingMemoryProvider()
+    provider._user = "alice"
+    provider._client = FakeClient({"result": {"written_bytes": 27}})
+
+    result = json.loads(
+        provider._tool_remember({
+            "content": "Prefers terse status updates.",
+            "category": "preference",
+        })
+    )
+
+    assert result == {
+        "status": "stored",
+        "message": "Memory stored (27b) and queued for vector indexing.",
+    }
+    assert provider._client.posts == [(
+        "/api/v1/content/write",
+        {
+            "uri": "viking://user/alice/memories/preferences/mem_abc123def456.md",
+            "content": "Prefers terse status updates.",
+            "mode": "create",
+        },
+        {},
+    )]
+
+
+def test_builtin_memory_write_mirrors_to_target_subdirectory(monkeypatch):
+    module = load_openviking_module(monkeypatch)
+    monkeypatch.setattr(
+        module.uuid,
+        "uuid4",
+        lambda: types.SimpleNamespace(hex="fedcba9876543210"),
+    )
+    fake_client = FakeClient()
+    monkeypatch.setattr(module, "_VikingClient", lambda *args, **kwargs: fake_client)
+
+    class ImmediateThread:
+        def __init__(self, target, **kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(module.threading, "Thread", ImmediateThread)
+
+    provider = module.OpenVikingMemoryProvider()
+    provider._client = object()
+    provider._endpoint = "http://openviking.test"
+    provider._api_key = "test-key"
+    provider._account = "default"
+    provider._user = "alice"
+    provider._agent = "hermes"
+
+    provider.on_memory_write(
+        "add",
+        "memory",
+        "A reusable troubleshooting pattern.",
+        metadata={"source": "test"},
+    )
+
+    assert fake_client.posts == [(
+        "/api/v1/content/write",
+        {
+            "uri": "viking://user/alice/memories/patterns/mem_fedcba987654.md",
+            "content": "A reusable troubleshooting pattern.",
+            "mode": "create",
+        },
+        {},
+    )]
+
+
+def test_zip_directory_skips_symlink_escape(monkeypatch, tmp_path):
+    module = load_openviking_module(monkeypatch)
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "safe.txt").write_text("safe", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+
+    try:
+        (root / "escape.txt").symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    zip_path = module._zip_directory(root)
+    try:
+        with zipfile.ZipFile(zip_path) as zip_file:
+            assert zip_file.namelist() == ["safe.txt"]
+            assert zip_file.read("safe.txt") == b"safe"
+    finally:
+        zip_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Port upstream OpenViking provider parity for direct content/write memory persistence and safer directory zip uploads.
- Add focused Ultra contract coverage for viking_remember, built-in memory mirroring, and symlink escape skipping.
- Regenerate shared-diff backlog after removing plugins/memory/openviking/__init__.py from pending review.

## Backlog Delta
- total_shared_different: 747 -> 746
- pending_review: 481 -> 480
- pending_classification: 0
- WS3: 43 -> 42

## Verification
- python3 -m json.tool docs/parity/shared-diff-backlog.json >/dev/null
- python3 -m py_compile plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_ultra_contracts.py
- pytest -q tests/plugins/memory/test_openviking_ultra_contracts.py
- git diff --check && git diff --cached --check
- TREE=$(git write-tree) && python3 scripts/generate-shared-diff-backlog.py --local-ref "$TREE" --no-fetch
- CARGO_TARGET_DIR=target cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture