### PR TITLE
parity(acp): align permission options

### DIFF
--- a/crates/hermes-acp/src/permissions.rs
+++ b/crates/hermes-acp/src/permissions.rs
@@ -4,6 +4,7 @@
 //! Mirrors the Python `acp_adapter/permissions.py` implementation.
 
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
@@ -72,29 +73,97 @@ pub enum PermissionOutcome {
     Timeout,
 }
 
+impl PermissionOutcome {
+    /// Map an ACP permission outcome into Hermes approval strings.
+    ///
+    /// ACP "kind" alone cannot express Hermes' session-scoped allowance, so
+    /// mapping is intentionally based on the stable option id.
+    pub fn to_hermes_result(&self, allowed_options: &[PermissionOption]) -> &'static str {
+        let Self::Allowed { option_id } = self else {
+            return "deny";
+        };
+        if !allowed_options
+            .iter()
+            .any(|option| option.option_id == *option_id)
+        {
+            return "deny";
+        }
+        match option_id.as_str() {
+            "allow_once" => "once",
+            "allow_session" => "session",
+            "allow_always" => "always",
+            "deny" | "deny_always" => "deny",
+            _ => "deny",
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Default permission options
 // ---------------------------------------------------------------------------
 
 /// Build the standard set of permission options.
 pub fn default_permission_options() -> Vec<PermissionOption> {
-    vec![
+    permission_options(true)
+}
+
+/// Build ACP permission options that match Hermes approval semantics.
+pub fn permission_options(allow_permanent: bool) -> Vec<PermissionOption> {
+    let mut options = vec![
         PermissionOption {
             option_id: "allow_once".to_string(),
             kind: PermissionKind::AllowOnce,
             name: "Allow once".to_string(),
         },
         PermissionOption {
+            option_id: "allow_session".to_string(),
+            // ACP has no session-scoped kind; keep Hermes semantics in the
+            // stable option id while using the closest ACP persistence hint.
+            kind: PermissionKind::AllowAlways,
+            name: "Allow for session".to_string(),
+        },
+    ];
+    if allow_permanent {
+        options.push(PermissionOption {
             option_id: "allow_always".to_string(),
             kind: PermissionKind::AllowAlways,
             name: "Allow always".to_string(),
-        },
+        });
+    }
+    options.extend([
         PermissionOption {
             option_id: "deny".to_string(),
             kind: PermissionKind::RejectOnce,
             name: "Deny".to_string(),
         },
-    ]
+        PermissionOption {
+            option_id: "deny_always".to_string(),
+            kind: PermissionKind::RejectAlways,
+            name: "Deny always".to_string(),
+        },
+    ]);
+    options
+}
+
+static PERMISSION_REQUEST_IDS: AtomicU64 = AtomicU64::new(1);
+
+/// Build a pending permission request with a stable, unique `perm-check-N` id.
+pub fn build_permission_request(
+    session_id: impl Into<String>,
+    command: impl Into<String>,
+    description: impl Into<String>,
+    allow_permanent: bool,
+    created_at: u64,
+) -> PermissionRequest {
+    let id = PERMISSION_REQUEST_IDS.fetch_add(1, Ordering::Relaxed);
+    PermissionRequest {
+        id: format!("perm-check-{id}"),
+        session_id: session_id.into(),
+        command: command.into(),
+        description: description.into(),
+        options: permission_options(allow_permanent),
+        created_at,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -185,19 +254,93 @@ mod tests {
         assert_eq!(PermissionKind::AllowOnce.to_hermes_result(), "once");
         assert_eq!(PermissionKind::AllowAlways.to_hermes_result(), "always");
         assert_eq!(PermissionKind::RejectOnce.to_hermes_result(), "deny");
+        assert_eq!(PermissionKind::RejectAlways.to_hermes_result(), "deny");
+    }
+
+    #[test]
+    fn test_permission_options_match_upstream_contract() {
+        let options = permission_options(true);
+        let ids: Vec<_> = options
+            .iter()
+            .map(|option| (option.option_id.as_str(), option.kind, option.name.as_str()))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                ("allow_once", PermissionKind::AllowOnce, "Allow once"),
+                (
+                    "allow_session",
+                    PermissionKind::AllowAlways,
+                    "Allow for session"
+                ),
+                ("allow_always", PermissionKind::AllowAlways, "Allow always"),
+                ("deny", PermissionKind::RejectOnce, "Deny"),
+                ("deny_always", PermissionKind::RejectAlways, "Deny always"),
+            ]
+        );
+
+        let no_permanent_options = permission_options(false);
+        let no_permanent_ids: Vec<_> = no_permanent_options
+            .iter()
+            .map(|option| option.option_id.as_str())
+            .collect();
+        assert_eq!(
+            no_permanent_ids,
+            vec!["allow_once", "allow_session", "deny", "deny_always"]
+        );
+    }
+
+    #[test]
+    fn test_permission_outcome_maps_by_option_id() {
+        let options = permission_options(true);
+        for (option_id, expected) in [
+            ("allow_once", "once"),
+            ("allow_session", "session"),
+            ("allow_always", "always"),
+            ("deny", "deny"),
+            ("deny_always", "deny"),
+            ("unexpected", "deny"),
+        ] {
+            let outcome = PermissionOutcome::Allowed {
+                option_id: option_id.to_string(),
+            };
+            assert_eq!(outcome.to_hermes_result(&options), expected);
+        }
+        assert_eq!(PermissionOutcome::Denied.to_hermes_result(&options), "deny");
+        assert_eq!(
+            PermissionOutcome::Timeout.to_hermes_result(&options),
+            "deny"
+        );
+    }
+
+    #[test]
+    fn test_permission_request_builder_uses_unique_perm_check_ids() {
+        let first = build_permission_request("s1", "rm -rf /", "dangerous command", true, 42);
+        let second = build_permission_request("s1", "echo ok", "safe command", false, 43);
+
+        assert!(first.id.starts_with("perm-check-"));
+        assert!(second.id.starts_with("perm-check-"));
+        assert_ne!(first.id, second.id);
+        assert_eq!(first.session_id, "s1");
+        assert_eq!(first.command, "rm -rf /");
+        assert_eq!(first.description, "dangerous command");
+        assert_eq!(first.created_at, 42);
+        assert_eq!(
+            second
+                .options
+                .iter()
+                .map(|option| option.option_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["allow_once", "allow_session", "deny", "deny_always"]
+        );
     }
 
     #[test]
     fn test_permission_store() {
         let store = PermissionStore::new();
-        store.add_pending(PermissionRequest {
-            id: "req1".to_string(),
-            session_id: "s1".to_string(),
-            command: "rm -rf /".to_string(),
-            description: "dangerous command".to_string(),
-            options: default_permission_options(),
-            created_at: 0,
-        });
+        let mut request = build_permission_request("s1", "rm -rf /", "dangerous command", true, 0);
+        request.id = "req1".to_string();
+        store.add_pending(request);
 
         assert_eq!(store.list_pending().len(), 1);
         assert!(store.resolve("req1", PermissionOutcome::Denied));

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T01:14:40.916594+00:00",
+  "generated_at_utc": "2026-05-30T01:29:35.389232+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "fc57078bd5d330cadae842c4512f2639013ff88d",
+    "local_sha": "db735720e0b8d454501a1136597f5b7f8158e85f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 803,
+    "commits_ahead": 805,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 685,
+    "local_patch_unique": 686,
     "files_only_upstream": 1474,
-    "files_only_local": 568,
+    "files_only_local": 569,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
-    "tree_files_changed": 3060,
+    "tree_files_changed": 3061,
     "tree_insertions": 740489,
-    "tree_deletions": 382098
+    "tree_deletions": 382573
   },
   "top_upstream_only": [
     {
@@ -391,16 +391,16 @@
       "count": 11
     },
     {
+      "path": "crates/hermes-acp",
+      "count": 9
+    },
+    {
       "path": "crates/hermes-cron",
       "count": 9
     },
     {
       "path": "docs/implementation",
       "count": 9
-    },
-    {
-      "path": "crates/hermes-acp",
-      "count": 8
     },
     {
       "path": "docs/roadmaps",
@@ -715,16 +715,16 @@
       "count": 11
     },
     {
+      "path": "crates/hermes-acp",
+      "count": 9
+    },
+    {
       "path": "crates/hermes-cron",
       "count": 9
     },
     {
       "path": "docs/implementation",
       "count": 9
-    },
-    {
-      "path": "crates/hermes-acp",
-      "count": 8
     },
     {
       "path": "docs/roadmaps",
@@ -858,7 +858,7 @@
       "name": "Compatibility and divergence policy",
       "upstream_only": 392,
       "shared_different": 12,
-      "local_only": 193,
+      "local_only": 194,
       "risk": "high",
       "effort": "XL"
     },
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 685,
+    "local_patch_unique": 686,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T01:14:40.916594+00:00`
+Generated: `2026-05-30T01:29:35.389232+00:00`
 
 ## Scope
 
-- Local ref: `main` (`fc57078bd5d330cadae842c4512f2639013ff88d`)
+- Local ref: `main` (`db735720e0b8d454501a1136597f5b7f8158e85f`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T01:14:40.916594+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 803 |
+| Commits ahead local (`local` ancestry only) | 805 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 685 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 686 |
 | Files only in upstream tree | 1474 |
-| Files only in local tree | 568 |
+| Files only in local tree | 569 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
-| Total files changed (`local` vs `upstream`) | 3060 |
+| Total files changed (`local` vs `upstream`) | 3061 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 382098 |
+| Deletions (`local` vs `upstream`) | 382573 |
 
 ## Top 40 upstream-only buckets
 
@@ -130,9 +130,9 @@ Generated: `2026-05-30T01:14:40.916594+00:00`
 | `crates/hermes-parity-tests` | 15 |
 | `crates/hermes-environments` | 13 |
 | `crates/hermes-core` | 11 |
+| `crates/hermes-acp` | 9 |
 | `crates/hermes-cron` | 9 |
 | `docs/implementation` | 9 |
-| `crates/hermes-acp` | 8 |
 | `docs/roadmaps` | 8 |
 | `crates/hermes-mcp` | 7 |
 | `crates/hermes-skills` | 7 |
@@ -176,7 +176,7 @@ Generated: `2026-05-30T01:14:40.916594+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `685`
+- Local unique by patch-id: `686`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1666,16 +1666,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/acp",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/acp/test_permissions.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "57e2bd4e5b997a6bed90aa54e209344fc99954d4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/acp/test_permissions.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "a7248aa7178a71fde8a8c17317939d837d7bd87d",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T01:14:38.807690+00:00",
+  "generated_at_utc": "2026-05-30T01:29:33.199437+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "fc57078bd5d330cadae842c4512f2639013ff88d",
+    "local_sha": "db735720e0b8d454501a1136597f5b7f8158e85f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 758,
-      "intentional_divergence": 91,
+      "functional": 757,
+      "intentional_divergence": 92,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 260,
-      "rust_equivalent_or_contract_test_required": 679,
+      "not_required_for_runtime": 261,
+      "rust_equivalent_or_contract_test_required": 678,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 91,
+      "cleared_intentional_divergence": 92,
       "cleared_non_runtime": 169,
-      "pending_review": 758
+      "pending_review": 757
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 91,
+    "cleared_intentional_divergence": 92,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 758,
+    "pending_review": 757,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T01:14:38.807690+00:00`
+Generated: `2026-05-30T01:29:33.199437+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `758`
+- Pending functional review: `757`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `91`
+- Cleared intentional divergence: `92`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 91 |
+| `cleared_intentional_divergence` | 92 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 758 |
+| `pending_review` | 757 |
 
 ## Workstream Counts
 
@@ -48,7 +48,7 @@ Generated: `2026-05-30T01:14:38.807690+00:00`
 | `ui-tui/packages` | 18 |
 | `tests/plugins` | 16 |
 | `tests/cron` | 11 |
-| `tests/acp` | 7 |
+| `tests/acp` | 6 |
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -416,6 +416,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/acp/test_permissions.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ACP permission option and outcome-mapping contracts are covered by Rust ACP permission tests; Python async scheduler mechanics are reference-only for the Rust runtime.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "plugins/google_meet",
       "classification": "functional",
       "rationale": "Google Meet plugin differences affect connector/plugin runtime behavior.",


### PR DESCRIPTION
## Summary
- Align Rust ACP permission options with upstream stable option IDs, including session and permanent deny choices.
- Add option-id based mapping from ACP permission outcomes to Hermes approval results.
- Cover the upstream ACP permission contract in Rust tests and classify the Python scheduler mechanics as reference-only for the Rust runtime.

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- cargo test -p hermes-acp permissions
- cargo test -p hermes-acp
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- cargo test -p hermes-tools
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli
