### PR TITLE
fix: address external issue triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/sheawinkler/hermes-agent-ultra/main
 ### From source
 
 ```bash
-cargo install --git https://github.com/sheawinkler/hermes-agent-ultra hermes-cli --locked --bin hermes-agent-ultra --bin hermes-ultra --bin hermes
+cargo install --git https://github.com/sheawinkler/hermes-agent-ultra hermes-cli --locked --bin hermes-agent-ultra --bin hermes-ultra
 ```
 
 ## Quick Start
@@ -115,13 +115,13 @@ Hermes Agent Ultra still supports direct provider and per-tool keys. If you pref
 Fresh install path:
 
 ```bash
-hermes setup --portal
+hermes-ultra setup --portal
 ```
 
 That starts Nous OAuth setup, sets Nous as the provider, and enables Tool Gateway routing. Inspect the current state with:
 
 ```bash
-hermes portal status
+hermes-ultra portal status
 ```
 
 You can still bring your own keys for individual tools; gateway routing is per backend, not all-or-nothing.

--- a/crates/hermes-cli/src/bin/hermes-ultra.rs
+++ b/crates/hermes-cli/src/bin/hermes-ultra.rs
@@ -32,19 +32,19 @@ fn candidate_targets() -> Vec<OsString> {
         }
     }
 
-    if let Ok(home) = std::env::var("HOME") {
-        let cargo_bin = PathBuf::from(home).join(".cargo/bin/hermes-agent-ultra");
-        if cargo_bin.exists() {
-            out.push(cargo_bin.into_os_string());
-        }
-    }
-
     if let Ok(current) = std::env::current_exe() {
         if let Some(dir) = current.parent() {
             let local = dir.join("hermes-agent-ultra");
             if local.exists() {
                 out.push(local.into_os_string());
             }
+        }
+    }
+
+    if let Ok(home) = std::env::var("HOME") {
+        let cargo_bin = PathBuf::from(home).join(".cargo/bin/hermes-agent-ultra");
+        if cargo_bin.exists() {
+            out.push(cargo_bin.into_os_string());
         }
     }
 

--- a/crates/hermes-cli/src/bin/hermes.rs
+++ b/crates/hermes-cli/src/bin/hermes.rs
@@ -32,19 +32,19 @@ fn candidate_targets() -> Vec<OsString> {
         }
     }
 
