### PR TITLE
Cover auxiliary named custom providers

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4168,6 +4168,28 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_maps_named_custom_runtime_provider() {
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "beans".to_string(),
+            LlmProviderConfig {
+                api_key: Some("sk-beans".to_string()),
+                base_url: Some("http://beans.local/v1".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let agent_cfg = build_agent_config(&cfg, "beans:my-model");
+        assert_eq!(agent_cfg.provider.as_deref(), Some("beans"));
+        let runtime = agent_cfg
+            .runtime_providers
+            .get("beans")
+            .expect("named custom runtime provider should exist");
+        assert_eq!(runtime.api_key.as_deref(), Some("sk-beans"));
+        assert_eq!(runtime.base_url.as_deref(), Some("http://beans.local/v1"));
+    }
+
+    #[test]
     fn test_build_agent_config_forwards_provider_extra_body() {
         let mut cfg = GatewayConfig::default();
         cfg.llm_providers.insert(
@@ -4301,6 +4323,22 @@ mod tests {
         let (provider, model) = resolve_provider_and_model(&cfg, "step-3.5-flash");
         assert_eq!(provider, "stepfun");
         assert_eq!(model, "step-3.5-flash");
+    }
+
+    #[test]
+    fn test_resolve_provider_and_model_uses_named_custom_provider_model() {
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "beans".to_string(),
+            LlmProviderConfig {
+                model: Some("my-model".to_string()),
+                base_url: Some("http://beans.local/v1".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+        let (provider, model) = resolve_provider_and_model(&cfg, "my-model");
+        assert_eq!(provider, "beans");
+        assert_eq!(model, "my-model");
     }
 
     #[test]

--- a/crates/hermes-config/src/python_yaml_compat.rs
+++ b/crates/hermes-config/src/python_yaml_compat.rs
@@ -38,6 +38,15 @@ fn normalized_base_url(value: &Value) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+fn canonical_custom_provider_name(provider: &str) -> String {
+    provider
+        .trim()
+        .strip_prefix("custom:")
+        .unwrap_or_else(|| provider.trim())
+        .trim()
+        .to_string()
+}
+
 /// Lift `agent.max_turns` to root `max_turns` when the latter is absent.
 fn lift_agent_max_turns(map: &mut Mapping) {
     let max_key = key("max_turns");
@@ -111,9 +120,9 @@ fn normalize_model_block(map: &mut Mapping) {
                 .filter(|s| !s.is_empty());
 
             let model_str = match (provider, default) {
-                (Some(p), Some(d)) => format!("{p}:{d}"),
+                (Some(p), Some(d)) => format!("{}:{d}", canonical_custom_provider_name(p)),
                 (None, Some(d)) => d.to_string(),
-                (Some(p), None) => format!("{p}:"),
+                (Some(p), None) => format!("{}:", canonical_custom_provider_name(p)),
                 (None, None) => {
                     map.insert(model_key, Value::Mapping(m));
                     return;
@@ -124,13 +133,14 @@ fn normalize_model_block(map: &mut Mapping) {
             if let Some(p) = provider
                 .filter(|_| base_url.is_some() || api_key.is_some() || api_key_env.is_some())
             {
+                let provider_name = canonical_custom_provider_name(p);
                 let llm_key = key("llm_providers");
                 let mut llm = match map.get(&llm_key).cloned() {
                     Some(Value::Mapping(x)) => x,
                     _ => Mapping::new(),
                 };
                 let prov_entry = llm
-                    .entry(Value::String(p.to_string()))
+                    .entry(Value::String(provider_name))
                     .or_insert_with(|| Value::Mapping(Mapping::new()));
                 if let Value::Mapping(ref mut em) = prov_entry {
                     if let Some(bu) = base_url {
@@ -150,6 +160,71 @@ fn normalize_model_block(map: &mut Mapping) {
             map.insert(model_key, other);
         }
     }
+}
+
+/// `custom_providers: [{ name, base_url, ... }]` → merge into `llm_providers`.
+fn merge_custom_providers_into_llm(map: &mut Mapping) {
+    let Some(Value::Sequence(providers)) = map.remove(&key("custom_providers")) else {
+        return;
+    };
+    if providers.is_empty() {
+        return;
+    }
+
+    let llm_key = key("llm_providers");
+    let mut llm = match map.get(&llm_key).cloned() {
+        Some(Value::Mapping(x)) => x,
+        _ => Mapping::new(),
+    };
+
+    for entry in providers {
+        let Value::Mapping(src) = entry else {
+            continue;
+        };
+        let Some(provider_name) = src
+            .get(&key("name"))
+            .and_then(as_str)
+            .map(canonical_custom_provider_name)
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        let slot = llm
+            .entry(Value::String(provider_name))
+            .or_insert_with(|| Value::Mapping(Mapping::new()));
+        if let Value::Mapping(provider_cfg) = slot {
+            for field in [
+                "api_key",
+                "api_key_env",
+                "base_url",
+                "command",
+                "args",
+                "model",
+                "max_tokens",
+                "temperature",
+                "extra_body",
+                "rate_limit",
+                "credential_pool",
+                "oauth_token_url",
+                "oauth_client_id",
+            ] {
+                let field_key = key(field);
+                let Some(value) = src.get(&field_key) else {
+                    continue;
+                };
+                let normalized = if field == "base_url" {
+                    normalized_base_url(value).map(Value::String)
+                } else {
+                    Some(value.clone())
+                };
+                if let Some(value) = normalized {
+                    provider_cfg.insert(field_key, value);
+                }
+            }
+        }
+    }
+
+    map.insert(llm_key, Value::Mapping(llm));
 }
 
 /// `providers: { openai: { api_key: ... } }` → merge into `llm_providers`.
@@ -464,6 +539,7 @@ fn lift_root_platform_blocks(map: &mut Mapping) {
 pub(crate) fn normalize_config_yaml_root(map: &mut Mapping) {
     // Order matters: model before merge_providers (may touch llm_providers)
     normalize_model_block(map);
+    merge_custom_providers_into_llm(map);
     merge_providers_into_llm(map);
     normalize_fallback_chain(map);
     lift_agent_max_turns(map);
@@ -523,6 +599,40 @@ model:
         );
         assert_eq!(provider.api_key.as_deref(), Some("sk-local"));
         assert_eq!(provider.api_key_env.as_deref(), Some("DEEPSEEK_API_KEY"));
+    }
+
+    #[test]
+    fn python_custom_providers_merge_into_llm_provider_config() {
+        let raw = r#"
+model:
+  default: my-model
+  provider: custom:beans
+custom_providers:
+  - name: beans
+    base_url: http://beans.local/v1/
+    api_key: sk-beans
+    api_key_env: BEANS_API_KEY
+    model: fallback-beans-model
+  - name: local
+    base_url: http://localhost:8080/v1/
+"#;
+        let mut root: Value = serde_yaml::from_str(raw).unwrap();
+        let Value::Mapping(ref mut m) = root else {
+            panic!();
+        };
+        normalize_config_yaml_root(m);
+        let cfg: crate::config::GatewayConfig = serde_yaml::from_value(root).unwrap();
+
+        assert_eq!(cfg.model.as_deref(), Some("beans:my-model"));
+        let beans = cfg.llm_providers.get("beans").expect("beans provider");
+        assert_eq!(beans.base_url.as_deref(), Some("http://beans.local/v1"));
+        assert_eq!(beans.api_key.as_deref(), Some("sk-beans"));
+        assert_eq!(beans.api_key_env.as_deref(), Some("BEANS_API_KEY"));
+        assert_eq!(beans.model.as_deref(), Some("fallback-beans-model"));
+
+        let local = cfg.llm_providers.get("local").expect("local provider");
+        assert_eq!(local.base_url.as_deref(), Some("http://localhost:8080/v1"));
+        assert!(local.api_key.is_none());
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T04:48:20.017825+00:00",
+  "generated_at_utc": "2026-05-30T05:07:55.768939+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "ebd45ee794ddb3e48e474f47c58b6ddb20bee5e6",
+    "local_sha": "ff1162b8e38a087802aa0145a14e1bac546fd3cb",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 829,
+    "commits_ahead": 831,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 698,
+    "local_patch_unique": 699,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 385986
+    "tree_deletions": 386441
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 698,
+    "local_patch_unique": 699,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T04:48:20.017825+00:00`
+Generated: `2026-05-30T05:07:55.768939+00:00`
 
 ## Scope
 
-- Local ref: `main` (`ebd45ee794ddb3e48e474f47c58b6ddb20bee5e6`)
+- Local ref: `main` (`ff1162b8e38a087802aa0145a14e1bac546fd3cb`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T04:48:20.017825+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 829 |
+| Commits ahead local (`local` ancestry only) | 831 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 698 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 699 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 385986 |
+| Deletions (`local` vs `upstream`) | 386441 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T04:48:20.017825+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `698`
+- Local unique by patch-id: `699`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1786,16 +1786,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_auxiliary_named_custom_providers.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "52c85998e3dbf5b9f882e7203912b6979c971159",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_auxiliary_named_custom_providers.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "afceeec02d94bd96451161beeb8bbca9f3e17ed5",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T04:48:25.190694+00:00",
+  "generated_at_utc": "2026-05-30T05:08:03.008294+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "ebd45ee794ddb3e48e474f47c58b6ddb20bee5e6",
+    "local_sha": "ff1162b8e38a087802aa0145a14e1bac546fd3cb",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 744,
-      "intentional_divergence": 105,
+      "functional": 743,
+      "intentional_divergence": 106,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 274,
-      "rust_equivalent_or_contract_test_required": 665,
+      "not_required_for_runtime": 275,
+      "rust_equivalent_or_contract_test_required": 664,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 105,
+      "cleared_intentional_divergence": 106,
       "cleared_non_runtime": 169,
-      "pending_review": 744
+      "pending_review": 743
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 105,
+    "cleared_intentional_divergence": 106,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 744,
+    "pending_review": 743,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T04:48:25.190694+00:00`
+Generated: `2026-05-30T05:08:03.008294+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `744`
+- Pending functional review: `743`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `105`
+- Cleared intentional divergence: `106`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 105 |
+| `cleared_intentional_divergence` | 106 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 744 |
+| `pending_review` | 743 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T04:48:25.190694+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 56 |
-| `tests/agent` | 50 |
+| `tests/agent` | 49 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -220,6 +220,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_auxiliary_named_custom_providers.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream named custom provider and custom:<name> main-provider alias intent is covered by Rust hermes-config Python-YAML compatibility normalization plus hermes-cli provider/model and runtime-provider contract tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- Normalize upstream Python custom_providers entries into Rust llm_providers.
- Canonicalize model.provider custom:<name> aliases to named Rust runtime providers.
- Add Rust contract tests for named custom provider runtime mapping and provider/model resolution.
- Mark tests/agent/test_auxiliary_named_custom_providers.py as covered intentional divergence in parity docs.

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n 'max_shared_different|max-shared-different|max shared different' . (no matches)
- cargo test -p hermes-config custom_providers -- --nocapture
- cargo test -p hermes-cli named_custom -- --nocapture
- cargo test -p hermes-config
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- cargo test -p hermes-agent
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md