### PR TITLE
parity(acp): add Rust auth methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,7 @@ version = "0.14.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "hermes-config",
  "hermes-core",
  "serde",
  "serde_json",

--- a/crates/hermes-acp/Cargo.toml
+++ b/crates/hermes-acp/Cargo.toml
@@ -8,6 +8,7 @@ description = "Agent Communication Protocol adapter for Hermes Agent"
 
 [dependencies]
 hermes-core = { workspace = true }
+hermes-config = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermes-acp/src/auth.rs
+++ b/crates/hermes-acp/src/auth.rs
@@ -1,0 +1,316 @@
+//! ACP authentication helpers.
+//!
+//! Mirrors the Python `acp_adapter/auth.py` contract: advertise a terminal
+//! setup method for first-run clients and, when Hermes can resolve configured
+//! runtime credentials, advertise that provider as an agent-managed auth method.
+
+use hermes_config::{load_config, GatewayConfig};
+
+use crate::protocol::AuthMethod;
+
+pub const TERMINAL_SETUP_AUTH_METHOD_ID: &str = "hermes-setup";
+
+/// Return true if Hermes can resolve a runtime provider with credentials.
+pub fn has_provider() -> bool {
+    detect_provider().is_some()
+}
+
+/// Resolve the active Hermes runtime provider, or `None` if unavailable.
+pub fn detect_provider() -> Option<String> {
+    let config = load_config(None).ok()?;
+    detect_provider_from_config(&config)
+}
+
+/// Build ACP auth methods for the currently configured runtime provider.
+pub fn build_auth_methods() -> Vec<AuthMethod> {
+    build_auth_methods_for_provider(detect_provider().as_deref())
+}
+
+pub(crate) fn build_auth_methods_for_provider(provider: Option<&str>) -> Vec<AuthMethod> {
+    let mut methods = Vec::new();
+    if let Some(provider) = provider.and_then(normalize_provider_with_credentials_marker) {
+        methods.push(AuthMethod {
+            id: provider.clone(),
+            name: format!("{provider} runtime credentials"),
+            description: Some(format!(
+                "Authenticate Hermes using the currently configured {provider} runtime credentials."
+            )),
+            method_type: None,
+            args: Vec::new(),
+        });
+    }
+
+    methods.push(AuthMethod {
+        id: TERMINAL_SETUP_AUTH_METHOD_ID.to_string(),
+        name: "Configure Hermes provider".to_string(),
+        description: Some(
+            "Open Hermes' interactive model/provider setup in a terminal. Use this when Hermes has not been configured on this machine yet."
+                .to_string(),
+        ),
+        method_type: Some("terminal".to_string()),
+        args: vec!["--setup".to_string()],
+    });
+    methods
+}
+
+pub(crate) fn detect_provider_from_config(config: &GatewayConfig) -> Option<String> {
+    let provider = active_provider(config)?;
+    provider_has_credentials(config, &provider).then_some(provider)
+}
+
+fn normalize_provider_with_credentials_marker(provider: &str) -> Option<String> {
+    let provider = normalize_provider_name(provider);
+    (!provider.is_empty()).then_some(provider)
+}
+
+fn normalize_provider_name(provider: &str) -> String {
+    let normalized = provider.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "codex" => "openai-codex".to_string(),
+        "claude" | "claude-code" => "anthropic".to_string(),
+        "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
+        "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "step" | "step-plan" => "stepfun".to_string(),
+        "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
+        "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
+        "minimax-cn" => "minimax".to_string(),
+        "novita-ai" | "novitaai" => "novita".to_string(),
+        "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
+        "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
+        "go" => "opencode-go".to_string(),
+        "ollama" => "ollama-local".to_string(),
+        "llama.cpp" | "llamacpp" => "llama-cpp".to_string(),
+        "ollvm" | "llvm" => "vllm".to_string(),
+        "mlx-lm" | "apple-mlx" => "mlx".to_string(),
+        "ane" | "apple-neural-engine" | "neural-engine" => "apple-ane".to_string(),
+        "text-generation-inference" => "tgi".to_string(),
+        _ => normalized,
+    }
+}
+
+fn active_provider(config: &GatewayConfig) -> Option<String> {
+    if let Some(provider) = env_trimmed("HERMES_INFERENCE_PROVIDER") {
+        return normalize_provider_with_credentials_marker(&provider);
+    }
+
+    let model = env_trimmed("HERMES_INFERENCE_MODEL")
+        .or_else(|| env_trimmed("HERMES_MODEL"))
+        .or_else(|| config.model.as_deref().map(str::to_string))
+        .unwrap_or_default();
+    let model = model.trim();
+
+    if let Some((provider, _model_name)) = model.split_once(':') {
+        return normalize_provider_with_credentials_marker(provider);
+    }
+
+    if !model.is_empty() {
+        if let Some((provider, _)) = config.llm_providers.iter().find(|(_, cfg)| {
+            cfg.model
+                .as_deref()
+                .map(str::trim)
+                .filter(|candidate| !candidate.is_empty())
+                .is_some_and(|candidate| candidate == model)
+        }) {
+            return normalize_provider_with_credentials_marker(provider);
+        }
+    }
+
+    if config.llm_providers.len() == 1 {
+        if let Some((provider, _)) = config.llm_providers.iter().next() {
+            return normalize_provider_with_credentials_marker(provider);
+        }
+    }
+
+    None
+}
+
+fn provider_has_credentials(config: &GatewayConfig, provider: &str) -> bool {
+    let provider_config = provider_config(config, provider);
+    let direct_config_key = provider_config
+        .and_then(|cfg| cfg.api_key.as_deref())
+        .is_some_and(non_empty);
+    if direct_config_key {
+        return true;
+    }
+
+    let config_env_key = provider_config
+        .and_then(|cfg| cfg.api_key_env.as_deref())
+        .and_then(env_trimmed)
+        .is_some();
+    if config_env_key {
+        return true;
+    }
+
+    provider_env_key_names(provider)
+        .iter()
+        .any(|key| env_trimmed(key).is_some())
+}
+
+fn provider_config<'a>(
+    config: &'a GatewayConfig,
+    provider: &str,
+) -> Option<&'a hermes_config::LlmProviderConfig> {
+    config.llm_providers.get(provider).or_else(|| {
+        config
+            .llm_providers
+            .iter()
+            .find(|(name, _)| normalize_provider_name(name) == provider)
+            .map(|(_, cfg)| cfg)
+    })
+}
+
+fn provider_env_key_names(provider: &str) -> &'static [&'static str] {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "openai" => &["HERMES_OPENAI_API_KEY", "OPENAI_API_KEY"],
+        "openai-codex" => &["HERMES_OPENAI_CODEX_API_KEY"],
+        "anthropic" => &[
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ],
+        "google-gemini-cli" => &[
+            "HERMES_GEMINI_OAUTH_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ],
+        "openrouter" => &["OPENROUTER_API_KEY"],
+        "qwen" => &["DASHSCOPE_API_KEY"],
+        "qwen-oauth" => &["HERMES_QWEN_OAUTH_API_KEY", "DASHSCOPE_API_KEY"],
+        "kimi" => &["MOONSHOT_API_KEY"],
+        "minimax" => &["MINIMAX_API_KEY"],
+        "nous" => &["NOUS_API_KEY", "HERMES_NOUS_API_KEY"],
+        "copilot" | "copilot-acp" => &["GITHUB_COPILOT_TOKEN"],
+        "stepfun" => &["STEPFUN_API_KEY"],
+        "ai-gateway" => &["AI_GATEWAY_API_KEY"],
+        "novita" => &["NOVITA_API_KEY"],
+        "xai" => &["XAI_API_KEY"],
+        "nvidia" => &["NVIDIA_API_KEY"],
+        "kilocode" => &["KILOCODE_API_KEY"],
+        "huggingface" => &["HF_TOKEN", "HUGGINGFACE_API_KEY"],
+        "zai" => &["ZAI_API_KEY"],
+        "arcee" => &["ARCEE_API_KEY"],
+        "ollama-cloud" => &["OLLAMA_API_KEY"],
+        _ => &[],
+    }
+}
+
+fn env_trimmed(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn non_empty(value: &str) -> bool {
+    !value.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use hermes_config::{GatewayConfig, LlmProviderConfig};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn build_auth_methods_returns_provider_and_terminal_when_configured() {
+        let methods = build_auth_methods_for_provider(Some(" OpenRouter "));
+        let payloads: Vec<_> = methods
+            .iter()
+            .map(|method| serde_json::to_value(method).unwrap())
+            .collect();
+
+        assert_eq!(payloads[0]["id"], "openrouter");
+        assert_eq!(payloads[0]["name"], "openrouter runtime credentials");
+        let terminal = payloads
+            .iter()
+            .find(|payload| payload["id"] == TERMINAL_SETUP_AUTH_METHOD_ID)
+            .expect("terminal setup auth method");
+        assert_eq!(terminal["type"], "terminal");
+        assert_eq!(terminal["args"], json!(["--setup"]));
+    }
+
+    #[test]
+    fn build_auth_methods_returns_terminal_setup_when_unconfigured() {
+        let payloads: Vec<_> = build_auth_methods_for_provider(None)
+            .iter()
+            .map(|method| serde_json::to_value(method).unwrap())
+            .collect();
+
+        assert_eq!(
+            payloads,
+            vec![json!({
+                "args": ["--setup"],
+                "description": "Open Hermes' interactive model/provider setup in a terminal. Use this when Hermes has not been configured on this machine yet.",
+                "id": TERMINAL_SETUP_AUTH_METHOD_ID,
+                "name": "Configure Hermes provider",
+                "type": "terminal",
+            })]
+        );
+    }
+
+    #[test]
+    fn detect_provider_from_config_requires_non_empty_key() {
+        let mut config = GatewayConfig {
+            model: Some("openrouter:anthropic/claude-sonnet".to_string()),
+            llm_providers: HashMap::from([(
+                "openrouter".to_string(),
+                LlmProviderConfig {
+                    api_key: Some("   ".to_string()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+        assert_eq!(detect_provider_from_config(&config), None);
+
+        config.llm_providers.get_mut("openrouter").unwrap().api_key =
+            Some("sk-or-test".to_string());
+        assert_eq!(
+            detect_provider_from_config(&config).as_deref(),
+            Some("openrouter")
+        );
+    }
+
+    #[test]
+    fn detect_provider_from_config_strips_and_lowercases_provider() {
+        let config = GatewayConfig {
+            model: Some(" OpenRouter : model ".to_string()),
+            llm_providers: HashMap::from([(
+                "openrouter".to_string(),
+                LlmProviderConfig {
+                    api_key: Some("sk-or-test".to_string()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            detect_provider_from_config(&config).as_deref(),
+            Some("openrouter")
+        );
+    }
+
+    #[test]
+    fn detect_provider_from_config_uses_credentials_from_alias_provider_block() {
+        let config = GatewayConfig {
+            model: Some("moonshot:kimi-k2".to_string()),
+            llm_providers: HashMap::from([(
+                "moonshot".to_string(),
+                LlmProviderConfig {
+                    api_key: Some("sk-moonshot-test".to_string()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            detect_provider_from_config(&config).as_deref(),
+            Some("kimi")
+        );
+    }
+}

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -13,6 +13,9 @@ use base64::Engine as _;
 use serde_json::{json, Value};
 use url::Url;
 
+use crate::auth::{
+    build_auth_methods_for_provider, detect_provider, TERMINAL_SETUP_AUTH_METHOD_ID,
+};
 use crate::events::{AcpEvent, EventSink};
 use crate::permissions::PermissionStore;
 use crate::protocol::*;
@@ -600,6 +603,7 @@ pub struct HermesAcpHandler {
     pub permission_store: Arc<PermissionStore>,
     version: String,
     prompt_executor: Option<Arc<dyn AcpPromptExecutor>>,
+    auth_provider_resolver: Arc<dyn Fn() -> Option<String> + Send + Sync>,
 }
 
 impl HermesAcpHandler {
@@ -614,11 +618,20 @@ impl HermesAcpHandler {
             permission_store,
             version: env!("CARGO_PKG_VERSION").to_string(),
             prompt_executor: None,
+            auth_provider_resolver: Arc::new(detect_provider),
         }
     }
 
     pub fn with_prompt_executor(mut self, prompt_executor: Arc<dyn AcpPromptExecutor>) -> Self {
         self.prompt_executor = Some(prompt_executor);
+        self
+    }
+
+    pub fn with_auth_provider_resolver(
+        mut self,
+        resolver: Arc<dyn Fn() -> Option<String> + Send + Sync>,
+    ) -> Self {
+        self.auth_provider_resolver = resolver;
         self
     }
 
@@ -838,6 +851,7 @@ impl AcpHandler for HermesAcpHandler {
         match method {
             // -- Lifecycle --------------------------------------------------
             AcpMethod::Initialize => {
+                let auth_provider = (self.auth_provider_resolver)();
                 let resp = InitializeResponse {
                     protocol_version: 1,
                     agent_info: Implementation {
@@ -854,12 +868,31 @@ impl AcpHandler for HermesAcpHandler {
                         streaming: true,
                         ..Default::default()
                     },
-                    auth_methods: None,
+                    auth_methods: Some(build_auth_methods_for_provider(auth_provider.as_deref())),
                 };
                 AcpResponse::success(request.id, serde_json::to_value(&resp).unwrap())
             }
 
-            AcpMethod::Authenticate => AcpResponse::success(request.id, json!({})),
+            AcpMethod::Authenticate => {
+                let method_id = params_obj(&request.params)
+                    .and_then(|p| param_str(p, "method_id").or_else(|| param_str(p, "methodId")))
+                    .map(str::trim)
+                    .unwrap_or("");
+                let normalized_method = method_id.to_ascii_lowercase();
+                let provider = (self.auth_provider_resolver)()
+                    .map(|provider| provider.trim().to_ascii_lowercase())
+                    .filter(|provider| !provider.is_empty());
+                let accepted = match provider.as_deref() {
+                    Some(provider) if normalized_method == provider => true,
+                    Some(_) if normalized_method == TERMINAL_SETUP_AUTH_METHOD_ID => true,
+                    _ => false,
+                };
+                if accepted {
+                    AcpResponse::success(request.id, json!({}))
+                } else {
+                    AcpResponse::success(request.id, Value::Null)
+                }
+            }
 
             // -- Session management -----------------------------------------
             AcpMethod::NewSession => {
@@ -1362,6 +1395,10 @@ mod tests {
         )
     }
 
+    fn make_handler_with_auth_provider(provider: Option<&'static str>) -> HermesAcpHandler {
+        make_handler().with_auth_provider_resolver(Arc::new(move || provider.map(str::to_string)))
+    }
+
     #[tokio::test]
     async fn test_initialize() {
         let handler = make_handler();
@@ -1375,6 +1412,113 @@ mod tests {
         assert!(resp.result.is_some());
         let result = resp.result.unwrap();
         assert_eq!(result["agent_info"]["name"], "hermes-agent");
+    }
+
+    #[tokio::test]
+    async fn test_initialize_advertises_provider_and_terminal_auth_methods() {
+        let handler = make_handler_with_auth_provider(Some("openrouter"));
+        let req = AcpRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "initialize".into(),
+            params: None,
+        };
+        let resp = handler.handle_request(req).await;
+        let result = resp.result.unwrap();
+        let methods = result["auth_methods"].as_array().expect("auth methods");
+
+        assert_eq!(methods[0]["id"], "openrouter");
+        assert_eq!(methods[0]["name"], "openrouter runtime credentials");
+        let terminal = methods
+            .iter()
+            .find(|method| method["id"] == TERMINAL_SETUP_AUTH_METHOD_ID)
+            .expect("terminal setup auth method");
+        assert_eq!(terminal["type"], "terminal");
+        assert_eq!(terminal["args"], json!(["--setup"]));
+    }
+
+    #[tokio::test]
+    async fn test_initialize_advertises_terminal_setup_auth_when_no_provider() {
+        let handler = make_handler_with_auth_provider(None);
+        let req = AcpRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "initialize".into(),
+            params: None,
+        };
+        let resp = handler.handle_request(req).await;
+        let result = resp.result.unwrap();
+
+        assert_eq!(
+            result["auth_methods"],
+            json!([{
+                "args": ["--setup"],
+                "description": "Open Hermes' interactive model/provider setup in a terminal. Use this when Hermes has not been configured on this machine yet.",
+                "id": TERMINAL_SETUP_AUTH_METHOD_ID,
+                "name": "Configure Hermes provider",
+                "type": "terminal",
+            }])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_accepts_matching_method_id_case_insensitively() {
+        let handler = make_handler_with_auth_provider(Some("openrouter"));
+        let req = AcpRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "authenticate".into(),
+            params: Some(json!({"method_id": "OpenRouter"})),
+        };
+
+        let resp = handler.handle_request(req).await;
+        assert_eq!(resp.result, Some(json!({})));
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_rejects_mismatched_method_id() {
+        let handler = make_handler_with_auth_provider(Some("openrouter"));
+        let req = AcpRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "authenticate".into(),
+            params: Some(json!({"method_id": "totally-invalid-method"})),
+        };
+
+        let resp = handler.handle_request(req).await;
+        assert_eq!(resp.result, Some(Value::Null));
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_accepts_terminal_setup_after_provider_configured() {
+        let handler = make_handler_with_auth_provider(Some("openrouter"));
+        let req = AcpRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "authenticate".into(),
+            params: Some(json!({"method_id": TERMINAL_SETUP_AUTH_METHOD_ID})),
+        };
+
+        let resp = handler.handle_request(req).await;
+        assert_eq!(resp.result, Some(json!({})));
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_rejects_terminal_setup_without_provider() {
+        let handler = make_handler_with_auth_provider(None);
+        let req = AcpRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "authenticate".into(),
+            params: Some(json!({"method_id": TERMINAL_SETUP_AUTH_METHOD_ID})),
+        };
+
+        let resp = handler.handle_request(req).await;
+        assert_eq!(resp.result, Some(Value::Null));
+        assert!(resp.error.is_none());
     }
 
     #[tokio::test]

--- a/crates/hermes-acp/src/lib.rs
+++ b/crates/hermes-acp/src/lib.rs
@@ -10,6 +10,7 @@
 //! - **Events**: thinking, tool progress, message streaming
 //! - **Permissions**: approval callback bridging
 
+pub mod auth;
 pub mod events;
 pub mod handler;
 pub mod permissions;
@@ -17,6 +18,7 @@ pub mod protocol;
 pub mod server;
 pub mod session;
 
+pub use auth::{build_auth_methods, detect_provider, has_provider, TERMINAL_SETUP_AUTH_METHOD_ID};
 pub use events::{AcpEvent, AcpEventKind, EventSink, ToolCallIdTracker};
 pub use handler::{
     AcpHandler, AcpPromptExecutor, DefaultAcpHandler, HermesAcpHandler, PromptExecutionOutput,

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -184,6 +184,10 @@ pub struct AuthMethod {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub method_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T00:54:56.848014+00:00",
+  "generated_at_utc": "2026-05-30T01:14:40.916594+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "049546fd77db89fc1eb6a037f613857d288857fd",
+    "local_sha": "fc57078bd5d330cadae842c4512f2639013ff88d",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 801,
+    "commits_ahead": 803,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 684,
+    "local_patch_unique": 685,
     "files_only_upstream": 1474,
     "files_only_local": 568,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3060,
     "tree_insertions": 740489,
-    "tree_deletions": 381962
+    "tree_deletions": 382098
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 684,
+    "local_patch_unique": 685,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T00:54:56.848014+00:00`
+Generated: `2026-05-30T01:14:40.916594+00:00`
 
 ## Scope
 
-- Local ref: `main` (`049546fd77db89fc1eb6a037f613857d288857fd`)
+- Local ref: `main` (`fc57078bd5d330cadae842c4512f2639013ff88d`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T00:54:56.848014+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 801 |
+| Commits ahead local (`local` ancestry only) | 803 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 684 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 685 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 568 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3060 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 381962 |
+| Deletions (`local` vs `upstream`) | 382098 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T00:54:56.848014+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `684`
+- Local unique by patch-id: `685`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1606,16 +1606,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/acp",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/acp/test_auth.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ffb07463f8d60eb933b263fc611e1bbdcaaace92",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/acp/test_auth.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0610d3e33505471d462dcca2bb53d1b3fe4e01cd",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T00:58:41.862565+00:00",
+  "generated_at_utc": "2026-05-30T01:14:38.807690+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "049546fd77db89fc1eb6a037f613857d288857fd",
+    "local_sha": "fc57078bd5d330cadae842c4512f2639013ff88d",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 759,
-      "intentional_divergence": 90,
+      "functional": 758,
+      "intentional_divergence": 91,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 259,
-      "rust_equivalent_or_contract_test_required": 680,
+      "not_required_for_runtime": 260,
+      "rust_equivalent_or_contract_test_required": 679,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 90,
+      "cleared_intentional_divergence": 91,
       "cleared_non_runtime": 169,
-      "pending_review": 759
+      "pending_review": 758
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 90,
+    "cleared_intentional_divergence": 91,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 759,
+    "pending_review": 758,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T00:58:41.862565+00:00`
+Generated: `2026-05-30T01:14:38.807690+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `759`
+- Pending functional review: `758`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `90`
+- Cleared intentional divergence: `91`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 90 |
+| `cleared_intentional_divergence` | 91 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 759 |
+| `pending_review` | 758 |
 
 ## Workstream Counts
 
@@ -48,7 +48,7 @@ Generated: `2026-05-30T00:58:41.862565+00:00`
 | `ui-tui/packages` | 18 |
 | `tests/plugins` | 16 |
 | `tests/cron` | 11 |
-| `tests/acp` | 8 |
+| `tests/acp` | 7 |
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -409,6 +409,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/acp/test_auth.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ACP auth helper behavior is covered by Rust ACP auth-method and initialize/authenticate tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "plugins/google_meet",
       "classification": "functional",
       "rationale": "Google Meet plugin differences affect connector/plugin runtime behavior.",


### PR DESCRIPTION
## Summary
- add Rust ACP auth helpers for runtime provider detection and terminal setup auth advertisement
- wire ACP initialize/authenticate to provider-scoped auth methods
- mark upstream `tests/acp/test_auth.py` as Rust-covered reference-only and refresh parity ledgers

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-runtime-placeholders.sh`
- `bash scripts/check-rust-runtime-no-python.sh`
- `rg -n "max_shared_different|max shared different|max-shared-different" .` (no matches; exit 1 expected)
- `cargo test -p hermes-acp`
- `cargo test -p hermes-parity-tests`
- `cargo test -p hermes-cli`
- `cargo test -p hermes-tools`
- `python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md`
- `cargo build -p hermes-cli`