### PR TITLE
parity(discord): port inbound bot policy contracts

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4126,6 +4126,18 @@ fn extra_bool_loose(platform_cfg: &PlatformConfig, key: &str) -> Option<bool> {
     })
 }
 
+fn discord_allow_bots_bypasses_gateway_allowlist(
+    platform: &str,
+    platform_cfg: &PlatformConfig,
+) -> bool {
+    if !platform.eq_ignore_ascii_case("discord") {
+        return false;
+    }
+    extra_string(platform_cfg, "allow_bots")
+        .map(|raw| matches!(raw.trim().to_ascii_lowercase().as_str(), "all" | "mentions"))
+        .unwrap_or(false)
+}
+
 fn build_gateway_dm_manager(config: &hermes_config::GatewayConfig) -> DmManager {
     let mut dm_manager = DmManager::with_pair_behavior();
     for platform_cfg in config.platforms.values().filter(|p| p.enabled) {
@@ -4196,6 +4208,11 @@ fn build_gateway_platform_access_policies(
                 admin_users,
                 group_mode,
                 slash_requires_allowlist,
+                bot_sender_bypasses_allowlist: discord_allow_bots_bypasses_gateway_allowlist(
+                    platform,
+                    platform_cfg,
+                ),
+                reactions_enabled: extra_bool_loose(platform_cfg, "reactions"),
             },
         );
     }

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -131,8 +131,47 @@ fn apply_ntfy_env(config: &mut GatewayConfig) {
     }
 }
 
+fn apply_discord_env(config: &mut GatewayConfig) {
+    let discord = config
+        .platforms
+        .entry("discord".into())
+        .or_insert_with(PlatformConfig::default);
+
+    if let Some(token) = env_nonempty("DISCORD_BOT_TOKEN") {
+        let enabled_was_explicit = discord
+            .extra
+            .remove("_enabled_explicit")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !discord.enabled && !enabled_was_explicit {
+            discord.enabled = true;
+        }
+        discord.token = Some(token);
+    }
+    if let Some(v) = env_nonempty("DISCORD_APPLICATION_ID") {
+        set_extra(discord, "application_id", json!(v));
+    }
+    if let Some(v) = env_nonempty("DISCORD_ALLOW_BOTS") {
+        set_extra(discord, "allow_bots", json!(v));
+    }
+    if let Some(v) = env_nonempty("DISCORD_REACTIONS") {
+        set_extra(
+            discord,
+            "reactions",
+            json!(matches!(
+                v.to_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )),
+        );
+    }
+    if let Some(v) = env_nonempty("DISCORD_REPLY_TO_MODE") {
+        set_extra(discord, "reply_to_mode", json!(v));
+    }
+}
+
 /// 应用与 Python 文档一致的平台环境变量到 `platforms`。
 pub fn apply_python_named_platform_env(config: &mut GatewayConfig) {
+    apply_discord_env(config);
     apply_weixin_env(config);
     apply_dingtalk_env(config);
     apply_ntfy_env(config);
@@ -175,6 +214,45 @@ mod tests {
             std::env::remove_var("WEIXIN_TOKEN");
             std::env::remove_var("WEIXIN_DM_POLICY");
             std::env::remove_var("WEIXIN_ALLOWED_USERS");
+        }
+    }
+
+    #[test]
+    fn discord_env_sets_bot_policy_and_reaction_fields() {
+        unsafe {
+            std::env::set_var("DISCORD_BOT_TOKEN", "discord-token");
+            std::env::set_var("DISCORD_APPLICATION_ID", "app-123");
+            std::env::set_var("DISCORD_ALLOW_BOTS", "mentions");
+            std::env::set_var("DISCORD_REACTIONS", "false");
+            std::env::set_var("DISCORD_REPLY_TO_MODE", "all");
+        }
+        let mut cfg = GatewayConfig::default();
+        apply_python_named_platform_env(&mut cfg);
+        let discord = cfg.platforms.get("discord").expect("discord block");
+        assert!(discord.enabled);
+        assert_eq!(discord.token.as_deref(), Some("discord-token"));
+        assert_eq!(
+            discord.extra.get("application_id").and_then(|v| v.as_str()),
+            Some("app-123")
+        );
+        assert_eq!(
+            discord.extra.get("allow_bots").and_then(|v| v.as_str()),
+            Some("mentions")
+        );
+        assert_eq!(
+            discord.extra.get("reactions").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            discord.extra.get("reply_to_mode").and_then(|v| v.as_str()),
+            Some("all")
+        );
+        unsafe {
+            std::env::remove_var("DISCORD_BOT_TOKEN");
+            std::env::remove_var("DISCORD_APPLICATION_ID");
+            std::env::remove_var("DISCORD_ALLOW_BOTS");
+            std::env::remove_var("DISCORD_REACTIONS");
+            std::env::remove_var("DISCORD_REPLY_TO_MODE");
         }
     }
 

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -102,6 +102,23 @@ pub struct IncomingMessage {
     pub is_dm: bool,
 }
 
