### PR TITLE
parity(spotify): port tools to Rust

### DIFF
--- a/crates/hermes-cli/src/tool_preview.rs
+++ b/crates/hermes-cli/src/tool_preview.rs
@@ -43,6 +43,13 @@ pub fn tool_emoji(tool_name: &str) -> &'static str {
         "vision_analyze" => "👁️",
         "video_analyze" => "🎬",
         "video_generate" => "🎞️",
+        "spotify_playback" => "🎵",
+        "spotify_devices" => "🔈",
+        "spotify_queue" => "📻",
+        "spotify_search" => "🔎",
+        "spotify_playlists" => "📚",
+        "spotify_albums" => "💿",
+        "spotify_library" => "❤️",
         "mixture_of_agents" => "🧠",
         "todo" => "📋",
         "send_message" => "📨",
@@ -172,6 +179,10 @@ pub fn build_tool_preview_from_value(
         "vision_analyze" => Some("question"),
         "video_analyze" => Some("question"),
         "video_generate" => Some("prompt"),
+        "spotify_search" => Some("query"),
+        "spotify_playlists" => Some("name"),
+        "spotify_queue" => Some("uri"),
+        "spotify_albums" => Some("album_id"),
         "mixture_of_agents" => Some("user_prompt"),
         "skill_view" => Some("name"),
         "skills_list" => Some("category"),
@@ -267,6 +278,7 @@ mod tests {
         assert_eq!(tool_emoji("process"), "⚙️");
         assert_eq!(tool_emoji("todo"), "📋");
         assert_eq!(tool_emoji("video_generate"), "🎞️");
+        assert_eq!(tool_emoji("spotify_playback"), "🎵");
         assert_eq!(tool_emoji("unknown"), "⚙️");
     }
 }

--- a/crates/hermes-tools/src/backends/mod.rs
+++ b/crates/hermes-tools/src/backends/mod.rs
@@ -15,6 +15,7 @@ pub mod image_gen;
 pub mod memory;
 pub mod messaging;
 pub mod session_search;
+pub mod spotify;
 pub mod todo;
 pub mod tts;
 pub mod video;

