### PR TITLE
Cover Codex Cloudflare headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ version = "0.14.2"
 dependencies = [
  "async-stream",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "dirs",
  "eventsource-stream",

--- a/crates/hermes-agent/Cargo.toml
+++ b/crates/hermes-agent/Cargo.toml
@@ -11,6 +11,7 @@ hermes-core = { workspace = true }
 hermes-auth = { workspace = true }
 hermes-intelligence = { workspace = true }
 hermes-skills = { workspace = true }
+base64 = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermes-agent/src/auxiliary_builder.rs
+++ b/crates/hermes-agent/src/auxiliary_builder.rs
@@ -13,7 +13,9 @@ use hermes_intelligence::auxiliary::{
     AuxiliaryClient, AuxiliaryConfig, AuxiliarySource, ProviderCandidate,
 };
 
-use crate::provider::{AnthropicProvider, GenericProvider, OpenRouterProvider};
+use crate::provider::{
+    openai_codex_provider, AnthropicProvider, GenericProvider, OpenRouterProvider,
+};
 use crate::providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,
 };
@@ -321,6 +323,7 @@ fn build_main_runtime_candidate(
                 .with_http_referer("https://hermes-agent.nousresearch.com")
                 .with_x_title("Hermes Agent"),
         ),
+        "openai-codex" => Arc::new(openai_codex_provider(api_key, model, base_url.as_deref())),
         "anthropic" => {
             let mut provider = AnthropicProvider::new(api_key).with_model(model);
             if let Some(url) = base_url {

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -4,6 +4,10 @@
 //! OpenAI, Anthropic, and OpenRouter APIs.
 
 use async_trait::async_trait;
+use base64::{
+    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+    Engine as _,
+};
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use reqwest::Client;
@@ -28,6 +32,77 @@ use crate::credential_pool::CredentialPool;
 use crate::rate_limit::RateLimitTracker;
 
 const ACP_MULTIMODAL_PREFIX: &str = "__hermes_acp_parts_json__:";
+pub const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+const CODEX_CLOUDFLARE_ORIGINATOR: &str = "codex_cli_rs";
+
+pub fn codex_cloudflare_headers(access_token: Option<&str>) -> Vec<(String, String)> {
+    let mut headers = vec![
+        (
+            "originator".to_string(),
+            CODEX_CLOUDFLARE_ORIGINATOR.to_string(),
+        ),
+        (
+            "User-Agent".to_string(),
+            format!(
+                "{CODEX_CLOUDFLARE_ORIGINATOR}/{}",
+                env!("CARGO_PKG_VERSION")
+            ),
+        ),
+    ];
+
+    if let Some(account_id) = access_token.and_then(codex_chatgpt_account_id) {
+        headers.push(("ChatGPT-Account-ID".to_string(), account_id));
+    }
+
+    headers
+}
+
+pub fn openai_codex_provider(
+    api_key: impl Into<String>,
+    model: impl Into<String>,
+    base_url: Option<&str>,
+) -> OpenAiProvider {
+    let api_key = api_key.into();
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(OPENAI_CODEX_BASE_URL)
+        .to_string();
+    let mut provider = OpenAiProvider::new(api_key.as_str())
+        .with_model(model)
+        .with_base_url(base_url.as_str());
+    if is_codex_cloudflare_base_url(base_url.as_str()) {
+        provider = provider.with_headers(codex_cloudflare_headers(Some(api_key.as_str())));
+    }
+    provider
+}
+
+fn is_codex_cloudflare_base_url(base_url: &str) -> bool {
+    base_url
+        .trim()
+        .to_ascii_lowercase()
+        .contains("chatgpt.com/backend-api/codex")
+}
+
+fn codex_chatgpt_account_id(token: &str) -> Option<String> {
+    let token = token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload.as_bytes())
+        .or_else(|_| URL_SAFE.decode(payload.as_bytes()))
+        .ok()?;
+    let claims: Value = serde_json::from_slice(&decoded).ok()?;
+    claims
+        .get("https://api.openai.com/auth")
+        .and_then(|auth| auth.get("chatgpt_account_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
 
 fn parse_acp_multimodal_parts(content: &str) -> Option<Vec<Value>> {
     let payload = content.trim().strip_prefix(ACP_MULTIMODAL_PREFIX)?;
@@ -827,6 +902,26 @@ impl OpenAiProvider {
         Self {
             inner: self.inner.with_model(model),
         }
+    }
+
+    /// Add a custom header to every OpenAI-compatible request.
+    pub fn with_header(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            inner: self.inner.with_header(key, value),
+        }
+    }
+
+    /// Add several custom headers to every OpenAI-compatible request.
+    pub fn with_headers<I, K, V>(mut self, headers: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (key, value) in headers {
+            self = self.with_header(key, value);
+        }
+        self
     }
 
     /// Attach a credential pool for API key rotation.
@@ -2284,6 +2379,116 @@ fn summarize_openai_response_shape(json: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn codex_jwt_with_account(account_id: Option<&str>) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256","typ":"JWT"}"#);
+        let claims = match account_id {
+            Some(account_id) => serde_json::json!({
+                "sub": "user-xyz",
+                "exp": 9_999_999_999_i64,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id,
+                    "chatgpt_plan_type": "plus"
+                }
+            }),
+            None => serde_json::json!({
+                "sub": "user-xyz",
+                "exp": 9_999_999_999_i64
+            }),
+        };
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+        format!("{header}.{payload}.sig")
+    }
+
+    fn header_value<'a>(headers: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        headers
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.as_str())
+    }
+
+    #[test]
+    fn codex_cloudflare_headers_match_codex_cli_rs_contract() {
+        let token = codex_jwt_with_account(Some("acct-abc-999"));
+        let headers = codex_cloudflare_headers(Some(token.as_str()));
+
+        assert_eq!(header_value(&headers, "originator"), Some("codex_cli_rs"));
+        assert!(header_value(&headers, "User-Agent")
+            .expect("user agent")
+            .starts_with("codex_cli_rs/"));
+        assert_eq!(
+            header_value(&headers, "ChatGPT-Account-ID"),
+            Some("acct-abc-999")
+        );
+        assert!(header_value(&headers, "chatgpt-account-id").is_none());
+        assert!(header_value(&headers, "ChatGPT-Account-Id").is_none());
+    }
+
+    #[test]
+    fn codex_cloudflare_headers_ignore_malformed_or_missing_account_tokens() {
+        for token in ["not-a-jwt", "", "only.one", "  ", "...."] {
+            let headers = codex_cloudflare_headers(Some(token));
+            assert_eq!(header_value(&headers, "originator"), Some("codex_cli_rs"));
+            assert!(header_value(&headers, "ChatGPT-Account-ID").is_none());
+        }
+
+        let token = codex_jwt_with_account(None);
+        let headers = codex_cloudflare_headers(Some(token.as_str()));
+        assert_eq!(header_value(&headers, "originator"), Some("codex_cli_rs"));
+        assert!(header_value(&headers, "ChatGPT-Account-ID").is_none());
+    }
+
+    #[test]
+    fn openai_codex_provider_attaches_cloudflare_headers_to_requests() {
+        let token = codex_jwt_with_account(Some("acct-request"));
+        let provider = openai_codex_provider(token.as_str(), "gpt-5.4", None);
+        assert_eq!(provider.inner.base_url, OPENAI_CODEX_BASE_URL);
+
+        let request = provider
+            .inner
+            .build_request(
+                &Client::new(),
+                &format!("{}/chat/completions", OPENAI_CODEX_BASE_URL),
+                token.as_str(),
+                &serde_json::json!({"model": "gpt-5.4", "messages": []}),
+            )
+            .build()
+            .expect("request");
+        let headers = request.headers();
+
+        assert_eq!(headers.get("originator").unwrap(), "codex_cli_rs");
+        assert!(headers
+            .get("User-Agent")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("codex_cli_rs/"));
+        assert_eq!(headers.get("ChatGPT-Account-ID").unwrap(), "acct-request");
+    }
+
+    #[test]
+    fn openai_codex_provider_skips_cloudflare_headers_for_non_chatgpt_override() {
+        let token = codex_jwt_with_account(Some("acct-request"));
+        let provider = openai_codex_provider(
+            token.as_str(),
+            "gpt-5.4",
+            Some("https://openrouter.ai/api/v1"),
+        );
+
+        let request = provider
+            .inner
+            .build_request(
+                &Client::new(),
+                "https://openrouter.ai/api/v1/chat/completions",
+                token.as_str(),
+                &serde_json::json!({"model": "gpt-5.4", "messages": []}),
+            )
+            .build()
+            .expect("request");
+
+        assert!(request.headers().get("originator").is_none());
+        assert!(request.headers().get("ChatGPT-Account-ID").is_none());
+    }
 
     #[test]
     fn test_format_tools_for_openai_api_shape() {

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -15,7 +15,8 @@ use uuid::Uuid;
 
 use hermes_agent::agent_loop::ToolRegistry as AgentToolRegistry;
 use hermes_agent::provider::{
-    AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
+    openai_codex_provider, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
+    OPENAI_CODEX_BASE_URL,
 };
 use hermes_agent::providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,
@@ -5334,7 +5335,6 @@ pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
 // ---------------------------------------------------------------------------
 
 const STEPFUN_BASE_URL: &str = "https://api.stepfun.ai/step_plan/v1";
-const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const QWEN_BASE_URL: &str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 const ALIBABA_CODING_PLAN_BASE_URL: &str = "https://coding-intl.dashscope.aliyuncs.com/v1";
 const GOOGLE_GEMINI_CLI_BASE_URL: &str = "cloudcode-pa://google";
@@ -5871,11 +5871,11 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             }
             Arc::new(p)
         }
