### PR TITLE
Add Discord reply/send parity

### DIFF
--- a/crates/hermes-cli/src/config_env.rs
+++ b/crates/hermes-cli/src/config_env.rs
@@ -73,7 +73,7 @@ pub fn hydrate_env_from_config(config: &GatewayConfig) -> usize {
         }
 
         for (extra_key, extra_val) in &platform_cfg.extra {
-            if let Some(value) = scalarish_json_to_string(extra_val) {
+            if let Some(value) = platform_extra_json_to_env_string(extra_key, extra_val) {
                 let key = normalize_env_component(extra_key);
                 applied += set_if_absent_owned(format!("{}_{}", scoped_prefix, key), value.clone());
                 applied += set_if_absent_owned(format!("{}_{}", platform_prefix, key), value);
@@ -166,6 +166,22 @@ fn scalarish_json_to_string(value: &Value) -> Option<String> {
     }
 }
 
+fn platform_extra_json_to_env_string(key: &str, value: &Value) -> Option<String> {
+    if key == "reply_to_mode" {
+        return match value {
+            Value::String(s) => {
+                let normalized = s.trim().to_ascii_lowercase();
+                matches!(normalized.as_str(), "off" | "first" | "all").then_some(normalized)
+            }
+            Value::Bool(false) => Some("off".to_string()),
+            Value::Bool(true) => Some("all".to_string()),
+            _ => None,
+        };
+    }
+
+    scalarish_json_to_string(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,6 +228,7 @@ mod tests {
             "DISCORD_IGNORED_CHANNELS",
             "DISCORD_NO_THREAD_CHANNELS",
             "DISCORD_AUTO_THREAD",
+            "DISCORD_REPLY_TO_MODE",
         ]);
         std::env::remove_var("HERMES_MODEL");
         std::env::remove_var("HERMES_MAX_TURNS");
@@ -221,6 +238,7 @@ mod tests {
         std::env::remove_var("DISCORD_IGNORED_CHANNELS");
         std::env::remove_var("DISCORD_NO_THREAD_CHANNELS");
         std::env::remove_var("DISCORD_AUTO_THREAD");
+        std::env::remove_var("DISCORD_REPLY_TO_MODE");
 
         let mut cfg = GatewayConfig {
             model: Some("openai:gpt-4o".to_string()),
@@ -250,6 +268,9 @@ mod tests {
         discord
             .extra
             .insert("auto_thread".to_string(), Value::Bool(false));
+        discord
+            .extra
+            .insert("reply_to_mode".to_string(), Value::Bool(false));
         cfg.platforms.insert("discord".to_string(), discord);
 
         let applied = hydrate_env_from_config(&cfg);
@@ -283,6 +304,10 @@ mod tests {
             std::env::var("DISCORD_AUTO_THREAD").unwrap(),
             "false".to_string()
         );
+        assert_eq!(
+            std::env::var("DISCORD_REPLY_TO_MODE").unwrap(),
+            "off".to_string()
+        );
     }
 
     #[test]
@@ -292,10 +317,12 @@ mod tests {
             "HERMES_MODEL",
             "DISCORD_ALLOWED_USERS",
             "DISCORD_IGNORED_CHANNELS",
+            "DISCORD_REPLY_TO_MODE",
         ]);
         std::env::set_var("HERMES_MODEL", "existing:model");
         std::env::set_var("DISCORD_ALLOWED_USERS", "from-env");
         std::env::set_var("DISCORD_IGNORED_CHANNELS", "999");
+        std::env::set_var("DISCORD_REPLY_TO_MODE", "first");
 
         let mut cfg = GatewayConfig {
             model: Some("openai:gpt-4o".to_string()),
@@ -309,6 +336,10 @@ mod tests {
             "ignored_channels".to_string(),
             Value::Array(vec![Value::String("111".to_string())]),
         );
+        discord.extra.insert(
+            "reply_to_mode".to_string(),
+            Value::String("all".to_string()),
+        );
         let mut platforms = HashMap::new();
         platforms.insert("discord".to_string(), discord);
         cfg.platforms = platforms;
@@ -318,5 +349,6 @@ mod tests {
         assert_eq!(std::env::var("HERMES_MODEL").unwrap(), "existing:model");
         assert_eq!(std::env::var("DISCORD_ALLOWED_USERS").unwrap(), "from-env");
         assert_eq!(std::env::var("DISCORD_IGNORED_CHANNELS").unwrap(), "999");
+        assert_eq!(std::env::var("DISCORD_REPLY_TO_MODE").unwrap(), "first");
     }
 }

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4083,6 +4083,18 @@ fn extra_string(platform_cfg: &PlatformConfig, key: &str) -> Option<String> {
         .map(String::from)
 }
 
+fn discord_reply_to_mode_string(platform_cfg: &PlatformConfig) -> Option<String> {
+    let raw = platform_cfg.extra.get("reply_to_mode")?;
+    let candidate = match raw {
+        serde_json::Value::String(value) => value.trim().to_ascii_lowercase(),
+        serde_json::Value::Bool(false) => "off".to_string(),
+        serde_json::Value::Bool(true) => "all".to_string(),
+        _ => return None,
+    };
+
+    matches!(candidate.as_str(), "off" | "first" | "all").then_some(candidate)
+}
+
 fn env_string(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
@@ -4440,6 +4452,8 @@ async fn register_gateway_adapters(
                         .get("intents")
                         .and_then(|v| v.as_u64())
                         .unwrap_or((1 << 0) | (1 << 9) | (1 << 15)),
+                    reply_to_mode: discord_reply_to_mode_string(platform_cfg)
+                        .unwrap_or_else(|| "first".to_string()),
                     channel_controls: DiscordChannelControls::from_extra(&platform_cfg.extra),
                     channel_skill_bindings: DiscordChannelSkillBinding::list_from_json(
                         platform_cfg.extra.get("channel_skill_bindings"),

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -26,6 +26,15 @@ fn env_bool(raw: &str) -> bool {
     matches!(raw.to_lowercase().as_str(), "1" | "true" | "yes" | "on")
 }
 
+fn discord_reply_to_mode(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "off" => Some("off"),
+        "first" => Some("first"),
+        "all" => Some("all"),
+        _ => None,
+    }
+}
+
 fn set_extra(pc: &mut PlatformConfig, key: &str, val: Value) {
     pc.extra.insert(key.to_string(), val);
 }
@@ -162,7 +171,9 @@ fn apply_discord_env(config: &mut GatewayConfig) {
         set_extra(discord, "reactions", json!(env_bool(&v)));
     }
     if let Some(v) = env_nonempty("DISCORD_REPLY_TO_MODE") {
-        set_extra(discord, "reply_to_mode", json!(v));
+        if let Some(mode) = discord_reply_to_mode(&v) {
+            set_extra(discord, "reply_to_mode", json!(mode));
+        }
     }
     if let Some(v) = env_nonempty("DISCORD_REQUIRE_MENTION") {
         discord.require_mention = Some(env_bool(&v));
@@ -251,7 +262,7 @@ mod tests {
             std::env::set_var("DISCORD_APPLICATION_ID", "app-123");
             std::env::set_var("DISCORD_ALLOW_BOTS", "mentions");
             std::env::set_var("DISCORD_REACTIONS", "false");
-            std::env::set_var("DISCORD_REPLY_TO_MODE", "all");
+            std::env::set_var("DISCORD_REPLY_TO_MODE", "ALL");
             std::env::set_var("DISCORD_REQUIRE_MENTION", "true");
             std::env::set_var("DISCORD_IGNORED_CHANNELS", "111, 222");
             std::env::set_var("DISCORD_NO_THREAD_CHANNELS", "333");
@@ -328,6 +339,30 @@ mod tests {
             std::env::remove_var("DISCORD_FREE_RESPONSE_CHANNELS");
             std::env::remove_var("DISCORD_AUTO_THREAD");
             std::env::remove_var("DISCORD_THREAD_REQUIRE_MENTION");
+        }
+    }
+
+    #[test]
+    fn discord_reply_to_mode_env_ignores_invalid_values() {
+        unsafe {
+            std::env::set_var("DISCORD_REPLY_TO_MODE", "banana");
+        }
+        let mut cfg = GatewayConfig::default();
+        cfg.platforms
+            .entry("discord".into())
+            .or_default()
+            .extra
+            .insert("reply_to_mode".into(), json!("off"));
+
+        apply_python_named_platform_env(&mut cfg);
+        let discord = cfg.platforms.get("discord").expect("discord block");
+        assert_eq!(
+            discord.extra.get("reply_to_mode").and_then(|v| v.as_str()),
+            Some("off")
+        );
+
+        unsafe {
+            std::env::remove_var("DISCORD_REPLY_TO_MODE");
         }
     }
 

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -55,6 +55,10 @@ pub struct DiscordConfig {
     #[serde(default = "default_intents")]
     pub intents: u64,
 
+    /// How outgoing chunks should reply-reference the original Discord message.
+    #[serde(default = "default_reply_to_mode")]
+    pub reply_to_mode: String,
+
     /// Channel-level inbound and auto-thread policy.
     #[serde(default)]
     pub channel_controls: DiscordChannelControls,
@@ -69,18 +73,43 @@ fn default_intents() -> u64 {
     (1 << 0) | (1 << 9) | (1 << 15)
 }
 
+fn default_reply_to_mode() -> String {
+    "first".to_string()
+}
+
 /// Optional Discord send metadata carried by higher-level gateway helpers.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiscordSendMetadata {
     /// Discord thread channel ID to target instead of the parent channel.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread_id: Option<String>,
+    /// Original Discord message ID to reply-reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<String>,
 }
 
 impl DiscordSendMetadata {
     pub fn with_thread_id(thread_id: impl Into<String>) -> Self {
         Self {
             thread_id: Some(thread_id.into()),
+            reply_to_message_id: None,
+        }
+    }
+
+    pub fn with_reply_to_message_id(message_id: impl Into<String>) -> Self {
+        Self {
+            thread_id: None,
+            reply_to_message_id: Some(message_id.into()),
+        }
+    }
+
+    pub fn with_thread_and_reply(
+        thread_id: impl Into<String>,
+        message_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            thread_id: Some(thread_id.into()),
+            reply_to_message_id: Some(message_id.into()),
         }
     }
 
@@ -91,6 +120,13 @@ impl DiscordSendMetadata {
             .filter(|id| !id.is_empty())
             .unwrap_or(fallback_channel_id)
     }
+
+    pub fn reply_to_message_id(&self) -> Option<&str> {
+        self.reply_to_message_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+    }
 }
 
 fn target_channel_id_for_metadata<'a>(
@@ -100,6 +136,36 @@ fn target_channel_id_for_metadata<'a>(
     metadata
         .map(|m| m.target_channel_id(channel_id))
         .unwrap_or(channel_id)
+}
+
+fn reply_to_message_id_for_metadata(metadata: Option<&DiscordSendMetadata>) -> Option<&str> {
+    metadata.and_then(DiscordSendMetadata::reply_to_message_id)
+}
+
+/// Effective behavior for Discord reply references across split chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordReplyToMode {
+    Off,
+    First,
+    All,
+}
+
+impl DiscordReplyToMode {
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(value) if value.eq_ignore_ascii_case("off") => Self::Off,
+            Some(value) if value.eq_ignore_ascii_case("all") => Self::All,
+            _ => Self::First,
+        }
+    }
+
+    pub fn references_chunk(self, chunk_index: usize) -> bool {
+        match self {
+            Self::Off => false,
+            Self::First => chunk_index == 0,
+            Self::All => true,
+        }
+    }
 }
 
 const DISCORD_ALLOW_MENTION_EVERYONE_ENV: &str = "DISCORD_ALLOW_MENTION_EVERYONE";
@@ -182,6 +248,68 @@ fn with_allowed_mentions(
 
 fn with_default_allowed_mentions(body: serde_json::Value) -> serde_json::Value {
     with_allowed_mentions(body, default_discord_allowed_mentions())
+}
+
+fn with_reply_reference(mut body: serde_json::Value, message_id: &str) -> serde_json::Value {
+    let message_id = message_id.trim();
+    if !message_id.is_empty() {
+        body["message_reference"] = serde_json::json!({
+            "message_id": message_id,
+            "fail_if_not_exists": false,
+        });
+    }
+    body
+}
+
+fn discord_message_body(
+    content: &str,
+    reply_to_message_id: Option<&str>,
+    allowed_mentions: DiscordAllowedMentions,
+) -> serde_json::Value {
+    let body = with_allowed_mentions(serde_json::json!({ "content": content }), allowed_mentions);
+    match reply_to_message_id {
+        Some(message_id) => with_reply_reference(body, message_id),
+        None => body,
+    }
+}
+
+fn discord_reply_reference_error_allows_retry(raw_error: &str) -> bool {
+    let normalized = raw_error.to_ascii_lowercase();
+    normalized.contains("cannot reply to a system message")
+        || normalized.contains("unknown message")
+        || normalized.contains("error code: 10008")
+}
+
+fn forum_thread_name(content: Option<&str>, file_name: Option<&str>) -> String {
+    let candidate = content
+        .and_then(|content| content.lines().map(str::trim).find(|line| !line.is_empty()))
+        .or_else(|| file_name.map(str::trim).filter(|name| !name.is_empty()))
+        .unwrap_or("Hermes");
+
+    candidate.chars().take(100).collect()
+}
+
+fn forum_thread_message_body(content: &str) -> serde_json::Value {
+    with_default_allowed_mentions(serde_json::json!({ "content": content }))
+}
+
+fn forum_thread_payload(
+    content: &str,
+    file_name: Option<&str>,
+    auto_archive_duration: Option<u32>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "name": forum_thread_name(Some(content), file_name),
+        "message": forum_thread_message_body(content),
+    });
+    if let Some(duration) = auto_archive_duration {
+        body["auto_archive_duration"] = serde_json::Value::Number(duration.into());
+    }
+    body
+}
+
+pub fn discord_channel_type_is_forum_parent(channel_type: Option<u8>) -> bool {
+    matches!(channel_type, Some(15))
 }
 
 /// Discord bot-message acceptance policy.
@@ -1147,6 +1275,24 @@ pub struct DiscordThread {
     pub parent_id: Option<String>,
 }
 
+/// Response from creating a Discord forum post thread.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiscordForumThread {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub message: Option<DiscordMessage>,
+}
+
+/// Result of a forum post send where follow-up chunk failures are non-fatal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordForumSendOutcome {
+    pub thread_id: String,
+    pub message_id: String,
+    pub warnings: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // DiscordAdapter
 // ---------------------------------------------------------------------------
@@ -1250,13 +1396,23 @@ impl DiscordAdapter {
         let target_channel_id = target_channel_id_for_metadata(channel_id, metadata);
         let chunks = split_message(content, MAX_MESSAGE_LENGTH);
         let mut message_ids = Vec::new();
+        let reply_to_message_id = reply_to_message_id_for_metadata(metadata);
+        let reply_to_mode = DiscordReplyToMode::parse(Some(&self.config.reply_to_mode));
+        let mut suppress_reply_references = false;
 
-        for chunk in &chunks {
+        for (index, chunk) in chunks.iter().enumerate() {
             let url = format!(
                 "{}/channels/{}/messages",
                 DISCORD_API_BASE, target_channel_id
             );
-            let body = with_default_allowed_mentions(serde_json::json!({ "content": chunk }));
+            let include_reply_reference = !suppress_reply_references
+                && reply_to_message_id.is_some()
+                && reply_to_mode.references_chunk(index);
+            let body = discord_message_body(
+                chunk,
+                include_reply_reference.then_some(reply_to_message_id.unwrap_or_default()),
+                default_discord_allowed_mentions(),
+            );
 
             let resp = self
                 .client
@@ -1270,6 +1426,38 @@ impl DiscordAdapter {
 
             if !resp.status().is_success() {
                 let text = resp.text().await.unwrap_or_default();
+                if include_reply_reference && discord_reply_reference_error_allows_retry(&text) {
+                    suppress_reply_references = true;
+                    let retry_body =
+                        discord_message_body(chunk, None, default_discord_allowed_mentions());
+                    let retry_resp = self
+                        .client
+                        .post(&url)
+                        .header("Authorization", self.auth_header())
+                        .header("Content-Type", "application/json")
+                        .json(&retry_body)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            GatewayError::SendFailed(format!("Discord send failed: {}", e))
+                        })?;
+
+                    if !retry_resp.status().is_success() {
+                        let retry_text = retry_resp.text().await.unwrap_or_default();
+                        return Err(GatewayError::SendFailed(format!(
+                            "Discord API error: {}",
+                            retry_text
+                        )));
+                    }
+
+                    let msg: DiscordMessage = retry_resp.json().await.map_err(|e| {
+                        GatewayError::SendFailed(format!("Failed to parse Discord response: {}", e))
+                    })?;
+
+                    message_ids.push(msg.id);
+                    continue;
+                }
+
                 return Err(GatewayError::SendFailed(format!(
                     "Discord API error: {}",
                     text
@@ -1284,6 +1472,72 @@ impl DiscordAdapter {
         }
 
         Ok(message_ids)
+    }
+
+    /// Create a Discord forum post thread from message content.
+    ///
+    /// Follow-up chunks are sent to the created thread. If the starter post is
+    /// created but a follow-up chunk fails, the successful starter message is
+    /// returned together with warnings, matching the upstream partial-send
+    /// behavior.
+    pub async fn send_forum_post(
+        &self,
+        forum_channel_id: &str,
+        content: &str,
+        auto_archive_duration: Option<u32>,
+    ) -> Result<DiscordForumSendOutcome, GatewayError> {
+        let chunks = split_message(content, MAX_MESSAGE_LENGTH);
+        let Some(first_chunk) = chunks.first() else {
+            return Err(GatewayError::SendFailed(
+                "Discord forum post requires content".into(),
+            ));
+        };
+        let url = format!("{}/channels/{}/threads", DISCORD_API_BASE, forum_channel_id);
+        let body = forum_thread_payload(first_chunk, None, auto_archive_duration);
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| GatewayError::SendFailed(format!("Discord forum post failed: {}", e)))?;
+
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(GatewayError::SendFailed(format!(
+                "Discord forum post API error: {}",
+                text
+            )));
+        }
+
+        let thread: DiscordForumThread = resp.json().await.map_err(|e| {
+            GatewayError::SendFailed(format!("Failed to parse forum thread response: {}", e))
+        })?;
+        let message_id = thread
+            .message
+            .as_ref()
+            .map(|message| message.id.clone())
+            .unwrap_or_else(|| thread.id.clone());
+        let mut warnings = Vec::new();
+
+        for chunk in chunks.iter().skip(1) {
+            let metadata = DiscordSendMetadata::with_thread_id(thread.id.clone());
+            if let Err(err) = self
+                .send_text_with_metadata(forum_channel_id, chunk, Some(&metadata))
+                .await
+            {
+                warnings.push(err.to_string());
+            }
+        }
+
+        Ok(DiscordForumSendOutcome {
+            thread_id: thread.id,
+            message_id,
+            warnings,
+        })
     }
 
     /// Edit an existing message in a Discord channel.
@@ -2283,6 +2537,7 @@ mod tests {
             proxy: AdapterProxyConfig::default(),
             require_mention: false,
             intents: default_intents(),
+            reply_to_mode: default_reply_to_mode(),
             channel_controls: DiscordChannelControls::default(),
             channel_skill_bindings: Vec::new(),
         }
@@ -2292,10 +2547,19 @@ mod tests {
     fn send_metadata_targets_thread_id_when_present() {
         let metadata = DiscordSendMetadata::with_thread_id(" 987654321 ");
         assert_eq!(metadata.target_channel_id("123"), "987654321");
+        assert_eq!(metadata.reply_to_message_id(), None);
 
         let blank_metadata = DiscordSendMetadata::with_thread_id("   ");
         assert_eq!(blank_metadata.target_channel_id("123"), "123");
         assert_eq!(target_channel_id_for_metadata("123", None), "123");
+
+        let reply_metadata = DiscordSendMetadata::with_reply_to_message_id(" origin-1 ");
+        assert_eq!(reply_metadata.target_channel_id("123"), "123");
+        assert_eq!(reply_metadata.reply_to_message_id(), Some("origin-1"));
+
+        let combined = DiscordSendMetadata::with_thread_and_reply("thread-1", "origin-2");
+        assert_eq!(combined.target_channel_id("123"), "thread-1");
+        assert_eq!(combined.reply_to_message_id(), Some("origin-2"));
     }
 
     #[test]
@@ -2307,6 +2571,100 @@ mod tests {
         let body = with_allowed_mentions(serde_json::json!({ "content": "hello" }), mentions);
         assert_eq!(
             body["allowed_mentions"],
+            serde_json::json!({ "parse": ["users"], "replied_user": true })
+        );
+    }
+
+    #[test]
+    fn reply_to_mode_defaults_to_first_and_parses_effective_behavior() {
+        assert_eq!(default_reply_to_mode(), "first");
+        assert_eq!(DiscordReplyToMode::parse(None), DiscordReplyToMode::First);
+        assert_eq!(
+            DiscordReplyToMode::parse(Some("")),
+            DiscordReplyToMode::First
+        );
+        assert_eq!(
+            DiscordReplyToMode::parse(Some("off")),
+            DiscordReplyToMode::Off
+        );
+        assert_eq!(
+            DiscordReplyToMode::parse(Some("ALL")),
+            DiscordReplyToMode::All
+        );
+        assert_eq!(
+            DiscordReplyToMode::parse(Some("banana")),
+            DiscordReplyToMode::First
+        );
+
+        assert!(!DiscordReplyToMode::Off.references_chunk(0));
+        assert!(DiscordReplyToMode::First.references_chunk(0));
+        assert!(!DiscordReplyToMode::First.references_chunk(1));
+        assert!(DiscordReplyToMode::All.references_chunk(0));
+        assert!(DiscordReplyToMode::All.references_chunk(7));
+    }
+
+    #[test]
+    fn reply_reference_body_matches_discord_reference_contract() {
+        let body = discord_message_body(
+            "chunk",
+            Some(" origin-1 "),
+            DiscordAllowedMentions::from_flags(false, false, true, true),
+        );
+
+        assert_eq!(body["content"], "chunk");
+        assert_eq!(
+            body["allowed_mentions"],
+            serde_json::json!({ "parse": ["users"], "replied_user": true })
+        );
+        assert_eq!(
+            body["message_reference"],
+            serde_json::json!({
+                "message_id": "origin-1",
+                "fail_if_not_exists": false
+            })
+        );
+
+        let no_reference = discord_message_body(
+            "chunk",
+            None,
+            DiscordAllowedMentions::from_flags(false, false, true, true),
+        );
+        assert!(no_reference.get("message_reference").is_none());
+    }
+
+    #[test]
+    fn reply_reference_retry_classifier_only_matches_reference_failures() {
+        assert!(discord_reply_reference_error_allows_retry(
+            "400 Bad Request (error code: 50035): Invalid Form Body\nIn message_reference: Cannot reply to a system message"
+        ));
+        assert!(discord_reply_reference_error_allows_retry(
+            "400 Bad Request (error code: 10008): Unknown Message"
+        ));
+        assert!(!discord_reply_reference_error_allows_retry(
+            "403 Forbidden (error code: 50013): Missing Permissions"
+        ));
+    }
+
+    #[test]
+    fn forum_parent_and_payload_contract_matches_python_send_path() {
+        assert!(!discord_channel_type_is_forum_parent(None));
+        assert!(!discord_channel_type_is_forum_parent(Some(0)));
+        assert!(!discord_channel_type_is_forum_parent(Some(11)));
+        assert!(discord_channel_type_is_forum_parent(Some(15)));
+
+        assert_eq!(
+            forum_thread_name(Some("  here is a photo\nsecond line"), Some("photo.png")),
+            "here is a photo"
+        );
+        assert_eq!(forum_thread_name(Some(""), Some("voice.ogg")), "voice.ogg");
+        assert_eq!(forum_thread_name(None, None), "Hermes");
+
+        let payload = forum_thread_payload("Hello forum!", None, Some(60));
+        assert_eq!(payload["name"], "Hello forum!");
+        assert_eq!(payload["auto_archive_duration"], 60);
+        assert_eq!(payload["message"]["content"], "Hello forum!");
+        assert_eq!(
+            payload["message"]["allowed_mentions"],
             serde_json::json!({ "parse": ["users"], "replied_user": true })
         );
     }

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T07:51:25.264919+00:00",
+  "generated_at_utc": "2026-05-30T08:17:55.647701+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b5a87fe8a48640568bcb8a8fc30d94a178e0737e",
+    "local_sha": "25cfd0b9dd2d95fcb1eb5fb6eb7417a1da6a69d5",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 847,
+    "commits_ahead": 849,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 707,
+    "local_patch_unique": 708,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 388261
+    "tree_deletions": 388977
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 707,
+    "local_patch_unique": 708,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T07:51:25.264919+00:00`
+Generated: `2026-05-30T08:17:55.647701+00:00`
 
 ## Scope
 
-- Local ref: `main` (`b5a87fe8a48640568bcb8a8fc30d94a178e0737e`)
+- Local ref: `main` (`25cfd0b9dd2d95fcb1eb5fb6eb7417a1da6a69d5`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T07:51:25.264919+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 847 |
+| Commits ahead local (`local` ancestry only) | 849 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 707 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 708 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 388261 |
+| Deletions (`local` vs `upstream`) | 388977 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T07:51:25.264919+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `707`
+- Local unique by patch-id: `708`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3916,16 +3916,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_reply_mode.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "64e27a27aa8453df8e0489ba7b6408951803f827",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_reply_mode.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "d113af2e6a2e78c300c15ee2f4a4a9ca9d3792c9",
       "workstream": "WS6"
@@ -3946,16 +3946,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_send.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "89be6885a9c2bcde045113cdd0638a526fb32f76",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_send.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "cd2950f9fbbb85809cee03f63e23512ba1290d59",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T07:51:31.116119+00:00",
+  "generated_at_utc": "2026-05-30T08:17:53.629547+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b5a87fe8a48640568bcb8a8fc30d94a178e0737e",
+    "local_sha": "25cfd0b9dd2d95fcb1eb5fb6eb7417a1da6a69d5",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 729,
-      "intentional_divergence": 120,
+      "functional": 727,
+      "intentional_divergence": 122,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 289,
-      "rust_equivalent_or_contract_test_required": 650,
+      "not_required_for_runtime": 291,
+      "rust_equivalent_or_contract_test_required": 648,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 120,
+      "cleared_intentional_divergence": 122,
       "cleared_non_runtime": 169,
-      "pending_review": 729
+      "pending_review": 727
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 120,
+    "cleared_intentional_divergence": 122,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 729,
+    "pending_review": 727,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T07:51:31.116119+00:00`
+Generated: `2026-05-30T08:17:53.629547+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `729`
+- Pending functional review: `727`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `120`
+- Cleared intentional divergence: `122`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 120 |
+| `cleared_intentional_divergence` | 122 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 729 |
+| `pending_review` | 727 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T07:51:31.116119+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 161 |
+| `tests/gateway` | 159 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -199,9 +199,23 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_reply_mode.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord reply_to_mode behavior is covered by Rust hermes-gateway reply-reference construction/retry tests, DiscordConfig defaults, CLI config hydration, Python-platform env bridging, and reply-text extraction contracts.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_reactions.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord processing-reaction lifecycle is covered by Rust Gateway Discord reaction lifecycle tests, platform-specific Discord emoji mapping, reactions_enabled policy tests, and Discord REST reaction parser/adapter contracts.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_send.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord send retry and forum-post behavior is covered by Rust hermes-gateway reply-reference retry classifiers, chunk reference-mode payload tests, forum thread payload contracts, and DiscordAdapter forum send outcome handling.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- add Rust Discord reply_to_mode config, env hydration, and send metadata support
- retry Discord reply sends without message_reference when Discord rejects stale/system reply targets
- add forum post thread payload/send outcome contracts and clear the two matching upstream parity test files

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different/max-shared-different/max shared different guard
- cargo test -p hermes-gateway --features discord
- cargo test -p hermes-config
- cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md