### PR TITLE
Serialize Hermes config path env test

### DIFF
--- a/crates/hermes-config/src/paths.rs
+++ b/crates/hermes-config/src/paths.rs
@@ -153,6 +153,7 @@ mod tests {
     /// avoid races with parallel test threads.
     #[test]
     fn derived_paths_and_explicit_home() {
+        let _guard = crate::managed_gateway::test_lock::lock();
         let original = std::env::var("HERMES_HOME").ok();
         let original_ultra = std::env::var("HERMES_AGENT_ULTRA_HOME").ok();
 


### PR DESCRIPTION
## Summary
- Lock the HERMES_HOME path helper test on the same hermes-config managed-gateway env test mutex.
- Fixes the parallel test race seen after PR #354 when managed-gateway tests temporarily set HERMES_HOME.

## Local verification
- cargo test -p hermes-config paths::tests::derived_paths_and_explicit_home -- --nocapture
- cargo test -p hermes-config
- cargo fmt --check
- git diff --check
- bash scripts/check-rust-runtime-no-python.sh