### PR TITLE
parity(auxiliary): omit max tokens for OAI-compatible side calls

### DIFF
--- a/crates/hermes-intelligence/src/auxiliary/candidate.rs
+++ b/crates/hermes-intelligence/src/auxiliary/candidate.rs
@@ -44,6 +44,19 @@ impl AuxiliarySource {
             AuxiliarySource::DirectKey(name) => name.clone(),
         }
     }
+
+    /// OpenAI-compatible auxiliary endpoints choose their own output budget for
+    /// side tasks. Sending `max_tokens` trips reasoning-model gateways that
+    /// accept the same endpoint shape but reject that parameter.
+    pub fn omits_auxiliary_max_tokens(&self) -> bool {
+        matches!(
+            self,
+            AuxiliarySource::OpenRouter
+                | AuxiliarySource::Nous
+                | AuxiliarySource::Custom
+                | AuxiliarySource::DirectKey(_)
+        )
+    }
 }
 
 /// A fully-resolved provider entry the chain can call into.

--- a/crates/hermes-intelligence/src/auxiliary/client.rs
+++ b/crates/hermes-intelligence/src/auxiliary/client.rs
@@ -231,7 +231,11 @@ impl AuxiliaryClient {
             let tools = request.tools.clone();
             let model_call = model.clone();
             let mut attempt_temperature = temperature;
-            let mut attempt_max_tokens = max_tokens;
+            let mut attempt_max_tokens = if candidate.source.omits_auxiliary_max_tokens() {
+                None
+            } else {
+                max_tokens
+            };
             let mut attempt_extra_body = extra_body.clone();
 
             loop {
@@ -785,9 +789,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unsupported_max_tokens_retries_with_max_completion_tokens() {
+    async fn openai_compatible_auxiliary_calls_omit_max_tokens_across_temperature_retry() {
         let p1 = ScriptedProvider::new(
             "openrouter",
+            vec![
+                Outcome::Err("HTTP 400: Unsupported parameter: temperature".into()),
+                Outcome::Ok("rescued".into()),
+            ],
+        );
+
+        let client = AuxiliaryClient::builder()
+            .add_candidate(ProviderCandidate::new(
+                AuxiliarySource::OpenRouter,
+                "gpt-5.5",
+                p1.clone(),
+            ))
+            .build();
+
+        let resp = client
+            .call(
+                AuxiliaryRequest::new(AuxiliaryTask::SessionSearch, vec![user_msg("query")])
+                    .with_temperature(0.3)
+                    .with_max_tokens(500),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.provider_label, "openrouter");
+        assert_eq!(resp.model, "gpt-5.5");
+        assert_eq!(resp.text(), Some("rescued"));
+
+        let calls = p1.recorded_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].temperature, Some(0.3));
+        assert_eq!(calls[1].temperature, None);
+        assert_eq!(calls[0].max_tokens, None);
+        assert_eq!(calls[1].max_tokens, None);
+        assert!(calls[0].extra_body.is_none());
+        assert!(calls[1].extra_body.is_none());
+    }
+
+    #[tokio::test]
+    async fn unsupported_max_tokens_retries_with_max_completion_tokens() {
+        let p1 = ScriptedProvider::new(
+            "anthropic",
             vec![
                 Outcome::Err("Unknown parameter: max_tokens".into()),
                 Outcome::Ok("rescued".into()),
@@ -796,8 +841,8 @@ mod tests {
 
         let client = AuxiliaryClient::builder()
             .add_candidate(ProviderCandidate::new(
-                AuxiliarySource::OpenRouter,
-                "or-model",
+                AuxiliarySource::Anthropic,
+                "claude-haiku",
                 p1.clone(),
             ))
             .build();
@@ -810,7 +855,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(resp.provider_label, "openrouter");
+        assert_eq!(resp.provider_label, "anthropic");
         assert_eq!(resp.text(), Some("rescued"));
 
         let calls = p1.recorded_calls();

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-29T23:51:53.084285+00:00",
+  "generated_at_utc": "2026-05-30T00:36:38.051139+00:00",
   "refs": {
-    "local_ref": "HEAD",
-    "local_sha": "5d65c13120fb246128eb356e2e83b496c4f36232",
+    "local_ref": "main",
+    "local_sha": "71d946dbd37df846677055d1a63fbcc8507c2303",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a",
+    "upstream_sha": "54aa4db1de76a7c4bb02c8a7f7411727384b8fea",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4399,
-    "commits_ahead": 793,
-    "upstream_patch_missing": 4281,
+    "commits_behind": 4402,
+    "commits_ahead": 799,
+    "upstream_patch_missing": 4284,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 680,
-    "files_only_upstream": 1470,
-    "files_only_local": 565,
-    "files_shared_identical": 1702,
-    "files_shared_different": 1017,
-    "tree_files_changed": 3052,
-    "tree_insertions": 739593,
-    "tree_deletions": 377910
+    "local_patch_unique": 683,
+    "files_only_upstream": 1471,
+    "files_only_local": 568,
+    "files_shared_identical": 1701,
+    "files_shared_different": 1018,
+    "tree_files_changed": 3057,
+    "tree_insertions": 739856,
+    "tree_deletions": 381880
   },
   "top_upstream_only": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 85
+      "count": 86
     },
     {
       "path": "web/src",
@@ -201,12 +201,12 @@
       "count": 126
     },
     {
-      "path": "ui-tui/src",
+      "path": "tests/agent",
       "count": 58
     },
     {
-      "path": "tests/agent",
-      "count": 57
+      "path": "ui-tui/src",
+      "count": 58
     },
     {
       "path": "tests/run_agent",
@@ -348,7 +348,7 @@
   "top_local_only": [
     {
       "path": "crates/hermes-tools",
-      "count": 78
+      "count": 79
     },
     {
       "path": "crates/hermes-agent",
@@ -360,7 +360,7 @@
     },
     {
       "path": "crates/hermes-cli",
-      "count": 44
+      "count": 45
     },
     {
       "path": "crates/hermes-intelligence",
@@ -514,7 +514,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 85
+      "count": 86
     },
     {
       "path": "web/src",
@@ -672,7 +672,7 @@
   "top_unique_to_local": [
     {
       "path": "crates/hermes-tools",
-      "count": 78
+      "count": 79
     },
     {
       "path": "crates/hermes-agent",
@@ -684,7 +684,7 @@
     },
     {
       "path": "crates/hermes-cli",
-      "count": 44
+      "count": 45
     },
     {
       "path": "crates/hermes-intelligence",
@@ -836,10 +836,10 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 317,
-      "shared_different": 682,
+      "upstream_only": 318,
+      "shared_different": 683,
       "local_only": 34,
-      "risk": "high",
+      "risk": "critical",
       "effort": "XL"
     },
     {
@@ -858,7 +858,7 @@
       "name": "Compatibility and divergence policy",
       "upstream_only": 391,
       "shared_different": 12,
-      "local_only": 192,
+      "local_only": 193,
       "risk": "high",
       "effort": "XL"
     },
@@ -868,7 +868,7 @@
       "name": "Tools and adapters parity",
       "upstream_only": 114,
       "shared_different": 53,
-      "local_only": 103,
+      "local_only": 104,
       "risk": "high",
       "effort": "L"
     },
@@ -888,7 +888,7 @@
       "name": "Core runtime parity",
       "upstream_only": 62,
       "shared_different": 0,
-      "local_only": 145,
+      "local_only": 146,
       "risk": "critical",
       "effort": "M"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4281,
+    "upstream_patch_missing": 4284,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 680,
+    "local_patch_unique": 683,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,36 +1,36 @@
 # Parity Matrix
 
-Generated: `2026-05-29T23:51:53.084285+00:00`
+Generated: `2026-05-30T00:36:38.051139+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`5d65c13120fb246128eb356e2e83b496c4f36232`)
-- Upstream ref: `upstream/main` (`689ef5e233980f5d5a32080e959f44c8991dd03a`)
+- Local ref: `main` (`71d946dbd37df846677055d1a63fbcc8507c2303`)
+- Upstream ref: `upstream/main` (`54aa4db1de76a7c4bb02c8a7f7411727384b8fea`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4399 |
-| Commits ahead local (`local` ancestry only) | 793 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4281 |
+| Commits behind local (`upstream` ancestry only) | 4402 |
+| Commits ahead local (`local` ancestry only) | 799 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4284 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 680 |
-| Files only in upstream tree | 1470 |
-| Files only in local tree | 565 |
-| Shared files identical content | 1702 |
-| Shared files different content | 1017 |
-| Total files changed (`local` vs `upstream`) | 3052 |
-| Insertions (`local` vs `upstream`) | 739593 |
-| Deletions (`local` vs `upstream`) | 377910 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 683 |
+| Files only in upstream tree | 1471 |
+| Files only in local tree | 568 |
+| Shared files identical content | 1701 |
+| Shared files different content | 1018 |
+| Total files changed (`local` vs `upstream`) | 3057 |
+| Insertions (`local` vs `upstream`) | 739856 |
+| Deletions (`local` vs `upstream`) | 381880 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
 | `website/i18n` | 332 |
-| `tests/hermes_cli` | 85 |
+| `tests/hermes_cli` | 86 |
 | `web/src` | 77 |
 | `tests/agent` | 53 |
 | `tests/gateway` | 40 |
@@ -78,8 +78,8 @@ Generated: `2026-05-29T23:51:53.084285+00:00`
 | `website/docs` | 138 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
+| `tests/agent` | 58 |
 | `ui-tui/src` | 58 |
-| `tests/agent` | 57 |
 | `tests/run_agent` | 56 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |
@@ -119,10 +119,10 @@ Generated: `2026-05-29T23:51:53.084285+00:00`
 
 | Bucket | Files |
 | --- | ---: |
-| `crates/hermes-tools` | 78 |
+| `crates/hermes-tools` | 79 |
 | `crates/hermes-agent` | 47 |
 | `crates/hermes-gateway` | 46 |
-| `crates/hermes-cli` | 44 |
+| `crates/hermes-cli` | 45 |
 | `crates/hermes-intelligence` | 37 |
 | `docs/parity` | 37 |
 | `crates/hermes-config` | 18 |
@@ -164,7 +164,7 @@ Generated: `2026-05-29T23:51:53.084285+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 317 | 682 | high | XL |
+| `WS6` | #10 | Tests and CI parity | 318 | 683 | critical | XL |
 | `WS5` | #9 | UX parity | 493 | 231 | high | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 391 | 12 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 114 | 53 | high | L |
@@ -174,9 +174,9 @@ Generated: `2026-05-29T23:51:53.084285+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4281`
+- Upstream missing by patch-id: `4284`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `680`
+- Local unique by patch-id: `683`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1752,7 +1752,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "66e52b6c10b9559036f5ca01f8545d7757b98ebf",
+      "upstream_blob": "97c3a7f6b66afc348c172adf5a1942f9cdabc6a9",
       "workstream": "WS6"
     },
     {
@@ -2473,6 +2473,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "6e6268dbb76f8379ed35b9f2276cb5bf0b579920",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_unsupported_temperature_retry.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "82d8d3208d2995da3153db85e43dbed5bdf15d46",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_unsupported_temperature_retry.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "4d2ebb980e3091f4d8a48481e8b0174db9f4212c",
       "workstream": "WS6"
     },
     {
@@ -9462,7 +9477,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "89d10f03b1d03c7a23e4c7b54a15153742a96375",
+      "upstream_blob": "d72c0224a692e31cf3a789a5695fe87d20965f17",
       "workstream": "WS6"
     },
     {
@@ -15256,27 +15271,27 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-29T23:51:50.711472+00:00",
+  "generated_at_utc": "2026-05-30T00:39:25.050744+00:00",
   "refs": {
-    "local_ref": "HEAD",
-    "local_sha": "5d65c13120fb246128eb356e2e83b496c4f36232",
+    "local_ref": "main",
+    "local_sha": "71d946dbd37df846677055d1a63fbcc8507c2303",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "689ef5e233980f5d5a32080e959f44c8991dd03a"
+    "upstream_sha": "54aa4db1de76a7c4bb02c8a7f7411727384b8fea"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
       "functional": 760,
-      "intentional_divergence": 88,
+      "intentional_divergence": 89,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 257,
+      "not_required_for_runtime": 258,
       "rust_equivalent_or_contract_test_required": 681,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 88,
+      "cleared_intentional_divergence": 89,
       "cleared_non_runtime": 169,
       "pending_review": 760
     },
@@ -15284,13 +15299,13 @@
       "WS3": 53,
       "WS4": 39,
       "WS5": 230,
-      "WS6": 682,
+      "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 88,
+    "cleared_intentional_divergence": 89,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
     "pending_review": 760,
-    "total_shared_different": 1017
+    "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,20 +1,20 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-29T23:51:50.711472+00:00`
+Generated: `2026-05-30T00:39:25.050744+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1017`
+- Total shared-different paths: `1018`
 - Pending classification: `0`
 - Pending functional review: `760`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `88`
+- Cleared intentional divergence: `89`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 88 |
+| `cleared_intentional_divergence` | 89 |
 | `cleared_non_runtime` | 169 |
 | `pending_review` | 760 |
 
@@ -25,7 +25,7 @@ Generated: `2026-05-29T23:51:50.711472+00:00`
 | `WS3` | 53 |
 | `WS4` | 39 |
 | `WS5` | 230 |
-| `WS6` | 682 |
+| `WS6` | 683 |
 | `WS8` | 13 |
 
 ## Pending Classification

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -185,6 +185,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_unsupported_temperature_retry.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream's unsupported-temperature and OpenAI-compatible max-token omission regression intent is covered by Rust auxiliary-client tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/run_agent",
       "classification": "functional",
       "rationale": "Run-agent tests cover orchestration and provider execution semantics.",


### PR DESCRIPTION
## Summary
- omit max_tokens for OpenAI-compatible auxiliary providers while preserving unsupported-temperature retry semantics
- add Rust auxiliary-client regression coverage for max-token omission across the temperature retry
- refresh upstream parity ledgers against upstream/main 54aa4db1 and mark the Python unsupported-temperature test delta as Rust-covered reference-only

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different guard
- cargo test -p hermes-intelligence auxiliary::client::tests
- cargo test -p hermes-intelligence
- cargo test -p hermes-parity-tests
- cargo test -p hermes-agent
- cargo test -p hermes-cli
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli