### PR TITLE
parity(acp): add tool metadata

### DIFF
--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -1,8 +1,8 @@
 //! ACP event types for bridging agent progress to the ACP client.
 //!
-//! Mirrors the Python `acp_adapter/events.py` — provides callback factories
-//! that bridge AIAgent events (tool progress, thinking, step completion,
-//! message streaming) to ACP session update notifications.
+//! Provides callback factories that bridge agent events (tool progress,
+//! thinking, step completion, message streaming) to ACP session update
+//! notifications.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
@@ -10,6 +10,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+use crate::tools::{tool_completion_status, tool_start_metadata};
 
 // ---------------------------------------------------------------------------
 // Event types
@@ -48,9 +50,15 @@ pub struct AcpEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -75,8 +83,11 @@ impl AcpEvent {
             text: Some(text.to_string()),
             tool_call_id: None,
             tool_name: None,
+            tool_kind: None,
+            title: None,
             arguments: None,
             result: None,
+            status: None,
             api_call_count: None,
             error: None,
         }
@@ -88,15 +99,19 @@ impl AcpEvent {
         tool_name: &str,
         arguments: Option<Value>,
     ) -> Self {
+        let metadata = tool_start_metadata(tool_name, arguments.as_ref());
         Self {
             kind: AcpEventKind::ToolCallStart,
             session_id: session_id.to_string(),
             timestamp: Self::now(),
             tool_call_id: Some(tool_call_id.to_string()),
             tool_name: Some(tool_name.to_string()),
+            tool_kind: Some(metadata.kind.to_string()),
+            title: Some(metadata.title),
             arguments,
             text: None,
             result: None,
+            status: None,
             api_call_count: None,
             error: None,
         }
@@ -108,15 +123,19 @@ impl AcpEvent {
         tool_name: &str,
         result: Option<String>,
     ) -> Self {
+        let status = tool_completion_status(tool_name, result.as_deref());
         Self {
             kind: AcpEventKind::ToolCallComplete,
             session_id: session_id.to_string(),
             timestamp: Self::now(),
             tool_call_id: Some(tool_call_id.to_string()),
             tool_name: Some(tool_name.to_string()),
+            tool_kind: Some(crate::tools::tool_kind(tool_name).to_string()),
+            title: Some(tool_start_metadata(tool_name, None).title),
             result,
             text: None,
             arguments: None,
+            status: Some(status.to_string()),
             api_call_count: None,
             error: None,
         }
@@ -130,8 +149,11 @@ impl AcpEvent {
             text: Some(text.to_string()),
             tool_call_id: None,
             tool_name: None,
+            tool_kind: None,
+            title: None,
             arguments: None,
             result: None,
+            status: None,
             api_call_count: None,
             error: None,
         }
@@ -145,8 +167,11 @@ impl AcpEvent {
             text: Some(text.to_string()),
             tool_call_id: None,
             tool_name: None,
+            tool_kind: None,
+            title: None,
             arguments: None,
             result: None,
+            status: None,
             api_call_count: None,
             error: None,
         }
@@ -160,8 +185,11 @@ impl AcpEvent {
             api_call_count: Some(api_call_count),
             tool_call_id: None,
             tool_name: None,
+            tool_kind: None,
+            title: None,
             arguments: None,
             result: None,
+            status: None,
             text: None,
             error: None,
         }
@@ -175,8 +203,11 @@ impl AcpEvent {
             error: Some(error.to_string()),
             tool_call_id: None,
             tool_name: None,
+            tool_kind: None,
+            title: None,
             arguments: None,
             result: None,
+            status: None,
             text: None,
             api_call_count: None,
         }
@@ -187,8 +218,7 @@ impl AcpEvent {
 // ToolCallIdTracker
 // ---------------------------------------------------------------------------
 
-/// Tracks tool call IDs per tool name using a FIFO queue, matching the Python
-/// `tool_call_ids: dict[str, Deque[str]]` pattern.
+/// Tracks tool call IDs per tool name using a FIFO queue.
 #[derive(Debug, Default)]
 pub struct ToolCallIdTracker {
     queues: HashMap<String, VecDeque<String>>,
@@ -323,11 +353,25 @@ mod tests {
 
     #[test]
     fn test_acp_event_kinds() {
-        let e = AcpEvent::tool_call_start("s1", "tc1", "read_file", None);
+        let e = AcpEvent::tool_call_start(
+            "s1",
+            "tc1",
+            "read_file",
+            Some(serde_json::json!({"path": "/tmp/a.txt"})),
+        );
         assert_eq!(e.kind, AcpEventKind::ToolCallStart);
         assert_eq!(e.tool_name.as_deref(), Some("read_file"));
+        assert_eq!(e.tool_kind.as_deref(), Some("read"));
+        assert_eq!(e.title.as_deref(), Some("read: /tmp/a.txt"));
 
-        let e2 = AcpEvent::tool_call_complete("s1", "tc1", "read_file", Some("ok".into()));
-        assert_eq!(e2.result.as_deref(), Some("ok"));
+        let e2 = AcpEvent::tool_call_complete(
+            "s1",
+            "tc1",
+            "read_file",
+            Some(r#"{"error":"missing"}"#.into()),
+        );
+        assert_eq!(e2.result.as_deref(), Some(r#"{"error":"missing"}"#));
+        assert_eq!(e2.tool_kind.as_deref(), Some("read"));
+        assert_eq!(e2.status.as_deref(), Some("failed"));
     }
 }

--- a/crates/hermes-acp/src/lib.rs
+++ b/crates/hermes-acp/src/lib.rs
@@ -17,6 +17,7 @@ pub mod permissions;
 pub mod protocol;
 pub mod server;
 pub mod session;
+pub mod tools;
 
 pub use auth::{build_auth_methods, detect_provider, has_provider, TERMINAL_SETUP_AUTH_METHOD_ID};
 pub use events::{AcpEvent, AcpEventKind, EventSink, ToolCallIdTracker};
@@ -34,6 +35,10 @@ pub use protocol::{
 };
 pub use server::AcpServer;
 pub use session::{SessionInfo, SessionManager, SessionPhase, SessionState};
+pub use tools::{
+    make_tool_call_id, tool_completion_status, tool_kind, tool_start_metadata, tool_title,
+    ToolStartMetadata,
+};
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/crates/hermes-acp/src/tools.rs
+++ b/crates/hermes-acp/src/tools.rs
@@ -1,0 +1,341 @@
+//! ACP tool metadata helpers.
+//!
+//! These helpers keep ACP tool events compact but informative for clients.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::Value;
+
+const TOOL_KIND_MAP: &[(&str, &str)] = &[
+    ("read_file", "read"),
+    ("search_files", "search"),
+    ("terminal", "execute"),
+    ("bash", "execute"),
+    ("process", "execute"),
+    ("execute_code", "execute"),
+    ("patch", "edit"),
+    ("write_file", "edit"),
+    ("web_search", "fetch"),
+    ("web_extract", "fetch"),
+    ("browser_navigate", "fetch"),
+    ("browser_click", "fetch"),
+    ("skill_view", "read"),
+    ("skill_manage", "edit"),
+    ("todo", "other"),
+    ("memory", "other"),
+    ("session_search", "read"),
+    ("delegate_task", "other"),
+];
+
+static TOOL_CALL_IDS: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolStartMetadata {
+    pub kind: &'static str,
+    pub title: String,
+}
+
+pub fn make_tool_call_id() -> String {
+    let id = TOOL_CALL_IDS.fetch_add(1, Ordering::Relaxed);
+    format!("tc-{id}")
+}
+
+pub fn tool_kind(tool_name: &str) -> &'static str {
+    TOOL_KIND_MAP
+        .iter()
+        .find_map(|(name, kind)| (*name == tool_name).then_some(*kind))
+        .unwrap_or("other")
+}
+
+pub fn tool_start_metadata(tool_name: &str, arguments: Option<&Value>) -> ToolStartMetadata {
+    ToolStartMetadata {
+        kind: tool_kind(tool_name),
+        title: tool_title(tool_name, arguments),
+    }
+}
+
+pub fn tool_title(tool_name: &str, arguments: Option<&Value>) -> String {
+    let value = arguments.unwrap_or(&Value::Null);
+    match tool_name {
+        "terminal" | "bash" => value_string(value, "command")
+            .map(|cmd| truncate_chars(&cmd, 110))
+            .unwrap_or_else(|| tool_name.to_string()),
+        "read_file" => value_string(value, "path")
+            .map(|path| format!("read: {path}"))
+            .unwrap_or_else(|| "read_file".to_string()),
+        "search_files" => value_string(value, "pattern")
+            .map(|pattern| format!("search: {pattern}"))
+            .unwrap_or_else(|| "search_files".to_string()),
+        "patch" | "write_file" => value_string(value, "path")
+            .map(|path| format!("{tool_name}: {path}"))
+            .unwrap_or_else(|| tool_name.to_string()),
+        "web_search" => value_string(value, "query")
+            .map(|query| format!("search: {query}"))
+            .unwrap_or_else(|| "web_search".to_string()),
+        "web_extract" => value_urls(value, "urls")
+            .first()
+            .map(|url| format!("extract: {url}"))
+            .unwrap_or_else(|| "web_extract".to_string()),
+        "browser_navigate" => value_string(value, "url")
+            .map(|url| format!("navigate: {url}"))
+            .unwrap_or_else(|| "browser_navigate".to_string()),
+        "skill_view" => {
+            let name = value_string(value, "name").unwrap_or_else(|| "unknown".to_string());
+            match value_string(value, "file_path") {
+                Some(file_path) if !file_path.trim().is_empty() => {
+                    format!("skill view ({name}/{file_path})")
+                }
+                _ => format!("skill view ({name})"),
+            }
+        }
+        "skill_manage" => {
+            let action = value_string(value, "action").unwrap_or_else(|| "manage".to_string());
+            let name = value_string(value, "name").unwrap_or_else(|| "unknown".to_string());
+            match value_string(value, "file_path") {
+                Some(file_path) if !file_path.trim().is_empty() => {
+                    format!("skill {action}: {name}/{file_path}")
+                }
+                _ => format!("skill {action}: {name}"),
+            }
+        }
+        "execute_code" => {
+            let language = value_string(value, "language").unwrap_or_else(|| "code".to_string());
+            value_string(value, "code")
+                .and_then(|code| first_non_empty_line(&code))
+                .map(|line| format!("{language}: {}", truncate_chars(&line, 90)))
+                .unwrap_or_else(|| "execute_code".to_string())
+        }
+        "todo" => todo_title(value),
+        other => other.to_string(),
+    }
+}
+
+pub fn tool_completion_status(tool_name: &str, result: Option<&str>) -> &'static str {
+    if result
+        .map(|output| tool_output_failed(tool_name, output))
+        .unwrap_or(false)
+    {
+        "failed"
+    } else {
+        "completed"
+    }
+}
+
+pub fn tool_output_failed(tool_name: &str, output: &str) -> bool {
+    let trimmed = output.trim();
+    if trimmed.starts_with("Error executing tool '") {
+        return true;
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+        return false;
+    };
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    if obj.get("success").and_then(Value::as_bool) == Some(false)
+        || obj.get("ok").and_then(Value::as_bool) == Some(false)
+    {
+        return true;
+    }
+    if obj
+        .get("exit_code")
+        .or_else(|| obj.get("returncode"))
+        .and_then(Value::as_i64)
+        .is_some_and(|code| code != 0)
+    {
+        return true;
+    }
+    obj.contains_key("error")
+        && matches!(
+            tool_name,
+            "read_file" | "write_file" | "patch" | "skill_manage" | "execute_code" | "terminal"
+        )
+}
+
+fn value_string(value: &Value, key: &str) -> Option<String> {
+    let raw = value.get(key)?;
+    if let Some(text) = raw.as_str() {
+        Some(text.to_string())
+    } else {
+        Some(raw.to_string())
+    }
+    .map(|text| text.trim().to_string())
+    .filter(|text| !text.is_empty())
+}
+
+fn value_urls(value: &Value, key: &str) -> Vec<String> {
+    let Some(raw) = value.get(key) else {
+        return Vec::new();
+    };
+    if let Some(url) = raw.as_str() {
+        return vec![url.to_string()];
+    }
+    raw.as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(ToString::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn first_non_empty_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToString::to_string)
+}
+
+fn todo_title(value: &Value) -> String {
+    let count = value
+        .get("todos")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    match count {
+        1 => "todo (1 item)".to_string(),
+        n => format!("todo ({n} items)"),
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let keep = max_chars.saturating_sub(3);
+    let head: String = text.chars().take(keep).collect();
+    format!("{head}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tool_kind_covers_common_hermes_tools() {
+        for (tool, expected) in [
+            ("read_file", "read"),
+            ("search_files", "search"),
+            ("terminal", "execute"),
+            ("patch", "edit"),
+            ("write_file", "edit"),
+            ("process", "execute"),
+            ("web_search", "fetch"),
+            ("execute_code", "execute"),
+            ("todo", "other"),
+            ("skill_view", "read"),
+            ("browser_navigate", "fetch"),
+            ("unknown_tool", "other"),
+        ] {
+            assert_eq!(tool_kind(tool), expected);
+        }
+    }
+
+    #[test]
+    fn make_tool_call_id_uses_stable_prefix_and_unique_values() {
+        let first = make_tool_call_id();
+        let second = make_tool_call_id();
+        assert!(first.starts_with("tc-"));
+        assert!(second.starts_with("tc-"));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn tool_title_uses_human_readable_arguments() {
+        assert_eq!(
+            tool_title("terminal", Some(&json!({"command": "ls -la /tmp"}))),
+            "ls -la /tmp"
+        );
+        assert_eq!(
+            tool_title("read_file", Some(&json!({"path": "/etc/hosts"}))),
+            "read: /etc/hosts"
+        );
+        assert_eq!(
+            tool_title("search_files", Some(&json!({"pattern": "TODO"}))),
+            "search: TODO"
+        );
+        assert_eq!(
+            tool_title("web_search", Some(&json!({"query": "rust acp"}))),
+            "search: rust acp"
+        );
+        assert_eq!(
+            tool_title("browser_navigate", Some(&json!({"url": "https://x.com"}))),
+            "navigate: https://x.com"
+        );
+        assert_eq!(
+            tool_title(
+                "skill_view",
+                Some(&json!({"name": "github-pitfalls", "file_path": "references/api.md"}))
+            ),
+            "skill view (github-pitfalls/references/api.md)"
+        );
+        assert_eq!(
+            tool_title(
+                "execute_code",
+                Some(&json!({"language": "rust", "code": "\nprintln!(\"hello\");"}))
+            ),
+            "rust: println!(\"hello\");"
+        );
+        assert_eq!(
+            tool_title(
+                "skill_manage",
+                Some(&json!({"action": "patch", "name": "ops", "file_path": "ref.md"}))
+            ),
+            "skill patch: ops/ref.md"
+        );
+        assert_eq!(
+            tool_title(
+                "todo",
+                Some(&json!({"todos": [{"id": "one", "content": "Fix ACP"}]}))
+            ),
+            "todo (1 item)"
+        );
+    }
+
+    #[test]
+    fn terminal_titles_are_truncated() {
+        let title = tool_title("terminal", Some(&json!({"command": "x".repeat(200)})));
+        assert!(title.len() < 120);
+        assert!(title.ends_with("..."));
+    }
+
+    #[test]
+    fn completion_status_detects_structured_failures() {
+        assert_eq!(
+            tool_completion_status("terminal", Some(r#"{"exit_code": 2}"#)),
+            "failed"
+        );
+        assert_eq!(
+            tool_completion_status("execute_code", Some(r#"{"returncode": 1}"#)),
+            "failed"
+        );
+        assert_eq!(
+            tool_completion_status("skill_manage", Some(r#"{"success": false}"#)),
+            "failed"
+        );
+        assert_eq!(
+            tool_completion_status("some_tool", Some(r#"{"ok": false}"#)),
+            "failed"
+        );
+        assert_eq!(
+            tool_completion_status("read_file", Some(r#"{"error": "File not found"}"#)),
+            "failed"
+        );
+        assert_eq!(
+            tool_completion_status("some_tool", Some(r#"{"error": "optional timeout"}"#)),
+            "completed"
+        );
+        assert_eq!(
+            tool_completion_status("terminal", Some("Error: pytest collected 0 items")),
+            "completed"
+        );
+        assert_eq!(
+            tool_completion_status("patch", Some("Error executing tool 'patch': boom")),
+            "failed"
+        );
+    }
+}

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T02:16:52.537316+00:00",
+  "generated_at_utc": "2026-05-30T02:30:53.941230+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "f688dbbe000e7c3e2d60b4e4a17ee5e7cffb9cb3",
+    "local_sha": "33e0e1d02afdf24df497c3b847487febdf6f733f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 811,
+    "commits_ahead": 813,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 689,
+    "local_patch_unique": 690,
     "files_only_upstream": 1474,
     "files_only_local": 569,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3061,
     "tree_insertions": 740489,
-    "tree_deletions": 383341
+    "tree_deletions": 383461
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 689,
+    "local_patch_unique": 690,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T02:16:52.537316+00:00`
+Generated: `2026-05-30T02:30:53.941230+00:00`
 
 ## Scope
 
-- Local ref: `main` (`f688dbbe000e7c3e2d60b4e4a17ee5e7cffb9cb3`)
+- Local ref: `main` (`33e0e1d02afdf24df497c3b847487febdf6f733f`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T02:16:52.537316+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 811 |
+| Commits ahead local (`local` ancestry only) | 813 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 689 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 690 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 569 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3061 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 383341 |
+| Deletions (`local` vs `upstream`) | 383461 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T02:16:52.537316+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `689`
+- Local unique by patch-id: `690`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1696,16 +1696,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/acp",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/acp/test_tools.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f9b0dac6d66a3142e4b32a3e213751d044f065d4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/acp/test_tools.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1da33df1ed4dae3f0fbc2b0a03ffd9271e65d51b",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T02:17:00.293906+00:00",
+  "generated_at_utc": "2026-05-30T02:31:00.609231+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "f688dbbe000e7c3e2d60b4e4a17ee5e7cffb9cb3",
+    "local_sha": "33e0e1d02afdf24df497c3b847487febdf6f733f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 753,
-      "intentional_divergence": 96,
+      "functional": 752,
+      "intentional_divergence": 97,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 265,
-      "rust_equivalent_or_contract_test_required": 674,
+      "not_required_for_runtime": 266,
+      "rust_equivalent_or_contract_test_required": 673,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 96,
+      "cleared_intentional_divergence": 97,
       "cleared_non_runtime": 169,
-      "pending_review": 753
+      "pending_review": 752
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 96,
+    "cleared_intentional_divergence": 97,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 753,
+    "pending_review": 752,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T02:17:00.293906+00:00`
+Generated: `2026-05-30T02:31:00.609231+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `753`
+- Pending functional review: `752`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `96`
+- Cleared intentional divergence: `97`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 96 |
+| `cleared_intentional_divergence` | 97 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 753 |
+| `pending_review` | 752 |
 
 ## Workstream Counts
 
@@ -55,5 +55,5 @@ Generated: `2026-05-30T02:17:00.293906+00:00`
 | `tests/tui_gateway` | 4 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
-| `tests/acp` | 2 |
 | `tests/e2e` | 2 |
+| `tests/acp` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -451,6 +451,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/acp/test_tools.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ACP tool metadata and rendering intent is covered by Rust ACP tool helpers and event metadata: common tool kind mapping, stable tc-* call IDs, human-readable titles, structured failure status detection, and tool_kind/title/status fields on emitted ACP tool events.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "plugins/google_meet",
       "classification": "functional",
       "rationale": "Google Meet plugin differences affect connector/plugin runtime behavior.",


### PR DESCRIPTION
## Summary
- Add Rust ACP tool metadata helpers for kind mapping, stable tc-* IDs, human-readable titles, and completion status detection.
- Emit tool_kind/title/status on Rust ACP tool start/complete events.
- Clear upstream tests/acp/test_tools.py as intentional Rust coverage and regenerate parity docs.

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p hermes-acp
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli