### PR TITLE
Port Discord allowed mentions contract

### DIFF
--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -92,6 +92,87 @@ fn target_channel_id_for_metadata<'a>(
         .unwrap_or(channel_id)
 }
 
+const DISCORD_ALLOW_MENTION_EVERYONE_ENV: &str = "DISCORD_ALLOW_MENTION_EVERYONE";
+const DISCORD_ALLOW_MENTION_ROLES_ENV: &str = "DISCORD_ALLOW_MENTION_ROLES";
+const DISCORD_ALLOW_MENTION_USERS_ENV: &str = "DISCORD_ALLOW_MENTION_USERS";
+const DISCORD_ALLOW_MENTION_REPLIED_USER_ENV: &str = "DISCORD_ALLOW_MENTION_REPLIED_USER";
+
+/// Discord REST `allowed_mentions` payload.
+///
+/// Safe defaults block broad server pings while preserving direct user and
+/// reply-reference pings, matching the upstream gateway adapter contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscordAllowedMentions {
+    pub parse: Vec<String>,
+    pub replied_user: bool,
+}
+
+impl DiscordAllowedMentions {
+    pub fn from_flags(everyone: bool, roles: bool, users: bool, replied_user: bool) -> Self {
+        let mut parse = Vec::new();
+        if everyone {
+            parse.push("everyone".to_string());
+        }
+        if roles {
+            parse.push("roles".to_string());
+        }
+        if users {
+            parse.push("users".to_string());
+        }
+
+        Self {
+            parse,
+            replied_user,
+        }
+    }
+}
+
+fn parse_allowed_mention_bool(raw: &str, default: bool) -> bool {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => true,
+        "false" | "0" | "no" | "off" => false,
+        "" => default,
+        _ => default,
+    }
+}
+
+fn discord_allowed_mentions_from_lookup<F>(mut lookup: F) -> DiscordAllowedMentions
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let allow_everyone = lookup(DISCORD_ALLOW_MENTION_EVERYONE_ENV)
+        .map(|raw| parse_allowed_mention_bool(&raw, false))
+        .unwrap_or(false);
+    let allow_roles = lookup(DISCORD_ALLOW_MENTION_ROLES_ENV)
+        .map(|raw| parse_allowed_mention_bool(&raw, false))
+        .unwrap_or(false);
+    let allow_users = lookup(DISCORD_ALLOW_MENTION_USERS_ENV)
+        .map(|raw| parse_allowed_mention_bool(&raw, true))
+        .unwrap_or(true);
+    let allow_replied_user = lookup(DISCORD_ALLOW_MENTION_REPLIED_USER_ENV)
+        .map(|raw| parse_allowed_mention_bool(&raw, true))
+        .unwrap_or(true);
+
+    DiscordAllowedMentions::from_flags(allow_everyone, allow_roles, allow_users, allow_replied_user)
+}
+
+fn default_discord_allowed_mentions() -> DiscordAllowedMentions {
+    discord_allowed_mentions_from_lookup(|name| std::env::var(name).ok())
+}
+
+fn with_allowed_mentions(
+    mut body: serde_json::Value,
+    allowed_mentions: DiscordAllowedMentions,
+) -> serde_json::Value {
+    body["allowed_mentions"] =
+        serde_json::to_value(allowed_mentions).expect("DiscordAllowedMentions serializes");
+    body
+}
+
+fn with_default_allowed_mentions(body: serde_json::Value) -> serde_json::Value {
+    with_allowed_mentions(body, default_discord_allowed_mentions())
+}
+
 // ---------------------------------------------------------------------------
 // Discord Gateway opcodes & payload
 // ---------------------------------------------------------------------------
@@ -697,7 +778,7 @@ impl DiscordAdapter {
                 "{}/channels/{}/messages",
                 DISCORD_API_BASE, target_channel_id
             );
-            let body = serde_json::json!({ "content": chunk });
+            let body = with_default_allowed_mentions(serde_json::json!({ "content": chunk }));
 
             let resp = self
                 .client
@@ -739,9 +820,9 @@ impl DiscordAdapter {
             DISCORD_API_BASE, channel_id, message_id
         );
 
-        let body = serde_json::json!({
+        let body = with_default_allowed_mentions(serde_json::json!({
             "content": &content[..content.len().min(MAX_MESSAGE_LENGTH)],
-        });
+        }));
 
         let resp = self
             .client
@@ -793,7 +874,7 @@ impl DiscordAdapter {
             DISCORD_API_BASE, target_channel_id
         );
 
-        let mut body = serde_json::json!({ "embeds": embeds });
+        let mut body = with_default_allowed_mentions(serde_json::json!({ "embeds": embeds }));
         if let Some(text) = content {
             body["content"] = serde_json::Value::String(text.to_string());
         }
