### PR TITLE
parity(api-server): add restricted Rust toolset

### DIFF
--- a/crates/hermes-cli/src/platform_toolsets.rs
+++ b/crates/hermes-cli/src/platform_toolsets.rs
@@ -25,6 +25,10 @@ pub fn default_platform_toolsets() -> HashMap<String, Vec<String>> {
     map.insert("discord".to_string(), vec!["hermes-discord".to_string()]);
     map.insert("whatsapp".to_string(), vec!["hermes-whatsapp".to_string()]);
     map.insert("slack".to_string(), vec!["hermes-slack".to_string()]);
+    map.insert(
+        "api_server".to_string(),
+        vec!["hermes-api-server".to_string()],
+    );
     map
 }
 
@@ -181,12 +185,24 @@ mod tests {
             );
         };
         register(&reg, "web_search", "web");
+        register(&reg, "web_extract", "web");
         register(&reg, "terminal", "terminal");
         register(&reg, "process", "terminal");
         register(&reg, "read_file", "file");
         register(&reg, "write_file", "file");
         register(&reg, "patch", "file");
         register(&reg, "search_files", "file");
+        register(&reg, "vision_analyze", "vision");
+        register(&reg, "image_generate", "image_gen");
+        register(&reg, "execute_code", "code_execution");
+        register(&reg, "delegate_task", "delegation");
+        register(&reg, "session_search", "session_search");
+        register(&reg, "cronjob", "cronjob");
+        register(&reg, "ha_list_entities", "homeassistant");
+        register(&reg, "ha_get_state", "homeassistant");
+        register(&reg, "ha_list_services", "homeassistant");
+        register(&reg, "ha_call_service", "homeassistant");
+        register(&reg, "text_to_speech", "tts");
         register(&reg, "send_message", "messaging");
         register(&reg, "skills_list", "skills");
         register(&reg, "skill_view", "skills");
@@ -204,9 +220,6 @@ mod tests {
         register(&reg, "browser_get_images", "browser");
         register(&reg, "browser_vision", "browser");
         register(&reg, "browser_console", "browser");
-        register(&reg, "vision_analyze", "vision");
-        register(&reg, "execute_code", "code_execution");
-        register(&reg, "delegate_task", "delegation");
         reg
     }
 