-    if let Ok(home) = std::env::var("HOME") {
-        let cargo_bin = PathBuf::from(home).join(".cargo/bin/hermes-agent-ultra");
-        if cargo_bin.exists() {
-            out.push(cargo_bin.into_os_string());
-        }
-    }
-
     if let Ok(current) = std::env::current_exe() {
         if let Some(dir) = current.parent() {
             let local = dir.join("hermes-agent-ultra");
             if local.exists() {
                 out.push(local.into_os_string());
             }
+        }
+    }
+
+    if let Ok(home) = std::env::var("HOME") {
+        let cargo_bin = PathBuf::from(home).join(".cargo/bin/hermes-agent-ultra");
+        if cargo_bin.exists() {
+            out.push(cargo_bin.into_os_string());
         }
     }
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -101,6 +101,7 @@ fn mask_secret_value(secret: &str) -> String {
 
 /// All supported slash commands and their descriptions.
 pub const SLASH_COMMANDS: &[(&str, &str)] = &[
+    ("/start", "Acknowledge platform start pings without a reply"),
     ("/new", "Start a new session"),
     ("/reset", "Reset the current session (clear messages)"),
     (
@@ -3400,6 +3401,7 @@ pub async fn handle_slash_command(
     args: &[&str],
 ) -> Result<CommandResult, AgentError> {
     match canonical_command(cmd) {
+        "/start" => Ok(CommandResult::Handled),
         "/new" => {
             app.new_session();
             emit_command_output(app, format!("[New session started: {}]", app.session_id));
@@ -25036,6 +25038,13 @@ mod tests {
         let content = messages[0].content.as_deref().unwrap_or("");
         assert!(content.contains("done"));
         assert!(content.contains("Attached image"));
+    }
+
+    #[test]
+    fn test_start_command_is_registered_and_completable() {
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/start"));
+        let results = autocomplete("/sta");
+        assert!(results.contains(&"/start"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -95,7 +95,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs::OpenOptions;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{IsTerminal, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
@@ -800,6 +800,20 @@ fn init_tracing(verbose: bool, interactive_tui: bool) {
 const INTERACTIVE_SESSION_LOCK_FILE: &str = "interactive.session.lock";
 const INTERACTIVE_SESSION_LOCK_BYPASS_ENV: &str = "HERMES_ALLOW_PARALLEL_INTERACTIVE";
 
+fn interactive_tty_error_message() -> &'static str {
+    "interactive Hermes requires a terminal (TTY). Run `hermes-ultra setup` first, \
+     use `hermes-ultra chat --query \"...\"` for non-interactive prompts, or run \
+     `hermes-ultra doctor --deep --snapshot --bundle` for diagnostics."
+}
+
+fn require_interactive_tty() -> Result<(), AgentError> {
+    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        Ok(())
+    } else {
+        Err(AgentError::Config(interactive_tty_error_message().into()))
+    }
+}
+
 fn interactive_lock_path_for_cli(cli: &Cli) -> PathBuf {
     hermes_state_root(cli).join(INTERACTIVE_SESSION_LOCK_FILE)
 }
@@ -1032,6 +1046,7 @@ impl Drop for InteractiveSessionLockGuard {
 
 /// Run the interactive REPL (default command).
 async fn run_interactive(cli: Cli) -> Result<(), AgentError> {
+    require_interactive_tty()?;
     let _session_lock = InteractiveSessionLockGuard::acquire(&cli)?;
     let app = App::new(cli).await?;
     hermes_cli::tui::run(app).await
@@ -1054,6 +1069,7 @@ struct ResumeSessionPayload {
 }
 
 async fn run_resume(cli: Cli, requested_session_id: Option<String>) -> Result<(), AgentError> {
+    require_interactive_tty()?;
     let _session_lock = InteractiveSessionLockGuard::acquire(&cli)?;
     let requested = requested_session_id.as_deref();
     let payload = match load_resume_payload(&cli, requested) {
@@ -6766,7 +6782,7 @@ async fn run_portal(cli: Cli, action: Option<String>) -> Result<(), AgentError> 
             .await
         }
         other => Err(AgentError::Config(format!(
-            "Unknown portal action '{}'. Use `hermes portal status` or `hermes portal setup`.",
+            "Unknown portal action '{}'. Use `hermes-ultra portal status` or `hermes-ultra portal setup`.",
             other
         ))),
     }
@@ -9371,7 +9387,9 @@ fn merge_missing_env_keys(src: &Path, dst: &Path, label: &str) -> Result<usize, 
     if !out.is_empty() && !out.ends_with('\n') {
         out.push('\n');
     }
-    out.push_str(&format!("# Imported by `hermes setup` from {label}\n"));
+    out.push_str(&format!(
+        "# Imported by `hermes-ultra setup` from {label}\n"
+    ));
     for line in &to_import {
         out.push_str(line);
         out.push('\n');
@@ -10059,10 +10077,10 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
     }
 
     println!(
-        "\nSetup complete! Run `hermes-ultra` (or `hermes-agent-ultra`/`hermes`) to start an interactive session."
+        "\nSetup complete! Run `hermes-ultra` (or `hermes-agent-ultra`) to start an interactive session."
     );
     println!(
-        "Run `hermes-ultra doctor` (or `hermes-agent-ultra doctor`/`hermes doctor`) to check system requirements."
+        "Run `hermes-ultra doctor` (or `hermes-agent-ultra doctor`) to check system requirements."
     );
     Ok(())
 }
@@ -10186,7 +10204,7 @@ async fn run_doctor(
     if config_dir_ok {
         println!("✓");
     } else {
-        println!("✗ (run `hermes setup`)");
+        println!("✗ (run `hermes-ultra setup`)");
     }
     checks.push(serde_json::json!({
         "name": "config_dir",
@@ -10200,7 +10218,7 @@ async fn run_doctor(
     if config_yaml_ok {
         println!("✓");
     } else {
-        println!("✗ (run `hermes setup`)");
+        println!("✗ (run `hermes-ultra setup`)");
     }
     checks.push(serde_json::json!({
         "name": "config_yaml",
@@ -10220,7 +10238,7 @@ async fn run_doctor(
     } else if let Some(ref p) = project_env {
         println!("✓ (using fallback {})", p.display());
     } else {
-        println!("✗ (run `hermes setup`)");
+        println!("✗ (run `hermes-ultra setup`)");
     }
     checks.push(serde_json::json!({
         "name": "env_file",
@@ -10235,7 +10253,7 @@ async fn run_doctor(
     if soul_ok {
         println!("✓");
     } else {
-        println!("✗ (will be created by `hermes setup` or installer)");
+        println!("✗ (will be created by `hermes-ultra setup` or installer)");
     }
     checks.push(serde_json::json!({
         "name": "soul_md",
@@ -13120,7 +13138,7 @@ async fn run_profile(
         }
         "list" => {
             if !profiles_dir.exists() {
-                println!("No profiles directory found. Run `hermes setup` first.");
+                println!("No profiles directory found. Run `hermes-ultra setup` first.");
                 return Ok(());
             }
             let active = read_active_profile_name(&profiles_dir);
@@ -14522,6 +14540,15 @@ max_turns: 50
         assert!(query_is_local_slash_command("/model list"));
         assert!(query_is_local_slash_command("   /graph status"));
         assert!(!query_is_local_slash_command("hello world"));
+    }
+
+    #[test]
+    fn interactive_tty_error_is_actionable() {
+        let msg = interactive_tty_error_message();
+        assert!(msg.contains("requires a terminal"));
+        assert!(msg.contains("hermes-ultra setup"));
+        assert!(msg.contains("chat --query"));
+        assert!(msg.contains("doctor --deep --snapshot --bundle"));
     }
 
     #[test]

--- a/crates/hermes-cli/tests/e2e_cli.rs
+++ b/crates/hermes-cli/tests/e2e_cli.rs
@@ -1,6 +1,5 @@
 use assert_cmd::Command;
 use std::fs;
-use std::process::Command as StdCommand;
 
 #[test]
 fn e2e_cli_model_command_prints_current_model() {
@@ -70,28 +69,25 @@ fn e2e_cli_config_set_dotted_llm_and_get_masks_key() {
 }
 
 #[test]
-fn e2e_cli_interactive_refuses_parallel_session_when_lock_pid_is_alive() {
+fn e2e_cli_interactive_without_tty_reports_actionable_diagnostic() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let lock_path = dir.path().join("interactive.session.lock");
-    let mut sleeper = StdCommand::new("sleep")
-        .arg("30")
-        .spawn()
-        .expect("spawn sleep process");
-
-    fs::write(&lock_path, format!("{}\n", sleeper.id())).expect("write lock");
-
     let mut cmd = Command::cargo_bin("hermes").expect("binary exists");
     cmd.env("HERMES_HOME", dir.path());
     cmd.env_remove("HERMES_ALLOW_PARALLEL_INTERACTIVE");
     let assert = cmd.assert().failure();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("Another Hermes interactive session is running"),
-        "expected lock guard error in stderr, got: {stderr:?}"
+        stderr.contains("interactive Hermes requires a terminal (TTY)"),
+        "expected TTY diagnostic in stderr, got: {stderr:?}"
     );
-
-    let _ = sleeper.kill();
-    let _ = sleeper.wait();
+    assert!(
+        stderr.contains("hermes-ultra chat --query"),
+        "expected non-interactive prompt guidance in stderr, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("hermes-ultra doctor --deep --snapshot --bundle"),
+        "expected doctor bundle guidance in stderr, got: {stderr:?}"
+    );
 }
 
 #[test]

--- a/crates/hermes-config/src/python_yaml_compat.rs
+++ b/crates/hermes-config/src/python_yaml_compat.rs
@@ -98,8 +98,14 @@ fn normalize_model_block(map: &mut Mapping) {
                 .and_then(as_str)
                 .map(str::trim)
                 .filter(|s| !s.is_empty());
-            let base_url = m
-                .get(&key("base_url"))
+            let base_url = m.get(&key("base_url")).and_then(normalized_base_url);
+            let api_key = m
+                .get(&key("api_key"))
+                .and_then(as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+            let api_key_env = m
+                .get(&key("api_key_env"))
                 .and_then(as_str)
                 .map(str::trim)
                 .filter(|s| !s.is_empty());
@@ -115,7 +121,9 @@ fn normalize_model_block(map: &mut Mapping) {
             };
             map.insert(model_key, Value::String(model_str));
 
-            if let (Some(p), Some(bu)) = (provider, base_url) {
+            if let Some(p) = provider
+                .filter(|_| base_url.is_some() || api_key.is_some() || api_key_env.is_some())
+            {
                 let llm_key = key("llm_providers");
                 let mut llm = match map.get(&llm_key).cloned() {
                     Some(Value::Mapping(x)) => x,
@@ -125,7 +133,15 @@ fn normalize_model_block(map: &mut Mapping) {
                     .entry(Value::String(p.to_string()))
                     .or_insert_with(|| Value::Mapping(Mapping::new()));
                 if let Value::Mapping(ref mut em) = prov_entry {
-                    em.insert(key("base_url"), Value::String(bu.to_string()));
+                    if let Some(bu) = base_url {
+                        em.insert(key("base_url"), Value::String(bu));
+                    }
+                    if let Some(key_value) = api_key {
+                        em.insert(key("api_key"), Value::String(key_value.to_string()));
+                    }
+                    if let Some(env_name) = api_key_env {
+                        em.insert(key("api_key_env"), Value::String(env_name.to_string()));
+                    }
                 }
                 map.insert(llm_key, Value::Mapping(llm));
             }
@@ -480,6 +496,33 @@ max_turns: 99
         assert_eq!(cfg.max_turns, 99);
         let or = cfg.llm_providers.get("openrouter").expect("openrouter");
         assert_eq!(or.base_url.as_deref(), Some("https://openrouter.ai/api/v1"));
+    }
+
+    #[test]
+    fn python_model_block_lifts_provider_credentials() {
+        let raw = r#"
+model:
+  default: deepseek-chat
+  provider: deepseek
+  base_url: https://api.deepseek.com/
+  api_key: sk-local
+  api_key_env: DEEPSEEK_API_KEY
+"#;
+        let mut root: Value = serde_yaml::from_str(raw).unwrap();
+        let Value::Mapping(ref mut m) = root else {
+            panic!();
+        };
+        normalize_config_yaml_root(m);
+        let cfg: crate::config::GatewayConfig = serde_yaml::from_value(root).unwrap();
+
+        assert_eq!(cfg.model.as_deref(), Some("deepseek:deepseek-chat"));
+        let provider = cfg.llm_providers.get("deepseek").expect("deepseek");
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("https://api.deepseek.com")
+        );
+        assert_eq!(provider.api_key.as_deref(), Some("sk-local"));
+        assert_eq!(provider.api_key_env.as_deref(), Some("DEEPSEEK_API_KEY"));
     }
 
     #[test]

--- a/crates/hermes-intelligence/src/auxiliary/config.rs
+++ b/crates/hermes-intelligence/src/auxiliary/config.rs
@@ -36,7 +36,7 @@ pub struct TaskOverride {
 ///
 /// Typically populated from the user's `config.yaml` `auxiliary` section but
 /// can also be assembled programmatically.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuxiliaryConfig {
     /// Per-task overrides keyed by [`AuxiliaryTask::as_key`].
     #[serde(default)]
@@ -44,6 +44,15 @@ pub struct AuxiliaryConfig {
     /// Whether to consult environment variables. Useful to disable in tests.
     #[serde(default = "default_true")]
     pub consult_env: bool,
+}
+
+impl Default for AuxiliaryConfig {
+    fn default() -> Self {
+        Self {
+            tasks: HashMap::new(),
+            consult_env: true,
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -241,6 +250,12 @@ mod tests {
         assert_eq!(r.provider, "auto");
         assert_eq!(r.model, None);
         assert_eq!(r.timeout, AuxiliaryTask::Title.default_timeout());
+    }
+
+    #[test]
+    fn default_config_consults_env() {
+        assert!(AuxiliaryConfig::default().consult_env);
+        assert!(AuxiliaryConfig::new().consult_env);
     }
 
     #[test]

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-27T08:06:30.743577+00:00",
+  "generated_at_utc": "2026-05-27T19:46:07.710068+00:00",
   "items": [
     {
       "errors": [],
@@ -107,6 +107,30 @@
     },
     {
       "errors": [],
+      "id": "upstream-python-plugin-backend-drift-20260527",
+      "last_reviewed": "2026-05-27",
+      "matched_files": 10,
+      "matched_sample": [
+        "plugins/dashboard_auth/nous/__init__.py",
+        "plugins/dashboard_auth/nous/plugin.yaml",
+        "plugins/image_gen/krea/__init__.py",
+        "plugins/image_gen/krea/plugin.yaml",
+        "plugins/security-guidance/LICENSE",
+        "plugins/security-guidance/NOTICE",
+        "plugins/security-guidance/README.md",
+        "plugins/security-guidance/__init__.py",
+        "plugins/security-guidance/patterns.py",
+        "plugins/security-guidance/plugin.yaml"
+      ],
+      "overdue": false,
+      "owner": "sheawinkler",
+      "review_date": "2026-06-10",
+      "status": "temporary",
+      "ticket": 319,
+      "warnings": []
+    },
+    {
+      "errors": [],
       "id": "upstream-s6-plan-doc-archive",
       "last_reviewed": "2026-05-26",
       "matched_files": 1,
@@ -124,7 +148,7 @@
       "errors": [],
       "id": "rust-cli-tui-primary-ux-surface",
       "last_reviewed": "2026-04-21",
-      "matched_files": 1181,
+      "matched_files": 1182,
       "matched_sample": [
         "ui-tui/.gitignore",
         "ui-tui/.prettierrc",
@@ -157,11 +181,11 @@
   ],
   "summary": {
     "errors": 0,
-    "items": 7,
-    "local_paths": 3275,
+    "items": 8,
+    "local_paths": 3276,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 4095,
+    "upstream_paths": 4138,
     "warnings": 0
   }
 }

--- a/docs/parity/intentional-divergence.json
+++ b/docs/parity/intentional-divergence.json
@@ -79,6 +79,22 @@
       ]
     },
     {
+      "id": "upstream-python-plugin-backend-drift-20260527",
+      "status": "temporary",
+      "workstream": "WS3",
+      "summary": "Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes.",
+      "owner": "sheawinkler",
+      "ticket": 319,
+      "last_reviewed": "2026-05-27",
+      "review_date": "2026-06-10",
+      "rationale": "dashboard_auth/nous, image_gen/krea, and security-guidance were added upstream after this PR branch started. Importing or porting those Python plugin trees is unrelated to the focused #292/#293/#317 fixes and should be handled in a dedicated plugin parity slice.",
+      "path_prefixes": [
+        "plugins/dashboard_auth/nous/",
+        "plugins/image_gen/krea/",
+        "plugins/security-guidance/"
+      ]
+    },
+    {
       "id": "upstream-s6-plan-doc-archive",
       "status": "approved",
       "workstream": "WS7",

--- a/packaging/homebrew/hermes-agent.rb
+++ b/packaging/homebrew/hermes-agent.rb
@@ -26,7 +26,7 @@ class HermesAgentUltra < Formula
 
   def install
     bin.install "hermes" => "hermes-agent-ultra"
-    bin.install_symlink "hermes-agent-ultra" => "hermes"
+    bin.install_symlink "hermes-agent-ultra" => "hermes-ultra"
   end
 
   test do

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -46,7 +46,7 @@ class HermesAgentUltra < Formula
 
   def install
     bin.install "hermes" => "hermes-agent-ultra"
-    bin.install_symlink "hermes-agent-ultra" => "hermes"
+    bin.install_symlink "hermes-agent-ultra" => "hermes-ultra"
   end
 
   test do

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,6 +48,7 @@ HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 CANONICAL_BIN_NAME="${CANONICAL_BIN_NAME:-hermes-agent-ultra}"
 PRIMARY_BIN_NAME="${PRIMARY_BIN_NAME:-hermes-ultra}"
 LEGACY_BIN_NAME="${LEGACY_BIN_NAME:-hermes}"
+INSTALL_LEGACY_ALIAS="${INSTALL_LEGACY_ALIAS:-false}"
 RELEASE_BIN_BASENAME="${RELEASE_BIN_BASENAME:-hermes}"
 RUN_SETUP_MODE="${RUN_SETUP_MODE:-auto}" # auto|always|never
 ROOT_FHS_LAYOUT=false
@@ -83,7 +84,8 @@ Environment variables:
   HERMES_HOME            Hermes config dir for SOUL.md bootstrap (default: $HOME/.hermes)
   CANONICAL_BIN_NAME     Installed binary name (default: hermes-agent-ultra)
   PRIMARY_BIN_NAME       Primary user-facing command symlink (default: hermes-ultra)
-  LEGACY_BIN_NAME        Compatibility alias symlink name (default: hermes)
+  INSTALL_LEGACY_ALIAS   Also install the legacy hermes alias (default: false)
+  LEGACY_BIN_NAME        Compatibility alias symlink name when enabled (default: hermes)
   RELEASE_BIN_BASENAME   Tarball executable basename (default: hermes)
   RUN_SETUP_MODE         auto|always|never for setup flow (default: auto)
 
@@ -235,6 +237,13 @@ prompt_yes_no() {
   esac
 }
 
+truthy_env() {
+  case "${1:-}" in
+    1|true|TRUE|True|yes|YES|Yes|on|ON|On) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 run_post_install_flow() {
   local bin_path="$1"
   local -a clean_python_env=(
@@ -345,7 +354,7 @@ install -m 0755 "${SOURCE_BIN}" "${INSTALL_DIR}/${CANONICAL_BIN_NAME}"
 if [[ "${PRIMARY_BIN_NAME}" != "${CANONICAL_BIN_NAME}" ]]; then
   ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${PRIMARY_BIN_NAME}"
 fi
-if [[ "${LEGACY_BIN_NAME}" != "${CANONICAL_BIN_NAME}" ]]; then
+if truthy_env "${INSTALL_LEGACY_ALIAS}" && [[ -n "${LEGACY_BIN_NAME}" ]] && [[ "${LEGACY_BIN_NAME}" != "${CANONICAL_BIN_NAME}" ]]; then
   ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${LEGACY_BIN_NAME}"
 fi
 
@@ -374,7 +383,7 @@ if command -v "${CANONICAL_BIN_NAME}" >/dev/null 2>&1; then
   if command -v "${PRIMARY_BIN_NAME}" >/dev/null 2>&1; then
     echo "Primary command available: $(command -v "${PRIMARY_BIN_NAME}")"
   fi
-  if command -v "${LEGACY_BIN_NAME}" >/dev/null 2>&1; then
+  if truthy_env "${INSTALL_LEGACY_ALIAS}" && [[ -n "${LEGACY_BIN_NAME}" ]] && command -v "${LEGACY_BIN_NAME}" >/dev/null 2>&1; then
     echo "Legacy alias available: $(command -v "${LEGACY_BIN_NAME}")"
   fi
 else

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -34,3 +34,13 @@ def test_homebrew_formula_has_platform_specific_checksummed_assets():
 
     shas = re.findall(r'sha256 "([0-9a-f]{64})"', formula)
     assert len(shas) == 4
+
+
+def test_homebrew_formula_does_not_clobber_upstream_hermes_command():
+    formula = (REPO_ROOT / "packaging/homebrew/hermes-agent.rb").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'bin.install "hermes" => "hermes-agent-ultra"' in formula
+    assert 'bin.install_symlink "hermes-agent-ultra" => "hermes-ultra"' in formula
+    assert '=> "hermes"' not in formula

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -34,7 +34,17 @@ def test_installer_uses_binary_symlinks_not_python_launcher_wrapper() -> None:
 
     assert 'install -m 0755 "${SOURCE_BIN}" "${INSTALL_DIR}/${CANONICAL_BIN_NAME}"' in text
     assert 'ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${PRIMARY_BIN_NAME}"' in text
+    assert 'INSTALL_LEGACY_ALIAS="${INSTALL_LEGACY_ALIAS:-false}"' in text
+    assert 'truthy_env "${INSTALL_LEGACY_ALIAS}"' in text
     assert 'ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${LEGACY_BIN_NAME}"' in text
     assert 'cat > "$command_link_dir/hermes" <<EOF' not in text
     assert "pip install" not in text
     assert "uv pip install" not in text
+
+
+def test_installer_keeps_legacy_hermes_alias_opt_in() -> None:
+    text = INSTALL_SH.read_text()
+
+    assert 'INSTALL_LEGACY_ALIAS="${INSTALL_LEGACY_ALIAS:-false}"' in text
+    legacy_link = 'ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${LEGACY_BIN_NAME}"'
+    assert text.index('truthy_env "${INSTALL_LEGACY_ALIAS}"') < text.index(legacy_link)

--- a/tests/test_readme_install_contract.py
+++ b/tests/test_readme_install_contract.py
@@ -17,6 +17,8 @@ def test_readme_points_to_ultra_installer() -> None:
         in text
     )
     assert "cargo install --git https://github.com/sheawinkler/hermes-agent-ultra" in text
+    assert "--bin hermes-agent-ultra --bin hermes-ultra" in text
+    assert "--bin hermes\n" not in text
 
 
 def test_readme_documents_rust_primary_runtime() -> None:


### PR DESCRIPTION
## Summary
- harvest only the narrow config compatibility fixes from the external fork proposal
- make the legacy `hermes` install alias opt-in so Ultra coexists with upstream Hermes by default
- improve `hermes`/`hermes-ultra` startup diagnostics and wrapper target ordering for stale-install avoidance

## Deliberately not included
- no workspace/dependency changes
- no CLI structure rewrite
- no audio/voice changes
- no gateway-internal rewrite or WeCom WebSocket import
- no home-dir behavior change

## Validation
- `cargo test -p hermes-config python_model_block -- --nocapture`
- `cargo test -p hermes-intelligence default_config_consults_env -- --nocapture`
- `cargo test -p hermes-intelligence env_override_promoted_when_enabled -- --nocapture`
- `cargo test -p hermes-agent build_default_auxiliary_client_scenarios -- --nocapture`
- `cargo test -p hermes-cli interactive_tty_error_is_actionable -- --nocapture`
- `pytest -q tests/test_homebrew_formula.py tests/test_install_sh_pythonpath_sanitization.py tests/test_readme_install_contract.py`
- `bash -n scripts/install.sh scripts/generate-homebrew-formula.sh`
- `cargo build -p hermes-cli --bin hermes --bin hermes-ultra --bin hermes-agent-ultra`
- no-TTY smoke: debug `hermes`, `hermes-ultra`, and `hermes-agent-ultra` all return the new actionable diagnostic
- version smoke: debug `hermes`, `hermes-ultra`, and `hermes-agent-ultra` all report `hermes-agent-ultra 0.14.2`
- `cargo fmt --all --check`
- `git diff --check`
