### PR TITLE
fix(openrouter): restore session id sticky routing

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-05-29T19:37:18.081095+00:00`_
+_Generated from source artifacts: `2026-05-29T19:55:49.284559+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `38c4f8c3717518e81bc64765ab80f3192f6a113a`
-- Workstream snapshot generated: `2026-05-29T13:39:28-06:00`
-- Parity matrix generated: `2026-05-29T19:41:07.849824+00:00`
-- Queue snapshot generated: `2026-05-29T19:41:06.566939+00:00`
-- Proof snapshot generated: `2026-05-29T19:37:18.081095+00:00`
+- Workstream snapshot generated: `2026-05-29T13:51:55-06:00`
+- Parity matrix generated: `2026-05-29T19:55:29.103698+00:00`
+- Queue snapshot generated: `2026-05-29T19:52:06.892187+00:00`
+- Proof snapshot generated: `2026-05-29T19:55:49.284559+00:00`
 
 ## Gate Status
 
@@ -31,14 +31,14 @@ _Generated from source artifacts: `2026-05-29T19:37:18.081095+00:00`_
 | Metric | Value |
 | --- | ---: |
 | commits_behind | 4385 |
-| commits_ahead | 773 |
+| commits_ahead | 775 |
 | upstream_patch_missing | 4267 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 668 |
+| local_patch_unique | 670 |
 | files_only_upstream | 1470 |
 | files_only_local | 560 |
-| files_shared_identical | 1701 |
-| files_shared_different | 1018 |
+| files_shared_identical | 1702 |
+| files_shared_different | 1017 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:41:27.083977+00:00",
+  "generated_at_utc": "2026-05-29T19:52:13.889102+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-05-29T19:41:27.083977+00:00`
+Generated: `2026-05-29T19:52:13.889102+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-29T19:41:27.985851+00:00",
+  "generated_at_utc": "2026-05-29T19:55:46.567903+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-29T19:41:35.803960+00:00",
+  "generated_at_utc": "2026-05-29T19:55:49.284559+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-29T19:41:35.803960+00:00`
+Generated: `2026-05-29T19:55:49.284559+00:00`
 
 ## Gate Status
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:41:27.081734+00:00",
+  "generated_at_utc": "2026-05-29T19:55:42.899656+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,6 +1,6 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-05-29T19:41:27.081734+00:00`
+Generated: `2026-05-29T19:55:42.899656+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
 - Total scoped commits: `2938`

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T19:41:07.849824+00:00",
+  "generated_at_utc": "2026-05-29T19:55:29.103698+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "2b018308b4821ee1e39c3273309136d8c2aa52ff",
+    "local_ref": "HEAD",
+    "local_sha": "d48f4bab48a69f776ba0062b610904de89a8b15b",
     "upstream_ref": "upstream/main",
     "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4385,
-    "commits_ahead": 773,
+    "commits_ahead": 775,
     "upstream_patch_missing": 4267,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 668,
+    "local_patch_unique": 670,
     "files_only_upstream": 1470,
     "files_only_local": 560,
-    "files_shared_identical": 1701,
-    "files_shared_different": 1018,
-    "tree_files_changed": 3048,
-    "tree_insertions": 738631,
-    "tree_deletions": 370590
+    "files_shared_identical": 1702,
+    "files_shared_different": 1017,
+    "tree_files_changed": 3047,
+    "tree_insertions": 738629,
+    "tree_deletions": 370787
   },
   "top_upstream_only": [
     {
@@ -253,12 +253,12 @@
       "count": 7
     },
     {
-      "path": "plugins/model-providers",
+      "path": "tests/skills",
       "count": 6
     },
     {
-      "path": "tests/skills",
-      "count": 6
+      "path": "plugins/model-providers",
+      "count": 5
     },
     {
       "path": "plugins/teams_pipeline",
@@ -867,7 +867,7 @@
       "issue": 7,
       "name": "Tools and adapters parity",
       "upstream_only": 114,
-      "shared_different": 55,
+      "shared_different": 54,
       "local_only": 99,
       "risk": "high",
       "effort": "L"
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4267,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 668,
+    "local_patch_unique": 670,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-29T19:41:07.849824+00:00`
+Generated: `2026-05-29T19:55:29.103698+00:00`
 
 ## Scope
 
-- Local ref: `main` (`2b018308b4821ee1e39c3273309136d8c2aa52ff`)
+- Local ref: `HEAD` (`d48f4bab48a69f776ba0062b610904de89a8b15b`)
 - Upstream ref: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-29T19:41:07.849824+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4385 |
-| Commits ahead local (`local` ancestry only) | 773 |
+| Commits ahead local (`local` ancestry only) | 775 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4267 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 668 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 670 |
 | Files only in upstream tree | 1470 |
 | Files only in local tree | 560 |
