### PR TITLE
parity(acp): cover approval isolation

### DIFF
--- a/crates/hermes-acp/src/permissions.rs
+++ b/crates/hermes-acp/src/permissions.rs
@@ -349,6 +349,83 @@ mod tests {
     }
 
     #[test]
+    fn permission_store_instances_do_not_share_pending_or_resolved_requests() {
+        let store_a = PermissionStore::new();
+        let store_b = PermissionStore::new();
+        let mut request = build_permission_request(
+            "acp-session-A",
+            "rm -rf /tmp/a",
+            "dangerous command",
+            true,
+            0,
+        );
+        request.id = "req-a".to_string();
+
+        store_a.add_pending(request);
+        assert_eq!(store_a.list_pending().len(), 1);
+        assert!(store_b.list_pending().is_empty());
+
+        assert!(store_a.resolve("req-a", PermissionOutcome::Denied));
+        assert!(!store_b.resolve("req-a", PermissionOutcome::Denied));
+        assert_eq!(store_a.drain_resolved().len(), 1);
+        assert!(store_b.drain_resolved().is_empty());
+    }
+
+    #[test]
+    fn permission_store_keeps_overlapping_sessions_isolated() {
+        use std::sync::{Arc, Barrier};
+
+        let store = Arc::new(PermissionStore::new());
+        let barrier = Arc::new(Barrier::new(3));
+        let mut handles = Vec::new();
+
+        for (session_id, request_id, command, outcome) in [
+            (
+                "acp-session-A",
+                "req-a",
+                "rm -rf /tmp/a",
+                PermissionOutcome::Denied,
+            ),
+            (
+                "acp-session-B",
+                "req-b",
+                "sudo apt update",
+                PermissionOutcome::Allowed {
+                    option_id: "allow_once".to_string(),
+                },
+            ),
+        ] {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                let mut request =
+                    build_permission_request(session_id, command, "dangerous command", true, 0);
+                request.id = request_id.to_string();
+                store.add_pending(request);
+                barrier.wait();
+                assert!(store.resolve(request_id, outcome));
+            }));
+        }
+
+        barrier.wait();
+        for handle in handles {
+            handle.join().expect("permission thread should not panic");
+        }
+
+        assert!(store.list_pending().is_empty());
+        let mut resolved = store.drain_resolved();
+        resolved.sort_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].0, "req-a");
+        assert!(matches!(resolved[0].1, PermissionOutcome::Denied));
+        assert_eq!(resolved[1].0, "req-b");
+        assert!(matches!(
+            &resolved[1].1,
+            PermissionOutcome::Allowed { option_id } if option_id == "allow_once"
+        ));
+    }
+
+    #[test]
     fn test_auto_callbacks() {
         let deny = auto_deny_callback();
         assert_eq!(deny("cmd", "desc"), "deny");

--- a/crates/hermes-acp/src/server.rs
+++ b/crates/hermes-acp/src/server.rs
@@ -197,6 +197,7 @@ mod tests {
     use super::*;
     use crate::events::AcpEvent;
     use crate::handler::HermesAcpHandler;
+    use crate::permissions::{build_permission_request, PermissionOutcome};
 
     #[tokio::test]
     async fn run_on_flushes_pending_events_after_each_response() {
@@ -235,5 +236,40 @@ mod tests {
         assert_eq!(lines[1]["params"]["tool_call_id"], "tc-read");
         assert_eq!(lines[1]["params"]["tool_name"], "read_file");
         assert_eq!(lines[1]["params"]["arguments"]["path"], "/tmp/a.txt");
+    }
+
+    #[test]
+    fn server_permission_stores_are_instance_scoped() {
+        let handler_a = Arc::new(HermesAcpHandler::new(
+            Arc::new(SessionManager::new()),
+            Arc::new(EventSink::default()),
+            Arc::new(PermissionStore::new()),
+        ));
+        let handler_b = Arc::new(HermesAcpHandler::new(
+            Arc::new(SessionManager::new()),
+            Arc::new(EventSink::default()),
+            Arc::new(PermissionStore::new()),
+        ));
+        let server_a = AcpServer::new(handler_a);
+        let server_b = AcpServer::new(handler_b);
+
+        let mut request = build_permission_request(
+            "acp-session-A",
+            "rm -rf /tmp/a",
+            "dangerous command",
+            true,
+            0,
+        );
+        request.id = "req-a".to_string();
+        server_a.permission_store().add_pending(request);
+
+        assert_eq!(server_a.permission_store().list_pending().len(), 1);
+        assert!(server_b.permission_store().list_pending().is_empty());
+        assert!(server_a
+            .permission_store()
+            .resolve("req-a", PermissionOutcome::Denied));
+        assert!(!server_b
+            .permission_store()
+            .resolve("req-a", PermissionOutcome::Denied));
     }
 }

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T02:06:02.628874+00:00",
+  "generated_at_utc": "2026-05-30T02:16:52.537316+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b3affd9de7c53ed5404fdf062ce9f4e24002702a",
+    "local_sha": "f688dbbe000e7c3e2d60b4e4a17ee5e7cffb9cb3",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 809,
+    "commits_ahead": 811,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 688,
+    "local_patch_unique": 689,
     "files_only_upstream": 1474,
     "files_only_local": 569,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3061,
     "tree_insertions": 740489,
-    "tree_deletions": 383009
+    "tree_deletions": 383341
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 688,
+    "local_patch_unique": 689,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T02:06:02.628874+00:00`
+Generated: `2026-05-30T02:16:52.537316+00:00`
 
 ## Scope
 
-- Local ref: `main` (`b3affd9de7c53ed5404fdf062ce9f4e24002702a`)
+- Local ref: `main` (`f688dbbe000e7c3e2d60b4e4a17ee5e7cffb9cb3`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T02:06:02.628874+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 809 |
+| Commits ahead local (`local` ancestry only) | 811 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 688 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 689 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 569 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3061 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 383009 |
+| Deletions (`local` vs `upstream`) | 383341 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T02:06:02.628874+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `688`
+- Local unique by patch-id: `689`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1591,16 +1591,16 @@
       "workstream": "WS4"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/acp",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/acp/test_approval_isolation.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "99a38aadd9ebfc0c2a99599d7ea55a1f67b92ae9",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/acp/test_approval_isolation.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e6d3f593f764a9f0d54c874f86e7d2466d8b925b",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T02:06:06.190260+00:00",
+  "generated_at_utc": "2026-05-30T02:17:00.293906+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b3affd9de7c53ed5404fdf062ce9f4e24002702a",
+    "local_sha": "f688dbbe000e7c3e2d60b4e4a17ee5e7cffb9cb3",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 754,
-      "intentional_divergence": 95,
+      "functional": 753,
+      "intentional_divergence": 96,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 264,
-      "rust_equivalent_or_contract_test_required": 675,
+      "not_required_for_runtime": 265,
+      "rust_equivalent_or_contract_test_required": 674,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 95,
+      "cleared_intentional_divergence": 96,
       "cleared_non_runtime": 169,
-      "pending_review": 754
+      "pending_review": 753
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 95,
+    "cleared_intentional_divergence": 96,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 754,
+    "pending_review": 753,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T02:06:06.190260+00:00`
+Generated: `2026-05-30T02:17:00.293906+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `754`
+- Pending functional review: `753`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `95`
+- Cleared intentional divergence: `96`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 95 |
+| `cleared_intentional_divergence` | 96 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 754 |
+| `pending_review` | 753 |
 
 ## Workstream Counts
 
@@ -53,7 +53,7 @@ Generated: `2026-05-30T02:06:06.190260+00:00`
 | `tests/stress` | 5 |
 | `tests/providers` | 4 |
 | `tests/tui_gateway` | 4 |
-| `tests/acp` | 3 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
+| `tests/acp` | 2 |
 | `tests/e2e` | 2 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -409,6 +409,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/acp/test_approval_isolation.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ACP approval-isolation regressions are covered by Rust ACP permission-store and server-instance tests: pending and resolved approvals are scoped to explicit PermissionStore instances, overlapping sessions resolve independently, and no Python module-global callback/runtime path exists.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/acp/test_auth.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream ACP auth helper behavior is covered by Rust ACP auth-method and initialize/authenticate tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- add Rust ACP permission-store regression tests for isolated pending/resolved approvals
- add Rust ACP server-instance regression test proving permission stores are instance scoped
- clear tests/acp/test_approval_isolation.py from the shared-diff backlog with regenerated parity docs

## Local verification
- cargo fmt --check
- git diff --check
- cargo test -p hermes-acp permission_store -- --nocapture
- cargo test -p hermes-acp server_permission_stores_are_instance_scoped -- --nocapture
- cargo test -p hermes-acp
- cargo test -p hermes-parity-tests
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" .
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli