### PR TITLE
parity(discord): port channel policy contracts

### DIFF
--- a/crates/hermes-cli/src/config_env.rs
+++ b/crates/hermes-cli/src/config_env.rs
@@ -209,12 +209,18 @@ mod tests {
             "DISCORD_ALLOWED_USERS",
             "HERMES_PLATFORM_DISCORD_ALLOWED_USERS",
             "DISCORD_CUSTOM_FLAG",
+            "DISCORD_IGNORED_CHANNELS",
+            "DISCORD_NO_THREAD_CHANNELS",
+            "DISCORD_AUTO_THREAD",
         ]);
         std::env::remove_var("HERMES_MODEL");
         std::env::remove_var("HERMES_MAX_TURNS");
         std::env::remove_var("DISCORD_ALLOWED_USERS");
         std::env::remove_var("HERMES_PLATFORM_DISCORD_ALLOWED_USERS");
         std::env::remove_var("DISCORD_CUSTOM_FLAG");
+        std::env::remove_var("DISCORD_IGNORED_CHANNELS");
+        std::env::remove_var("DISCORD_NO_THREAD_CHANNELS");
+        std::env::remove_var("DISCORD_AUTO_THREAD");
 
         let mut cfg = GatewayConfig {
             model: Some("openai:gpt-4o".to_string()),
@@ -230,6 +236,20 @@ mod tests {
             "custom-flag".to_string(),
             Value::String("enabled".to_string()),
         );
+        discord.extra.insert(
+            "ignored_channels".to_string(),
+            Value::Array(vec![
+                Value::String("111".to_string()),
+                Value::Number(222.into()),
+            ]),
+        );
+        discord.extra.insert(
+            "no_thread_channels".to_string(),
+            Value::Array(vec![Value::String("333".to_string())]),
+        );
+        discord
+            .extra
+            .insert("auto_thread".to_string(), Value::Bool(false));
         cfg.platforms.insert("discord".to_string(), discord);
 
         let applied = hydrate_env_from_config(&cfg);
@@ -251,23 +271,44 @@ mod tests {
             std::env::var("DISCORD_CUSTOM_FLAG").unwrap(),
             "enabled".to_string()
         );
+        assert_eq!(
+            std::env::var("DISCORD_IGNORED_CHANNELS").unwrap(),
+            "111,222".to_string()
+        );
+        assert_eq!(
+            std::env::var("DISCORD_NO_THREAD_CHANNELS").unwrap(),
+            "333".to_string()
+        );
+        assert_eq!(
+            std::env::var("DISCORD_AUTO_THREAD").unwrap(),
+            "false".to_string()
+        );
     }
 
     #[test]
     fn hydrate_env_never_overwrites_existing_values() {
         let _lock = ENV_TEST_LOCK.lock().expect("env test lock");
-        let _guard = EnvGuard::capture(&["HERMES_MODEL", "DISCORD_ALLOWED_USERS"]);
+        let _guard = EnvGuard::capture(&[
+            "HERMES_MODEL",
+            "DISCORD_ALLOWED_USERS",
+            "DISCORD_IGNORED_CHANNELS",
+        ]);
         std::env::set_var("HERMES_MODEL", "existing:model");
         std::env::set_var("DISCORD_ALLOWED_USERS", "from-env");
+        std::env::set_var("DISCORD_IGNORED_CHANNELS", "999");
 
         let mut cfg = GatewayConfig {
             model: Some("openai:gpt-4o".to_string()),
             ..GatewayConfig::default()
         };
-        let discord = PlatformConfig {
+        let mut discord = PlatformConfig {
             allowed_users: vec!["123".into()],
             ..PlatformConfig::default()
         };
+        discord.extra.insert(
+            "ignored_channels".to_string(),
+            Value::Array(vec![Value::String("111".to_string())]),
+        );
         let mut platforms = HashMap::new();
         platforms.insert("discord".to_string(), discord);
         cfg.platforms = platforms;
@@ -276,5 +317,6 @@ mod tests {
 
         assert_eq!(std::env::var("HERMES_MODEL").unwrap(), "existing:model");
         assert_eq!(std::env::var("DISCORD_ALLOWED_USERS").unwrap(), "from-env");
+        assert_eq!(std::env::var("DISCORD_IGNORED_CHANNELS").unwrap(), "999");
     }
 }

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -67,7 +67,9 @@ use hermes_gateway::hooks::HookRegistry;
 use hermes_gateway::platforms::api_server::{ApiInboundRequest, ApiServerAdapter, ApiServerConfig};
 use hermes_gateway::platforms::bluebubbles::{BlueBubblesAdapter, BlueBubblesConfig};
 use hermes_gateway::platforms::dingtalk::{DingTalkAdapter, DingTalkConfig};
-use hermes_gateway::platforms::discord::{DiscordAdapter, DiscordConfig};
+use hermes_gateway::platforms::discord::{
+    DiscordAdapter, DiscordChannelControls, DiscordChannelSkillBinding, DiscordConfig,
+};
 use hermes_gateway::platforms::email::{EmailAdapter, EmailConfig};
 use hermes_gateway::platforms::feishu::{FeishuAdapter, FeishuConfig};
 use hermes_gateway::platforms::homeassistant::{HomeAssistantAdapter, HomeAssistantConfig};
@@ -4438,6 +4440,10 @@ async fn register_gateway_adapters(
                         .get("intents")
                         .and_then(|v| v.as_u64())
                         .unwrap_or((1 << 0) | (1 << 9) | (1 << 15)),
+                    channel_controls: DiscordChannelControls::from_extra(&platform_cfg.extra),
+                    channel_skill_bindings: DiscordChannelSkillBinding::list_from_json(
+                        platform_cfg.extra.get("channel_skill_bindings"),
+                    ),
                 };
                 match DiscordAdapter::new(discord_cfg) {
                     Ok(adapter) => gateway.register_adapter("discord", Arc::new(adapter)).await,

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -22,6 +22,10 @@ fn comma_list_to_strings(raw: &str) -> Vec<String> {
         .collect()
 }
 
+fn env_bool(raw: &str) -> bool {
+    matches!(raw.to_lowercase().as_str(), "1" | "true" | "yes" | "on")
+}
+
 fn set_extra(pc: &mut PlatformConfig, key: &str, val: Value) {
     pc.extra.insert(key.to_string(), val);
 }
@@ -155,17 +159,40 @@ fn apply_discord_env(config: &mut GatewayConfig) {
         set_extra(discord, "allow_bots", json!(v));
     }
     if let Some(v) = env_nonempty("DISCORD_REACTIONS") {
-        set_extra(
-            discord,
-            "reactions",
-            json!(matches!(
-                v.to_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )),
-        );
+        set_extra(discord, "reactions", json!(env_bool(&v)));
     }
     if let Some(v) = env_nonempty("DISCORD_REPLY_TO_MODE") {
         set_extra(discord, "reply_to_mode", json!(v));
+    }
+    if let Some(v) = env_nonempty("DISCORD_REQUIRE_MENTION") {
+        discord.require_mention = Some(env_bool(&v));
+    }
+    if let Some(v) = env_nonempty("DISCORD_IGNORED_CHANNELS") {
+        set_extra(
+            discord,
+            "ignored_channels",
+            json!(comma_list_to_strings(&v)),
+        );
+    }
+    if let Some(v) = env_nonempty("DISCORD_NO_THREAD_CHANNELS") {
+        set_extra(
+            discord,
+            "no_thread_channels",
+            json!(comma_list_to_strings(&v)),
+        );
+    }
+    if let Some(v) = env_nonempty("DISCORD_FREE_RESPONSE_CHANNELS") {
+        set_extra(
+            discord,
+            "free_response_channels",
+            json!(comma_list_to_strings(&v)),
+        );
+    }
+    if let Some(v) = env_nonempty("DISCORD_AUTO_THREAD") {
+        set_extra(discord, "auto_thread", json!(env_bool(&v)));
+    }
+    if let Some(v) = env_nonempty("DISCORD_THREAD_REQUIRE_MENTION") {
+        set_extra(discord, "thread_require_mention", json!(env_bool(&v)));
     }
 }
 
@@ -225,12 +252,19 @@ mod tests {
             std::env::set_var("DISCORD_ALLOW_BOTS", "mentions");
             std::env::set_var("DISCORD_REACTIONS", "false");
             std::env::set_var("DISCORD_REPLY_TO_MODE", "all");
+            std::env::set_var("DISCORD_REQUIRE_MENTION", "true");
+            std::env::set_var("DISCORD_IGNORED_CHANNELS", "111, 222");
+            std::env::set_var("DISCORD_NO_THREAD_CHANNELS", "333");
+            std::env::set_var("DISCORD_FREE_RESPONSE_CHANNELS", "444,555");
+            std::env::set_var("DISCORD_AUTO_THREAD", "false");
+            std::env::set_var("DISCORD_THREAD_REQUIRE_MENTION", "yes");
         }
         let mut cfg = GatewayConfig::default();
         apply_python_named_platform_env(&mut cfg);
         let discord = cfg.platforms.get("discord").expect("discord block");
         assert!(discord.enabled);
         assert_eq!(discord.token.as_deref(), Some("discord-token"));
+        assert_eq!(discord.require_mention, Some(true));
         assert_eq!(
             discord.extra.get("application_id").and_then(|v| v.as_str()),
             Some("app-123")
@@ -247,12 +281,53 @@ mod tests {
             discord.extra.get("reply_to_mode").and_then(|v| v.as_str()),
             Some("all")
         );
+        assert_eq!(
+            discord
+                .extra
+                .get("ignored_channels")
+                .and_then(|v| v.as_array())
+                .map(|items| { items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>() }),
+            Some(vec!["111", "222"])
+        );
+        assert_eq!(
+            discord
+                .extra
+                .get("no_thread_channels")
+                .and_then(|v| v.as_array())
+                .map(|items| { items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>() }),
+            Some(vec!["333"])
+        );
+        assert_eq!(
+            discord
+                .extra
+                .get("free_response_channels")
+                .and_then(|v| v.as_array())
+                .map(|items| { items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>() }),
+            Some(vec!["444", "555"])
+        );
+        assert_eq!(
+            discord.extra.get("auto_thread").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            discord
+                .extra
+                .get("thread_require_mention")
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
         unsafe {
             std::env::remove_var("DISCORD_BOT_TOKEN");
             std::env::remove_var("DISCORD_APPLICATION_ID");
             std::env::remove_var("DISCORD_ALLOW_BOTS");
             std::env::remove_var("DISCORD_REACTIONS");
             std::env::remove_var("DISCORD_REPLY_TO_MODE");
+            std::env::remove_var("DISCORD_REQUIRE_MENTION");
+            std::env::remove_var("DISCORD_IGNORED_CHANNELS");
+            std::env::remove_var("DISCORD_NO_THREAD_CHANNELS");
+            std::env::remove_var("DISCORD_FREE_RESPONSE_CHANNELS");
+            std::env::remove_var("DISCORD_AUTO_THREAD");
+            std::env::remove_var("DISCORD_THREAD_REQUIRE_MENTION");
         }
     }
 

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -8,7 +8,9 @@
 //! MESSAGE_CREATE, MESSAGE_UPDATE, INTERACTION_CREATE, VOICE_STATE_UPDATE,
 //! MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE).
 
-use std::sync::Arc;
+use std::collections::{BTreeSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use reqwest::Client;
@@ -52,6 +54,14 @@ pub struct DiscordConfig {
     /// Gateway intents bitmask (default: GUILDS | GUILD_MESSAGES | MESSAGE_CONTENT).
     #[serde(default = "default_intents")]
     pub intents: u64,
+
+    /// Channel-level inbound and auto-thread policy.
+    #[serde(default)]
+    pub channel_controls: DiscordChannelControls,
+
+    /// Channel-bound skills injected for Discord sessions.
+    #[serde(default)]
+    pub channel_skill_bindings: Vec<DiscordChannelSkillBinding>,
 }
 
 fn default_intents() -> u64 {
@@ -217,6 +227,374 @@ pub fn discord_reactions_enabled_from_raw(raw: Option<&str>) -> bool {
         None => true,
     }
 }
+
+// ---------------------------------------------------------------------------
+// Discord channel policy
+// ---------------------------------------------------------------------------
+
+fn scalar_json_to_discord_id(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => {
+            let trimmed = s.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+fn discord_id_set_from_csv(raw: &str) -> BTreeSet<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn discord_id_set_from_json(value: Option<&serde_json::Value>) -> BTreeSet<String> {
+    let Some(value) = value else {
+        return BTreeSet::new();
+    };
+    match value {
+        serde_json::Value::String(raw) => discord_id_set_from_csv(raw),
+        serde_json::Value::Array(values) => values
+            .iter()
+            .filter_map(scalar_json_to_discord_id)
+            .collect::<BTreeSet<_>>(),
+        other => scalar_json_to_discord_id(other).into_iter().collect(),
+    }
+}
+
+fn bool_from_json(value: Option<&serde_json::Value>, default: bool) -> bool {
+    match value {
+        Some(serde_json::Value::Bool(v)) => *v,
+        Some(serde_json::Value::Number(n)) => n.as_i64().map(|v| v != 0).unwrap_or(default),
+        Some(serde_json::Value::String(raw)) => parse_allowed_mention_bool(raw, default),
+        _ => default,
+    }
+}
+
+fn channel_matches(
+    ids: &BTreeSet<String>,
+    channel_id: &str,
+    parent_channel_id: Option<&str>,
+) -> bool {
+    let channel_id = channel_id.trim();
+    let parent_channel_id = parent_channel_id.map(str::trim).filter(|s| !s.is_empty());
+    (!channel_id.is_empty() && ids.contains(channel_id))
+        || parent_channel_id
+            .map(|parent| ids.contains(parent))
+            .unwrap_or(false)
+}
+
+/// Discord channel-level policy controls.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscordChannelControls {
+    /// Server channel IDs whose messages are always dropped.
+    #[serde(default)]
+    pub ignored_channels: BTreeSet<String>,
+    /// Server channel IDs where automatic thread creation is suppressed.
+    #[serde(default)]
+    pub no_thread_channels: BTreeSet<String>,
+    /// Server channel IDs where mention-free responses are allowed.
+    #[serde(default)]
+    pub free_response_channels: BTreeSet<String>,
+    /// Global auto-thread toggle. Defaults to true to match upstream behavior.
+    #[serde(default = "default_true_channel_control")]
+    pub auto_thread: bool,
+    /// Require explicit mentions even in participated/free-response threads.
+    #[serde(default)]
+    pub thread_require_mention: bool,
+}
+
+fn default_true_channel_control() -> bool {
+    true
+}
+
+impl Default for DiscordChannelControls {
+    fn default() -> Self {
+        Self {
+            ignored_channels: BTreeSet::new(),
+            no_thread_channels: BTreeSet::new(),
+            free_response_channels: BTreeSet::new(),
+            auto_thread: true,
+            thread_require_mention: false,
+        }
+    }
+}
+
+impl DiscordChannelControls {
+    pub fn from_extra(extra: &std::collections::HashMap<String, serde_json::Value>) -> Self {
+        Self {
+            ignored_channels: discord_id_set_from_json(extra.get("ignored_channels")),
+            no_thread_channels: discord_id_set_from_json(extra.get("no_thread_channels")),
+            free_response_channels: discord_id_set_from_json(extra.get("free_response_channels")),
+            auto_thread: bool_from_json(extra.get("auto_thread"), true),
+            thread_require_mention: bool_from_json(extra.get("thread_require_mention"), false),
+        }
+    }
+
+    pub fn is_ignored(&self, context: &DiscordChannelContext) -> bool {
+        if context.is_dm {
+            return false;
+        }
+        channel_matches(
+            &self.ignored_channels,
+            &context.channel_id,
+            context.parent_channel_id.as_deref(),
+        )
+    }
+
+    pub fn allows_free_response(&self, context: &DiscordChannelContext) -> bool {
+        if context.is_dm {
+            return true;
+        }
+        context.voice_linked_text_channel
+            || channel_matches(
+                &self.free_response_channels,
+                &context.channel_id,
+                context.parent_channel_id.as_deref(),
+            )
+    }
+
+    pub fn should_auto_thread(&self, context: &DiscordChannelContext) -> bool {
+        if !self.auto_thread
+            || context.is_dm
+            || context.is_thread
+            || context.is_reply
+            || context.voice_linked_text_channel
+            || self.allows_free_response(context)
+        {
+            return false;
+        }
+
+        !channel_matches(
+            &self.no_thread_channels,
+            &context.channel_id,
+            context.parent_channel_id.as_deref(),
+        )
+    }
+}
+
+/// Discord channel context used by pure Rust policy checks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscordChannelContext {
+    pub channel_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_channel_id: Option<String>,
+    #[serde(default)]
+    pub is_dm: bool,
+    #[serde(default)]
+    pub is_thread: bool,
+    #[serde(default)]
+    pub is_reply: bool,
+    #[serde(default)]
+    pub voice_linked_text_channel: bool,
+}
+
+impl DiscordChannelContext {
+    pub fn server(channel_id: impl Into<String>) -> Self {
+        Self {
+            channel_id: channel_id.into(),
+            parent_channel_id: None,
+            is_dm: false,
+            is_thread: false,
+            is_reply: false,
+            voice_linked_text_channel: false,
+        }
+    }
+
+    pub fn thread(channel_id: impl Into<String>, parent_channel_id: impl Into<String>) -> Self {
+        Self {
+            channel_id: channel_id.into(),
+            parent_channel_id: Some(parent_channel_id.into()),
+            is_dm: false,
+            is_thread: true,
+            is_reply: false,
+            voice_linked_text_channel: false,
+        }
+    }
+
+    pub fn dm(channel_id: impl Into<String>) -> Self {
+        Self {
+            channel_id: channel_id.into(),
+            parent_channel_id: None,
+            is_dm: true,
+            is_thread: false,
+            is_reply: false,
+            voice_linked_text_channel: false,
+        }
+    }
+}
+
+/// Channel-bound skill binding parsed from Python-style Discord config.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscordChannelSkillBinding {
+    pub id: String,
+    pub skills: Vec<String>,
+}
+
+impl DiscordChannelSkillBinding {
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        let obj = value.as_object()?;
+        let id = obj.get("id").and_then(scalar_json_to_discord_id)?;
+        let skills_value = obj.get("skills").or_else(|| obj.get("skill"))?;
+        let mut skills = Vec::new();
+        match skills_value {
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    if let Some(skill) = scalar_json_to_discord_id(value) {
+                        if !skills.contains(&skill) {
+                            skills.push(skill);
+                        }
+                    }
+                }
+            }
+            value => {
+                if let Some(skill) = scalar_json_to_discord_id(value) {
+                    skills.push(skill);
+                }
+            }
+        }
+        (!skills.is_empty()).then_some(Self { id, skills })
+    }
+
+    pub fn list_from_json(value: Option<&serde_json::Value>) -> Vec<Self> {
+        match value {
+            Some(serde_json::Value::Array(values)) => {
+                values.iter().filter_map(Self::from_json).collect()
+            }
+            Some(value) => Self::from_json(value).into_iter().collect(),
+            None => Vec::new(),
+        }
+    }
+}
+
+fn resolve_channel_skills_from_bindings(
+    bindings: &[DiscordChannelSkillBinding],
+    channel_id: &str,
+    parent_id: Option<&str>,
+) -> Option<Vec<String>> {
+    let channel_id = channel_id.trim();
+    let parent_id = parent_id.map(str::trim).filter(|id| !id.is_empty());
+
+    bindings
+        .iter()
+        .find(|binding| binding.id.trim() == channel_id)
+        .or_else(|| {
+            parent_id.and_then(|parent| bindings.iter().find(|binding| binding.id.trim() == parent))
+        })
+        .map(|binding| binding.skills.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Discord thread participation persistence
+// ---------------------------------------------------------------------------
+
+/// Persistent ordered set of Discord threads the bot has participated in.
+#[derive(Debug, Clone)]
+pub struct DiscordThreadParticipationTracker {
+    path: PathBuf,
+    threads: VecDeque<String>,
+    max_tracked: usize,
+}
+
+impl DiscordThreadParticipationTracker {
+    pub const DEFAULT_MAX_TRACKED: usize = 2048;
+
+    pub fn new(platform: &str) -> Self {
+        let filename = format!("{}_threads.json", platform.trim());
+        Self::from_path(
+            hermes_config::hermes_home().join(filename),
+            Self::DEFAULT_MAX_TRACKED,
+        )
+    }
+
+    pub fn from_path(path: impl Into<PathBuf>, max_tracked: usize) -> Self {
+        let path = path.into();
+        let mut tracker = Self {
+            path,
+            threads: VecDeque::new(),
+            max_tracked: max_tracked.max(1),
+        };
+        tracker.load();
+        tracker
+    }
+
+    pub fn set_max_tracked(&mut self, max_tracked: usize) {
+        self.max_tracked = max_tracked.max(1);
+        self.enforce_capacity();
+    }
+
+    pub fn contains(&self, thread_id: &str) -> bool {
+        let thread_id = thread_id.trim();
+        !thread_id.is_empty() && self.threads.iter().any(|existing| existing == thread_id)
+    }
+
+    pub fn mark(&mut self, thread_id: impl Into<String>) -> std::io::Result<bool> {
+        let thread_id = thread_id.into();
+        let thread_id = thread_id.trim();
+        if thread_id.is_empty() || self.contains(thread_id) {
+            return Ok(false);
+        }
+
+        self.threads.push_back(thread_id.to_string());
+        self.enforce_capacity();
+        self.save()?;
+        Ok(true)
+    }
+
+    pub fn len(&self) -> usize {
+        self.threads.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.threads.is_empty()
+    }
+
+    pub fn entries(&self) -> Vec<String> {
+        self.threads.iter().cloned().collect()
+    }
+
+    fn load(&mut self) {
+        let Ok(raw) = std::fs::read_to_string(&self.path) else {
+            return;
+        };
+        let Ok(values) = serde_json::from_str::<Vec<String>>(&raw) else {
+            return;
+        };
+
+        let mut seen = BTreeSet::new();
+        for value in values {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
+                self.threads.push_back(trimmed.to_string());
+            }
+        }
+        self.enforce_capacity();
+    }
+
+    fn enforce_capacity(&mut self) {
+        while self.threads.len() > self.max_tracked {
+            self.threads.pop_front();
+        }
+    }
+
+    fn save(&self) -> std::io::Result<()> {
+        if let Some(parent) = self.path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)?;
+        }
+        let values: Vec<&str> = self.threads.iter().map(String::as_str).collect();
+        let body = serde_json::to_string(&values).expect("thread id list serializes");
+        std::fs::write(&self.path, body)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+pub type ThreadParticipationTracker = DiscordThreadParticipationTracker;
 
 // ---------------------------------------------------------------------------
 // Discord Gateway opcodes & payload
@@ -779,6 +1157,7 @@ pub struct DiscordAdapter {
     config: DiscordConfig,
     client: Client,
     stop_signal: Arc<Notify>,
+    thread_participation: Mutex<DiscordThreadParticipationTracker>,
 }
 
 impl DiscordAdapter {
@@ -795,12 +1174,51 @@ impl DiscordAdapter {
             config,
             client,
             stop_signal: Arc::new(Notify::new()),
+            thread_participation: Mutex::new(DiscordThreadParticipationTracker::new("discord")),
         })
     }
 
     /// Get a reference to the configuration.
     pub fn config(&self) -> &DiscordConfig {
         &self.config
+    }
+
+    pub fn channel_controls(&self) -> &DiscordChannelControls {
+        &self.config.channel_controls
+    }
+
+    pub fn should_ignore_channel(&self, context: &DiscordChannelContext) -> bool {
+        self.config.channel_controls.is_ignored(context)
+    }
+
+    pub fn should_auto_thread(&self, context: &DiscordChannelContext) -> bool {
+        self.config.channel_controls.should_auto_thread(context)
+    }
+
+    pub fn resolve_channel_skills(
+        &self,
+        channel_id: &str,
+        parent_id: Option<&str>,
+    ) -> Option<Vec<String>> {
+        resolve_channel_skills_from_bindings(
+            &self.config.channel_skill_bindings,
+            channel_id,
+            parent_id,
+        )
+    }
+
+    pub fn thread_participation_contains(&self, thread_id: &str) -> bool {
+        self.thread_participation
+            .lock()
+            .map(|tracker| tracker.contains(thread_id))
+            .unwrap_or(false)
+    }
+
+    pub fn mark_thread_participation(&self, thread_id: &str) -> std::io::Result<bool> {
+        self.thread_participation
+            .lock()
+            .map_err(|_| std::io::Error::other("discord thread tracker lock poisoned"))?
+            .mark(thread_id)
     }
 
     /// Return the authorization header value.