-| Shared files identical content | 1701 |
-| Shared files different content | 1018 |
-| Total files changed (`local` vs `upstream`) | 3048 |
-| Insertions (`local` vs `upstream`) | 738631 |
-| Deletions (`local` vs `upstream`) | 370590 |
+| Shared files identical content | 1702 |
+| Shared files different content | 1017 |
+| Total files changed (`local` vs `upstream`) | 3047 |
+| Insertions (`local` vs `upstream`) | 738629 |
+| Deletions (`local` vs `upstream`) | 370787 |
 
 ## Top 40 upstream-only buckets
 
@@ -91,8 +91,8 @@ Generated: `2026-05-29T19:41:07.849824+00:00`
 | `plugins/platforms` | 9 |
 | `tests/acp` | 8 |
 | `skills/productivity` | 7 |
-| `plugins/model-providers` | 6 |
 | `tests/skills` | 6 |
+| `plugins/model-providers` | 5 |
 | `plugins/teams_pipeline` | 5 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |
@@ -167,7 +167,7 @@ Generated: `2026-05-29T19:41:07.849824+00:00`
 | `WS6` | #10 | Tests and CI parity | 317 | 681 | high | XL |
 | `WS5` | #9 | UX parity | 493 | 231 | high | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 391 | 12 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 114 | 55 | high | L |
+| `WS3` | #7 | Tools and adapters parity | 114 | 54 | high | L |
 | `WS4` | #8 | Skills parity | 93 | 39 | medium | L |
 | `WS2` | #6 | Core runtime parity | 62 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
@@ -176,7 +176,7 @@ Generated: `2026-05-29T19:41:07.849824+00:00`
 
 - Upstream missing by patch-id: `4267`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `668`
+- Local unique by patch-id: `670`
 - Intentional divergence tracked items: `8` (covered files: `898`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -856,21 +856,6 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/model-providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "d1bf10de11da604cee02b3f2f0db28315073e2ba",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/model-providers/openrouter/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "1b464b42e828b6bb7d075b217ba9cb2693f9882e",
-      "workstream": "WS3"
-    },
-    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "plugins/observability/langfuse/README.md",
@@ -15271,33 +15256,33 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T19:41:27.157091+00:00",
+  "generated_at_utc": "2026-05-29T19:55:35.356167+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "2b018308b4821ee1e39c3273309136d8c2aa52ff",
+    "local_ref": "HEAD",
+    "local_sha": "d48f4bab48a69f776ba0062b610904de89a8b15b",
     "upstream_ref": "upstream/main",
     "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 772,