@@ -866,10 +947,11 @@ impl DiscordAdapter {
 
         let mut form = reqwest::multipart::Form::new().part("files[0]", part);
 
-        if let Some(cap) = caption {
-            let payload = serde_json::json!({ "content": cap });
-            form = form.text("payload_json", payload.to_string());
-        }
+        let payload = with_default_allowed_mentions(match caption {
+            Some(cap) => serde_json::json!({ "content": cap }),
+            None => serde_json::json!({}),
+        });
+        form = form.text("payload_json", payload.to_string());
 
         let resp = self
             .client
@@ -1677,6 +1759,50 @@ mod tests {
         let blank_metadata = DiscordSendMetadata::with_thread_id("   ");
         assert_eq!(blank_metadata.target_channel_id("123"), "123");
         assert_eq!(target_channel_id_for_metadata("123", None), "123");
+    }
+
+    #[test]
+    fn allowed_mentions_safe_defaults_block_broad_pings() {
+        let mentions = discord_allowed_mentions_from_lookup(|_| None);
+        assert_eq!(mentions.parse, vec!["users".to_string()]);
+        assert!(mentions.replied_user);
+
+        let body = with_allowed_mentions(serde_json::json!({ "content": "hello" }), mentions);
+        assert_eq!(
+            body["allowed_mentions"],
+            serde_json::json!({ "parse": ["users"], "replied_user": true })
+        );
+    }
+
+    #[test]
+    fn allowed_mentions_env_style_knobs_parse_like_upstream() {
+        let mentions = discord_allowed_mentions_from_lookup(|name| match name {
+            DISCORD_ALLOW_MENTION_EVERYONE_ENV => Some(" true ".to_string()),
+            DISCORD_ALLOW_MENTION_ROLES_ENV => Some("YES".to_string()),
+            DISCORD_ALLOW_MENTION_USERS_ENV => Some("false".to_string()),
+            DISCORD_ALLOW_MENTION_REPLIED_USER_ENV => Some("0".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(
+            mentions,
+            DiscordAllowedMentions::from_flags(true, true, false, false)
+        );
+    }
+
+    #[test]
+    fn allowed_mentions_boolean_parser_falls_back_for_empty_or_unknown_values() {
+        for raw in ["true", "True", "1", "yes", "on", " true "] {
+            assert!(parse_allowed_mention_bool(raw, false));
+        }
+        for raw in ["false", "False", "0", "no", "off"] {
+            assert!(!parse_allowed_mention_bool(raw, true));
+        }
+
+        assert!(!parse_allowed_mention_bool("", false));
+        assert!(parse_allowed_mention_bool("", true));
+        assert!(!parse_allowed_mention_bool("garbage", false));
+        assert!(parse_allowed_mention_bool("garbage", true));
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T06:39:12.876453+00:00",
+  "generated_at_utc": "2026-05-30T06:55:41.562711+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "502586dc149e5fce6cc9ee9a73183a009574272a",
+    "local_sha": "7b392964bd952377e68354b249ca65d272faf4ea",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 841,
+    "commits_ahead": 843,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 704,
+    "local_patch_unique": 705,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 387261
+    "tree_deletions": 387440
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 704,
+    "local_patch_unique": 705,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T06:39:12.876453+00:00`
+Generated: `2026-05-30T06:55:41.562711+00:00`
 
 ## Scope
 
-- Local ref: `main` (`502586dc149e5fce6cc9ee9a73183a009574272a`)
+- Local ref: `main` (`7b392964bd952377e68354b249ca65d272faf4ea`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T06:39:12.876453+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 841 |
+| Commits ahead local (`local` ancestry only) | 843 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 704 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 705 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 387261 |
+| Deletions (`local` vs `upstream`) | 387440 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T06:39:12.876453+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `704`
+- Local unique by patch-id: `705`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3661,16 +3661,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_allowed_mentions.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c717c3cd196e4278cc4c6c6faf91195b6bc707ce",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_allowed_mentions.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "dee9c379a2dc8213023e3af97841e168123f1a9b",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T06:39:17.701229+00:00",
+  "generated_at_utc": "2026-05-30T06:55:48.379811+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "502586dc149e5fce6cc9ee9a73183a009574272a",
+    "local_sha": "7b392964bd952377e68354b249ca65d272faf4ea",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 738,
-      "intentional_divergence": 111,
+      "functional": 737,
+      "intentional_divergence": 112,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 280,
-      "rust_equivalent_or_contract_test_required": 659,
+      "not_required_for_runtime": 281,
+      "rust_equivalent_or_contract_test_required": 658,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 111,
+      "cleared_intentional_divergence": 112,
       "cleared_non_runtime": 169,
-      "pending_review": 738
+      "pending_review": 737
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 111,
+    "cleared_intentional_divergence": 112,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 738,
+    "pending_review": 737,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T06:39:17.701229+00:00`
+Generated: `2026-05-30T06:55:48.379811+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `738`
+- Pending functional review: `737`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `111`
+- Cleared intentional divergence: `112`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 111 |
+| `cleared_intentional_divergence` | 112 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 738 |
+| `pending_review` | 737 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T06:39:17.701229+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 170 |
+| `tests/gateway` | 169 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -150,6 +150,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_allowed_mentions.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord allowed_mentions safe-default intent is covered by Rust hermes-gateway DiscordAllowedMentions payload construction and env-style parsing tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_media_metadata.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord media metadata signature intent is covered by Rust hermes-gateway DiscordSendMetadata routing tests plus metadata-aware send_voice, send_image_file, and send_image method contracts; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- add Rust DiscordAllowedMentions REST payload construction with safe defaults
- apply allowed_mentions to Discord text, edit, embed, and upload payloads
- cover env-style parsing and safe default behavior with Rust tests
- clear tests/gateway/test_discord_allowed_mentions.py in the shared diff backlog via Rust coverage

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max-shared-different|max shared different" .; test $? -eq 1
- cargo test -p hermes-gateway --features discord
- cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md