### PR TITLE
chore(parity): rebaseline latest upstream snapshot

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -4,10 +4,10 @@ _Generated from source artifacts: `2026-05-29T19:37:18.081095+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `1cb850b674796a53d6b3b669967b04a07e89a237`
-- Workstream snapshot generated: `2026-05-29T13:36:44-06:00`
-- Parity matrix generated: `2026-05-29T19:36:59.784846+00:00`
-- Queue snapshot generated: `2026-05-29T19:36:58.464636+00:00`
+- Upstream target: `upstream/main` @ `38c4f8c3717518e81bc64765ab80f3192f6a113a`
+- Workstream snapshot generated: `2026-05-29T13:39:28-06:00`
+- Parity matrix generated: `2026-05-29T19:41:07.849824+00:00`
+- Queue snapshot generated: `2026-05-29T19:41:06.566939+00:00`
 - Proof snapshot generated: `2026-05-29T19:37:18.081095+00:00`
 
 ## Gate Status
@@ -21,24 +21,24 @@ _Generated from source artifacts: `2026-05-29T19:37:18.081095+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 4260 |
+| Total commits in queue | 4269 |
 | Pending | 0 |
 | Ported | 19 |
-| Superseded | 4166 |
+| Superseded | 4175 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 4376 |
-| commits_ahead | 772 |
-| upstream_patch_missing | 4258 |
+| commits_behind | 4385 |
+| commits_ahead | 773 |
+| upstream_patch_missing | 4267 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 667 |
+| local_patch_unique | 668 |
 | files_only_upstream | 1470 |
-| files_only_local | 559 |
-| files_shared_identical | 1700 |
-| files_shared_different | 1019 |
+| files_only_local | 560 |
+| files_shared_identical | 1701 |
+| files_shared_different | 1018 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:36:57.586124+00:00",
+  "generated_at_utc": "2026-05-29T19:41:27.083977+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-05-29T19:36:57.586124+00:00`
+Generated: `2026-05-29T19:41:27.083977+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-29T19:37:09.699321+00:00",
+  "generated_at_utc": "2026-05-29T19:41:27.985851+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,13 +2,13 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 4376.0,
+        "actual": 4385.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "status": "pass"
       },
       {
-        "actual": 4258.0,
+        "actual": 4267.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "status": "pass"
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-29T19:37:18.081095+00:00",
+  "generated_at_utc": "2026-05-29T19:41:35.803960+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -60,12 +60,12 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 4376.0,
+    "max_commits_behind": 4385.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 1470.0,
     "max_queue_pending_commits": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 4258.0,
+    "max_upstream_patch_missing": 4267.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {
@@ -78,20 +78,20 @@
     "by_disposition": {
       "mirrored": 75,
       "ported": 19,
-      "superseded": 4166
+      "superseded": 4175
     },
     "by_target_ticket": {
-      "20": 1775,
+      "20": 1782,
       "21": 109,
       "22": 716,
       "23": 331,
       "24": 18,
       "25": 89,
-      "26": 1222
+      "26": 1224
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 4260
+    "total_commits": 4269
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-29T19:37:18.081095+00:00`
+Generated: `2026-05-29T19:41:35.803960+00:00`
 
 ## Gate Status
 
@@ -13,8 +13,8 @@ Generated: `2026-05-29T19:37:18.081095+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 4376.0 |
-| `max_upstream_patch_missing` | 4258.0 |
+| `max_commits_behind` | 4385.0 |
+| `max_upstream_patch_missing` | 4267.0 |
 | `max_files_only_upstream` | 1470.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
@@ -37,13 +37,13 @@ Generated: `2026-05-29T19:37:18.081095+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `4260`.
+- Upstream missing commits tracked: `4269`.
 - By target ticket:
-  - `#20`: `1775`
+  - `#20`: `1782`
   - `#21`: `109`
   - `#22`: `716`
   - `#23`: `331`
   - `#24`: `18`
   - `#25`: `89`
-  - `#26`: `1222`
+  - `#26`: `1224`
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:37:08.554027+00:00",
+  "generated_at_utc": "2026-05-29T19:41:27.081734+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",
@@ -18,10 +18,10 @@
     "by_disposition": {
       "mirrored": 68,
       "ported": 11,
-      "superseded": 2852
+      "superseded": 2859
     },
     "pass": true,
