### PR TITLE
Port Discord media metadata contract

### DIFF
--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -59,6 +59,39 @@ fn default_intents() -> u64 {
     (1 << 0) | (1 << 9) | (1 << 15)
 }
 
+/// Optional Discord send metadata carried by higher-level gateway helpers.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscordSendMetadata {
+    /// Discord thread channel ID to target instead of the parent channel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+}
+
+impl DiscordSendMetadata {
+    pub fn with_thread_id(thread_id: impl Into<String>) -> Self {
+        Self {
+            thread_id: Some(thread_id.into()),
+        }
+    }
+
+    pub fn target_channel_id<'a>(&'a self, fallback_channel_id: &'a str) -> &'a str {
+        self.thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .unwrap_or(fallback_channel_id)
+    }
+}
+
+fn target_channel_id_for_metadata<'a>(
+    channel_id: &'a str,
+    metadata: Option<&'a DiscordSendMetadata>,
+) -> &'a str {
+    metadata
+        .map(|m| m.target_channel_id(channel_id))
+        .unwrap_or(channel_id)
+}
+
 // ---------------------------------------------------------------------------
 // Discord Gateway opcodes & payload
 // ---------------------------------------------------------------------------
@@ -644,11 +677,26 @@ impl DiscordAdapter {
         channel_id: &str,
         content: &str,
     ) -> Result<Vec<String>, GatewayError> {
+        self.send_text_with_metadata(channel_id, content, None)
+            .await
+    }
+
+    /// Send a message, honoring Discord thread routing metadata when present.
+    pub async fn send_text_with_metadata(
+        &self,
+        channel_id: &str,
+        content: &str,
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<Vec<String>, GatewayError> {
+        let target_channel_id = target_channel_id_for_metadata(channel_id, metadata);
         let chunks = split_message(content, MAX_MESSAGE_LENGTH);
         let mut message_ids = Vec::new();
 
         for chunk in &chunks {
-            let url = format!("{}/channels/{}/messages", DISCORD_API_BASE, channel_id);
+            let url = format!(
+                "{}/channels/{}/messages",
+                DISCORD_API_BASE, target_channel_id
+            );
             let body = serde_json::json!({ "content": chunk });
 
             let resp = self
@@ -727,7 +775,23 @@ impl DiscordAdapter {
         content: Option<&str>,
         embeds: &[DiscordEmbed],
     ) -> Result<String, GatewayError> {
-        let url = format!("{}/channels/{}/messages", DISCORD_API_BASE, channel_id);
+        self.send_embed_with_metadata(channel_id, content, embeds, None)
+            .await
+    }
+
+    /// Send embeds, honoring Discord thread routing metadata when present.
+    pub async fn send_embed_with_metadata(
+        &self,
+        channel_id: &str,
+        content: Option<&str>,
+        embeds: &[DiscordEmbed],
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<String, GatewayError> {
+        let target_channel_id = target_channel_id_for_metadata(channel_id, metadata);
+        let url = format!(
+            "{}/channels/{}/messages",
+            DISCORD_API_BASE, target_channel_id
+        );
 
         let mut body = serde_json::json!({ "embeds": embeds });
         if let Some(text) = content {
@@ -770,7 +834,23 @@ impl DiscordAdapter {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<String, GatewayError> {
-        let url = format!("{}/channels/{}/messages", DISCORD_API_BASE, channel_id);
+        self.upload_file_with_metadata(channel_id, file_path, caption, None)
+            .await
+    }
+
+    /// Upload a file, honoring Discord thread routing metadata when present.
+    pub async fn upload_file_with_metadata(
+        &self,
+        channel_id: &str,
+        file_path: &str,
+        caption: Option<&str>,
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<String, GatewayError> {
+        let target_channel_id = target_channel_id_for_metadata(channel_id, metadata);
+        let url = format!(
+            "{}/channels/{}/messages",
+            DISCORD_API_BASE, target_channel_id
+        );
 
         let file_bytes = tokio::fs::read(file_path).await.map_err(|e| {
             GatewayError::SendFailed(format!("Failed to read file {}: {}", file_path, e))
@@ -813,6 +893,58 @@ impl DiscordAdapter {
         })?;
 
         Ok(msg.id)
+    }
+
+    /// Send a local image file as a Discord attachment.
+    pub async fn send_image_file(
+        &self,
+        channel_id: &str,
+        image_path: &str,
+        caption: Option<&str>,
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<String, GatewayError> {
+        self.upload_file_with_metadata(channel_id, image_path, caption, metadata)
+            .await
+    }
+
+    /// Send an image URL as a Discord embed.
+    pub async fn send_image(
+        &self,
+        channel_id: &str,
+        image_url: &str,
+        caption: Option<&str>,
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<String, GatewayError> {
+        self.send_image_url_with_metadata(channel_id, image_url, caption, metadata)
+            .await
+    }
+
+    /// Send a voice/audio file as a Discord attachment.
+    pub async fn send_voice(
+        &self,
+        channel_id: &str,
+        audio_path: &str,
+        caption: Option<&str>,
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<String, GatewayError> {
+        self.upload_file_with_metadata(channel_id, audio_path, caption, metadata)
+            .await
+    }
+
+    /// Send an image URL as an embed, honoring thread routing metadata.
+    pub async fn send_image_url_with_metadata(
+        &self,
+        channel_id: &str,
+        image_url: &str,
+        caption: Option<&str>,
+        metadata: Option<&DiscordSendMetadata>,
+    ) -> Result<String, GatewayError> {
+        let mut embed = DiscordEmbed::new();
+        embed.image = Some(EmbedMedia {
+            url: image_url.to_string(),
+        });
+        self.send_embed_with_metadata(channel_id, caption, &[embed], metadata)
+            .await
     }
 
     // -----------------------------------------------------------------------
@@ -1453,11 +1585,8 @@ impl PlatformAdapter for DiscordAdapter {
         image_url: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
-        let mut embed = DiscordEmbed::new();
-        embed.image = Some(EmbedMedia {
-            url: image_url.to_string(),
-        });
-        self.send_embed(chat_id, caption, &[embed]).await?;
+        self.send_image_url_with_metadata(chat_id, image_url, caption, None)
+            .await?;
         Ok(())
     }
 
@@ -1530,6 +1659,56 @@ mod tests {
 
     // -- existing tests (preserved) -----------------------------------------
 
+    fn test_config() -> DiscordConfig {
+        DiscordConfig {
+            token: "test-token".into(),
+            application_id: None,
+            proxy: AdapterProxyConfig::default(),
+            require_mention: false,
+            intents: default_intents(),
+        }
+    }
+
+    #[test]
+    fn send_metadata_targets_thread_id_when_present() {
+        let metadata = DiscordSendMetadata::with_thread_id(" 987654321 ");
+        assert_eq!(metadata.target_channel_id("123"), "987654321");
+
+        let blank_metadata = DiscordSendMetadata::with_thread_id("   ");
+        assert_eq!(blank_metadata.target_channel_id("123"), "123");
+        assert_eq!(target_channel_id_for_metadata("123", None), "123");
+    }
+
+    #[test]
+    fn media_methods_accept_metadata_contract() {
+        let adapter = DiscordAdapter::new(test_config()).unwrap();
+        let metadata = DiscordSendMetadata::with_thread_id("thread-1");
+
+        let image_file = adapter.send_image_file(
+            "channel-1",
+            "/tmp/missing-image.png",
+            Some("caption"),
+            Some(&metadata),
+        );
+        drop(image_file);
+
+        let image = adapter.send_image(
+            "channel-1",
+            "https://example.com/image.png",
+            Some("caption"),
+            Some(&metadata),
+        );
+        drop(image);
+
+        let voice = adapter.send_voice(
+            "channel-1",
+            "/tmp/missing-audio.ogg",
+            Some("caption"),
+            Some(&metadata),
+        );
+        drop(voice);
+    }
+
     #[test]
     fn split_message_short() {
         let chunks = split_message("hello", 2000);
@@ -1547,14 +1726,7 @@ mod tests {
 
     #[test]
     fn gateway_payload_identify() {
-        let config = DiscordConfig {
-            token: "test-token".into(),
-            application_id: None,
-            proxy: AdapterProxyConfig::default(),
-            require_mention: false,
-            intents: default_intents(),
-        };
-        let adapter = DiscordAdapter::new(config).unwrap();
+        let adapter = DiscordAdapter::new(test_config()).unwrap();
         let payload = adapter.build_identify_payload();
         assert_eq!(payload.op, opcodes::IDENTIFY);
         assert!(payload.d.is_some());

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T06:17:31.817365+00:00",
+  "generated_at_utc": "2026-05-30T06:39:12.876453+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "6b956e698fdbff87372a641cfc32625a977c409c",
+    "local_sha": "502586dc149e5fce6cc9ee9a73183a009574272a",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 839,
+    "commits_ahead": 841,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 703,
+    "local_patch_unique": 704,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 386990
+    "tree_deletions": 387261
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 703,
+    "local_patch_unique": 704,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T06:17:31.817365+00:00`
+Generated: `2026-05-30T06:39:12.876453+00:00`
 
 ## Scope
 
-- Local ref: `main` (`6b956e698fdbff87372a641cfc32625a977c409c`)
+- Local ref: `main` (`502586dc149e5fce6cc9ee9a73183a009574272a`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T06:17:31.817365+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 839 |
+| Commits ahead local (`local` ancestry only) | 841 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 703 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 704 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 386990 |
+| Deletions (`local` vs `upstream`) | 387261 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T06:17:31.817365+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `703`
+- Local unique by patch-id: `704`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3841,16 +3841,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_media_metadata.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a98ac4fc043ec01805c8b810891f2a5c92030b0b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_media_metadata.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "966700b700dea7bb3f2e068e83ce5d69cdbaa96c",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T06:17:36.974041+00:00",
+  "generated_at_utc": "2026-05-30T06:39:17.701229+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "6b956e698fdbff87372a641cfc32625a977c409c",
+    "local_sha": "502586dc149e5fce6cc9ee9a73183a009574272a",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 739,
-      "intentional_divergence": 110,
+      "functional": 738,
+      "intentional_divergence": 111,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 279,
-      "rust_equivalent_or_contract_test_required": 660,
+      "not_required_for_runtime": 280,
+      "rust_equivalent_or_contract_test_required": 659,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 110,
+      "cleared_intentional_divergence": 111,
       "cleared_non_runtime": 169,
-      "pending_review": 739
+      "pending_review": 738
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 110,
+    "cleared_intentional_divergence": 111,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 739,
+    "pending_review": 738,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T06:17:36.974041+00:00`
+Generated: `2026-05-30T06:39:17.701229+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `739`
+- Pending functional review: `738`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `110`
+- Cleared intentional divergence: `111`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 110 |
+| `cleared_intentional_divergence` | 111 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 739 |
+| `pending_review` | 738 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T06:17:36.974041+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 171 |
+| `tests/gateway` | 170 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -150,6 +150,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_media_metadata.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord media metadata signature intent is covered by Rust hermes-gateway DiscordSendMetadata routing tests plus metadata-aware send_voice, send_image_file, and send_image method contracts; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "website/docs",
       "classification": "policy_only",
       "rationale": "Documentation-site content differs by project positioning and release policy; runtime behavior is unaffected.",


### PR DESCRIPTION
## Summary
- add Rust DiscordSendMetadata and metadata-aware Discord media/send helpers
- cover thread-id routing and send_voice/send_image_file/send_image metadata contracts under the discord feature
- clear tests/gateway/test_discord_media_metadata.py in the shared diff backlog via Rust coverage

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max-shared-different|max shared different" .; test $? -eq 1
- cargo test -p hermes-gateway --features discord
- cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md