--- a/crates/hermes-tools/src/backends/spotify.rs
+++ b/crates/hermes-tools/src/backends/spotify.rs
@@ -1,0 +1,446 @@
+//! Rust-native Spotify Web API backend.
+
+use async_trait::async_trait;
+use reqwest::{Client, Method, StatusCode};
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::tools::spotify::{SpotifyApiRequest, SpotifyBackend, SpotifyHttpMethod};
+use hermes_core::ToolError;
+
+const DEFAULT_SPOTIFY_API_BASE_URL: &str = "https://api.spotify.com/v1";
+const SPOTIFY_AUTH_ERROR: &str =
+    "Spotify authentication failed or expired. Run `hermes auth spotify` again.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpotifyRuntimeCredentials {
+    pub access_token: String,
+    pub base_url: String,
+    pub source: String,
+}
+
+#[derive(Debug)]
+pub struct SpotifyWebApiBackend {
+    client: Client,
+    credentials: Option<SpotifyRuntimeCredentials>,
+}
+
+impl SpotifyWebApiBackend {
+    pub fn new(credentials: SpotifyRuntimeCredentials) -> Self {
+        Self {
+            client: spotify_http_client(),
+            credentials: Some(credentials),
+        }
+    }
+
+    pub fn unconfigured() -> Self {
+        Self {
+            client: spotify_http_client(),
+            credentials: None,
+        }
+    }
+
+    pub fn from_env_or_auth_store() -> Result<Self, ToolError> {
+        Ok(Self::new(resolve_spotify_runtime_credentials()?))
+    }
+
+    pub fn credentials(&self) -> Option<&SpotifyRuntimeCredentials> {
+        self.credentials.as_ref()
+    }
+}
+
+#[async_trait]
+impl SpotifyBackend for SpotifyWebApiBackend {
+    async fn call(&self, request: SpotifyApiRequest) -> Result<Value, ToolError> {
+        let credentials = self
+            .credentials
+            .as_ref()
+            .ok_or_else(|| ToolError::ExecutionFailed(SPOTIFY_AUTH_ERROR.into()))?;
+        let url = build_url(&credentials.base_url, &request)?;
+        let response = self
+            .client
+            .request(method(request.method), url)
+            .bearer_auth(&credentials.access_token)
+            .header("Content-Type", "application/json")
+            .json_if_some(request.body.as_ref())
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Spotify API request failed: {e}")))?;
+
+        read_spotify_response(response, &request.path, request.empty_response).await
+    }
+}
+
+fn spotify_http_client() -> Client {
+    Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
+trait JsonIfSome {
+    fn json_if_some(self, body: Option<&Value>) -> Self;
+}
+
+impl JsonIfSome for reqwest::RequestBuilder {
+    fn json_if_some(self, body: Option<&Value>) -> Self {
+        match body {
+            Some(body) => self.json(body),
+            None => self,
+        }
+    }
+}
+
+fn method(method: SpotifyHttpMethod) -> Method {
+    match method {
+        SpotifyHttpMethod::Get => Method::GET,
+        SpotifyHttpMethod::Post => Method::POST,
+        SpotifyHttpMethod::Put => Method::PUT,
+        SpotifyHttpMethod::Delete => Method::DELETE,
+    }
+}
+
+fn build_url(base_url: &str, request: &SpotifyApiRequest) -> Result<reqwest::Url, ToolError> {
+    let base = base_url.trim_end_matches('/');
+    let path = request.path.trim_start_matches('/');
+    let mut url = reqwest::Url::parse(&format!("{base}/{path}")).map_err(|e| {
+        ToolError::ExecutionFailed(format!("invalid Spotify API URL for {}: {e}", request.path))
+    })?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        for (key, value) in &request.query {
+            pairs.append_pair(key, value);
+        }
+    }
+    Ok(url)
+}
+
+async fn read_spotify_response(
+    response: reqwest::Response,
+    path: &str,
+    empty_response: Option<Value>,
+) -> Result<Value, ToolError> {
+    let status = response.status();
+    let retry_after = response
+        .headers()
+        .get("Retry-After")
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let text = response
+        .text()
+        .await
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read Spotify response: {e}")))?;
+
+    if !status.is_success() {
+        let detail = extract_spotify_error_detail(&text);
+        return Err(ToolError::ExecutionFailed(friendly_spotify_error_message(
+            status,
+            &detail,
+            path,
+            retry_after.as_deref(),
+        )));
+    }
+
+    if status == StatusCode::NO_CONTENT || text.trim().is_empty() {
+        return Ok(empty_response.unwrap_or_else(|| {
+            json!({
+                "success": true,
+                "status_code": status.as_u16(),
+                "empty": true
+            })
+        }));
+    }
+
+    if content_type.contains("application/json") {
+        serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to parse Spotify response: {e}"))
+        })
+    } else {
+        Ok(json!({"success": true, "text": text}))
+    }
+}
+
+fn extract_spotify_error_detail(raw: &str) -> String {
+    let fallback = raw.trim().to_string();
+    let Ok(payload) = serde_json::from_str::<Value>(raw) else {
+        return fallback;
+    };
+    payload
+        .get("error")
+        .and_then(|error| {
+            error
+                .as_object()
+                .and_then(|object| object.get("message").and_then(Value::as_str))
+                .or_else(|| error.as_str())
+        })
+        .map(str::trim)
+        .filter(|detail| !detail.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or(fallback)
+}
+
+fn friendly_spotify_error_message(
+    status: StatusCode,
+    detail: &str,
+    path: &str,
+    retry_after: Option<&str>,
+) -> String {
+    let normalized_detail = detail.to_ascii_lowercase();
+    let is_playback_path = path.starts_with("/me/player");
+
+    match status.as_u16() {
+        401 => SPOTIFY_AUTH_ERROR.to_string(),
+        403 if is_playback_path => {
+            "Spotify rejected this playback request. Playback control usually requires a Spotify Premium account and an active Spotify Connect device.".to_string()
+        }
+        403 if normalized_detail.contains("scope") || normalized_detail.contains("permission") => {
+            "Spotify rejected the request because the current auth scope is insufficient. Re-run `hermes auth spotify` to refresh permissions.".to_string()
+        }
+        403 => {
+            "Spotify rejected the request. The account may not have permission for this action."
+                .to_string()
+        }
+        404 if is_playback_path => {
+            "Spotify could not find an active playback device or player session for this request."
+                .to_string()
+        }
+        404 => "Spotify resource not found.".to_string(),
+        429 => {
+            let mut message = "Spotify rate limit exceeded.".to_string();
+            if let Some(retry_after) = retry_after.filter(|value| !value.trim().is_empty()) {
+                message.push_str(&format!(" Retry after {retry_after} seconds."));
+            }
+            message
+        }
+        _ if !detail.trim().is_empty() => detail.trim().to_string(),
+        _ => format!("Spotify API request failed with status {status}."),
+    }
+}
+
+fn resolve_spotify_runtime_credentials() -> Result<SpotifyRuntimeCredentials, ToolError> {
+    if let Some(access_token) =
+        env_string("HERMES_SPOTIFY_ACCESS_TOKEN").or_else(|| env_string("SPOTIFY_ACCESS_TOKEN"))
+    {
+        return Ok(SpotifyRuntimeCredentials {
+            access_token,
+            base_url: env_string("HERMES_SPOTIFY_API_BASE_URL")
+                .or_else(|| env_string("SPOTIFY_API_BASE_URL"))
+                .unwrap_or_else(|| DEFAULT_SPOTIFY_API_BASE_URL.to_string())
+                .trim_end_matches('/')
+                .to_string(),
+            source: "env".to_string(),
+        });
+    }
+
+    for path in auth_store_candidates() {
+        if let Some(credentials) = read_spotify_credentials_from_auth_store(&path) {
+            return Ok(credentials);
+        }
+    }
+
+    Err(ToolError::ExecutionFailed(SPOTIFY_AUTH_ERROR.into()))
+}
+
+fn env_string(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn auth_store_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = env_string("HERMES_AUTH_FILE") {
+        candidates.push(PathBuf::from(path));
+    }
+    candidates.push(hermes_config::paths::auth_json_path());
+    if let Some(home) = user_home_dir() {
+        candidates.push(home.join(".hermes-agent-ultra").join("auth.json"));
+        candidates.push(home.join(".hermes").join("auth.json"));
+    }
+
+    let mut seen = Vec::<PathBuf>::new();
+    candidates
+        .into_iter()
+        .filter(|path| path.is_file())
+        .filter(|path| {
+            if seen.contains(path) {
+                false
+            } else {
+                seen.push(path.clone());
+                true
+            }
+        })
+        .collect()
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn read_spotify_credentials_from_auth_store(path: &PathBuf) -> Option<SpotifyRuntimeCredentials> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<Value>(&raw).ok()?;
+    let spotify = value
+        .get("providers")
+        .and_then(Value::as_object)?
+        .get("spotify")?
+        .as_object()?;
+    let access_token = spotify
+        .get("access_token")
+        .or_else(|| spotify.get("api_key"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    let base_url = spotify
+        .get("base_url")
+        .or_else(|| spotify.get("api_base_url"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_SPOTIFY_API_BASE_URL)
+        .trim_end_matches('/')
+        .to_string();
+    Some(SpotifyRuntimeCredentials {
+        access_token,
+        base_url,
+        source: path.display().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hermes_config::managed_gateway::test_lock;
+
+    struct EnvGuard {
+        _tmp: tempfile::TempDir,
+        original: Vec<(&'static str, Option<String>)>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let lock = test_lock::lock();
+            let tmp = tempfile::tempdir().unwrap();
+            let keys = [
+                "HERMES_HOME",
+                "HERMES_AUTH_FILE",
+                "HERMES_SPOTIFY_ACCESS_TOKEN",
+                "SPOTIFY_ACCESS_TOKEN",
+                "HERMES_SPOTIFY_API_BASE_URL",
+                "SPOTIFY_API_BASE_URL",
+            ];
+            let original = keys
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+            for key in keys {
+                std::env::remove_var(key);
+            }
+            std::env::set_var("HERMES_HOME", tmp.path());
+            Self {
+                _tmp: tmp,
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.original {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolves_credentials_from_env() {
+        let _guard = EnvGuard::new();
+        std::env::set_var("HERMES_SPOTIFY_ACCESS_TOKEN", "env-token");
+        std::env::set_var("HERMES_SPOTIFY_API_BASE_URL", "https://spotify.test/v1/");
+
+        let backend = SpotifyWebApiBackend::from_env_or_auth_store().unwrap();
+        let credentials = backend.credentials().unwrap();
+        assert_eq!(credentials.access_token, "env-token");
+        assert_eq!(credentials.base_url, "https://spotify.test/v1");
+        assert_eq!(credentials.source, "env");
+    }
+
+    #[test]
+    fn resolves_credentials_from_auth_store() {
+        let _guard = EnvGuard::new();
+        let path = hermes_config::paths::auth_json_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "providers": {
+                    "spotify": {
+                        "access_token": "store-token",
+                        "api_base_url": "https://store.spotify.test/v1/"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let backend = SpotifyWebApiBackend::from_env_or_auth_store().unwrap();
+        let credentials = backend.credentials().unwrap();
+        assert_eq!(credentials.access_token, "store-token");
+        assert_eq!(credentials.base_url, "https://store.spotify.test/v1");
+        assert_eq!(credentials.source, path.display().to_string());
+    }
+
+    #[tokio::test]
+    async fn unconfigured_backend_returns_auth_error_without_network() {
+        let _guard = EnvGuard::new();
+        let backend = SpotifyWebApiBackend::unconfigured();
+        let err = backend
+            .call(SpotifyApiRequest::new(SpotifyHttpMethod::Get, "/me/player"))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Run `hermes auth spotify` again"));
+    }
+
+    #[test]
+    fn friendly_errors_match_upstream_messages() {
+        assert_eq!(
+            friendly_spotify_error_message(StatusCode::UNAUTHORIZED, "bad", "/me/player", None),
+            SPOTIFY_AUTH_ERROR
+        );
+        assert!(friendly_spotify_error_message(
+            StatusCode::FORBIDDEN,
+            "scope missing",
+            "/search",
+            None
+        )
+        .contains("scope is insufficient"));
+        assert!(friendly_spotify_error_message(
+            StatusCode::TOO_MANY_REQUESTS,
+            "",
+            "/search",
+            Some("12")
+        )
+        .contains("Retry after 12 seconds"));
+    }
+}

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -76,6 +76,9 @@ pub use tools::session_search::{SessionSearchBackend, SessionSearchHandler};
 pub use tools::skill_commands;
 pub use tools::skill_utils;
 pub use tools::skills::{SkillManageHandler, SkillViewHandler, SkillsListHandler};
+pub use tools::spotify::{
+    SpotifyApiRequest, SpotifyBackend, SpotifyHandler, SpotifyHttpMethod, SpotifyTool,
+};
 pub use tools::terminal::{ProcessBackend, ProcessHandler, TerminalHandler};
 pub use tools::todo::{TodoBackend, TodoHandler};
 pub use tools::tool_result_storage::ToolResultStorageHandler;
@@ -109,6 +112,7 @@ pub use backends::image_gen::FalImageGenBackend;
 pub use backends::memory::FileMemoryBackend;
 pub use backends::messaging::SignalMessagingBackend;
 pub use backends::session_search::SqliteSessionSearchBackend;
+pub use backends::spotify::{SpotifyRuntimeCredentials, SpotifyWebApiBackend};
 pub use backends::todo::FileTodoBackend;
 pub use backends::tts::MultiTtsBackend;
 pub use backends::video::VisionFrameSamplingVideoBackend;

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -196,6 +196,40 @@ pub fn register_builtin_tools(
         );
     }
 
+    // -- Spotify -------------------------------------------------------------
+    {
+        let backend: Arc<dyn crate::tools::spotify::SpotifyBackend> =
+            match crate::backends::spotify::SpotifyWebApiBackend::from_env_or_auth_store() {
+                Ok(backend) => Arc::new(backend),
+                Err(_) => Arc::new(crate::backends::spotify::SpotifyWebApiBackend::unconfigured()),
+            };
+        let deps = vec![
+            "HERMES_SPOTIFY_ACCESS_TOKEN".into(),
+            "SPOTIFY_ACCESS_TOKEN".into(),
+            "HERMES_AUTH_FILE".into(),
+        ];
+        for (tool, emoji) in [
+            (crate::tools::spotify::SpotifyTool::Playback, "🎵"),
+            (crate::tools::spotify::SpotifyTool::Devices, "🔈"),
+            (crate::tools::spotify::SpotifyTool::Queue, "📻"),
+            (crate::tools::spotify::SpotifyTool::Search, "🔎"),
+            (crate::tools::spotify::SpotifyTool::Playlists, "📚"),
+            (crate::tools::spotify::SpotifyTool::Albums, "💿"),
+            (crate::tools::spotify::SpotifyTool::Library, "❤️"),
+        ] {
+            reg(
+                registry,
+                "spotify",
+                Arc::new(crate::tools::spotify::SpotifyHandler::new(
+                    tool,
+                    backend.clone(),
+                )),
+                emoji,
+                deps.clone(),
+            );
+        }
+    }
+
     // -- Skills (3 tools) ----------------------------------------------------
     reg(
         registry,

--- a/crates/hermes-tools/src/tools/mod.rs
+++ b/crates/hermes-tools/src/tools/mod.rs
@@ -25,6 +25,7 @@ pub mod session_search;
 pub mod skill_commands;
 pub mod skill_utils;
 pub mod skills;
+pub mod spotify;
 pub mod terminal;
 pub mod todo;
 pub mod tool_result_storage;

--- a/crates/hermes-tools/src/tools/spotify.rs
+++ b/crates/hermes-tools/src/tools/spotify.rs
@@ -1,0 +1,1269 @@
+//! Spotify Web API tools.
+//!
+//! These handlers port the upstream bundled Spotify plugin into the Rust
+//! runtime. The Python plugin remains reference material only.
+
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde_json::{json, Map, Number, Value};
+use std::sync::Arc;
+
+use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpotifyHttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpotifyApiRequest {
+    pub method: SpotifyHttpMethod,
+    pub path: String,
+    pub query: Vec<(String, String)>,
+    pub body: Option<Value>,
+    pub empty_response: Option<Value>,
+}
+
+impl SpotifyApiRequest {
+    pub fn new(method: SpotifyHttpMethod, path: impl Into<String>) -> Self {
+        Self {
+            method,
+            path: path.into(),
+            query: Vec::new(),
+            body: None,
+            empty_response: None,
+        }
+    }
+
+    fn with_query(mut self, key: &str, value: Option<String>) -> Self {
+        if let Some(value) = value
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+        {
+            self.query.push((key.to_string(), value));
+        }
+        self
+    }
+
+    fn with_body(mut self, body: Value) -> Self {
+        self.body = Some(strip_null_object(body));
+        self
+    }
+
+    fn with_empty_response(mut self, value: Value) -> Self {
+        self.empty_response = Some(value);
+        self
+    }
+}
+
+#[async_trait]
+pub trait SpotifyBackend: Send + Sync {
+    async fn call(&self, request: SpotifyApiRequest) -> Result<Value, ToolError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpotifyTool {
+    Playback,
+    Devices,
+    Queue,
+    Search,
+    Playlists,
+    Albums,
+    Library,
+}
+
+pub struct SpotifyHandler {
+    tool: SpotifyTool,
+    backend: Arc<dyn SpotifyBackend>,
+}
+
+impl SpotifyHandler {
+    pub fn new(tool: SpotifyTool, backend: Arc<dyn SpotifyBackend>) -> Self {
+        Self { tool, backend }
+    }
+}
+
+#[async_trait]
+impl ToolHandler for SpotifyHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        let result = match self.tool {
+            SpotifyTool::Playback => handle_playback(&*self.backend, params).await?,
+            SpotifyTool::Devices => handle_devices(&*self.backend, params).await?,
+            SpotifyTool::Queue => handle_queue(&*self.backend, params).await?,
+            SpotifyTool::Search => handle_search(&*self.backend, params).await?,
+            SpotifyTool::Playlists => handle_playlists(&*self.backend, params).await?,
+            SpotifyTool::Albums => handle_albums(&*self.backend, params).await?,
+            SpotifyTool::Library => handle_library(&*self.backend, params).await?,
+        };
+        Ok(result.to_string())
+    }
+
+    fn schema(&self) -> ToolSchema {
+        self.tool.schema()
+    }
+}
+
+impl SpotifyTool {
+    fn schema(self) -> ToolSchema {
+        let common_string = json!({"type": "string"});
+        match self {
+            Self::Playback => {
+                let mut props = IndexMap::new();
+                props.insert(
+                    "action".into(),
+                    json!({
+                        "type": "string",
+                        "enum": ["get_state", "get_currently_playing", "play", "pause", "next", "previous", "seek", "set_repeat", "set_shuffle", "set_volume", "recently_played"]
+                    }),
+                );
+                props.insert("device_id".into(), common_string.clone());
+                props.insert("market".into(), common_string.clone());
+                props.insert("context_uri".into(), common_string.clone());
+                props.insert(
+                    "uris".into(),
+                    json!({"type": "array", "items": common_string.clone()}),
+                );
+                props.insert("offset".into(), json!({"type": "object"}));
+                props.insert("position_ms".into(), json!({"type": "integer"}));
+                props.insert(
+                    "state".into(),
+                    json!({
+                        "description": "For set_repeat use track/context/off. For set_shuffle use boolean-like true/false.",
+                        "oneOf": [{"type": "string"}, {"type": "boolean"}]
+                    }),
+                );
+                props.insert("volume_percent".into(), json!({"type": "integer"}));
+                props.insert(
+                    "limit".into(),
+                    json!({"type": "integer", "description": "For recently_played: number of tracks (max 50)"}),
+                );
+                props.insert(
+                    "after".into(),
+                    json!({"type": "integer", "description": "For recently_played: Unix ms cursor (after this timestamp)"}),
+                );
+                props.insert(
+                    "before".into(),
+                    json!({"type": "integer", "description": "For recently_played: Unix ms cursor (before this timestamp)"}),
+                );
+                tool_schema(
+                    "spotify_playback",
+                    "Control Spotify playback, inspect the active playback state, or fetch recently played tracks.",
+                    JsonSchema::object(props, vec!["action".into()]),
+                )
+            }
+            Self::Devices => {
+                let mut props = IndexMap::new();
+                props.insert(
+                    "action".into(),
+                    json!({"type": "string", "enum": ["list", "transfer"]}),
+                );
+                props.insert("device_id".into(), common_string.clone());
+                props.insert("play".into(), json!({"type": "boolean"}));
+                tool_schema(
+                    "spotify_devices",
+                    "List Spotify Connect devices or transfer playback to a different device.",
+                    JsonSchema::object(props, vec!["action".into()]),
+                )
+            }
+            Self::Queue => {
+                let mut props = IndexMap::new();
+                props.insert(
+                    "action".into(),
+                    json!({"type": "string", "enum": ["get", "add"]}),
+                );
+                props.insert("uri".into(), common_string.clone());
+                props.insert("device_id".into(), common_string.clone());
+                tool_schema(
+                    "spotify_queue",
+                    "Inspect the user's Spotify queue or add an item to it.",
+                    JsonSchema::object(props, vec!["action".into()]),
+                )
+            }
+            Self::Search => {
+                let mut props = IndexMap::new();
+                props.insert("query".into(), common_string.clone());
+                props.insert(
+                    "types".into(),
+                    json!({"type": "array", "items": common_string.clone()}),
+                );
+                props.insert("type".into(), common_string.clone());
+                props.insert("limit".into(), json!({"type": "integer"}));
+                props.insert("offset".into(), json!({"type": "integer"}));
+                props.insert("market".into(), common_string.clone());
+                props.insert("include_external".into(), common_string.clone());
+                tool_schema(
+                    "spotify_search",
+                    "Search the Spotify catalog for tracks, albums, artists, playlists, shows, or episodes.",
+                    JsonSchema::object(props, vec!["query".into()]),
+                )
+            }
+            Self::Playlists => {
+                let mut props = IndexMap::new();
+                props.insert(
+                    "action".into(),
+                    json!({"type": "string", "enum": ["list", "get", "create", "add_items", "remove_items", "update_details"]}),
+                );
+                props.insert("playlist_id".into(), common_string.clone());
+                props.insert("market".into(), common_string.clone());
+                props.insert("limit".into(), json!({"type": "integer"}));
+                props.insert("offset".into(), json!({"type": "integer"}));
+                props.insert("name".into(), common_string.clone());
+                props.insert("description".into(), common_string.clone());
+                props.insert("public".into(), json!({"type": "boolean"}));
+                props.insert("collaborative".into(), json!({"type": "boolean"}));
+                props.insert(
+                    "uris".into(),
+                    json!({"type": "array", "items": common_string.clone()}),
+                );
+                props.insert("position".into(), json!({"type": "integer"}));
+                props.insert("snapshot_id".into(), common_string.clone());
+                tool_schema(
+                    "spotify_playlists",
+                    "List, inspect, create, update, and modify Spotify playlists.",
+                    JsonSchema::object(props, vec!["action".into()]),
+                )
+            }
+            Self::Albums => {
+                let mut props = IndexMap::new();
+                props.insert(
+                    "action".into(),
+                    json!({"type": "string", "enum": ["get", "tracks"]}),
+                );
+                props.insert("album_id".into(), common_string.clone());
+                props.insert("id".into(), common_string.clone());
+                props.insert("market".into(), common_string.clone());
+                props.insert("limit".into(), json!({"type": "integer"}));
+                props.insert("offset".into(), json!({"type": "integer"}));
+                tool_schema(
+                    "spotify_albums",
+                    "Fetch Spotify album metadata or album tracks.",
+                    JsonSchema::object(props, vec!["action".into()]),
+                )
+            }
+            Self::Library => {
+                let mut props = IndexMap::new();
+                props.insert(
+                    "kind".into(),
+                    json!({"type": "string", "enum": ["tracks", "albums"], "description": "Which library to operate on"}),
+                );
+                props.insert(
+                    "action".into(),
+                    json!({"type": "string", "enum": ["list", "save", "remove"]}),
+                );
+                props.insert("limit".into(), json!({"type": "integer"}));
+                props.insert("offset".into(), json!({"type": "integer"}));
+                props.insert("market".into(), common_string.clone());
+                props.insert(
+                    "uris".into(),
+                    json!({"type": "array", "items": common_string.clone()}),
+                );
+                props.insert(
+                    "ids".into(),
+                    json!({"type": "array", "items": common_string.clone()}),
+                );
+                props.insert(
+                    "items".into(),
+                    json!({"type": "array", "items": common_string}),
+                );
+                tool_schema(
+                    "spotify_library",
+                    "List, save, or remove the user's saved Spotify tracks or albums. Use `kind` to select which.",
+                    JsonSchema::object(props, vec!["kind".into(), "action".into()]),
+                )
+            }
+        }
+    }
+}
+
+async fn handle_playback(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let action = action(&params, "get_state");
+    match action.as_str() {
+        "get_state" => {
+            let payload = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Get, "/me/player")
+                        .with_query("market", optional_string(&params, "market"))
+                        .with_empty_response(json!({
+                            "status_code": 204,
+                            "empty": true,
+                            "message": "No active Spotify playback session was found. Open Spotify on a device and start playback, or transfer playback to an available device."
+                        })),
+                )
+                .await?;
+            Ok(describe_empty_playback(payload, &action))
+        }
+        "get_currently_playing" => {
+            let payload = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Get, "/me/player/currently-playing")
+                        .with_query("market", optional_string(&params, "market"))
+                        .with_empty_response(json!({
+                            "status_code": 204,
+                            "empty": true,
+                            "message": "Spotify is not currently playing anything. Start playback in Spotify and try again."
+                        })),
+                )
+                .await?;
+            Ok(describe_empty_playback(payload, &action))
+        }
+        "play" => {
+            let mut body = Map::new();
+            if let Some(context_uri) = optional_string(&params, "context_uri") {
+                let context_type = infer_context_type(&context_uri);
+                body.insert(
+                    "context_uri".into(),
+                    Value::String(normalize_spotify_uri(&context_uri, context_type)?),
+                );
+            }
+            if params.get("uris").is_some() {
+                let uris = normalize_spotify_uris(as_list(params.get("uris")), Some("track"))?;
+                body.insert(
+                    "uris".into(),
+                    Value::Array(uris.into_iter().map(Value::String).collect()),
+                );
+            }
+            if let Some(offset) = params.get("offset").and_then(Value::as_object) {
+                let clean: Map<String, Value> = offset
+                    .iter()
+                    .filter(|(_, value)| !value.is_null())
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+                if !clean.is_empty() {
+                    body.insert("offset".into(), Value::Object(clean));
+                }
+            }
+            if params.get("position_ms").is_some() {
+                body.insert(
+                    "position_ms".into(),
+                    Value::Number(Number::from(required_i64(&params, "position_ms")?)),
+                );
+            }
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/player/play")
+                        .with_query("device_id", optional_string(&params, "device_id"))
+                        .with_body(Value::Object(body)),
+                )
+                .await?;
+            Ok(action_result(&action, result))
+        }
+        "pause" => {
+            playback_command(
+                backend,
+                &action,
+                SpotifyHttpMethod::Put,
+                "/me/player/pause",
+                &params,
+            )
+            .await
+        }
+        "next" => {
+            playback_command(
+                backend,
+                &action,
+                SpotifyHttpMethod::Post,
+                "/me/player/next",
+                &params,
+            )
+            .await
+        }
+        "previous" => {
+            playback_command(
+                backend,
+                &action,
+                SpotifyHttpMethod::Post,
+                "/me/player/previous",
+                &params,
+            )
+            .await
+        }
+        "seek" => {
+            let position_ms = required_i64(&params, "position_ms")?;
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/player/seek")
+                        .with_query("position_ms", Some(position_ms.to_string()))
+                        .with_query("device_id", optional_string(&params, "device_id")),
+                )
+                .await?;
+            Ok(action_result(&action, result))
+        }
+        "set_repeat" => {
+            let state = optional_string(&params, "state")
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            if !matches!(state.as_str(), "track" | "context" | "off") {
+                return Err(ToolError::InvalidParams(
+                    "state must be one of: track, context, off".into(),
+                ));
+            }
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/player/repeat")
+                        .with_query("state", Some(state))
+                        .with_query("device_id", optional_string(&params, "device_id")),
+                )
+                .await?;
+            Ok(action_result(&action, result))
+        }
+        "set_shuffle" => {
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/player/shuffle")
+                        .with_query(
+                            "state",
+                            Some(coerce_bool(params.get("state"), false).to_string()),
+                        )
+                        .with_query("device_id", optional_string(&params, "device_id")),
+                )
+                .await?;
+            Ok(action_result(&action, result))
+        }
+        "set_volume" => {
+            let volume = required_i64(&params, "volume_percent")?.clamp(0, 100);
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/player/volume")
+                        .with_query("volume_percent", Some(volume.to_string()))
+                        .with_query("device_id", optional_string(&params, "device_id")),
+                )
+                .await?;
+            Ok(action_result(&action, result))
+        }
+        "recently_played" => {
+            let after = optional_i64(&params, "after")?;
+            let before = optional_i64(&params, "before")?;
+            if after.is_some() && before.is_some() {
+                return Err(ToolError::InvalidParams(
+                    "Provide only one of 'after' or 'before'".into(),
+                ));
+            }
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Get, "/me/player/recently-played")
+                        .with_query(
+                            "limit",
+                            Some(coerce_limit(params.get("limit"), 20, 1, 50).to_string()),
+                        )
+                        .with_query("after", after.map(|v| v.to_string()))
+                        .with_query("before", before.map(|v| v.to_string())),
+                )
+                .await
+        }
+        _ => Err(ToolError::InvalidParams(format!(
+            "Unknown spotify_playback action: {action}"
+        ))),
+    }
+}
+
+async fn playback_command(
+    backend: &dyn SpotifyBackend,
+    action: &str,
+    method: SpotifyHttpMethod,
+    path: &str,
+    params: &Value,
+) -> Result<Value, ToolError> {
+    let result = backend
+        .call(
+            SpotifyApiRequest::new(method, path)
+                .with_query("device_id", optional_string(params, "device_id")),
+        )
+        .await?;
+    Ok(action_result(action, result))
+}
+
+async fn handle_devices(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let action = action(&params, "list");
+    match action.as_str() {
+        "list" => {
+            backend
+                .call(SpotifyApiRequest::new(
+                    SpotifyHttpMethod::Get,
+                    "/me/player/devices",
+                ))
+                .await
+        }
+        "transfer" => {
+            let device_id = required_string(
+                &params,
+                "device_id",
+                "device_id is required for action='transfer'",
+            )?;
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/player").with_body(json!({
+                        "device_ids": [device_id],
+                        "play": coerce_bool(params.get("play"), false)
+                    })),
+                )
+                .await?;
+            Ok(action_result(&action, result))
+        }
+        _ => Err(ToolError::InvalidParams(format!(
+            "Unknown spotify_devices action: {action}"
+        ))),
+    }
+}
+
+async fn handle_queue(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let action = action(&params, "get");
+    match action.as_str() {
+        "get" => {
+            backend
+                .call(SpotifyApiRequest::new(
+                    SpotifyHttpMethod::Get,
+                    "/me/player/queue",
+                ))
+                .await
+        }
+        "add" => {
+            let uri = normalize_spotify_uri(
+                &required_string(&params, "uri", "Spotify URI/url/id is required.")?,
+                None,
+            )?;
+            let result = backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Post, "/me/player/queue")
+                        .with_query("uri", Some(uri.clone()))
+                        .with_query("device_id", optional_string(&params, "device_id")),
+                )
+                .await?;
+            Ok(json!({"success": true, "action": action, "uri": uri, "result": result}))
+        }
+        _ => Err(ToolError::InvalidParams(format!(
+            "Unknown spotify_queue action: {action}"
+        ))),
+    }
+}
+
+async fn handle_search(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let query = required_string(&params, "query", "query is required")?;
+    let valid = [
+        "album",
+        "artist",
+        "playlist",
+        "track",
+        "show",
+        "episode",
+        "audiobook",
+    ];
+    let raw_types = params
+        .get("types")
+        .or_else(|| params.get("type"))
+        .map(|value| as_list(Some(value)))
+        .unwrap_or_else(|| vec!["track".to_string()]);
+    let search_types: Vec<String> = raw_types
+        .into_iter()
+        .map(|value| value.to_ascii_lowercase())
+        .filter(|value| valid.contains(&value.as_str()))
+        .collect();
+    if search_types.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "types must contain one or more of: album, artist, playlist, track, show, episode, audiobook".into(),
+        ));
+    }
+
+    backend
+        .call(
+            SpotifyApiRequest::new(SpotifyHttpMethod::Get, "/search")
+                .with_query("q", Some(query))
+                .with_query("type", Some(search_types.join(",")))
+                .with_query(
+                    "limit",
+                    Some(coerce_limit(params.get("limit"), 10, 1, 50).to_string()),
+                )
+                .with_query(
+                    "offset",
+                    Some(nonnegative_i64(params.get("offset"), 0)?.to_string()),
+                )
+                .with_query("market", optional_string(&params, "market"))
+                .with_query(
+                    "include_external",
+                    optional_string(&params, "include_external"),
+                ),
+        )
+        .await
+}
+
+async fn handle_playlists(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let action = action(&params, "list");
+    match action.as_str() {
+        "list" => {
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Get, "/me/playlists")
+                        .with_query(
+                            "limit",
+                            Some(coerce_limit(params.get("limit"), 20, 1, 50).to_string()),
+                        )
+                        .with_query(
+                            "offset",
+                            Some(nonnegative_i64(params.get("offset"), 0)?.to_string()),
+                        ),
+                )
+                .await
+        }
+        "get" => {
+            let playlist_id = normalize_spotify_id(
+                &required_string(&params, "playlist_id", "Spotify id/uri/url is required.")?,
+                Some("playlist"),
+            )?;
+            backend
+                .call(
+                    SpotifyApiRequest::new(
+                        SpotifyHttpMethod::Get,
+                        format!("/playlists/{playlist_id}"),
+                    )
+                    .with_query("market", optional_string(&params, "market")),
+                )
+                .await
+        }
+        "create" => {
+            let name = required_string(&params, "name", "name is required for action='create'")?;
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Post, "/me/playlists").with_body(
+                        json!({
+                            "name": name,
+                            "public": coerce_bool(params.get("public"), false),
+                            "collaborative": coerce_bool(params.get("collaborative"), false),
+                            "description": optional_string(&params, "description")
+                        }),
+                    ),
+                )
+                .await
+        }
+        "add_items" => {
+            let playlist_id = normalize_spotify_id(
+                &required_string(&params, "playlist_id", "Spotify id/uri/url is required.")?,
+                Some("playlist"),
+            )?;
+            let uris = normalize_spotify_uris(as_list(params.get("uris")), None)?;
+            let mut body = Map::new();
+            body.insert(
+                "uris".into(),
+                Value::Array(uris.into_iter().map(Value::String).collect()),
+            );
+            if params.get("position").is_some() {
+                body.insert(
+                    "position".into(),
+                    Value::Number(Number::from(required_i64(&params, "position")?)),
+                );
+            }
+            backend
+                .call(
+                    SpotifyApiRequest::new(
+                        SpotifyHttpMethod::Post,
+                        format!("/playlists/{playlist_id}/items"),
+                    )
+                    .with_body(Value::Object(body)),
+                )
+                .await
+        }
+        "remove_items" => {
+            let playlist_id = normalize_spotify_id(
+                &required_string(&params, "playlist_id", "Spotify id/uri/url is required.")?,
+                Some("playlist"),
+            )?;
+            let uris = normalize_spotify_uris(as_list(params.get("uris")), None)?;
+            backend
+                .call(
+                    SpotifyApiRequest::new(
+                        SpotifyHttpMethod::Delete,
+                        format!("/playlists/{playlist_id}/items"),
+                    )
+                    .with_body(json!({
+                        "items": uris.into_iter().map(|uri| json!({"uri": uri})).collect::<Vec<_>>(),
+                        "snapshot_id": optional_string(&params, "snapshot_id")
+                    })),
+                )
+                .await
+        }
+        "update_details" => {
+            let playlist_id = normalize_spotify_id(
+                &required_string(&params, "playlist_id", "Spotify id/uri/url is required.")?,
+                Some("playlist"),
+            )?;
+            let mut body = Map::new();
+            insert_raw_non_null(&mut body, &params, "name");
+            insert_raw_non_null(&mut body, &params, "public");
+            insert_raw_non_null(&mut body, &params, "collaborative");
+            insert_raw_non_null(&mut body, &params, "description");
+            backend
+                .call(
+                    SpotifyApiRequest::new(
+                        SpotifyHttpMethod::Put,
+                        format!("/playlists/{playlist_id}"),
+                    )
+                    .with_body(Value::Object(body)),
+                )
+                .await
+        }
+        _ => Err(ToolError::InvalidParams(format!(
+            "Unknown spotify_playlists action: {action}"
+        ))),
+    }
+}
+
+async fn handle_albums(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let action = action(&params, "get");
+    let album_id = normalize_spotify_id(
+        &params
+            .get("album_id")
+            .or_else(|| params.get("id"))
+            .and_then(value_to_string)
+            .filter(|s| !s.trim().is_empty())
+            .ok_or_else(|| ToolError::InvalidParams("Spotify id/uri/url is required.".into()))?,
+        Some("album"),
+    )?;
+    match action.as_str() {
+        "get" => {
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Get, format!("/albums/{album_id}"))
+                        .with_query("market", optional_string(&params, "market")),
+                )
+                .await
+        }
+        "tracks" => {
+            backend
+                .call(
+                    SpotifyApiRequest::new(
+                        SpotifyHttpMethod::Get,
+                        format!("/albums/{album_id}/tracks"),
+                    )
+                    .with_query(
+                        "limit",
+                        Some(coerce_limit(params.get("limit"), 20, 1, 50).to_string()),
+                    )
+                    .with_query(
+                        "offset",
+                        Some(nonnegative_i64(params.get("offset"), 0)?.to_string()),
+                    )
+                    .with_query("market", optional_string(&params, "market")),
+                )
+                .await
+        }
+        _ => Err(ToolError::InvalidParams(format!(
+            "Unknown spotify_albums action: {action}"
+        ))),
+    }
+}
+
+async fn handle_library(backend: &dyn SpotifyBackend, params: Value) -> Result<Value, ToolError> {
+    let kind = optional_string(&params, "kind")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if !matches!(kind.as_str(), "tracks" | "albums") {
+        return Err(ToolError::InvalidParams(
+            "kind must be one of: tracks, albums".into(),
+        ));
+    }
+    let action = action(&params, "list");
+    let item_type = if kind == "tracks" { "track" } else { "album" };
+    match action.as_str() {
+        "list" => {
+            let path = if kind == "tracks" {
+                "/me/tracks"
+            } else {
+                "/me/albums"
+            };
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Get, path)
+                        .with_query(
+                            "limit",
+                            Some(coerce_limit(params.get("limit"), 20, 1, 50).to_string()),
+                        )
+                        .with_query(
+                            "offset",
+                            Some(nonnegative_i64(params.get("offset"), 0)?.to_string()),
+                        )
+                        .with_query("market", optional_string(&params, "market")),
+                )
+                .await
+        }
+        "save" => {
+            let uris = normalize_spotify_uris(
+                as_list(params.get("uris").or_else(|| params.get("items"))),
+                Some(item_type),
+            )?;
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Put, "/me/library")
+                        .with_query("uris", Some(uris.join(","))),
+                )
+                .await
+        }
+        "remove" => {
+            let ids = as_list(params.get("ids").or_else(|| params.get("items")));
+            if ids.is_empty() {
+                return Err(ToolError::InvalidParams(
+                    "ids/items is required for action='remove'".into(),
+                ));
+            }
+            let ids: Vec<String> = ids
+                .into_iter()
+                .map(|item| normalize_spotify_id(&item, Some(item_type)))
+                .collect::<Result<_, _>>()?;
+            let uris: Vec<String> = ids
+                .into_iter()
+                .map(|id| format!("spotify:{item_type}:{id}"))
+                .collect();
+            backend
+                .call(
+                    SpotifyApiRequest::new(SpotifyHttpMethod::Delete, "/me/library")
+                        .with_query("uris", Some(uris.join(","))),
+                )
+                .await
+        }
+        _ => Err(ToolError::InvalidParams(format!(
+            "Unknown spotify_library action: {action}"
+        ))),
+    }
+}
+
+fn action(params: &Value, default: &str) -> String {
+    optional_string(params, "action")
+        .unwrap_or_else(|| default.to_string())
+        .to_ascii_lowercase()
+}
+
+fn action_result(action: &str, result: Value) -> Value {
+    json!({"success": true, "action": action, "result": result})
+}
+
+fn describe_empty_playback(payload: Value, action: &str) -> Value {
+    let Some(obj) = payload.as_object() else {
+        return payload;
+    };
+    if obj.get("empty").and_then(Value::as_bool) != Some(true) {
+        return payload;
+    }
+    let status_code = obj
+        .get("status_code")
+        .cloned()
+        .unwrap_or_else(|| json!(204));
+    let message = obj
+        .get("message")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    match action {
+        "get_currently_playing" => json!({
+            "success": true,
+            "action": action,
+            "is_playing": false,
+            "status_code": status_code,
+            "message": message.unwrap_or_else(|| "Spotify is not currently playing anything.".to_string())
+        }),
+        "get_state" => json!({
+            "success": true,
+            "action": action,
+            "has_active_device": false,
+            "status_code": status_code,
+            "message": message.unwrap_or_else(|| "No active Spotify playback session was found.".to_string())
+        }),
+        _ => payload,
+    }
+}
+
+fn optional_string(params: &Value, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(value_to_string)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn required_string(params: &Value, key: &str, message: &str) -> Result<String, ToolError> {
+    optional_string(params, key).ok_or_else(|| ToolError::InvalidParams(message.into()))
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn optional_i64(params: &Value, key: &str) -> Result<Option<i64>, ToolError> {
+    match params.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value_as_i64(value)
+            .map(Some)
+            .ok_or_else(|| ToolError::InvalidParams(format!("{key} must be an integer"))),
+    }
+}
+
+fn required_i64(params: &Value, key: &str) -> Result<i64, ToolError> {
+    optional_i64(params, key)?.ok_or_else(|| {
+        ToolError::InvalidParams(format!(
+            "{key} is required for action='{}'",
+            action(params, "")
+        ))
+    })
+}
+
+fn nonnegative_i64(raw: Option<&Value>, default: i64) -> Result<i64, ToolError> {
+    match raw {
+        None | Some(Value::Null) => Ok(default),
+        Some(value) => value_as_i64(value)
+            .map(|n| n.max(0))
+            .ok_or_else(|| ToolError::InvalidParams("offset must be an integer".into())),
+    }
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
+        .or_else(|| value.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
+}
+
+fn coerce_limit(raw: Option<&Value>, default: i64, minimum: i64, maximum: i64) -> i64 {
+    raw.and_then(value_as_i64)
+        .unwrap_or(default)
+        .clamp(minimum, maximum)
+}
+
+fn coerce_bool(raw: Option<&Value>, default: bool) -> bool {
+    match raw {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::String(value)) => match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => default,
+        },
+        _ => default,
+    }
+}
+
+fn as_list(raw: Option<&Value>) -> Vec<String> {
+    match raw {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::Array(values)) => values
+            .iter()
+            .filter_map(value_to_string)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        Some(value) => value_to_string(value)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .into_iter()
+            .collect(),
+    }
+}
+
+fn infer_context_type(value: &str) -> Option<&'static str> {
+    if value.starts_with("spotify:album:") || value.contains("/album/") {
+        Some("album")
+    } else if value.starts_with("spotify:playlist:") || value.contains("/playlist/") {
+        Some("playlist")
+    } else if value.starts_with("spotify:artist:") || value.contains("/artist/") {
+        Some("artist")
+    } else {
+        None
+    }
+}
+
+fn normalize_spotify_id(value: &str, expected_type: Option<&str>) -> Result<String, ToolError> {
+    let cleaned = value.trim();
+    if cleaned.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "Spotify id/uri/url is required.".into(),
+        ));
+    }
+    if let Some(rest) = cleaned.strip_prefix("spotify:") {
+        let parts: Vec<&str> = rest.split(':').collect();
+        if parts.len() >= 2 {
+            let item_type = parts[0];
+            if let Some(expected) = expected_type {
+                if item_type != expected {
+                    return Err(ToolError::InvalidParams(format!(
+                        "Expected a Spotify {expected}, got {item_type}."
+                    )));
+                }
+            }
+            return Ok(parts[1].to_string());
+        }
+    }
+    if cleaned.contains("open.spotify.com") {
+        if let Ok(parsed) = reqwest::Url::parse(cleaned) {
+            let parts: Vec<&str> = parsed
+                .path_segments()
+                .map(|segments| segments.filter(|part| !part.is_empty()).collect())
+                .unwrap_or_default();
+            if parts.len() >= 2 {
+                let item_type = parts[0];
+                let item_id = parts[1];
+                if let Some(expected) = expected_type {
+                    if item_type != expected {
+                        return Err(ToolError::InvalidParams(format!(
+                            "Expected a Spotify {expected}, got {item_type}."
+                        )));
+                    }
+                }
+                return Ok(item_id.to_string());
+            }
+        }
+    }
+    Ok(cleaned.to_string())
+}
+
+fn normalize_spotify_uri(value: &str, expected_type: Option<&str>) -> Result<String, ToolError> {
+    let cleaned = value.trim();
+    if cleaned.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "Spotify URI/url/id is required.".into(),
+        ));
+    }
+    if let Some(rest) = cleaned.strip_prefix("spotify:") {
+        if let Some(expected) = expected_type {
+            let parts: Vec<&str> = rest.split(':').collect();
+            if parts.len() >= 2 && parts[0] != expected {
+                return Err(ToolError::InvalidParams(format!(
+                    "Expected a Spotify {expected}, got {}.",
+                    parts[0]
+                )));
+            }
+        }
+        return Ok(cleaned.to_string());
+    }
+    let item_id = normalize_spotify_id(cleaned, expected_type)?;
+    Ok(expected_type
+        .map(|item_type| format!("spotify:{item_type}:{item_id}"))
+        .unwrap_or(item_id))
+}
+
+fn normalize_spotify_uris(
+    values: Vec<String>,
+    expected_type: Option<&str>,
+) -> Result<Vec<String>, ToolError> {
+    let mut uris = Vec::new();
+    for value in values {
+        let uri = normalize_spotify_uri(&value, expected_type)?;
+        if !uris.contains(&uri) {
+            uris.push(uri);
+        }
+    }
+    if uris.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "At least one Spotify item is required.".into(),
+        ));
+    }
+    Ok(uris)
+}
+
+fn insert_raw_non_null(out: &mut Map<String, Value>, params: &Value, key: &str) {
+    if let Some(value) = params.get(key).filter(|value| !value.is_null()) {
+        out.insert(key.to_string(), value.clone());
+    }
+}
+
+fn strip_null_object(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(_, value)| !value.is_null())
+                .collect::<Map<_, _>>(),
+        ),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingSpotifyBackend {
+        calls: Mutex<Vec<SpotifyApiRequest>>,
+        responses: Mutex<Vec<Value>>,
+    }
+
+    impl RecordingSpotifyBackend {
+        fn with_response(value: Value) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                responses: Mutex::new(vec![value]),
+            }
+        }
+
+        fn take_call(&self) -> SpotifyApiRequest {
+            self.calls.lock().unwrap().remove(0)
+        }
+    }
+
+    #[async_trait]
+    impl SpotifyBackend for RecordingSpotifyBackend {
+        async fn call(&self, request: SpotifyApiRequest) -> Result<Value, ToolError> {
+            self.calls.lock().unwrap().push(request);
+            Ok(self
+                .responses
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or_else(|| json!({"ok": true})))
+        }
+    }
+
+    #[tokio::test]
+    async fn playback_play_shapes_context_and_track_uris() {
+        let backend = Arc::new(RecordingSpotifyBackend::default());
+        let handler = SpotifyHandler::new(SpotifyTool::Playback, backend.clone());
+
+        let out = handler
+            .execute(json!({
+                "action": "play",
+                "device_id": "speaker-1",
+                "context_uri": "https://open.spotify.com/album/album123?si=x",
+                "uris": ["track-a", "spotify:track:track-a", "spotify:track:track-b"],
+                "position_ms": "2500"
+            }))
+            .await
+            .unwrap();
+
+        let out: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(out["success"], true);
+        let call = backend.take_call();
+        assert_eq!(call.method, SpotifyHttpMethod::Put);
+        assert_eq!(call.path, "/me/player/play");
+        assert_eq!(call.query, vec![("device_id".into(), "speaker-1".into())]);
+        let body = call.body.unwrap();
+        assert_eq!(body["context_uri"], "spotify:album:album123");
+        assert_eq!(
+            body["uris"],
+            json!(["spotify:track:track-a", "spotify:track:track-b"])
+        );
+        assert_eq!(body["position_ms"], 2500);
+    }
+
+    #[tokio::test]
+    async fn search_filters_types_and_clamps_numbers() {
+        let backend = Arc::new(RecordingSpotifyBackend::default());
+        let handler = SpotifyHandler::new(SpotifyTool::Search, backend.clone());
+
+        handler
+            .execute(json!({
+                "query": "glass beams",
+                "types": ["track", "garbage", "album"],
+                "limit": 99,
+                "offset": -10,
+                "market": "US"
+            }))
+            .await
+            .unwrap();
+
+        let call = backend.take_call();
+        assert_eq!(call.path, "/search");
+        assert_eq!(
+            call.query,
+            vec![
+                ("q".into(), "glass beams".into()),
+                ("type".into(), "track,album".into()),
+                ("limit".into(), "50".into()),
+                ("offset".into(), "0".into()),
+                ("market".into(), "US".into())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_playback_response_is_described() {
+        let backend = Arc::new(RecordingSpotifyBackend::with_response(json!({
+            "status_code": 204,
+            "empty": true,
+            "message": "nothing active"
+        })));
+        let handler = SpotifyHandler::new(SpotifyTool::Playback, backend);
+
+        let out = handler
+            .execute(json!({"action": "get_state"}))
+            .await
+            .unwrap();
+        let out: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(out["success"], true);
+        assert_eq!(out["has_active_device"], false);
+        assert_eq!(out["message"], "nothing active");
+    }
+
+    #[tokio::test]
+    async fn library_remove_normalizes_album_ids() {
+        let backend = Arc::new(RecordingSpotifyBackend::default());
+        let handler = SpotifyHandler::new(SpotifyTool::Library, backend.clone());
+
+        handler
+            .execute(json!({
+                "kind": "albums",
+                "action": "remove",
+                "items": ["https://open.spotify.com/album/abc", "spotify:album:def"]
+            }))
+            .await
+            .unwrap();
+
+        let call = backend.take_call();
+        assert_eq!(call.method, SpotifyHttpMethod::Delete);
+        assert_eq!(call.path, "/me/library");
+        assert_eq!(
+            call.query,
+            vec![("uris".into(), "spotify:album:abc,spotify:album:def".into())]
+        );
+    }
+
+    #[tokio::test]
+    async fn validation_errors_match_upstream_contracts() {
+        let backend = Arc::new(RecordingSpotifyBackend::default());
+        let playback = SpotifyHandler::new(SpotifyTool::Playback, backend.clone());
+        let err = playback
+            .execute(json!({"action": "set_repeat", "state": "all"}))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("state must be one of"));
+
+        let library = SpotifyHandler::new(SpotifyTool::Library, backend);
+        let err = library
+            .execute(json!({"kind": "tracks", "action": "remove"}))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ids/items is required"));
+    }
+
+    #[test]
+    fn schemas_keep_upstream_tool_names() {
+        let backend = Arc::new(RecordingSpotifyBackend::default());
+        let names: Vec<String> = [
+            SpotifyTool::Playback,
+            SpotifyTool::Devices,
+            SpotifyTool::Queue,
+            SpotifyTool::Search,
+            SpotifyTool::Playlists,
+            SpotifyTool::Albums,
+            SpotifyTool::Library,
+        ]
+        .into_iter()
+        .map(|tool| SpotifyHandler::new(tool, backend.clone()).schema().name)
+        .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "spotify_playback",
+                "spotify_devices",
+                "spotify_queue",
+                "spotify_search",
+                "spotify_playlists",
+                "spotify_albums",
+                "spotify_library"
+            ]
+        );
+    }
+}

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -38,6 +38,18 @@ pub const TOOLSET_BROWSER: &[&str] = &[
 pub const TOOLSET_VISION: &[&str] = &["vision_analyze", "video_analyze"];
 /// Image generation tools.
 pub const TOOLSET_IMAGE_GEN: &[&str] = &["image_generate"];
+/// Video generation tools.
+pub const TOOLSET_VIDEO_GEN: &[&str] = &["video_generate"];
+/// Spotify Web API tools.
+pub const TOOLSET_SPOTIFY: &[&str] = &[
+    "spotify_playback",
+    "spotify_devices",
+    "spotify_queue",
+    "spotify_search",
+    "spotify_playlists",
+    "spotify_albums",
+    "spotify_library",
+];
 /// Skills management tools.
 pub const TOOLSET_SKILLS: &[&str] = &["skills_list", "skill_view", "skill_manage"];
 /// Persistent memory tools.
@@ -168,6 +180,14 @@ impl ToolsetManager {
             TOOLSET_IMAGE_GEN.iter().map(|s| s.to_string()).collect(),
         ));
         self.register(Toolset::new(
+            "video_gen",
+            TOOLSET_VIDEO_GEN.iter().map(|s| s.to_string()).collect(),
+        ));
+        self.register(Toolset::new(
+            "spotify",
+            TOOLSET_SPOTIFY.iter().map(|s| s.to_string()).collect(),
+        ));
+        self.register(Toolset::new(
             "skills",
             TOOLSET_SKILLS.iter().map(|s| s.to_string()).collect(),
         ));