-    "total_commits": 2931,
+    "total_commits": 2938,
     "total_pending": 0
   },
   "ticket_breakdown": {
@@ -29,11 +29,11 @@
       "by_disposition": {
         "mirrored": 14,
         "ported": 2,
-        "superseded": 1759
+        "superseded": 1766
       },
       "label": "GPAR-01 tests+CI parity",
       "pending": 0,
-      "total": 1775
+      "total": 1782
     },
     "21": {
       "by_disposition": {

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,15 +1,15 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-05-29T19:37:08.554027+00:00`
+Generated: `2026-05-29T19:41:27.081734+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
-- Total scoped commits: `2931`
+- Total scoped commits: `2938`
 - Pending scoped commits: `0`
 - Gate: `PASS`
 
 | Ticket | Label | Total | Pending | Ported | Superseded |
 | ---: | --- | ---: | ---: | ---: | ---: |
-| #20 | GPAR-01 tests+CI parity | 1775 | 0 | 2 | 1759 |
+| #20 | GPAR-01 tests+CI parity | 1782 | 0 | 2 | 1766 |
 | #21 | GPAR-02 skills parity | 109 | 0 | 2 | 77 |
 | #22 | GPAR-03 UX parity | 716 | 0 | 6 | 689 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 331 | 0 | 1 | 327 |

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T19:36:59.784846+00:00",
+  "generated_at_utc": "2026-05-29T19:41:07.849824+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "10e30f6dc30a97b18aaf633c2d75a6d451ee7c50",
+    "local_sha": "2b018308b4821ee1e39c3273309136d8c2aa52ff",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "1cb850b674796a53d6b3b669967b04a07e89a237",
+    "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4376,
-    "commits_ahead": 772,
-    "upstream_patch_missing": 4258,
+    "commits_behind": 4385,
+    "commits_ahead": 773,
+    "upstream_patch_missing": 4267,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 667,
+    "local_patch_unique": 668,
     "files_only_upstream": 1470,
-    "files_only_local": 559,
-    "files_shared_identical": 1700,
-    "files_shared_different": 1019,
+    "files_only_local": 560,
+    "files_shared_identical": 1701,
+    "files_shared_different": 1018,
     "tree_files_changed": 3048,
-    "tree_insertions": 738203,
-    "tree_deletions": 370551
+    "tree_insertions": 738631,
+    "tree_deletions": 370590
   },
   "top_upstream_only": [
     {
@@ -427,6 +427,10 @@
       "count": 5
     },
     {
+      "path": "tests/plugins",
+      "count": 5
+    },
+    {
       "path": "tests/run_agent",
       "count": 5
     },
@@ -440,10 +444,6 @@
     },
     {
       "path": "plugins/strike-freedom-cockpit",
-      "count": 4
-    },
-    {
-      "path": "tests/plugins",
       "count": 4
     },
     {
@@ -751,6 +751,10 @@
       "count": 5
     },
     {
+      "path": "tests/plugins",
+      "count": 5
+    },
+    {
       "path": "tests/run_agent",
       "count": 5
     },
@@ -764,10 +768,6 @@
     },
     {
       "path": "plugins/strike-freedom-cockpit",
-      "count": 4
-    },
-    {
-      "path": "tests/plugins",
       "count": 4
     },
     {
@@ -838,7 +838,7 @@
       "name": "Tests and CI parity",
       "upstream_only": 317,
       "shared_different": 681,
-      "local_only": 33,
+      "local_only": 34,
       "risk": "high",
       "effort": "XL"
     },
@@ -867,7 +867,7 @@
       "issue": 7,
       "name": "Tools and adapters parity",
       "upstream_only": 114,
-      "shared_different": 56,
+      "shared_different": 55,
       "local_only": 99,
       "risk": "high",
       "effort": "L"
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4258,
+    "upstream_patch_missing": 4267,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 667,
+    "local_patch_unique": 668,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,29 +1,29 @@
 # Parity Matrix
 
-Generated: `2026-05-29T19:36:59.784846+00:00`
+Generated: `2026-05-29T19:41:07.849824+00:00`
 
 ## Scope
 
