### PR TITLE
parity(agent): port redaction contracts

### DIFF
--- a/crates/hermes-intelligence/src/lib.rs
+++ b/crates/hermes-intelligence/src/lib.rs
@@ -26,7 +26,7 @@ pub mod usage_pricing;
 pub use error_classifier::{ErrorCategory, ErrorClassifier, RetryStrategy};
 pub use insights::Insights;
 pub use prompt::PromptBuilder;
-pub use redact::{RedactionPattern, Redactor};
+pub use redact::{redact_sensitive_text, RedactionPattern, Redactor};
 pub use router::{
     ModelCapability, ModelInfo as RouterModelInfo, ModelRequirements, RouterError, SmartModelRouter,
 };

--- a/crates/hermes-intelligence/src/redact.rs
+++ b/crates/hermes-intelligence/src/redact.rs
@@ -100,6 +100,375 @@ static BUILTIN_PATTERNS: LazyLock<Vec<RedactionPattern>> = LazyLock::new(|| {
     ]
 });
 
+static SENSITIVE_QUERY_PARAMS: &[&str] = &[
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "password",
+    "auth",
+    "jwt",
+    "session",
+    "secret",
+    "key",
+    "code",
+    "signature",
+    "x-amz-signature",
+];
+
+static SENSITIVE_BODY_KEYS: &[&str] = &[
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "password",
+    "auth",
+    "jwt",
+    "secret",
+    "private_key",
+    "authorization",
+    "key",
+];
+
+static PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"(^|[^A-Za-z0-9_-])(",
+        r"sk-[A-Za-z0-9_-]{10,}",
+        r"|ghp_[A-Za-z0-9]{10,}",
+        r"|github_pat_[A-Za-z0-9_]{10,}",
+        r"|gho_[A-Za-z0-9]{10,}",
+        r"|ghu_[A-Za-z0-9]{10,}",
+        r"|ghs_[A-Za-z0-9]{10,}",
+        r"|ghr_[A-Za-z0-9]{10,}",
+        r"|xox[baprs]-[A-Za-z0-9-]{10,}",
+        r"|AIza[A-Za-z0-9_-]{30,}",
+        r"|pplx-[A-Za-z0-9]{10,}",
+        r"|fal_[A-Za-z0-9_-]{10,}",
+        r"|fc-[A-Za-z0-9]{10,}",
+        r"|bb_live_[A-Za-z0-9_-]{10,}",
+        r"|gAAAA[A-Za-z0-9_=-]{20,}",
+        r"|AKIA[A-Z0-9]{16}",
+        r"|sk_live_[A-Za-z0-9]{10,}",
+        r"|sk_test_[A-Za-z0-9]{10,}",
+        r"|rk_live_[A-Za-z0-9]{10,}",
+        r"|SG\.[A-Za-z0-9_-]{10,}",
+        r"|hf_[A-Za-z0-9]{10,}",
+        r"|r8_[A-Za-z0-9]{10,}",
+        r"|npm_[A-Za-z0-9]{10,}",
+        r"|pypi-[A-Za-z0-9_-]{10,}",
+        r"|dop_v1_[A-Za-z0-9]{10,}",
+        r"|doo_v1_[A-Za-z0-9]{10,}",
+        r"|am_[A-Za-z0-9_-]{10,}",
+        r"|sk_[A-Za-z0-9_]{10,}",
+        r"|tvly-[A-Za-z0-9]{10,}",
+        r"|exa_[A-Za-z0-9]{10,}",
+        r"|gsk_[A-Za-z0-9]{10,}",
+        r"|syt_[A-Za-z0-9]{10,}",
+        r"|retaindb_[A-Za-z0-9]{10,}",
+        r"|hsk-[A-Za-z0-9]{10,}",
+        r"|mem0_[A-Za-z0-9]{10,}",
+        r"|brv_[A-Za-z0-9]{10,}",
+        r"|xai-[A-Za-z0-9]{30,}",
+        r")"
+    ))
+    .unwrap()
+});
+
+static ENV_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?m)\b([A-Z0-9_]{0,50}(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)[A-Z0-9_]{0,50})(\s*=\s*)(['"]?)([^\s'"]+)(['"]?)"#,
+    )
+    .unwrap()
+});
+
+static JSON_FIELD_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)("(?:api_?key|apikey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)")(\s*:\s*)"([^"]+)""#,
+    )
+    .unwrap()
+});
+
+static AUTH_HEADER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)(authorization:\s*bearer\s+)(\S+)"#).unwrap());
+
+static TELEGRAM_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(bot)?(\d{8,}):([-A-Za-z0-9_]{30,})"#).unwrap());
+
+static PRIVATE_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?s)-----BEGIN[A-Z ]*PRIVATE KEY-----.*?-----END[A-Z ]*PRIVATE KEY-----"#)
+        .unwrap()
+});
+
+static DB_CONNSTR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^:]+:)([^@]+)(@)"#)
+        .unwrap()
+});
+
+static JWT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"eyJ[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_=-]{4,}){0,2}"#).unwrap());
+
+static DISCORD_MENTION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"<@!?(\d{17,20})>"#).unwrap());
+
+static SIGNAL_PHONE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\+[1-9]\d{6,14}\b"#).unwrap());
+
+static URL_WITH_QUERY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)\b(https?|wss?|ftp)://([^\s/?#]+)([^\s?#]*)\?([^\s#]+)(#\S*)?"#).unwrap()
+});
+
+static URL_USERINFO_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)\b(https?|wss?|ftp)://([^/\s:@]+):([^/\s@]+)@"#).unwrap());
+
+static HTTP_REQUEST_TARGET_QUERY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)\b((?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)\s+[^ \t\r\n"']*?)\?([^ \t\r\n"']+)"#,
+    )
+    .unwrap()
+});
+
+static FORM_BODY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*(?:&[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*)+$"#)
+        .unwrap()
+});
+
+static PASSWORD_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)\b(password|passwd|pwd)(\s*[:=]\s*)(['"]?)([^\s'"]{4,})(['"]?)"#).unwrap()
+});
+
+static EMAIL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"#).unwrap());
+
+static PHONE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?:\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}"#).unwrap()
+});
+
+static CREDIT_CARD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{1,4}\b"#).unwrap());
+
+static IPV4_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b"#).unwrap());
+
+fn mask_token(value: &str) -> String {
+    let char_count = value.chars().count();
+    if value.is_empty() || char_count < 18 {
+        "***".to_string()
+    } else {
+        let head = value.chars().take(6).collect::<String>();
+        let tail = value
+            .chars()
+            .rev()
+            .take(4)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<String>();
+        format!("{head}...{tail}")
+    }
+}
+
+fn is_sensitive_key(key: &str, set: &[&str]) -> bool {
+    set.iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(key))
+}
+
+fn redact_query_string(query: &str, sensitive_keys: &[&str]) -> String {
+    query
+        .split('&')
+        .map(|pair| {
+            let Some((key, _value)) = pair.split_once('=') else {
+                return pair.to_string();
+            };
+            if is_sensitive_key(key, sensitive_keys) {
+                format!("{key}=***")
+            } else {
+                pair.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn redact_form_body(text: &str) -> String {
+    if text.is_empty() || text.contains('\n') || !text.contains('&') {
+        return text.to_string();
+    }
+    let trimmed = text.trim();
+    if !FORM_BODY_RE.is_match(trimmed) {
+        return text.to_string();
+    }
+    redact_query_string(trimmed, SENSITIVE_BODY_KEYS)
+}
+
+fn same_pattern(left: &RedactionPattern, right: &RedactionPattern) -> bool {
+    left.name == right.name
+        && left.regex.as_str() == right.regex.as_str()
+        && left.replacement == right.replacement
+}
+
+fn is_builtin_pattern(pattern: &RedactionPattern) -> bool {
+    BUILTIN_PATTERNS
+        .iter()
+        .any(|builtin| same_pattern(pattern, builtin))
+}
+
+fn has_builtin_patterns(patterns: &[RedactionPattern]) -> bool {
+    BUILTIN_PATTERNS.iter().all(|builtin| {
+        patterns
+            .iter()
+            .any(|pattern| same_pattern(pattern, builtin))
+    })
+}
+
+fn redact_builtin_text(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let mut result = text.to_string();
+
+    result = PREFIX_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            format!("{}{}", &caps[1], mask_token(&caps[2]))
+        })
+        .to_string();
+
+    if result.contains('=') {
+        result = ENV_ASSIGN_RE
+            .replace_all(&result, |caps: &regex::Captures<'_>| {
+                format!(
+                    "{}{}{}{}{}",
+                    &caps[1],
+                    &caps[2],
+                    &caps[3],
+                    mask_token(&caps[4]),
+                    &caps[5]
+                )
+            })
+            .to_string();
+    }
+
+    if result.contains(':') && result.contains('"') {
+        result = JSON_FIELD_RE
+            .replace_all(&result, |caps: &regex::Captures<'_>| {
+                format!("{}{}\"{}\"", &caps[1], &caps[2], mask_token(&caps[3]))
+            })
+            .to_string();
+    }
+
+    result = AUTH_HEADER_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            format!("{}{}", &caps[1], mask_token(&caps[2]))
+        })
+        .to_string();
+
+    result = TELEGRAM_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            let bot = caps.get(1).map_or("", |m| m.as_str());
+            format!("{}{}:***", bot, &caps[2])
+        })
+        .to_string();
+
+    result = PRIVATE_KEY_RE
+        .replace_all(&result, "[REDACTED PRIVATE KEY]")
+        .to_string();
+
+    result = DB_CONNSTR_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            format!("{}***{}", &caps[1], &caps[3])
+        })
+        .to_string();
+
+    result = JWT_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            mask_token(caps.get(0).map_or("", |m| m.as_str()))
+        })
+        .to_string();
+
+    result = URL_WITH_QUERY_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            let fragment = caps.get(5).map_or("", |m| m.as_str());
+            format!(
+                "{}://{}{}?{}{}",
+                &caps[1],
+                &caps[2],
+                &caps[3],
+                redact_query_string(&caps[4], SENSITIVE_QUERY_PARAMS),
+                fragment
+            )
+        })
+        .to_string();
+
+    result = URL_USERINFO_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            format!("{}://{}:***@", &caps[1], &caps[2])
+        })
+        .to_string();
+
+    result = HTTP_REQUEST_TARGET_QUERY_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            format!(
+                "{}?{}",
+                &caps[1],
+                redact_query_string(&caps[2], SENSITIVE_QUERY_PARAMS)
+            )
+        })
+        .to_string();
+
+    result = redact_form_body(&result);
+
+    if !result.contains('&') {
+        result = PASSWORD_ASSIGN_RE
+            .replace_all(&result, "[REDACTED_PASSWORD]")
+            .to_string();
+    }
+
+    result = DISCORD_MENTION_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            if caps.get(0).map_or("", |m| m.as_str()).contains('!') {
+                "<@!***>".to_string()
+            } else {
+                "<@***>".to_string()
+            }
+        })
+        .to_string();
+
+    result = SIGNAL_PHONE_RE
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            let phone = caps.get(0).map_or("", |m| m.as_str());
+            if phone.len() <= 8 {
+                format!("{}****{}", &phone[..2], &phone[phone.len() - 2..])
+            } else {
+                format!("{}****{}", &phone[..4], &phone[phone.len() - 4..])
+            }
+        })
+        .to_string();
+
+    result = CREDIT_CARD_RE
+        .replace_all(&result, "[REDACTED_CC]")
+        .to_string();
+    result = EMAIL_RE
+        .replace_all(&result, "[REDACTED_EMAIL]")
+        .to_string();
+    result = PHONE_RE
+        .replace_all(&result, "[REDACTED_PHONE]")
+        .to_string();
+    result = IPV4_RE.replace_all(&result, "[REDACTED_IP]").to_string();
+
+    result
+}
+
+/// Apply the default Hermes secret redaction policy to text.
+pub fn redact_sensitive_text<T: ToString>(text: T) -> String {
+    redact_builtin_text(&text.to_string())
+}
+
 // ---------------------------------------------------------------------------
 // Sensitive file path patterns
 // ---------------------------------------------------------------------------
