### PR TITLE
parity(video-gen): port FAL backend to Rust

### DIFF
--- a/crates/hermes-cli/src/tool_preview.rs
+++ b/crates/hermes-cli/src/tool_preview.rs
@@ -42,6 +42,7 @@ pub fn tool_emoji(tool_name: &str) -> &'static str {
         "browser_vision" => "👁️",
         "vision_analyze" => "👁️",
         "video_analyze" => "🎬",
+        "video_generate" => "🎞️",
         "mixture_of_agents" => "🧠",
         "todo" => "📋",
         "send_message" => "📨",
@@ -170,6 +171,7 @@ pub fn build_tool_preview_from_value(
         "text_to_speech" => Some("text"),
         "vision_analyze" => Some("question"),
         "video_analyze" => Some("question"),
+        "video_generate" => Some("prompt"),
         "mixture_of_agents" => Some("user_prompt"),
         "skill_view" => Some("name"),
         "skills_list" => Some("category"),
@@ -264,6 +266,7 @@ mod tests {
     fn emoji_map_covers_process_and_todo() {
         assert_eq!(tool_emoji("process"), "⚙️");
         assert_eq!(tool_emoji("todo"), "📋");
+        assert_eq!(tool_emoji("video_generate"), "🎞️");
         assert_eq!(tool_emoji("unknown"), "⚙️");
     }
 }

--- a/crates/hermes-tools/src/backends/mod.rs
+++ b/crates/hermes-tools/src/backends/mod.rs
@@ -18,5 +18,6 @@ pub mod session_search;
 pub mod todo;
 pub mod tts;
 pub mod video;
+pub mod video_gen;
 pub mod vision;
 pub mod web;

--- a/crates/hermes-tools/src/backends/video_gen.rs
+++ b/crates/hermes-tools/src/backends/video_gen.rs
@@ -1,0 +1,789 @@
+//! Rust-native FAL video generation backend.
+//!
+//! This ports the FAL video plugin surface into the built-in Rust tool
+//! runtime. Direct mode uses FAL's queue HTTP API, matching
+//! `fal_client.subscribe`; managed mode routes through the existing Nous
+//! `fal-queue` gateway resolver.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{Map, Value};
+use std::path::Path;
+use std::time::Duration;
+
+use crate::tools::video::{VideoGenerateBackend, VideoGenerateRequest};
+use hermes_config::managed_gateway::{
+    resolve_managed_tool_gateway, ManagedToolGatewayConfig, ResolveOptions,
+};
+use hermes_core::ToolError;
+
+const DEFAULT_FAL_VIDEO_MODEL: &str = "pixverse-v6";
+const DEFAULT_TIMEOUT_SECONDS: u64 = 600;
+const DEFAULT_POLL_INTERVAL_SECONDS: u64 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DurationSpec {
+    Range(u32, u32),
+    Enum(&'static [u32]),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FalVideoFamily {
+    id: &'static str,
+    text_endpoint: &'static str,
+    image_endpoint: &'static str,
+    image_param_key: &'static str,
+    aspect_ratios: &'static [&'static str],
+    resolutions: &'static [&'static str],
+    durations: Option<DurationSpec>,
+    audio: bool,
+    negative: bool,
+}
+
+const VEO_DURATIONS: &[u32] = &[4, 6, 8];
+
+const FAL_VIDEO_FAMILIES: &[FalVideoFamily] = &[
+    FalVideoFamily {
+        id: "ltx-2.3",
+        text_endpoint: "fal-ai/ltx-2.3-22b/text-to-video",
+        image_endpoint: "fal-ai/ltx-2.3-22b/image-to-video",
+        image_param_key: "image_url",
+        aspect_ratios: &[],
+        resolutions: &[],
+        durations: None,
+        audio: true,
+        negative: true,
+    },
+    FalVideoFamily {
+        id: "pixverse-v6",
+        text_endpoint: "fal-ai/pixverse/v6/text-to-video",
+        image_endpoint: "fal-ai/pixverse/v6/image-to-video",
+        image_param_key: "image_url",
+        aspect_ratios: &[],
+        resolutions: &["360p", "540p", "720p", "1080p"],
+        durations: Some(DurationSpec::Range(1, 15)),
+        audio: true,
+        negative: true,
+    },
+    FalVideoFamily {
+        id: "veo3.1",
+        text_endpoint: "fal-ai/veo3.1",
+        image_endpoint: "fal-ai/veo3.1/image-to-video",
+        image_param_key: "image_url",
+        aspect_ratios: &["16:9", "9:16"],
+        resolutions: &["720p", "1080p"],
+        durations: Some(DurationSpec::Enum(VEO_DURATIONS)),
+        audio: true,
+        negative: true,
+    },
+    FalVideoFamily {
+        id: "seedance-2.0",
+        text_endpoint: "bytedance/seedance-2.0/text-to-video",
+        image_endpoint: "bytedance/seedance-2.0/image-to-video",
+        image_param_key: "image_url",
+        aspect_ratios: &["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+        resolutions: &["480p", "720p", "1080p"],
+        durations: Some(DurationSpec::Range(4, 15)),
+        audio: true,
+        negative: false,
+    },
+    FalVideoFamily {
+        id: "kling-v3-4k",
+        text_endpoint: "fal-ai/kling-video/v3/4k/text-to-video",
+        image_endpoint: "fal-ai/kling-video/v3/4k/image-to-video",
+        image_param_key: "start_image_url",
+        aspect_ratios: &["16:9", "9:16", "1:1"],
+        resolutions: &[],
+        durations: Some(DurationSpec::Range(3, 15)),
+        audio: true,
+        negative: true,
+    },
+    FalVideoFamily {
+        id: "happy-horse",
+        text_endpoint: "fal-ai/happy-horse/text-to-video",
+        image_endpoint: "fal-ai/happy-horse/image-to-video",
+        image_param_key: "image_url",
+        aspect_ratios: &[],
+        resolutions: &[],
+        durations: None,
+        audio: false,
+        negative: false,
+    },
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FalVideoTransport {
+    Direct {
+        api_key: String,
+    },
+    Managed {
+        gateway_origin: String,
+        nous_token: String,
+    },
+    Unconfigured,
+}
+
+impl FalVideoTransport {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Direct { .. } => "direct",
+            Self::Managed { .. } => "managed",
+            Self::Unconfigured => "unconfigured",
+        }
+    }
+
+    fn submit_url(&self, endpoint: &str) -> Result<String, ToolError> {
+        match self {
+            Self::Direct { .. } => Ok(format!("https://queue.fal.run/{endpoint}")),
+            Self::Managed { gateway_origin, .. } => {
+                let root = gateway_origin.trim_end_matches('/');
+                Ok(format!("{root}/run/{endpoint}"))
+            }
+            Self::Unconfigured => Err(ToolError::ExecutionFailed(
+                "FAL_KEY not set and Nous-managed fal-queue gateway is not configured.".into(),
+            )),
+        }
+    }
+
+    fn auth_header(&self) -> Result<(String, String), ToolError> {
+        match self {
+            Self::Direct { api_key } => Ok(("Authorization".into(), format!("Key {api_key}"))),
+            Self::Managed { nous_token, .. } => {
+                Ok(("Authorization".into(), format!("Bearer {nous_token}")))
+            }
+            Self::Unconfigured => Err(ToolError::ExecutionFailed(
+                "FAL_KEY not set and Nous-managed fal-queue gateway is not configured.".into(),
+            )),
+        }
+    }
+}
+
+/// FAL video generation backend using direct FAL queue API or the
+/// Nous-managed fal-queue gateway.
+#[derive(Debug)]
+pub struct FalVideoGenBackend {
+    client: Client,
+    transport: FalVideoTransport,
+}
+
+impl FalVideoGenBackend {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            client: Client::new(),
+            transport: FalVideoTransport::Direct { api_key },
+        }
+    }
+
+    pub fn from_managed(cfg: &ManagedToolGatewayConfig) -> Self {
+        Self {
+            client: Client::new(),
+            transport: FalVideoTransport::Managed {
+                gateway_origin: cfg.gateway_origin.clone(),
+                nous_token: cfg.nous_user_token.clone(),
+            },
+        }
+    }
+
+    pub fn unconfigured() -> Self {
+        Self {
+            client: Client::new(),
+            transport: FalVideoTransport::Unconfigured,
+        }
+    }
+
+    /// Priority: direct `FAL_KEY` -> Nous-managed `fal-queue` -> error.
+    pub fn from_env_or_managed() -> Result<Self, ToolError> {
+        if let Ok(key) = std::env::var("FAL_KEY") {
+            let trimmed = key.trim();
+            if !trimmed.is_empty() {
+                return Ok(Self::new(trimmed.to_string()));
+            }
+        }
+        if let Some(cfg) = resolve_managed_tool_gateway("fal-queue", ResolveOptions::default()) {
+            return Ok(Self::from_managed(&cfg));
+        }
+        Err(ToolError::ExecutionFailed(
+            "FAL_KEY not set and Nous-managed fal-queue gateway is not configured.".into(),
+        ))
+    }
+
+    pub fn transport_label(&self) -> &'static str {
+        self.transport.label()
+    }
+
+    async fn submit_managed(&self, endpoint: &str, payload: &Value) -> Result<Value, ToolError> {
+        let url = self.transport.submit_url(endpoint)?;
+        let (auth_name, auth_value) = self.transport.auth_header()?;
+        let resp = self
+            .client
+            .post(url)
+            .header(auth_name, auth_value)
+            .header("Content-Type", "application/json")
+            .json(payload)
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("FAL video request failed: {e}")))?;
+        read_json_response(resp, "FAL video generation").await
+    }
+
+    async fn submit_direct_queue(
+        &self,
+        endpoint: &str,
+        payload: &Value,
+    ) -> Result<Value, ToolError> {
+        let url = self.transport.submit_url(endpoint)?;
+        let (auth_name, auth_value) = self.transport.auth_header()?;
+        let submit = self
+            .client
+            .post(url)
+            .header(auth_name, auth_value.clone())
+            .header("Content-Type", "application/json")
+            .json(payload)
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("FAL queue submit failed: {e}")))?;
+        let submitted = read_json_response(submit, "FAL queue submit").await?;
+        if extract_video(&submitted).is_some() {
+            return Ok(submitted);
+        }
+
+        let status_url = submitted
+            .get("status_url")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let response_url = submitted
+            .get("response_url")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let request_id = submitted
+            .get("request_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+
+        let timeout = env_u64("FAL_VIDEO_TIMEOUT_SECONDS").unwrap_or(DEFAULT_TIMEOUT_SECONDS);
+        let poll_interval =
+            env_u64("FAL_VIDEO_POLL_INTERVAL_SECONDS").unwrap_or(DEFAULT_POLL_INTERVAL_SECONDS);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
+
+        if let Some(status_url) = status_url.as_deref() {
+            loop {
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(ToolError::ExecutionFailed(format!(
+                        "Timed out waiting for FAL video generation after {timeout}s"
+                    )));
+                }
+                let resp = self
+                    .client
+                    .get(status_url)
+                    .header("Authorization", auth_value.clone())
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        ToolError::ExecutionFailed(format!("FAL queue status failed: {e}"))
+                    })?;
+                let status = read_json_response(resp, "FAL queue status").await?;
+                match status
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                {
+                    "COMPLETED" | "OK" => break,
+                    "FAILED" | "ERROR" => {
+                        return Err(ToolError::ExecutionFailed(format!(
+                            "FAL video generation failed: {status}"
+                        )));
+                    }
+                    _ => tokio::time::sleep(Duration::from_secs(poll_interval.max(1))).await,
+                }
+            }
+        }
+
+        let response_url = response_url
+            .or_else(|| {
+                request_id.map(|id| format!("https://queue.fal.run/{endpoint}/requests/{id}"))
+            })
+            .ok_or_else(|| {
+                ToolError::ExecutionFailed("FAL queue response omitted request URL".into())
+            })?;
+        let resp = self
+            .client
+            .get(response_url)
+            .header("Authorization", auth_value)
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("FAL queue response failed: {e}")))?;
+        read_json_response(resp, "FAL queue response").await
+    }
+}
+
+#[async_trait]
+impl VideoGenerateBackend for FalVideoGenBackend {
+    async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError> {
+        let prompt = request.prompt.trim();
+        if prompt.is_empty() {
+            return Err(ToolError::InvalidParams("prompt is required.".into()));
+        }
+
+        let family = resolve_family(request.model.as_deref());
+        let image_url = request
+            .image_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let (endpoint, modality) = if image_url.is_some() {
+            (family.image_endpoint, "image")
+        } else {
+            (family.text_endpoint, "text")
+        };
+        let payload_meta = build_payload(family, &request);
+        let payload = Value::Object(payload_meta.payload);
+        let response = match self.transport {
+            FalVideoTransport::Direct { .. } => {
+                self.submit_direct_queue(endpoint, &payload).await?
+            }
+            FalVideoTransport::Managed { .. } => self.submit_managed(endpoint, &payload).await?,
+            FalVideoTransport::Unconfigured => {
+                return Err(ToolError::ExecutionFailed(
+                    "FAL_KEY not set and Nous-managed fal-queue gateway is not configured.".into(),
+                ));
+            }
+        };
+
+        let video = extract_video(&response).ok_or_else(|| {
+            ToolError::ExecutionFailed("FAL returned no video URL in response".into())
+        })?;
+
+        let mut out = Map::new();
+        out.insert("success".into(), Value::Bool(true));
+        out.insert("video".into(), Value::String(video.url));
+        out.insert("model".into(), Value::String(family.id.to_string()));
+        out.insert("prompt".into(), Value::String(prompt.to_string()));
+        out.insert("modality".into(), Value::String(modality.to_string()));
+        out.insert(
+            "aspect_ratio".into(),
+            Value::String(payload_meta.aspect_ratio.unwrap_or_default()),
+        );
+        out.insert(
+            "duration".into(),
+            payload_meta
+                .duration
+                .map(|d| Value::Number(d.into()))
+                .unwrap_or_else(|| Value::Number(0.into())),
+        );
+        out.insert("provider".into(), Value::String("fal".into()));
+        out.insert("endpoint".into(), Value::String(endpoint.to_string()));
+        out.insert(
+            "transport".into(),
+            Value::String(self.transport.label().to_string()),
+        );
+        if let Some(file_size) = video.file_size {
+            out.insert("file_size".into(), Value::Number(file_size.into()));
+        }
+        if let Some(content_type) = video.content_type {
+            out.insert("content_type".into(), Value::String(content_type));
+        }
+
+        Ok(Value::Object(out).to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PayloadMeta {
+    payload: Map<String, Value>,
+    aspect_ratio: Option<String>,
+    duration: Option<u32>,
+}
+
+fn build_payload(family: &FalVideoFamily, request: &VideoGenerateRequest) -> PayloadMeta {
+    let mut payload = Map::new();
+    payload.insert(
+        "prompt".into(),
+        Value::String(request.prompt.trim().to_string()),
+    );
+    if let Some(image_url) = request
+        .image_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        payload.insert(
+            family.image_param_key.into(),
+            Value::String(image_url.to_string()),
+        );
+    }
+    if let Some(seed) = request.seed {
+        payload.insert("seed".into(), Value::Number(seed.into()));
+    }
+
+    let mut sent_aspect_ratio = None;
+    if !family.aspect_ratios.is_empty()
+        && family
+            .aspect_ratios
+            .contains(&request.aspect_ratio.as_str())
+    {
+        payload.insert(
+            "aspect_ratio".into(),
+            Value::String(request.aspect_ratio.clone()),
+        );
+        sent_aspect_ratio = Some(request.aspect_ratio.clone());
+    }
+
+    if !family.resolutions.is_empty() && family.resolutions.contains(&request.resolution.as_str()) {
+        payload.insert(
+            "resolution".into(),
+            Value::String(request.resolution.clone()),
+        );
+    }
+
+    let duration = clamp_duration(family.durations, request.duration);
+    if let Some(duration) = duration {
+        payload.insert("duration".into(), Value::String(duration.to_string()));
+    }
+
+    if family.audio {
+        if let Some(audio) = request.audio {
+            payload.insert("generate_audio".into(), Value::Bool(audio));
+        }
+    }
+
+    if family.negative {
+        if let Some(negative_prompt) = request.negative_prompt.as_deref() {
+            payload.insert(
+                "negative_prompt".into(),
+                Value::String(negative_prompt.to_string()),
+            );
+        }
+    }
+
+    PayloadMeta {
+        payload,
+        aspect_ratio: sent_aspect_ratio,
+        duration,
+    }
+}
+
+fn clamp_duration(spec: Option<DurationSpec>, duration: Option<u32>) -> Option<u32> {
+    match spec {
+        None => None,
+        Some(DurationSpec::Range(lo, hi)) => Some(duration.unwrap_or(lo).clamp(lo, hi)),
+        Some(DurationSpec::Enum(values)) => {
+            let requested = duration.unwrap_or_else(|| values[0]);
+            values
+                .iter()
+                .copied()
+                .min_by_key(|candidate| candidate.abs_diff(requested))
+        }
+    }
+}
+
+fn resolve_family(explicit: Option<&str>) -> &'static FalVideoFamily {
+    let candidates = explicit
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .chain(std::env::var("FAL_VIDEO_MODEL").ok())
+        .chain(configured_video_model_candidates());
+    for candidate in candidates {
+        if let Some(family) = family_by_id(candidate.trim()) {
+            return family;
+        }
+    }
+    family_by_id(DEFAULT_FAL_VIDEO_MODEL).expect("default FAL video family exists")
+}
+
+fn family_by_id(id: &str) -> Option<&'static FalVideoFamily> {
+    FAL_VIDEO_FAMILIES.iter().find(|family| family.id == id)
+}
+
+fn configured_video_model_candidates() -> Vec<String> {
+    let mut out = Vec::new();
+    for path in [
+        hermes_config::cli_config_path(),
+        hermes_config::config_path(),
+    ] {
+        collect_video_model_candidates(&path, &mut out);
+    }
+    out
+}
+
+fn collect_video_model_candidates(path: &Path, out: &mut Vec<String>) {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(root) = serde_yaml::from_str::<serde_yaml::Value>(&raw) else {
+        return;
+    };
+    let Some(video_gen) = root.get("video_gen") else {
+        return;
+    };
+    if let Some(model) = video_gen
+        .get("fal")
+        .and_then(|fal| fal.get("model"))
+        .and_then(serde_yaml::Value::as_str)
+    {
+        out.push(model.to_string());
+    }
+    if let Some(model) = video_gen.get("model").and_then(serde_yaml::Value::as_str) {
+        out.push(model.to_string());
+    }
+}
+
+fn env_u64(name: &str) -> Option<u64> {
+    std::env::var(name).ok()?.trim().parse::<u64>().ok()
+}
+
+async fn read_json_response(resp: reqwest::Response, label: &str) -> Result<Value, ToolError> {
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read {label} response: {e}")))?;
+    if !status.is_success() {
+        return Err(ToolError::ExecutionFailed(format!(
+            "{label} error ({status}): {text}"
+        )));
+    }
+    serde_json::from_str(&text)
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to parse {label} response: {e}")))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VideoArtifact {
+    url: String,
+    file_size: Option<u64>,
+    content_type: Option<String>,
+}
+
+fn extract_video(value: &Value) -> Option<VideoArtifact> {
+    if let Some(data) = value.get("data").filter(|data| data.is_object()) {
+        if let Some(video) = extract_video(data) {
+            return Some(video);
+        }
+    }
+    let video = value.get("video")?;
+    if let Some(url) = video.as_str().filter(|url| !url.trim().is_empty()) {
+        return Some(VideoArtifact {
+            url: url.to_string(),
+            file_size: None,
+            content_type: None,
+        });
+    }
+    let obj = video.as_object()?;
+    let url = obj.get("url")?.as_str()?.trim();
+    if url.is_empty() {
+        return None;
+    }
+    Some(VideoArtifact {
+        url: url.to_string(),
+        file_size: obj.get("file_size").and_then(Value::as_u64),
+        content_type: obj
+            .get("content_type")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hermes_config::managed_gateway::test_lock;
+    use serde_json::json;
+
+    struct EnvScope {
+        _tmp: tempfile::TempDir,
+        original: Vec<(&'static str, Option<String>)>,
+        _g: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvScope {
+        fn new() -> Self {
+            let g = test_lock::lock();
+            let tmp = tempfile::tempdir().unwrap();
+            let keys = [
+                "HERMES_HOME",
+                "FAL_KEY",
+                "FAL_VIDEO_MODEL",
+                "FAL_VIDEO_TIMEOUT_SECONDS",
+                "FAL_VIDEO_POLL_INTERVAL_SECONDS",
+                "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+                "TOOL_GATEWAY_USER_TOKEN",
+                "TOOL_GATEWAY_DOMAIN",
+                "TOOL_GATEWAY_SCHEME",
+            ];
+            let original = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+            for k in keys {
+                std::env::remove_var(k);
+            }
+            std::env::set_var("HERMES_HOME", tmp.path());
+            Self {
+                _tmp: tmp,
+                original,
+                _g: g,
+            }
+        }
+    }
+
+    impl Drop for EnvScope {
+        fn drop(&mut self) {
+            for (key, value) in &self.original {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn request(model: Option<&str>) -> VideoGenerateRequest {
+        VideoGenerateRequest {
+            prompt: "make a trailer".into(),
+            model: model.map(ToOwned::to_owned),
+            image_url: None,
+            duration: None,
+            aspect_ratio: "16:9".into(),
+            resolution: "720p".into(),
+            negative_prompt: None,
+            audio: None,
+            seed: None,
+        }
+    }
+
+    #[test]
+    fn resolve_family_prefers_explicit_then_env_then_default() {
+        let _env = EnvScope::new();
+        std::env::set_var("FAL_VIDEO_MODEL", "veo3.1");
+        assert_eq!(resolve_family(Some("seedance-2.0")).id, "seedance-2.0");
+        assert_eq!(resolve_family(None).id, "veo3.1");
+        std::env::set_var("FAL_VIDEO_MODEL", "not-real");
+        assert_eq!(resolve_family(None).id, DEFAULT_FAL_VIDEO_MODEL);
+    }
+
+    #[test]
+    fn resolve_family_reads_config_candidates() {
+        let _env = EnvScope::new();
+        let config = hermes_config::config_path();
+        std::fs::write(
+            config,
+            "video_gen:\n  fal:\n    model: kling-v3-4k\n  model: veo3.1\n",
+        )
+        .unwrap();
+        assert_eq!(resolve_family(None).id, "kling-v3-4k");
+    }
+
+    #[test]
+    fn payload_clamps_range_duration_and_uses_kling_start_image_key() {
+        let family = family_by_id("kling-v3-4k").unwrap();
+        let mut req = request(Some("kling-v3-4k"));
+        req.image_url = Some("https://example.com/start.png".into());
+        req.duration = Some(99);
+        req.resolution = "1080p".into();
+        req.audio = Some(true);
+        let payload = build_payload(family, &req).payload;
+        assert_eq!(
+            payload.get("start_image_url"),
+            Some(&json!("https://example.com/start.png"))
+        );
+        assert_eq!(payload.get("duration"), Some(&json!("15")));
+        assert_eq!(payload.get("generate_audio"), Some(&json!(true)));
+        assert!(payload.get("resolution").is_none());
+    }
+
+    #[test]
+    fn payload_snaps_enum_duration_and_drops_unsupported_negative_prompt() {
+        let family = family_by_id("seedance-2.0").unwrap();
+        let mut req = request(Some("seedance-2.0"));
+        req.duration = Some(2);
+        req.negative_prompt = Some("low quality".into());
+        req.aspect_ratio = "21:9".into();
+        req.resolution = "480p".into();
+        let meta = build_payload(family, &req);
+        assert_eq!(meta.payload.get("duration"), Some(&json!("4")));
+        assert_eq!(meta.payload.get("aspect_ratio"), Some(&json!("21:9")));
+        assert_eq!(meta.payload.get("resolution"), Some(&json!("480p")));
+        assert!(meta.payload.get("negative_prompt").is_none());
+    }
+
+    #[test]
+    fn payload_uses_nearest_veo_duration() {
+        let family = family_by_id("veo3.1").unwrap();
+        let mut req = request(Some("veo3.1"));
+        req.duration = Some(5);
+        let meta = build_payload(family, &req);
+        assert_eq!(meta.payload.get("duration"), Some(&json!("4")));
+    }
+
+    #[test]
+    fn transport_urls_and_auth_match_direct_and_managed_modes() {
+        let direct = FalVideoGenBackend::new("fal-key".into());
+        assert_eq!(
+            direct
+                .transport
+                .submit_url("fal-ai/pixverse/v6/text-to-video")
+                .unwrap(),
+            "https://queue.fal.run/fal-ai/pixverse/v6/text-to-video"
+        );
+        assert_eq!(direct.transport.auth_header().unwrap().1, "Key fal-key");
+
+        let cfg = ManagedToolGatewayConfig {
+            vendor: "fal-queue".into(),
+            gateway_origin: "https://fal-queue.gw.example.com".into(),
+            nous_user_token: "tok".into(),
+            managed_mode: true,
+        };
+        let managed = FalVideoGenBackend::from_managed(&cfg);
+        assert_eq!(
+            managed
+                .transport
+                .submit_url("fal-ai/pixverse/v6/text-to-video")
+                .unwrap(),
+            "https://fal-queue.gw.example.com/run/fal-ai/pixverse/v6/text-to-video"
+        );
+        assert_eq!(managed.transport.auth_header().unwrap().1, "Bearer tok");
+    }
+
+    #[test]
+    fn from_env_or_managed_prefers_direct_and_supports_managed() {
+        let _env = EnvScope::new();
+        std::env::set_var("FAL_KEY", "direct-key");
+        assert_eq!(
+            FalVideoGenBackend::from_env_or_managed()
+                .unwrap()
+                .transport_label(),
+            "direct"
+        );
+        std::env::remove_var("FAL_KEY");
+        std::env::set_var("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+        std::env::set_var("TOOL_GATEWAY_USER_TOKEN", "nous-token");
+        assert_eq!(
+            FalVideoGenBackend::from_env_or_managed()
+                .unwrap()
+                .transport_label(),
+            "managed"
+        );
+    }
+
+    #[tokio::test]
+    async fn unconfigured_backend_errors_before_network() {
+        let backend = FalVideoGenBackend::unconfigured();
+        let err = backend.generate_video(request(None)).await.unwrap_err();
+        assert!(err.to_string().contains("FAL_KEY"));
+    }
+
+    #[test]
+    fn extract_video_handles_wrapped_and_string_shapes() {
+        assert_eq!(
+            extract_video(&json!({"data":{"video":{"url":"https://cdn.example/v.mp4","file_size":42,"content_type":"video/mp4"}}}))
+                .unwrap(),
+            VideoArtifact {
+                url: "https://cdn.example/v.mp4".into(),
+                file_size: Some(42),
+                content_type: Some("video/mp4".into()),
+            }
+        );
+        assert_eq!(
+            extract_video(&json!({"video":"https://cdn.example/v.mp4"}))
+                .unwrap()
+                .url,
+            "https://cdn.example/v.mp4"
+        );
+    }
+}

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -83,7 +83,10 @@ pub use tools::transcription::TranscriptionHandler;
 pub use tools::tts::{TextToSpeechHandler, TtsBackend};
 pub use tools::tts_premium::TtsPremiumHandler;
 pub use tools::url_safety::UrlSafetyHandler;
-pub use tools::video::{VideoAnalyzeHandler, VideoBackend};
+pub use tools::video::{
+    VideoAnalyzeHandler, VideoBackend, VideoGenerateBackend, VideoGenerateHandler,
+    VideoGenerateRequest,
+};
 pub use tools::vision::{VisionAnalyzeHandler, VisionBackend};
 pub use tools::voice_mode::VoiceModeHandler;
 pub use tools::web::{
@@ -109,6 +112,7 @@ pub use backends::session_search::SqliteSessionSearchBackend;
 pub use backends::todo::FileTodoBackend;
 pub use backends::tts::MultiTtsBackend;
 pub use backends::video::VisionFrameSamplingVideoBackend;
+pub use backends::video_gen::FalVideoGenBackend;
 pub use backends::vision::OpenAiVisionBackend;
 pub use backends::web::{
     crawl_backend_from_env_or_fallback, extract_backend_from_env_or_fallback,

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -181,6 +181,21 @@ pub fn register_builtin_tools(
         );
     }
 
+    // -- Video generation ----------------------------------------------------
+    {
+        let backend = crate::backends::video_gen::FalVideoGenBackend::from_env_or_managed()
+            .unwrap_or_else(|_| crate::backends::video_gen::FalVideoGenBackend::unconfigured());
+        reg(
+            registry,
+            "video_gen",
+            Arc::new(crate::tools::video::VideoGenerateHandler::new(Arc::new(
+                backend,
+            ))),
+            "🎞️",
+            vec!["FAL_KEY".into()],
+        );
+    }
+
     // -- Skills (3 tools) ----------------------------------------------------
     reg(
         registry,

--- a/crates/hermes-tools/src/tools/video.rs
+++ b/crates/hermes-tools/src/tools/video.rs
@@ -1,4 +1,4 @@
-//! Video analysis tool.
+//! Video analysis and generation tools.
 //!
 //! This tool samples representative frames from a video and runs vision
 //! analysis across them, returning a structured synthesis.
@@ -23,6 +23,27 @@ pub trait VideoBackend: Send + Sync {
     ) -> Result<String, ToolError>;
 }
 
+/// Parameters for text-to-video or image-to-video generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoGenerateRequest {
+    pub prompt: String,
+    pub model: Option<String>,
+    pub image_url: Option<String>,
+    pub duration: Option<u32>,
+    pub aspect_ratio: String,
+    pub resolution: String,
+    pub negative_prompt: Option<String>,
+    pub audio: Option<bool>,
+    pub seed: Option<i64>,
+}
+
+/// Backend for video generation operations.
+#[async_trait]
+pub trait VideoGenerateBackend: Send + Sync {
+    /// Generate a video and return a structured result payload.
+    async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError>;
+}
+
 /// Tool for analyzing videos using frame-sampled vision passes.
 pub struct VideoAnalyzeHandler {
     backend: Arc<dyn VideoBackend>,
@@ -31,6 +52,152 @@ pub struct VideoAnalyzeHandler {
 impl VideoAnalyzeHandler {
     pub fn new(backend: Arc<dyn VideoBackend>) -> Self {
         Self { backend }
+    }
+}
+
+/// Tool for generating videos from text prompts, optionally guided by a
+/// starting image.
+pub struct VideoGenerateHandler {
+    backend: Arc<dyn VideoGenerateBackend>,
+}
+
+impl VideoGenerateHandler {
+    pub fn new(backend: Arc<dyn VideoGenerateBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+fn optional_string(params: &Value, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn optional_u32(params: &Value, key: &str) -> Option<u32> {
+    params.get(key).and_then(|v| {
+        v.as_u64()
+            .and_then(|n| u32::try_from(n).ok())
+            .or_else(|| v.as_str().and_then(|s| s.trim().parse::<u32>().ok()))
+    })
+}
+
+fn optional_i64(params: &Value, key: &str) -> Option<i64> {
+    params.get(key).and_then(|v| {
+        v.as_i64()
+            .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
+            .or_else(|| v.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
+    })
+}
+
+#[async_trait]
+impl ToolHandler for VideoGenerateHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        let prompt = params
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ToolError::InvalidParams("Missing 'prompt' parameter".into()))?;
+
+        let request = VideoGenerateRequest {
+            prompt: prompt.to_string(),
+            model: optional_string(&params, "model"),
+            image_url: optional_string(&params, "image_url"),
+            duration: optional_u32(&params, "duration"),
+            aspect_ratio: optional_string(&params, "aspect_ratio")
+                .unwrap_or_else(|| "16:9".to_string()),
+            resolution: optional_string(&params, "resolution")
+                .unwrap_or_else(|| "720p".to_string()),
+            negative_prompt: optional_string(&params, "negative_prompt"),
+            audio: params.get("audio").and_then(|v| v.as_bool()),
+            seed: optional_i64(&params, "seed"),
+        };
+
+        self.backend.generate_video(request).await
+    }
+
+    fn schema(&self) -> ToolSchema {
+        let mut props = IndexMap::new();
+        props.insert(
+            "prompt".into(),
+            json!({
+                "type": "string",
+                "description": "Text prompt for text-to-video or image-to-video generation."
+            }),
+        );
+        props.insert(
+            "model".into(),
+            json!({
+                "type": "string",
+                "description": "FAL model family to use.",
+                "enum": ["ltx-2.3", "pixverse-v6", "veo3.1", "seedance-2.0", "kling-v3-4k", "happy-horse"],
+                "default": "pixverse-v6"
+            }),
+        );
+        props.insert(
+            "image_url".into(),
+            json!({
+                "type": "string",
+                "description": "Optional starting image URL for image-to-video generation."
+            }),
+        );
+        props.insert(
+            "duration".into(),
+            json!({
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 15,
+                "description": "Requested duration in seconds. The backend clamps or snaps to the selected family."
+            }),
+        );
+        props.insert(
+            "aspect_ratio".into(),
+            json!({
+                "type": "string",
+                "description": "Requested output aspect ratio when the selected family supports it.",
+                "enum": ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                "default": "16:9"
+            }),
+        );
+        props.insert(
+            "resolution".into(),
+            json!({
+                "type": "string",
+                "description": "Requested output resolution when the selected family supports it.",
+                "enum": ["360p", "480p", "540p", "720p", "1080p"],
+                "default": "720p"
+            }),
+        );
+        props.insert(
+            "negative_prompt".into(),
+            json!({
+                "type": "string",
+                "description": "Optional negative prompt for families that support it."
+            }),
+        );
+        props.insert(
+            "audio".into(),
+            json!({
+                "type": "boolean",
+                "description": "Whether to request generated audio when the selected family supports it."
+            }),
+        );
+        props.insert(
+            "seed".into(),
+            json!({
+                "type": "integer",
+                "description": "Optional deterministic seed."
+            }),
+        );
+
+        tool_schema(
+            "video_generate",
+            "Generate a video from a prompt, optionally using an image-to-video starting image.",
+            JsonSchema::object(props, vec!["prompt".into()]),
+        )
     }
 }
 
@@ -125,6 +292,22 @@ mod tests {
         }
     }
 
+    struct MockVideoGenerateBackend;
+
+    #[async_trait]
+    impl VideoGenerateBackend for MockVideoGenerateBackend {
+        async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError> {
+            Ok(format!(
+                "{}|{}|{}|{}|{}",
+                request.prompt,
+                request.model.unwrap_or_default(),
+                request.image_url.unwrap_or_default(),
+                request.duration.unwrap_or_default(),
+                request.aspect_ratio
+            ))
+        }
+    }
+
     #[tokio::test]
     async fn execute_accepts_video_path_alias_and_user_prompt_string() {
         let handler = VideoAnalyzeHandler::new(Arc::new(MockVideoBackend));
@@ -152,5 +335,38 @@ mod tests {
             .await
             .expect("execute");
         assert!(out.contains("Summarize this video and list key visual events."));
+    }
+
+    #[tokio::test]
+    async fn generate_execute_normalizes_optional_params() {
+        let handler = VideoGenerateHandler::new(Arc::new(MockVideoGenerateBackend));
+        let out = handler
+            .execute(json!({
+                "prompt": " cinematic city ",
+                "model": "veo3.1",
+                "image_url": " https://example.com/start.png ",
+                "duration": "8",
+                "aspect_ratio": "9:16"
+            }))
+            .await
+            .expect("execute");
+        assert_eq!(
+            out,
+            "cinematic city|veo3.1|https://example.com/start.png|8|9:16"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_requires_prompt() {
+        let handler = VideoGenerateHandler::new(Arc::new(MockVideoGenerateBackend));
+        let err = handler.execute(json!({"prompt":"   "})).await.unwrap_err();
+        assert!(err.to_string().contains("prompt"));
+    }
+
+    #[tokio::test]
+    async fn generate_schema_declares_video_generate() {
+        let handler = VideoGenerateHandler::new(Arc::new(MockVideoGenerateBackend));
+        let schema = handler.schema();
+        assert_eq!(schema.name, "video_generate");
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-29T20:37:59.378566+00:00",
+  "generated_at_utc": "2026-05-29T22:52:31.646536+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -77,8 +77,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 75,
-      "ported": 21,
-      "superseded": 4187
+      "ported": 22,
+      "superseded": 4186
     },
     "by_target_ticket": {
       "20": 1790,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-29T20:37:59.378566+00:00`
+Generated: `2026-05-29T22:52:31.646536+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T22:32:06.633302+00:00",
+  "generated_at_utc": "2026-05-29T22:52:27.438886+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "bb795e224ed1cc9760f40f23151297d856e0852a",
+    "local_sha": "9ea0700d04a6842f2612a45bd205dd87e441314f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4399,
-    "commits_ahead": 787,
+    "commits_ahead": 790,
     "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 677,
+    "local_patch_unique": 679,
     "files_only_upstream": 1470,
-    "files_only_local": 562,
+    "files_only_local": 563,
     "files_shared_identical": 1702,
     "files_shared_different": 1017,
-    "tree_files_changed": 3049,
+    "tree_files_changed": 3050,
     "tree_insertions": 739593,
-    "tree_deletions": 375064
+    "tree_deletions": 376104
   },
   "top_upstream_only": [
     {
@@ -348,7 +348,7 @@
   "top_local_only": [
     {
       "path": "crates/hermes-tools",
-      "count": 75
+      "count": 76
     },
     {
       "path": "crates/hermes-agent",
@@ -672,7 +672,7 @@
   "top_unique_to_local": [
     {
       "path": "crates/hermes-tools",
-      "count": 75
+      "count": 76
     },
     {
       "path": "crates/hermes-agent",
@@ -868,7 +868,7 @@
       "name": "Tools and adapters parity",
       "upstream_only": 114,
       "shared_different": 53,
-      "local_only": 100,
+      "local_only": 101,
       "risk": "high",
       "effort": "L"
     },
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 677,
+    "local_patch_unique": 679,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-29T22:32:06.633302+00:00`
+Generated: `2026-05-29T22:52:27.438886+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`bb795e224ed1cc9760f40f23151297d856e0852a`)
+- Local ref: `HEAD` (`9ea0700d04a6842f2612a45bd205dd87e441314f`)
 - Upstream ref: `upstream/main` (`689ef5e233980f5d5a32080e959f44c8991dd03a`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-29T22:32:06.633302+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4399 |
-| Commits ahead local (`local` ancestry only) | 787 |
+| Commits ahead local (`local` ancestry only) | 790 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4281 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 677 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 679 |
 | Files only in upstream tree | 1470 |
-| Files only in local tree | 562 |
+| Files only in local tree | 563 |
 | Shared files identical content | 1702 |
 | Shared files different content | 1017 |
-| Total files changed (`local` vs `upstream`) | 3049 |
+| Total files changed (`local` vs `upstream`) | 3050 |
 | Insertions (`local` vs `upstream`) | 739593 |
-| Deletions (`local` vs `upstream`) | 375064 |
+| Deletions (`local` vs `upstream`) | 376104 |
 
 ## Top 40 upstream-only buckets
 
@@ -119,7 +119,7 @@ Generated: `2026-05-29T22:32:06.633302+00:00`
 
 | Bucket | Files |
 | --- | ---: |
-| `crates/hermes-tools` | 75 |
+| `crates/hermes-tools` | 76 |
 | `crates/hermes-agent` | 47 |
 | `crates/hermes-gateway` | 46 |
 | `crates/hermes-cli` | 44 |
@@ -176,7 +176,7 @@ Generated: `2026-05-29T22:32:06.633302+00:00`
 
 - Upstream missing by patch-id: `4281`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `677`
+- Local unique by patch-id: `679`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1096,16 +1096,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/video_gen",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/video_gen/fal/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "61b367898556e97207d16421f2f171e16d27f7ec",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/video_gen/fal/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e3ee7ffa100a531a384b45c4af54e1021d8fd95a",
       "workstream": "WS3"
@@ -15256,30 +15256,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T22:32:00.373312+00:00",
+  "generated_at_utc": "2026-05-29T22:52:25.243614+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "bb795e224ed1cc9760f40f23151297d856e0852a",
+    "local_sha": "9ea0700d04a6842f2612a45bd205dd87e441314f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 763,
-      "intentional_divergence": 85,
+      "functional": 762,
+      "intentional_divergence": 86,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 254,
+      "not_required_for_runtime": 255,
       "rust_equivalent_or_contract_test_required": 681,
-      "rust_native_runtime_parity_required_if_needed": 3,
+      "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 85,
+      "cleared_intentional_divergence": 86,
       "cleared_non_runtime": 169,
-      "pending_review": 763
+      "pending_review": 762
     },
     "by_workstream": {
       "WS3": 53,
@@ -15288,10 +15288,10 @@
       "WS6": 682,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 85,
+    "cleared_intentional_divergence": 86,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 763,
+    "pending_review": 762,
     "total_shared_different": 1017
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T22:32:00.373312+00:00`
+Generated: `2026-05-29T22:52:25.243614+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1017`
 - Pending classification: `0`
-- Pending functional review: `763`
+- Pending functional review: `762`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `85`
+- Cleared intentional divergence: `86`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 85 |
+| `cleared_intentional_divergence` | 86 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 763 |
+| `pending_review` | 762 |
 
 ## Workstream Counts
 
@@ -59,4 +59,3 @@ Generated: `2026-05-29T22:32:00.373312+00:00`
 | `tests/e2e` | 2 |
 | `plugins/spotify/tools.py` | 1 |
 | `plugins/teams_pipeline` | 1 |
-| `plugins/video_gen` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -801,6 +801,13 @@
       "ticket": 25
     },
     {
+      "path": "plugins/video_gen/fal/__init__.py",
+      "classification": "intentional_divergence",
+      "rationale": "FAL video generation behavior is now covered by the Rust-native video_generate tool and FalVideoGenBackend, including family routing, family-specific payload filtering, direct queue.fal.run polling, and Nous-managed fal-queue routing; the Python plugin remains reference-only compatibility material.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "plugins/context_engine/__init__.py",
       "classification": "functional",
       "rationale": "Context engine loader differences affect plugin registration behavior and need runtime parity review against the Rust-first plugin command surface.",


### PR DESCRIPTION
## Summary
- add Rust-native video_generate tool contract and builtin registration
- add FAL video backend with family routing, payload filtering, direct queue.fal.run polling, and Nous-managed fal-queue routing
- mark the legacy FAL Python video plugin as reference-only in parity docs

## Local verification
- cargo fmt --check
- git diff --check
- cargo test -p hermes-tools
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- cargo build -p hermes-cli
- bash scripts/check-runtime-placeholders.sh
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --check-ci --check-release