+      "functional": 771,
       "intentional_divergence": 76,
       "policy_only": 169
     },
     "by_rust_requirement": {
       "not_required_for_runtime": 246,
       "rust_equivalent_or_contract_test_required": 680,
-      "rust_native_runtime_parity_required_if_needed": 13,
+      "rust_native_runtime_parity_required_if_needed": 12,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
       "cleared_intentional_divergence": 76,
       "cleared_non_runtime": 170,
-      "pending_review": 772
+      "pending_review": 771
     },
     "by_workstream": {
-      "WS3": 55,
+      "WS3": 54,
       "WS4": 39,
       "WS5": 230,
       "WS6": 681,
@@ -15306,7 +15291,7 @@
     "cleared_intentional_divergence": 76,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 772,
-    "total_shared_different": 1018
+    "pending_review": 771,
+    "total_shared_different": 1017
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,12 +1,12 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T19:41:27.157091+00:00`
+Generated: `2026-05-29T19:55:35.356167+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1018`
+- Total shared-different paths: `1017`
 - Pending classification: `0`
-- Pending functional review: `772`
+- Pending functional review: `771`
 - Cleared non-runtime: `170`
 - Cleared intentional divergence: `76`
 
@@ -16,13 +16,13 @@ Generated: `2026-05-29T19:41:27.157091+00:00`
 | --- | ---: |
 | `cleared_intentional_divergence` | 76 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 772 |
+| `pending_review` | 771 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 55 |
+| `WS3` | 54 |
 | `WS4` | 39 |
 | `WS5` | 230 |
 | `WS6` | 681 |
@@ -58,9 +58,9 @@ Generated: `2026-05-29T19:41:27.157091+00:00`
 | `plugins/memory` | 3 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
-| `plugins/model-providers` | 2 |
 | `tests/e2e` | 2 |
 | `plugins/browser/browserbase/provider.py` | 1 |
+| `plugins/model-providers` | 1 |
 | `plugins/spotify/tools.py` | 1 |
 | `plugins/teams_pipeline` | 1 |
 | `plugins/video_gen` | 1 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:41:27.012818+00:00",
+  "generated_at_utc": "2026-05-29T19:52:11.671295+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-05-29T19:41:27.012818+00:00`
+Generated: `2026-05-29T19:52:11.671295+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -93587,7 +93587,7 @@
       "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "hermes_cli/mcp_config.py",
@@ -93609,7 +93609,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "cli.py"
@@ -93629,7 +93629,7 @@
       "target_ticket_name": "GPAR-07 upstream queue backfill"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "hermes_cli/model_switch.py",
@@ -93651,7 +93651,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "scripts/release.py"
@@ -93671,7 +93671,7 @@
       "target_ticket_name": "GPAR-07 upstream queue backfill"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "hermes_cli/profiles.py",
@@ -93692,7 +93692,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "hermes_cli/main.py",
@@ -93714,7 +93714,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "pyproject.toml",
@@ -93735,7 +93735,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
-      "classification_rule": "rust_primary_surface_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "hermes_cli/gateway.py",
@@ -93756,7 +93756,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     },
     {
-      "classification_rule": "rust_only_python_test_guard",
+      "classification_rule": "prior_state",
       "disposition": "superseded",
       "files_sample": [
         "tests/hermes_cli/test_gateway_service.py"
@@ -93776,7 +93776,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-05-29T19:41:06.566939+00:00",
+  "generated_at_utc": "2026-05-29T19:52:06.892187+00:00",
   "refs": {
     "local_ref": "main",
     "range": "main..upstream/main",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-05-29T19:41:06.566939+00:00`
+Generated: `2026-05-29T19:52:06.892187+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `4269`.
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,6 +1,6 @@
 {
-  "generated_at_utc": "2026-05-29T13:39:28-06:00",
-  "head_sha": "2b018308b4821ee1e39c3273309136d8c2aa52ff",
+  "generated_at_utc": "2026-05-29T13:51:55-06:00",
+  "head_sha": "d48f4bab48a69f776ba0062b610904de89a8b15b",
   "states": {
     "complete": 7
   },

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,6 +1,6 @@
 # Workstream Status
 
-- Local HEAD: `2b018308b4821ee1e39c3273309136d8c2aa52ff`
+- Local HEAD: `d48f4bab48a69f776ba0062b610904de89a8b15b`
 - Upstream: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
 
 | Workstream | Title | State |

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -43,6 +43,8 @@ class OpenRouterProfile(ProviderProfile):
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
         body: dict[str, Any] = {}
+        if session_id:
+            body["session_id"] = session_id
         prefs = context.get("provider_preferences")
         if prefs:
             body["provider"] = prefs

--- a/tests/test_ws3_model_provider_contracts.py
+++ b/tests/test_ws3_model_provider_contracts.py
@@ -120,6 +120,30 @@ def test_xiaomi_disables_dedicated_health_check() -> None:
     assert profile.supports_health_check is False
 
 
+def test_openrouter_session_id_sticky_routing_matches_upstream_contract() -> None:
+    _module, registered = _load_provider(
+        "plugins/model-providers/openrouter/__init__.py",
+        "_ws3_openrouter_provider",
+    )
+    (profile,) = registered
+
+    body = profile.build_extra_body(session_id="sess-abc123")
+    assert body == {"session_id": "sess-abc123"}
+
+    body = profile.build_extra_body(
+        session_id="sess-abc123",
+        provider_preferences={"allow": ["anthropic"]},
+    )
+    assert body["session_id"] == "sess-abc123"
+    assert body["provider"] == {"allow": ["anthropic"]}
+
+    _extra_body, top_level = profile.build_api_kwargs_extras(
+        model="x-ai/grok-4",
+        session_id="sess-abc123",
+    )
+    assert top_level["extra_headers"]["x-grok-conv-id"] == "sess-abc123"
+
+
 def test_local_model_provider_deltas_remain_exact_and_documented() -> None:
     azure_profile = _read("plugins/model-providers/azure-foundry/__init__.py")
     azure_manifest = _read("plugins/model-providers/azure-foundry/plugin.yaml")


### PR DESCRIPTION
## Summary
- restore OpenRouter `session_id` forwarding in `extra_body` for sticky routing parity with upstream
- add a self-contained WS3 provider contract covering OpenRouter sticky routing plus existing Grok affinity header behavior
- refresh parity artifacts; shared-diff backlog drops from 1018 to 1017 and WS3 pending review drops from 55 to 54

## Local verification
- `python3 -m py_compile plugins/model-providers/openrouter/__init__.py tests/test_ws3_model_provider_contracts.py scripts/generate-global-parity-proof.py scripts/generate-shared-diff-backlog.py scripts/generate-upstream-patch-queue.py`
- `pytest tests/test_ws3_model_provider_contracts.py -q`
- `python3 scripts/generate-global-parity-proof.py --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof-openrouter.json --out-md /tmp/hermes-agent-ultra-global-parity-proof-openrouter.md`
- `bash scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json`
- `python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD --json`
- `cargo fmt --check`
- `pytest tests/plugins/test_context_engine_collector.py tests/test_install_sh_pythonpath_sanitization.py tests/test_readme_install_contract.py -q`
- `cargo test -p hermes-parity-tests`
- `cargo test -p hermes-environments file_sync`
- `cargo build -p hermes-cli`

Remote GitHub CI is optional for this repo; local deterministic gates above are authoritative.