### PR TITLE
fix(hindsight): honor recall types in rust provider

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -23,6 +23,7 @@ use crate::memory_manager::MemoryProviderPlugin;
 
 const DEFAULT_API_URL: &str = "https://api.hindsight.vectorize.io";
 const DEFAULT_LOCAL_URL: &str = "http://localhost:8888";
+const DEFAULT_RECALL_TYPE: &str = "observation";
 const VALID_BUDGETS: &[&str] = &["low", "mid", "high"];
 
 // ---------------------------------------------------------------------------
@@ -92,6 +93,7 @@ struct HindsightConfig {
     retain_context: String,
     recall_max_tokens: usize,
     recall_max_input_chars: usize,
+    recall_types: Vec<String>,
     recall_prompt_preamble: String,
     bank_mission: String,
     retain_async: bool,
@@ -115,6 +117,7 @@ impl HindsightConfig {
             retain_context: "conversation between Hermes Agent and the User".into(),
             recall_max_tokens: 4096,
             recall_max_input_chars: 800,
+            recall_types: default_recall_types(),
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
@@ -204,6 +207,9 @@ impl HindsightConfig {
                 }
                 if let Some(mic) = raw.get("recall_max_input_chars").and_then(|v| v.as_u64()) {
                     config.recall_max_input_chars = mic as usize;
+                }
+                if let Some(types) = raw.get("recall_types").and_then(parse_recall_types_value) {
+                    config.recall_types = types;
                 }
                 if let Some(p) = raw.get("recall_prompt_preamble").and_then(|v| v.as_str()) {
                     config.recall_prompt_preamble = p.to_string();
@@ -436,6 +442,7 @@ impl MemoryProviderPlugin for HindsightPlugin {
                     &q,
                     &cfg.budget,
                     cfg.recall_max_tokens,
+                    &cfg.recall_types,
                 ) {
                     Ok(t) => t,
                     Err(e) => {
@@ -579,6 +586,7 @@ impl MemoryProviderPlugin for HindsightPlugin {
                     query,
                     &cfg.budget,
                     cfg.recall_max_tokens,
+                    &cfg.recall_types,
                 ) {
                     Ok(text) if !text.is_empty() => json!({"result": text}).to_string(),
                     Ok(_) => json!({"result": "No relevant memories found."}).to_string(),
@@ -621,6 +629,7 @@ impl MemoryProviderPlugin for HindsightPlugin {
             {"key": "bank_id_template", "description": "Optional dynamic bank template with placeholders: {profile}, {workspace}, {platform}, {user}, {session}", "default": ""},
             {"key": "hindsight_timeout", "description": "HTTP timeout in seconds", "default": 90},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
+            {"key": "recall_types", "description": "Fact types returned by recall", "default": DEFAULT_RECALL_TYPE},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]}
         ]))
     }
@@ -689,6 +698,57 @@ fn resolve_bank_id_template(
     }
 }
 