@@ -235,6 +248,53 @@ mod tests {
         let names = resolve_platform_tool_names(&cfg, "discord", &reg);
         assert!(names.contains(&"send_message".to_string()));
         assert!(names.contains(&"terminal".to_string()));
+    }
+
+    #[test]
+    fn api_server_defaults_to_restricted_toolset() {
+        let cfg = GatewayConfig::default();
+        let reg = registry_with_minimal_tools();
+        let names = resolve_platform_tool_names(&cfg, "api_server", &reg);
+        for expected in [
+            "web_search",
+            "web_extract",
+            "terminal",
+            "process",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "vision_analyze",
+            "image_generate",
+            "execute_code",
+            "delegate_task",
+            "todo",
+            "memory",
+            "session_search",
+            "cronjob",
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
+        ] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "api_server should include {expected}"
+            );
+        }
+        for excluded in ["clarify", "send_message", "text_to_speech"] {
+            assert!(
+                !names.contains(&excluded.to_string()),
+                "api_server should exclude {excluded}"
+            );
+        }
     }
 
     #[test]

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -289,6 +289,27 @@ impl ToolsetManager {
             .collect(),
         ));
         self.register(Toolset::with_includes(
+            "hermes-api-server",
+            vec![
+                "web",
+                "terminal",
+                "file",
+                "browser",
+                "vision",
+                "image_gen",
+                "memory",
+                "session_search",
+                "todo",
+                "code_execution",
+                "delegation",
+                "cronjob",
+                "homeassistant",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ));
+        self.register(Toolset::with_includes(
             "hermes-telegram",
             vec!["hermes-cli"].into_iter().map(String::from).collect(),
         ));
@@ -565,6 +586,54 @@ mod tests {
         assert!(tools.contains(&"send_message".to_string()));
         assert!(tools.contains(&"ha_call_service".to_string()));
         assert!(tools.contains(&"cronjob".to_string()));
+    }
+
+    #[test]
+    fn test_hermes_api_server_toolset() {
+        let manager = ToolsetManager::new(empty_registry());
+        let tools = manager
+            .resolve_toolset_unfiltered("hermes-api-server")
+            .unwrap();
+        for expected in [
+            "web_search",
+            "web_extract",
+            "terminal",
+            "process",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
+            "vision_analyze",
+            "image_generate",
+            "execute_code",
+            "delegate_task",
+            "todo",
+            "memory",
+            "session_search",
+            "cronjob",
+        ] {
+            assert!(
+                tools.contains(&expected.to_string()),
+                "hermes-api-server should include {expected}"
+            );
+        }
+        for excluded in ["clarify", "send_message", "text_to_speech", "tts_premium"] {
+            assert!(
+                !tools.contains(&excluded.to_string()),
+                "hermes-api-server should exclude {excluded}"
+            );
+        }
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T00:36:38.051139+00:00",
+  "generated_at_utc": "2026-05-30T00:54:56.848014+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "71d946dbd37df846677055d1a63fbcc8507c2303",
+    "local_sha": "049546fd77db89fc1eb6a037f613857d288857fd",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "54aa4db1de76a7c4bb02c8a7f7411727384b8fea",
+    "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4402,
-    "commits_ahead": 799,
-    "upstream_patch_missing": 4284,
+    "commits_behind": 4403,
+    "commits_ahead": 801,
+    "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 683,
-    "files_only_upstream": 1471,
+    "local_patch_unique": 684,
+    "files_only_upstream": 1474,
     "files_only_local": 568,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
-    "tree_files_changed": 3057,
-    "tree_insertions": 739856,
-    "tree_deletions": 381880
+    "tree_files_changed": 3060,
+    "tree_insertions": 740489,
+    "tree_deletions": 381962
   },
   "top_upstream_only": [
     {
@@ -75,11 +75,11 @@
       "count": 19
     },
     {
-      "path": ".github/workflows",
-      "count": 15
+      "path": "tests/cli",
+      "count": 17
     },
     {
-      "path": "tests/cli",
+      "path": ".github/workflows",
       "count": 15
     },
     {
@@ -561,11 +561,11 @@
       "count": 19
     },
     {
-      "path": ".github/workflows",
-      "count": 15
+      "path": "tests/cli",
+      "count": 17
     },
     {
-      "path": "tests/cli",
+      "path": ".github/workflows",
       "count": 15
     },
     {
@@ -836,7 +836,7 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 318,
+      "upstream_only": 320,
       "shared_different": 683,
       "local_only": 34,
       "risk": "critical",
@@ -856,7 +856,7 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 391,
+      "upstream_only": 392,
       "shared_different": 12,
       "local_only": 193,
       "risk": "high",
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4284,
+    "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 683,
+    "local_patch_unique": 684,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,29 +1,29 @@
 # Parity Matrix
 
-Generated: `2026-05-30T00:36:38.051139+00:00`
+Generated: `2026-05-30T00:54:56.848014+00:00`
 
 ## Scope
 
-- Local ref: `main` (`71d946dbd37df846677055d1a63fbcc8507c2303`)
-- Upstream ref: `upstream/main` (`54aa4db1de76a7c4bb02c8a7f7411727384b8fea`)
+- Local ref: `main` (`049546fd77db89fc1eb6a037f613857d288857fd`)
+- Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4402 |
-| Commits ahead local (`local` ancestry only) | 799 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4284 |
+| Commits behind local (`upstream` ancestry only) | 4403 |
+| Commits ahead local (`local` ancestry only) | 801 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 683 |
-| Files only in upstream tree | 1471 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 684 |
+| Files only in upstream tree | 1474 |
 | Files only in local tree | 568 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
-| Total files changed (`local` vs `upstream`) | 3057 |
-| Insertions (`local` vs `upstream`) | 739856 |
-| Deletions (`local` vs `upstream`) | 381880 |
+| Total files changed (`local` vs `upstream`) | 3060 |
+| Insertions (`local` vs `upstream`) | 740489 |
+| Deletions (`local` vs `upstream`) | 381962 |
 
 ## Top 40 upstream-only buckets
 
@@ -42,8 +42,8 @@ Generated: `2026-05-30T00:36:38.051139+00:00`
 | `tests/plugins` | 21 |
 | `tests/run_agent` | 19 |
 | `ui-tui/src` | 19 |
+| `tests/cli` | 17 |
 | `.github/workflows` | 15 |
-| `tests/cli` | 15 |
 | `tests/docker` | 12 |
 | `agent/lsp` | 11 |
 | `agent/transports` | 11 |
@@ -164,9 +164,9 @@ Generated: `2026-05-30T00:36:38.051139+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 318 | 683 | critical | XL |
+| `WS6` | #10 | Tests and CI parity | 320 | 683 | critical | XL |
 | `WS5` | #9 | UX parity | 493 | 231 | high | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 391 | 12 | high | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 392 | 12 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 114 | 53 | high | L |
 | `WS4` | #8 | Skills parity | 93 | 39 | medium | L |
 | `WS2` | #6 | Core runtime parity | 62 | 0 | critical | M |
@@ -174,9 +174,9 @@ Generated: `2026-05-30T00:36:38.051139+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4284`
+- Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `683`
+- Local unique by patch-id: `684`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3376,16 +3376,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_api_server_toolset.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "943d867e6132df63cd5c96d53af986a460132001",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_api_server_toolset.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "add2ce27345a8efc3d477373028d593b0b33d238",
       "workstream": "WS6"
@@ -13887,7 +13887,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "776d53089e89a829a631895112dd593254da7d23",
+      "upstream_blob": "3c8d7bbc1dbef7a1a0d3ab0f5f79be791d63dbbd",
       "workstream": "WS5"
     },
     {
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T00:39:25.050744+00:00",
+  "generated_at_utc": "2026-05-30T00:58:41.862565+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "71d946dbd37df846677055d1a63fbcc8507c2303",
+    "local_sha": "049546fd77db89fc1eb6a037f613857d288857fd",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "54aa4db1de76a7c4bb02c8a7f7411727384b8fea"
+    "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 760,
-      "intentional_divergence": 89,
+      "functional": 759,
+      "intentional_divergence": 90,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 258,
-      "rust_equivalent_or_contract_test_required": 681,
+      "not_required_for_runtime": 259,
+      "rust_equivalent_or_contract_test_required": 680,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 89,
+      "cleared_intentional_divergence": 90,
       "cleared_non_runtime": 169,
-      "pending_review": 760
+      "pending_review": 759
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 89,
+    "cleared_intentional_divergence": 90,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 760,
+    "pending_review": 759,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T00:39:25.050744+00:00`
+Generated: `2026-05-30T00:58:41.862565+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `760`
+- Pending functional review: `759`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `89`
+- Cleared intentional divergence: `90`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 89 |
+| `cleared_intentional_divergence` | 90 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 760 |
+| `pending_review` | 759 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T00:39:25.050744+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 172 |
+| `tests/gateway` | 171 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -143,6 +143,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_api_server_toolset.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream's API-server toolset contract is covered by Rust toolset and platform-toolset tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "website/docs",
       "classification": "policy_only",
       "rationale": "Documentation-site content differs by project positioning and release policy; runtime behavior is unaffected.",


### PR DESCRIPTION
## Summary
- add the Rust-only `hermes-api-server` composite toolset preset
- map `api_server` platform defaults to that restricted preset
- classify upstream API-server Python toolset test as Rust-covered reference-only and refresh parity ledgers

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-runtime-placeholders.sh`
- `bash scripts/check-rust-runtime-no-python.sh`
- `rg -n "max_shared_different|max shared different|max-shared-different" .` (no matches; exit 1 expected)
- `cargo test -p hermes-tools`
- `cargo test -p hermes-parity-tests`
- `cargo test -p hermes-cli`
- `python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md`
- `cargo build -p hermes-cli`