### PR TITLE
parity(config): cover auxiliary bridge contracts

### DIFF
--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -1,6 +1,6 @@
 //! Gateway configuration: the top-level config struct and its sub-types.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -81,6 +81,13 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub smart_model_routing: SmartModelRoutingConfig,
 
+    /// Per-task auxiliary model/direct-endpoint overrides.
+    ///
+    /// Keys match the user-facing `auxiliary.<task>.*` config.yaml surface
+    /// used by side tasks such as `vision`, `web_extract`, and `approval`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub auxiliary: BTreeMap<String, AuxiliaryTaskConfig>,
+
     /// Optional HTTP/SOCKS proxy settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy: Option<ProxyConfig>,
@@ -137,6 +144,7 @@ impl Default for GatewayConfig {
             fallback_model: None,
             fallback_models: Vec::new(),
             smart_model_routing: SmartModelRoutingConfig::default(),
+            auxiliary: BTreeMap::new(),
             proxy: None,
             approval: ApprovalConfig::default(),
             security: SecurityConfig::default(),
@@ -146,6 +154,196 @@ impl Default for GatewayConfig {
             profile: ProfileConfig::default(),
             agent: AgentLoopBehaviorConfig::default(),
             home_dir: None,
+        }
+    }
+}
+
+/// User-facing override for one auxiliary side task.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuxiliaryTaskConfig {
+    /// `auto` means resolve through the standard auxiliary chain.
+    #[serde(default = "default_auxiliary_provider")]
+    pub provider: String,
+    /// Empty means use the selected provider's default auxiliary model.
+    #[serde(default)]
+    pub model: String,
+    /// Direct OpenAI-compatible endpoint. When set, it takes precedence over provider.
+    #[serde(default)]
+    pub base_url: String,
+    /// API key for a direct endpoint or explicit task provider.
+    #[serde(default)]
+    pub api_key: String,
+    /// Per-attempt timeout in seconds. Accepts both `timeout` and legacy `timeout_secs`.
+    #[serde(
+        default,
+        alias = "timeout_secs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timeout: Option<u64>,
+    /// Provider-specific OpenAI-compatible request body additions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
+    /// Vision-only image download timeout in seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub download_timeout: Option<u64>,
+    /// Preserve unknown future task keys without dropping user config.
+    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl Default for AuxiliaryTaskConfig {
+    fn default() -> Self {
+        Self {
+            provider: default_auxiliary_provider(),
+            model: String::new(),
+            base_url: String::new(),
+            api_key: String::new(),
+            timeout: None,
+            extra_body: None,
+            download_timeout: None,
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+impl AuxiliaryTaskConfig {
+    pub fn with_timeout(mut self, timeout: u64) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn with_download_timeout(mut self, timeout: u64) -> Self {
+        self.download_timeout = Some(timeout);
+        self
+    }
+}
+
+fn default_auxiliary_provider() -> String {
+    "auto".to_string()
+}
+
+/// Upstream-shaped default auxiliary task table used by setup/config UIs.
+///
+/// `GatewayConfig::default()` intentionally keeps `auxiliary` empty so normal
+/// config layering does not treat defaults as user overrides. Runtime
+/// resolution still defaults each missing task to provider=`auto`, model=`""`.
+pub fn default_auxiliary_task_configs() -> BTreeMap<String, AuxiliaryTaskConfig> {
+    let mut tasks = BTreeMap::new();
+    tasks.insert(
+        "vision".to_string(),
+        AuxiliaryTaskConfig::default()
+            .with_timeout(120)
+            .with_download_timeout(30),
+    );
+    tasks.insert(
+        "web_extract".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(360),
+    );
+    tasks.insert(
+        "compression".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(120),
+    );
+    tasks.insert(
+        "skills_hub".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(30),
+    );
+    tasks.insert(
+        "approval".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(30),
+    );
+    tasks.insert(
+        "mcp".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(30),
+    );
+    tasks.insert(
+        "title_generation".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(30),
+    );
+    tasks.insert(
+        "triage_specifier".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(120),
+    );
+    tasks.insert(
+        "kanban_decomposer".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(180),
+    );
+    tasks.insert(
+        "profile_describer".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(60),
+    );
+    tasks.insert(
+        "curator".to_string(),
+        AuxiliaryTaskConfig::default().with_timeout(600),
+    );
+    tasks
+}
+
+const BUILTIN_AUXILIARY_ENV_BRIDGE_TASKS: &[&str] = &["approval", "vision", "web_extract"];
+
+impl GatewayConfig {
+    /// Return config-derived environment overrides for the built-in auxiliary
+    /// bridge set (`vision`, `web_extract`, `approval`).
+    pub fn builtin_auxiliary_env_overrides(&self) -> Vec<(String, String)> {
+        self.auxiliary_env_overrides_for(std::iter::empty::<&str>())
+    }
+
+    /// Return config-derived `AUXILIARY_<TASK>_*` assignments for built-ins
+    /// plus caller-provided plugin task keys.
+    ///
+    /// The helper mirrors Python's gateway/CLI bridge contract without forcing
+    /// Rust runtime code to rely on process-global env mutation.
+    pub fn auxiliary_env_overrides_for<I, S>(&self, extra_task_keys: I) -> Vec<(String, String)>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut bridged: BTreeSet<String> = BUILTIN_AUXILIARY_ENV_BRIDGE_TASKS
+            .iter()
+            .map(|task| (*task).to_string())
+            .collect();
+        for task in extra_task_keys {
+            let normalized = normalize_auxiliary_task_key(task.as_ref());
+            if !normalized.is_empty() {
+                bridged.insert(normalized);
+            }
+        }
+
+        let mut overrides = Vec::new();
+        for task_key in bridged {
+            let Some(task_cfg) = self.auxiliary.get(task_key.as_str()) else {
+                continue;
+            };
+            push_auxiliary_task_env_overrides(&mut overrides, &task_key, task_cfg);
+        }
+        overrides
+    }
+}
+
+fn normalize_auxiliary_task_key(task: &str) -> String {
+    task.trim().to_ascii_lowercase()
+}
+
+fn auxiliary_task_env_suffix(task: &str) -> String {
+    task.trim().to_ascii_uppercase()
+}
+
+fn push_auxiliary_task_env_overrides(
+    overrides: &mut Vec<(String, String)>,
+    task_key: &str,
+    task_cfg: &AuxiliaryTaskConfig,
+) {
+    let upper = auxiliary_task_env_suffix(task_key);
+    let provider = task_cfg.provider.trim();
+    if !provider.is_empty() && !provider.eq_ignore_ascii_case("auto") {
+        overrides.push((format!("AUXILIARY_{upper}_PROVIDER"), provider.to_string()));
+    }
+    for (field, value) in [
+        ("MODEL", task_cfg.model.trim()),
+        ("BASE_URL", task_cfg.base_url.trim()),
+        ("API_KEY", task_cfg.api_key.trim()),
+    ] {
+        if !value.is_empty() {
+            overrides.push((format!("AUXILIARY_{upper}_{field}"), value.to_string()));
         }
     }
 }
@@ -644,6 +842,7 @@ mod tests {
         assert_eq!(cfg.max_turns, 250);
         assert!(!cfg.tools.is_empty());
         assert!(cfg.model.is_none());
+        assert!(cfg.auxiliary.is_empty());
         assert!(cfg.proxy.is_none());
         assert_eq!(
             cfg.platform_toolsets
@@ -663,11 +862,119 @@ mod tests {
 
     #[test]
     fn gateway_config_serde_roundtrip() {
-        let cfg = GatewayConfig::default();
+        let mut cfg = GatewayConfig::default();
+        cfg.auxiliary.insert(
+            "vision".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "openrouter".to_string(),
+                model: "google/gemini-2.5-flash".to_string(),
+                ..Default::default()
+            },
+        );
         let json = serde_json::to_string(&cfg).unwrap();
         let back: GatewayConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.max_turns, cfg.max_turns);
         assert_eq!(back.tools, cfg.tools);
+        assert_eq!(back.auxiliary["vision"].model, "google/gemini-2.5-flash");
+    }
+
+    #[test]
+    fn default_auxiliary_task_configs_match_upstream_shape() {
+        let tasks = default_auxiliary_task_configs();
+        for key in ["vision", "web_extract", "approval"] {
+            let task = tasks.get(key).expect("built-in task default");
+            assert_eq!(task.provider, "auto");
+            assert_eq!(task.model, "");
+            assert_eq!(task.base_url, "");
+            assert_eq!(task.api_key, "");
+        }
+        assert_eq!(tasks["vision"].timeout, Some(120));
+        assert_eq!(tasks["vision"].download_timeout, Some(30));
+        assert_eq!(tasks["web_extract"].timeout, Some(360));
+        assert_eq!(tasks["curator"].timeout, Some(600));
+    }
+
+    #[test]
+    fn builtin_auxiliary_env_overrides_bridge_non_default_values() {
+        let mut cfg = GatewayConfig::default();
+        cfg.auxiliary.insert(
+            "vision".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "  openrouter  ".to_string(),
+                model: "  google/gemini-2.5-flash  ".to_string(),
+                ..Default::default()
+            },
+        );
+        cfg.auxiliary.insert(
+            "web_extract".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "auto".to_string(),
+                model: "custom-llm".to_string(),
+                ..Default::default()
+            },
+        );
+        cfg.auxiliary.insert(
+            "approval".to_string(),
+            AuxiliaryTaskConfig {
+                base_url: "http://localhost:1234/v1".to_string(),
+                api_key: "local-key".to_string(),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            cfg.builtin_auxiliary_env_overrides(),
+            vec![
+                (
+                    "AUXILIARY_APPROVAL_BASE_URL".to_string(),
+                    "http://localhost:1234/v1".to_string()
+                ),
+                (
+                    "AUXILIARY_APPROVAL_API_KEY".to_string(),
+                    "local-key".to_string()
+                ),
+                (
+                    "AUXILIARY_VISION_PROVIDER".to_string(),
+                    "openrouter".to_string()
+                ),
+                (
+                    "AUXILIARY_VISION_MODEL".to_string(),
+                    "google/gemini-2.5-flash".to_string()
+                ),
+                (
+                    "AUXILIARY_WEB_EXTRACT_MODEL".to_string(),
+                    "custom-llm".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn auxiliary_env_overrides_skip_compression_until_registered() {
+        let mut cfg = GatewayConfig::default();
+        cfg.auxiliary.insert(
+            "compression".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "openrouter".to_string(),
+                model: "compressor".to_string(),
+                ..Default::default()
+            },
+        );
+
+        assert!(cfg.builtin_auxiliary_env_overrides().is_empty());
+        assert_eq!(
+            cfg.auxiliary_env_overrides_for(["compression"]),
+            vec![
+                (
+                    "AUXILIARY_COMPRESSION_PROVIDER".to_string(),
+                    "openrouter".to_string()
+                ),
+                (
+                    "AUXILIARY_COMPRESSION_MODEL".to_string(),
+                    "compressor".to_string()
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -20,10 +20,10 @@ pub mod streaming;
 
 // Re-export key types for convenience
 pub use config::{
-    AgentLoopBehaviorConfig, ApprovalConfig, CheapModelRouteConfig, GatewayConfig,
-    LlmProviderConfig, McpServerEntry, ProfileConfig, ProxyConfig, SecurityConfig,
-    SessionsMaintenanceConfig, SkillsSettings, SmartModelRoutingConfig, TerminalBackendType,
-    TerminalConfig, ToolsSettings,
+    default_auxiliary_task_configs, AgentLoopBehaviorConfig, ApprovalConfig, AuxiliaryTaskConfig,
+    CheapModelRouteConfig, GatewayConfig, LlmProviderConfig, McpServerEntry, ProfileConfig,
+    ProxyConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
+    SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings,
 };
 pub use loader::{
     apply_user_config_patch, load_config, load_user_config_file, save_config_yaml,

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -362,7 +362,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, llm.<provider>.api_key|api_key_env|base_url|model|command|args|oauth_token_url|oauth_client_id, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, llm.<provider>.api_key|api_key_env|base_url|model|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -514,6 +514,40 @@ fn apply_user_config_patch_dotted(
                     value
                 ))
             })?;
+        }
+        ["auxiliary", task, field] => {
+            let entry = config
+                .auxiliary
+                .entry((*task).to_string())
+                .or_insert_with(crate::config::AuxiliaryTaskConfig::default);
+            match *field {
+                "provider" => entry.provider = value.to_string(),
+                "model" => entry.model = value.to_string(),
+                "base_url" => entry.base_url = value.to_string(),
+                "api_key" => entry.api_key = value.to_string(),
+                "timeout" | "timeout_secs" => {
+                    entry.timeout = Some(value.parse().map_err(|_| {
+                        ConfigError::ValidationError(format!(
+                            "auxiliary.{}.{} must be a non-negative integer: {}",
+                            task, field, value
+                        ))
+                    })?);
+                }
+                "download_timeout" => {
+                    entry.download_timeout = Some(value.parse().map_err(|_| {
+                        ConfigError::ValidationError(format!(
+                            "auxiliary.{}.download_timeout must be a non-negative integer: {}",
+                            task, value
+                        ))
+                    })?);
+                }
+                other => {
+                    return Err(ConfigError::NotFound(format!(
+                        "unknown auxiliary field: auxiliary.{}.{} (supported: provider, model, base_url, api_key, timeout, download_timeout)",
+                        task, other
+                    )));
+                }
+            }
         }
         ["llm", provider, field] => {
             let entry = config
@@ -702,6 +736,46 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .and_then(|c| c.oauth_client_id.as_deref())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["auxiliary", task, "provider"] => Ok(config
+            .auxiliary
+            .get(*task)
+            .map(|c| c.provider.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "auto".to_string())),
+        ["auxiliary", task, "model"] => Ok(config
+            .auxiliary
+            .get(*task)
+            .map(|c| c.model.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["auxiliary", task, "base_url"] => Ok(config
+            .auxiliary
+            .get(*task)
+            .map(|c| c.base_url.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["auxiliary", task, "api_key"] => Ok(config
+            .auxiliary
+            .get(*task)
+            .map(|c| c.api_key.trim())
+            .filter(|s| !s.is_empty())
+            .map(mask_secret)
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["auxiliary", task, "timeout"] | ["auxiliary", task, "timeout_secs"] => Ok(config
+            .auxiliary
+            .get(*task)
+            .and_then(|c| c.timeout)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["auxiliary", task, "download_timeout"] => Ok(config
+            .auxiliary
+            .get(*task)
+            .and_then(|c| c.download_timeout)
+            .map(|v| v.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
         ["smart_model_routing", "enabled"] => Ok(config.smart_model_routing.enabled.to_string()),
         ["smart_model_routing", "max_simple_chars"] => {
@@ -1078,6 +1152,46 @@ mod tests {
     }
 
     #[test]
+    fn load_user_config_file_parses_auxiliary_task_overrides() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+auxiliary:
+  vision:
+    provider: openrouter
+    model: google/gemini-2.5-flash
+    base_url: http://localhost:1234/v1
+    api_key: local-key
+    timeout: 120
+    download_timeout: 30
+  web_extract:
+    provider: auto
+    model: custom-llm
+"#,
+        )
+        .unwrap();
+
+        let loaded = load_user_config_file(&path).unwrap();
+        let vision = loaded.auxiliary.get("vision").expect("vision config");
+        assert_eq!(vision.provider, "openrouter");
+        assert_eq!(vision.model, "google/gemini-2.5-flash");
+        assert_eq!(vision.base_url, "http://localhost:1234/v1");
+        assert_eq!(vision.api_key, "local-key");
+        assert_eq!(vision.timeout, Some(120));
+        assert_eq!(vision.download_timeout, Some(30));
+        let web_extract = loaded
+            .auxiliary
+            .get("web_extract")
+            .expect("web extract config");
+        assert_eq!(web_extract.provider, "auto");
+        assert_eq!(web_extract.model, "custom-llm");
+    }
+
+    #[test]
     fn apply_patch_dotted_llm_proxy_budget() {
         let mut c = GatewayConfig::default();
         apply_user_config_patch(&mut c, "llm.openai.api_key", "sk-test").unwrap();
@@ -1138,6 +1252,47 @@ mod tests {
         assert_eq!(
             user_config_field_display(&c, "sessions.retention_days").unwrap(),
             "30"
+        );
+    }
+
+    #[test]
+    fn apply_patch_dotted_auxiliary_values() {
+        let mut c = GatewayConfig::default();
+        apply_user_config_patch(&mut c, "auxiliary.vision.provider", "openrouter").unwrap();
+        apply_user_config_patch(&mut c, "auxiliary.vision.model", "google/gemini-2.5-flash")
+            .unwrap();
+        apply_user_config_patch(
+            &mut c,
+            "auxiliary.vision.base_url",
+            "http://localhost:1234/v1",
+        )
+        .unwrap();
+        apply_user_config_patch(&mut c, "auxiliary.vision.api_key", "local-key").unwrap();
+        apply_user_config_patch(&mut c, "auxiliary.vision.timeout", "120").unwrap();
+        apply_user_config_patch(&mut c, "auxiliary.vision.download_timeout", "30").unwrap();
+
+        let vision = c.auxiliary.get("vision").expect("vision config");
+        assert_eq!(vision.provider, "openrouter");
+        assert_eq!(vision.model, "google/gemini-2.5-flash");
+        assert_eq!(vision.base_url, "http://localhost:1234/v1");
+        assert_eq!(vision.api_key, "local-key");
+        assert_eq!(vision.timeout, Some(120));
+        assert_eq!(vision.download_timeout, Some(30));
+        assert_eq!(
+            user_config_field_display(&c, "auxiliary.vision.provider").unwrap(),
+            "openrouter"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "auxiliary.vision.model").unwrap(),
+            "google/gemini-2.5-flash"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "auxiliary.vision.api_key").unwrap(),
+            "***-key"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "auxiliary.vision.timeout").unwrap(),
+            "120"
         );
     }
 

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -125,6 +125,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 fallback_model: None,
                 fallback_models: Vec::new(),
                 smart_model_routing: SmartModelRoutingConfig::default(),
+                auxiliary: Default::default(),
                 proxy: None,
                 approval: ApprovalConfig::default(),
                 security: SecurityConfig::default(),

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T04:10:11.171744+00:00",
+  "generated_at_utc": "2026-05-30T04:26:17.647165+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "24d5ff17ae49feece3d3f4bff93980d7a6b00f79",
+    "local_sha": "93cb2f42b64f26351383b70fa80ff7db4cbd87c1",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 825,
+    "commits_ahead": 827,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 696,
+    "local_patch_unique": 697,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 385345
+    "tree_deletions": 385516
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 696,
+    "local_patch_unique": 697,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T04:10:11.171744+00:00`
+Generated: `2026-05-30T04:26:17.647165+00:00`
 
 ## Scope
 
-- Local ref: `main` (`24d5ff17ae49feece3d3f4bff93980d7a6b00f79`)
+- Local ref: `main` (`93cb2f42b64f26351383b70fa80ff7db4cbd87c1`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T04:10:11.171744+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 825 |
+| Commits ahead local (`local` ancestry only) | 827 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 696 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 697 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 385345 |
+| Deletions (`local` vs `upstream`) | 385516 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T04:10:11.171744+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `696`
+- Local unique by patch-id: `697`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1756,16 +1756,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_auxiliary_config_bridge.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "11fe9f71c23055547dc709094c3ad3a1526dc7b1",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_auxiliary_config_bridge.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "b2727d33608e3fa854a8657c0b8d055661b15161",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T04:10:09.358439+00:00",
+  "generated_at_utc": "2026-05-30T04:26:20.693631+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "24d5ff17ae49feece3d3f4bff93980d7a6b00f79",
+    "local_sha": "93cb2f42b64f26351383b70fa80ff7db4cbd87c1",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 746,
-      "intentional_divergence": 103,
+      "functional": 745,
+      "intentional_divergence": 104,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 272,
-      "rust_equivalent_or_contract_test_required": 667,
+      "not_required_for_runtime": 273,
+      "rust_equivalent_or_contract_test_required": 666,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 103,
+      "cleared_intentional_divergence": 104,
       "cleared_non_runtime": 169,
-      "pending_review": 746
+      "pending_review": 745
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 103,
+    "cleared_intentional_divergence": 104,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 746,
+    "pending_review": 745,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T04:10:09.358439+00:00`
+Generated: `2026-05-30T04:26:20.693631+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `746`
+- Pending functional review: `745`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `103`
+- Cleared intentional divergence: `104`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 103 |
+| `cleared_intentional_divergence` | 104 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 746 |
+| `pending_review` | 745 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T04:10:09.358439+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 56 |
-| `tests/agent` | 52 |
+| `tests/agent` | 51 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -206,6 +206,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_auxiliary_config_bridge.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream auxiliary config/default-shape and config-to-AUXILIARY_* bridge intent is covered by Rust hermes-config auxiliary task override parsing, default task metadata, and bridge contract tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",


### PR DESCRIPTION
Summary:
- Add the Rust GatewayConfig auxiliary task override surface for user-facing auxiliary.<task> config.
- Add upstream-shaped auxiliary default task metadata and a typed AUXILIARY_<TASK>_* bridge contract for built-in/plugin task keys without adding Python runtime paths.
- Add config set/get, YAML parse, serde, and bridge tests; classify tests/agent/test_auxiliary_config_bridge.py as covered by Rust contracts and regenerate parity docs/backlog.

Local verification:
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max shared different|max-shared-different" . (no matches)
- cargo test -p hermes-config auxiliary -- --nocapture
- cargo test -p hermes-config
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