+/// Sender metadata carried by platform adapters when routing a message.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IncomingSender {
+    /// True when the source user is a bot/webhook account.
+    pub is_bot: bool,
+}
+
+impl IncomingSender {
+    pub fn human() -> Self {
+        Self { is_bot: false }
+    }
+
+    pub fn bot() -> Self {
+        Self { is_bot: true }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // MessageHandler callback
 // ---------------------------------------------------------------------------
@@ -278,6 +295,8 @@ pub struct PlatformAccessPolicy {
     pub admin_users: HashSet<String>,
     pub group_mode: GroupAccessMode,
     pub slash_requires_allowlist: bool,
+    pub bot_sender_bypasses_allowlist: bool,
+    pub reactions_enabled: Option<bool>,
 }
 
 impl PlatformAccessPolicy {
@@ -308,6 +327,23 @@ impl PlatformAccessPolicy {
         Self::user_matches_any(user_id, &self.admin_users)
             || Self::user_matches_any(user_id, &self.allowed_users)
     }
+
+    fn allows_sender_without_user_allowlist(
+        &self,
+        incoming: &IncomingMessage,
+        sender: IncomingSender,
+    ) -> bool {
+        incoming.platform.eq_ignore_ascii_case("discord")
+            && sender.is_bot
+            && self.bot_sender_bypasses_allowlist
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReactionLifecyclePlan {
+    start: &'static str,
+    success: &'static str,
+    error: &'static str,
 }
 
 impl Gateway {
@@ -395,12 +431,12 @@ impl Gateway {
         }
     }
 
-    fn should_apply_slack_reaction_lifecycle(incoming: &IncomingMessage) -> bool {
-        if !incoming.platform.eq_ignore_ascii_case("slack") {
-            return false;
-        }
+    fn reaction_lifecycle_plan(
+        incoming: &IncomingMessage,
+        access_policy: Option<&PlatformAccessPolicy>,
+    ) -> Option<ReactionLifecyclePlan> {
         if incoming.text.trim_start().starts_with('/') {
-            return false;
+            return None;
         }
         if incoming
             .message_id
@@ -409,9 +445,33 @@ impl Gateway {
             .filter(|s| !s.is_empty())
             .is_none()
         {
-            return false;
+            return None;
         }
-        incoming.is_dm || incoming.text.contains("<@")
+        if matches!(
+            access_policy.and_then(|policy| policy.reactions_enabled),
+            Some(false)
+        ) {
+            return None;
+        }
+        if !(incoming.is_dm || incoming.text.contains("<@")) {
+            return None;
+        }
+
+        if incoming.platform.eq_ignore_ascii_case("slack") {
+            return Some(ReactionLifecyclePlan {
+                start: "eyes",
+                success: "white_check_mark",
+                error: "x",
+            });
+        }
+        if incoming.platform.eq_ignore_ascii_case("discord") {
+            return Some(ReactionLifecyclePlan {
+                start: "👀",
+                success: "✅",
+                error: "❌",
+            });
+        }
+        None
     }
 
     /// Set the message handler for processing incoming messages.
@@ -522,9 +582,21 @@ impl Gateway {
     /// Route an incoming message through the full pipeline:
     /// DM check → session lookup → agent loop → response.
     pub async fn route_message(&self, incoming: &IncomingMessage) -> Result<(), GatewayError> {
+        self.route_message_from_sender(incoming, IncomingSender::human())
+            .await
+    }
+
+    /// Route an incoming message with platform-provided sender metadata.
+    pub async fn route_message_from_sender(
+        &self,
+        incoming: &IncomingMessage,
+        sender: IncomingSender,
+    ) -> Result<(), GatewayError> {
         let access_policy = self.platform_access_policy(&incoming.platform).await;
         let is_slash_command = incoming.text.trim_start().starts_with('/');
         if let Some(policy) = access_policy.as_ref() {
+            let bypasses_user_allowlist =
+                policy.allows_sender_without_user_allowlist(incoming, sender);
             if !incoming.is_dm {
                 match policy.group_mode {
                     GroupAccessMode::Disabled => {
@@ -536,7 +608,7 @@ impl Gateway {
                         return Ok(());
                     }
                     GroupAccessMode::Allowlist => {
-                        if !policy.is_user_allowed(&incoming.user_id) {
+                        if !bypasses_user_allowlist && !policy.is_user_allowed(&incoming.user_id) {
                             debug!(
                                 platform = incoming.platform,
                                 user_id = incoming.user_id,
@@ -551,6 +623,7 @@ impl Gateway {
             if is_slash_command
                 && policy.slash_requires_allowlist
                 && policy.has_allowlist()
+                && !bypasses_user_allowlist
                 && !policy.is_user_allowed(&incoming.user_id)
             {
                 debug!(
@@ -629,16 +702,19 @@ impl Gateway {
             }
         }
 
-        let reaction_adapter = if Self::should_apply_slack_reaction_lifecycle(incoming) {
+        let reaction_plan = Self::reaction_lifecycle_plan(incoming, access_policy.as_ref());
+        let reaction_adapter = if reaction_plan.is_some() {
             self.get_adapter(&incoming.platform).await
         } else {
             None
         };
-        if let (Some(adapter), Some(message_id)) =
-            (&reaction_adapter, incoming.message_id.as_deref())
-        {
+        if let (Some(adapter), Some(message_id), Some(plan)) = (
+            &reaction_adapter,
+            incoming.message_id.as_deref(),
+            reaction_plan,
+        ) {
             if let Err(err) = adapter
-                .add_reaction(&incoming.chat_id, message_id, "eyes")
+                .add_reaction(&incoming.chat_id, message_id, plan.start)
                 .await
             {
                 debug!(
@@ -675,11 +751,13 @@ impl Gateway {
                 .await
         };
 
-        if let (Some(adapter), Some(message_id)) =
-            (&reaction_adapter, incoming.message_id.as_deref())
-        {
+        if let (Some(adapter), Some(message_id), Some(plan)) = (
+            &reaction_adapter,
+            incoming.message_id.as_deref(),
+            reaction_plan,
+        ) {
             if let Err(err) = adapter
-                .remove_reaction(&incoming.chat_id, message_id, "eyes")
+                .remove_reaction(&incoming.chat_id, message_id, plan.start)
                 .await
             {
                 debug!(
@@ -691,9 +769,9 @@ impl Gateway {
                 );
             }
             let emoji = if processing_result.is_ok() {
-                "white_check_mark"
+                plan.success
             } else {
-                "x"
+                plan.error
             };
             if let Err(err) = adapter
                 .add_reaction(&incoming.chat_id, message_id, emoji)
@@ -2611,6 +2689,139 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_discord_bot_sender_can_bypass_user_allowlist_when_enabled() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let mut policies = HashMap::new();
+        let mut policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Allowlist,
+            bot_sender_bypasses_allowlist: true,
+            ..PlatformAccessPolicy::default()
+        };
+        policy.allowed_users.insert("human_user".to_string());
+        policies.insert("discord".to_string(), policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let incoming = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "guild:1".into(),
+            user_id: "worker_bot".into(),
+            text: "notion event".into(),
+            message_id: Some("m1".into()),
+            is_dm: false,
+        };
+
+        assert!(gw
+            .route_message_from_sender(&incoming, IncomingSender::bot())
+            .await
+            .is_err());
+        assert_eq!(
+            gw.session_transcript_len("discord", "guild:1", "worker_bot")
+                .await,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_discord_bot_sender_still_rejected_when_bypass_disabled() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let mut policies = HashMap::new();
+        let mut policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Allowlist,
+            bot_sender_bypasses_allowlist: false,
+            ..PlatformAccessPolicy::default()
+        };
+        policy.allowed_users.insert("human_user".to_string());
+        policies.insert("discord".to_string(), policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let incoming = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "guild:1".into(),
+            user_id: "worker_bot".into(),
+            text: "notion event".into(),
+            message_id: Some("m1".into()),
+            is_dm: false,
+        };
+
+        assert!(gw
+            .route_message_from_sender(&incoming, IncomingSender::bot())
+            .await
+            .is_ok());
+        assert_eq!(
+            gw.session_transcript_len("discord", "guild:1", "worker_bot")
+                .await,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_discord_bot_bypass_does_not_apply_to_humans_or_other_platforms() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let mut policies = HashMap::new();
+        let mut discord_policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Allowlist,
+            bot_sender_bypasses_allowlist: true,
+            ..PlatformAccessPolicy::default()
+        };
+        discord_policy
+            .allowed_users
+            .insert("human_user".to_string());
+        policies.insert("discord".to_string(), discord_policy);
+        let mut telegram_policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Allowlist,
+            bot_sender_bypasses_allowlist: true,
+            ..PlatformAccessPolicy::default()
+        };
+        telegram_policy
+            .allowed_users
+            .insert("human_user".to_string());
+        policies.insert("telegram".to_string(), telegram_policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let discord_human = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "guild:1".into(),
+            user_id: "other_human".into(),
+            text: "hello".into(),
+            message_id: Some("m1".into()),
+            is_dm: false,
+        };
+        assert!(gw
+            .route_message_from_sender(&discord_human, IncomingSender::human())
+            .await
+            .is_ok());
+        assert_eq!(
+            gw.session_transcript_len("discord", "guild:1", "other_human")
+                .await,
+            0
+        );
+
+        let telegram_bot = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "-100123".into(),
+            user_id: "worker_bot".into(),
+            text: "hello".into(),
+            message_id: Some("m2".into()),
+            is_dm: false,
+        };
+        assert!(gw
+            .route_message_from_sender(&telegram_bot, IncomingSender::bot())
+            .await
+            .is_ok());
+        assert_eq!(
+            gw.session_transcript_len("telegram", "-100123", "worker_bot")
+                .await,
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn gateway_executes_status_command_without_agent_handler() {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let adapter = Arc::new(TestAdapter {
@@ -3201,6 +3412,87 @@ mod tests {
                 "add:C123:1710000000.123:white_check_mark".to_string()
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn gateway_discord_reaction_lifecycle_success_uses_discord_emojis() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let reactions = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(ReactionTestAdapter {
+            messages: sent.clone(),
+            reactions: reactions.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("discord", adapter).await;
+        gw.set_message_handler(Arc::new(|_messages| {
+            Box::pin(async { Ok("done".to_string()) })
+        }))
+        .await;
+
+        let incoming = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "C123".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: Some("123456789".into()),
+            is_dm: true,
+        };
+        assert!(gw.route_message(&incoming).await.is_ok());
+
+        let got = reactions.lock().unwrap().clone();
+        assert_eq!(
+            got,
+            vec![
+                "add:C123:123456789:👀".to_string(),
+                "remove:C123:123456789:👀".to_string(),
+                "add:C123:123456789:✅".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_discord_reactions_can_be_disabled_by_policy() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let reactions = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(ReactionTestAdapter {
+            messages: sent.clone(),
+            reactions: reactions.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("discord", adapter).await;
+        gw.set_message_handler(Arc::new(|_messages| {
+            Box::pin(async { Ok("done".to_string()) })
+        }))
+        .await;
+
+        let mut policies = HashMap::new();
+        policies.insert(
+            "discord".to_string(),
+            PlatformAccessPolicy {
+                reactions_enabled: Some(false),
+                ..PlatformAccessPolicy::default()
+            },
+        );
+        gw.set_platform_access_policies(policies).await;
+
+        let incoming = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "C123".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: Some("123456789".into()),
+            is_dm: true,
+        };
+        assert!(gw.route_message(&incoming).await.is_ok());
+        assert!(reactions.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -96,6 +96,7 @@ const DISCORD_ALLOW_MENTION_EVERYONE_ENV: &str = "DISCORD_ALLOW_MENTION_EVERYONE
 const DISCORD_ALLOW_MENTION_ROLES_ENV: &str = "DISCORD_ALLOW_MENTION_ROLES";
 const DISCORD_ALLOW_MENTION_USERS_ENV: &str = "DISCORD_ALLOW_MENTION_USERS";
 const DISCORD_ALLOW_MENTION_REPLIED_USER_ENV: &str = "DISCORD_ALLOW_MENTION_REPLIED_USER";
+const DISCORD_ALLOW_BOTS_ENV: &str = "DISCORD_ALLOW_BOTS";
 
 /// Discord REST `allowed_mentions` payload.
 ///
@@ -171,6 +172,50 @@ fn with_allowed_mentions(
 
 fn with_default_allowed_mentions(body: serde_json::Value) -> serde_json::Value {
     with_allowed_mentions(body, default_discord_allowed_mentions())
+}
+
+/// Discord bot-message acceptance policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordBotMessagePolicy {
+    /// Reject other bot/webhook senders.
+    None,
+    /// Accept bot/webhook senders only when they mention this bot.
+    Mentions,
+    /// Accept all bot/webhook senders.
+    All,
+}
+
+impl DiscordBotMessagePolicy {
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(value) if value.eq_ignore_ascii_case("all") => Self::All,
+            Some(value) if value.eq_ignore_ascii_case("mentions") => Self::Mentions,
+            _ => Self::None,
+        }
+    }
+
+    pub fn from_lookup<F>(mut lookup: F) -> Self
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        Self::parse(lookup(DISCORD_ALLOW_BOTS_ENV).as_deref())
+    }
+
+    pub fn bypasses_gateway_allowlist(self) -> bool {
+        matches!(self, Self::Mentions | Self::All)
+    }
+}
+
+fn discord_message_type_is_user_visible(message_type: u8) -> bool {
+    matches!(message_type, 0 | 19)
+}
+
+/// Parse Discord reaction lifecycle opt-in values. Default is enabled.
+pub fn discord_reactions_enabled_from_raw(raw: Option<&str>) -> bool {
+    match raw.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(value) => parse_allowed_mention_bool(value, true),
+        None => true,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -452,6 +497,21 @@ pub struct IncomingDiscordMessage {
     pub username: Option<String>,
     pub content: String,
     pub is_bot: bool,
+    pub message_type: u8,
+    pub mention_user_ids: Vec<String>,
+    pub reply_to_message_id: Option<String>,
+    pub reply_to_text: Option<String>,
+}
+
+impl IncomingDiscordMessage {
+    pub fn mentions_user(&self, user_id: &str) -> bool {
+        let needle = user_id.trim();
+        !needle.is_empty()
+            && self
+                .mention_user_ids
+                .iter()
+                .any(|mentioned| mentioned.trim() == needle)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1397,6 +1457,30 @@ impl DiscordAdapter {
             .and_then(|a| a.get("bot"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let message_type = data.get("type").and_then(|v| v.as_u64()).unwrap_or(0) as u8;
+        let mention_user_ids = data
+            .get("mentions")
+            .and_then(|v| v.as_array())
+            .map(|mentions| {
+                mentions
+                    .iter()
+                    .filter_map(|mention| mention.get("id").and_then(|id| id.as_str()))
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let reply_to_message_id = data
+            .get("message_reference")
+            .and_then(|reference| reference.get("message_id"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let reply_to_text = data
+            .get("referenced_message")
+            .and_then(|message| message.get("content"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(String::from);
 
         Some(IncomingDiscordMessage {
             channel_id,
@@ -1405,7 +1489,40 @@ impl DiscordAdapter {
             username,
             content,
             is_bot,
+            message_type,
+            mention_user_ids,
+            reply_to_message_id,
+            reply_to_text,
         })
+    }
+
+    /// Apply Discord inbound self/system/bot filtering to a parsed message.
+    pub fn should_accept_message(
+        message: &IncomingDiscordMessage,
+        client_user_id: Option<&str>,
+        bot_policy: DiscordBotMessagePolicy,
+    ) -> bool {
+        if let (Some(author_id), Some(client_id)) = (message.user_id.as_deref(), client_user_id) {
+            if author_id.trim() == client_id.trim() {
+                return false;
+            }
+        }
+
+        if !discord_message_type_is_user_visible(message.message_type) {
+            return false;
+        }
+
+        if !message.is_bot {
+            return true;
+        }
+
+        match bot_policy {
+            DiscordBotMessagePolicy::None => false,
+            DiscordBotMessagePolicy::All => true,
+            DiscordBotMessagePolicy::Mentions => client_user_id
+                .map(|id| message.mentions_user(id))
+                .unwrap_or(false),
+        }
     }
 
     /// Parse a MESSAGE_UPDATE dispatch event.
@@ -1806,6 +1923,145 @@ mod tests {
     }
 
     #[test]
+    fn bot_message_policy_defaults_to_none_and_parses_case_insensitively() {
+        assert_eq!(
+            DiscordBotMessagePolicy::parse(None),
+            DiscordBotMessagePolicy::None
+        );
+        assert_eq!(
+            DiscordBotMessagePolicy::parse(Some(" ALL ")),
+            DiscordBotMessagePolicy::All
+        );
+        assert_eq!(
+            DiscordBotMessagePolicy::parse(Some("mentions")),
+            DiscordBotMessagePolicy::Mentions
+        );
+        assert_eq!(
+            DiscordBotMessagePolicy::parse(Some("banana")),
+            DiscordBotMessagePolicy::None
+        );
+        assert_eq!(
+            DiscordBotMessagePolicy::from_lookup(|name| {
+                (name == DISCORD_ALLOW_BOTS_ENV).then(|| "Mentions".to_string())
+            }),
+            DiscordBotMessagePolicy::Mentions
+        );
+        assert!(!DiscordBotMessagePolicy::None.bypasses_gateway_allowlist());
+        assert!(DiscordBotMessagePolicy::Mentions.bypasses_gateway_allowlist());
+        assert!(DiscordBotMessagePolicy::All.bypasses_gateway_allowlist());
+    }
+
+    #[test]
+    fn bot_message_filter_matches_upstream_contract() {
+        let human = IncomingDiscordMessage {
+            channel_id: "channel".into(),
+            message_id: "message".into(),
+            user_id: Some("human".into()),
+            username: Some("Jezza".into()),
+            content: "hello".into(),
+            is_bot: false,
+            message_type: 0,
+            mention_user_ids: Vec::new(),
+            reply_to_message_id: None,
+            reply_to_text: None,
+        };
+        assert!(DiscordAdapter::should_accept_message(
+            &human,
+            Some("self"),
+            DiscordBotMessagePolicy::None
+        ));
+
+        let bot = IncomingDiscordMessage {
+            is_bot: true,
+            user_id: Some("bot".into()),
+            username: Some("Worker".into()),
+            mention_user_ids: vec!["self".into()],
+            ..human.clone()
+        };
+        assert!(!DiscordAdapter::should_accept_message(
+            &bot,
+            Some("self"),
+            DiscordBotMessagePolicy::None
+        ));
+        assert!(DiscordAdapter::should_accept_message(
+            &bot,
+            Some("self"),
+            DiscordBotMessagePolicy::All
+        ));
+        assert!(DiscordAdapter::should_accept_message(
+            &bot,
+            Some("self"),
+            DiscordBotMessagePolicy::Mentions
+        ));
+
+        let unmentioned_bot = IncomingDiscordMessage {
+            mention_user_ids: vec!["someone-else".into()],
+            ..bot.clone()
+        };
+        assert!(!DiscordAdapter::should_accept_message(
+            &unmentioned_bot,
+            Some("self"),
+            DiscordBotMessagePolicy::Mentions
+        ));
+
+        let own_message = IncomingDiscordMessage {
+            user_id: Some("self".into()),
+            is_bot: true,
+            ..bot
+        };
+        assert!(!DiscordAdapter::should_accept_message(
+            &own_message,
+            Some("self"),
+            DiscordBotMessagePolicy::All
+        ));
+    }
+
+    #[test]
+    fn system_message_filter_only_accepts_default_and_reply() {
+        let mut msg = IncomingDiscordMessage {
+            channel_id: "channel".into(),
+            message_id: "message".into(),
+            user_id: Some("human".into()),
+            username: Some("Jezza".into()),
+            content: "hello".into(),
+            is_bot: false,
+            message_type: 0,
+            mention_user_ids: Vec::new(),
+            reply_to_message_id: None,
+            reply_to_text: None,
+        };
+        assert!(DiscordAdapter::should_accept_message(
+            &msg,
+            Some("self"),
+            DiscordBotMessagePolicy::None
+        ));
+        msg.message_type = 19;
+        assert!(DiscordAdapter::should_accept_message(
+            &msg,
+            Some("self"),
+            DiscordBotMessagePolicy::None
+        ));
+        for system_type in [1, 6, 7, 8] {
+            msg.message_type = system_type;
+            assert!(!DiscordAdapter::should_accept_message(
+                &msg,
+                Some("self"),
+                DiscordBotMessagePolicy::None
+            ));
+        }
+    }
+
+    #[test]
+    fn discord_reactions_default_enabled_and_false_values_disable() {
+        assert!(discord_reactions_enabled_from_raw(None));
+        assert!(discord_reactions_enabled_from_raw(Some("")));
+        assert!(discord_reactions_enabled_from_raw(Some("yes")));
+        assert!(!discord_reactions_enabled_from_raw(Some("false")));
+        assert!(!discord_reactions_enabled_from_raw(Some("0")));
+        assert!(!discord_reactions_enabled_from_raw(Some("off")));
+    }
+
+    #[test]
     fn media_methods_accept_metadata_contract() {
         let adapter = DiscordAdapter::new(test_config()).unwrap();
         let metadata = DiscordSendMetadata::with_thread_id("thread-1");
@@ -1871,6 +2127,12 @@ mod tests {
             "id": "msg123",
             "channel_id": "ch456",
             "content": "hello world",
+            "type": 19,
+            "mentions": [
+                { "id": "bot-self", "username": "Hermes" }
+            ],
+            "message_reference": { "message_id": "origin-1" },
+            "referenced_message": { "content": "original message" },
             "author": {
                 "id": "user789",
                 "username": "testuser",
@@ -1885,6 +2147,10 @@ mod tests {
         assert_eq!(msg.user_id, Some("user789".into()));
         assert_eq!(msg.username, Some("testuser".into()));
         assert!(!msg.is_bot);
+        assert_eq!(msg.message_type, 19);
+        assert!(msg.mentions_user("bot-self"));
+        assert_eq!(msg.reply_to_message_id.as_deref(), Some("origin-1"));
+        assert_eq!(msg.reply_to_text.as_deref(), Some("original message"));
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T06:55:41.562711+00:00",
+  "generated_at_utc": "2026-05-30T07:23:10.371313+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "7b392964bd952377e68354b249ca65d272faf4ea",
+    "local_sha": "0c3524743a54891078f6330e2835675488cdb902",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 843,
+    "commits_ahead": 845,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 705,
+    "local_patch_unique": 706,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 387440
+    "tree_deletions": 387573
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 705,
+    "local_patch_unique": 706,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T06:55:41.562711+00:00`
+Generated: `2026-05-30T07:23:10.371313+00:00`
 
 ## Scope
 
-- Local ref: `main` (`7b392964bd952377e68354b249ca65d272faf4ea`)
+- Local ref: `main` (`0c3524743a54891078f6330e2835675488cdb902`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T06:55:41.562711+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 843 |
+| Commits ahead local (`local` ancestry only) | 845 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 705 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 706 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 387440 |
+| Deletions (`local` vs `upstream`) | 387573 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T06:55:41.562711+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `705`
+- Local unique by patch-id: `706`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3691,31 +3691,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_bot_auth_bypass.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8ff39a1bf4990d8be356bbd970a6c256118b3244",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_bot_auth_bypass.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8e10dfbcb94fd8d1e34106f8f4024b17c72e4267",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_bot_filter.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "09a78ae6308f4c8c8701b1efa19c282b0b3519bf",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_bot_filter.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "90dc9f8de00b6979f367de7c270cbe86a7e85775",
       "workstream": "WS6"
@@ -3826,16 +3826,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_imports.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "bbda79c9ece2bb3db29ef08505f3dde930867cc5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_imports.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7246b4f09a4f421082319e77a33e1bce8094134b",
       "workstream": "WS6"
@@ -3901,16 +3901,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_reactions.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2d7b2a2c934347fb51611cd4082e336ff73868af",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_reactions.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e968b750ea3b3fac2c835860bf45dcc6be994570",
       "workstream": "WS6"
@@ -3991,16 +3991,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_system_messages.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8e2fb27e78834a672daa87d3cab2003ee64d7228",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_system_messages.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e58f2812745a96e53374fd2479f1de17f93714a2",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T06:55:48.379811+00:00",
+  "generated_at_utc": "2026-05-30T07:23:08.531065+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "7b392964bd952377e68354b249ca65d272faf4ea",
+    "local_sha": "0c3524743a54891078f6330e2835675488cdb902",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 737,
-      "intentional_divergence": 112,
+      "functional": 732,
+      "intentional_divergence": 117,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 281,
-      "rust_equivalent_or_contract_test_required": 658,
+      "not_required_for_runtime": 286,
+      "rust_equivalent_or_contract_test_required": 653,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 112,
+      "cleared_intentional_divergence": 117,
       "cleared_non_runtime": 169,
-      "pending_review": 737
+      "pending_review": 732
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 112,
+    "cleared_intentional_divergence": 117,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 737,
+    "pending_review": 732,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T06:55:48.379811+00:00`
+Generated: `2026-05-30T07:23:08.531065+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `737`
+- Pending functional review: `732`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `112`
+- Cleared intentional divergence: `117`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 112 |
+| `cleared_intentional_divergence` | 117 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 737 |
+| `pending_review` | 732 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T06:55:48.379811+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 169 |
+| `tests/gateway` | 164 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -157,9 +157,44 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_bot_auth_bypass.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord bot-allowance auth bypass intent is covered by Rust Gateway route_message_from_sender tests for Discord bot senders, human allowlists, and non-Discord isolation, with DISCORD_ALLOW_BOTS env bridging into platform policy.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_bot_filter.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream DISCORD_ALLOW_BOTS filtering semantics are covered by Rust DiscordBotMessagePolicy parsing and DiscordAdapter::should_accept_message tests for own messages, humans, all bots, mentioned bots, and default rejection.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_imports.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream discord.py-missing import safety is covered by the Rust-only hermes-gateway Discord module compiling and testing behind the discord feature without any discord.py runtime dependency.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_media_metadata.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord media metadata signature intent is covered by Rust hermes-gateway DiscordSendMetadata routing tests plus metadata-aware send_voice, send_image_file, and send_image method contracts; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_reactions.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord processing-reaction lifecycle is covered by Rust Gateway Discord reaction lifecycle tests, platform-specific Discord emoji mapping, reactions_enabled policy tests, and Discord REST reaction parser/adapter contracts.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_system_messages.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord system-message filtering is covered by Rust DiscordAdapter::should_accept_message tests accepting default/reply message types and rejecting thread rename, pin, join, and boost-style system message types.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- port Discord bot-message policy parsing/filtering, mention capture, system-message filtering, and reply-reference extraction into Rust
- add Discord bot sender allowlist bypass and Discord reaction lifecycle support in the Rust gateway
- bridge Discord env knobs into Rust config and clear five upstream Discord parity test intents

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max-shared-different|max shared different" .; test 0 -eq 1
- cargo test -p hermes-gateway --features discord
- cargo test -p hermes-config
- cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md