+fn default_recall_types() -> Vec<String> {
+    vec![DEFAULT_RECALL_TYPE.to_string()]
+}
+
+fn parse_recall_types_str(value: &str) -> Option<Vec<String>> {
+    let types: Vec<String> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    if types.is_empty() {
+        None
+    } else {
+        Some(types)
+    }
+}
+
+fn parse_recall_types_value(value: &Value) -> Option<Vec<String>> {
+    if let Some(text) = value.as_str() {
+        return parse_recall_types_str(text);
+    }
+    let items = value.as_array()?;
+    let types: Vec<String> = items
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    if types.is_empty() {
+        None
+    } else {
+        Some(types)
+    }
+}
+
+fn hindsight_recall_body(
+    query: &str,
+    budget: &str,
+    max_tokens: usize,
+    recall_types: &[String],
+) -> Value {
+    json!({
+        "query": query,
+        "budget": budget,
+        "max_tokens": max_tokens,
+        "types": recall_types,
+    })
+}
+
 fn hindsight_recall(
     client: &Client,
     base: &str,
@@ -697,13 +757,10 @@ fn hindsight_recall(
     query: &str,
     budget: &str,
     max_tokens: usize,
+    recall_types: &[String],
 ) -> Result<String, String> {
     let url = format!("{}/v1/default/banks/{}/memories/recall", base, bank);
-    let body = json!({
-        "query": query,
-        "budget": budget,
-        "max_tokens": max_tokens,
-    });
+    let body = hindsight_recall_body(query, budget, max_tokens, recall_types);
     let mut req = client.post(&url).json(&body);
     if !api_key.is_empty() {
         req = req.bearer_auth(api_key);
@@ -841,6 +898,7 @@ mod tests {
             retain_context: String::new(),
             recall_max_tokens: 4096,
             recall_max_input_chars: 800,
+            recall_types: default_recall_types(),
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
@@ -867,6 +925,7 @@ mod tests {
             retain_context: String::new(),
             recall_max_tokens: 4096,
             recall_max_input_chars: 800,
+            recall_types: default_recall_types(),
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
@@ -888,6 +947,32 @@ mod tests {
         let plugin = HindsightPlugin::new();
         let result = plugin.handle_tool_call("hindsight_recall", &json!({}));
         assert!(result.contains("error"));
+    }
+
+    #[test]
+    fn test_hindsight_recall_body_defaults_to_observations() {
+        let body = hindsight_recall_body("dark mode", "mid", 4096, &default_recall_types());
+        assert_eq!(body["query"], "dark mode");
+        assert_eq!(body["budget"], "mid");
+        assert_eq!(body["max_tokens"], 4096);
+        assert_eq!(body["types"], json!(["observation"]));
+    }
+
+    #[test]
+    fn test_parse_recall_types_accepts_string_or_list() {
+        assert_eq!(
+            parse_recall_types_value(&json!("observation,world, experience")),
+            Some(vec![
+                "observation".to_string(),
+                "world".to_string(),
+                "experience".to_string()
+            ])
+        );
+        assert_eq!(
+            parse_recall_types_value(&json!(["world", " experience ", "", 7])),
+            Some(vec!["world".to_string(), "experience".to_string()])
+        );
+        assert_eq!(parse_recall_types_value(&json!(" , ")), None);
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-05-29T19:55:49.284559+00:00`_
+_Generated from source artifacts: `2026-05-29T20:05:45.672855+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `38c4f8c3717518e81bc64765ab80f3192f6a113a`
-- Workstream snapshot generated: `2026-05-29T13:51:55-06:00`
-- Parity matrix generated: `2026-05-29T19:55:29.103698+00:00`
-- Queue snapshot generated: `2026-05-29T19:52:06.892187+00:00`
-- Proof snapshot generated: `2026-05-29T19:55:49.284559+00:00`
+- Workstream snapshot generated: `2026-05-29T14:05:15-06:00`
+- Parity matrix generated: `2026-05-29T20:05:30.461016+00:00`
+- Queue snapshot generated: `2026-05-29T20:05:34.683184+00:00`
+- Proof snapshot generated: `2026-05-29T20:05:45.672855+00:00`
 
 ## Gate Status
 
@@ -31,14 +31,14 @@ _Generated from source artifacts: `2026-05-29T19:55:49.284559+00:00`_
 | Metric | Value |
 | --- | ---: |
 | commits_behind | 4385 |
-| commits_ahead | 775 |
+| commits_ahead | 776 |
 | upstream_patch_missing | 4267 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 670 |
+| local_patch_unique | 671 |
 | files_only_upstream | 1470 |
 | files_only_local | 560 |
-| files_shared_identical | 1702 |
-| files_shared_different | 1017 |
+| files_shared_identical | 1703 |
+| files_shared_different | 1016 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:52:13.889102+00:00",
+  "generated_at_utc": "2026-05-29T20:05:44.514368+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-05-29T19:52:13.889102+00:00`
+Generated: `2026-05-29T20:05:44.514368+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-29T19:55:46.567903+00:00",
+  "generated_at_utc": "2026-05-29T20:05:45.566631+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-29T19:55:49.284559+00:00",
+  "generated_at_utc": "2026-05-29T20:05:45.672855+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-29T19:55:49.284559+00:00`
+Generated: `2026-05-29T20:05:45.672855+00:00`
 
 ## Gate Status
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:55:42.899656+00:00",
+  "generated_at_utc": "2026-05-29T20:05:44.565854+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,6 +1,6 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-05-29T19:55:42.899656+00:00`
+Generated: `2026-05-29T20:05:44.565854+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
 - Total scoped commits: `2938`

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T19:55:29.103698+00:00",
+  "generated_at_utc": "2026-05-29T20:05:30.461016+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "d48f4bab48a69f776ba0062b610904de89a8b15b",
+    "local_sha": "f519f22525748870912b4cbde064db52e2368b09",
     "upstream_ref": "upstream/main",
     "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4385,
-    "commits_ahead": 775,
+    "commits_ahead": 776,
     "upstream_patch_missing": 4267,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 670,
+    "local_patch_unique": 671,
     "files_only_upstream": 1470,
     "files_only_local": 560,
-    "files_shared_identical": 1702,
-    "files_shared_different": 1017,
-    "tree_files_changed": 3047,
-    "tree_insertions": 738629,
-    "tree_deletions": 370787
+    "files_shared_identical": 1703,
+    "files_shared_different": 1016,
+    "tree_files_changed": 3046,
+    "tree_insertions": 738620,
+    "tree_deletions": 370857
   },
   "top_upstream_only": [
     {
@@ -237,12 +237,12 @@
       "count": 9
     },
     {
-      "path": "plugins/memory",
+      "path": "plugins/platforms",
       "count": 9
     },
     {
-      "path": "plugins/platforms",
-      "count": 9
+      "path": "plugins/memory",
+      "count": 8
     },
     {
       "path": "tests/acp",
@@ -867,7 +867,7 @@
       "issue": 7,
       "name": "Tools and adapters parity",
       "upstream_only": 114,
-      "shared_different": 54,
+      "shared_different": 53,
       "local_only": 99,
       "risk": "high",
       "effort": "L"
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4267,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 670,
+    "local_patch_unique": 671,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-29T19:55:29.103698+00:00`
+Generated: `2026-05-29T20:05:30.461016+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`d48f4bab48a69f776ba0062b610904de89a8b15b`)
+- Local ref: `HEAD` (`f519f22525748870912b4cbde064db52e2368b09`)
 - Upstream ref: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-29T19:55:29.103698+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4385 |
-| Commits ahead local (`local` ancestry only) | 775 |
+| Commits ahead local (`local` ancestry only) | 776 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4267 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 670 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 671 |
 | Files only in upstream tree | 1470 |
 | Files only in local tree | 560 |
-| Shared files identical content | 1702 |
-| Shared files different content | 1017 |
-| Total files changed (`local` vs `upstream`) | 3047 |
-| Insertions (`local` vs `upstream`) | 738629 |
-| Deletions (`local` vs `upstream`) | 370787 |
+| Shared files identical content | 1703 |
+| Shared files different content | 1016 |
+| Total files changed (`local` vs `upstream`) | 3046 |
+| Insertions (`local` vs `upstream`) | 738620 |
+| Deletions (`local` vs `upstream`) | 370857 |
 
 ## Top 40 upstream-only buckets
 
@@ -87,8 +87,8 @@ Generated: `2026-05-29T19:55:29.103698+00:00`
 | `skills/creative` | 11 |
 | `tests/cron` | 11 |
 | `plugins/google_meet` | 9 |
-| `plugins/memory` | 9 |
 | `plugins/platforms` | 9 |
+| `plugins/memory` | 8 |
 | `tests/acp` | 8 |
 | `skills/productivity` | 7 |
 | `tests/skills` | 6 |
@@ -167,7 +167,7 @@ Generated: `2026-05-29T19:55:29.103698+00:00`
 | `WS6` | #10 | Tests and CI parity | 317 | 681 | high | XL |
 | `WS5` | #9 | UX parity | 493 | 231 | high | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 391 | 12 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 114 | 54 | high | L |
+| `WS3` | #7 | Tools and adapters parity | 114 | 53 | high | L |
 | `WS4` | #8 | Skills parity | 93 | 39 | medium | L |
 | `WS2` | #6 | Core runtime parity | 62 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
@@ -176,7 +176,7 @@ Generated: `2026-05-29T19:55:29.103698+00:00`
 
 - Upstream missing by patch-id: `4267`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `670`
+- Local unique by patch-id: `671`
 - Intentional divergence tracked items: `8` (covered files: `898`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -661,21 +661,6 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "4c7e0f6be30ee8ae438aa178dfe529f1c8a60c0f",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/memory/hindsight/README.md",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "d8f96a45e1e9a20c8cc45c309358a64d266c7276",
-      "workstream": "WS3"
-    },
-    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "plugins/memory/hindsight/__init__.py",
@@ -15256,33 +15241,33 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T19:55:35.356167+00:00",
+  "generated_at_utc": "2026-05-29T20:05:39.916289+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "d48f4bab48a69f776ba0062b610904de89a8b15b",
+    "local_sha": "f519f22525748870912b4cbde064db52e2368b09",
     "upstream_ref": "upstream/main",
     "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 771,
+      "functional": 770,
       "intentional_divergence": 76,
       "policy_only": 169
     },
     "by_rust_requirement": {
       "not_required_for_runtime": 246,
       "rust_equivalent_or_contract_test_required": 680,
-      "rust_native_runtime_parity_required_if_needed": 12,
+      "rust_native_runtime_parity_required_if_needed": 11,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
       "cleared_intentional_divergence": 76,
       "cleared_non_runtime": 170,
-      "pending_review": 771
+      "pending_review": 770
     },
     "by_workstream": {
-      "WS3": 54,
+      "WS3": 53,
       "WS4": 39,
       "WS5": 230,
       "WS6": 681,
@@ -15291,7 +15276,7 @@
     "cleared_intentional_divergence": 76,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 771,
-    "total_shared_different": 1017
+    "pending_review": 770,
+    "total_shared_different": 1016
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,12 +1,12 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T19:55:35.356167+00:00`
+Generated: `2026-05-29T20:05:39.916289+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1017`
+- Total shared-different paths: `1016`
 - Pending classification: `0`
-- Pending functional review: `771`
+- Pending functional review: `770`
 - Cleared non-runtime: `170`
 - Cleared intentional divergence: `76`
 
@@ -16,13 +16,13 @@ Generated: `2026-05-29T19:55:35.356167+00:00`
 | --- | ---: |
 | `cleared_intentional_divergence` | 76 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 771 |
+| `pending_review` | 770 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 54 |
+| `WS3` | 53 |
 | `WS4` | 39 |
 | `WS5` | 230 |
 | `WS6` | 681 |
@@ -55,9 +55,9 @@ Generated: `2026-05-29T19:55:35.356167+00:00`
 | `plugins/web` | 4 |
 | `tests/providers` | 4 |
 | `tests/tui_gateway` | 4 |
-| `plugins/memory` | 3 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
+| `plugins/memory` | 2 |
 | `tests/e2e` | 2 |
 | `plugins/browser/browserbase/provider.py` | 1 |
 | `plugins/model-providers` | 1 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T19:52:11.671295+00:00",
+  "generated_at_utc": "2026-05-29T20:05:44.465489+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-05-29T19:52:11.671295+00:00`
+Generated: `2026-05-29T20:05:44.465489+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -93776,7 +93776,7 @@
       "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-05-29T19:52:06.892187+00:00",
+  "generated_at_utc": "2026-05-29T20:05:34.683184+00:00",
   "refs": {
     "local_ref": "main",
     "range": "main..upstream/main",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-05-29T19:52:06.892187+00:00`
+Generated: `2026-05-29T20:05:34.683184+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `4269`.
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,6 +1,6 @@
 {
-  "generated_at_utc": "2026-05-29T13:51:55-06:00",
-  "head_sha": "d48f4bab48a69f776ba0062b610904de89a8b15b",
+  "generated_at_utc": "2026-05-29T14:05:15-06:00",
+  "head_sha": "f519f22525748870912b4cbde064db52e2368b09",
   "states": {
     "complete": 7
   },

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,6 +1,6 @@
 # Workstream Status
 
-- Local HEAD: `d48f4bab48a69f776ba0062b610904de89a8b15b`
+- Local HEAD: `f519f22525748870912b4cbde064db52e2368b09`
 - Upstream: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
 
 | Workstream | Title | State |

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -75,7 +75,16 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
+| `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
+
+> **Behavior change — `recall_types` defaults to `observation` only.**
+>
+> Previously recall returned all three fact types. It now returns only observations.
+>
+> Per [Hindsight's docs](https://hindsight.vectorize.io/developer/observations), observations are the **consolidated** knowledge layer Hindsight builds on top of raw facts: deduplicated beliefs grounded in evidence, refined as new facts arrive, with proof counts and freshness signals. Raw `world` / `experience` facts are the individual supporting evidence that feeds them. For per-turn context injection, observations are denser per token and avoid feeding the model multiple raw facts that one observation already summarizes.
+>
+> Restore the broad recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. This applies to **both** auto-recall and the `hindsight_recall` tool — both read the same `recall_types` setting (the tool schema has no per-call `types` argument), so narrowing the default narrows both paths.
 
 ### Retain
 


### PR DESCRIPTION
## Summary
- add Rust Hindsight `recall_types` config support with `observation` as the default
- send `types` in Hindsight recall requests for both auto-prefetch and `hindsight_recall`
- match the Hindsight README to upstream and refresh parity artifacts; shared-diff backlog drops from 1017 to 1016 and native-runtime-needed items drop from 12 to 11

## Local verification
- `cargo fmt --check`
- `cargo test -p hermes-agent memory_plugins::hindsight --lib`
- `python3 -m py_compile scripts/generate-global-parity-proof.py scripts/generate-shared-diff-backlog.py scripts/generate-upstream-patch-queue.py scripts/generate-parity-matrix.py`
- `python3 scripts/generate-global-parity-proof.py --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof-hindsight.json --out-md /tmp/hermes-agent-ultra-global-parity-proof-hindsight.md`
- `bash scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json`
- `python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD --json`
- `cargo test -p hermes-parity-tests`
- `cargo test -p hermes-environments file_sync`
- `cargo build -p hermes-cli`

Remote GitHub CI is optional for this repo; local deterministic gates above are authoritative.