### PR TITLE
parity(opencode): mark rust provider coverage

### DIFF
--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T22:08:01.387229+00:00",
+  "generated_at_utc": "2026-05-29T22:32:06.633302+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "073f1700966d91bde1121522ee952e46795591c8",
+    "local_sha": "bb795e224ed1cc9760f40f23151297d856e0852a",
     "upstream_ref": "upstream/main",
     "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4399,
-    "commits_ahead": 783,
+    "commits_ahead": 787,
     "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 675,
+    "local_patch_unique": 677,
     "files_only_upstream": 1470,
     "files_only_local": 562,
     "files_shared_identical": 1702,
     "files_shared_different": 1017,
     "tree_files_changed": 3049,
     "tree_insertions": 739593,
-    "tree_deletions": 374893
+    "tree_deletions": 375064
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 675,
+    "local_patch_unique": 677,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-29T22:08:01.387229+00:00`
+Generated: `2026-05-29T22:32:06.633302+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`073f1700966d91bde1121522ee952e46795591c8`)
+- Local ref: `HEAD` (`bb795e224ed1cc9760f40f23151297d856e0852a`)
 - Upstream ref: `upstream/main` (`689ef5e233980f5d5a32080e959f44c8991dd03a`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-29T22:08:01.387229+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4399 |
-| Commits ahead local (`local` ancestry only) | 783 |
+| Commits ahead local (`local` ancestry only) | 787 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4281 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 675 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 677 |
 | Files only in upstream tree | 1470 |
 | Files only in local tree | 562 |
 | Shared files identical content | 1702 |
 | Shared files different content | 1017 |
 | Total files changed (`local` vs `upstream`) | 3049 |
 | Insertions (`local` vs `upstream`) | 739593 |
-| Deletions (`local` vs `upstream`) | 374893 |
+| Deletions (`local` vs `upstream`) | 375064 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-29T22:08:01.387229+00:00`
 
 - Upstream missing by patch-id: `4281`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `675`
+- Local unique by patch-id: `677`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -826,16 +826,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/model-providers",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/model-providers/opencode-zen/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "385741f09a1df77b4475ffdcac8770fd7a3b314b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/opencode-zen/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "a8c72cdc25c37c4c638b106091712e4008197aba",
       "workstream": "WS3"
@@ -15256,30 +15256,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T22:07:59.279032+00:00",
+  "generated_at_utc": "2026-05-29T22:32:00.373312+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "073f1700966d91bde1121522ee952e46795591c8",
+    "local_sha": "bb795e224ed1cc9760f40f23151297d856e0852a",
     "upstream_ref": "upstream/main",
     "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 764,
-      "intentional_divergence": 84,
+      "functional": 763,
+      "intentional_divergence": 85,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 253,
+      "not_required_for_runtime": 254,
       "rust_equivalent_or_contract_test_required": 681,
-      "rust_native_runtime_parity_required_if_needed": 4,
+      "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 84,
+      "cleared_intentional_divergence": 85,
       "cleared_non_runtime": 169,
-      "pending_review": 764
+      "pending_review": 763
     },
     "by_workstream": {
       "WS3": 53,
@@ -15288,10 +15288,10 @@
       "WS6": 682,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 84,
+    "cleared_intentional_divergence": 85,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 764,
+    "pending_review": 763,
     "total_shared_different": 1017
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T22:07:59.279032+00:00`
+Generated: `2026-05-29T22:32:00.373312+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1017`
 - Pending classification: `0`
-- Pending functional review: `764`
+- Pending functional review: `763`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `84`
+- Cleared intentional divergence: `85`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 84 |
+| `cleared_intentional_divergence` | 85 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 764 |
+| `pending_review` | 763 |
 
 ## Workstream Counts
 
@@ -57,7 +57,6 @@ Generated: `2026-05-29T22:07:59.279032+00:00`
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
 | `tests/e2e` | 2 |
-| `plugins/model-providers` | 1 |
 | `plugins/spotify/tools.py` | 1 |
 | `plugins/teams_pipeline` | 1 |
 | `plugins/video_gen` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -353,6 +353,13 @@
       "ticket": 304
     },
     {
+      "path": "plugins/model-providers/opencode-zen/__init__.py",
+      "classification": "intentional_divergence",
+      "rationale": "OpenCode Zen and Go provider behavior is covered by Rust provider normalization, env-key resolution, default base URLs, model catalog merge, and GenericProvider OpenCode Go reasoning controls; this legacy upstream Python provider profile is reference-only and is not used by the Rust-only runtime.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "plugins/model-providers/azure-foundry/plugin.yaml",
       "classification": "intentional_divergence",
       "rationale": "Local Azure Foundry manifest intentionally uses Azure AI Foundry naming while preserving provider registration metadata.",


### PR DESCRIPTION
## Summary
- mark the legacy OpenCode Zen provider Python file as reference-only because Rust provider paths already cover it
- verified Rust coverage includes provider normalization, aliases, OPENCODE_* env key lookup, default Zen/Go base URLs, model catalog merge, and OpenCode Go reasoning-control tests
- regenerate parity matrix and shared-diff backlog; native-runtime backlog drops from 4 to 3

## Local verification
- git diff --check
- cargo fmt --check
- cargo test -p hermes-parity-tests
- cargo build -p hermes-cli
- bash scripts/check-runtime-placeholders.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- python3 -m py_compile scripts/generate-global-parity-proof.py scripts/generate-shared-diff-backlog.py scripts/generate-upstream-patch-queue.py scripts/generate-parity-matrix.py
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main --local-ref HEAD --json
- python3 scripts/generate-global-parity-proof.py --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof-opencode-prepr.json --out-md /tmp/hermes-agent-ultra-global-parity-proof-opencode-prepr.md