### PR TITLE
fix(parity): resolve honcho and ntfy in rust

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/honcho.rs
+++ b/crates/hermes-agent/src/memory_plugins/honcho.rs
@@ -18,8 +18,12 @@ use std::time::Duration;
 
 use reqwest::Method;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 use crate::memory_manager::MemoryProviderPlugin;
+
+const HOST: &str = "hermes";
+const PEER_ID_HASH_ESCALATION_LENGTHS: &[usize] = &[8, 12, 16, 24, 32, 64];
 
 // ---------------------------------------------------------------------------
 // Tool schemas
@@ -94,6 +98,9 @@ struct HonchoConfig {
     workspace_id: String,
     peer_name: Option<String>,
     ai_peer: String,
+    pin_user_peer: bool,
+    user_peer_aliases: HashMap<String, String>,
+    runtime_peer_prefix: String,
     timeout_secs: f64,
     endpoints: HashMap<String, String>,
 }
@@ -132,6 +139,9 @@ impl HonchoConfig {
             workspace_id: "hermes".to_string(),
             peer_name: None,
             ai_peer: "hermes".to_string(),
+            pin_user_peer: false,
+            user_peer_aliases: HashMap::new(),
+            runtime_peer_prefix: String::new(),
             timeout_secs,
             endpoints,
         }
