### PR TITLE
parity(agent): cover title generation contracts

### DIFF
--- a/crates/hermes-intelligence/src/title.rs
+++ b/crates/hermes-intelligence/src/title.rs
@@ -6,6 +6,9 @@ use std::sync::Arc;
 
 use hermes_core::{AgentError, LlmProvider, Message};
 
+const MAX_TITLE_CHARS: usize = 80;
+const TITLE_ELLIPSIS_CHARS: usize = 3;
+
 // ---------------------------------------------------------------------------
 // TitleError
 // ---------------------------------------------------------------------------
@@ -101,25 +104,14 @@ impl TitleGenerator {
             .await
             .map_err(TitleError::from)?;
 
-        let title = response
+        let raw_title = response
             .message
             .content
             .unwrap_or_default()
             .trim()
             .to_string();
 
-        if title.is_empty() {
-            return Err(TitleError::EmptyResult);
-        }
-
-        // Strip surrounding quotes if present
-        let title = title
-            .strip_prefix('"')
-            .and_then(|t| t.strip_suffix('"'))
-            .unwrap_or(&title)
-            .to_string();
-
-        Ok(title)
+        clean_generated_title(&raw_title).ok_or(TitleError::EmptyResult)
     }
 
     /// Truncate messages into a single string for the title prompt.
@@ -152,9 +144,133 @@ impl TitleGenerator {
     }
 }
 
