### PR TITLE
hardening: remove Rust runtime Python paths

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -9,7 +9,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -19,7 +18,7 @@ use futures::StreamExt;
 use hermes_auth::{exchange_refresh_token, OAuth2Endpoints};
 use hermes_intelligence::get_model_context_length;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tokio::task::JoinSet;
 use tokio::time::sleep;
@@ -266,7 +265,9 @@ Only act if there's something genuinely worth saving. \
 If nothing stands out, just say 'Nothing to save.' and stop.";
 
 const TOOL_USE_ENFORCEMENT_GUIDANCE: &str = "# Tool-use enforcement\nUse tools whenever they are necessary to verify facts, inspect code/files, or execute requested actions. Do not describe an action without making the corresponding tool call in the same response. Do not call tools only to satisfy policy or to emit no-op commands. If the request is fully answerable without tools, return a direct final answer. Avoid repetitive tool loops: if additional tool calls will not add new evidence, stop and provide the best grounded final result.";
-const CONTEXTLATTICE_OPERATIONAL_GUIDANCE: &str = "# ContextLattice operational guidance\nWhen a user asks to confirm, connect, verify, or harden ContextLattice integration, do not answer from assumptions. First check local integration instructions when present (env `HERMES_CONTEXTLATTICE_INSTRUCTIONS_PATH`, or local `scripts/agent_orchestration.py` in the workspace, typically `/Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py`). Then attempt ContextLattice tool calls: use `contextlattice_search` for a direct probe and `contextlattice_context_pack` when broader grounding is needed. If a call fails, report the concrete error and provide the exact remediation steps. Never run shell command `contextlattice` for this workflow; use the ContextLattice tools directly. Do not claim lack of access before attempting at least one ContextLattice tool call in the current turn.";
+const CONTEXTLATTICE_OPERATIONAL_GUIDANCE: &str = "# ContextLattice operational guidance\nWhen a user asks to confirm, connect, verify, or harden ContextLattice integration, do not answer from assumptions. First check local integration instructions when present via env `HERMES_CONTEXTLATTICE_INSTRUCTIONS_PATH`. Then attempt ContextLattice tool calls: use `contextlattice_search` for a direct probe and `contextlattice_context_pack` when broader grounding is needed. Use `contextlattice_write` for checkpoints. If a call fails, report the concrete error and provide the exact remediation steps. Never run shell command `contextlattice` for this workflow; use the ContextLattice tools directly. Do not claim lack of access before attempting at least one ContextLattice tool call in the current turn.";
+const CONTEXTLATTICE_DEFAULT_ORCHESTRATOR_URL: &str = "http://127.0.0.1:8075";
+const CONTEXTLATTICE_COMPACTION_FILE: &str = "notes/hermes-agent-compaction.md";
 
 const OPENAI_MODEL_EXECUTION_GUIDANCE: &str = "# Execution discipline (OpenAI)\nUse tools whenever they improve correctness, completeness, or grounding. Do not stop early when another tool call would materially improve the result. Verify outcomes before declaring completion.";
 
@@ -306,25 +307,54 @@ fn compaction_governance_mode_runtime() -> CompactionGovernanceMode {
         .unwrap_or(CompactionGovernanceMode::Advisory)
 }
 
