### PR TITLE
parity(acp): finish server wire contract

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -1,6 +1,4 @@
-//! Full ACP request handler — implements all ACP protocol methods.
-//!
-//! Mirrors the Python `acp_adapter/server.py` HermesACPAgent class.
+//! Full ACP request handler that implements the ACP protocol methods.
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -439,7 +437,7 @@ fn embedded_resource_to_parts(block: &serde_json::Map<String, Value>) -> Vec<Val
 }
 
 fn extract_prompt_payload(p: &serde_json::Map<String, Value>) -> PromptExtraction {
-    if let Some(prompt_val) = p.get("prompt") {
+    if let Some(prompt_val) = p.get("prompt").or_else(|| p.get("content")) {
         if let Some(s) = prompt_val.as_str() {
             let text = s.to_string();
             return PromptExtraction {
@@ -836,6 +834,10 @@ fn param_str<'a>(p: &'a serde_json::Map<String, Value>, key: &str) -> Option<&'a
     p.get(key)?.as_str()
 }
 
+fn param_str_any<'a>(p: &'a serde_json::Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| param_str(p, key))
+}
+
 fn param_value_as_string(p: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
     let value = p.get(key)?;
     if let Some(s) = value.as_str() {
@@ -843,6 +845,60 @@ fn param_value_as_string(p: &serde_json::Map<String, Value>, key: &str) -> Optio
     } else {
         Some(value.to_string())
     }
+}
+
+fn param_value_as_string_any(p: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| param_value_as_string(p, key))
+}
+
+fn prompt_response_value(stop_reason: StopReason, usage: Option<Usage>) -> Value {
+    serde_json::to_value(PromptResponse { stop_reason, usage }).unwrap_or_else(|_| json!({}))
+}
+
+fn session_id_response(session_id: &str) -> Value {
+    json!({"sessionId": session_id})
+}
+
+fn session_title_from_history(history: &[Value]) -> Option<String> {
+    history.iter().find_map(|message| {
+        let role = message.get("role").and_then(Value::as_str)?;
+        if role != "user" {
+            return None;
+        }
+        let content = message.get("content")?;
+        let text = if let Some(text) = content.as_str() {
+            text.to_string()
+        } else if let Some(parts) = content.as_array() {
+            parts
+                .iter()
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(" ")
+        } else {
+            String::new()
+        };
+        let title = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        (!title.is_empty()).then(|| {
+            if title.chars().count() > 80 {
+                format!("{}...", title.chars().take(77).collect::<String>())
+            } else {
+                title
+            }
+        })
+    })
+}
+
+fn session_info_value(session: &SessionState) -> Value {
+    json!({
+        "sessionId": session.session_id,
+        "cwd": session.cwd,
+        "model": session.model,
+        "phase": session.phase,
+        "historyLen": session.history.len(),
+        "createdAt": session.created_at.to_string(),
+        "updatedAt": session.updated_at.to_string(),
+        "title": session_title_from_history(&session.history),
+    })
 }
 
 #[async_trait::async_trait]