+fn clean_generated_title(raw_title: &str) -> Option<String> {
+    let mut title = raw_title.trim();
+    if title.is_empty() {
+        return None;
+    }
+
+    title = strip_matching_quotes(title).trim();
+    if title
+        .get(..6)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("title:"))
+    {
+        title = title[6..].trim();
+        title = strip_matching_quotes(title).trim();
+    }
+
+    if title.is_empty() {
+        return None;
+    }
+
+    if title.chars().count() > MAX_TITLE_CHARS {
+        let keep = MAX_TITLE_CHARS.saturating_sub(TITLE_ELLIPSIS_CHARS);
+        let mut truncated = title.chars().take(keep).collect::<String>();
+        truncated.push_str("...");
+        return Some(truncated);
+    }
+
+    Some(title.to_string())
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hermes_core::{LlmResponse, MessageRole, StreamChunk, ToolSchema};
+    use std::sync::{Arc, Mutex};
+
+    struct ScriptedProvider {
+        response: Mutex<Result<String, AgentError>>,
+        recorded: Mutex<Vec<RecordedTitleCall>>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecordedTitleCall {
+        messages: Vec<Message>,
+        max_tokens: Option<u32>,
+        temperature: Option<f64>,
+        model: Option<String>,
+    }
+
+    impl ScriptedProvider {
+        fn with_response(text: &str) -> Arc<Self> {
+            Arc::new(Self {
+                response: Mutex::new(Ok(text.to_string())),
+                recorded: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn with_error(message: &str) -> Arc<Self> {
+            Arc::new(Self {
+                response: Mutex::new(Err(AgentError::LlmApi(message.to_string()))),
+                recorded: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn recorded(&self) -> Vec<RecordedTitleCall> {
+            self.recorded.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for ScriptedProvider {
+        async fn chat_completion(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+            max_tokens: Option<u32>,
+            temperature: Option<f64>,
+            model: Option<&str>,
+            _extra_body: Option<&serde_json::Value>,
+        ) -> Result<LlmResponse, AgentError> {
+            self.recorded.lock().unwrap().push(RecordedTitleCall {
+                messages: messages.to_vec(),
+                max_tokens,
+                temperature,
+                model: model.map(ToOwned::to_owned),
+            });
+
+            let response = self.response.lock().unwrap().clone()?;
+            Ok(LlmResponse {
+                message: Message {
+                    role: MessageRole::Assistant,
+                    content: Some(response),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
+                    reasoning_content: None,
+                    cache_control: None,
+                },
+                usage: None,
+                model: model.unwrap_or("test-title-model").to_string(),
+                finish_reason: Some("stop".into()),
+            })
+        }
+
+        fn chat_completion_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            _model: Option<&str>,
+            _extra_body: Option<&serde_json::Value>,
+        ) -> futures::stream::BoxStream<'static, Result<StreamChunk, AgentError>> {
+            panic!("ScriptedProvider streaming is not used by title tests")
+        }
+    }
 
     #[test]
     fn test_truncate_messages() {
@@ -186,6 +302,107 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let result = rt.block_on(gen.generate_title(&[]));
         assert!(matches!(result, Err(TitleError::NoMessages)));
+    }
+
+    #[test]
+    fn test_generate_title_strips_quotes() {
+        let provider = ScriptedProvider::with_response("\"Setting Up Docker Environment\"");
+        let gen = TitleGenerator::new(provider, "title-model");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let title = rt
+            .block_on(gen.generate_title(&[
+                Message::user("how do I set up docker"),
+                Message::assistant("First install Docker Desktop."),
+            ]))
+            .unwrap();
+
+        assert_eq!(title, "Setting Up Docker Environment");
+    }
+
+    #[test]
+    fn test_generate_title_strips_title_prefix() {
+        let provider = ScriptedProvider::with_response("Title: Kubernetes Pod Debugging");
+        let gen = TitleGenerator::new(provider, "title-model");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let title = rt
+            .block_on(gen.generate_title(&[
+                Message::user("my pod keeps crashing"),
+                Message::assistant("Let me inspect the logs."),
+            ]))
+            .unwrap();
+
+        assert_eq!(title, "Kubernetes Pod Debugging");
+    }
+
+    #[test]
+    fn test_generate_title_truncates_long_titles() {
+        let provider = ScriptedProvider::with_response(&"A".repeat(100));
+        let gen = TitleGenerator::new(provider, "title-model");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let title = rt
+            .block_on(
+                gen.generate_title(&[Message::user("question"), Message::assistant("answer")]),
+            )
+            .unwrap();
+
+        assert_eq!(title.chars().count(), 80);
+        assert!(title.ends_with("..."));
+    }
+
+    #[test]
+    fn test_generate_title_returns_empty_result_for_empty_response() {
+        let provider = ScriptedProvider::with_response("");
+        let gen = TitleGenerator::new(provider, "title-model");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result = rt.block_on(
+            gen.generate_title(&[Message::user("question"), Message::assistant("answer")]),
+        );
+
+        assert!(matches!(result, Err(TitleError::EmptyResult)));
+    }
+
+    #[test]
+    fn test_generate_title_surfaces_provider_errors() {
+        let provider = ScriptedProvider::with_error("no provider");
+        let gen = TitleGenerator::new(provider, "title-model");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result = rt.block_on(
+            gen.generate_title(&[Message::user("question"), Message::assistant("answer")]),
+        );
+
+        assert!(
+            matches!(result, Err(TitleError::LlmError(message)) if message.contains("no provider"))
+        );
+    }
+
+    #[test]
+    fn test_generate_title_request_uses_small_title_budget_and_truncated_prompt() {
+        let provider = ScriptedProvider::with_response("Short Title");
+        let gen = TitleGenerator::new(provider.clone(), "title-model").with_max_message_chars(20);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let title = rt
+            .block_on(gen.generate_title(&[
+                Message::user("x".repeat(1000)),
+                Message::assistant("y".repeat(1000)),
+            ]))
+            .unwrap();
+
+        assert_eq!(title, "Short Title");
+        let calls = provider.recorded();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].max_tokens, Some(32));
+        assert_eq!(calls[0].temperature, Some(0.3));
+        assert_eq!(calls[0].model.as_deref(), Some("title-model"));
+        let user_prompt = calls[0].messages[1].content.as_deref().unwrap();
+        assert!(user_prompt.contains("User:"));
+        assert!(user_prompt.contains("Assistant:"));
+        assert!(user_prompt.len() < 100);
     }
 
     // Helper for tests that don't need a real provider

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T03:19:49.258030+00:00",
+  "generated_at_utc": "2026-05-30T03:32:33.566112+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "bc82b38ff0c7153d917852c43c6fff0797900070",
+    "local_sha": "106288212242e5baebf9fbb4a57864f97b3295a3",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 819,
+    "commits_ahead": 821,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 693,
+    "local_patch_unique": 694,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 384693
+    "tree_deletions": 384789
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 693,
+    "local_patch_unique": 694,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T03:19:49.258030+00:00`
+Generated: `2026-05-30T03:32:33.566112+00:00`
 
 ## Scope
 
-- Local ref: `main` (`bc82b38ff0c7153d917852c43c6fff0797900070`)
+- Local ref: `main` (`106288212242e5baebf9fbb4a57864f97b3295a3`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T03:19:49.258030+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 819 |
+| Commits ahead local (`local` ancestry only) | 821 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 693 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 694 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 384693 |
+| Deletions (`local` vs `upstream`) | 384789 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T03:19:49.258030+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `693`
+- Local unique by patch-id: `694`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -2446,16 +2446,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_title_generator.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c498a71ab50b7457c124a55166ab79c60bbd1c27",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_title_generator.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "56286f6ecc990222b1b3c416994b437f1b74d88e",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T03:19:56.795106+00:00",
+  "generated_at_utc": "2026-05-30T03:32:38.565986+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "bc82b38ff0c7153d917852c43c6fff0797900070",
+    "local_sha": "106288212242e5baebf9fbb4a57864f97b3295a3",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 749,
-      "intentional_divergence": 100,
+      "functional": 748,
+      "intentional_divergence": 101,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 269,
-      "rust_equivalent_or_contract_test_required": 670,
+      "not_required_for_runtime": 270,
+      "rust_equivalent_or_contract_test_required": 669,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 100,
+      "cleared_intentional_divergence": 101,
       "cleared_non_runtime": 169,
-      "pending_review": 749
+      "pending_review": 748
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 100,
+    "cleared_intentional_divergence": 101,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 749,
+    "pending_review": 748,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T03:19:56.795106+00:00`
+Generated: `2026-05-30T03:32:38.565986+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `749`
+- Pending functional review: `748`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `100`
+- Cleared intentional divergence: `101`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 100 |
+| `cleared_intentional_divergence` | 101 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 749 |
+| `pending_review` | 748 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T03:19:56.795106+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 56 |
-| `tests/agent` | 55 |
+| `tests/agent` | 54 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -199,6 +199,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_title_generator.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream title-generation sanitization, truncation, provider-error, and prompt-budget intent is covered by Rust hermes-intelligence TitleGenerator tests; Python thread/session DB worker tests remain reference-only because Hermes Ultra owns session title orchestration in Rust CLI/session code.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_unsupported_temperature_retry.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream's unsupported-temperature and OpenAI-compatible max-token omission regression intent is covered by Rust auxiliary-client tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- Added Rust title-generation cleanup for quoted titles, Title: prefixes, and 80-character title caps.
- Added Rust TitleGenerator tests for sanitization, empty/provider-error results, request model/budget, and prompt truncation.
- Marked tests/agent/test_title_generator.py as reference-only with Rust coverage and regenerated parity docs; pending functional review is now 748.

## Local Verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different variants: no matches, exit 1
- cargo test -p hermes-intelligence title -- --nocapture
- cargo test -p hermes-intelligence
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
- cargo build -p hermes-cli

## Notes
- GitHub Actions are optional; local gates above are authoritative.