### PR TITLE
parity(agent): cover usage pricing contracts

### DIFF
--- a/crates/hermes-intelligence/src/usage_pricing.rs
+++ b/crates/hermes-intelligence/src/usage_pricing.rs
@@ -233,6 +233,15 @@ fn official_pricing_db() -> HashMap<(&'static str, &'static str), PricingEntry> 
         None,
         None,
     );
+    add(
+        &mut db,
+        "deepseek",
+        "deepseek-v4-pro",
+        1.74,
+        3.48,
+        Some(0.0145),
+        None,
+    );
 
     db
 }
@@ -372,6 +381,22 @@ pub fn calculate_cost(
     }
     if let Some(output_cost) = entry.output_cost_per_million {
         amount += (usage.output_tokens as f64) * output_cost / million;
+    }
+    if usage.cache_read_tokens > 0 && entry.cache_read_cost_per_million.is_none() {
+        return CostResult {
+            amount_usd: None,
+            status: CostStatus::Unknown,
+            source: CostSource::None,
+            label: "n/a".into(),
+        };
+    }
+    if usage.cache_write_tokens > 0 && entry.cache_write_cost_per_million.is_none() {
+        return CostResult {
+            amount_usd: None,
+            status: CostStatus::Unknown,
+            source: CostSource::None,
+            label: "n/a".into(),
+        };
     }
     if let Some(cache_read_cost) = entry.cache_read_cost_per_million {
         amount += (usage.cache_read_tokens as f64) * cache_read_cost / million;
@@ -622,6 +647,35 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_usage_anthropic_keeps_cache_buckets_separate() {
+        let raw = serde_json::json!({
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 2000,
+            "cache_creation_input_tokens": 400,
+        });
+        let usage = normalize_usage(&raw, Some("anthropic"), Some("anthropic_messages"));
+        assert_eq!(usage.input_tokens, 1000);
+        assert_eq!(usage.output_tokens, 500);
+        assert_eq!(usage.cache_read_tokens, 2000);
+        assert_eq!(usage.cache_write_tokens, 400);
+        assert_eq!(usage.prompt_tokens(), 3400);
+    }
+
+    #[test]
+    fn test_normalize_usage_openai_subtracts_cached_prompt_tokens() {
+        let raw = serde_json::json!({
+            "prompt_tokens": 3000,
+            "completion_tokens": 700,
+            "prompt_tokens_details": { "cached_tokens": 1800 }
+        });
+        let usage = normalize_usage(&raw, Some("openai"), Some("chat_completions"));
+        assert_eq!(usage.input_tokens, 1200);
+        assert_eq!(usage.cache_read_tokens, 1800);
+        assert_eq!(usage.output_tokens, 700);
+    }
+
+    #[test]
     fn test_normalize_usage_openai_top_level_write_with_nested_read() {
         let raw = serde_json::json!({
             "prompt_tokens": 1000,
@@ -666,6 +720,41 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 600);
         assert_eq!(usage.cache_write_tokens, 150);
         assert_eq!(usage.input_tokens, 250);
+    }
+
+    #[test]
+    fn test_cache_usage_without_matching_rate_is_unknown() {
+        let usage = CanonicalUsage {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_tokens: 100,
+            request_count: 1,
+            ..Default::default()
+        };
+        let result = calculate_cost("gemini-2.5-pro", &usage, Some("google"), None);
+        assert_eq!(result.status, CostStatus::Unknown);
+        assert_eq!(result.amount_usd, None);
+    }
+
+    #[test]
+    fn test_deepseek_v4_pro_pricing_entry_exists() {
+        let entry = get_pricing_entry("deepseek-v4-pro", Some("deepseek"), None).unwrap();
+        assert_eq!(entry.input_cost_per_million, Some(1.74));
+        assert_eq!(entry.output_cost_per_million, Some(3.48));
+        assert_eq!(entry.cache_read_cost_per_million, Some(0.0145));
+    }
+
+    #[test]
+    fn test_deepseek_v4_pro_calculate_cost() {
+        let usage = CanonicalUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 500_000,
+            request_count: 1,
+            ..Default::default()
+        };
+        let result = calculate_cost("deepseek-v4-pro", &usage, Some("deepseek"), None);
+        assert_eq!(result.status, CostStatus::Estimated);
+        assert_eq!(result.amount_usd, Some(3.48));
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T03:04:20.194969+00:00",
+  "generated_at_utc": "2026-05-30T03:19:49.258030+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "7517fb487268c7c7afb81e53fcc72604bf80d800",
+    "local_sha": "bc82b38ff0c7153d917852c43c6fff0797900070",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 817,
+    "commits_ahead": 819,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 692,
+    "local_patch_unique": 693,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 384185
+    "tree_deletions": 384693
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 692,
+    "local_patch_unique": 693,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T03:04:20.194969+00:00`
+Generated: `2026-05-30T03:19:49.258030+00:00`
 
 ## Scope
 
-- Local ref: `main` (`7517fb487268c7c7afb81e53fcc72604bf80d800`)
+- Local ref: `main` (`bc82b38ff0c7153d917852c43c6fff0797900070`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T03:04:20.194969+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 817 |
+| Commits ahead local (`local` ancestry only) | 819 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 692 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 693 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 384185 |
+| Deletions (`local` vs `upstream`) | 384693 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T03:04:20.194969+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `692`
+- Local unique by patch-id: `693`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -2491,16 +2491,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_usage_pricing.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "5daace97deab263b289b951e2992d63256557f0d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_usage_pricing.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "3a745a6044122d21fb9e407d3658b001f3803a29",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T03:04:23.696643+00:00",
+  "generated_at_utc": "2026-05-30T03:19:56.795106+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "7517fb487268c7c7afb81e53fcc72604bf80d800",
+    "local_sha": "bc82b38ff0c7153d917852c43c6fff0797900070",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 750,
-      "intentional_divergence": 99,
+      "functional": 749,
+      "intentional_divergence": 100,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 268,
-      "rust_equivalent_or_contract_test_required": 671,
+      "not_required_for_runtime": 269,
+      "rust_equivalent_or_contract_test_required": 670,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 99,
+      "cleared_intentional_divergence": 100,
       "cleared_non_runtime": 169,
-      "pending_review": 750
+      "pending_review": 749
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 99,
+    "cleared_intentional_divergence": 100,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 750,
+    "pending_review": 749,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T03:04:23.696643+00:00`
+Generated: `2026-05-30T03:19:56.795106+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `750`
+- Pending functional review: `749`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `99`
+- Cleared intentional divergence: `100`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 99 |
+| `cleared_intentional_divergence` | 100 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 750 |
+| `pending_review` | 749 |
 
 ## Workstream Counts
 
@@ -41,8 +41,8 @@ Generated: `2026-05-30T03:04:23.696643+00:00`
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
-| `tests/agent` | 56 |
 | `tests/run_agent` | 56 |
+| `tests/agent` | 55 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -206,6 +206,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_usage_pricing.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream usage-pricing normalization, subscription billing, cache-rate safety, and DeepSeek v4 Pro pricing intent is covered by Rust hermes-intelligence usage_pricing tests; dynamic Python metadata monkeypatch tests remain reference-only for Hermes Ultra's Rust pricing snapshot path.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/run_agent",
       "classification": "functional",
       "rationale": "Run-agent tests cover orchestration and provider execution semantics.",


### PR DESCRIPTION
## Summary
- Added Rust usage-pricing coverage for upstream normalization cases, cache bucket separation, cache-rate safety, and DeepSeek v4 Pro pricing.
- Added DeepSeek v4 Pro to the Rust official pricing snapshot and return unknown rather than underestimating when cache usage has no matching rate.
- Marked tests/agent/test_usage_pricing.py as reference-only with Rust coverage and regenerated parity docs; pending functional review is now 749.

## Local Verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches; exit 1)
- cargo test -p hermes-intelligence usage_pricing -- --nocapture
- cargo test -p hermes-intelligence
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli

## Notes
- GitHub Actions are optional; local gates above are authoritative.
- Dynamic Python metadata monkeypatch tests remain reference-only because Hermes Ultra uses Rust pricing snapshot behavior for this contract.