### PR TITLE
parity(agent): cover gemini rate-limit fallback

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -973,6 +973,31 @@ fn classify_error(err: &str) -> ErrorClass {
     }
 }
 
+fn provider_or_base_url_uses_cloudcode_quota(provider: &str, base_url: Option<&str>) -> bool {
+    let provider = provider.trim().to_ascii_lowercase();
+    matches!(
+        provider.as_str(),
+        "google-gemini-cli" | "gemini-cli" | "gemini-oauth"
+    ) || base_url
+        .map(str::trim)
+        .map(|url| url.to_ascii_lowercase().starts_with("cloudcode-pa://"))
+        .unwrap_or(false)
+}
+
+fn credential_pool_may_recover_from_rate_limit(
+    pool: Option<&Arc<CredentialPool>>,
+    provider: &str,
+    base_url: Option<&str>,
+) -> bool {
+    let Some(pool) = pool else {
+        return false;
+    };
+    if provider_or_base_url_uses_cloudcode_quota(provider, base_url) {
+        return false;
+    }
+    pool.has_available() && pool.len() > 1
+}
+
 fn is_tool_payload_validation_error(err: &str) -> bool {
     let lower = err.to_ascii_lowercase();
     (lower.contains("invalid input") && lower.contains("function"))
@@ -3741,6 +3766,9 @@ impl AgentLoop {
             .filter(|s| !s.is_empty())
             .map(str::to_string);
         let active_provider = route_provider_hint.unwrap_or(inferred_provider);
+        let active_base_url = route
+            .and_then(|r| r.base_url.clone())
+            .or_else(|| self.resolve_runtime_base_url(active_provider.as_str(), None));
         // Always try the requested model first. Some providers only reveal tool
         // schema limitations at request time, so proactive substitution hides
         // the real model behavior and makes quorum voters appear to "succeed"
@@ -4021,13 +4049,49 @@ impl AgentLoop {
                             return Err(AgentError::LlmApi(err_str));
                         }
                         ErrorClass::RateLimit | ErrorClass::Retryable => {
-                            if attempt >= effective_max_retries {
-                                let failover_chain = self.resolve_retry_failover_chain(model);
+                            let pool_may_recover = if class == ErrorClass::RateLimit {
+                                let active_pool = match route {
+                                    Some(rt) => self.credential_pool_for_route(rt),
+                                    None => self.primary_credential_pool.as_ref(),
+                                };
+                                credential_pool_may_recover_from_rate_limit(
+                                    active_pool,
+                                    active_provider.as_str(),
+                                    active_base_url.as_deref(),
+                                )
+                            } else {
+                                false
+                            };
+                            let configured_failover = !retry.fallback_models.is_empty()
+                                || retry
+                                    .fallback_model
+                                    .as_deref()
+                                    .map(str::trim)
+                                    .map(|m| !m.is_empty())
+                                    .unwrap_or(false);
+                            let eager_failover = class == ErrorClass::RateLimit
+                                && !pool_may_recover
+                                && configured_failover;
+                            let failover_chain =
+                                if attempt >= effective_max_retries || eager_failover {
+                                    self.resolve_retry_failover_chain(model)
+                                } else {
+                                    Vec::new()
+                                };
+                            if attempt >= effective_max_retries
+                                || (eager_failover && !failover_chain.is_empty())
+                            {
                                 if !failover_chain.is_empty() {
                                     let mut failover_errors = Vec::new();
                                     for fallback in failover_chain {
+                                        let reason = if eager_failover {
+                                            "Rate limited; credential pool rotation cannot recover"
+                                        } else {
+                                            "All retries exhausted"
+                                        };
                                         tracing::info!(
-                                            "All retries exhausted on {}. Trying fallback: {}",
+                                            "{} on {}. Trying fallback: {}",
+                                            reason,
                                             model,
                                             fallback
                                         );
@@ -4047,8 +4111,8 @@ impl AgentLoop {
                                                 self.emit_status(
                                                     "lifecycle",
                                                     &format!(
-                                                        "Failover recovered request via {}",
-                                                        fallback
+                                                        "{}; failover recovered request via {}",
+                                                        reason, fallback
                                                     ),
                                                 );
                                                 return Ok(resp);
@@ -9628,6 +9692,188 @@ mod tests {
         assert_eq!(resp.message.content.as_deref(), Some("ok"));
 
         let seen = seen_models.lock().expect("seen model lock").clone();
+        assert_eq!(
+            seen,
+            vec!["primary-model".to_string(), "backup-model".to_string()]
+        );
+    }
+
+    struct RateLimitFallbackProvider {
+        seen_models: Arc<std::sync::Mutex<Vec<String>>>,
+        primary_calls_before_success: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RateLimitFallbackProvider {
+        async fn chat_completion(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            model: Option<&str>,
+            _extra_body: Option<&serde_json::Value>,
+        ) -> Result<hermes_core::LlmResponse, AgentError> {
+            let model = model.unwrap_or_default().to_string();
+            self.seen_models
+                .lock()
+                .expect("seen model lock")
+                .push(model.clone());
+            if model == "backup-model" {
+                return Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("fallback-ok"),
+                    usage: None,
+                    model: "backup-model".to_string(),
+                    finish_reason: Some("stop".to_string()),
+                });
+            }
+            let remaining = self
+                .primary_calls_before_success
+                .fetch_update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |value| value.checked_sub(1),
+                )
+                .unwrap_or(0);
+            if remaining > 0 {
+                return Err(AgentError::LlmApi(
+                    "API error 429: synthetic rate limit".to_string(),
+                ));
+            }
+            Ok(hermes_core::LlmResponse {
+                message: Message::assistant("primary-ok"),
+                usage: None,
+                model: "primary-model".to_string(),
+                finish_reason: Some("stop".to_string()),
+            })
+        }
+
+        fn chat_completion_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            _model: Option<&str>,
+            _extra_body: Option<&serde_json::Value>,
+        ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+            futures::stream::empty().boxed()
+        }
+    }
+
+    async fn run_rate_limit_fallback_probe(
+        provider: &str,
+        base_url: Option<&str>,
+        pool: Arc<CredentialPool>,
+        primary_failures_before_success: usize,
+    ) -> Vec<String> {
+        let seen_models = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let mut cfg = AgentConfig::default();
+        cfg.model = "primary-model".to_string();
+        cfg.provider = Some(provider.to_string());
+        cfg.retry.max_retries = 3;
+        cfg.retry.base_delay_ms = 0;
+        cfg.retry.max_delay_ms = 0;
+        cfg.retry.fallback_model = Some("openrouter:backup-model".to_string());
+        if let Some(base_url) = base_url {
+            cfg.runtime_providers.insert(
+                provider.to_string(),
+                RuntimeProviderConfig {
+                    base_url: Some(base_url.to_string()),
+                    ..RuntimeProviderConfig::default()
+                },
+            );
+        }
+
+        let provider = Arc::new(RateLimitFallbackProvider {
+            seen_models: seen_models.clone(),
+            primary_calls_before_success: std::sync::atomic::AtomicUsize::new(
+                primary_failures_before_success,
+            ),
+        });
+        let agent = AgentLoop::new(cfg, Arc::new(ToolRegistry::new()), provider)
+            .with_primary_credential_pool(pool);
+        let mut ctx = ContextManager::new(32);
+        ctx.add_message(Message::user("hello"));
+
+        let _ = agent
+            .call_llm_with_retry_inner(&ctx, &[], None, None)
+            .await
+            .expect("probe should recover");
+        let seen = seen_models.lock().expect("seen model lock").clone();
+        seen
+    }
+
+    #[tokio::test]
+    async fn cloudcode_rate_limit_uses_fallback_without_pool_retry() {
+        let seen = run_rate_limit_fallback_probe(
+            "google-gemini-cli",
+            None,
+            Arc::new(CredentialPool::new(vec![
+                "oauth-a".to_string(),
+                "oauth-b".to_string(),
+                "oauth-c".to_string(),
+            ])),
+            10,
+        )
+        .await;
+
+        assert_eq!(
+            seen,
+            vec!["primary-model".to_string(), "backup-model".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn cloudcode_base_url_uses_fallback_even_for_alias_provider() {
+        let seen = run_rate_limit_fallback_probe(
+            "custom-provider",
+            Some("cloudcode-pa://google"),
+            Arc::new(CredentialPool::new(vec![
+                "oauth-a".to_string(),
+                "oauth-b".to_string(),
+                "oauth-c".to_string(),
+            ])),
+            10,
+        )
+        .await;
+
+        assert_eq!(
+            seen,
+            vec!["primary-model".to_string(), "backup-model".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_cloudcode_multi_key_pool_retries_primary_before_fallback() {
+        let seen = run_rate_limit_fallback_probe(
+            "openrouter",
+            Some("https://openrouter.ai/api/v1"),
+            Arc::new(CredentialPool::new(vec![
+                "key-a".to_string(),
+                "key-b".to_string(),
+                "key-c".to_string(),
+            ])),
+            1,
+        )
+        .await;
+
+        assert_eq!(
+            seen,
+            vec!["primary-model".to_string(), "primary-model".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn single_entry_pool_rate_limit_uses_fallback_without_retry() {
+        let seen = run_rate_limit_fallback_probe(
+            "openrouter",
+            Some("https://openrouter.ai/api/v1"),
+            Arc::new(CredentialPool::single("key-a")),
+            10,
+        )
+        .await;
+
         assert_eq!(
             seen,
             vec!["primary-model".to_string(), "backup-model".to_string()]

--- a/crates/hermes-agent/src/credential_pool.rs
+++ b/crates/hermes-agent/src/credential_pool.rs
@@ -150,6 +150,20 @@ impl CredentialPool {
         self.inner.lock().map(|i| i.keys.len()).unwrap_or(0)
     }
 
+    /// Return true when at least one active key is not currently rate-limited.
+    pub fn has_available(&self) -> bool {
+        let mut inner = match self.inner.lock() {
+            Ok(i) => i,
+            Err(e) => e.into_inner(),
+        };
+        Self::recover_failed_inner(&mut inner);
+        let now = Instant::now();
+        inner
+            .keys
+            .iter()
+            .any(|entry| entry.rate_limited_until.map_or(true, |until| until <= now))
+    }
+
     /// Check if the pool is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -274,8 +288,11 @@ mod tests {
             "key-c".to_string(),
         ]);
 
+        assert!(pool.has_available());
+
         // Rate-limit key-a
         pool.mark_rate_limited("key-a", Duration::from_secs(60));
+        assert!(pool.has_available());
 
         let k1 = pool.get_key();
         assert_ne!(k1, "key-a");
@@ -296,6 +313,7 @@ mod tests {
 
         pool.mark_rate_limited("key-a", Duration::from_secs(60));
         pool.mark_rate_limited("key-b", Duration::from_secs(10));
+        assert!(!pool.has_available());
 
         // Should pick key-b since it expires sooner
         let key = pool.get_key();

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T05:54:25.494564+00:00",
+  "generated_at_utc": "2026-05-30T06:17:31.817365+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "318b5be61fbd59e3780edcdc6ad24a9aecf23f63",
+    "local_sha": "6b956e698fdbff87372a641cfc32625a977c409c",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 837,
+    "commits_ahead": 839,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 702,
+    "local_patch_unique": 703,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 386814
+    "tree_deletions": 386990
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 702,
+    "local_patch_unique": 703,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T05:54:25.494564+00:00`
+Generated: `2026-05-30T06:17:31.817365+00:00`
 
 ## Scope
 
-- Local ref: `main` (`318b5be61fbd59e3780edcdc6ad24a9aecf23f63`)
+- Local ref: `main` (`6b956e698fdbff87372a641cfc32625a977c409c`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T05:54:25.494564+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 837 |
+| Commits ahead local (`local` ancestry only) | 839 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 702 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 703 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 386814 |
+| Deletions (`local` vs `upstream`) | 386990 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T05:54:25.494564+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `702`
+- Local unique by patch-id: `703`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -2086,16 +2086,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_gemini_fast_fallback.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "3a842e57aeffdcd5078c81f4281f5bd7fb8cd97e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_gemini_fast_fallback.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "41fafca8a50adb94d0448df5d81eb3fef702f941",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T05:54:25.644744+00:00",
+  "generated_at_utc": "2026-05-30T06:17:36.974041+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "318b5be61fbd59e3780edcdc6ad24a9aecf23f63",
+    "local_sha": "6b956e698fdbff87372a641cfc32625a977c409c",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 740,
-      "intentional_divergence": 109,
+      "functional": 739,
+      "intentional_divergence": 110,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 278,
-      "rust_equivalent_or_contract_test_required": 661,
+      "not_required_for_runtime": 279,
+      "rust_equivalent_or_contract_test_required": 660,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 109,
+      "cleared_intentional_divergence": 110,
       "cleared_non_runtime": 169,
-      "pending_review": 740
+      "pending_review": 739
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 109,
+    "cleared_intentional_divergence": 110,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 740,
+    "pending_review": 739,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T05:54:25.644744+00:00`
+Generated: `2026-05-30T06:17:36.974041+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `740`
+- Pending functional review: `739`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `109`
+- Cleared intentional divergence: `110`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 109 |
+| `cleared_intentional_divergence` | 110 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 740 |
+| `pending_review` | 739 |
 
 ## Workstream Counts
 
@@ -42,7 +42,7 @@ Generated: `2026-05-30T05:54:25.644744+00:00`
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 55 |
-| `tests/agent` | 47 |
+| `tests/agent` | 46 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -241,6 +241,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/agent/test_gemini_fast_fallback.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream CloudCode/Gemini CLI rate-limit fallback intent is covered by Rust hermes-agent retry tests for google-gemini-cli, cloudcode-pa:// base URLs, non-CloudCode multi-key pool retries, and single-key fallback; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/agent/test_redact.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- Add Rust retry logic so Gemini CLI / cloudcode-pa rate-limit errors skip credential-pool waiting and use configured failover immediately.
- Preserve non-CloudCode multi-key pool retry behavior and single-key fallback behavior with Rust tests.
- Mark upstream tests/agent/test_gemini_fast_fallback.py as reference-only because the intent is covered by Rust contracts; regenerate parity docs.

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max-shared-different|max shared different" .; test $? -eq 1
- cargo test -p hermes-agent rate_limit
- cargo test -p hermes-agent cloudcode_base_url_uses_fallback_even_for_alias_provider
- cargo test -p hermes-agent non_cloudcode_multi_key_pool_retries_primary_before_fallback
- cargo test -p hermes-agent chaos_harness_profiles_verify_retry_and_fallback
- cargo test -p hermes-agent
- cargo test -p hermes-cli
- cargo test -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md