-        "openai-codex" | "codex" => {
-            let mut p = OpenAiProvider::new(&api_key).with_model(model_name.as_str());
-            p = p.with_base_url(base_url.unwrap_or_else(|| OPENAI_CODEX_BASE_URL.to_string()));
-            Arc::new(p)
-        }
+        "openai-codex" | "codex" => Arc::new(openai_codex_provider(
+            &api_key,
+            model_name.as_str(),
+            base_url.as_deref(),
+        )),
         "anthropic" => {
             let mut p = AnthropicProvider::new(&api_key).with_model(model_name.as_str());
             if let Some(url) = base_url {

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T05:07:55.768939+00:00",
+  "generated_at_utc": "2026-05-30T05:30:41.351472+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "ff1162b8e38a087802aa0145a14e1bac546fd3cb",
+    "local_sha": "b5e5ff0a3579ee381d98e56eeadbcecb124eb171",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 831,
+    "commits_ahead": 835,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 699,
+    "local_patch_unique": 701,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 386441
+    "tree_deletions": 386597
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 699,
+    "local_patch_unique": 701,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T05:07:55.768939+00:00`
+Generated: `2026-05-30T05:30:41.351472+00:00`
 
 ## Scope
 
-- Local ref: `main` (`ff1162b8e38a087802aa0145a14e1bac546fd3cb`)
+- Local ref: `main` (`b5e5ff0a3579ee381d98e56eeadbcecb124eb171`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T05:07:55.768939+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 831 |
+| Commits ahead local (`local` ancestry only) | 835 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 699 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 701 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 386441 |
+| Deletions (`local` vs `upstream`) | 386597 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T05:07:55.768939+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `699`
+- Local unique by patch-id: `701`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1846,16 +1846,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_codex_cloudflare_headers.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2d9633a80390eeed2b5023c1c6423d963b521bbe",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_codex_cloudflare_headers.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "fc52b78e886ad18416b433be62544d5ad8edf601",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T05:08:03.008294+00:00",
+  "generated_at_utc": "2026-05-30T05:30:51.699717+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "ff1162b8e38a087802aa0145a14e1bac546fd3cb",
+    "local_sha": "b5e5ff0a3579ee381d98e56eeadbcecb124eb171",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 743,
-      "intentional_divergence": 106,
+      "functional": 742,
+      "intentional_divergence": 107,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 275,
-      "rust_equivalent_or_contract_test_required": 664,
+      "not_required_for_runtime": 276,
+      "rust_equivalent_or_contract_test_required": 663,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 106,
+      "cleared_intentional_divergence": 107,
       "cleared_non_runtime": 169,
-      "pending_review": 743
+      "pending_review": 742
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 106,
+    "cleared_intentional_divergence": 107,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 743,
+    "pending_review": 742,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T05:08:03.008294+00:00`
+Generated: `2026-05-30T05:30:51.699717+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `743`
+- Pending functional review: `742`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `106`
+- Cleared intentional divergence: `107`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 106 |
+| `cleared_intentional_divergence` | 107 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 743 |
+| `pending_review` | 742 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T05:08:03.008294+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 56 |
-| `tests/agent` | 49 |
+| `tests/agent` | 48 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -227,6 +227,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_codex_cloudflare_headers.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Codex Cloudflare mitigation header intent is covered by Rust hermes-agent Codex header extraction/build-request tests plus shared openai-codex provider wiring used by primary and auxiliary runtime construction; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- Add Rust Codex Cloudflare mitigation headers with codex_cli_rs originator/User-Agent and ChatGPT-Account-ID extraction from Codex OAuth JWTs.
- Route primary openai-codex and auxiliary main-runtime openai-codex provider construction through the shared Rust Codex provider builder.
- Mark tests/agent/test_codex_cloudflare_headers.py covered by Rust provider contract tests and update parity backlog.

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n 'max_shared_different|max-shared-different|max shared different' . (no matches)
- cargo test -p hermes-agent codex -- --nocapture
- cargo test -p hermes-agent
- cargo test -p hermes-cli codex -- --nocapture
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md