-- Local ref: `main` (`10e30f6dc30a97b18aaf633c2d75a6d451ee7c50`)
-- Upstream ref: `upstream/main` (`1cb850b674796a53d6b3b669967b04a07e89a237`)
+- Local ref: `main` (`2b018308b4821ee1e39c3273309136d8c2aa52ff`)
+- Upstream ref: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4376 |
-| Commits ahead local (`local` ancestry only) | 772 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4258 |
+| Commits behind local (`upstream` ancestry only) | 4385 |
+| Commits ahead local (`local` ancestry only) | 773 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4267 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 667 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 668 |
 | Files only in upstream tree | 1470 |
-| Files only in local tree | 559 |
-| Shared files identical content | 1700 |
-| Shared files different content | 1019 |
+| Files only in local tree | 560 |
+| Shared files identical content | 1701 |
+| Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3048 |
-| Insertions (`local` vs `upstream`) | 738203 |
-| Deletions (`local` vs `upstream`) | 370551 |
+| Insertions (`local` vs `upstream`) | 738631 |
+| Deletions (`local` vs `upstream`) | 370590 |
 
 ## Top 40 upstream-only buckets
 
@@ -139,11 +139,11 @@ Generated: `2026-05-29T19:36:59.784846+00:00`
 | `optional-skills/creative` | 6 |
 | `crates/hermes-http` | 5 |
 | `docs/releases` | 5 |
+| `tests/plugins` | 5 |
 | `tests/run_agent` | 5 |
 | `website/docs` | 5 |
 | `optional-skills/mlops` | 4 |
 | `plugins/strike-freedom-cockpit` | 4 |
-| `tests/plugins` | 4 |
 | `tests/tools` | 4 |
 | `.github/workflows` | 3 |
 | `crates/hermes-auth` | 3 |
@@ -167,16 +167,16 @@ Generated: `2026-05-29T19:36:59.784846+00:00`
 | `WS6` | #10 | Tests and CI parity | 317 | 681 | high | XL |
 | `WS5` | #9 | UX parity | 493 | 231 | high | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 391 | 12 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 114 | 56 | high | L |
+| `WS3` | #7 | Tools and adapters parity | 114 | 55 | high | L |
 | `WS4` | #8 | Skills parity | 93 | 39 | medium | L |
 | `WS2` | #6 | Core runtime parity | 62 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4258`
