### PR TITLE
parity(agent): cover anthropic adapter contracts

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -13,7 +13,11 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use hermes_intelligence::anthropic_adapter::get_anthropic_max_output;
+use hermes_intelligence::anthropic_adapter::{
+    default_anthropic_beta_header_value, forbids_sampling_params, get_anthropic_max_output,
+    is_azure_anthropic_endpoint, is_oauth_token, is_third_party_endpoint, requires_bearer_auth,
+    supports_fast_mode,
+};
 
 use hermes_core::{
     AgentError, FunctionCall, FunctionCallDelta, LlmProvider, LlmResponse, Message, MessageRole,
@@ -1019,12 +1023,79 @@ impl AnthropicProvider {
         api_key: &str,
         body: &Value,
     ) -> reqwest::RequestBuilder {
-        client
+        let base_url = self.base_url.as_str();
+        let native_oauth = !is_third_party_endpoint(Some(base_url)) && is_oauth_token(api_key);
+        let bearer_auth = native_oauth || requires_bearer_auth(Some(base_url));
+        let beta_header = default_anthropic_beta_header_value(Some(base_url), native_oauth);
+
+        let mut request = client
             .post(url)
-            .header("x-api-key", api_key)
             .header("anthropic-version", &self.api_version)
             .header("Content-Type", "application/json")
-            .json(body)
+            .header("anthropic-beta", beta_header)
+            .json(body);
+
+        if bearer_auth {
+            request = request.header("Authorization", format!("Bearer {api_key}"));
+        } else {
+            request = request.header("x-api-key", api_key);
+        }
+        if native_oauth {
+            request = request
+                .header("user-agent", "claude-cli/2.1.74 (external, cli)")
+                .header("x-app", "cli");
+        }
+        request
+    }
+
+    fn messages_url(&self) -> String {
+        Self::messages_url_for_base_url(&self.base_url)
+    }
+
+    fn messages_url_for_base_url(base_url: &str) -> String {
+        let trimmed = base_url.trim().trim_end_matches('/');
+        if let Ok(mut url) = reqwest::Url::parse(trimmed) {
+            let mut path = url.path().trim_end_matches('/').to_string();
+            if path.is_empty() {
+                path.push_str("/v1/messages");
+            } else if path.ends_with("/v1") {
+                path.push_str("/messages");
+            } else {
+                path.push_str("/v1/messages");
+            }
+            url.set_path(&path);
+            if is_azure_anthropic_endpoint(Some(trimmed))
+                && !url
+                    .query_pairs()
+                    .any(|(key, _)| key.eq_ignore_ascii_case("api-version"))
+            {
+                url.query_pairs_mut()
+                    .append_pair("api-version", "2025-04-15");
+            }
+            return url.to_string();
+        }
+
+        let mut url = format!("{trimmed}/v1/messages");
+        if is_azure_anthropic_endpoint(Some(trimmed)) && !url.contains("api-version=") {
+            let sep = if url.contains('?') { '&' } else { '?' };
+            url.push(sep);
+            url.push_str("api-version=2025-04-15");
+        }
+        url
+    }
+
+    fn strip_unsupported_anthropic_controls(body: &mut Value, model: &str) {
+        let Some(obj) = body.as_object_mut() else {
+            return;
+        };
+        if forbids_sampling_params(model) {
+            obj.remove("temperature");
+            obj.remove("top_p");
+            obj.remove("top_k");
+        }
+        if obj.get("speed").and_then(Value::as_str) == Some("fast") && !supports_fast_mode(model) {
+            obj.remove("speed");
+        }
     }
 
     async fn send_with_dead_connection_recovery(
@@ -1333,8 +1404,9 @@ impl LlmProvider for AnthropicProvider {
             body["tools"] = serde_json::json!(Self::convert_tools(tools));
         }
         GenericProvider::merge_extra_body_fields(&mut body, extra_body);
+        Self::strip_unsupported_anthropic_controls(&mut body, effective_model);
 
-        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let url = self.messages_url();
         let resp = self
             .send_with_dead_connection_recovery(&url, &api_key, &body)
             .await?;
@@ -1404,8 +1476,9 @@ impl LlmProvider for AnthropicProvider {
                 body["tools"] = serde_json::json!(AnthropicProvider::convert_tools(&tools));
             }
             GenericProvider::merge_extra_body_fields(&mut body, extra_body.as_ref());
+            AnthropicProvider::strip_unsupported_anthropic_controls(&mut body, effective_model);
 
-            let url = format!("{}/v1/messages", provider.base_url.trim_end_matches('/'));
+            let url = provider.messages_url();
 
             let resp = match provider.send_with_dead_connection_recovery(&url, &api_key, &body).await {
                 Ok(r) => r,
@@ -2665,6 +2738,133 @@ mod tests {
             AnthropicProvider::convert_messages(&messages, Some("https://api.anthropic.com"));
         let content = msgs[0]["content"].as_array().unwrap();
         assert_eq!(content[0]["type"], "tool_use");
+    }
+
+    #[test]
+    fn test_anthropic_messages_url_adds_azure_api_version_query() {
+        let url = AnthropicProvider::messages_url_for_base_url(
+            "https://my-resource.openai.azure.com/anthropic",
+        );
+        assert_eq!(
+            url,
+            "https://my-resource.openai.azure.com/anthropic/v1/messages?api-version=2025-04-15"
+        );
+
+        let existing = AnthropicProvider::messages_url_for_base_url(
+            "https://my-resource.openai.azure.com/anthropic?api-version=2024-01-01",
+        );
+        assert_eq!(
+            existing,
+            "https://my-resource.openai.azure.com/anthropic/v1/messages?api-version=2024-01-01"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_request_uses_bearer_auth_and_azure_betas_for_foundry() {
+        let provider = AnthropicProvider::new("azure-foundry-secret")
+            .with_base_url("https://my-resource.openai.azure.com/anthropic");
+        let url = provider.messages_url();
+        let request = provider
+            .build_request(
+                &Client::new(),
+                &url,
+                "azure-foundry-secret",
+                &serde_json::json!({}),
+            )
+            .build()
+            .expect("request");
+        let headers = request.headers();
+        assert_eq!(
+            headers.get("Authorization").and_then(|h| h.to_str().ok()),
+            Some("Bearer azure-foundry-secret")
+        );
+        assert!(headers.get("x-api-key").is_none());
+        let betas = headers
+            .get("anthropic-beta")
+            .and_then(|h| h.to_str().ok())
+            .expect("anthropic-beta");
+        assert!(betas.contains("context-1m-2025-08-07"));
+        assert!(betas.contains("fine-grained-tool-streaming-2025-05-14"));
+    }
+
+    #[test]
+    fn test_anthropic_request_uses_api_key_for_native_api_key() {
+        let provider = AnthropicProvider::new("sk-ant-api03-secret");
+        let request = provider
+            .build_request(
+                &Client::new(),
+                "https://api.anthropic.com/v1/messages",
+                "sk-ant-api03-secret",
+                &serde_json::json!({}),
+            )
+            .build()
+            .expect("request");
+        let headers = request.headers();
+        assert_eq!(
+            headers.get("x-api-key").and_then(|h| h.to_str().ok()),
+            Some("sk-ant-api03-secret")
+        );
+        assert!(headers.get("Authorization").is_none());
+        let betas = headers
+            .get("anthropic-beta")
+            .and_then(|h| h.to_str().ok())
+            .expect("anthropic-beta");
+        assert!(betas.contains("interleaved-thinking-2025-05-14"));
+        assert!(!betas.contains("oauth-2025-04-20"));
+        assert!(!betas.contains("context-1m-2025-08-07"));
+    }
+
+    #[test]
+    fn test_anthropic_request_uses_bearer_and_oauth_betas_for_native_oauth() {
+        let provider = AnthropicProvider::new("sk-ant-oat01-secret");
+        let request = provider
+            .build_request(
+                &Client::new(),
+                "https://api.anthropic.com/v1/messages",
+                "sk-ant-oat01-secret",
+                &serde_json::json!({}),
+            )
+            .build()
+            .expect("request");
+        let headers = request.headers();
+        assert_eq!(
+            headers.get("Authorization").and_then(|h| h.to_str().ok()),
+            Some("Bearer sk-ant-oat01-secret")
+        );
+        assert!(headers.get("x-api-key").is_none());
+        let betas = headers
+            .get("anthropic-beta")
+            .and_then(|h| h.to_str().ok())
+            .expect("anthropic-beta");
+        assert!(betas.contains("oauth-2025-04-20"));
+        assert!(betas.contains("claude-code-20250219"));
+    }
+
+    #[test]
+    fn test_anthropic_strips_sampling_and_unsupported_fast_controls() {
+        let mut body = serde_json::json!({
+            "model": "claude-opus-4-8-fast",
+            "messages": [],
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 20,
+            "speed": "fast"
+        });
+        AnthropicProvider::strip_unsupported_anthropic_controls(&mut body, "claude-opus-4-8-fast");
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("top_p").is_none());
+        assert!(body.get("top_k").is_none());
+        assert!(body.get("speed").is_none());
+
+        let mut supported = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "messages": [],
+            "temperature": 0.7,
+            "speed": "fast"
+        });
+        AnthropicProvider::strip_unsupported_anthropic_controls(&mut supported, "claude-opus-4-6");
+        assert_eq!(supported["temperature"], serde_json::json!(0.7));
+        assert_eq!(supported["speed"], serde_json::json!("fast"));
     }
 
     #[test]

--- a/crates/hermes-intelligence/src/anthropic_adapter.rs
+++ b/crates/hermes-intelligence/src/anthropic_adapter.rs
@@ -21,6 +21,8 @@ const MCP_TOOL_PREFIX: &str = "mcp_";
 
 /// Max output token limits per Anthropic model.
 static ANTHROPIC_OUTPUT_LIMITS: &[(&str, u32)] = &[
+    ("claude-opus-4-8", 128_000),
+    ("claude-opus-4-7", 128_000),
     ("claude-opus-4-6", 128_000),
     ("claude-sonnet-4-6", 64_000),
     ("claude-opus-4-5", 64_000),
@@ -35,6 +37,7 @@ static ANTHROPIC_OUTPUT_LIMITS: &[(&str, u32)] = &[
     ("claude-3-sonnet", 4_096),
     ("claude-3-haiku", 4_096),
     ("minimax", 131_072),
+    ("qwen3", 65_536),
 ];
 
 const ANTHROPIC_DEFAULT_OUTPUT_LIMIT: u32 = 128_000;
@@ -45,8 +48,13 @@ const COMMON_BETAS: &[&str] = &[
     "fine-grained-tool-streaming-2025-05-14",
 ];
 const TOOL_STREAMING_BETA: &str = "fine-grained-tool-streaming-2025-05-14";
+const CONTEXT_1M_BETA: &str = "context-1m-2025-08-07";
 const FAST_MODE_BETA: &str = "fast-mode-2026-02-01";
 const OAUTH_ONLY_BETAS: &[&str] = &["claude-code-20250219", "oauth-2025-04-20"];
+const ADAPTIVE_THINKING_SUBSTRINGS: &[&str] = &["4-6", "4.6", "4-7", "4.7", "4-8", "4.8"];
+const XHIGH_EFFORT_SUBSTRINGS: &[&str] = &["4-7", "4.7", "4-8", "4.8"];
+const NO_SAMPLING_PARAMS_SUBSTRINGS: &[&str] = &["4-7", "4.7", "4-8", "4.8"];
+const FAST_MODE_SUPPORTED_SUBSTRINGS: &[&str] = &["opus-4-6", "opus-4.6"];
 
 // ---------------------------------------------------------------------------
 // Types
@@ -188,7 +196,30 @@ pub fn get_anthropic_max_output(model: &str) -> u32 {
 
 /// Return true for Claude 4.6 models that support adaptive thinking.
 pub fn supports_adaptive_thinking(model: &str) -> bool {
-    model.contains("4-6") || model.contains("4.6")
+    ADAPTIVE_THINKING_SUBSTRINGS
+        .iter()
+        .any(|needle| model.contains(needle))
+}
+
+/// Return true for models that accept Anthropic's `xhigh` adaptive effort.
+pub fn supports_xhigh_effort(model: &str) -> bool {
+    XHIGH_EFFORT_SUBSTRINGS
+        .iter()
+        .any(|needle| model.contains(needle))
+}
+
+/// Return true for models that reject explicit sampling parameters.
+pub fn forbids_sampling_params(model: &str) -> bool {
+    NO_SAMPLING_PARAMS_SUBSTRINGS
+        .iter()
+        .any(|needle| model.contains(needle))
+}
+
+/// Return true for models that support the Anthropic `speed=fast` parameter.
+pub fn supports_fast_mode(model: &str) -> bool {
+    FAST_MODE_SUPPORTED_SUBSTRINGS
+        .iter()
+        .any(|needle| model.contains(needle))
 }
 
 // ---------------------------------------------------------------------------
@@ -732,6 +763,9 @@ pub fn is_oauth_token(key: &str) -> bool {
     if key.starts_with("eyJ") {
         return true;
     }
+    if key.starts_with("cc-") {
+        return true;
+    }
     false
 }
 
@@ -749,17 +783,55 @@ pub fn is_third_party_endpoint(base_url: Option<&str>) -> bool {
     }
 }
 
+/// Return true for MiniMax's Anthropic-compatible endpoints.
+pub fn is_minimax_anthropic_endpoint(base_url: Option<&str>) -> bool {
+    match base_url {
+        None => false,
+        Some(url) => {
+            let normalized = url.trim().trim_end_matches('/').to_lowercase();
+            normalized.starts_with("https://api.minimax.io/anthropic")
+                || normalized.starts_with("https://api.minimaxi.com/anthropic")
+        }
+    }
+}
+
+/// Return true for Azure-hosted Anthropic Messages endpoints.
+pub fn is_azure_anthropic_endpoint(base_url: Option<&str>) -> bool {
+    let Some(raw) = base_url.map(str::trim).filter(|url| !url.is_empty()) else {
+        return false;
+    };
+    let Ok(parsed) = reqwest::Url::parse(raw) else {
+        return false;
+    };
+    let host = parsed
+        .host_str()
+        .unwrap_or("")
+        .trim_end_matches('.')
+        .to_lowercase();
+    let path = parsed.path().to_lowercase();
+    let host_padded = format!(".{host}.");
+    let is_foundry_host = host_padded.contains(".services.ai.azure.");
+    let is_legacy_azoai_host = host_padded.contains(".openai.azure.");
+    (is_foundry_host || is_legacy_azoai_host) && path.contains("/anthropic")
+}
+
+/// Return true for endpoints that still gate 1M context behind a beta header.
+pub fn base_url_needs_context_1m_beta(base_url: Option<&str>) -> bool {
+    base_url
+        .map(|url| url.trim().to_lowercase().contains("azure.com"))
+        .unwrap_or(false)
+}
+
 /// Return beta headers safe for the configured endpoint.
 pub fn common_betas_for_base_url(base_url: Option<&str>) -> Vec<&'static str> {
-    if requires_bearer_auth(base_url) {
-        COMMON_BETAS
-            .iter()
-            .copied()
-            .filter(|b| *b != TOOL_STREAMING_BETA)
-            .collect()
-    } else {
-        COMMON_BETAS.to_vec()
+    let mut betas = COMMON_BETAS.to_vec();
+    if base_url_needs_context_1m_beta(base_url) {
+        betas.push(CONTEXT_1M_BETA);
     }
+    if is_minimax_anthropic_endpoint(base_url) {
+        betas.retain(|beta| *beta != TOOL_STREAMING_BETA && *beta != CONTEXT_1M_BETA);
+    }
+    betas
 }
 
 /// Beta list for `default_headers["anthropic-beta"]` when constructing an Anthropic client.
@@ -799,14 +871,14 @@ pub fn fast_mode_request_beta_list(
     Some(betas)
 }
 
-/// Check if a base URL requires Bearer auth (e.g. MiniMax).
+/// Check if a base URL requires Bearer auth (e.g. MiniMax or Azure Foundry).
 pub fn requires_bearer_auth(base_url: Option<&str>) -> bool {
     match base_url {
         None => false,
         Some(url) => {
             let normalized = url.trim().trim_end_matches('/').to_lowercase();
-            normalized.starts_with("https://api.minimax.io/anthropic")
-                || normalized.starts_with("https://api.minimaxi.com/anthropic")
+            is_minimax_anthropic_endpoint(Some(normalized.as_str()))
+                || normalized.contains("azure.com")
         }
     }
 }
@@ -858,6 +930,7 @@ mod tests {
     #[test]
     fn test_get_anthropic_max_output() {
         assert_eq!(get_anthropic_max_output("claude-opus-4-6"), 128_000);
+        assert_eq!(get_anthropic_max_output("claude-opus-4-8-fast"), 128_000);
         assert_eq!(
             get_anthropic_max_output("claude-sonnet-4-6-20260101"),
             64_000
@@ -881,6 +954,7 @@ mod tests {
         assert!(!is_oauth_token("sk-ant-api03-xxx"));
         assert!(is_oauth_token("sk-ant-oat-xxx"));
         assert!(is_oauth_token("eyJhbGci..."));
+        assert!(is_oauth_token("cc-claude-code-oauth"));
         assert!(!is_oauth_token("sk-proj-xxx"));
         assert!(!is_oauth_token(""));
     }
@@ -889,7 +963,23 @@ mod tests {
     fn test_supports_adaptive_thinking() {
         assert!(supports_adaptive_thinking("claude-opus-4-6"));
         assert!(supports_adaptive_thinking("claude-sonnet-4.6"));
+        assert!(supports_adaptive_thinking("claude-opus-4-7"));
+        assert!(supports_adaptive_thinking("claude-opus-4.8"));
         assert!(!supports_adaptive_thinking("claude-sonnet-4"));
+    }
+
+    #[test]
+    fn test_sampling_and_fast_mode_predicates_cover_opus_4_8() {
+        assert!(supports_xhigh_effort("claude-opus-4-7"));
+        assert!(supports_xhigh_effort("claude-opus-4.8-fast"));
+        assert!(forbids_sampling_params("claude-opus-4-7"));
+        assert!(forbids_sampling_params("claude-opus-4-8-fast"));
+        assert!(!forbids_sampling_params("claude-opus-4-6"));
+        assert!(supports_fast_mode("claude-opus-4-6"));
+        assert!(supports_fast_mode("anthropic/claude-opus-4.6"));
+        assert!(!supports_fast_mode("claude-opus-4-7"));
+        assert!(!supports_fast_mode("claude-opus-4-8-fast"));
+        assert!(!supports_fast_mode("claude-sonnet-4-6"));
     }
 
     #[test]
@@ -947,6 +1037,41 @@ mod tests {
         let oauth = default_anthropic_beta_list(None, true);
         assert!(oauth.iter().any(|b| *b == "oauth-2025-04-20"));
         assert!(oauth.len() > api.len());
+    }
+
+    #[test]
+    fn test_azure_anthropic_endpoint_detection_is_host_and_path_scoped() {
+        assert!(is_azure_anthropic_endpoint(Some(
+            "https://example.services.ai.azure.com/models/anthropic"
+        )));
+        assert!(is_azure_anthropic_endpoint(Some(
+            "https://example.services.ai.azure.us/anthropic"
+        )));
+        assert!(!is_azure_anthropic_endpoint(Some(
+            "https://example.openai.azure.com/openai/v1"
+        )));
+        assert!(!is_azure_anthropic_endpoint(Some(
+            "https://management.azure.com/anthropic"
+        )));
+    }
+
+    #[test]
+    fn test_azure_endpoint_keeps_context_1m_and_tool_streaming_betas() {
+        let betas =
+            common_betas_for_base_url(Some("https://my-resource.openai.azure.com/anthropic"));
+        assert!(betas.iter().any(|b| *b == CONTEXT_1M_BETA));
+        assert!(betas.iter().any(|b| *b == TOOL_STREAMING_BETA));
+    }
+
+    #[test]
+    fn test_requires_bearer_auth_covers_minimax_and_azure() {
+        assert!(requires_bearer_auth(Some(
+            "https://api.minimax.io/anthropic"
+        )));
+        assert!(requires_bearer_auth(Some(
+            "https://my-resource.openai.azure.com/anthropic"
+        )));
+        assert!(!requires_bearer_auth(Some("https://api.anthropic.com")));
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T03:32:33.566112+00:00",
+  "generated_at_utc": "2026-05-30T03:52:08.637638+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "106288212242e5baebf9fbb4a57864f97b3295a3",
+    "local_sha": "31e11ef94adda727b5026422b651b3c703690f82",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 821,
+    "commits_ahead": 823,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 694,
+    "local_patch_unique": 695,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 384789
+    "tree_deletions": 385013
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 694,
+    "local_patch_unique": 695,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T03:32:33.566112+00:00`
+Generated: `2026-05-30T03:52:08.637638+00:00`
 
 ## Scope
 
-- Local ref: `main` (`106288212242e5baebf9fbb4a57864f97b3295a3`)
+- Local ref: `main` (`31e11ef94adda727b5026422b651b3c703690f82`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T03:32:33.566112+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 821 |
+| Commits ahead local (`local` ancestry only) | 823 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 694 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 695 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 384789 |
+| Deletions (`local` vs `upstream`) | 385013 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T03:32:33.566112+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `694`
+- Local unique by patch-id: `695`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1711,16 +1711,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_anthropic_adapter.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0ba2ba29f51bdf77392b53b2fa54bc3dfe53954d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_anthropic_adapter.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7c7e8e333734b268cb2871815a353697ea728703",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T03:32:38.565986+00:00",
+  "generated_at_utc": "2026-05-30T03:52:06.811168+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "106288212242e5baebf9fbb4a57864f97b3295a3",
+    "local_sha": "31e11ef94adda727b5026422b651b3c703690f82",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 748,
-      "intentional_divergence": 101,
+      "functional": 747,
+      "intentional_divergence": 102,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 270,
-      "rust_equivalent_or_contract_test_required": 669,
+      "not_required_for_runtime": 271,
+      "rust_equivalent_or_contract_test_required": 668,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 101,
+      "cleared_intentional_divergence": 102,
       "cleared_non_runtime": 169,
-      "pending_review": 748
+      "pending_review": 747
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 101,
+    "cleared_intentional_divergence": 102,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 748,
+    "pending_review": 747,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T03:32:38.565986+00:00`
+Generated: `2026-05-30T03:52:06.811168+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `748`
+- Pending functional review: `747`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `101`
+- Cleared intentional divergence: `102`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 101 |
+| `cleared_intentional_divergence` | 102 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 748 |
+| `pending_review` | 747 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T03:32:38.565986+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 56 |
-| `tests/agent` | 54 |
+| `tests/agent` | 53 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -192,6 +192,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_anthropic_adapter.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Anthropic adapter endpoint, auth, beta-header, OAuth-token, 4.8 sampling, and fast-mode intent is covered by Rust hermes-intelligence adapter contracts and hermes-agent provider request construction tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- Port upstream Anthropic adapter endpoint/auth contracts into Rust: Azure Anthropic endpoint detection, Azure api-version URL handling, bearer auth, beta header selection, OAuth token detection, Opus 4.8 output/sampling/fast-mode predicates.
- Wire the Rust Anthropic provider to use bearer vs x-api-key auth correctly and strip unsupported Anthropic sampling/fast-mode controls before requests.
- Mark upstream tests/agent/test_anthropic_adapter.py as Rust-covered reference-only and regenerate parity docs.

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- cargo test -p hermes-intelligence
- cargo test -p hermes-agent
- cargo test -p hermes-parity-tests
- cargo test -p hermes-cli
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md