### PR TITLE
Preserve compression summary continuity

### DIFF
--- a/crates/hermes-agent/src/compression.rs
+++ b/crates/hermes-agent/src/compression.rs
@@ -269,6 +269,19 @@ impl ContextCompressor {
         current_prompt_tokens.unwrap_or(self.last_prompt_tokens) >= self.threshold_tokens
     }
 
+    fn rehydrate_previous_summary_from_messages(&mut self, messages: &[Message]) {
+        if self.previous_summary.is_some() {
+            return;
+        }
+        self.previous_summary = messages
+            .iter()
+            .filter_map(|msg| msg.content.as_deref())
+            .filter_map(summary_body_from_handoff)
+            .map(|body| body.trim().to_string())
+            .filter(|body| !body.is_empty())
+            .last();
+    }
+
     // ------------------------------------------------------------------
     // Phase 1: tool-output pruning (cheap, no LLM call).
     // ------------------------------------------------------------------
@@ -731,6 +744,7 @@ Write only the summary body. Do not include any preamble or prefix."
                 pruned_count
             );
         }
+        self.rehydrate_previous_summary_from_messages(&messages);
 
         // Phase 2: determine boundaries.
         let compress_start = self.align_boundary_forward(&messages, self.config.protect_first_n);
@@ -738,7 +752,14 @@ Write only the summary body. Do not include any preamble or prefix."
         if compress_start >= compress_end {
             return messages;
         }
-        let turns_to_summarize: Vec<Message> = messages[compress_start..compress_end].to_vec();
+        let turns_to_summarize: Vec<Message> = messages[compress_start..compress_end]
+            .iter()
+            .filter(|msg| !is_summary_handoff_message(msg))
+            .cloned()
+            .collect();
+        if turns_to_summarize.is_empty() {
+            return messages;
+        }
 
         if !self.config.quiet_mode {
             let tail_msgs = n_messages - compress_end;
@@ -901,6 +922,24 @@ pub fn with_summary_prefix(summary: &str) -> String {
     }
 }
 