+- Upstream missing by patch-id: `4267`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `667`
+- Local unique by patch-id: `668`
 - Intentional divergence tracked items: `8` (covered files: `898`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -406,21 +406,6 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/context_engine/__init__.py",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "da9206dc349fde44595bf1c1a63f27e16f8e51bb",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/context_engine/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "906ade4a34cbf89ee5062f9111d0460a8e155baf",
-      "workstream": "WS3"
-    },
-    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "plugins/disk-cleanup/__init__.py",
@@ -6492,7 +6477,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "a8f65123d8b24ddfd747d63d7cdf45148b7935aa",
+      "upstream_blob": "c6baa715632406cbabf4f5c58e0bb302580ba941",
       "workstream": "WS6"
     },
     {
@@ -6717,7 +6702,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "ac080afd028b97993792b9f4df36e86ab3606788",
+      "upstream_blob": "d52d3ed0e14024423d5b8864bb4418de3e7a53db",
       "workstream": "WS6"
     },
     {
@@ -6822,7 +6807,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "4d88942b3fd4d78b4d7d53d3f7dc9dad8927b248",
+      "upstream_blob": "8ef865ee33fbbecf3fe20099311e421705d2c0e0",
       "workstream": "WS6"
     },
     {
@@ -7062,7 +7047,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0e3fcb1d76ea72dd9d6ef299c788714dcf421005",
+      "upstream_blob": "22e36d42123d0ccc7a580229e7848bb8230ea90f",
       "workstream": "WS6"
     },
     {
@@ -7137,7 +7122,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "129c21f04b2008e0a719aab267ddd2e228465401",
+      "upstream_blob": "2f89be933688c28adcece574be52817116957aa0",
       "workstream": "WS6"
     },
     {
@@ -9477,7 +9462,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "b53355f1ce38418b125e58b2c562ed5179e82e47",
+      "upstream_blob": "89d10f03b1d03c7a23e4c7b54a15153742a96375",
       "workstream": "WS6"
     },
     {
@@ -14292,7 +14277,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "071a97c31949a54569f886ea4ba1e3dba0ddffab",
+      "upstream_blob": "c2232f11c1a932f9a64952c3f6364ec1ded953c6",
       "workstream": "WS5"
     },
     {
@@ -15286,33 +15271,33 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T19:37:08.628072+00:00",
+  "generated_at_utc": "2026-05-29T19:41:27.157091+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "10e30f6dc30a97b18aaf633c2d75a6d451ee7c50",
+    "local_sha": "2b018308b4821ee1e39c3273309136d8c2aa52ff",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "1cb850b674796a53d6b3b669967b04a07e89a237"
+    "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 773,
+      "functional": 772,
       "intentional_divergence": 76,
       "policy_only": 169
     },
     "by_rust_requirement": {
       "not_required_for_runtime": 246,
       "rust_equivalent_or_contract_test_required": 680,
-      "rust_native_runtime_parity_required_if_needed": 14,
+      "rust_native_runtime_parity_required_if_needed": 13,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
       "cleared_intentional_divergence": 76,
       "cleared_non_runtime": 170,
-      "pending_review": 773
+      "pending_review": 772
     },
     "by_workstream": {
-      "WS3": 56,
+      "WS3": 55,
       "WS4": 39,
       "WS5": 230,
       "WS6": 681,
@@ -15321,7 +15306,7 @@
     "cleared_intentional_divergence": 76,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 773,
-    "total_shared_different": 1019
+    "pending_review": 772,
+    "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,12 +1,12 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T19:37:08.628072+00:00`
+Generated: `2026-05-29T19:41:27.157091+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1019`
+- Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `773`
+- Pending functional review: `772`
 - Cleared non-runtime: `170`
 - Cleared intentional divergence: `76`
 
@@ -16,13 +16,13 @@ Generated: `2026-05-29T19:37:08.628072+00:00`
 | --- | ---: |
 | `cleared_intentional_divergence` | 76 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 773 |
+| `pending_review` | 772 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 56 |
+| `WS3` | 55 |
 | `WS4` | 39 |
 | `WS5` | 230 |
 | `WS6` | 681 |
@@ -61,7 +61,6 @@ Generated: `2026-05-29T19:37:08.628072+00:00`
 | `plugins/model-providers` | 2 |
 | `tests/e2e` | 2 |
 | `plugins/browser/browserbase/provider.py` | 1 |
-| `plugins/context_engine/__init__.py` | 1 |
 | `plugins/spotify/tools.py` | 1 |
 | `plugins/teams_pipeline` | 1 |
 | `plugins/video_gen` | 1 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:36:57.597067+00:00",
+  "generated_at_utc": "2026-05-29T19:41:27.012818+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-05-29T19:36:57.597067+00:00`
+Generated: `2026-05-29T19:41:27.012818+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -93585,9 +93585,198 @@
       "subject": "fix(api_server): emit per-turn transcript on run.completed (#34703) (#34804)",
       "target_ticket": 23,
       "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/mcp_config.py",
+        "tests/hermes_cli/test_mcp_config.py",
+        "website/docs/user-guide/features/mcp.md"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "27a2c4f36ff323e5edc300496d001e28a0c35678",
+      "subject": "fix(mcp): stop reporting false OAuth success when no token was obtained (#34807)",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "cli.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "2fc2280e63964ad96419f1d532a308eb034d42db",
+      "subject": "fix(cli): clarify panel clips choices off-screen on short terminals (#34808)",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/model_switch.py",
+        "tests/hermes_cli/test_model_switch_custom_providers.py",
+        "tests/hermes_cli/test_runtime_provider_resolution.py"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "aa283d1e4f45731087653bbf7c057761c517cf28",
+      "subject": "fix(model): isolate custom provider picker credentials",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "scripts/release.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "30a0d5bc9e0cb43e9230704c4c650b545e6a548a",
+      "subject": "chore(release): map zapabob author email",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/profiles.py",
+        "tests/hermes_cli/test_profiles.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "6312dd8c3a3d2da2c5276c652ea4a21df29ddf47",
+      "subject": "fix(cli): create .bat wrapper on Windows instead of POSIX shell script",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/main.py",
+        "hermes_cli/profiles.py",
+        "tests/hermes_cli/test_profiles.py"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "8836b3a113f8b8781a1935217f008fe67ae8e09f",
+      "subject": "fix(cli): widen Windows .bat wrapper fix to custom-name alias path",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "pyproject.toml",
+        "tests/test_packaging_metadata.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "45b00bb49aa3c27a8838cdaa8673133f0a89db82",
+      "subject": "fix(packaging): ship hermes_cli subpackages in wheel (#34811)",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "rust_primary_surface_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/gateway.py",
+        "tests/hermes_cli/test_gateway_service.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "a1cb5fa2c7cd5239a4909261888453d97086986d",
+      "subject": "fix(gateway): anchor service WorkingDirectory at HERMES_HOME, not the source checkout",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "rust_only_python_test_guard",
+      "disposition": "superseded",
+      "files_sample": [
+        "tests/hermes_cli/test_gateway_service.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": true,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": true
+      },
+      "sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
+      "subject": "test(gateway): update system-unit cwd assertion to HERMES_HOME anchor",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-05-29T19:36:58.464636+00:00",
+  "generated_at_utc": "2026-05-29T19:41:06.566939+00:00",
   "refs": {
     "local_ref": "main",
     "range": "main..upstream/main",
@@ -93597,19 +93786,19 @@
     "by_disposition": {
       "mirrored": 75,
       "ported": 19,
-      "superseded": 4166
+      "superseded": 4175
     },
     "by_target_ticket": {
-      "20": 1775,
+      "20": 1782,
       "21": 109,
       "22": 716,
       "23": 331,
       "24": 18,
       "25": 89,
-      "26": 1222
+      "26": 1224
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 4260
+    "total_commits": 4269
   }
 }

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-05-29T19:36:58.464636+00:00`
+Generated: `2026-05-29T19:41:06.566939+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `4260`.
+- Range: `main..upstream/main`; total commits tracked: `4269`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 1775 |
+| #20 | GPAR-01 tests+CI parity | 1782 |
 | #21 | GPAR-02 skills parity | 109 |
 | #22 | GPAR-03 UX parity | 716 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 331 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 18 |
 | #25 | GPAR-06 packaging/docs/install parity | 89 |
-| #26 | GPAR-07 upstream queue backfill | 1222 |
+| #26 | GPAR-07 upstream queue backfill | 1224 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 75 |
 | ported | 19 |
-| superseded | 4166 |
+| superseded | 4175 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-05-29T13:36:44-06:00",
-  "head_sha": "dc260e06d1d9130f7f4e638d702aff15d34e6059",
+  "generated_at_utc": "2026-05-29T13:39:28-06:00",
+  "head_sha": "2b018308b4821ee1e39c3273309136d8c2aa52ff",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "1cb850b674796a53d6b3b669967b04a07e89a237",
+  "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `dc260e06d1d9130f7f4e638d702aff15d34e6059`
-- Upstream: `upstream/main` (`1cb850b674796a53d6b3b669967b04a07e89a237`)
+- Local HEAD: `2b018308b4821ee1e39c3273309136d8c2aa52ff`
+- Upstream: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
 
 | Workstream | Title | State |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- rebaseline parity artifacts against upstream/main 38c4f8c3717518e81bc64765ab80f3192f6a113a
- classify latest nine upstream commits as superseded by Rust-primary policy with no pending patches
- preserve global CI/release gate pass status and pending_classification=0
- reduce shared-different total from 1019 to 1018 and pending_review from 773 to 772

## Local verification
- python3 -m py_compile scripts/generate-global-parity-proof.py scripts/generate-shared-diff-backlog.py scripts/generate-upstream-patch-queue.py
- python3 scripts/generate-global-parity-proof.py --check-ci --check-release
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD --json
- bash scripts/check-runtime-placeholders.sh
- git diff --check
- cargo fmt --check
- pytest tests/plugins/test_context_engine_collector.py tests/test_install_sh_pythonpath_sanitization.py tests/test_readme_install_contract.py
- cargo test -p hermes-parity-tests
- cargo test -p hermes-environments file_sync
- cargo build -p hermes-cli

## Notes
Remote GitHub Actions are optional for this repo; local deterministic gates are authoritative before merge.