@@ -901,14 +957,14 @@ impl AcpHandler for HermesAcpHandler {
                     .and_then(|p| param_str(p, "cwd"))
                     .unwrap_or(".");
                 let state = self.session_manager.create_session(cwd);
-                AcpResponse::success(request.id, json!({"session_id": state.session_id}))
+                AcpResponse::success(request.id, session_id_response(&state.session_id))
             }
 
             AcpMethod::LoadSession => {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
 
                 match self.session_manager.update_cwd(session_id, cwd) {
@@ -925,7 +981,7 @@ impl AcpHandler for HermesAcpHandler {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
 
                 if self.session_manager.get_session(session_id).is_some() {
@@ -933,7 +989,7 @@ impl AcpHandler for HermesAcpHandler {
                     AcpResponse::success(request.id, json!({}))
                 } else {
                     let state = self.session_manager.create_session(cwd);
-                    AcpResponse::success(request.id, json!({"session_id": state.session_id}))
+                    AcpResponse::success(request.id, session_id_response(&state.session_id))
                 }
             }
 
@@ -941,14 +997,13 @@ impl AcpHandler for HermesAcpHandler {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
 
                 match self.session_manager.fork_session(session_id, cwd) {
-                    Some(new_state) => AcpResponse::success(
-                        request.id,
-                        json!({"session_id": new_state.session_id}),
-                    ),
+                    Some(new_state) => {
+                        AcpResponse::success(request.id, session_id_response(&new_state.session_id))
+                    }
                     None => AcpResponse::error(
                         request.id,
                         -32602,
@@ -958,23 +1013,48 @@ impl AcpHandler for HermesAcpHandler {
             }
 
             AcpMethod::ListSessions => {
-                let sessions: Vec<Value> = self
-                    .session_manager
-                    .list_sessions()
-                    .iter()
-                    .map(|s| {
-                        json!({
-                            "session_id": s.session_id,
-                            "cwd": s.cwd,
-                        })
-                    })
-                    .collect();
-                AcpResponse::success(request.id, json!({"sessions": sessions}))
+                let cwd_filter = params_obj(&request.params)
+                    .and_then(|p| param_str(p, "cwd"))
+                    .filter(|cwd| !cwd.trim().is_empty());
+                let cursor = params_obj(&request.params)
+                    .and_then(|p| param_str(p, "cursor"))
+                    .filter(|cursor| !cursor.trim().is_empty());
+                let mut sessions = self.session_manager.list_session_states();
+                if let Some(cwd) = cwd_filter {
+                    sessions.retain(|s| s.cwd == cwd);
+                }
+                sessions.sort_by(|a, b| {
+                    b.updated_at
+                        .cmp(&a.updated_at)
+                        .then_with(|| a.session_id.cmp(&b.session_id))
+                });
+                if let Some(cursor) = cursor {
+                    if let Some(index) = sessions.iter().position(|s| s.session_id == cursor) {
+                        sessions = sessions.into_iter().skip(index + 1).collect();
+                    } else {
+                        sessions.clear();
+                    }
+                }
+                const LIST_SESSIONS_PAGE_SIZE: usize = 50;
+                let next_cursor = (sessions.len() > LIST_SESSIONS_PAGE_SIZE)
+                    .then(|| sessions[LIST_SESSIONS_PAGE_SIZE - 1].session_id.clone());
+                let page = sessions
+                    .into_iter()
+                    .take(LIST_SESSIONS_PAGE_SIZE)
+                    .map(|s| session_info_value(&s))
+                    .collect::<Vec<_>>();
+                AcpResponse::success(
+                    request.id,
+                    json!({
+                        "sessions": page,
+                        "nextCursor": next_cursor,
+                    }),
+                )
             }
 
             AcpMethod::Cancel => {
                 let session_id = params_obj(&request.params)
-                    .and_then(|p| param_str(p, "session_id"))
+                    .and_then(|p| param_str_any(p, &["sessionId", "session_id"]))
                     .unwrap_or("");
                 self.session_manager
                     .set_phase(session_id, SessionPhase::Cancelled);
@@ -987,13 +1067,12 @@ impl AcpHandler for HermesAcpHandler {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
 
                 if self.session_manager.get_session(session_id).is_none() {
-                    return AcpResponse::error(
+                    return AcpResponse::success(
                         request.id,
-                        -32602,
-                        format!("Session not found: {}", session_id),
+                        prompt_response_value(StopReason::Refusal, None),
                     );
                 }
 
@@ -1004,7 +1083,10 @@ impl AcpHandler for HermesAcpHandler {
                 let has_content = extraction.has_content;
 
                 if !has_content {
-                    return AcpResponse::success(request.id, json!({"stop_reason": "end_turn"}));
+                    return AcpResponse::success(
+                        request.id,
+                        prompt_response_value(StopReason::EndTurn, None),
+                    );
                 }
 
                 // Intercept slash commands
@@ -1014,7 +1096,7 @@ impl AcpHandler for HermesAcpHandler {
                             .push(AcpEvent::message_complete(session_id, &response_text));
                         return AcpResponse::success(
                             request.id,
-                            json!({"stop_reason": "end_turn"}),
+                            prompt_response_value(StopReason::EndTurn, None),
                         );
                     }
                 }
@@ -1126,11 +1208,10 @@ impl AcpHandler for HermesAcpHandler {
                 self.session_manager
                     .set_phase(session_id, SessionPhase::Idle);
 
-                let mut payload = json!({"stop_reason": "end_turn"});
-                if let Some(usage) = usage {
-                    payload["usage"] = serde_json::to_value(usage).unwrap_or_else(|_| json!({}));
-                }
-                AcpResponse::success(request.id, payload)
+                AcpResponse::success(
+                    request.id,
+                    prompt_response_value(StopReason::EndTurn, usage),
+                )
             }
 
             // -- Session configuration --------------------------------------
@@ -1138,8 +1219,8 @@ impl AcpHandler for HermesAcpHandler {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
-                let model_id = param_str(p, "model_id")
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
+                let model_id = param_str_any(p, &["modelId", "model_id"])
                     .or_else(|| param_str(p, "model"))
                     .unwrap_or("");
 
@@ -1168,8 +1249,8 @@ impl AcpHandler for HermesAcpHandler {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
-                let mode_id = param_str(p, "mode_id")
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
+                let mode_id = param_str_any(p, &["modeId", "mode_id"])
                     .or_else(|| param_str(p, "mode"))
                     .unwrap_or("");
                 if mode_id.trim().is_empty() {
@@ -1193,13 +1274,14 @@ impl AcpHandler for HermesAcpHandler {
                 let Some(p) = params_obj(&request.params) else {
                     return AcpResponse::error(request.id, -32602, "Missing params");
                 };
-                let session_id = param_str(p, "session_id").unwrap_or("");
-                let key = param_str(p, "key")
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
+                let key = param_str_any(p, &["configId", "config_id"])
+                    .or_else(|| param_str(p, "key"))
                     .or_else(|| param_str(p, "option"))
                     .or_else(|| param_str(p, "name"))
                     .unwrap_or("");
                 let value = param_value_as_string(p, "value")
-                    .or_else(|| param_value_as_string(p, "option_value"))
+                    .or_else(|| param_value_as_string_any(p, &["optionValue", "option_value"]))
                     .unwrap_or_default();
 
                 if key.trim().is_empty() {
@@ -1216,7 +1298,7 @@ impl AcpHandler for HermesAcpHandler {
                 {
                     Some(_) => AcpResponse::success(
                         request.id,
-                        json!({"config_options": [{"key": key, "value": value}]}),
+                        json!({"configOptions": [{"configId": key, "value": value}]}),
                     ),
                     None => AcpResponse::error(
                         request.id,
@@ -1458,7 +1540,32 @@ mod tests {
         let resp = handler.handle_request(req).await;
         assert!(resp.result.is_some());
         let result = resp.result.unwrap();
-        assert_eq!(result["agent_info"]["name"], "hermes-agent");
+        assert_eq!(result["agentInfo"]["name"], "hermes-agent");
+    }
+
+    #[tokio::test]
+    async fn test_initialize_uses_acp_wire_aliases() {
+        let handler = make_handler();
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "initialize".into(),
+                params: None,
+            })
+            .await;
+        let result = resp.result.unwrap();
+
+        assert_eq!(result["protocolVersion"], 1);
+        assert_eq!(result["agentInfo"]["name"], "hermes-agent");
+        assert_eq!(result["agentCapabilities"]["loadSession"], true);
+        assert_eq!(
+            result["agentCapabilities"]["sessionCapabilities"]["fork"],
+            true
+        );
+        assert!(result.get("protocol_version").is_none());
+        assert!(result.get("agent_info").is_none());
+        assert!(result["agentCapabilities"].get("load_session").is_none());
     }
 
     #[tokio::test]
@@ -1472,7 +1579,7 @@ mod tests {
         };
         let resp = handler.handle_request(req).await;
         let result = resp.result.unwrap();
-        let methods = result["auth_methods"].as_array().expect("auth methods");
+        let methods = result["authMethods"].as_array().expect("auth methods");
 
         assert_eq!(methods[0]["id"], "openrouter");
         assert_eq!(methods[0]["name"], "openrouter runtime credentials");
@@ -1497,7 +1604,7 @@ mod tests {
         let result = resp.result.unwrap();
 
         assert_eq!(
-            result["auth_methods"],
+            result["authMethods"],
             json!([{
                 "args": ["--setup"],
                 "description": "Open Hermes' interactive model/provider setup in a terminal. Use this when Hermes has not been configured on this machine yet.",
@@ -1580,7 +1687,7 @@ mod tests {
             params: Some(json!({"cwd": "/tmp"})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1608,6 +1715,139 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_session_methods_accept_camel_case_wire_fields() {
+        let handler = make_handler();
+        let created = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/new".into(),
+                params: Some(json!({"cwd": "/tmp"})),
+            })
+            .await
+            .result
+            .unwrap();
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        let loaded = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session/load".into(),
+                params: Some(json!({"sessionId": session_id, "cwd": "/work"})),
+            })
+            .await;
+        assert!(loaded.error.is_none());
+
+        let model = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(3)),
+                method: "session/set_model".into(),
+                params: Some(json!({"sessionId": session_id, "modelId": "nous:gpt-5.4"})),
+            })
+            .await;
+        assert!(model.error.is_none());
+
+        let mode = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(4)),
+                method: "session/set_mode".into(),
+                params: Some(json!({"sessionId": session_id, "modeId": "code"})),
+            })
+            .await;
+        assert!(mode.error.is_none());
+
+        let config = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(5)),
+                method: "session/set_config".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "configId": "approval_mode",
+                    "value": "auto"
+                })),
+            })
+            .await
+            .result
+            .unwrap();
+        assert_eq!(config["configOptions"][0]["configId"], "approval_mode");
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.cwd, "/work");
+        assert_eq!(state.model.as_deref(), Some("nous:gpt-5.4"));
+        assert_eq!(state.mode.as_deref(), Some("code"));
+        assert_eq!(
+            state
+                .config_options
+                .get("approval_mode")
+                .map(String::as_str),
+            Some("auto")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions_filters_paginates_and_uses_wire_metadata() {
+        let handler = make_handler();
+        let keep = handler.session_manager.create_session("/keep");
+        handler.session_manager.set_history(
+            &keep.session_id,
+            vec![json!({"role": "user", "content": "Fix server wire format"})],
+        );
+        handler.session_manager.create_session("/drop");
+
+        let filtered = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/list".into(),
+                params: Some(json!({"cwd": "/keep"})),
+            })
+            .await
+            .result
+            .unwrap();
+        let sessions = filtered["sessions"].as_array().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["sessionId"], keep.session_id);
+        assert_eq!(sessions[0]["title"], "Fix server wire format");
+        assert!(sessions[0].get("updatedAt").is_some());
+        assert!(sessions[0].get("historyLen").is_some());
+
+        let pager = make_handler();
+        for _ in 0..52 {
+            pager.session_manager.create_session("/page");
+        }
+        let first_page = pager
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session/list".into(),
+                params: Some(json!({"cwd": "/page"})),
+            })
+            .await
+            .result
+            .unwrap();
+        let first_sessions = first_page["sessions"].as_array().unwrap();
+        assert_eq!(first_sessions.len(), 50);
+        let cursor = first_page["nextCursor"].as_str().unwrap();
+
+        let second_page = pager
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(3)),
+                method: "session/list".into(),
+                params: Some(json!({"cwd": "/page", "cursor": cursor})),
+            })
+            .await
+            .result
+            .unwrap();
+        assert_eq!(second_page["sessions"].as_array().unwrap().len(), 2);
+        assert!(second_page["nextCursor"].is_null());
+    }
+
+    #[tokio::test]
     async fn test_prompt_slash_command() {
         let handler = make_handler();
 
@@ -1618,7 +1858,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1634,9 +1874,57 @@ mod tests {
         };
         let resp = handler.handle_request(req).await;
         assert_eq!(
-            resp.result.unwrap()["stop_reason"].as_str().unwrap(),
+            resp.result.unwrap()["stopReason"].as_str().unwrap(),
             "end_turn"
         );
+    }
+
+    #[tokio::test]
+    async fn test_prompt_accepts_content_alias_and_refuses_missing_session() {
+        let handler = make_handler();
+        let created = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/new".into(),
+                params: Some(json!({"cwd": "."})),
+            })
+            .await
+            .result
+            .unwrap();
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+
+        let prompt = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "content": [{"type": "text", "text": "ping"}],
+                })),
+            })
+            .await
+            .result
+            .unwrap();
+        assert_eq!(prompt["stopReason"], "end_turn");
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.history[0]["content"][0]["text"], "ping");
+
+        let missing = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(3)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "sessionId": "missing",
+                    "content": [{"type": "text", "text": "ping"}],
+                })),
+            })
+            .await;
+        assert!(missing.error.is_none());
+        assert_eq!(missing.result.unwrap()["stopReason"], "refusal");
     }
 
     #[tokio::test]