@@ -166,8 +535,21 @@ impl Redactor {
 
     /// Redact sensitive data from a text string.
     pub fn redact(&self, text: &str) -> String {
-        let mut result = text.to_string();
+        if self.patterns.is_empty() {
+            return text.to_string();
+        }
+
+        let uses_builtins = has_builtin_patterns(&self.patterns);
+        let mut result = if uses_builtins {
+            redact_builtin_text(text)
+        } else {
+            text.to_string()
+        };
+
         for pattern in &self.patterns {
+            if uses_builtins && is_builtin_pattern(pattern) {
+                continue;
+            }
             result = pattern
                 .regex
                 .replace_all(&result, pattern.replacement.as_str())
@@ -219,8 +601,9 @@ mod tests {
         let redactor = Redactor::new();
         let text = "My key is sk-abc123def456ghi789jkl012mno345";
         let result = redactor.redact(text);
-        assert!(result.contains("[REDACTED_API_KEY]"));
-        assert!(!result.contains("sk-abc123"));
+        assert!(result.contains("sk-abc"));
+        assert!(result.contains("..."));
+        assert!(!result.contains("def456ghi789"));
     }
 
     #[test]
@@ -271,7 +654,7 @@ mod tests {
         let redactor = Redactor::new();
         let text = "TELEGRAM_BOT_TOKEN=123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcd1234";
         let result = redactor.redact(text);
-        assert!(result.contains("[REDACTED_TELEGRAM_TOKEN]"));
+        assert!(result.contains("TELEGRAM_BOT_TOKEN="));
         assert!(!result.contains("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcd1234"));
     }
 
@@ -285,7 +668,125 @@ mod tests {
         assert_eq!(redacted.role, MessageRole::User);
         let content = redacted.content.unwrap();
         assert!(content.contains("[REDACTED_EMAIL]"));
-        assert!(content.contains("[REDACTED_API_KEY]"));
+        assert!(!content.contains("def456ghi789"));
+    }
+
+    #[test]
+    fn test_redact_known_vendor_prefixes() {
+        let redactor = Redactor::new();
+        let slack_token = format!("{}-{}-{}", "xoxb", "0".repeat(12), "a".repeat(14));
+        let text = format!(
+            "{} {}",
+            concat!(
+                "ghp_abc123def456ghi789jkl ",
+                "github_pat_abc123def456ghi789jklmno ",
+                "AIzaSyB-abc123def456ghi789jklmno012345 ",
+                "pplx-abcdef123456789012345 ",
+                "fal_abc123def456ghi789jkl ",
+                "sk_abc123def456ghi789jklmnopqrstu ",
+                "tvly-ABCdef123456789GHIJKL0000 ",
+                "exa_XYZ789abcdef000000000000000"
+            ),
+            slack_token
+        );
+        let result = redactor.redact(&text);
+        assert!(!result.contains("abc123def456"));
+        assert!(!result.contains("aaaaaaaaaaaaaa"));
+        assert!(!result.contains("ABCdef123456789"));
+        assert!(!result.contains("XYZ789abcdef"));
+    }
+
+    #[test]
+    fn test_short_secret_is_fully_masked() {
+        let result = redact_sensitive_text("key=sk-short1234567");
+        assert!(result.contains("***"));
+        assert!(!result.contains("short1234567"));
+    }
+
+    #[test]
+    fn test_env_assignments_preserve_non_secrets_and_code() {
+        assert_eq!(redact_sensitive_text("HOME=/home/user"), "HOME=/home/user");
+        assert_eq!(
+            redact_sensitive_text("PATH=/usr/local/bin:/usr/bin"),
+            "PATH=/usr/local/bin:/usr/bin"
+        );
+        assert_eq!(
+            redact_sensitive_text("before_tokens = response.usage.prompt_tokens"),
+            "before_tokens = response.usage.prompt_tokens"
+        );
+        assert_eq!(
+            redact_sensitive_text("api_key = config.get('api_key')"),
+            "api_key = config.get('api_key')"
+        );
+        assert_eq!(
+            redact_sensitive_text("const token = await getToken();"),
+            "const token = await getToken();"
+        );
+
+        let result = redact_sensitive_text("export SECRET_TOKEN=mypassword");
+        assert!(result.starts_with("export "));
+        assert!(result.contains("SECRET_TOKEN="));
+        assert!(!result.contains("mypassword"));
+    }
+
+    #[test]
+    fn test_json_auth_jwt_and_discord_redaction() {
+        let json = redact_sensitive_text(r#"{"apiKey": "sk-proj-abc123def456ghi789jkl012"}"#);
+        assert!(!json.contains("abc123def456"));
+
+        let auth = redact_sensitive_text("authorization: bearer mytoken123456789012345678");
+        assert!(auth.contains("authorization: bearer"));
+        assert!(!auth.contains("mytoken12345"));
+
+        let jwt = redact_sensitive_text(
+            "Token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456ghij",
+        );
+        assert!(jwt.contains("Token:"));
+        assert!(!jwt.contains("eyJzdWIi"));
+        assert!(!jwt.contains("abc123def456"));
+
+        assert_eq!(
+            redact_sensitive_text("Hello <@222589316709220353>"),
+            "Hello <@***>"
+        );
+        assert_eq!(
+            redact_sensitive_text("Ping <@!1331549159177846844>"),
+            "Ping <@!***>"
+        );
+        assert_eq!(redact_sensitive_text("<@12345>"), "<@12345>");
+    }
+
+    #[test]
+    fn test_url_query_userinfo_and_form_redaction() {
+        let oauth = redact_sensitive_text(
+            "GET https://api.example.com/oauth/cb?code=abc123xyz789&state=csrf_ok",
+        );
+        assert!(oauth.contains("code=***"));
+        assert!(oauth.contains("state=csrf_ok"));
+        assert!(!oauth.contains("abc123xyz789"));
+
+        let query =
+            redact_sensitive_text("https://example.com/cb?token_count=42&session_id=xyz&foo=bar");
+        assert!(query.contains("token_count=42"));
+        assert!(query.contains("session_id=xyz"));
+
+        let userinfo = redact_sensitive_text("https://user:supersecretpw@host.example.com/path");
+        assert!(userinfo.contains("https://user:***@host.example.com"));
+        assert!(!userinfo.contains("supersecretpw"));
+
+        let db = redact_sensitive_text("postgres://admin:dbpass@db.internal:5432/app");
+        assert!(db.contains("postgres://admin:***@db.internal"));
+        assert!(!db.contains("dbpass"));
+
+        let form = redact_sensitive_text("password=mysecret&username=bob&token=opaqueValue");
+        assert!(form.contains("password=***"));
+        assert!(form.contains("token=***"));
+        assert!(form.contains("username=bob"));
+        assert!(!form.contains("mysecret"));
+        assert!(!form.contains("opaqueValue"));
+
+        let sentence = "I have password=foo and other things";
+        assert_eq!(redact_sensitive_text(sentence), sentence);
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T02:46:19.315779+00:00",
+  "generated_at_utc": "2026-05-30T03:04:20.194969+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "74da92c2bdf7d865b3df3efb30c56842b71054e7",
+    "local_sha": "7517fb487268c7c7afb81e53fcc72604bf80d800",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 815,
+    "commits_ahead": 817,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 691,
+    "local_patch_unique": 692,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 383858
+    "tree_deletions": 384185
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 691,
+    "local_patch_unique": 692,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T02:46:19.315779+00:00`
+Generated: `2026-05-30T03:04:20.194969+00:00`
 
 ## Scope
 
-- Local ref: `main` (`74da92c2bdf7d865b3df3efb30c56842b71054e7`)
+- Local ref: `main` (`7517fb487268c7c7afb81e53fcc72604bf80d800`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T02:46:19.315779+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 815 |
+| Commits ahead local (`local` ancestry only) | 817 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 691 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 692 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 383858 |
+| Deletions (`local` vs `upstream`) | 384185 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T02:46:19.315779+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `691`
+- Local unique by patch-id: `692`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -2326,16 +2326,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_redact.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a2c6b60b2763df1640271ff4eed43d2afafe1142",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_redact.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e4fa5e950435f3ee3261bb23639d66587eb43794",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T02:46:27.306232+00:00",
+  "generated_at_utc": "2026-05-30T03:04:23.696643+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "74da92c2bdf7d865b3df3efb30c56842b71054e7",
+    "local_sha": "7517fb487268c7c7afb81e53fcc72604bf80d800",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 751,
-      "intentional_divergence": 98,
+      "functional": 750,
+      "intentional_divergence": 99,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 267,
-      "rust_equivalent_or_contract_test_required": 672,
+      "not_required_for_runtime": 268,
+      "rust_equivalent_or_contract_test_required": 671,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 98,
+      "cleared_intentional_divergence": 99,
       "cleared_non_runtime": 169,
-      "pending_review": 751
+      "pending_review": 750
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 98,
+    "cleared_intentional_divergence": 99,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 751,
+    "pending_review": 750,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T02:46:27.306232+00:00`
+Generated: `2026-05-30T03:04:23.696643+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `751`
+- Pending functional review: `750`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `98`
+- Cleared intentional divergence: `99`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 98 |
+| `cleared_intentional_divergence` | 99 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 751 |
+| `pending_review` | 750 |
 
 ## Workstream Counts
 
@@ -41,7 +41,7 @@ Generated: `2026-05-30T02:46:27.306232+00:00`
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
-| `tests/agent` | 57 |
+| `tests/agent` | 56 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |
 | `tests/cli` | 29 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -192,6 +192,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_redact.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_unsupported_temperature_retry.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream's unsupported-temperature and OpenAI-compatible max-token omission regression intent is covered by Rust auxiliary-client tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- Ported the agent redaction contract into Rust in hermes-intelligence, including vendor token prefixes, env/json/auth token handling, Telegram/JWT/Discord redaction, URL query/userinfo redaction, DB connection strings, and form-urlencoded bodies.
- Re-exported the Rust redact_sensitive_text helper and marked tests/agent/test_redact.py as reference-only because the runtime contract is now covered by Rust tests.
- Regenerated parity matrix/backlog; pending functional review is now 750.

## Local Verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches; exit 1)
- cargo test -p hermes-intelligence redact -- --nocapture
- cargo test -p hermes-intelligence
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli

## Notes
- GitHub Actions are optional for this repo; local gates above are authoritative.
- cargo clippy -p hermes-intelligence --all-targets -- -D warnings currently fails on an existing hermes-core manual_map lint outside this batch.