+fn summary_body_from_handoff(content: &str) -> Option<String> {
+    let trimmed = content.trim();
+    if let Some(rest) = trimmed.strip_prefix(SUMMARY_PREFIX) {
+        Some(rest.trim_start().to_string())
+    } else {
+        trimmed
+            .strip_prefix(LEGACY_SUMMARY_PREFIX)
+            .map(|rest| rest.trim_start().to_string())
+    }
+}
+
+fn is_summary_handoff_message(msg: &Message) -> bool {
+    msg.content
+        .as_deref()
+        .and_then(summary_body_from_handoff)
+        .is_some()
+}
+
 fn role_label(role: MessageRole) -> &'static str {
     match role {
         MessageRole::System => "system",
@@ -1035,6 +1074,7 @@ mod tests {
     struct CannedSummaryProvider {
         canned: String,
         calls: Mutex<usize>,
+        prompts: Mutex<Vec<String>>,
     }
 
     impl CannedSummaryProvider {
@@ -1042,10 +1082,14 @@ mod tests {
             Arc::new(Self {
                 canned: canned.into(),
                 calls: Mutex::new(0),
+                prompts: Mutex::new(Vec::new()),
             })
         }
         fn call_count(&self) -> usize {
             *self.calls.lock().unwrap()
+        }
+        fn last_prompt(&self) -> Option<String> {
+            self.prompts.lock().unwrap().last().cloned()
         }
     }
 
@@ -1053,7 +1097,7 @@ mod tests {
     impl LlmProvider for CannedSummaryProvider {
         async fn chat_completion(
             &self,
-            _messages: &[Message],
+            messages: &[Message],
             _tools: &[ToolSchema],
             _max_tokens: Option<u32>,
             _temperature: Option<f64>,
@@ -1061,6 +1105,12 @@ mod tests {
             _extra_body: Option<&serde_json::Value>,
         ) -> Result<LlmResponse, AgentError> {
             *self.calls.lock().unwrap() += 1;
+            self.prompts.lock().unwrap().push(
+                messages
+                    .first()
+                    .and_then(|message| message.content.clone())
+                    .unwrap_or_default(),
+            );
             Ok(LlmResponse {
                 message: Message {
                     role: MessageRole::Assistant,
@@ -1266,6 +1316,22 @@ mod tests {
     }
 
     #[test]
+    fn should_compress_uses_prompt_tokens_only() {
+        let cfg = CompressorConfig {
+            context_length: 200_000,
+            threshold_percent: 0.5,
+            ..quiet_config()
+        };
+        let mut compressor =
+            ContextCompressor::new(cfg, aux_with_provider(CannedSummaryProvider::new("x")));
+
+        compressor.update_from_usage(40_000);
+        assert!(!compressor.should_compress(None));
+        assert!(!compressor.should_compress(Some(40_000)));
+        assert!(compressor.should_compress(Some(110_000)));
+    }
+
+    #[test]
     fn budget_clamped_between_min_and_ceiling() {
         let cfg = CompressorConfig {
             context_length: 1_000_000,
@@ -1366,6 +1432,102 @@ mod tests {
         let s2 = compressor.generate_summary(&turns).await.unwrap().unwrap();
         assert!(s2.contains("Goal: build it."));
         assert_eq!(provider.call_count(), 2);
+    }
+
+    fn messages_with_handoff(summary_body: &str) -> Vec<Message> {
+        vec![
+            msg(MessageRole::System, "system prompt"),
+            msg(
+                MessageRole::User,
+                &format!("{SUMMARY_PREFIX}\n{summary_body}"),
+            ),
+            msg(MessageRole::Assistant, "handoff acknowledged after resume"),
+            msg(MessageRole::User, "new user turn after resume"),
+            msg(MessageRole::Assistant, "new assistant work after resume"),
+            msg(MessageRole::User, "more new work after resume"),
+            msg(MessageRole::Assistant, "latest tail response"),
+            msg(
+                MessageRole::User,
+                "final active request stays in protected tail",
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn compress_rehydrates_previous_summary_from_handoff_message() {
+        let old_summary = "RESUMED-SUMMARY-BODY durable continuity facts";
+        let provider = CannedSummaryProvider::new("updated summary");
+        let aux = aux_with_provider(provider.clone());
+        let cfg = CompressorConfig {
+            context_length: 1_000,
+            threshold_percent: 0.10,
+            protect_first_n: 1,
+            protect_last_n: 1,
+            ..quiet_config()
+        };
+        let mut compressor = ContextCompressor::new(cfg, aux);
+
+        let _ = compressor
+            .compress(messages_with_handoff(old_summary), Some(150))
+            .await;
+
+        let prompt = provider.last_prompt().expect("summary prompt");
+        assert!(prompt.contains("PREVIOUS SUMMARY:"));
+        assert!(prompt.contains("NEW TURNS TO INCORPORATE:"));
+        assert!(!prompt.contains("TURNS TO SUMMARIZE:"));
+        assert_eq!(prompt.matches(old_summary).count(), 1);
+        assert!(!prompt.contains(&format!("[USER]: {SUMMARY_PREFIX}")));
+    }
+
+    #[tokio::test]
+    async fn compress_does_not_serialize_existing_handoff_twice() {
+        let old_summary = "OLD-SUMMARY-BODY unique continuity facts";
+        let provider = CannedSummaryProvider::new("updated summary");
+        let aux = aux_with_provider(provider.clone());
+        let cfg = CompressorConfig {
+            context_length: 1_000,
+            threshold_percent: 0.10,
+            protect_first_n: 1,
+            protect_last_n: 1,
+            ..quiet_config()
+        };
+        let mut compressor = ContextCompressor::new(cfg, aux);
+        compressor.previous_summary = Some(old_summary.to_string());
+
+        let _ = compressor
+            .compress(messages_with_handoff(old_summary), Some(150))
+            .await;
+
+        let prompt = provider.last_prompt().expect("summary prompt");
+        assert!(prompt.contains("PREVIOUS SUMMARY:"));
+        assert!(prompt.contains("NEW TURNS TO INCORPORATE:"));
+        assert_eq!(prompt.matches(old_summary).count(), 1);
+        assert!(!prompt.contains(&format!("[USER]: {SUMMARY_PREFIX}")));
+    }
+
+    #[tokio::test]
+    async fn protected_head_handoff_rehydrates_previous_summary() {
+        let old_summary = "PROTECTED-HEAD-SUMMARY durable facts from before restart";
+        let provider = CannedSummaryProvider::new("updated summary");
+        let aux = aux_with_provider(provider.clone());
+        let cfg = CompressorConfig {
+            context_length: 1_000,
+            threshold_percent: 0.10,
+            protect_first_n: 2,
+            protect_last_n: 1,
+            ..quiet_config()
+        };
+        let mut compressor = ContextCompressor::new(cfg, aux);
+
+        let _ = compressor
+            .compress(messages_with_handoff(old_summary), Some(150))
+            .await;
+
+        let prompt = provider.last_prompt().expect("summary prompt");
+        assert!(prompt.contains("PREVIOUS SUMMARY:"));
+        assert!(prompt.contains("NEW TURNS TO INCORPORATE:"));
+        assert_eq!(prompt.matches(old_summary).count(), 1);
+        assert!(!prompt.contains(&format!("[USER]: {SUMMARY_PREFIX}")));
     }
 
     #[tokio::test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T05:30:41.351472+00:00",
+  "generated_at_utc": "2026-05-30T05:54:25.494564+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b5e5ff0a3579ee381d98e56eeadbcecb124eb171",
+    "local_sha": "318b5be61fbd59e3780edcdc6ad24a9aecf23f63",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 835,
+    "commits_ahead": 837,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 701,
+    "local_patch_unique": 702,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 386597
+    "tree_deletions": 386814
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 701,
+    "local_patch_unique": 702,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T05:30:41.351472+00:00`
+Generated: `2026-05-30T05:54:25.494564+00:00`
 
 ## Scope
 
-- Local ref: `main` (`b5e5ff0a3579ee381d98e56eeadbcecb124eb171`)
+- Local ref: `main` (`318b5be61fbd59e3780edcdc6ad24a9aecf23f63`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T05:30:41.351472+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 835 |
+| Commits ahead local (`local` ancestry only) | 837 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 701 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 702 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 386597 |
+| Deletions (`local` vs `upstream`) | 386814 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T05:30:41.351472+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `701`
+- Local unique by patch-id: `702`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1891,16 +1891,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_context_compressor_summary_continuity.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d9a273758347541ca893f3f60d00f111cc6ef915",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_context_compressor_summary_continuity.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f3101913ceb7ebfc0d9466ac4a46537c0ee24766",
       "workstream": "WS6"
@@ -8341,16 +8341,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/run_agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/run_agent/test_compression_trigger_excludes_reasoning.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "24fe2868fcb7a998da1f11a70630a3a5fceed190",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/run_agent/test_compression_trigger_excludes_reasoning.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "22fb37bf525a021e972d5d217933956d7d48d861",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T05:30:51.699717+00:00",
+  "generated_at_utc": "2026-05-30T05:54:25.644744+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b5e5ff0a3579ee381d98e56eeadbcecb124eb171",
+    "local_sha": "318b5be61fbd59e3780edcdc6ad24a9aecf23f63",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 742,
-      "intentional_divergence": 107,
+      "functional": 740,
+      "intentional_divergence": 109,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 276,
-      "rust_equivalent_or_contract_test_required": 663,
+      "not_required_for_runtime": 278,
+      "rust_equivalent_or_contract_test_required": 661,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 107,
+      "cleared_intentional_divergence": 109,
       "cleared_non_runtime": 169,
-      "pending_review": 742
+      "pending_review": 740
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 107,
+    "cleared_intentional_divergence": 109,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 742,
+    "pending_review": 740,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T05:30:51.699717+00:00`
+Generated: `2026-05-30T05:54:25.644744+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `742`
+- Pending functional review: `740`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `107`
+- Cleared intentional divergence: `109`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 107 |
+| `cleared_intentional_divergence` | 109 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 742 |
+| `pending_review` | 740 |
 
 ## Workstream Counts
 
@@ -41,8 +41,8 @@ Generated: `2026-05-30T05:30:51.699717+00:00`
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
-| `tests/run_agent` | 56 |
-| `tests/agent` | 48 |
+| `tests/run_agent` | 55 |
+| `tests/agent` | 47 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -234,6 +234,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_context_compressor_summary_continuity.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream iterative context-summary continuity intent is covered by Rust hermes-agent ContextCompressor tests for same-process previous-summary reuse, resume handoff rehydration, protected-head handoffs, and exclusion of existing handoff messages from the new-turn summary block; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",
@@ -265,6 +272,13 @@
       "path": "tests/run_agent",
       "classification": "functional",
       "rationale": "Run-agent tests cover orchestration and provider execution semantics.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/run_agent/test_compression_trigger_excludes_reasoning.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream compression-trigger prompt-token-only intent is covered by Rust hermes-agent ContextCompressor threshold tests: usage updates track prompt tokens only, completion/reasoning tokens are not accepted by the trigger path, and explicit prompt-token values gate compression; the Python test file remains reference-only.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- rehydrate prior context-compression handoff summaries before summarizing resumed conversations
- exclude existing handoff summary messages from the new-turn summary block
- add Rust contracts for prompt-token-only compression triggering and iterative summary continuity
- clear the two corresponding shared-diff backlog items

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max-shared-different|max shared different" .; test 0 -eq 1
- cargo test -p hermes-agent
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md