@@ -1655,7 +1943,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1678,7 +1966,7 @@ mod tests {
         };
         let resp = handler.handle_request(req).await;
         assert_eq!(
-            resp.result.as_ref().unwrap()["stop_reason"].as_str(),
+            resp.result.as_ref().unwrap()["stopReason"].as_str(),
             Some("end_turn")
         );
         let state = handler.session_manager.get_session(&session_id).unwrap();
@@ -1713,7 +2001,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1781,7 +2069,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1846,7 +2134,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1862,8 +2150,8 @@ mod tests {
         };
         let resp = handler.handle_request(req).await;
         let usage = resp.result.unwrap()["usage"].clone();
-        assert_eq!(usage["input_tokens"], 3);
-        assert_eq!(usage["output_tokens"], 5);
+        assert_eq!(usage["inputTokens"], 3);
+        assert_eq!(usage["outputTokens"], 5);
 
         let state = handler.session_manager.get_session(&session_id).unwrap();
         assert_eq!(state.total_prompt_tokens, 3);
@@ -1895,7 +2183,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();
@@ -1911,7 +2199,7 @@ mod tests {
         };
         let resp = handler.handle_request(req).await;
         assert_eq!(
-            resp.result.unwrap()["stop_reason"].as_str(),
+            resp.result.unwrap()["stopReason"].as_str(),
             Some("end_turn")
         );
 