@@ -250,6 +270,8 @@ impl ToolsetManager {
                 "browser",
                 "vision",
                 "image_gen",
+                "video_gen",
+                "spotify",
                 "skills",
                 "memory",
                 "session_search",
@@ -536,6 +558,8 @@ mod tests {
         assert!(tools.contains(&"read_file".to_string()));
         // Python parity core for CLI.
         assert!(tools.contains(&"image_generate".to_string()));
+        assert!(tools.contains(&"video_generate".to_string()));
+        assert!(tools.contains(&"spotify_playback".to_string()));
         assert!(tools.contains(&"session_search".to_string()));
         assert!(tools.contains(&"text_to_speech".to_string()));
         assert!(tools.contains(&"send_message".to_string()));
@@ -564,6 +588,14 @@ mod tests {
             assert!(
                 tools.contains(&"image_generate".to_string()),
                 "preset {preset} should include image_generate"
+            );
+            assert!(
+                tools.contains(&"video_generate".to_string()),
+                "preset {preset} should include video_generate"
+            );
+            assert!(
+                tools.contains(&"spotify_search".to_string()),
+                "preset {preset} should include spotify tools"
             );
             assert!(
                 tools.contains(&"cronjob".to_string()),

--- a/crates/hermes-tools/src/toolset_distributions.rs
+++ b/crates/hermes-tools/src/toolset_distributions.rs
@@ -73,6 +73,8 @@ fn base_weights() -> HashMap<String, f64> {
     w.insert("browser".into(), 0.3);
     w.insert("vision".into(), 0.5);
     w.insert("image_gen".into(), 0.2);
+    w.insert("video_gen".into(), 0.2);
+    w.insert("spotify".into(), 0.1);
     w.insert("skills".into(), 0.7);
     w.insert("memory".into(), 0.6);
     w.insert("session_search".into(), 0.4);
@@ -99,6 +101,7 @@ fn make_default() -> ToolsetDistribution {
 fn make_image_gen() -> ToolsetDistribution {
     let mut w = base_weights();
     w.insert("image_gen".into(), 1.0);
+    w.insert("video_gen".into(), 0.8);
     w.insert("vision".into(), 0.9);
     w.insert("terminal".into(), 0.3);
     ToolsetDistribution {
@@ -160,6 +163,8 @@ fn make_safe() -> ToolsetDistribution {
     w.insert("file".into(), 0.5);
     w.insert("browser".into(), 0.0);
     w.insert("vision".into(), 0.3);
+    w.insert("video_gen".into(), 0.0);
+    w.insert("spotify".into(), 0.0);
     w.insert("skills".into(), 0.5);
     w.insert("memory".into(), 0.5);
     w.insert("todo".into(), 0.8);
@@ -180,6 +185,8 @@ fn make_balanced() -> ToolsetDistribution {
         "file",
         "browser",
         "vision",
+        "video_gen",
+        "spotify",
         "skills",
         "memory",
         "todo",
@@ -232,6 +239,7 @@ fn make_terminal_web() -> ToolsetDistribution {
 fn make_creative() -> ToolsetDistribution {
     let mut w = base_weights();
     w.insert("image_gen".into(), 1.0);
+    w.insert("video_gen".into(), 0.9);
     w.insert("tts".into(), 0.8);
     w.insert("voice_mode".into(), 0.7);
     w.insert("vision".into(), 0.9);

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-29T22:52:31.646536+00:00",
+  "generated_at_utc": "2026-05-29T23:10:17.457471+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-29T22:52:31.646536+00:00`
+Generated: `2026-05-29T23:10:17.457471+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,15 +1,15 @@
 {
-  "generated_at_utc": "2026-05-29T22:52:27.438886+00:00",
+  "generated_at_utc": "2026-05-29T23:10:12.599877+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "9ea0700d04a6842f2612a45bd205dd87e441314f",
+    "local_sha": "a3c95880eb2f9acb6c6757ab82e5a536c614a835",
     "upstream_ref": "upstream/main",
     "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4399,
-    "commits_ahead": 790,
+    "commits_ahead": 791,
     "upstream_patch_missing": 4281,
     "upstream_patch_represented": 2,
     "local_patch_unique": 679,

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-29T22:52:27.438886+00:00`
+Generated: `2026-05-29T23:10:12.599877+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`9ea0700d04a6842f2612a45bd205dd87e441314f`)
+- Local ref: `HEAD` (`a3c95880eb2f9acb6c6757ab82e5a536c614a835`)
 - Upstream ref: `upstream/main` (`689ef5e233980f5d5a32080e959f44c8991dd03a`)
 - Merge base: `none (history divergence)`
 
@@ -13,7 +13,7 @@ Generated: `2026-05-29T22:52:27.438886+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4399 |
-| Commits ahead local (`local` ancestry only) | 790 |
+| Commits ahead local (`local` ancestry only) | 791 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4281 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
 | Local commits unique by patch-id (`git cherry upstream local`, `+`) | 679 |

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1006,16 +1006,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/spotify/tools.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f6022ff5aabcc16075f6527e609aeeefcaf407b7",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/spotify/tools.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "4bd18a02b61653d33aef4ce7a10b19589efd6558",
       "workstream": "WS3"
@@ -15256,30 +15256,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T22:52:25.243614+00:00",
+  "generated_at_utc": "2026-05-29T23:10:07.749940+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "9ea0700d04a6842f2612a45bd205dd87e441314f",
+    "local_sha": "a3c95880eb2f9acb6c6757ab82e5a536c614a835",
     "upstream_ref": "upstream/main",
     "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 762,
-      "intentional_divergence": 86,
+      "functional": 761,
+      "intentional_divergence": 87,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 255,
+      "not_required_for_runtime": 256,
       "rust_equivalent_or_contract_test_required": 681,
-      "rust_native_runtime_parity_required_if_needed": 2,
+      "rust_native_runtime_parity_required_if_needed": 1,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 86,
+      "cleared_intentional_divergence": 87,
       "cleared_non_runtime": 169,
-      "pending_review": 762
+      "pending_review": 761
     },
     "by_workstream": {
       "WS3": 53,
@@ -15288,10 +15288,10 @@
       "WS6": 682,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 86,
+    "cleared_intentional_divergence": 87,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 762,
+    "pending_review": 761,
     "total_shared_different": 1017
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T22:52:25.243614+00:00`
+Generated: `2026-05-29T23:10:07.749940+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1017`
 - Pending classification: `0`
-- Pending functional review: `762`
+- Pending functional review: `761`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `86`
+- Cleared intentional divergence: `87`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 86 |
+| `cleared_intentional_divergence` | 87 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 762 |
+| `pending_review` | 761 |
 
 ## Workstream Counts
 
@@ -57,5 +57,4 @@ Generated: `2026-05-29T22:52:25.243614+00:00`
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
 | `tests/e2e` | 2 |
-| `plugins/spotify/tools.py` | 1 |
 | `plugins/teams_pipeline` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -816,8 +816,8 @@
     },
     {
       "path": "plugins/spotify/tools.py",
-      "classification": "functional",
-      "rationale": "Spotify tool differences live on a runtime tool adapter surface even when the current diff is type-import hygiene.",
+      "classification": "intentional_divergence",
+      "rationale": "Spotify tool behavior is now covered by Rust-native spotify_* built-ins and SpotifyWebApiBackend, including playback, devices, queue, search, playlists, albums, library normalization, auth-store/env token resolution, and friendly API errors; the Python plugin remains reference-only compatibility material.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- Add Rust-native Spotify tool handlers for playback, devices, queue, search, playlists, albums, and library operations.
- Add Spotify Web API backend with env/auth-store credential resolution and upstream-compatible friendly API errors.
- Register spotify built-ins, expose spotify and video_gen through Rust toolsets, and clear the Spotify Python plugin as reference-only in parity docs.

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- python3 -m py_compile scripts/generate-global-parity-proof.py scripts/generate-shared-diff-backlog.py scripts/generate-upstream-patch-queue.py scripts/generate-parity-matrix.py
- cargo test -p hermes-tools
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md