### PR TITLE
parity(agent): cover Anthropic keychain contracts

### DIFF
--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -3,6 +3,7 @@ use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;
@@ -33,6 +34,8 @@ pub const ANTHROPIC_OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5
 pub const ANTHROPIC_OAUTH_REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
 pub const ANTHROPIC_OAUTH_SCOPE: &str = "org:create_api_key user:profile user:inference";
 pub const ANTHROPIC_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS: i64 = 60;
+const ANTHROPIC_CLAUDE_CODE_KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
+const ANTHROPIC_CLAUDE_CODE_KEYCHAIN_TIMEOUT: Duration = Duration::from_secs(5);
 pub const DEFAULT_QWEN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 pub const QWEN_OAUTH_CLIENT_ID: &str = "f0304373b74a44d2b584a3fb70ca9e56";
 pub const QWEN_OAUTH_TOKEN_URL: &str = "https://chat.qwen.ai/api/v1/oauth2/token";
@@ -791,34 +794,108 @@ fn normalize_unix_millis(timestamp: i64) -> i64 {
     }
 }
 
+fn anthropic_keychain_source_path() -> PathBuf {
+    PathBuf::from(format!(
+        "macos-keychain://{}",
+        ANTHROPIC_CLAUDE_CODE_KEYCHAIN_SERVICE
+    ))
+}
+
+fn load_anthropic_oauth_import_from_claude_credentials_json(
+    raw: &str,
+    source_path: PathBuf,
+    source: &str,
+) -> Option<AnthropicOAuthImport> {
+    let parsed = serde_json::from_str::<ExternalClaudeCredentialsFile>(raw).ok()?;
+    let oauth = parsed.claude_ai_oauth?;
+    let access_token = oauth
+        .access_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?
+        .to_string();
+    let refresh_token = oauth
+        .refresh_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let expires_at_ms = oauth.expires_at_ms.map(normalize_unix_millis);
+    Some(AnthropicOAuthImport {
+        state: AnthropicOAuthState {
+            access_token,
+            refresh_token,
+            expires_at_ms,
+        },
+        source_path,
+        source: source.to_string(),
+    })
+}
+
+fn load_anthropic_oauth_import_from_keychain_payload(raw: &str) -> Option<AnthropicOAuthImport> {
+    load_anthropic_oauth_import_from_claude_credentials_json(
+        raw,
+        anthropic_keychain_source_path(),
+        "macos_keychain",
+    )
+}
+
+fn run_anthropic_keychain_read() -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+
+    let mut child = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            ANTHROPIC_CLAUDE_CODE_KEYCHAIN_SERVICE,
+            "-w",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let started = Instant::now();
+    loop {
+        if started.elapsed() >= ANTHROPIC_CLAUDE_CODE_KEYCHAIN_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        match child.try_wait().ok()? {
+            Some(status) => {
+                let output = child.wait_with_output().ok()?;
+                if !status.success() {
+                    return None;
+                }
+                let stdout = String::from_utf8(output.stdout).ok()?;
+                let trimmed = stdout.trim();
+                if trimmed.is_empty() {
+                    return None;
+                }
+                return Some(trimmed.to_string());
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+fn load_anthropic_oauth_import_from_keychain() -> Option<AnthropicOAuthImport> {
+    let raw = run_anthropic_keychain_read()?;
+    load_anthropic_oauth_import_from_keychain_payload(&raw)
+}
+
 fn load_anthropic_oauth_import_from_path(path: &Path) -> Option<AnthropicOAuthImport> {
     let raw = std::fs::read_to_string(path).ok()?;
 
-    if let Ok(parsed) = serde_json::from_str::<ExternalClaudeCredentialsFile>(&raw) {
-        if let Some(oauth) = parsed.claude_ai_oauth {
-            let access_token = oauth
-                .access_token
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())?
-                .to_string();
-            let refresh_token = oauth
-                .refresh_token
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string);
-            let expires_at_ms = oauth.expires_at_ms.map(normalize_unix_millis);
-            return Some(AnthropicOAuthImport {
-                state: AnthropicOAuthState {
-                    access_token,
-                    refresh_token,
-                    expires_at_ms,
-                },
-                source_path: path.to_path_buf(),
-                source: "claude_code_credentials_file".to_string(),
-            });
-        }
+    if let Some(imported) = load_anthropic_oauth_import_from_claude_credentials_json(
+        &raw,
+        path.to_path_buf(),
+        "claude_code_credentials_file",
+    ) {
+        return Some(imported);
     }
 
     let parsed: Value = serde_json::from_str(&raw).ok()?;
@@ -901,6 +978,15 @@ fn load_anthropic_oauth_import_from_store(path: &Path) -> Option<AnthropicOAuthI
 }
 
 pub fn discover_existing_anthropic_oauth() -> Result<Option<AnthropicOAuthImport>, AgentError> {
+    discover_existing_anthropic_oauth_with_keychain(load_anthropic_oauth_import_from_keychain())
+}
+
+fn discover_existing_anthropic_oauth_with_keychain(
+    keychain_import: Option<AnthropicOAuthImport>,
+) -> Result<Option<AnthropicOAuthImport>, AgentError> {
+    if let Some(imported) = keychain_import {
+        return Ok(Some(imported));
+    }
     for path in anthropic_oauth_discovery_paths() {
         if let Some(imported) = load_anthropic_oauth_import_from_path(&path) {
             return Ok(Some(imported));
@@ -3244,7 +3330,7 @@ mod tests {
             cred_path.to_string_lossy().to_string(),
         );
 
-        let imported = discover_existing_anthropic_oauth()
+        let imported = discover_existing_anthropic_oauth_with_keychain(None)
             .expect("discover")
             .expect("imported");
         assert_eq!(imported.source_path, cred_path);
@@ -3252,6 +3338,84 @@ mod tests {
         assert_eq!(imported.state.access_token, "ant-access");
         assert_eq!(imported.state.refresh_token.as_deref(), Some("ant-refresh"));
         assert_eq!(imported.state.expires_at_ms, Some(expires_at));
+        std::env::remove_var("CLAUDE_CODE_CREDENTIALS_FILE");
+    }
+
+    #[test]
+    fn anthropic_oauth_keychain_payload_parses_valid_claude_code_entry() {
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "keychain-access",
+                "refreshToken": "keychain-refresh",
+                "expiresAt": 9_999_999_999_999i64,
+            }
+        });
+        let imported = load_anthropic_oauth_import_from_keychain_payload(
+            &serde_json::to_string(&raw).expect("serialize keychain payload"),
+        )
+        .expect("imported");
+
+        assert_eq!(imported.source_path, anthropic_keychain_source_path());
+        assert_eq!(imported.source, "macos_keychain");
+        assert_eq!(imported.state.access_token, "keychain-access");
+        assert_eq!(
+            imported.state.refresh_token.as_deref(),
+            Some("keychain-refresh")
+        );
+        assert_eq!(imported.state.expires_at_ms, Some(9_999_999_999_999));
+    }
+
+    #[test]
+    fn anthropic_oauth_keychain_payload_rejects_invalid_entries() {
+        assert!(load_anthropic_oauth_import_from_keychain_payload("").is_none());
+        assert!(load_anthropic_oauth_import_from_keychain_payload("not json").is_none());
+        assert!(load_anthropic_oauth_import_from_keychain_payload(
+            r#"{"someOtherService":{"accessToken":"tok"}}"#
+        )
+        .is_none());
+        assert!(load_anthropic_oauth_import_from_keychain_payload(
+            r#"{"claudeAiOauth":{"accessToken":"","refreshToken":"refresh"}}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn discover_existing_anthropic_oauth_prefers_keychain_over_json_file() {
+        let _guard = test_env_lock::lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cred_path = tmp.path().join(".credentials.json");
+        let raw = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "json-access",
+                "refreshToken": "json-refresh",
+                "expiresAt": 9_999_999_999_999i64,
+            }
+        });
+        std::fs::write(
+            &cred_path,
+            serde_json::to_string_pretty(&raw).expect("serialize credentials"),
+        )
+        .expect("write credentials");
+        std::env::set_var(
+            "CLAUDE_CODE_CREDENTIALS_FILE",
+            cred_path.to_string_lossy().to_string(),
+        );
+
+        let keychain_import = AnthropicOAuthImport {
+            state: AnthropicOAuthState {
+                access_token: "keychain-access".to_string(),
+                refresh_token: Some("keychain-refresh".to_string()),
+                expires_at_ms: Some(9_999_999_999_999),
+            },
+            source_path: anthropic_keychain_source_path(),
+            source: "macos_keychain".to_string(),
+        };
+        let imported = discover_existing_anthropic_oauth_with_keychain(Some(keychain_import))
+            .expect("discover")
+            .expect("imported");
+
+        assert_eq!(imported.state.access_token, "keychain-access");
+        assert_eq!(imported.source, "macos_keychain");
         std::env::remove_var("CLAUDE_CODE_CREDENTIALS_FILE");
     }
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T03:52:08.637638+00:00",
+  "generated_at_utc": "2026-05-30T04:10:11.171744+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "31e11ef94adda727b5026422b651b3c703690f82",
+    "local_sha": "24d5ff17ae49feece3d3f4bff93980d7a6b00f79",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 823,
+    "commits_ahead": 825,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 695,
+    "local_patch_unique": 696,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 385013
+    "tree_deletions": 385345
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 695,
+    "local_patch_unique": 696,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T03:52:08.637638+00:00`
+Generated: `2026-05-30T04:10:11.171744+00:00`
 
 ## Scope
 
-- Local ref: `main` (`31e11ef94adda727b5026422b651b3c703690f82`)
+- Local ref: `main` (`24d5ff17ae49feece3d3f4bff93980d7a6b00f79`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T03:52:08.637638+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 823 |
+| Commits ahead local (`local` ancestry only) | 825 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 695 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 696 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 385013 |
+| Deletions (`local` vs `upstream`) | 385345 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T03:52:08.637638+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `695`
+- Local unique by patch-id: `696`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1726,16 +1726,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_anthropic_keychain.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c0f9c7718246985fa027b32540dc049c67b44e0d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_anthropic_keychain.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "44a458fdf72c7ff823e417c40f335a5d3e40d474",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T03:52:06.811168+00:00",
+  "generated_at_utc": "2026-05-30T04:10:09.358439+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "31e11ef94adda727b5026422b651b3c703690f82",
+    "local_sha": "24d5ff17ae49feece3d3f4bff93980d7a6b00f79",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 747,
-      "intentional_divergence": 102,
+      "functional": 746,
+      "intentional_divergence": 103,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 271,
-      "rust_equivalent_or_contract_test_required": 668,
+      "not_required_for_runtime": 272,
+      "rust_equivalent_or_contract_test_required": 667,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 102,
+      "cleared_intentional_divergence": 103,
       "cleared_non_runtime": 169,
-      "pending_review": 747
+      "pending_review": 746
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 102,
+    "cleared_intentional_divergence": 103,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 747,
+    "pending_review": 746,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T03:52:06.811168+00:00`
+Generated: `2026-05-30T04:10:09.358439+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `747`
+- Pending functional review: `746`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `102`
+- Cleared intentional divergence: `103`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 102 |
+| `cleared_intentional_divergence` | 103 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 747 |
+| `pending_review` | 746 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T03:52:06.811168+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 56 |
-| `tests/agent` | 53 |
+| `tests/agent` | 52 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -199,6 +199,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_anthropic_keychain.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Claude Code macOS Keychain discovery, malformed-entry rejection, JSON fallback, and Keychain-priority intent is covered by Rust hermes-cli auth discovery and parser tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",


### PR DESCRIPTION
Summary:
- Add Rust-native macOS Keychain discovery for Claude Code Anthropic OAuth credentials before JSON/auth-store fallback.
- Reuse the Claude credentials parser for both Keychain and JSON payloads, with Rust tests for valid payloads, invalid payload rejection, and Keychain priority.
- Classify tests/agent/test_anthropic_keychain.py as covered by the Rust auth contracts and regenerate parity docs/backlog.

Local verification:
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- cargo test -p hermes-cli anthropic_oauth -- --nocapture
- cargo test -p hermes-cli discover_existing_anthropic_oauth -- --nocapture
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