@@ -1865,6 +2283,8 @@ mod tests {
             proxy: AdapterProxyConfig::default(),
             require_mention: false,
             intents: default_intents(),
+            channel_controls: DiscordChannelControls::default(),
+            channel_skill_bindings: Vec::new(),
         }
     }
 
@@ -2059,6 +2479,158 @@ mod tests {
         assert!(!discord_reactions_enabled_from_raw(Some("false")));
         assert!(!discord_reactions_enabled_from_raw(Some("0")));
         assert!(!discord_reactions_enabled_from_raw(Some("off")));
+    }
+
+    #[test]
+    fn discord_channel_controls_parse_csv_and_yaml_shapes() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "ignored_channels".into(),
+            serde_json::json!("500, 600 ,700"),
+        );
+        extra.insert("no_thread_channels".into(), serde_json::json!(["800", 900]));
+        extra.insert("free_response_channels".into(), serde_json::json!(1000));
+        extra.insert("auto_thread".into(), serde_json::json!("false"));
+        extra.insert("thread_require_mention".into(), serde_json::json!("yes"));
+
+        let controls = DiscordChannelControls::from_extra(&extra);
+        assert_eq!(
+            controls.ignored_channels,
+            ["500", "600", "700"]
+                .into_iter()
+                .map(String::from)
+                .collect()
+        );
+        assert_eq!(
+            controls.no_thread_channels,
+            ["800", "900"].into_iter().map(String::from).collect()
+        );
+        assert_eq!(
+            controls.free_response_channels,
+            ["1000"].into_iter().map(String::from).collect()
+        );
+        assert!(!controls.auto_thread);
+        assert!(controls.thread_require_mention);
+    }
+
+    #[test]
+    fn discord_channel_controls_ignore_server_channels_and_thread_parents() {
+        let controls = DiscordChannelControls {
+            ignored_channels: ["500"].into_iter().map(String::from).collect(),
+            ..DiscordChannelControls::default()
+        };
+
+        assert!(controls.is_ignored(&DiscordChannelContext::server("500")));
+        assert!(controls.is_ignored(&DiscordChannelContext::thread("501", "500")));
+        assert!(!controls.is_ignored(&DiscordChannelContext::server("700")));
+        assert!(!controls.is_ignored(&DiscordChannelContext::dm("500")));
+    }
+
+    #[test]
+    fn discord_channel_controls_auto_thread_policy_matches_upstream_cases() {
+        let controls = DiscordChannelControls {
+            no_thread_channels: ["800"].into_iter().map(String::from).collect(),
+            free_response_channels: ["900"].into_iter().map(String::from).collect(),
+            ..DiscordChannelControls::default()
+        };
+
+        assert!(!controls.should_auto_thread(&DiscordChannelContext::server("800")));
+        assert!(!controls.should_auto_thread(&DiscordChannelContext::thread("801", "800")));
+        assert!(!controls.should_auto_thread(&DiscordChannelContext::server("900")));
+        assert!(!controls.should_auto_thread(&DiscordChannelContext::dm("700")));
+        let mut reply = DiscordChannelContext::server("700");
+        reply.is_reply = true;
+        assert!(!controls.should_auto_thread(&reply));
+        assert!(controls.should_auto_thread(&DiscordChannelContext::server("700")));
+
+        let disabled = DiscordChannelControls {
+            auto_thread: false,
+            no_thread_channels: ["800"].into_iter().map(String::from).collect(),
+            ..DiscordChannelControls::default()
+        };
+        assert!(!disabled.should_auto_thread(&DiscordChannelContext::server("700")));
+        assert!(!disabled.should_auto_thread(&DiscordChannelContext::server("800")));
+    }
+
+    #[test]
+    fn discord_channel_skill_bindings_resolve_exact_parent_and_deduped_skills() {
+        let bindings = DiscordChannelSkillBinding::list_from_json(Some(&serde_json::json!([
+            {"id": "100", "skills": ["a", "b", "a", "c", "b"]},
+            {"id": "200", "skill": "forum-skill"},
+            {"id": 300, "skills": "solo"},
+        ])));
+
+        assert_eq!(
+            resolve_channel_skills_from_bindings(&bindings, "100", None),
+            Some(vec!["a".into(), "b".into(), "c".into()])
+        );
+        assert_eq!(
+            resolve_channel_skills_from_bindings(&bindings, "999", Some("200")),
+            Some(vec!["forum-skill".into()])
+        );
+        assert_eq!(
+            resolve_channel_skills_from_bindings(&bindings, "300", None),
+            Some(vec!["solo".into()])
+        );
+        assert_eq!(
+            resolve_channel_skills_from_bindings(&bindings, "999", None),
+            None
+        );
+    }
+
+    #[test]
+    fn discord_adapter_resolves_configured_channel_skills() {
+        let mut cfg = test_config();
+        cfg.channel_skill_bindings = DiscordChannelSkillBinding::list_from_json(Some(
+            &serde_json::json!([{"id": "100", "skills": ["skill-a", "skill-b"]}]),
+        ));
+        let adapter = DiscordAdapter::new(cfg).unwrap();
+        assert_eq!(
+            adapter.resolve_channel_skills("100", None),
+            Some(vec!["skill-a".into(), "skill-b".into()])
+        );
+        assert_eq!(adapter.resolve_channel_skills("101", None), None);
+    }
+
+    #[test]
+    fn discord_thread_participation_tracker_persists_and_keeps_newest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("discord_threads.json");
+        let mut tracker = DiscordThreadParticipationTracker::from_path(&path, 5);
+
+        assert!(tracker.is_empty());
+        assert!(tracker.mark("0").unwrap());
+        assert!(!tracker.mark("0").unwrap());
+        for id in ["1", "2", "3", "4", "newest"] {
+            assert!(tracker.mark(id).unwrap());
+        }
+
+        assert_eq!(tracker.entries(), vec!["1", "2", "3", "4", "newest"]);
+        let saved: Vec<String> =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(saved, vec!["1", "2", "3", "4", "newest"]);
+
+        let reloaded = DiscordThreadParticipationTracker::from_path(&path, 5);
+        assert!(reloaded.contains("newest"));
+        assert!(!reloaded.contains("0"));
+    }
+
+    #[test]
+    fn discord_thread_participation_tracker_tolerates_corrupt_and_missing_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let corrupt_path = tmp.path().join("discord_threads.json");
+        std::fs::write(&corrupt_path, "not valid json{{{").unwrap();
+        let tracker = DiscordThreadParticipationTracker::from_path(&corrupt_path, 5);
+        assert!(tracker.is_empty());
+
+        let missing_parent = tmp
+            .path()
+            .join("missing")
+            .join("deep")
+            .join("discord_threads.json");
+        let mut tracker = DiscordThreadParticipationTracker::from_path(&missing_parent, 5);
+        assert!(tracker.mark("111").unwrap());
+        assert!(missing_parent.exists());
     }
 
     #[test]

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T07:23:10.371313+00:00",
+  "generated_at_utc": "2026-05-30T07:51:25.264919+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "0c3524743a54891078f6330e2835675488cdb902",
+    "local_sha": "b5a87fe8a48640568bcb8a8fc30d94a178e0737e",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 845,
+    "commits_ahead": 847,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 706,
+    "local_patch_unique": 707,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 387573
+    "tree_deletions": 388261
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 706,
+    "local_patch_unique": 707,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T07:23:10.371313+00:00`
+Generated: `2026-05-30T07:51:25.264919+00:00`
 
 ## Scope
 
-- Local ref: `main` (`0c3524743a54891078f6330e2835675488cdb902`)
+- Local ref: `main` (`b5a87fe8a48640568bcb8a8fc30d94a178e0737e`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T07:23:10.371313+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 845 |
+| Commits ahead local (`local` ancestry only) | 847 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 706 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 707 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 387573 |
+| Deletions (`local` vs `upstream`) | 388261 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T07:23:10.371313+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `706`
+- Local unique by patch-id: `707`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3721,16 +3721,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_channel_controls.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "dc7971529a1b396043a4749674f71cbb679dcb24",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_channel_controls.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "3142ef839d73c16be4d47845c931564c4124158c",
       "workstream": "WS6"
@@ -3751,16 +3751,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_channel_skills.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "26c75f0a9f753a429fd2fed48c9b49dc25c22053",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_channel_skills.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "a1b958d06b0629986f3a52252b1c231bcb82f138",
       "workstream": "WS6"
@@ -4006,16 +4006,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_thread_persistence.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b6be0a66832f7e06b1878033d8e40efb65a9a11a",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_thread_persistence.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "41ffcb2b5bbed90d39b35e9a654366800a69b352",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T07:23:08.531065+00:00",
+  "generated_at_utc": "2026-05-30T07:51:31.116119+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "0c3524743a54891078f6330e2835675488cdb902",
+    "local_sha": "b5a87fe8a48640568bcb8a8fc30d94a178e0737e",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 732,
-      "intentional_divergence": 117,
+      "functional": 729,
+      "intentional_divergence": 120,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 286,
-      "rust_equivalent_or_contract_test_required": 653,
+      "not_required_for_runtime": 289,
+      "rust_equivalent_or_contract_test_required": 650,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 117,
+      "cleared_intentional_divergence": 120,
       "cleared_non_runtime": 169,
-      "pending_review": 732
+      "pending_review": 729
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 117,
+    "cleared_intentional_divergence": 120,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 732,
+    "pending_review": 729,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T07:23:08.531065+00:00`
+Generated: `2026-05-30T07:51:31.116119+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `732`
+- Pending functional review: `729`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `117`
+- Cleared intentional divergence: `120`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 117 |
+| `cleared_intentional_divergence` | 120 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 732 |
+| `pending_review` | 729 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T07:23:08.531065+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 164 |
+| `tests/gateway` | 161 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -171,6 +171,20 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_channel_controls.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord ignored_channels and no_thread_channels behavior is covered by Rust DiscordChannelControls tests for CSV/YAML parsing, DM bypass, thread-parent matching, auto-thread suppression, config env bridging, and config-to-env hydration precedence.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_channel_skills.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord channel_skill_bindings resolver intent is covered by Rust DiscordChannelSkillBinding parsing and DiscordAdapter::resolve_channel_skills tests for channel matches, parent matches, single-skill shorthand, no-match, and ordered deduplication.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_imports.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream discord.py-missing import safety is covered by the Rust-only hermes-gateway Discord module compiling and testing behind the discord feature without any discord.py runtime dependency.",
@@ -195,6 +209,13 @@
       "path": "tests/gateway/test_discord_system_messages.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord system-message filtering is covered by Rust DiscordAdapter::should_accept_message tests accepting default/reply message types and rejecting thread rename, pin, join, and boost-style system message types.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_thread_persistence.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord thread participation persistence is covered by Rust ThreadParticipationTracker tests for missing/corrupt state, duplicate no-op marks, ordered newest retention, capacity eviction, restart reload, and missing-parent save creation.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- add Rust DiscordChannelControls for ignored/no-thread/free-response channel policy parsing and decisions
- add persistent Discord ThreadParticipationTracker with ordered capacity retention
- add Rust channel_skill_bindings parser/resolver and Discord adapter accessors
- bridge Discord channel policy env/config values and refresh parity backlog artifacts

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg -n "max_shared_different|max-shared-different|max shared different" .; test $? -eq 1
- cargo test -p hermes-gateway --features discord
- cargo test -p hermes-config
- cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md