-fn contextlattice_orchestration_script_path() -> Option<PathBuf> {
-    if let Ok(path) = std::env::var("HERMES_CONTEXTLATTICE_ORCH_SCRIPT") {
-        let candidate = PathBuf::from(path);
-        if candidate.exists() {
-            return Some(candidate);
+fn contextlattice_orchestrator_url_runtime() -> String {
+    std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
+        .or_else(|_| std::env::var("MEMMCP_ORCHESTRATOR_URL"))
+        .unwrap_or_else(|_| CONTEXTLATTICE_DEFAULT_ORCHESTRATOR_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn contextlattice_timeout_runtime() -> Duration {
+    let seconds = std::env::var("HERMES_CONTEXTLATTICE_TIMEOUT_SECS")
+        .or_else(|_| std::env::var("CONTEXTLATTICE_TIMEOUT_SECS"))
+        .ok()
+        .and_then(|raw| raw.parse::<f64>().ok())
+        .unwrap_or(10.0)
+        .clamp(1.0, 60.0);
+    Duration::from_secs_f64(seconds)
+}
+
+fn write_contextlattice_checkpoint(
+    topic_path: &str,
+    file_name: &str,
+    content: &str,
+) -> Result<(), String> {
+    let url = format!("{}/memory/write", contextlattice_orchestrator_url_runtime());
+    let payload = json!({
+        "projectName": "hermes-agent-ultra",
+        "fileName": file_name,
+        "topicPath": topic_path,
+        "content": content,
+    });
+    let client = reqwest::blocking::Client::builder()
+        .timeout(contextlattice_timeout_runtime())
+        .build()
+        .map_err(|err| err.to_string())?;
+    let mut request = client.post(&url).json(&payload);
+    if let Ok(api_key) = std::env::var("CONTEXTLATTICE_API_KEY") {
+        if !api_key.trim().is_empty() {
+            request = request.bearer_auth(api_key);
         }
     }
-    let default =
-        PathBuf::from("/Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py");
-    if default.exists() {
-        return Some(default);
+    let response = request.send().map_err(|err| err.to_string())?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
     }
-    if let Ok(cwd) = std::env::current_dir() {
-        let candidate = cwd.join("scripts").join("agent_orchestration.py");
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-    None
+    let body = response.text().unwrap_or_default();
+    let preview: String = body.chars().take(240).collect();
+    Err(format!("HTTP {status}: {}", preview.trim()))
 }
 
 fn should_inject_tool_enforcement_for_model(_model: &str) -> bool {
@@ -3480,16 +3510,6 @@ impl AgentLoop {
             return;
         }
 
-        let Some(script_path) = contextlattice_orchestration_script_path() else {
-            if matches!(mode, CompactionGovernanceMode::Enforce) {
-                self.emit_status(
-                    "lifecycle",
-                    "Compaction governance enforce-mode: ContextLattice script missing; checkpoint skipped.",
-                );
-            }
-            return;
-        };
-
         let session = self
             .config
             .session_id
@@ -3510,35 +3530,8 @@ impl AgentLoop {
             pressure_after
         );
 
-        let output = Command::new("python3")
-            .arg(script_path)
-            .arg("write")
-            .arg("hermes-agent-ultra")
-            .arg(topic)
-            .arg(content)
-            .env(
-                "MEMMCP_ORCHESTRATOR_URL",
-                std::env::var("MEMMCP_ORCHESTRATOR_URL")
-                    .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string()),
-            )
-            .env(
-                "CONTEXTLATTICE_ORCHESTRATOR_URL",
-                std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
-                    .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string()),
-            )
-            .env(
-                "CONTEXTLATTICE_AGENT_ID",
-                std::env::var("CONTEXTLATTICE_AGENT_ID")
-                    .unwrap_or_else(|_| "codex_gpt5".to_string()),
-            )
-            .env(
-                "MEMMCP_AGENT_ID",
-                std::env::var("MEMMCP_AGENT_ID").unwrap_or_else(|_| "codex_gpt5".to_string()),
-            )
-            .output();
-
-        match output {
-            Ok(out) if out.status.success() => {
+        match write_contextlattice_checkpoint(&topic, CONTEXTLATTICE_COMPACTION_FILE, &content) {
+            Ok(()) => {
                 self.emit_status(
                     "lifecycle",
                     &format!(
@@ -3547,24 +3540,12 @@ impl AgentLoop {
                     ),
                 );
             }
-            Ok(out) => {
-                if matches!(mode, CompactionGovernanceMode::Enforce) {
-                    self.emit_status(
-                        "lifecycle",
-                        &format!(
-                            "Compaction governance enforce-mode: checkpoint failed (exit={}) {}",
-                            out.status.code().unwrap_or(-1),
-                            String::from_utf8_lossy(&out.stderr)
-                        ),
-                    );
-                }
-            }
             Err(err) => {
                 if matches!(mode, CompactionGovernanceMode::Enforce) {
                     self.emit_status(
                         "lifecycle",
                         &format!(
-                            "Compaction governance enforce-mode: checkpoint error: {}",
+                            "Compaction governance enforce-mode: checkpoint failed: {}",
                             err
                         ),
                     );
@@ -8739,7 +8720,6 @@ fn contextlattice_connect_system_hint(messages: &[Message]) -> Option<String> {
     Some(
         "[SYSTEM] ContextLattice integration intent detected. Execute this order: \
          (1) If available, inspect local instructions file from `HERMES_CONTEXTLATTICE_INSTRUCTIONS_PATH` \
-         or workspace `scripts/agent_orchestration.py` (preferred path: `/Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py`); \
          (2) call `contextlattice_search` for a direct connectivity probe; \
          (3) if needed call `contextlattice_context_pack` for broader grounding; \
          (4) call `contextlattice_write` to checkpoint what was verified. \
@@ -12871,7 +12851,7 @@ mod tests {
         let msgs = vec![Message::user("connect to contextlattice and verify health")];
         let hint = contextlattice_connect_system_hint(&msgs).expect("expected hint");
         assert!(hint.contains("contextlattice_search"));
-        assert!(hint.contains("scripts/agent_orchestration.py"));
+        assert!(hint.contains("HERMES_CONTEXTLATTICE_INSTRUCTIONS_PATH"));
         assert!(hint.contains("Never use terminal command `contextlattice`"));
     }
 

--- a/crates/hermes-agent/src/lsp_context.rs
+++ b/crates/hermes-agent/src/lsp_context.rs
@@ -6,7 +6,6 @@
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde_json::Value;
 
@@ -236,31 +235,10 @@ fn diagnose_rust(path: &Path) -> String {
 }
 
 fn diagnose_python(path: &Path) -> String {
-    let output = Command::new("python3")
-        .args(["-m", "py_compile"])
-        .arg(path)
-        .output();
-    match output {
-        Ok(out) if out.status.success() => {
-            format!(
-                "- Diagnostics [{}]\n  - python syntax: ok\n",
-                path.display()
-            )
-        }
-        Ok(out) => {
-            let err = String::from_utf8_lossy(&out.stderr);
-            format!(
-                "- Diagnostics [{}]\n  - python syntax: error: {}\n",
-                path.display(),
-                truncate(err.trim(), 240)
-            )
-        }
-        Err(e) => format!(
-            "- Diagnostics [{}]\n  - python syntax: check unavailable: {}\n",
-            path.display(),
-            e
-        ),
-    }
+    format!(
+        "- Diagnostics [{}]\n  - python syntax: skipped (Rust-only runtime does not spawn Python)\n",
+        path.display()
+    )
 }
 
 fn build_reference_section(

--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -340,7 +340,7 @@ pub struct LoopRuntimeState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextLatticeStatus {
     pub health_line: String,
-    pub preflight_script_line: String,
+    pub preflight_line: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1741,13 +1741,18 @@ pub fn refresh_loop_runtime_state(
 }
 
 pub async fn contextlattice_status() -> ContextLatticeStatus {
+    let base_url = std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
+        .or_else(|_| std::env::var("MEMMCP_ORCHESTRATOR_URL"))
+        .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string())
+        .trim_end_matches('/')
+        .to_string();
     let health_line = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
         .build()
     {
-        Ok(client) => match client.get("http://127.0.0.1:8075/health").send().await {
+        Ok(client) => match client.get(format!("{base_url}/health")).send().await {
             Ok(resp) if resp.status().is_success() => {
-                "contextlattice: healthy (127.0.0.1:8075)".to_string()
+                format!("contextlattice: healthy ({base_url})")
             }
             Ok(resp) => format!("contextlattice: unhealthy (status {})", resp.status()),
             Err(err) => format!("contextlattice: unreachable ({})", err),
@@ -1755,20 +1760,13 @@ pub async fn contextlattice_status() -> ContextLatticeStatus {
         Err(err) => format!("contextlattice: client_error ({})", err),
     };
 
-    let script_path =
-        PathBuf::from("/Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py");
-    let preflight_script_line = if script_path.exists() {
-        format!(
-            "contextlattice preflight: available ({})",
-            script_path.display()
-        )
-    } else {
-        "contextlattice preflight: missing scripts/agent_orchestration.py".to_string()
-    };
+    let preflight_line = format!(
+        "contextlattice preflight: Rust-native memory write endpoint {base_url}/memory/write"
+    );
 
     ContextLatticeStatus {
         health_line,
-        preflight_script_line,
+        preflight_line,
     }
 }
 
@@ -1975,7 +1973,7 @@ pub async fn render_mission_board(
 
     out.push_str("ContextLattice\n");
     out.push_str(&format!("- {}\n", ctx_status.health_line));
-    out.push_str(&format!("- {}\n", ctx_status.preflight_script_line));
+    out.push_str(&format!("- {}\n", ctx_status.preflight_line));
     out.push_str(&format!(
         "- policy: preflight={} context_pack_on_start={} degradation_aware={} readback_required={}\n",
         ctx_policy.preflight_required,

--- a/crates/hermes-cli/src/kanban.rs
+++ b/crates/hermes-cli/src/kanban.rs
@@ -1,16 +1,17 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::time::Duration;
 
 use chrono::Utc;
 use hermes_core::AgentError;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 const KANBAN_STATE_DIR: &str = "alpha/kanban";
 const KANBAN_STORE_FILE: &str = "boards.json";
 const KANBAN_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_BOARD_ID: &str = "main";
-const CONTEXTLATTICE_DEFAULT_SCRIPT: &str =
-    "/Users/sheawinkler/Documents/Projects/scripts/agent_orchestration.py";
+const CONTEXTLATTICE_DEFAULT_ORCHESTRATOR_URL: &str = "http://127.0.0.1:8075";
+const CONTEXTLATTICE_KANBAN_FILE: &str = "notes/hermes-kanban.md";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -362,15 +363,6 @@ pub fn maybe_checkpoint_to_contextlattice(
                 .to_string(),
         };
     }
-    let Some(script_path) = contextlattice_script_path() else {
-        return KanbanCheckpointResult {
-            attempted: false,
-            succeeded: false,
-            detail: "ContextLattice orchestration script not found; skipped checkpoint."
-                .to_string(),
-        };
-    };
-
     let mut content = format!(
         "kanban_action={} board_id={} board_name={} summary={}",
         payload.action,
@@ -386,51 +378,16 @@ pub fn maybe_checkpoint_to_contextlattice(
     }
 
     let topic_path = format!("runbooks/kanban/{}", board.id);
-    let output = Command::new("python3")
-        .arg(&script_path)
-        .arg("write")
-        .arg("hermes-agent-ultra")
-        .arg(&topic_path)
-        .arg(content)
-        .env(
-            "MEMMCP_ORCHESTRATOR_URL",
-            std::env::var("MEMMCP_ORCHESTRATOR_URL")
-                .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string()),
-        )
-        .env(
-            "CONTEXTLATTICE_ORCHESTRATOR_URL",
-            std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
-                .unwrap_or_else(|_| "http://127.0.0.1:8075".to_string()),
-        )
-        .env(
-            "CONTEXTLATTICE_AGENT_ID",
-            std::env::var("CONTEXTLATTICE_AGENT_ID").unwrap_or_else(|_| "codex_gpt5".to_string()),
-        )
-        .env(
-            "MEMMCP_AGENT_ID",
-            std::env::var("MEMMCP_AGENT_ID").unwrap_or_else(|_| "codex_gpt5".to_string()),
-        )
-        .output();
-
-    match output {
-        Ok(out) if out.status.success() => KanbanCheckpointResult {
+    match write_contextlattice_checkpoint(&topic_path, CONTEXTLATTICE_KANBAN_FILE, &content) {
+        Ok(()) => KanbanCheckpointResult {
             attempted: true,
             succeeded: true,
             detail: format!("ContextLattice checkpointed to topic `{topic_path}`."),
         },
-        Ok(out) => KanbanCheckpointResult {
-            attempted: true,
-            succeeded: false,
-            detail: format!(
-                "ContextLattice checkpoint failed (exit={}): {}",
-                out.status.code().unwrap_or(-1),
-                String::from_utf8_lossy(&out.stderr).trim()
-            ),
-        },
         Err(err) => KanbanCheckpointResult {
             attempted: true,
             succeeded: false,
-            detail: format!("ContextLattice checkpoint error: {err}"),
+            detail: format!("ContextLattice checkpoint failed: {err}"),
         },
     }
 }
@@ -558,21 +515,54 @@ fn kanban_contextlattice_sync_enabled() -> bool {
         .unwrap_or(true)
 }
 
-fn contextlattice_script_path() -> Option<PathBuf> {
-    let mut candidates = Vec::new();
-    if let Ok(path) = std::env::var("HERMES_KANBAN_CONTEXTLATTICE_SCRIPT") {
-        candidates.push(PathBuf::from(path));
-    }
-    candidates.push(PathBuf::from(CONTEXTLATTICE_DEFAULT_SCRIPT));
-    if let Ok(cwd) = std::env::current_dir() {
-        candidates.push(cwd.join("scripts/agent_orchestration.py"));
-    }
-    for candidate in candidates {
-        if candidate.is_file() {
-            return Some(candidate);
+fn contextlattice_orchestrator_url() -> String {
+    std::env::var("CONTEXTLATTICE_ORCHESTRATOR_URL")
+        .or_else(|_| std::env::var("MEMMCP_ORCHESTRATOR_URL"))
+        .unwrap_or_else(|_| CONTEXTLATTICE_DEFAULT_ORCHESTRATOR_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn contextlattice_timeout() -> Duration {
+    let seconds = std::env::var("HERMES_KANBAN_CONTEXTLATTICE_TIMEOUT_SECS")
+        .or_else(|_| std::env::var("CONTEXTLATTICE_TIMEOUT_SECS"))
+        .ok()
+        .and_then(|raw| raw.parse::<f64>().ok())
+        .unwrap_or(10.0)
+        .clamp(1.0, 60.0);
+    Duration::from_secs_f64(seconds)
+}
+
+fn write_contextlattice_checkpoint(
+    topic_path: &str,
+    file_name: &str,
+    content: &str,
+) -> Result<(), String> {
+    let url = format!("{}/memory/write", contextlattice_orchestrator_url());
+    let payload = json!({
+        "projectName": "hermes-agent-ultra",
+        "fileName": file_name,
+        "topicPath": topic_path,
+        "content": content,
+    });
+    let client = reqwest::blocking::Client::builder()
+        .timeout(contextlattice_timeout())
+        .build()
+        .map_err(|err| err.to_string())?;
+    let mut request = client.post(&url).json(&payload);
+    if let Ok(api_key) = std::env::var("CONTEXTLATTICE_API_KEY") {
+        if !api_key.trim().is_empty() {
+            request = request.bearer_auth(api_key);
         }
     }
-    None
+    let response = request.send().map_err(|err| err.to_string())?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let body = response.text().unwrap_or_default();
+    let preview: String = body.chars().take(240).collect();
+    Err(format!("HTTP {status}: {}", preview.trim()))
 }
 
 #[cfg(test)]

--- a/crates/hermes-tools/src/backends/code_execution.rs
+++ b/crates/hermes-tools/src/backends/code_execution.rs
@@ -1,4 +1,4 @@
-//! Real code execution backend: run scripts via tokio::process::Command.
+//! Real code execution backend: run snippets via tokio::process::Command.
 
 use async_trait::async_trait;
 use serde_json::json;
@@ -8,7 +8,7 @@ use tokio::process::Command as TokioCommand;
 use crate::tools::code_execution::CodeExecutionBackend;
 use hermes_core::ToolError;
 
-/// Code execution backend using local interpreters.
+/// Code execution backend using local non-Python interpreters.
 pub struct LocalCodeExecutionBackend {
     default_timeout_secs: u64,
 }
@@ -35,11 +35,19 @@ impl CodeExecutionBackend for LocalCodeExecutionBackend {
         language: Option<&str>,
         timeout: Option<u64>,
     ) -> Result<String, ToolError> {
-        let lang = language.unwrap_or("python");
+        let Some(lang) = language else {
+            return Err(ToolError::InvalidParams(
+                "Missing language parameter; Hermes Agent Ultra does not default to Python in the Rust-only runtime".into(),
+            ));
+        };
         let timeout_secs = timeout.unwrap_or(self.default_timeout_secs);
 
         let (interpreter, flag) = match lang {
-            "python" | "python3" => ("python3", "-c"),
+            "python" | "python3" => {
+                return Err(ToolError::InvalidParams(
+                    "Python execution is disabled in Hermes Agent Ultra's Rust-only runtime".into(),
+                ))
+            }
             "javascript" | "js" | "node" => ("node", "-e"),
             "typescript" | "ts" => ("npx", ""),
             "bash" | "sh" => ("bash", "-c"),
@@ -99,5 +107,32 @@ impl CodeExecutionBackend for LocalCodeExecutionBackend {
                 timeout_secs
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_language_does_not_default_to_python() {
+        let backend = LocalCodeExecutionBackend::default();
+        let err = backend
+            .execute("print(1)", None, Some(1))
+            .await
+            .expect_err("missing language should fail");
+        assert!(err
+            .to_string()
+            .contains("does not default to Python in the Rust-only runtime"));
+    }
+
+    #[tokio::test]
+    async fn python_execution_is_disabled() {
+        let backend = LocalCodeExecutionBackend::default();
+        let err = backend
+            .execute("print(1)", Some("python"), Some(1))
+            .await
+            .expect_err("python should fail");
+        assert!(err.to_string().contains("Python execution is disabled"));
     }
 }

--- a/crates/hermes-tools/src/tools/code_execution.rs
+++ b/crates/hermes-tools/src/tools/code_execution.rs
@@ -1,4 +1,4 @@
-//! Code execution tool: run Python scripts with hermes_tools RPC
+//! Code execution tool: run local non-Python snippets through hermes_tools RPC.
 
 use async_trait::async_trait;
 use indexmap::IndexMap;
@@ -15,7 +15,7 @@ use std::sync::Arc;
 /// Backend for code execution operations.
 #[async_trait]
 pub trait CodeExecutionBackend: Send + Sync {
-    /// Execute Python code and return the output.
+    /// Execute code and return the output.
     async fn execute(
         &self,
         code: &str,
@@ -28,7 +28,7 @@ pub trait CodeExecutionBackend: Send + Sync {
 // ExecuteCodeHandler
 // ---------------------------------------------------------------------------
 
-/// Tool for executing code (primarily Python) in a sandboxed environment.
+/// Tool for executing code in a sandboxed environment.
 pub struct ExecuteCodeHandler {
     backend: Arc<dyn CodeExecutionBackend>,
 }
@@ -47,10 +47,18 @@ impl ToolHandler for ExecuteCodeHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'code' parameter".into()))?;
 
-        let language = params.get("language").and_then(|v| v.as_str());
+        let language = params
+            .get("language")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                ToolError::InvalidParams(
+                    "Missing 'language' parameter; Python is not a default in Hermes Agent Ultra"
+                        .into(),
+                )
+            })?;
         let timeout = params.get("timeout").and_then(|v| v.as_u64());
 
-        self.backend.execute(code, language, timeout).await
+        self.backend.execute(code, Some(language), timeout).await
     }
 
     fn schema(&self) -> ToolSchema {
@@ -66,9 +74,8 @@ impl ToolHandler for ExecuteCodeHandler {
             "language".into(),
             json!({
                 "type": "string",
-                "description": "Programming language (default: 'python')",
-                "enum": ["python", "javascript", "typescript"],
-                "default": "python"
+                "description": "Programming language. Python execution is disabled in Hermes Agent Ultra's Rust-only runtime.",
+                "enum": ["javascript", "typescript", "bash", "sh"]
             }),
         );
         props.insert(
@@ -82,8 +89,8 @@ impl ToolHandler for ExecuteCodeHandler {
 
         tool_schema(
             "execute_code",
-            "Execute code in a sandboxed environment. Supports Python, JavaScript, and TypeScript.",
-            JsonSchema::object(props, vec!["code".into()]),
+            "Execute code in a sandboxed environment. Supports JavaScript, TypeScript, and shell snippets; Python execution is disabled in Hermes Agent Ultra's Rust-only runtime.",
+            JsonSchema::object(props, vec!["code".into(), "language".into()]),
         )
     }
 }
@@ -108,16 +115,30 @@ mod tests {
     #[tokio::test]
     async fn test_execute_code_schema() {
         let handler = ExecuteCodeHandler::new(Arc::new(MockCodeBackend));
-        assert_eq!(handler.schema().name, "execute_code");
+        let schema = handler.schema();
+        assert_eq!(schema.name, "execute_code");
+        let rendered = serde_json::to_string(&schema.parameters).expect("schema json");
+        assert!(!rendered.contains("\"python\""));
+        assert!(rendered.contains("\"language\""));
     }
 
     #[tokio::test]
     async fn test_execute_code() {
         let handler = ExecuteCodeHandler::new(Arc::new(MockCodeBackend));
         let result = handler
-            .execute(json!({"code": "print(1+1)"}))
+            .execute(json!({"code": "console.log(1+1)", "language": "javascript"}))
             .await
             .unwrap();
-        assert!(result.contains("print(1+1)"));
+        assert!(result.contains("console.log(1+1)"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_code_requires_language() {
+        let handler = ExecuteCodeHandler::new(Arc::new(MockCodeBackend));
+        let err = handler
+            .execute(json!({"code": "print(1+1)"}))
+            .await
+            .expect_err("language is required");
+        assert!(err.to_string().contains("Missing 'language' parameter"));
     }
 }

--- a/scripts/check-rust-runtime-no-python.sh
+++ b/scripts/check-rust-runtime-no-python.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DIRECT_SPAWN_PATTERN='(Command::new\("python|tokio::process::Command::new\("python|std::process::Command::new\("python)'
+REFERENCE_PATTERN='agent_orchestration\.py|scripts/agent_orchestration\.py|HERMES_CONTEXTLATTICE_ORCH_SCRIPT|HERMES_KANBAN_CONTEXTLATTICE_SCRIPT'
+PYTHON_DEFAULT_PATTERN="default: 'python'|default\": \"python\"|Supports Python|primarily Python|run Python|py_compile"
+
+if HITS="$(rg -n --color never "${DIRECT_SPAWN_PATTERN}" crates 2>/dev/null)"; then
+  if [[ -n "${HITS}" ]]; then
+    echo "Rust runtime Python process spawns detected:"
+    echo "${HITS}"
+    exit 1
+  fi
+fi
+
+if HITS="$(rg -n --color never "${REFERENCE_PATTERN}" crates 2>/dev/null)"; then
+  if [[ -n "${HITS}" ]]; then
+    echo "Rust runtime Python ContextLattice script references detected:"
+    echo "${HITS}"
+    exit 1
+  fi
+fi
+
+if HITS="$(rg -n --color never "${PYTHON_DEFAULT_PATTERN}" crates/hermes-tools/src/tools/code_execution.rs crates/hermes-tools/src/backends/code_execution.rs 2>/dev/null)"; then
+  if [[ -n "${HITS}" ]]; then
+    echo "Python-default code execution contract detected:"
+    echo "${HITS}"
+    exit 1
+  fi
+fi
+
+echo "No Rust runtime Python execution paths detected."


### PR DESCRIPTION
Summary:
- replace Kanban and compaction ContextLattice Python-script checkpointing with direct Rust HTTP writes
- disable Python execution/defaults in execute_code and make language explicit
- skip Python LSP syntax checks instead of spawning python3
- add local guard script for Rust runtime Python paths

Local verification before push:
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- cargo test -p hermes-tools
- cargo test -p hermes-agent
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- cargo build -p hermes-cli

GitHub CI is optional; local checks above are authoritative.