@@ -1947,7 +2235,7 @@ mod tests {
             params: Some(json!({"cwd": "."})),
         };
         let resp = handler.handle_request(req).await;
-        let session_id = resp.result.unwrap()["session_id"]
+        let session_id = resp.result.unwrap()["sessionId"]
             .as_str()
             .unwrap()
             .to_string();

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -2,7 +2,6 @@
 //!
 //! Defines the full set of ACP JSON-RPC methods, request/response types,
 //! capability declarations, content blocks, and session update structures.
-//! Mirrors the Python `acp.schema` module.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -140,9 +139,14 @@ impl From<&str> for AcpMethod {
 /// Agent capabilities advertised during `initialize`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AgentCapabilities {
-    #[serde(default)]
+    #[serde(rename = "loadSession", alias = "load_session", default)]
     pub load_session: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    #[serde(
+        rename = "sessionCapabilities",
+        alias = "session_capabilities",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub session_capabilities: Option<SessionCapabilities>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<String>>,
@@ -196,10 +200,18 @@ pub struct AuthMethod {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InitializeResponse {
+    #[serde(rename = "protocolVersion", alias = "protocol_version")]
     pub protocol_version: u32,
+    #[serde(rename = "agentInfo", alias = "agent_info")]
     pub agent_info: Implementation,
+    #[serde(rename = "agentCapabilities", alias = "agent_capabilities")]
     pub agent_capabilities: AgentCapabilities,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "authMethods",
+        alias = "auth_methods",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub auth_methods: Option<Vec<AuthMethod>>,
 }
 
@@ -285,7 +297,12 @@ pub enum SessionUpdate {
 pub struct AvailableCommand {
     pub name: String,
     pub description: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "inputHint",
+        alias = "input_hint",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub input_hint: Option<String>,
 }
 
@@ -296,15 +313,25 @@ pub struct AvailableCommand {
 /// Token usage statistics.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Usage {
-    #[serde(default)]
+    #[serde(rename = "inputTokens", alias = "input_tokens", default)]
     pub input_tokens: u64,
-    #[serde(default)]
+    #[serde(rename = "outputTokens", alias = "output_tokens", default)]
     pub output_tokens: u64,
-    #[serde(default)]
+    #[serde(rename = "totalTokens", alias = "total_tokens", default)]
     pub total_tokens: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "thoughtTokens",
+        alias = "thought_tokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub thought_tokens: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "cachedReadTokens",
+        alias = "cached_read_tokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cached_read_tokens: Option<u64>,
 }
 
@@ -326,6 +353,7 @@ pub enum StopReason {
 /// Response to a `prompt` request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptResponse {
+    #[serde(rename = "stopReason", alias = "stop_reason")]
     pub stop_reason: StopReason,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
@@ -374,6 +402,7 @@ pub struct EnvVar {
 /// Session info for listing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcpSessionInfo {
+    #[serde(rename = "sessionId", alias = "session_id")]
     pub session_id: String,
     pub cwd: String,
 }
@@ -454,7 +483,8 @@ mod tests {
             ..Default::default()
         };
         let json = serde_json::to_value(&caps).unwrap();
-        assert_eq!(json["load_session"], true);
+        assert_eq!(json["loadSession"], true);
+        assert_eq!(json["sessionCapabilities"]["fork"], true);
         assert_eq!(json["streaming"], true);
     }
 }

--- a/crates/hermes-acp/src/session.rs
+++ b/crates/hermes-acp/src/session.rs
@@ -1,7 +1,6 @@
 //! ACP session state management.
 //!
 //! Maps ACP sessions to Hermes agent instances with persistence support.
-//! Mirrors the Python `acp_adapter/session.py` implementation.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -285,6 +284,12 @@ impl SessionManager {
     pub fn list_sessions(&self) -> Vec<SessionInfo> {
         let sessions = self.sessions.lock().unwrap();
         sessions.values().map(SessionInfo::from).collect()
+    }
+
+    /// List all session states.
+    pub fn list_session_states(&self) -> Vec<SessionState> {
+        let sessions = self.sessions.lock().unwrap();
+        sessions.values().cloned().collect()
     }
 
     /// Persist a session state via the registered callback.

--- a/crates/hermes-cli/src/systems.rs
+++ b/crates/hermes-cli/src/systems.rs
@@ -894,13 +894,13 @@ pub async fn build_acp_conformance_report() -> ProtocolConformanceReport {
         .await;
     checks.push(match initialize.result.as_ref() {
         Some(value)
-            if value.get("protocol_version").is_some()
-                && value.get("agent_info").is_some()
-                && value.get("agent_capabilities").is_some() =>
+            if value.get("protocolVersion").is_some()
+                && value.get("agentInfo").is_some()
+                && value.get("agentCapabilities").is_some() =>
         {
             pass(
                 "initialize",
-                "advertises protocol, agent_info, and capabilities",
+                "advertises protocol, agentInfo, and capabilities",
             )
         }
         Some(value) => fail("initialize", format!("unexpected response shape: {value}")),
@@ -913,7 +913,7 @@ pub async fn build_acp_conformance_report() -> ProtocolConformanceReport {
     let session_id = new_session
         .result
         .as_ref()
-        .and_then(|value| value.get("session_id"))
+        .and_then(|value| value.get("sessionId"))
         .and_then(Value::as_str)
         .map(str::to_string);
     checks.push(match session_id.as_deref() {
@@ -926,13 +926,11 @@ pub async fn build_acp_conformance_report() -> ProtocolConformanceReport {
             .handle_request(acp_request(
                 3,
                 "prompt",
-                Some(
-                    json!({"session_id": session_id, "content": [{"type":"text", "text":"ping"}]}),
-                ),
+                Some(json!({"sessionId": session_id, "content": [{"type":"text", "text":"ping"}]})),
             ))
             .await;
         checks.push(match prompt.result.as_ref() {
-            Some(value) if value.get("stop_reason").and_then(Value::as_str) == Some("end_turn") => {
+            Some(value) if value.get("stopReason").and_then(Value::as_str) == Some("end_turn") => {
                 pass("prompt", "accepts text content and returns end_turn")
             }
             Some(value) => fail("prompt", format!("unexpected response shape: {value}")),
@@ -943,7 +941,7 @@ pub async fn build_acp_conformance_report() -> ProtocolConformanceReport {
             .handle_request(acp_request(
                 4,
                 "session/cancel",
-                Some(json!({"session_id": session_id})),
+                Some(json!({"sessionId": session_id})),
             ))
             .await;
         checks.push(match cancel.result.as_ref() {

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T02:30:53.941230+00:00",
+  "generated_at_utc": "2026-05-30T02:46:19.315779+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "33e0e1d02afdf24df497c3b847487febdf6f733f",
+    "local_sha": "74da92c2bdf7d865b3df3efb30c56842b71054e7",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 813,
+    "commits_ahead": 815,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 690,
+    "local_patch_unique": 691,
     "files_only_upstream": 1474,
-    "files_only_local": 569,
+    "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
-    "tree_files_changed": 3061,
+    "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 383461
+    "tree_deletions": 383858
   },
   "top_upstream_only": [
     {
@@ -392,7 +392,7 @@
     },
     {
       "path": "crates/hermes-acp",
-      "count": 9
+      "count": 10
     },
     {
       "path": "crates/hermes-cron",
@@ -716,7 +716,7 @@
     },
     {
       "path": "crates/hermes-acp",
-      "count": 9
+      "count": 10
     },
     {
       "path": "crates/hermes-cron",
@@ -858,7 +858,7 @@
       "name": "Compatibility and divergence policy",
       "upstream_only": 392,
       "shared_different": 12,
-      "local_only": 194,
+      "local_only": 195,
       "risk": "high",
       "effort": "XL"
     },
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 690,
+    "local_patch_unique": 691,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T02:30:53.941230+00:00`
+Generated: `2026-05-30T02:46:19.315779+00:00`
 
 ## Scope
 
-- Local ref: `main` (`33e0e1d02afdf24df497c3b847487febdf6f733f`)
+- Local ref: `main` (`74da92c2bdf7d865b3df3efb30c56842b71054e7`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T02:30:53.941230+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 813 |
+| Commits ahead local (`local` ancestry only) | 815 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 690 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 691 |
 | Files only in upstream tree | 1474 |
-| Files only in local tree | 569 |
+| Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
-| Total files changed (`local` vs `upstream`) | 3061 |
+| Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 383461 |
+| Deletions (`local` vs `upstream`) | 383858 |
 
 ## Top 40 upstream-only buckets
 
@@ -130,7 +130,7 @@ Generated: `2026-05-30T02:30:53.941230+00:00`
 | `crates/hermes-parity-tests` | 15 |
 | `crates/hermes-environments` | 13 |
 | `crates/hermes-core` | 11 |
-| `crates/hermes-acp` | 9 |
+| `crates/hermes-acp` | 10 |
 | `crates/hermes-cron` | 9 |
 | `docs/implementation` | 9 |
 | `docs/roadmaps` | 8 |
@@ -176,7 +176,7 @@ Generated: `2026-05-30T02:30:53.941230+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `690`
+- Local unique by patch-id: `691`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1681,16 +1681,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/acp",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/acp/test_server.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a4dad4aefa87ea2aae8faecd55b585047cbd3d62",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/acp/test_server.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "33fb72c2edc7cb7183070066d5c40c05ef8f8752",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T02:31:00.609231+00:00",
+  "generated_at_utc": "2026-05-30T02:46:27.306232+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "33e0e1d02afdf24df497c3b847487febdf6f733f",
+    "local_sha": "74da92c2bdf7d865b3df3efb30c56842b71054e7",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 752,
-      "intentional_divergence": 97,
+      "functional": 751,
+      "intentional_divergence": 98,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 266,
-      "rust_equivalent_or_contract_test_required": 673,
+      "not_required_for_runtime": 267,
+      "rust_equivalent_or_contract_test_required": 672,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 97,
+      "cleared_intentional_divergence": 98,
       "cleared_non_runtime": 169,
-      "pending_review": 752
+      "pending_review": 751
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 97,
+    "cleared_intentional_divergence": 98,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 752,
+    "pending_review": 751,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T02:31:00.609231+00:00`
+Generated: `2026-05-30T02:46:27.306232+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `752`
+- Pending functional review: `751`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `97`
+- Cleared intentional divergence: `98`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 97 |
+| `cleared_intentional_divergence` | 98 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 752 |
+| `pending_review` | 751 |
 
 ## Workstream Counts
 
@@ -56,4 +56,3 @@ Generated: `2026-05-30T02:31:00.609231+00:00`
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
 | `tests/e2e` | 2 |
-| `tests/acp` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -451,6 +451,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/acp/test_server.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ACP server lifecycle intent is covered by Rust ACP JSON-RPC server and handler tests: initialize/authenticate, camelCase wire aliases, session create/load/resume/fork/list/cancel, list filtering and pagination, prompt content aliases, refusal handling for missing sessions, usage serialization, slash commands, and MCP/server event flushing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/acp/test_tools.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream ACP tool metadata and rendering intent is covered by Rust ACP tool helpers and event metadata: common tool kind mapping, stable tc-* call IDs, human-readable titles, structured failure status detection, and tool_kind/title/status fields on emitted ACP tool events.",


### PR DESCRIPTION
## Summary
- Make the Rust ACP server emit camelCase ACP wire fields for initialize/session/prompt responses while retaining snake_case request aliases where needed.
- Add Rust handler coverage for initialize/authenticate, session lifecycle, camelCase session params, list filtering/pagination/title metadata, prompt content alias handling, missing-session refusal, usage serialization, and updated systems conformance.
- Clear upstream tests/acp/test_server.py as Rust ACP server coverage and regenerate parity docs; all tests/acp/* items are now cleared.

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p hermes-acp
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli