### PR TITLE
parity: clear stale context engine functional gate

### DIFF
--- a/crates/hermes-parity-tests/tests/global_parity_governance.rs
+++ b/crates/hermes-parity-tests/tests/global_parity_governance.rs
@@ -102,3 +102,40 @@ fn test_shared_diff_classification_covers_matrix_items() {
         );
     }
 }
+
+#[test]
+fn test_exact_file_functional_classifications_are_current_shared_diffs() {
+    let backlog = read_json("docs/parity/shared-diff-backlog.json");
+    let classification = read_json("docs/parity/shared-different-classification.json");
+
+    let backlog_entries = backlog["entries"]
+        .as_array()
+        .expect("entries should be array");
+    let active_paths: std::collections::BTreeSet<String> = backlog_entries
+        .iter()
+        .filter_map(|entry| entry["path"].as_str().map(|s| s.to_string()))
+        .collect();
+    let active_classification_paths: std::collections::BTreeSet<String> = backlog_entries
+        .iter()
+        .filter_map(|entry| entry["classification_path"].as_str().map(|s| s.to_string()))
+        .collect();
+
+    let class_items = classification["items"]
+        .as_array()
+        .expect("classification items should be array");
+    for item in class_items {
+        if item["classification"].as_str() != Some("functional") {
+            continue;
+        }
+        let path = item["path"].as_str().expect("path should be string");
+        let basename = path.rsplit('/').next().unwrap_or(path);
+        if !basename.contains('.') {
+            continue;
+        }
+        assert!(
+            active_paths.contains(path) || active_classification_paths.contains(path),
+            "exact-file functional classification is stale or unbacked by the current shared-diff backlog: {}",
+            path
+        );
+    }
+}

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -809,8 +809,8 @@
     },
     {
       "path": "plugins/context_engine/__init__.py",
-      "classification": "functional",
-      "rationale": "Context engine loader differences affect plugin registration behavior and need runtime parity review against the Rust-first plugin command surface.",
+      "classification": "policy_only",
+      "rationale": "No current shared-different content remains for this upstream file; the Rust-first command surface rejects Python plugin dispatch and the Python context-engine loader is retained only as upstream reference material.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
Summary:
- reclassify the stale exact-file context_engine classification now that local and upstream content match
- add a parity governance test so exact-file functional classifications must be backed by current shared-diff backlog entries

Local verification before push:
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different scan
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- cargo build -p hermes-cli

GitHub CI is optional; local checks above are authoritative.