@@ -139,63 +149,15 @@ impl HonchoConfig {
 
     fn from_config_file(hermes_home: &str) -> Self {
         let mut config = Self::from_env();
+        let host = active_host();
+        config.workspace_id = host.clone();
+        config.ai_peer = host.clone();
         let config_path = std::path::Path::new(hermes_home).join("honcho.json");
         if let Ok(content) = std::fs::read_to_string(&config_path) {
             if let Ok(raw) = serde_json::from_str::<Value>(&content) {
-                if let Some(key) = raw.get("apiKey").and_then(|v| v.as_str()) {
-                    if !key.is_empty() {
-                        config.api_key = key.to_string();
-                    }
-                }
-                if let Some(url) = raw
-                    .get("baseUrl")
-                    .or_else(|| raw.get("base_url"))
-                    .and_then(|v| v.as_str())
-                {
-                    if !url.is_empty() {
-                        config.base_url = url.to_string();
-                    }
-                }
-                if let Some(mode) = raw.get("recallMode").and_then(|v| v.as_str()) {
-                    config.recall_mode = match mode {
-                        "context" | "tools" | "hybrid" => mode.to_string(),
-                        "auto" => "hybrid".to_string(),
-                        _ => "hybrid".to_string(),
-                    };
-                }
-                if let Some(tokens) = raw.get("contextTokens").and_then(|v| v.as_u64()) {
-                    config.context_tokens = Some(tokens.clamp(32, 4000) as usize);
-                }
-                if let Some(ws) = raw.get("workspace").and_then(|v| v.as_str()) {
-                    config.workspace_id = ws.to_string();
-                }
-                if let Some(peer) = raw.get("peerName").and_then(|v| v.as_str()) {
-                    config.peer_name = Some(peer.to_string());
-                }
-                if let Some(ai) = raw.get("aiPeer").and_then(|v| v.as_str()) {
-                    config.ai_peer = ai.to_string();
-                }
-                if let Some(timeout) = raw
-                    .get("timeout")
-                    .or_else(|| raw.get("requestTimeout"))
-                    .and_then(|v| v.as_f64())
-                {
-                    config.timeout_secs = timeout.clamp(1.0, 60.0);
-                }
-                if let Some(enabled) = raw.get("enabled").and_then(|v| v.as_bool()) {
-                    config.enabled = enabled;
-                } else {
-                    config.enabled =
-                        !config.api_key.is_empty() || !config.base_url.trim().is_empty();
-                }
-                if let Some(map) = raw.get("endpoints").and_then(|v| v.as_object()) {
-                    for (k, v) in map {
-                        if let Some(path) = v.as_str() {
-                            if !path.trim().is_empty() {
-                                config.endpoints.insert(k.to_string(), path.to_string());
-                            }
-                        }
-                    }
+                Self::apply_config_value(&mut config, &raw);
+                if let Some(host_block) = raw.get("hosts").and_then(|v| v.get(&host)) {
+                    Self::apply_config_value(&mut config, host_block);
                 }
             }
         }
@@ -208,6 +170,104 @@ impl HonchoConfig {
             .get(key)
             .cloned()
             .unwrap_or_else(|| default.to_string())
+    }
+
+    fn apply_config_value(config: &mut Self, raw: &Value) {
+        if let Some(key) = raw.get("apiKey").and_then(|v| v.as_str()) {
+            if !key.is_empty() {
+                config.api_key = key.to_string();
+            }
+        }
+        if let Some(url) = raw
+            .get("baseUrl")
+            .or_else(|| raw.get("base_url"))
+            .and_then(|v| v.as_str())
+        {
+            if !url.is_empty() {
+                config.base_url = url.to_string();
+            }
+        }
+        if let Some(mode) = raw.get("recallMode").and_then(|v| v.as_str()) {
+            config.recall_mode = match mode {
+                "context" | "tools" | "hybrid" => mode.to_string(),
+                "auto" => "hybrid".to_string(),
+                _ => "hybrid".to_string(),
+            };
+        }
+        if let Some(tokens) = raw.get("contextTokens").and_then(|v| v.as_u64()) {
+            config.context_tokens = Some(tokens.clamp(32, 4000) as usize);
+        }
+        if let Some(ws) = raw.get("workspace").and_then(|v| v.as_str()) {
+            config.workspace_id = ws.to_string();
+        }
+        if let Some(peer) = raw.get("peerName").and_then(|v| v.as_str()) {
+            config.peer_name = Some(peer.to_string());
+        }
+        if let Some(ai) = raw.get("aiPeer").and_then(|v| v.as_str()) {
+            config.ai_peer = ai.to_string();
+        }
+        if let Some(pin) = raw
+            .get("pinUserPeer")
+            .or_else(|| raw.get("pinPeerName"))
+            .and_then(|v| v.as_bool())
+        {
+            config.pin_user_peer = pin;
+        }
+        if let Some(map) = raw.get("userPeerAliases").and_then(|v| v.as_object()) {
+            config.user_peer_aliases = map
+                .iter()
+                .filter_map(|(key, value)| {
+                    let alias = value.as_str()?.trim();
+                    if key.trim().is_empty() || alias.is_empty() {
+                        None
+                    } else {
+                        Some((key.trim().to_string(), alias.to_string()))
+                    }
+                })
+                .collect();
+        }
+        if let Some(prefix) = raw.get("runtimePeerPrefix").and_then(|v| v.as_str()) {
+            config.runtime_peer_prefix = prefix.trim().to_string();
+        }
+        if let Some(timeout) = raw
+            .get("timeout")
+            .or_else(|| raw.get("requestTimeout"))
+            .and_then(|v| v.as_f64())
+        {
+            config.timeout_secs = timeout.clamp(1.0, 60.0);
+        }
+        if let Some(enabled) = raw.get("enabled").and_then(|v| v.as_bool()) {
+            config.enabled = enabled;
+        } else {
+            config.enabled = !config.api_key.is_empty() || !config.base_url.trim().is_empty();
+        }
+        if let Some(map) = raw.get("endpoints").and_then(|v| v.as_object()) {
+            for (key, value) in map {
+                if let Some(path) = value.as_str() {
+                    if !path.trim().is_empty() {
+                        config.endpoints.insert(key.to_string(), path.to_string());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn active_host() -> String {
+    if let Ok(explicit) = std::env::var("HERMES_HONCHO_HOST") {
+        let explicit = explicit.trim();
+        if !explicit.is_empty() {
+            return explicit.to_string();
+        }
+    }
+    let profile = std::env::var("HERMES_PROFILE").unwrap_or_default();
+    let profile = profile.trim();
+    if profile.is_empty() || matches!(profile, "default" | "custom") {
+        HOST.to_string()
+    } else if profile == HOST || profile.starts_with("hermes.") {
+        profile.to_string()
+    } else {
+        format!("{HOST}.{profile}")
     }
 }
 
@@ -260,12 +320,56 @@ impl HonchoMemoryPlugin {
     fn extract_peer(config: &HonchoConfig, args: &Value) -> String {
         match args.get("peer").and_then(|v| v.as_str()).unwrap_or("user") {
             "ai" => config.ai_peer.clone(),
-            "user" => config
-                .peer_name
-                .clone()
-                .unwrap_or_else(|| "user".to_string()),
-            other => other.to_string(),
+            "user" => {
+                let runtime_ids = runtime_user_ids_from_args(args)
+                    .into_iter()
+                    .chain(runtime_user_ids_from_env())
+                    .collect::<Vec<_>>();
+                Self::resolve_user_peer_id(config, "", &runtime_ids)
+            }
+            other => sanitize_id(other),
         }
+    }
+
+    fn resolve_user_peer_id(
+        config: &HonchoConfig,
+        session_key: &str,
+        runtime_ids: &[String],
+    ) -> String {
+        if config.pin_user_peer {
+            if let Some(peer) = config.peer_name.as_deref() {
+                if !peer.trim().is_empty() {
+                    return sanitize_id(peer.trim());
+                }
+            }
+        }
+
+        for runtime_id in unique_nonempty(runtime_ids) {
+            if let Some(alias) = config.user_peer_aliases.get(&runtime_id) {
+                if !alias.trim().is_empty() {
+                    return sanitize_id(alias.trim());
+                }
+            }
+        }
+
+        if let Some(primary_runtime_id) = unique_nonempty(runtime_ids).into_iter().next() {
+            if !config.runtime_peer_prefix.is_empty() {
+                return generated_runtime_peer_id(
+                    config,
+                    &config.runtime_peer_prefix,
+                    &primary_runtime_id,
+                );
+            }
+            return sanitize_id(&primary_runtime_id);
+        }
+
+        if let Some(peer) = config.peer_name.as_deref() {
+            if !peer.trim().is_empty() {
+                return sanitize_id(peer.trim());
+            }
+        }
+
+        session_key_fallback_peer_id(session_key)
     }
 
     fn client(config: &HonchoConfig) -> Result<reqwest::blocking::Client, String> {
@@ -455,8 +559,9 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
         let out = Arc::clone(&self.prefetch_result);
         let query = trimmed.to_string();
         let max_tokens = config.context_tokens.unwrap_or(800).min(2000).max(64);
+        let peer = Self::resolve_user_peer_id(&config, &session_id, &runtime_user_ids_from_env());
         std::thread::spawn(move || {
-            match Self::context_query(&config, &session_id, &query, max_tokens, "user") {
+            match Self::context_query(&config, &session_id, &query, max_tokens, &peer) {
                 Ok(v) => {
                     if let Some(text) = Self::extract_text_result(&v) {
                         if !text.trim().is_empty() {
@@ -693,11 +798,12 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
             Err(_) => return,
         };
         let session_id = self.session_key.lock().unwrap().clone();
+        let peer = Self::resolve_user_peer_id(&config, &session_id, &runtime_user_ids_from_env());
         let template = config.endpoint("conclude", "/v1/conclusions");
         let body = json!({
             "workspace_id": config.workspace_id,
             "session_id": session_id,
-            "peer": "user",
+            "peer": peer,
             "conclusion": content.trim(),
             "source": "memory_write_hook"
         });
@@ -717,6 +823,9 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
             {"key": "api_key", "description": "Honcho API key", "secret": true, "env_var": "HONCHO_API_KEY", "url": "https://app.honcho.dev"},
             {"key": "baseUrl", "description": "Honcho base URL (for self-hosted)"},
             {"key": "timeout", "description": "HTTP timeout seconds", "default": 12},
+            {"key": "pinUserPeer", "description": "Pin gateway runtime users to peerName", "default": false},
+            {"key": "userPeerAliases", "description": "Runtime user ID to Honcho peer ID map"},
+            {"key": "runtimePeerPrefix", "description": "Prefix for unknown gateway runtime user peers", "default": ""},
             {"key": "endpoints", "description": "Optional endpoint path overrides"}
         ]))
     }
@@ -727,6 +836,99 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
         }
         Ok(())
     }
+}
+
+fn sanitize_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn unique_nonempty(values: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    for value in values {
+        let candidate = value.trim();
+        if !candidate.is_empty() && !out.iter().any(|existing| existing == candidate) {
+            out.push(candidate.to_string());
+        }
+    }
+    out
+}
+
+fn runtime_user_ids_from_args(args: &Value) -> Vec<String> {
+    [
+        "runtime_user_id",
+        "runtimeUserId",
+        "runtime_id",
+        "runtimeId",
+        "user_id",
+        "userId",
+        "runtime_user_id_alt",
+        "runtimeUserIdAlt",
+        "username",
+    ]
+    .into_iter()
+    .filter_map(|key| args.get(key).and_then(Value::as_str))
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn runtime_user_ids_from_env() -> Vec<String> {
+    [
+        "HERMES_RUNTIME_USER_ID",
+        "HERMES_GATEWAY_USER_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_USER_ID",
+        "HERMES_USER",
+    ]
+    .into_iter()
+    .filter_map(|key| std::env::var(key).ok())
+    .collect()
+}
+
+fn session_key_fallback_peer_id(key: &str) -> String {
+    let (channel, chat_id) = key.split_once(':').unwrap_or(("default", key));
+    sanitize_id(&format!("user-{channel}-{chat_id}"))
+}
+
+fn explicit_user_peer_ids(config: &HonchoConfig) -> Vec<String> {
+    let mut explicit = Vec::new();
+    if let Some(peer) = config.peer_name.as_deref() {
+        if !peer.trim().is_empty() {
+            explicit.push(sanitize_id(peer.trim()));
+        }
+    }
+    for alias in config.user_peer_aliases.values() {
+        if !alias.trim().is_empty() {
+            explicit.push(sanitize_id(alias.trim()));
+        }
+    }
+    unique_nonempty(&explicit)
+}
+
+fn generated_runtime_peer_id(config: &HonchoConfig, prefix: &str, runtime_id: &str) -> String {
+    let raw_peer_id = format!("{prefix}{runtime_id}");
+    let sanitized_peer_id = sanitize_id(&raw_peer_id);
+    let explicit_ids = explicit_user_peer_ids(config);
+    if sanitized_peer_id != raw_peer_id || explicit_ids.contains(&sanitized_peer_id) {
+        let digest = Sha256::digest(raw_peer_id.as_bytes());
+        let hex = format!("{digest:x}");
+        for len in PEER_ID_HASH_ESCALATION_LENGTHS {
+            let candidate = format!("{sanitized_peer_id}-{}", &hex[..*len]);
+            if !explicit_ids.contains(&candidate) {
+                return candidate;
+            }
+        }
+        return format!("{sanitized_peer_id}-{hex}");
+    }
+    sanitized_peer_id
 }
 
 #[cfg(test)]
@@ -781,5 +983,122 @@ mod tests {
         let path =
             HonchoMemoryPlugin::apply_template("/v1/sessions/{session}/peers/{peer}", "user", "s1");
         assert_eq!(path, "/v1/sessions/s1/peers/user");
+    }
+
+    fn test_config() -> HonchoConfig {
+        HonchoConfig {
+            api_key: String::new(),
+            base_url: "https://api.honcho.dev".to_string(),
+            enabled: true,
+            recall_mode: "hybrid".to_string(),
+            context_tokens: Some(800),
+            workspace_id: "hermes".to_string(),
+            peer_name: Some("eri".to_string()),
+            ai_peer: "hermes".to_string(),
+            pin_user_peer: false,
+            user_peer_aliases: HashMap::new(),
+            runtime_peer_prefix: String::new(),
+            timeout_secs: 12.0,
+            endpoints: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_honcho_pin_user_peer_wins_over_runtime_identity() {
+        let mut config = test_config();
+        config.pin_user_peer = true;
+        assert_eq!(
+            HonchoMemoryPlugin::resolve_user_peer_id(
+                &config,
+                "telegram:chat-1",
+                &["86701400".to_string()],
+            ),
+            "eri"
+        );
+    }
+
+    #[test]
+    fn test_honcho_runtime_aliases_check_primary_and_alt_ids() {
+        let mut config = test_config();
+        config
+            .user_peer_aliases
+            .insert("@eri".to_string(), "eri/main".to_string());
+        assert_eq!(
+            HonchoMemoryPlugin::resolve_user_peer_id(
+                &config,
+                "telegram:chat-1",
+                &["86701400".to_string(), "@eri".to_string()],
+            ),
+            "eri-main"
+        );
+    }
+
+    #[test]
+    fn test_honcho_runtime_prefix_hashes_colliding_explicit_peer() {
+        let mut config = test_config();
+        config.peer_name = Some("telegram_86701400".to_string());
+        config.runtime_peer_prefix = "telegram_".to_string();
+        let peer = HonchoMemoryPlugin::resolve_user_peer_id(
+            &config,
+            "telegram:chat-1",
+            &["86701400".to_string()],
+        );
+        assert!(peer.starts_with("telegram_86701400-"));
+        assert!(peer.len() > "telegram_86701400-".len());
+    }
+
+    #[test]
+    fn test_honcho_user_peer_falls_back_to_sanitized_session_key() {
+        let mut config = test_config();
+        config.peer_name = None;
+        assert_eq!(
+            HonchoMemoryPlugin::resolve_user_peer_id(&config, "telegram:chat/1", &[]),
+            "user-telegram-chat-1"
+        );
+    }
+
+    #[test]
+    fn test_honcho_extract_peer_uses_runtime_mapping_and_sanitizes_explicit_peer() {
+        let mut config = test_config();
+        config
+            .user_peer_aliases
+            .insert("42".to_string(), "eri".to_string());
+        assert_eq!(
+            HonchoMemoryPlugin::extract_peer(&config, &json!({"runtime_user_id": "42"})),
+            "eri"
+        );
+        assert_eq!(
+            HonchoMemoryPlugin::extract_peer(&config, &json!({"peer": "team/user"})),
+            "team-user"
+        );
+        assert_eq!(
+            HonchoMemoryPlugin::extract_peer(&config, &json!({"peer": "ai"})),
+            "hermes"
+        );
+    }
+
+    #[test]
+    fn test_honcho_identity_mapping_config_replaces_root_map_at_host_level() {
+        let mut config = test_config();
+        let root = json!({
+            "pinUserPeer": true,
+            "userPeerAliases": {"root-id": "root-peer"},
+            "runtimePeerPrefix": "root_"
+        });
+        let host = json!({
+            "pinPeerName": false,
+            "userPeerAliases": {"host-id": "host-peer"},
+            "runtimePeerPrefix": ""
+        });
+        HonchoConfig::apply_config_value(&mut config, &root);
+        HonchoConfig::apply_config_value(&mut config, &host);
+
+        assert!(!config.pin_user_peer);
+        assert_eq!(config.user_peer_aliases.len(), 1);
+        assert_eq!(
+            config.user_peer_aliases.get("host-id").map(String::as_str),
+            Some("host-peer")
+        );
+        assert_eq!(config.runtime_peer_prefix, "");
     }
 }

--- a/crates/hermes-cli/Cargo.toml
+++ b/crates/hermes-cli/Cargo.toml
@@ -47,6 +47,7 @@ hermes-gateway = { workspace = true, features = [
     "email",
     "sms",
     "homeassistant",
+    "ntfy",
     "api-server",
     "webhook",
 ] }

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -73,6 +73,7 @@ use hermes_gateway::platforms::feishu::{FeishuAdapter, FeishuConfig};
 use hermes_gateway::platforms::homeassistant::{HomeAssistantAdapter, HomeAssistantConfig};
 use hermes_gateway::platforms::matrix::{MatrixAdapter, MatrixConfig};
 use hermes_gateway::platforms::mattermost::{MattermostAdapter, MattermostConfig};
+use hermes_gateway::platforms::ntfy::{NtfyAdapter, NtfyConfig};
 use hermes_gateway::platforms::qqbot::{QqBotAdapter, QqBotConfig};
 use hermes_gateway::platforms::signal::{SignalAdapter, SignalConfig};
 use hermes_gateway::platforms::slack::{SlackAdapter, SlackConfig};
@@ -3587,6 +3588,18 @@ async fn configure_platform_basic_prompts(
             let webhook_id = prompt_line("HomeAssistant webhook_id (optional): ").await?;
             set_extra_string_if_nonempty(p, "webhook_id", &webhook_id);
         }
+        "ntfy" => {
+            let topic = prompt_line("ntfy subscribe topic: ").await?;
+            set_extra_string_if_nonempty(p, "topic", &topic);
+            let server = prompt_line("ntfy server URL (default https://ntfy.sh): ").await?;
+            set_extra_string_if_nonempty(p, "server", &server);
+            let publish_topic = prompt_line("ntfy publish topic (optional): ").await?;
+            set_extra_string_if_nonempty(p, "publish_topic", &publish_topic);
+            let token = prompt_line("ntfy auth token (optional): ").await?;
+            if !token.trim().is_empty() {
+                p.token = Some(token.trim().to_string());
+            }
+        }
         "webhook" => {
             let secret = prompt_line("Webhook secret: ").await?;
             set_extra_string_if_nonempty(p, "secret", &secret);
@@ -3639,6 +3652,7 @@ async fn run_gateway_setup(cli: &Cli) -> Result<(), AgentError> {
         ("email", "Email"),
         ("sms", "SMS"),
         ("homeassistant", "HomeAssistant"),
+        ("ntfy", "ntfy"),
         ("webhook", "Webhook"),
         ("api_server", "API Server"),
     ];
@@ -4127,6 +4141,12 @@ fn gateway_requirement_issues(config: &hermes_config::GatewayConfig) -> Vec<Stri
     if let Some(p) = config.platforms.get("slack") {
         if check(p.enabled, platform_token_or_extra(p).is_some()) {
             issues.push("slack.enabled=true 但缺少 token".to_string());
+        }
+    }
+    if let Some(p) = config.platforms.get("ntfy") {
+        let topic = extra_string(p, "topic").is_some() || std::env::var("NTFY_TOPIC").is_ok();
+        if check(p.enabled, topic) {
+            issues.push("ntfy.enabled=true but topic is missing".to_string());
         }
     }
     if let Some(p) = config
@@ -4727,6 +4747,25 @@ async fn register_gateway_adapters(
         }
     }
 
+    if let Some(platform_cfg) = config.platforms.get("ntfy") {
+        if platform_cfg.enabled {
+            let ntfy_cfg = NtfyConfig::from_platform_config(platform_cfg);
+            match NtfyAdapter::new(ntfy_cfg) {
+                Ok(adapter) => {
+                    let adapter = Arc::new(adapter);
+                    let (tx, rx) = mpsc::channel::<GatewayIncomingMessage>(512);
+                    adapter.set_inbound_sender(tx).await;
+                    gateway.register_adapter("ntfy", adapter).await;
+                    let gw_clone = gateway.clone();
+                    sidecar_tasks.push(tokio::spawn(async move {
+                        run_gateway_incoming_loop(gw_clone, rx, "ntfy").await;
+                    }));
+                }
+                Err(e) => println!("ntfy enabled but failed to initialize: {}", e),
+            }
+        }
+    }
+
     if let Some(platform_cfg) = config.platforms.get("webhook") {
         if platform_cfg.enabled {
             let secret = platform_token_or_extra(platform_cfg)
@@ -4913,6 +4952,7 @@ fn gateway_platform_provider_key(provider: &str) -> Option<&'static str> {
         "email" => Some("email"),
         "sms" => Some("sms"),
         "homeassistant" => Some("homeassistant"),
+        "ntfy" => Some("ntfy"),
         "webhook" => Some("webhook"),
         "api_server" => Some("api_server"),
         _ => None,
@@ -8075,6 +8115,7 @@ fn parse_deliver_config(raw: &str) -> Option<hermes_cron::DeliverConfig> {
         "bluebubbles" | "imessage" => hermes_cron::DeliverTarget::BlueBubbles,
         "sms" => hermes_cron::DeliverTarget::Sms,
         "homeassistant" | "ha" => hermes_cron::DeliverTarget::HomeAssistant,
+        "ntfy" => hermes_cron::DeliverTarget::Ntfy,
         _ => return None,
     };
     Some(hermes_cron::DeliverConfig {

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -262,6 +262,7 @@ pub fn load_from_yaml(path: &Path) -> Result<GatewayConfig, ConfigError> {
         crate::python_yaml_compat::normalize_config_yaml_root(m);
     }
     mark_platform_enabled_explicit(&mut root, "slack");
+    mark_platform_enabled_explicit(&mut root, "ntfy");
     let config: GatewayConfig = serde_yaml::from_value(root).map_err(yaml_to_config_error)?;
     Ok(config)
 }

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -87,10 +87,55 @@ fn apply_dingtalk_env(config: &mut GatewayConfig) {
     }
 }
 
-/// 应用与 Python 文档一致的 `WEIXIN_*` / `DINGTALK_*` 环境变量到 `platforms`。
+fn apply_ntfy_env(config: &mut GatewayConfig) {
+    let Some(topic) = env_nonempty("NTFY_TOPIC") else {
+        return;
+    };
+    let ntfy = config
+        .platforms
+        .entry("ntfy".into())
+        .or_insert_with(PlatformConfig::default);
+    let enabled_was_explicit = ntfy
+        .extra
+        .remove("_enabled_explicit")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !ntfy.enabled && !enabled_was_explicit {
+        ntfy.enabled = true;
+    }
+    set_extra(ntfy, "topic", json!(topic));
+    if let Some(v) = env_nonempty("NTFY_SERVER_URL") {
+        set_extra(ntfy, "server", json!(v));
+    }
+    if let Some(v) = env_nonempty("NTFY_PUBLISH_TOPIC") {
+        set_extra(ntfy, "publish_topic", json!(v));
+    }
+    if let Some(v) = env_nonempty("NTFY_TOKEN") {
+        ntfy.token = Some(v);
+    }
+    if let Some(v) = env_nonempty("NTFY_MARKDOWN") {
+        set_extra(
+            ntfy,
+            "markdown",
+            json!(matches!(
+                v.to_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )),
+        );
+    }
+    if let Some(v) = env_nonempty("NTFY_HOME_CHANNEL") {
+        ntfy.home_channel = Some(v);
+    }
+    if let Some(v) = env_nonempty("NTFY_HOME_CHANNEL_NAME") {
+        set_extra(ntfy, "home_channel_name", json!(v));
+    }
+}
+
+/// 应用与 Python 文档一致的平台环境变量到 `platforms`。
 pub fn apply_python_named_platform_env(config: &mut GatewayConfig) {
     apply_weixin_env(config);
     apply_dingtalk_env(config);
+    apply_ntfy_env(config);
 }
 
 #[cfg(test)]
@@ -159,6 +204,45 @@ mod tests {
             std::env::remove_var("DINGTALK_CLIENT_ID");
             std::env::remove_var("DINGTALK_CLIENT_SECRET");
             std::env::remove_var("DINGTALK_OPENAPI_ENDPOINT");
+        }
+    }
+
+    #[test]
+    fn ntfy_env_sets_topic_and_auto_enables() {
+        unsafe {
+            std::env::set_var("NTFY_TOPIC", "hermes-in");
+            std::env::set_var("NTFY_SERVER_URL", "https://ntfy.example.com");
+            std::env::set_var("NTFY_PUBLISH_TOPIC", "hermes-out");
+            std::env::set_var("NTFY_TOKEN", "token");
+            std::env::set_var("NTFY_MARKDOWN", "true");
+        }
+        let mut cfg = GatewayConfig::default();
+        apply_python_named_platform_env(&mut cfg);
+        let ntfy = cfg.platforms.get("ntfy").expect("ntfy block");
+        assert!(ntfy.enabled);
+        assert_eq!(ntfy.token.as_deref(), Some("token"));
+        assert_eq!(
+            ntfy.extra.get("topic").and_then(|v| v.as_str()),
+            Some("hermes-in")
+        );
+        assert_eq!(
+            ntfy.extra.get("server").and_then(|v| v.as_str()),
+            Some("https://ntfy.example.com")
+        );
+        assert_eq!(
+            ntfy.extra.get("publish_topic").and_then(|v| v.as_str()),
+            Some("hermes-out")
+        );
+        assert_eq!(
+            ntfy.extra.get("markdown").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        unsafe {
+            std::env::remove_var("NTFY_TOPIC");
+            std::env::remove_var("NTFY_SERVER_URL");
+            std::env::remove_var("NTFY_PUBLISH_TOPIC");
+            std::env::remove_var("NTFY_TOKEN");
+            std::env::remove_var("NTFY_MARKDOWN");
         }
     }
 }

--- a/crates/hermes-cron/src/job.rs
+++ b/crates/hermes-cron/src/job.rs
@@ -90,6 +90,8 @@ pub enum DeliverTarget {
     Sms,
     /// Deliver via Home Assistant.
     HomeAssistant,
+    /// Deliver via ntfy push notifications.
+    Ntfy,
 }
 
 /// Delivery configuration for a cron job's results.

--- a/crates/hermes-cron/src/runner.rs
+++ b/crates/hermes-cron/src/runner.rs
@@ -391,7 +391,8 @@ impl CronRunner {
             | DeliverTarget::Weixin
             | DeliverTarget::BlueBubbles
             | DeliverTarget::Sms
-            | DeliverTarget::HomeAssistant => {
+            | DeliverTarget::HomeAssistant
+            | DeliverTarget::Ntfy => {
                 // Platform delivery requires a platform adapter, which is not
                 // directly available in the runner. This would be wired up
                 // through the gateway crate. For now, log the intended delivery.
@@ -435,7 +436,8 @@ impl CronRunner {
             | DeliverTarget::Weixin
             | DeliverTarget::BlueBubbles
             | DeliverTarget::Sms
-            | DeliverTarget::HomeAssistant => {
+            | DeliverTarget::HomeAssistant
+            | DeliverTarget::Ntfy => {
                 tracing::warn!(
                     "Cron job error delivery to {:?} (platform: {:?}):\n{}",
                     deliver.target,

--- a/crates/hermes-gateway/Cargo.toml
+++ b/crates/hermes-gateway/Cargo.toml
@@ -25,6 +25,7 @@ bluebubbles = []
 email = []
 sms = []
 homeassistant = []
+ntfy = []
 api-server = []
 webhook = []
 

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -116,6 +116,9 @@ pub use platforms::sms::SmsAdapter;
 #[cfg(feature = "homeassistant")]
 pub use platforms::homeassistant::HomeAssistantAdapter;
 
+#[cfg(feature = "ntfy")]
+pub use platforms::ntfy::NtfyAdapter;
+
 #[cfg(feature = "api-server")]
 pub use platforms::api_server::ApiServerAdapter;
 

--- a/crates/hermes-gateway/src/platforms/mod.rs
+++ b/crates/hermes-gateway/src/platforms/mod.rs
@@ -54,6 +54,9 @@ pub mod sms;
 #[cfg(feature = "homeassistant")]
 pub mod homeassistant;
 
+#[cfg(feature = "ntfy")]
+pub mod ntfy;
+
 #[cfg(feature = "api-server")]
 pub mod api_server;
 

--- a/crates/hermes-gateway/src/platforms/ntfy.rs
+++ b/crates/hermes-gateway/src/platforms/ntfy.rs
@@ -1,0 +1,607 @@
+//! ntfy push-notification platform adapter.
+//!
+//! The adapter subscribes to `{server}/{topic}/json` and publishes replies with
+//! `X-Tags: hermes-agent`. Incoming messages carrying that tag are skipped so a
+//! shared subscribe/publish topic cannot make the agent answer its own replies.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
+use futures::StreamExt;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, Notify, RwLock};
+use tracing::{debug, info, warn};
+
+use hermes_core::errors::GatewayError;
+use hermes_core::traits::{ParseMode, PlatformAdapter};
+
+use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::gateway::IncomingMessage;
+
+pub const DEFAULT_SERVER: &str = "https://ntfy.sh";
+pub const ECHO_TAG: &str = "hermes-agent";
+pub const MAX_MESSAGE_LENGTH: usize = 4096;
+
+const DEDUP_WINDOW: Duration = Duration::from_secs(300);
+const DEDUP_MAX: usize = 1000;
+const STREAM_TIMEOUT_SECONDS: u64 = 90;
+const RECONNECT_SECS: &[u64] = &[2, 5, 10, 30, 60];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NtfyConfig {
+    #[serde(default = "default_server")]
+    pub server: String,
+    pub topic: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publish_topic: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(default)]
+    pub markdown: bool,
+    #[serde(default = "default_stream_timeout_secs")]
+    pub stream_timeout_secs: u64,
+    #[serde(default)]
+    pub proxy: AdapterProxyConfig,
+}
+
+impl NtfyConfig {
+    pub fn from_platform_config(platform: &hermes_config::PlatformConfig) -> Self {
+        let extra = &platform.extra;
+        let server = extra_string(extra, "server")
+            .or_else(|| std::env::var("NTFY_SERVER_URL").ok())
+            .map(|v| v.trim().trim_end_matches('/').to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(default_server);
+        let topic = extra_string(extra, "topic")
+            .or_else(|| std::env::var("NTFY_TOPIC").ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_default();
+        let publish_topic = extra_string(extra, "publish_topic")
+            .or_else(|| std::env::var("NTFY_PUBLISH_TOPIC").ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let token = platform
+            .token
+            .clone()
+            .or_else(|| extra_string(extra, "token"))
+            .or_else(|| std::env::var("NTFY_TOKEN").ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let markdown = extra_bool(extra, "markdown").unwrap_or_else(|| {
+            std::env::var("NTFY_MARKDOWN")
+                .ok()
+                .map(|v| truthy(&v))
+                .unwrap_or(false)
+        });
+        let stream_timeout_secs = extra
+            .get("stream_timeout_secs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(STREAM_TIMEOUT_SECONDS);
+
+        Self {
+            server,
+            topic,
+            publish_topic,
+            token,
+            markdown,
+            stream_timeout_secs,
+            proxy: AdapterProxyConfig::default(),
+        }
+    }
+}
+
+fn default_server() -> String {
+    DEFAULT_SERVER.to_string()
+}
+
+fn default_stream_timeout_secs() -> u64 {
+    STREAM_TIMEOUT_SECONDS
+}
+
+fn extra_string(extra: &HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
+    extra
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(String::from)
+}
+
+fn extra_bool(extra: &HashMap<String, serde_json::Value>, key: &str) -> Option<bool> {
+    match extra.get(key)? {
+        serde_json::Value::Bool(v) => Some(*v),
+        serde_json::Value::String(v) => Some(truthy(v)),
+        serde_json::Value::Number(n) => Some(n.as_i64().unwrap_or_default() != 0),
+        _ => None,
+    }
+}
+
+fn truthy(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NtfyEvent {
+    #[serde(default)]
+    pub event: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub topic: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub time: Option<i64>,
+}
+
+struct NtfyInner {
+    config: NtfyConfig,
+    client: Client,
+    base: BasePlatformAdapter,
+    inbound_tx: RwLock<Option<mpsc::Sender<IncomingMessage>>>,
+    seen: RwLock<HashMap<String, Instant>>,
+    stop: Notify,
+}
+
+pub struct NtfyAdapter {
+    inner: Arc<NtfyInner>,
+    run_task: RwLock<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl NtfyAdapter {
+    pub fn new(config: NtfyConfig) -> Result<Self, GatewayError> {
+        if config.topic.trim().is_empty() {
+            return Err(GatewayError::Platform(
+                "ntfy requires topic (platforms.ntfy.topic or NTFY_TOPIC)".into(),
+            ));
+        }
+        let base = BasePlatformAdapter::new(config.token.clone().unwrap_or_else(|| {
+            if config.topic.is_empty() {
+                "ntfy".to_string()
+            } else {
+                config.topic.clone()
+            }
+        }))
+        .with_proxy(config.proxy.clone());
+        let client = base.build_client()?;
+        let inner = Arc::new(NtfyInner {
+            config,
+            client,
+            base,
+            inbound_tx: RwLock::new(None),
+            seen: RwLock::new(HashMap::new()),
+            stop: Notify::new(),
+        });
+        Ok(Self {
+            inner,
+            run_task: RwLock::new(None),
+        })
+    }
+
+    pub fn config(&self) -> &NtfyConfig {
+        &self.inner.config
+    }
+
+    pub async fn set_inbound_sender(&self, tx: mpsc::Sender<IncomingMessage>) {
+        *self.inner.inbound_tx.write().await = Some(tx);
+    }
+
+    pub async fn handle_event(&self, event: NtfyEvent) -> Result<bool, GatewayError> {
+        Self::process_event(self.inner.clone(), event).await
+    }
+
+    fn build_headers(
+        &self,
+        include_echo_tag: bool,
+        markdown: bool,
+    ) -> Result<HeaderMap, GatewayError> {
+        build_headers(
+            self.inner.config.token.as_deref(),
+            include_echo_tag,
+            markdown,
+        )
+    }
+
+    async fn is_duplicate(inner: &NtfyInner, message_id: &str) -> bool {
+        let now = Instant::now();
+        let mut seen = inner.seen.write().await;
+        if seen.len() > DEDUP_MAX {
+            seen.retain(|_, at| now.duration_since(*at) <= DEDUP_WINDOW);
+        }
+        if seen.contains_key(message_id) {
+            return true;
+        }
+        seen.insert(message_id.to_string(), now);
+        false
+    }
+
+    async fn process_event(inner: Arc<NtfyInner>, event: NtfyEvent) -> Result<bool, GatewayError> {
+        if event.event != "message" {
+            return Ok(false);
+        }
+        let message_id = event.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        if Self::is_duplicate(&inner, &message_id).await {
+            debug!("ntfy duplicate message {}, skipping", message_id);
+            return Ok(false);
+        }
+        if event.tags.iter().any(|tag| tag == ECHO_TAG) {
+            debug!("ntfy skipping own echoed message tagged {}", ECHO_TAG);
+            return Ok(false);
+        }
+        let text = event.message.unwrap_or_default().trim().to_string();
+        if text.is_empty() {
+            debug!("ntfy empty message body, skipping");
+            return Ok(false);
+        }
+        let topic = event
+            .topic
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or(inner.config.topic.as_str())
+            .to_string();
+        let incoming = IncomingMessage {
+            platform: "ntfy".to_string(),
+            chat_id: topic.clone(),
+            user_id: topic,
+            text,
+            message_id: Some(message_id),
+            is_dm: true,
+        };
+        if let Some(tx) = inner.inbound_tx.read().await.as_ref() {
+            tx.send(incoming)
+                .await
+                .map_err(|e| GatewayError::Platform(format!("ntfy inbound channel closed: {e}")))?;
+            Ok(true)
+        } else {
+            debug!("ntfy inbound sender unset; dropping message");
+            Ok(false)
+        }
+    }
+
+    async fn run_stream(inner: Arc<NtfyInner>) {
+        let mut backoff_idx = 0;
+        while inner.base.is_running() {
+            match Self::consume_stream(inner.clone()).await {
+                Ok(()) => backoff_idx = 0,
+                Err(e) => {
+                    warn!("ntfy stream error: {}", e);
+                    let delay = RECONNECT_SECS
+                        .get(backoff_idx)
+                        .copied()
+                        .unwrap_or(*RECONNECT_SECS.last().unwrap_or(&60));
+                    backoff_idx += 1;
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(delay)) => {}
+                        _ = inner.stop.notified() => break,
+                    }
+                }
+            }
+        }
+    }
+
+    async fn consume_stream(inner: Arc<NtfyInner>) -> Result<(), GatewayError> {
+        let url = format!(
+            "{}/{}/json",
+            inner.config.server.trim_end_matches('/'),
+            inner.config.topic
+        );
+        let headers = build_headers(inner.config.token.as_deref(), false, false)?;
+        let response = inner
+            .client
+            .get(&url)
+            .headers(headers)
+            .query(&[("poll", "false")])
+            .timeout(Duration::from_secs(inner.config.stream_timeout_secs))
+            .send()
+            .await
+            .map_err(|e| GatewayError::ConnectionFailed(format!("ntfy stream connect: {e}")))?;
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(GatewayError::Auth(
+                "ntfy server rejected auth (401). Check NTFY_TOKEN.".into(),
+            ));
+        }
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GatewayError::ConnectionFailed(format!(
+                "ntfy topic '{}' returned 404",
+                inner.config.topic
+            )));
+        }
+        if !status.is_success() {
+            return Err(GatewayError::ConnectionFailed(format!(
+                "ntfy stream HTTP {status}"
+            )));
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        while let Some(chunk) = stream.next().await {
+            if !inner.base.is_running() {
+                break;
+            }
+            let chunk =
+                chunk.map_err(|e| GatewayError::ConnectionFailed(format!("ntfy stream: {e}")))?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            while let Some(pos) = buffer.find('\n') {
+                let line = buffer[..pos].trim().to_string();
+                buffer = buffer[pos + 1..].to_string();
+                if line.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<NtfyEvent>(&line) {
+                    Ok(event) => {
+                        if let Err(e) = Self::process_event(inner.clone(), event).await {
+                            warn!("ntfy event dispatch failed: {}", e);
+                        }
+                    }
+                    Err(e) => debug!("ntfy ignored malformed event line: {}", e),
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn build_headers(
+    token: Option<&str>,
+    include_echo_tag: bool,
+    markdown: bool,
+) -> Result<HeaderMap, GatewayError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    if include_echo_tag {
+        headers.insert("X-Tags", HeaderValue::from_static(ECHO_TAG));
+    }
+    if markdown {
+        headers.insert("X-Markdown", HeaderValue::from_static("true"));
+    }
+    if let Some(token) = token.map(str::trim).filter(|v| !v.is_empty()) {
+        let value = if token.contains(':') {
+            let encoded = general_purpose::STANDARD.encode(token.as_bytes());
+            format!("Basic {encoded}")
+        } else {
+            format!("Bearer {token}")
+        };
+        let header = HeaderValue::from_str(&value)
+            .map_err(|e| GatewayError::Auth(format!("invalid ntfy auth header: {e}")))?;
+        headers.insert(AUTHORIZATION, header);
+    }
+    Ok(headers)
+}
+
+fn truncate_message(text: &str) -> String {
+    text.chars().take(MAX_MESSAGE_LENGTH).collect()
+}
+
+#[async_trait]
+impl PlatformAdapter for NtfyAdapter {
+    async fn start(&self) -> Result<(), GatewayError> {
+        info!(
+            "ntfy adapter starting (server: {}, topic: {})",
+            self.inner.config.server, self.inner.config.topic
+        );
+        self.inner.base.mark_running();
+        let inner = self.inner.clone();
+        let task = tokio::spawn(async move {
+            Self::run_stream(inner).await;
+        });
+        *self.run_task.write().await = Some(task);
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), GatewayError> {
+        info!("ntfy adapter stopping");
+        self.inner.base.mark_stopped();
+        self.inner.stop.notify_waiters();
+        if let Some(task) = self.run_task.write().await.take() {
+            task.abort();
+        }
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+    ) -> Result<(), GatewayError> {
+        let publish_topic = self
+            .inner
+            .config
+            .publish_topic
+            .as_deref()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or(chat_id)
+            .trim();
+        if publish_topic.is_empty() {
+            return Err(GatewayError::SendFailed(
+                "ntfy publish topic is empty".into(),
+            ));
+        }
+        let markdown =
+            self.inner.config.markdown || matches!(parse_mode, Some(ParseMode::Markdown));
+        let headers = self.build_headers(true, markdown)?;
+        let url = format!(
+            "{}/{}",
+            self.inner.config.server.trim_end_matches('/'),
+            publish_topic
+        );
+        let body = truncate_message(text);
+        let response = self
+            .inner
+            .client
+            .post(&url)
+            .headers(headers)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| GatewayError::SendFailed(format!("ntfy publish failed: {e}")))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(GatewayError::SendFailed(format!(
+                "ntfy HTTP {status}: {}",
+                body.chars().take(200).collect::<String>()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn edit_message(
+        &self,
+        chat_id: &str,
+        _message_id: &str,
+        text: &str,
+    ) -> Result<(), GatewayError> {
+        self.send_message(chat_id, text, None).await
+    }
+
+    async fn send_file(
+        &self,
+        chat_id: &str,
+        file_path: &str,
+        caption: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        let text = match caption.map(str::trim).filter(|v| !v.is_empty()) {
+            Some(caption) => format!("{caption}\n[Attachment: {file_path}]"),
+            None => format!("[Attachment: {file_path}]"),
+        };
+        self.send_message(chat_id, &text, None).await
+    }
+
+    fn is_running(&self) -> bool {
+        self.inner.base.is_running()
+    }
+
+    fn platform_name(&self) -> &str {
+        "ntfy"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+    use wiremock::matchers::{body_string, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_config(server: String) -> NtfyConfig {
+        NtfyConfig {
+            server,
+            topic: "hermes-in".to_string(),
+            publish_topic: None,
+            token: None,
+            markdown: false,
+            stream_timeout_secs: STREAM_TIMEOUT_SECONDS,
+            proxy: AdapterProxyConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn echo_tagged_event_is_skipped() {
+        let adapter = NtfyAdapter::new(test_config(DEFAULT_SERVER.to_string())).unwrap();
+        let (tx, mut rx) = mpsc::channel(1);
+        adapter.set_inbound_sender(tx).await;
+
+        let dispatched = adapter
+            .handle_event(NtfyEvent {
+                event: "message".into(),
+                id: Some("echo-1".into()),
+                topic: Some("hermes-in".into()),
+                message: Some("own reply".into()),
+                tags: vec![ECHO_TAG.into()],
+                time: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!dispatched);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn event_with_other_tags_is_dispatched() {
+        let adapter = NtfyAdapter::new(test_config(DEFAULT_SERVER.to_string())).unwrap();
+        let (tx, mut rx) = mpsc::channel(1);
+        adapter.set_inbound_sender(tx).await;
+
+        let dispatched = adapter
+            .handle_event(NtfyEvent {
+                event: "message".into(),
+                id: Some("user-1".into()),
+                topic: Some("hermes-in".into()),
+                message: Some("hello".into()),
+                tags: vec!["warning".into()],
+                time: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(dispatched);
+        let incoming = rx.recv().await.unwrap();
+        assert_eq!(incoming.platform, "ntfy");
+        assert_eq!(incoming.chat_id, "hermes-in");
+        assert_eq!(incoming.user_id, "hermes-in");
+        assert_eq!(incoming.text, "hello");
+        assert_eq!(incoming.message_id.as_deref(), Some("user-1"));
+    }
+
+    #[tokio::test]
+    async fn send_message_emits_echo_tag_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hermes-in"))
+            .and(header("X-Tags", ECHO_TAG))
+            .and(body_string("Hello!"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "id-1"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = NtfyAdapter::new(test_config(server.uri())).unwrap();
+        adapter
+            .send_message("hermes-in", "Hello!", None)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_message_emits_auth_and_markdown_headers() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hermes-in"))
+            .and(header("Authorization", "Bearer mytoken"))
+            .and(header("X-Markdown", "true"))
+            .and(header("X-Tags", ECHO_TAG))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config(server.uri());
+        config.token = Some("mytoken".into());
+        config.markdown = true;
+        let adapter = NtfyAdapter::new(config).unwrap();
+        adapter
+            .send_message("hermes-in", "**bold**", None)
+            .await
+            .unwrap();
+    }
+}

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-05-29T20:05:45.672855+00:00`_
+_Generated from source artifacts: `2026-05-29T20:37:59.378566+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `38c4f8c3717518e81bc64765ab80f3192f6a113a`
-- Workstream snapshot generated: `2026-05-29T14:05:15-06:00`
-- Parity matrix generated: `2026-05-29T20:05:30.461016+00:00`
-- Queue snapshot generated: `2026-05-29T20:05:34.683184+00:00`
-- Proof snapshot generated: `2026-05-29T20:05:45.672855+00:00`
+- Upstream target: `upstream/main` @ `689ef5e233980f5d5a32080e959f44c8991dd03a`
+- Workstream snapshot generated: `2026-05-29T14:31:44-06:00`
+- Parity matrix generated: `2026-05-29T20:36:13.168736+00:00`
+- Queue snapshot generated: `2026-05-29T20:37:52.077525+00:00`
+- Proof snapshot generated: `2026-05-29T20:37:59.378566+00:00`
 
 ## Gate Status
 
@@ -21,24 +21,24 @@ _Generated from source artifacts: `2026-05-29T20:05:45.672855+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 4269 |
+| Total commits in queue | 4283 |
 | Pending | 0 |
-| Ported | 19 |
-| Superseded | 4175 |
+| Ported | 21 |
+| Superseded | 4187 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 4385 |
-| commits_ahead | 776 |
-| upstream_patch_missing | 4267 |
+| commits_behind | 4399 |
+| commits_ahead | 777 |
+| upstream_patch_missing | 4281 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 671 |
+| local_patch_unique | 672 |
 | files_only_upstream | 1470 |
-| files_only_local | 560 |
-| files_shared_identical | 1703 |
-| files_shared_different | 1016 |
+| files_only_local | 561 |
+| files_shared_identical | 1702 |
+| files_shared_different | 1017 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T20:05:44.514368+00:00",
+  "generated_at_utc": "2026-05-29T20:36:30.746412+00:00",
   "items": [
     {
       "category": "memory_plugin",
@@ -111,6 +111,12 @@
     },
     {
       "category": "platform_adapter",
+      "feature": "ntfy",
+      "name": "ntfy",
+      "status": "rust-native"
+    },
+    {
+      "category": "platform_adapter",
       "feature": "qqbot",
       "name": "qqbot",
       "status": "rust-native"
@@ -174,6 +180,6 @@
     "memory_plugins": 9,
     "non_rust_native": 0,
     "placeholder_status_entries": 0,
-    "platform_adapters": 19
+    "platform_adapters": 20
   }
 }

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-05-29T20:05:44.514368+00:00`
+Generated: `2026-05-29T20:36:30.746412+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |
@@ -22,6 +22,7 @@ Generated: `2026-05-29T20:05:44.514368+00:00`
 | platform_adapter | `homeassistant` | `homeassistant` | rust-native |
 | platform_adapter | `matrix` | `matrix` | rust-native |
 | platform_adapter | `mattermost` | `mattermost` | rust-native |
+| platform_adapter | `ntfy` | `ntfy` | rust-native |
 | platform_adapter | `qqbot` | `qqbot` | rust-native |
 | platform_adapter | `signal` | `signal` | rust-native |
 | platform_adapter | `slack` | `slack` | rust-native |
@@ -33,4 +34,4 @@ Generated: `2026-05-29T20:05:44.514368+00:00`
 | platform_adapter | `weixin` | `weixin` | rust-native |
 | platform_adapter | `whatsapp` | `whatsapp` | rust-native |
 
-- Platform adapters: `19`, memory plugins: `9`.
+- Platform adapters: `20`, memory plugins: `9`.

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-29T20:05:45.566631+00:00",
+  "generated_at_utc": "2026-05-29T20:36:38.958736+00:00",
   "items": [
     {
       "errors": [],
@@ -92,11 +92,14 @@
       "errors": [],
       "id": "rust-gateway-platform-plugin-parity",
       "last_reviewed": "2026-05-26",
-      "matched_files": 3,
+      "matched_files": 6,
       "matched_sample": [
         "plugins/platforms/mattermost/__init__.py",
         "plugins/platforms/mattermost/adapter.py",
-        "plugins/platforms/mattermost/plugin.yaml"
+        "plugins/platforms/mattermost/plugin.yaml",
+        "plugins/platforms/ntfy/__init__.py",
+        "plugins/platforms/ntfy/adapter.py",
+        "plugins/platforms/ntfy/plugin.yaml"
       ],
       "overdue": false,
       "owner": "sheawinkler",
@@ -182,7 +185,7 @@
   "summary": {
     "errors": 0,
     "items": 8,
-    "local_paths": 3279,
+    "local_paths": 3280,
     "review_overdue": 0,
     "unowned": 0,
     "upstream_paths": 4189,

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,13 +2,13 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 4385.0,
+        "actual": 4399.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "status": "pass"
       },
       {
-        "actual": 4267.0,
+        "actual": 4281.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "status": "pass"
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-29T20:05:45.672855+00:00",
+  "generated_at_utc": "2026-05-29T20:37:59.378566+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -60,12 +60,12 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 4385.0,
+    "max_commits_behind": 4399.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 1470.0,
     "max_queue_pending_commits": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 4267.0,
+    "max_upstream_patch_missing": 4281.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {
@@ -77,21 +77,21 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 75,
-      "ported": 19,
-      "superseded": 4175
+      "ported": 21,
+      "superseded": 4187
     },
     "by_target_ticket": {
-      "20": 1782,
+      "20": 1790,
       "21": 109,
       "22": 716,
-      "23": 331,
+      "23": 333,
       "24": 18,
       "25": 89,
-      "26": 1224
+      "26": 1228
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 4269
+    "total_commits": 4283
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-29T20:05:45.672855+00:00`
+Generated: `2026-05-29T20:37:59.378566+00:00`
 
 ## Gate Status
 
@@ -13,8 +13,8 @@ Generated: `2026-05-29T20:05:45.672855+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 4385.0 |
-| `max_upstream_patch_missing` | 4267.0 |
+| `max_commits_behind` | 4399.0 |
+| `max_upstream_patch_missing` | 4281.0 |
 | `max_files_only_upstream` | 1470.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
@@ -37,13 +37,13 @@ Generated: `2026-05-29T20:05:45.672855+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `4269`.
+- Upstream missing commits tracked: `4283`.
 - By target ticket:
-  - `#20`: `1782`
+  - `#20`: `1790`
   - `#21`: `109`
   - `#22`: `716`
-  - `#23`: `331`
+  - `#23`: `333`
   - `#24`: `18`
   - `#25`: `89`
-  - `#26`: `1224`
+  - `#26`: `1228`
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-05-29T20:05:44.565854+00:00",
+  "generated_at_utc": "2026-05-29T20:36:33.902963+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",
@@ -17,23 +17,25 @@
   "summary": {
     "by_disposition": {
       "mirrored": 68,
-      "ported": 11,
-      "superseded": 2859
+      "pending": 1,
+      "ported": 12,
+      "superseded": 2867
     },
-    "pass": true,
-    "total_commits": 2938,
-    "total_pending": 0
+    "pass": false,
+    "total_commits": 2948,
+    "total_pending": 1
   },
   "ticket_breakdown": {
     "20": {
       "by_disposition": {
         "mirrored": 14,
-        "ported": 2,
-        "superseded": 1766
+        "pending": 1,
+        "ported": 3,
+        "superseded": 1772
       },
       "label": "GPAR-01 tests+CI parity",
-      "pending": 0,
-      "total": 1782
+      "pending": 1,
+      "total": 1790
     },
     "21": {
       "by_disposition": {
@@ -59,11 +61,11 @@
       "by_disposition": {
         "mirrored": 3,
         "ported": 1,
-        "superseded": 327
+        "superseded": 329
       },
       "label": "GPAR-04 gateway/plugin-memory parity",
       "pending": 0,
-      "total": 331
+      "total": 333
     }
   }
 }

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,16 +1,16 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-05-29T20:05:44.565854+00:00`
+Generated: `2026-05-29T20:36:33.902963+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
-- Total scoped commits: `2938`
-- Pending scoped commits: `0`
-- Gate: `PASS`
+- Total scoped commits: `2948`
+- Pending scoped commits: `1`
+- Gate: `FAIL`
 
 | Ticket | Label | Total | Pending | Ported | Superseded |
 | ---: | --- | ---: | ---: | ---: | ---: |
-| #20 | GPAR-01 tests+CI parity | 1782 | 0 | 2 | 1766 |
+| #20 | GPAR-01 tests+CI parity | 1790 | 1 | 3 | 1772 |
 | #21 | GPAR-02 skills parity | 109 | 0 | 2 | 77 |
 | #22 | GPAR-03 UX parity | 716 | 0 | 6 | 689 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 331 | 0 | 1 | 327 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 333 | 0 | 1 | 329 |
 

--- a/docs/parity/intentional-divergence.json
+++ b/docs/parity/intentional-divergence.json
@@ -73,9 +73,10 @@
       "ticket": 7,
       "last_reviewed": "2026-05-26",
       "review_date": "2026-08-26",
-      "rationale": "Mattermost platform behavior is represented by the Rust-native gateway adapter and adapter matrix; upstream Python plugin files are not vendored into the Rust runtime tree.",
+      "rationale": "Mattermost and ntfy platform behavior are represented by Rust-native gateway adapters and adapter contracts; upstream Python plugin files are not vendored into the Rust runtime path.",
       "path_prefixes": [
-        "plugins/platforms/mattermost/"
+        "plugins/platforms/mattermost/",
+        "plugins/platforms/ntfy/"
       ]
     },
     {

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T20:05:30.461016+00:00",
+  "generated_at_utc": "2026-05-29T20:36:13.168736+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "f519f22525748870912b4cbde064db52e2368b09",
+    "local_sha": "e233c98cca45e8481853be3f8d0bfa881253e1a4",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
+    "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4385,
-    "commits_ahead": 776,
-    "upstream_patch_missing": 4267,
+    "commits_behind": 4399,
+    "commits_ahead": 777,
+    "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 671,
+    "local_patch_unique": 672,
     "files_only_upstream": 1470,
-    "files_only_local": 560,
-    "files_shared_identical": 1703,
-    "files_shared_different": 1016,
-    "tree_files_changed": 3046,
-    "tree_insertions": 738620,
-    "tree_deletions": 370857
+    "files_only_local": 561,
+    "files_shared_identical": 1702,
+    "files_shared_different": 1017,
+    "tree_files_changed": 3048,
+    "tree_insertions": 739593,
+    "tree_deletions": 372007
   },
   "top_upstream_only": [
     {
@@ -186,15 +186,15 @@
   "top_shared_different": [
     {
       "path": "tests/gateway",
-      "count": 171
-    },
-    {
-      "path": "tests/tools",
-      "count": 138
+      "count": 172
     },
     {
       "path": "website/docs",
       "count": 138
+    },
+    {
+      "path": "tests/tools",
+      "count": 137
     },
     {
       "path": "tests/hermes_cli",
@@ -222,7 +222,7 @@
     },
     {
       "path": "tests/plugins",
-      "count": 15
+      "count": 16
     },
     {
       "path": "skills/creative",
@@ -241,12 +241,12 @@
       "count": 9
     },
     {
-      "path": "plugins/memory",
+      "path": "tests/acp",
       "count": 8
     },
     {
-      "path": "tests/acp",
-      "count": 8
+      "path": "plugins/memory",
+      "count": 7
     },
     {
       "path": "skills/productivity",
@@ -317,6 +317,10 @@
       "count": 2
     },
     {
+      "path": "plugins/disk-cleanup",
+      "count": 2
+    },
+    {
       "path": "plugins/example-dashboard",
       "count": 2
     },
@@ -339,10 +343,6 @@
     {
       "path": "tests/e2e",
       "count": 2
-    },
-    {
-      "path": ".gitattributes",
-      "count": 1
     }
   ],
   "top_local_only": [
@@ -356,7 +356,7 @@
     },
     {
       "path": "crates/hermes-gateway",
-      "count": 45
+      "count": 46
     },
     {
       "path": "crates/hermes-cli",
@@ -680,7 +680,7 @@
     },
     {
       "path": "crates/hermes-gateway",
-      "count": 45
+      "count": 46
     },
     {
       "path": "crates/hermes-cli",
@@ -837,7 +837,7 @@
       "issue": 10,
       "name": "Tests and CI parity",
       "upstream_only": 317,
-      "shared_different": 681,
+      "shared_different": 682,
       "local_only": 34,
       "risk": "high",
       "effort": "XL"
@@ -888,7 +888,7 @@
       "name": "Core runtime parity",
       "upstream_only": 62,
       "shared_different": 0,
-      "local_only": 144,
+      "local_only": 145,
       "risk": "critical",
       "effort": "M"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4267,
+    "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 671,
+    "local_patch_unique": 672,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",
@@ -960,7 +960,7 @@
       "6b69de4772eac5f982c097553dc6bcfeb60350e6"
     ],
     "intentional_divergence_items": 8,
-    "intentional_divergence_covered_files": 898
+    "intentional_divergence_covered_files": 900
   },
   "intentional_divergence": [
     {
@@ -1034,11 +1034,13 @@
       "status": "approved",
       "workstream": "WS3",
       "summary": "Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees.",
-      "matched_files": 3,
+      "matched_files": 5,
       "matched_sample": [
         "plugins/platforms/mattermost/__init__.py",
         "plugins/platforms/mattermost/adapter.py",
-        "plugins/platforms/mattermost/plugin.yaml"
+        "plugins/platforms/mattermost/plugin.yaml",
+        "plugins/platforms/ntfy/adapter.py",
+        "plugins/platforms/ntfy/plugin.yaml"
       ]
     },
     {

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,29 +1,29 @@
 # Parity Matrix
 
-Generated: `2026-05-29T20:05:30.461016+00:00`
+Generated: `2026-05-29T20:36:13.168736+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`f519f22525748870912b4cbde064db52e2368b09`)
-- Upstream ref: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
+- Local ref: `HEAD` (`e233c98cca45e8481853be3f8d0bfa881253e1a4`)
+- Upstream ref: `upstream/main` (`689ef5e233980f5d5a32080e959f44c8991dd03a`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4385 |
-| Commits ahead local (`local` ancestry only) | 776 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4267 |
+| Commits behind local (`upstream` ancestry only) | 4399 |
+| Commits ahead local (`local` ancestry only) | 777 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4281 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 671 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 672 |
 | Files only in upstream tree | 1470 |
-| Files only in local tree | 560 |
-| Shared files identical content | 1703 |
-| Shared files different content | 1016 |
-| Total files changed (`local` vs `upstream`) | 3046 |
-| Insertions (`local` vs `upstream`) | 738620 |
-| Deletions (`local` vs `upstream`) | 370857 |
+| Files only in local tree | 561 |
+| Shared files identical content | 1702 |
+| Shared files different content | 1017 |
+| Total files changed (`local` vs `upstream`) | 3048 |
+| Insertions (`local` vs `upstream`) | 739593 |
+| Deletions (`local` vs `upstream`) | 372007 |
 
 ## Top 40 upstream-only buckets
 
@@ -74,22 +74,22 @@ Generated: `2026-05-29T20:05:30.461016+00:00`
 
 | Bucket | Files |
 | --- | ---: |
-| `tests/gateway` | 171 |
-| `tests/tools` | 138 |
+| `tests/gateway` | 172 |
 | `website/docs` | 138 |
+| `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/agent` | 57 |
 | `tests/run_agent` | 56 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |
-| `tests/plugins` | 15 |
+| `tests/plugins` | 16 |
 | `skills/creative` | 11 |
 | `tests/cron` | 11 |
 | `plugins/google_meet` | 9 |
 | `plugins/platforms` | 9 |
-| `plugins/memory` | 8 |
 | `tests/acp` | 8 |
+| `plugins/memory` | 7 |
 | `skills/productivity` | 7 |
 | `tests/skills` | 6 |
 | `plugins/model-providers` | 5 |
@@ -107,13 +107,13 @@ Generated: `2026-05-29T20:05:30.461016+00:00`
 | `optional-skills/finance` | 2 |
 | `optional-skills/health` | 2 |
 | `optional-skills/mlops` | 2 |
+| `plugins/disk-cleanup` | 2 |
 | `plugins/example-dashboard` | 2 |
 | `plugins/observability` | 2 |
 | `plugins/video_gen` | 2 |
 | `skills/devops` | 2 |
 | `skills/research` | 2 |
 | `tests/e2e` | 2 |
-| `.gitattributes` | 1 |
 
 ## Top 40 local-only buckets
 
@@ -121,7 +121,7 @@ Generated: `2026-05-29T20:05:30.461016+00:00`
 | --- | ---: |
 | `crates/hermes-tools` | 74 |
 | `crates/hermes-agent` | 47 |
-| `crates/hermes-gateway` | 45 |
+| `crates/hermes-gateway` | 46 |
 | `crates/hermes-cli` | 44 |
 | `crates/hermes-intelligence` | 37 |
 | `docs/parity` | 37 |
@@ -164,7 +164,7 @@ Generated: `2026-05-29T20:05:30.461016+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 317 | 681 | high | XL |
+| `WS6` | #10 | Tests and CI parity | 317 | 682 | high | XL |
 | `WS5` | #9 | UX parity | 493 | 231 | high | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 391 | 12 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 114 | 53 | high | L |
@@ -174,10 +174,10 @@ Generated: `2026-05-29T20:05:30.461016+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4267`
+- Upstream missing by patch-id: `4281`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `671`
-- Intentional divergence tracked items: `8` (covered files: `898`)
+- Local unique by patch-id: `672`
+- Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -188,7 +188,7 @@ Generated: `2026-05-29T20:05:30.461016+00:00`
 | `ultra-webhook-queue-backends` | approved | WS7 | 4 | Preserve webhook-driven sync queue worker architecture with sqlite, SQS, and Kafka support. |
 | `ultra-launchd-webhook-lifecycle` | approved | WS7 | 4 | Preserve launchd-based interactive dev lifecycle management for webhook listener and worker. |
 | `rust-skills-catalog-governance` | approved | WS4 | 146 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
-| `rust-gateway-platform-plugin-parity` | approved | WS3 | 3 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
+| `rust-gateway-platform-plugin-parity` | approved | WS3 | 5 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
 | `upstream-python-plugin-backend-drift-20260527` | temporary | WS3 | 10 | Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes. |
 | `upstream-s6-plan-doc-archive` | approved | WS7 | 1 | Do not import upstream implementation-plan archive documents unless they change local runtime or release behavior. |
 | `rust-cli-tui-primary-ux-surface` | approved | WS5 | 728 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -540,6 +540,18 @@
       "disposition": "ported",
       "notes": "Ntfy robustness and docs are represented by plugins/platforms/ntfy, tests/gateway/test_ntfy_plugin.py, website ntfy messaging docs, sidebars, and environment-variable reference entries."
     },
+    "9405cdc8dd03": {
+      "disposition": "ported",
+      "notes": "Rust ntfy gateway adapter now tags outgoing messages with X-Tags: hermes-agent and skips incoming events carrying that tag to prevent self-echo loops."
+    },
+    "8055d0f09246": {
+      "disposition": "ported",
+      "notes": "Rust ntfy gateway tests cover echo-tag outbound headers, inbound echo filtering, genuine tagged messages, and env-driven platform enablement; Python release AUTHOR_MAP updates are not part of the Rust release pipeline."
+    },
+    "d473e7c9385e": {
+      "disposition": "superseded",
+      "notes": "Upstream Python disk-cleanup auto-tracking is outside the Rust-only runtime path; Rust cron jobs.json is owned by hermes-cron FileJobPersistence and covered by the hermes-cron persistence tests, not by a Python cleanup hook."
+    },
     "7de8cd4c5f67": {
       "disposition": "ported",
       "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync."

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -421,6 +421,21 @@
       "workstream": "WS3"
     },
     {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/disk-cleanup",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "b7f748e7f21049615fce3150a5f9102d736dd1a4",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/disk-cleanup/disk_cleanup.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "8d984273e795a01ae310a4529c1ebfd91ace2cd7",
+      "workstream": "WS3"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "plugins/example-dashboard/dashboard/manifest.json",
@@ -676,21 +691,6 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "4f8d10ea9ecb5f1fabb32733cfaa915fed2a9104",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "plugins/memory/honcho/README.md",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "dbe3eebc9a56d1910a111800666634dbb1810273",
-      "workstream": "WS3"
-    },
-    {
       "action": "No runtime implementation; keep rationale current.",
       "classification": "policy_only",
       "classification_path": "plugins/memory/honcho/__init__.py",
@@ -736,16 +736,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/honcho/session.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "788be9c669b4ae94155635fccc62fa980b9198a5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/honcho/session.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e83c714b51bb2ea4a0ebe298f39922d25937751f",
       "workstream": "WS3"
@@ -946,18 +946,18 @@
       "workstream": "WS3"
     },
     {
-      "action": "No runtime implementation; keep rationale current.",
-      "classification": "policy_only",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/platforms/ntfy/adapter.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b401ecfd775b58633a0578a9c1836e25171b40ec",
-      "necessity": "not_runtime_required",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/platforms/ntfy/adapter.py",
       "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_non_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "b9280ab9e6e73a27805eeb4bc7e8d61b7f6f7561",
+      "upstream_blob": "4ab46cecfb279048ae2162e8ce08ccc017988037",
       "workstream": "WS3"
     },
     {
@@ -4122,7 +4122,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "b6472b04e00bc06e042d9fd1cc5d714e0faba6a6",
+      "upstream_blob": "0f65fd052be2d4ca007a8bd2918c4e97b6830c52",
       "workstream": "WS6"
     },
     {
@@ -4370,6 +4370,21 @@
       "classification": "functional",
       "classification_path": "tests/gateway",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "20f7d73a8fe0379daa058d1db1772af0c5a857ba",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_media_extraction.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "f5a5e104f52780f5994177ecc2443a23e766f1ba",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/gateway",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "4a140f2761b89f6718865b00260fed69e723af36",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -4437,7 +4452,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "f2f24ae4aa89f404fd622bd93ed48e07c26f064e",
+      "upstream_blob": "f59ee2d6a2a3e49200c0c7d93413e6a4b0ddeb2d",
       "workstream": "WS6"
     },
     {
@@ -4467,7 +4482,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "6a5b8c15c14bf67e9a59785c5d475d3b5db58615",
+      "upstream_blob": "e0f2c80cb0438391e407a9d68aad392e2abe9788",
       "workstream": "WS6"
     },
     {
@@ -6042,7 +6057,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "a8657d7709429bf3373b9bcebd44cfaaaecaa658",
+      "upstream_blob": "8c0f2a39874f9b1b92398a0575a88f6943051778",
       "workstream": "WS6"
     },
     {
@@ -7557,7 +7572,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "8a68d6a178d090db5d671e700701c6b77a9cad56",
+      "upstream_blob": "c7cc1c867241c5b581b74627f75cf85a20bded1f",
       "workstream": "WS6"
     },
     {
@@ -7888,6 +7903,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "a23b6aff659dcea5fe701cbd6dcd5c40c19dc77d",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/plugins",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "e1463bced7ad702595ad2a52591076d350a0163c",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/plugins/test_disk_cleanup_plugin.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "4f7f66e028a400f712fa66875ddc07cc9a22a04f",
       "workstream": "WS6"
     },
     {
@@ -9477,7 +9507,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "45afb3c1aa42e705ea6ff5d476896b22a993c359",
+      "upstream_blob": "51ca9cf9128b6f094eb07a02d091fd0af84bb464",
       "workstream": "WS6"
     },
     {
@@ -9612,7 +9642,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "2631dab378740a96cab1ee6379064e1b2fd27b3a",
+      "upstream_blob": "4524fb88cb68f831c09812a3f05f012af2b30dd3",
       "workstream": "WS6"
     },
     {
@@ -11337,7 +11367,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "5a0517c3beecd0272484c4a94f76df3be73cc1f2",
+      "upstream_blob": "e764ac0b42609b2f4210e1442892cd639d45e1e4",
       "workstream": "WS6"
     },
     {
@@ -11352,7 +11382,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0e1c0ef78f117df22919850b4080ada1c3ded155",
+      "upstream_blob": "f3c0cf29c8355d926eeb785a5d3580abc9fd5917",
       "workstream": "WS6"
     },
     {
@@ -11413,21 +11443,6 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "49ae5ca2f4b9624e0152255f2d33c7c56542bb73",
-      "workstream": "WS6"
-    },
-    {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "6e98946b6c0c6aaffeb572a5850a7b0827b491db",
-      "necessity": "necessary_review",
-      "owner": "sheawinkler",
-      "path": "tests/tools/test_tts_mistral.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
-      "upstream_blob": "818a6c1d1174ebc42e32ec31ab4469c2a9b35d65",
       "workstream": "WS6"
     },
     {
@@ -15241,42 +15256,42 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T20:05:39.916289+00:00",
+  "generated_at_utc": "2026-05-29T20:36:20.591466+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "f519f22525748870912b4cbde064db52e2368b09",
+    "local_sha": "e233c98cca45e8481853be3f8d0bfa881253e1a4",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a"
+    "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
       "functional": 770,
-      "intentional_divergence": 76,
-      "policy_only": 169
+      "intentional_divergence": 78,
+      "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 246,
-      "rust_equivalent_or_contract_test_required": 680,
-      "rust_native_runtime_parity_required_if_needed": 11,
+      "not_required_for_runtime": 247,
+      "rust_equivalent_or_contract_test_required": 681,
+      "rust_native_runtime_parity_required_if_needed": 10,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 76,
-      "cleared_non_runtime": 170,
+      "cleared_intentional_divergence": 78,
+      "cleared_non_runtime": 169,
       "pending_review": 770
     },
     "by_workstream": {
       "WS3": 53,
       "WS4": 39,
       "WS5": 230,
-      "WS6": 681,
+      "WS6": 682,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 76,
-    "cleared_non_runtime": 170,
+    "cleared_intentional_divergence": 78,
+    "cleared_non_runtime": 169,
     "pending_classification": 0,
     "pending_review": 770,
-    "total_shared_different": 1016
+    "total_shared_different": 1017
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,21 +1,21 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T20:05:39.916289+00:00`
+Generated: `2026-05-29T20:36:20.591466+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1016`
+- Total shared-different paths: `1017`
 - Pending classification: `0`
 - Pending functional review: `770`
-- Cleared non-runtime: `170`
-- Cleared intentional divergence: `76`
+- Cleared non-runtime: `169`
+- Cleared intentional divergence: `78`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 76 |
-| `cleared_non_runtime` | 170 |
+| `cleared_intentional_divergence` | 78 |
+| `cleared_non_runtime` | 169 |
 | `pending_review` | 770 |
 
 ## Workstream Counts
@@ -25,7 +25,7 @@ Generated: `2026-05-29T20:05:39.916289+00:00`
 | `WS3` | 53 |
 | `WS4` | 39 |
 | `WS5` | 230 |
-| `WS6` | 681 |
+| `WS6` | 682 |
 | `WS8` | 13 |
 
 ## Pending Classification
@@ -37,8 +37,8 @@ Generated: `2026-05-29T20:05:39.916289+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 171 |
-| `tests/tools` | 138 |
+| `tests/gateway` | 172 |
+| `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/agent` | 57 |
@@ -46,7 +46,7 @@ Generated: `2026-05-29T20:05:39.916289+00:00`
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |
-| `tests/plugins` | 15 |
+| `tests/plugins` | 16 |
 | `tests/cron` | 11 |
 | `tests/acp` | 8 |
 | `tests/skills` | 6 |
@@ -57,9 +57,9 @@ Generated: `2026-05-29T20:05:39.916289+00:00`
 | `tests/tui_gateway` | 4 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
-| `plugins/memory` | 2 |
 | `tests/e2e` | 2 |
 | `plugins/browser/browserbase/provider.py` | 1 |
+| `plugins/disk-cleanup` | 1 |
 | `plugins/model-providers` | 1 |
 | `plugins/spotify/tools.py` | 1 |
 | `plugins/teams_pipeline` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -325,6 +325,13 @@
       "ticket": 304
     },
     {
+      "path": "plugins/memory/honcho/session.py",
+      "classification": "intentional_divergence",
+      "rationale": "Ultra supersedes the upstream Python Honcho gateway identity resolver with the Rust Honcho memory provider resolver in crates/hermes-agent/src/memory_plugins/honcho.rs, including pinUserPeer, userPeerAliases, runtimePeerPrefix, and hash-escalated collision handling.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "plugins/memory/supermemory/__init__.py",
       "classification": "policy_only",
       "rationale": "The shared diff is behavior-equivalent tuple membership for boolean parsing, context guards, and session-role filtering.",
@@ -508,8 +515,8 @@
     },
     {
       "path": "plugins/platforms/ntfy/adapter.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is documentation punctuation and the local ASCII platform emoji label; ntfy runtime behavior and auth/header contracts are unchanged.",
+      "classification": "intentional_divergence",
+      "rationale": "Ultra supersedes the upstream Python ntfy adapter with the Rust-native gateway adapter in crates/hermes-gateway/src/platforms/ntfy.rs, including X-Tags echo-loop prevention, auth/header handling, inbound event filtering, env enablement, and cron delivery target parsing.",
       "owner": "sheawinkler",
       "ticket": 304
     },

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,9 +1,9 @@
 {
-  "generated_at_utc": "2026-05-29T20:05:44.465489+00:00",
+  "generated_at_utc": "2026-05-29T20:36:27.637841+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {
-      "evidence_count": 23,
+      "evidence_count": 24,
       "evidence_sample": [
         "crates/hermes-cli/tests/e2e_gateway_cron_webhook.rs",
         "crates/hermes-cli/tests/e2e_gateway_process.rs",
@@ -18,6 +18,7 @@
         "crates/hermes-gateway/src/platforms/matrix.rs",
         "crates/hermes-gateway/src/platforms/mattermost.rs",
         "crates/hermes-gateway/src/platforms/mod.rs",
+        "crates/hermes-gateway/src/platforms/ntfy.rs",
         "crates/hermes-gateway/src/platforms/qqbot.rs",
         "crates/hermes-gateway/src/platforms/signal.rs",
         "crates/hermes-gateway/src/platforms/slack.rs",

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,10 +1,10 @@
 # Test Intent Mapping
 
-Generated: `2026-05-29T20:05:44.465489+00:00`
+Generated: `2026-05-29T20:36:27.637841+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |
-| `gateway-platform-behavior` | yes | 23 |
+| `gateway-platform-behavior` | yes | 24 |
 | `tool-runtime-behavior` | yes | 73 |
 | `cli-command-surface` | yes | 39 |
 | `agent-loop-and-runtime` | yes | 43 |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -93774,9 +93774,314 @@
       "subject": "test(gateway): update system-unit cwd assertion to HERMES_HOME anchor",
       "target_ticket": 20,
       "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "gateway/run.py",
+        "tests/gateway/test_media_extraction.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "08c0b22417a80874032cae4a6d9e43d77d55f89a",
+      "subject": "fix(gateway): scope tool-result MEDIA scan to current turn",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "plugins/platforms/ntfy/adapter.py"
+      ],
+      "files_touched": 1,
+      "notes": "Rust ntfy gateway adapter now tags outgoing messages with X-Tags: hermes-agent and skips incoming events carrying that tag to prevent self-echo loops.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "9405cdc8dd0347fee65b554e3aba0d2eab7a7b7f",
+      "subject": "fix(ntfy): prevent echo loop by tagging outgoing messages",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "ported",
+      "files_sample": [
+        "plugins/platforms/ntfy/adapter.py",
+        "scripts/release.py",
+        "tests/gateway/test_ntfy_plugin.py"
+      ],
+      "files_touched": 3,
+      "notes": "Rust ntfy gateway tests cover echo-tag outbound headers, inbound echo filtering, genuine tagged messages, and env-driven platform enablement; Python release AUTHOR_MAP updates are not part of the Rust release pipeline.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "8055d0f09246555d9a7d9b95295def612e500c70",
+      "subject": "test(ntfy): cover echo-tag filter; tag standalone send path",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "gateway/platforms/feishu.py",
+        "tests/gateway/test_feishu.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "91b174038c7e2bf6cde056da05f8f90673e8c87a",
+      "subject": "fix(feishu): bound _chat_locks with LRU eviction (#34836)",
+      "target_ticket": 23,
+      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
+    },
+    {
+      "classification_rule": "sha_override",
+      "disposition": "superseded",
+      "files_sample": [
+        "plugins/disk-cleanup/disk_cleanup.py",
+        "tests/plugins/test_disk_cleanup_plugin.py"
+      ],
+      "files_touched": 2,
+      "notes": "Upstream Python disk-cleanup auto-tracking is outside the Rust-only runtime path; Rust cron jobs.json is owned by hermes-cron FileJobPersistence and covered by the hermes-cron persistence tests, not by a Python cleanup hook.",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": false,
+        "superseded_by_guard": false
+      },
+      "sha": "d473e7c9385e04c975b32d2d2cde3a02ba7d4f47",
+      "subject": "fix(cron): exclude jobs.json registry from disk-cleanup pattern",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/backup.py",
+        "hermes_cli/main.py",
+        "tests/hermes_cli/test_backup.py"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "3845d86b9330d8952fc1e9534d438f62ad1d53e5",
+      "subject": "fix(cron): restore jobs.json emptied by config migration on update",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "scripts/release.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "0dc0c5ea6be051f33d287a02f274b913cbc7cb00",
+      "subject": "chore: add AUTHOR_MAP entry for sweetcornna",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "gateway/platforms/base.py",
+        "gateway/run.py",
+        "gateway/stream_consumer.py",
+        "scripts/release.py",
+        "tests/gateway/test_platform_base.py"
+      ],
+      "files_touched": 5,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "781604ce4c826ec06b69a0bde703ab935308893d",
+      "subject": "fix(gateway): unify MEDIA: extraction extension set + close the unknown-ext black hole (#34517) (#34844)",
+      "target_ticket": 23,
+      "target_ticket_name": "GPAR-04 gateway/plugin-memory parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/security_advisories.py",
+        "hermes_cli/tools_config.py",
+        "hermes_cli/web_server.py",
+        "pyproject.toml",
+        "tests/test_project_metadata.py",
+        "tests/tools/test_transcription_dotenv_fallback.py",
+        "tests/tools/test_transcription_tools.py",
+        "tests/tools/test_tts_mistral.py",
+        "tools/lazy_deps.py",
+        "tools/transcription_tools.py",
+        "tools/tts_tool.py",
+        "uv.lock"
+      ],
+      "files_touched": 12,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "3a2c03061ce912ff7421286c8197f844b63bbefb",
+      "subject": "fix(stt,tts): restore mistralai \u2014 2.4.8 is clean, ban lifted (#34841)",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "cli.py",
+        "tests/cli/test_cli_resume_command.py"
+      ],
+      "files_touched": 2,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "edfdc776649cd50637d8aa3a35b584c4458416ef",
+      "subject": "fix(cli): resume the selected chat when a bare number follows /resume",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "tests/test_tui_gateway_server.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-only parity guard: upstream Python test-only commit not ported",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": true,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": true
+      },
+      "sha": "4fd8521e44e920fbf545b408ea8727423436cad4",
+      "subject": "test(tui-gateway): isolate completion_queue in poller requeue test",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "tools/mcp_tool.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "9f5afc7636246320dc3e8fd4f9d5aef50fbadcfb",
+      "subject": "fix(mcp): widen isinstance check to BaseException for CancelledError",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "scripts/release.py"
+      ],
+      "files_touched": 1,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "bb5082571671739afe336c1e7998ceeb55df3627",
+      "subject": "chore(release): map annguyenNous to AUTHOR_MAP",
+      "target_ticket": 26,
+      "target_ticket_name": "GPAR-07 upstream queue backfill"
+    },
+    {
+      "classification_rule": "prior_state",
+      "disposition": "superseded",
+      "files_sample": [
+        "hermes_cli/banner.py",
+        "tests/hermes_cli/test_pip_install_detection.py",
+        "tests/hermes_cli/test_update_check.py"
+      ],
+      "files_touched": 3,
+      "notes": "rust-primary parity policy: upstream Python runtime surface commit is covered by Rust-native architecture and tracked via Rust gates",
+      "owner": "",
+      "rust_only_guard": {
+        "allow_python_test_surfaces": false,
+        "python_test_only_commit": false,
+        "rust_primary_surface_only_commit": true,
+        "superseded_by_guard": false
+      },
+      "sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
+      "subject": "feat(cli): warn on unsupported pip installs + fix stale update-check cache (#34491) (#34846)",
+      "target_ticket": 20,
+      "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-05-29T20:05:34.683184+00:00",
+  "generated_at_utc": "2026-05-29T20:37:52.077525+00:00",
   "refs": {
     "local_ref": "main",
     "range": "main..upstream/main",
@@ -93785,20 +94090,20 @@
   "summary": {
     "by_disposition": {
       "mirrored": 75,
-      "ported": 19,
-      "superseded": 4175
+      "ported": 21,
+      "superseded": 4187
     },
     "by_target_ticket": {
-      "20": 1782,
+      "20": 1790,
       "21": 109,
       "22": 716,
-      "23": 331,
+      "23": 333,
       "24": 18,
       "25": 89,
-      "26": 1224
+      "26": 1228
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 4269
+    "total_commits": 4283
   }
 }

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-05-29T20:05:34.683184+00:00`
+Generated: `2026-05-29T20:37:52.077525+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `4269`.
+- Range: `main..upstream/main`; total commits tracked: `4283`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 1782 |
+| #20 | GPAR-01 tests+CI parity | 1790 |
 | #21 | GPAR-02 skills parity | 109 |
 | #22 | GPAR-03 UX parity | 716 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 331 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 333 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 18 |
 | #25 | GPAR-06 packaging/docs/install parity | 89 |
-| #26 | GPAR-07 upstream queue backfill | 1224 |
+| #26 | GPAR-07 upstream queue backfill | 1228 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 75 |
-| ported | 19 |
-| superseded | 4175 |
+| ported | 21 |
+| superseded | 4187 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-05-29T14:05:15-06:00",
-  "head_sha": "f519f22525748870912b4cbde064db52e2368b09",
+  "generated_at_utc": "2026-05-29T14:31:44-06:00",
+  "head_sha": "e233c98cca45e8481853be3f8d0bfa881253e1a4",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "38c4f8c3717518e81bc64765ab80f3192f6a113a",
+  "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `f519f22525748870912b4cbde064db52e2368b09`
-- Upstream: `upstream/main` (`38c4f8c3717518e81bc64765ab80f3192f6a113a`)
+- Local HEAD: `e233c98cca45e8481853be3f8d0bfa881253e1a4`
+- Upstream: `upstream/main` (`689ef5e233980f5d5a32080e959f44c8991dd03a`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -127,6 +127,41 @@ For every key, resolution order is: **host block > root > env var > default**.
 | `peerName` | string | — | User peer identity |
 | `aiPeer` | string | host key | AI peer identity |
 
+### Identity Mapping (Gateway Multi-User)
+
+In gateway deployments (Telegram, Discord, Slack, etc.) each user arrives with a platform-native runtime ID (Telegram UID, Discord snowflake, Slack user). These three keys control how those runtime IDs map to Honcho peers. The resolver is config-driven and deterministic — no automatic merging or runtime inference.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `pinUserPeer` | bool | `false` | When `true`, every gateway runtime user collapses to `peerName`. Single-operator deployments where you want all your platforms (and any other users) to share one peer. Also accepted as `pinPeerName` |
+| `pinPeerName` | bool | `false` | Alias for `pinUserPeer`; same effect |
+| `userPeerAliases` | object | `{}` | Map of runtime IDs to peer IDs (`{"86701400": "eri"}`). Many-to-one is the intended pattern — alias all your runtime IDs to one peer name. One-to-many is not supported; one runtime ID resolves to exactly one peer |
+| `runtimePeerPrefix` | string | `""` | Prepended to unknown runtime IDs to namespace them (e.g. `"telegram_"` → `telegram_86701400`). Used only when no alias matches. Prevents collisions between platforms whose runtime IDs share the same shape |
+
+**Resolver ladder** (first match wins):
+
+```
+1. pinUserPeer / pinPeerName=true → return peerName (ignore runtime ID)
+2. userPeerAliases[runtime_id]   → return aliased peer
+3. userPeerAliases[runtime_id_alt] → check alt-ID too (Telegram UID + username, etc.)
+4. runtimePeerPrefix + runtime_id → namespaced peer, with sha256 collision escalation
+5. raw sanitized runtime_id      → fallback peer
+6. peerName                      → no runtime ID at all (CLI/TUI)
+7. session-key fallback          → no config either
+```
+
+**Why no `pinAiPeer`?** The AI peer is already pinned by construction — `aiPeer` is the only AI-side identity setting and the resolver never overrides it. Only the user-side peer has the runtime-vs-config tension that `pinUserPeer` resolves.
+
+**Host vs root semantics.** All three keys are accepted at both root and `hosts.<host>` levels. Host-level wins. For maps and prefixes, host-level *replaces* the root value as a whole (not merge), so a host can intentionally own its identity universe or wipe it with `userPeerAliases: {}` / `runtimePeerPrefix: ""`.
+
+**Deployment shapes** (`hermes honcho setup` asks one prompt to set these):
+
+- **Single-operator** — `pinUserPeer: true`. All gateway users → `peerName`. Recommended for personal use where you connect Hermes to your own Telegram/Discord/etc.
+- **Multi-user gateway** — `pinUserPeer: false`, optional `runtimePeerPrefix`. Each runtime user → own peer. Recommended for bots serving many humans.
+- **Hybrid** — `pinUserPeer: false`, `userPeerAliases` mapping the operator's runtime IDs to `peerName`. Multi-user gateway where YOU are routed but others stay distinct.
+
+**Migrating single → multi.** Flipping `pinUserPeer` from `true` to `false` does not migrate data. Memory accumulated under `peerName` while pinned stays there; runtime users now resolve to fresh, empty peers. To preserve your own continuity, use the **hybrid** shape — alias your runtime IDs back to `peerName` so your turns keep landing on the pooled history while other users get their own peers. The setup wizard offers this path automatically when it detects a single → multi transition.
+
 ### Memory & Recall
 
 | Key | Type | Default | Description |


### PR DESCRIPTION
## Summary
- ports upstream Honcho gateway identity mapping into the Rust memory provider (`pinUserPeer`, `userPeerAliases`, `runtimePeerPrefix`, and hash-escalated peer collision handling)
- adds a Rust-native ntfy gateway adapter with echo-loop prevention (`X-Tags: hermes-agent` outbound, tagged inbound skip), env enablement, CLI registration, and cron delivery target parsing
- refreshes parity artifacts against upstream/main 689ef5e and clears pending upstream queue commits without editing Python product runtime paths

## Local verification
- cargo fmt --check
- cargo test -p hermes-agent memory_plugins::honcho --lib
- cargo test -p hermes-gateway ntfy --features ntfy
- cargo test -p hermes-config ntfy_env_sets_topic_and_auto_enables
- cargo test -p hermes-cron
- python3 -m py_compile scripts/generate-global-parity-proof.py scripts/generate-shared-diff-backlog.py scripts/generate-upstream-patch-queue.py scripts/generate-parity-matrix.py
- python3 scripts/generate-global-parity-proof.py --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof-honcho-ntfy-upstream689.json --out-md /tmp/hermes-agent-ultra-global-parity-proof-honcho-ntfy-upstream689.md
- bash scripts/check-runtime-placeholders.sh
- git diff --check
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD --json
- cargo test -p hermes-parity-tests
- cargo test -p hermes-environments file_sync
- cargo build -p hermes-cli

Remote GitHub CI is optional and will be cancelled per local-gates policy.