### PR TITLE
Add Discord auth policy parity

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4083,6 +4083,42 @@ fn extra_string(platform_cfg: &PlatformConfig, key: &str) -> Option<String> {
         .map(String::from)
 }
 
+fn extra_string_set(platform_cfg: &PlatformConfig, key: &str) -> HashSet<String> {
+    let Some(raw) = platform_cfg.extra.get(key) else {
+        return HashSet::new();
+    };
+
+    let mut values = HashSet::new();
+    match raw {
+        serde_json::Value::String(s) => {
+            for item in s.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                values.insert(item.to_string());
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                match item {
+                    serde_json::Value::String(s) => {
+                        let trimmed = s.trim();
+                        if !trimmed.is_empty() {
+                            values.insert(trimmed.to_string());
+                        }
+                    }
+                    serde_json::Value::Number(n) => {
+                        values.insert(n.to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+        serde_json::Value::Number(n) => {
+            values.insert(n.to_string());
+        }
+        _ => {}
+    }
+    values
+}
+
 fn discord_reply_to_mode_string(platform_cfg: &PlatformConfig) -> Option<String> {
     let raw = platform_cfg.extra.get("reply_to_mode")?;
     let candidate = match raw {
@@ -4220,6 +4256,8 @@ fn build_gateway_platform_access_policies(
             PlatformAccessPolicy {
                 allowed_users,
                 admin_users,
+                allowed_channels: extra_string_set(platform_cfg, "allowed_channels"),
+                ignored_channels: extra_string_set(platform_cfg, "ignored_channels"),
                 group_mode,
                 slash_requires_allowlist,
                 bot_sender_bypasses_allowlist: discord_allow_bots_bypasses_gateway_allowlist(
@@ -14170,6 +14208,30 @@ mod tests {
             Some(value) => std::env::set_var("MATRIX_HOME_ROOM", value),
             None => std::env::remove_var("MATRIX_HOME_ROOM"),
         }
+    }
+
+    #[test]
+    fn gateway_platform_access_policy_reads_discord_channel_lists() {
+        let mut config = hermes_config::GatewayConfig::default();
+        let mut discord = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        discord
+            .extra
+            .insert("allowed_channels".to_string(), serde_json::json!("111, *"));
+        discord.extra.insert(
+            "ignored_channels".to_string(),
+            serde_json::json!(["222", 333]),
+        );
+        config.platforms.insert("discord".to_string(), discord);
+
+        let policies = build_gateway_platform_access_policies(&config);
+        let policy = policies.get("discord").expect("discord policy");
+        assert!(policy.allowed_channels.contains("111"));
+        assert!(policy.allowed_channels.contains("*"));
+        assert!(policy.ignored_channels.contains("222"));
+        assert!(policy.ignored_channels.contains("333"));
     }
 
     #[test]

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -167,6 +167,19 @@ fn apply_discord_env(config: &mut GatewayConfig) {
     if let Some(v) = env_nonempty("DISCORD_ALLOW_BOTS") {
         set_extra(discord, "allow_bots", json!(v));
     }
+    if let Some(v) = env_nonempty("DISCORD_ALLOWED_USERS") {
+        discord.allowed_users = comma_list_to_strings(&v);
+    }
+    if let Some(v) = env_nonempty("DISCORD_ALLOWED_ROLES") {
+        set_extra(discord, "allowed_roles", json!(comma_list_to_strings(&v)));
+    }
+    if let Some(v) = env_nonempty("DISCORD_ALLOWED_CHANNELS") {
+        set_extra(
+            discord,
+            "allowed_channels",
+            json!(comma_list_to_strings(&v)),
+        );
+    }
     if let Some(v) = env_nonempty("DISCORD_REACTIONS") {
         set_extra(discord, "reactions", json!(env_bool(&v)));
     }
@@ -261,6 +274,9 @@ mod tests {
             std::env::set_var("DISCORD_BOT_TOKEN", "discord-token");
             std::env::set_var("DISCORD_APPLICATION_ID", "app-123");
             std::env::set_var("DISCORD_ALLOW_BOTS", "mentions");
+            std::env::set_var("DISCORD_ALLOWED_USERS", "100, 200");
+            std::env::set_var("DISCORD_ALLOWED_ROLES", "300,400");
+            std::env::set_var("DISCORD_ALLOWED_CHANNELS", "500,*");
             std::env::set_var("DISCORD_REACTIONS", "false");
             std::env::set_var("DISCORD_REPLY_TO_MODE", "ALL");
             std::env::set_var("DISCORD_REQUIRE_MENTION", "true");
@@ -283,6 +299,23 @@ mod tests {
         assert_eq!(
             discord.extra.get("allow_bots").and_then(|v| v.as_str()),
             Some("mentions")
+        );
+        assert_eq!(discord.allowed_users, vec!["100", "200"]);
+        assert_eq!(
+            discord
+                .extra
+                .get("allowed_roles")
+                .and_then(|v| v.as_array())
+                .map(|items| { items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>() }),
+            Some(vec!["300", "400"])
+        );
+        assert_eq!(
+            discord
+                .extra
+                .get("allowed_channels")
+                .and_then(|v| v.as_array())
+                .map(|items| { items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>() }),
+            Some(vec!["500", "*"])
         );
         assert_eq!(
             discord.extra.get("reactions").and_then(|v| v.as_bool()),
@@ -331,6 +364,9 @@ mod tests {
             std::env::remove_var("DISCORD_BOT_TOKEN");
             std::env::remove_var("DISCORD_APPLICATION_ID");
             std::env::remove_var("DISCORD_ALLOW_BOTS");
+            std::env::remove_var("DISCORD_ALLOWED_USERS");
+            std::env::remove_var("DISCORD_ALLOWED_ROLES");
+            std::env::remove_var("DISCORD_ALLOWED_CHANNELS");
             std::env::remove_var("DISCORD_REACTIONS");
             std::env::remove_var("DISCORD_REPLY_TO_MODE");
             std::env::remove_var("DISCORD_REQUIRE_MENTION");

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -293,6 +293,8 @@ impl Default for GroupAccessMode {
 pub struct PlatformAccessPolicy {
     pub allowed_users: HashSet<String>,
     pub admin_users: HashSet<String>,
+    pub allowed_channels: HashSet<String>,
+    pub ignored_channels: HashSet<String>,
     pub group_mode: GroupAccessMode,
     pub slash_requires_allowlist: bool,
     pub bot_sender_bypasses_allowlist: bool,
@@ -326,6 +328,26 @@ impl PlatformAccessPolicy {
     pub fn is_user_allowed(&self, user_id: &str) -> bool {
         Self::user_matches_any(user_id, &self.admin_users)
             || Self::user_matches_any(user_id, &self.allowed_users)
+    }
+
+    fn channel_matches_any(channel_id: &str, set: &HashSet<String>) -> bool {
+        let candidate = channel_id.trim();
+        if candidate.is_empty() {
+            return false;
+        }
+        set.iter().any(|entry| {
+            let allowed = entry.trim();
+            allowed == "*" || allowed.eq_ignore_ascii_case(candidate)
+        })
+    }
+
+    fn is_channel_allowed(&self, channel_id: &str) -> bool {
+        self.allowed_channels.is_empty()
+            || Self::channel_matches_any(channel_id, &self.allowed_channels)
+    }
+
+    fn is_channel_ignored(&self, channel_id: &str) -> bool {
+        Self::channel_matches_any(channel_id, &self.ignored_channels)
     }
 
     fn allows_sender_without_user_allowlist(
@@ -598,6 +620,22 @@ impl Gateway {
             let bypasses_user_allowlist =
                 policy.allows_sender_without_user_allowlist(incoming, sender);
             if !incoming.is_dm {
+                if policy.is_channel_ignored(&incoming.chat_id) {
+                    debug!(
+                        platform = incoming.platform,
+                        chat_id = incoming.chat_id,
+                        "Group message denied: channel is ignored by platform policy"
+                    );
+                    return Ok(());
+                }
+                if !policy.is_channel_allowed(&incoming.chat_id) {
+                    debug!(
+                        platform = incoming.platform,
+                        chat_id = incoming.chat_id,
+                        "Group message denied: channel not in platform allowlist"
+                    );
+                    return Ok(());
+                }
                 match policy.group_mode {
                     GroupAccessMode::Disabled => {
                         debug!(
@@ -2635,6 +2673,77 @@ mod tests {
                 .await,
             0
         );
+    }
+
+    #[tokio::test]
+    async fn gateway_channel_allow_and_ignore_policy_matches_discord_contract() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("discord", adapter).await;
+        gw.set_message_handler(Arc::new(|_messages| {
+            Box::pin(async { Ok("handled".to_string()) })
+        }))
+        .await;
+
+        let mut policies = HashMap::new();
+        let mut policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Open,
+            ..PlatformAccessPolicy::default()
+        };
+        policy.allowed_channels.insert("allowed".to_string());
+        policy.ignored_channels.insert("ignored".to_string());
+        policies.insert("discord".to_string(), policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let ignored = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "ignored".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: None,
+            is_dm: false,
+        };
+        assert!(gw.route_message(&ignored).await.is_ok());
+        assert_eq!(
+            gw.session_transcript_len("discord", "ignored", "user1")
+                .await,
+            0
+        );
+
+        let not_allowed = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "other".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: None,
+            is_dm: false,
+        };
+        assert!(gw.route_message(&not_allowed).await.is_ok());
+        assert_eq!(
+            gw.session_transcript_len("discord", "other", "user1").await,
+            0
+        );
+
+        let allowed = IncomingMessage {
+            platform: "discord".into(),
+            chat_id: "allowed".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: None,
+            is_dm: false,
+        };
+        assert!(gw.route_message(&allowed).await.is_ok());
+        assert_eq!(
+            gw.session_transcript_len("discord", "allowed", "user1")
+                .await,
+            2
+        );
+        assert_eq!(sent.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -407,6 +407,9 @@ fn channel_matches(
     channel_id: &str,
     parent_channel_id: Option<&str>,
 ) -> bool {
+    if ids.iter().any(|id| id.trim() == "*") {
+        return true;
+    }
     let channel_id = channel_id.trim();
     let parent_channel_id = parent_channel_id.map(str::trim).filter(|s| !s.is_empty());
     (!channel_id.is_empty() && ids.contains(channel_id))
@@ -553,6 +556,309 @@ impl DiscordChannelContext {
             voice_linked_text_channel: false,
         }
     }
+}
+
+fn id_matches_any(candidate: &str, allowed: &BTreeSet<String>) -> bool {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return false;
+    }
+    let candidate_no_at = candidate.strip_prefix('@').unwrap_or(candidate);
+    allowed.iter().any(|entry| {
+        let allowed = entry.trim();
+        if allowed.is_empty() {
+            return false;
+        }
+        let allowed_no_at = allowed.strip_prefix('@').unwrap_or(allowed);
+        allowed.eq_ignore_ascii_case(candidate)
+            || allowed.eq_ignore_ascii_case(candidate_no_at)
+            || allowed_no_at.eq_ignore_ascii_case(candidate)
+            || allowed_no_at.eq_ignore_ascii_case(candidate_no_at)
+    })
+}
+
+/// Discord user/member data relevant to slash and component authorization.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiscordInteractionSubject {
+    pub user_id: Option<String>,
+    pub role_ids: BTreeSet<String>,
+    /// Guild that the resolved role list belongs to.
+    ///
+    /// Component interactions carry the resolved member role list directly and
+    /// do not need this field. Slash/on-message role checks use it to avoid
+    /// trusting roles from a different mutual guild.
+    pub role_guild_id: Option<String>,
+}
+
+impl DiscordInteractionSubject {
+    pub fn user(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: Some(user_id.into()),
+            role_ids: BTreeSet::new(),
+            role_guild_id: None,
+        }
+    }
+
+    pub fn member(
+        user_id: impl Into<String>,
+        role_ids: impl IntoIterator<Item = impl Into<String>>,
+        role_guild_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            user_id: Some(user_id.into()),
+            role_ids: role_ids.into_iter().map(Into::into).collect(),
+            role_guild_id: Some(role_guild_id.into()),
+        }
+    }
+
+    fn has_role_match(&self, allowed_role_ids: &BTreeSet<String>) -> bool {
+        self.role_ids
+            .iter()
+            .any(|role_id| id_matches_any(role_id, allowed_role_ids))
+    }
+}
+
+/// Slash/component authorization policy matching Discord's Python gate shape.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiscordInteractionAuthPolicy {
+    pub allowed_user_ids: BTreeSet<String>,
+    pub allowed_role_ids: BTreeSet<String>,
+    pub allowed_channels: BTreeSet<String>,
+    pub ignored_channels: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordAuthDecision {
+    Allow,
+    Deny(DiscordAuthDenyReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordAuthDenyReason {
+    AllowedUsersOrRoles,
+    AllowedChannels,
+    IgnoredChannels,
+}
+
+impl DiscordInteractionAuthPolicy {
+    pub fn has_identity_policy(&self) -> bool {
+        !self.allowed_user_ids.is_empty() || !self.allowed_role_ids.is_empty()
+    }
+
+    pub fn component_allows(&self, subject: &DiscordInteractionSubject) -> bool {
+        if !self.has_identity_policy() {
+            return true;
+        }
+        subject
+            .user_id
+            .as_deref()
+            .map(|user_id| id_matches_any(user_id, &self.allowed_user_ids))
+            .unwrap_or(false)
+            || subject.has_role_match(&self.allowed_role_ids)
+    }
+
+    fn slash_role_allows(
+        &self,
+        subject: &DiscordInteractionSubject,
+        guild_id: Option<&str>,
+        is_dm: bool,
+        dm_role_auth_guild: Option<&str>,
+    ) -> bool {
+        if self.allowed_role_ids.is_empty() || !subject.has_role_match(&self.allowed_role_ids) {
+            return false;
+        }
+
+        let Some(role_guild_id) = subject
+            .role_guild_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        else {
+            return false;
+        };
+
+        if is_dm {
+            return dm_role_auth_guild
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(|trusted| trusted == role_guild_id)
+                .unwrap_or(false);
+        }
+
+        guild_id
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(|origin| origin == role_guild_id)
+            .unwrap_or(false)
+    }
+
+    pub fn authorize_slash(
+        &self,
+        subject: &DiscordInteractionSubject,
+        channel_context: Option<&DiscordChannelContext>,
+        guild_id: Option<&str>,
+        dm_role_auth_guild: Option<&str>,
+    ) -> DiscordAuthDecision {
+        let is_dm = channel_context
+            .map(|ctx| ctx.is_dm)
+            .unwrap_or(guild_id.is_none());
+        if !is_dm {
+            let Some(context) = channel_context else {
+                if !self.allowed_channels.is_empty() {
+                    return DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedChannels);
+                }
+                if !self.ignored_channels.is_empty() {
+                    return DiscordAuthDecision::Deny(DiscordAuthDenyReason::IgnoredChannels);
+                }
+                return self.authorize_slash_identity(subject, guild_id, is_dm, dm_role_auth_guild);
+            };
+
+            if channel_matches(
+                &self.ignored_channels,
+                &context.channel_id,
+                context.parent_channel_id.as_deref(),
+            ) {
+                return DiscordAuthDecision::Deny(DiscordAuthDenyReason::IgnoredChannels);
+            }
+
+            if !self.allowed_channels.is_empty()
+                && !channel_matches(
+                    &self.allowed_channels,
+                    &context.channel_id,
+                    context.parent_channel_id.as_deref(),
+                )
+            {
+                return DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedChannels);
+            }
+        }
+
+        if !self.has_identity_policy() {
+            return DiscordAuthDecision::Allow;
+        }
+
+        self.authorize_slash_identity(subject, guild_id, is_dm, dm_role_auth_guild)
+    }
+
+    fn authorize_slash_identity(
+        &self,
+        subject: &DiscordInteractionSubject,
+        guild_id: Option<&str>,
+        is_dm: bool,
+        dm_role_auth_guild: Option<&str>,
+    ) -> DiscordAuthDecision {
+        if !self.has_identity_policy() {
+            return DiscordAuthDecision::Allow;
+        }
+
+        let user_allowed = subject
+            .user_id
+            .as_deref()
+            .map(|user_id| id_matches_any(user_id, &self.allowed_user_ids))
+            .unwrap_or(false);
+        if user_allowed || self.slash_role_allows(subject, guild_id, is_dm, dm_role_auth_guild) {
+            DiscordAuthDecision::Allow
+        } else {
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
+        }
+    }
+}
+
+/// Determine whether a Discord message may be routed without an explicit bot mention.
+pub fn discord_allows_message_without_mention(
+    require_mention: bool,
+    controls: &DiscordChannelControls,
+    context: &DiscordChannelContext,
+    bot_participated_in_thread: bool,
+    bot_mentioned: bool,
+) -> bool {
+    if bot_mentioned || !require_mention || context.is_dm || controls.allows_free_response(context)
+    {
+        return true;
+    }
+    context.is_thread && bot_participated_in_thread && !controls.thread_require_mention
+}
+
+/// Discord SendResult-style success handling for unauthorized slash notifications.
+pub fn discord_notify_result_counts_delivered(success: Option<bool>) -> bool {
+    success.unwrap_or(true)
+}
+
+/// Catalog entry used by the flat `/skill` Discord command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordSkillCommandEntry {
+    pub name: String,
+    pub description: String,
+    pub command_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscordSkillCommandDecision {
+    Unauthorized,
+    UnknownSkill { requested_name: String },
+    Dispatch { text: String },
+}
+
+pub fn discord_skill_autocomplete_choices(
+    policy: &DiscordInteractionAuthPolicy,
+    subject: &DiscordInteractionSubject,
+    channel_context: Option<&DiscordChannelContext>,
+    guild_id: Option<&str>,
+    dm_role_auth_guild: Option<&str>,
+    entries: &[DiscordSkillCommandEntry],
+    current: &str,
+) -> Vec<String> {
+    if policy.authorize_slash(subject, channel_context, guild_id, dm_role_auth_guild)
+        != DiscordAuthDecision::Allow
+    {
+        return Vec::new();
+    }
+
+    let needle = current.trim().to_ascii_lowercase();
+    entries
+        .iter()
+        .filter(|entry| {
+            needle.is_empty()
+                || entry.name.to_ascii_lowercase().contains(&needle)
+                || entry.description.to_ascii_lowercase().contains(&needle)
+        })
+        .take(25)
+        .map(|entry| entry.name.clone())
+        .collect()
+}
+
+pub fn discord_skill_command_decision(
+    policy: &DiscordInteractionAuthPolicy,
+    subject: &DiscordInteractionSubject,
+    channel_context: Option<&DiscordChannelContext>,
+    guild_id: Option<&str>,
+    dm_role_auth_guild: Option<&str>,
+    entries: &[DiscordSkillCommandEntry],
+    requested_name: &str,
+    args: &str,
+) -> DiscordSkillCommandDecision {
+    if policy.authorize_slash(subject, channel_context, guild_id, dm_role_auth_guild)
+        != DiscordAuthDecision::Allow
+    {
+        return DiscordSkillCommandDecision::Unauthorized;
+    }
+
+    let requested = requested_name.trim();
+    let Some(entry) = entries
+        .iter()
+        .find(|entry| entry.name.eq_ignore_ascii_case(requested))
+    else {
+        return DiscordSkillCommandDecision::UnknownSkill {
+            requested_name: requested.to_string(),
+        };
+    };
+
+    let args = args.trim();
+    let text = if args.is_empty() {
+        entry.command_key.clone()
+    } else {
+        format!("{} {}", entry.command_key, args)
+    };
+    DiscordSkillCommandDecision::Dispatch { text }
 }
 
 /// Channel-bound skill binding parsed from Python-style Discord config.
@@ -1107,6 +1413,9 @@ pub struct SlashCommand {
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Vec<SlashCommandOption>>,
+    /// Discord permission bitset string. "0" hides the command by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_member_permissions: Option<String>,
     /// Command type (1 = CHAT_INPUT, 2 = USER, 3 = MESSAGE). Default 1.
     #[serde(rename = "type", default = "default_command_type")]
     pub command_type: u8,
@@ -1131,6 +1440,12 @@ pub struct SlashCommandOption {
 pub struct SlashCommandChoice {
     pub name: String,
     pub value: serde_json::Value,
+}
+
+pub fn apply_owner_only_slash_visibility(commands: &mut [SlashCommand]) {
+    for command in commands {
+        command.default_member_permissions = Some("0".to_string());
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2911,6 +3226,338 @@ mod tests {
     }
 
     #[test]
+    fn discord_channel_controls_honor_wildcard_lists() {
+        let ignored = DiscordChannelControls {
+            ignored_channels: ["*"].into_iter().map(String::from).collect(),
+            ..DiscordChannelControls::default()
+        };
+        assert!(ignored.is_ignored(&DiscordChannelContext::server("700")));
+        assert!(ignored.is_ignored(&DiscordChannelContext::thread("701", "700")));
+        assert!(!ignored.is_ignored(&DiscordChannelContext::dm("700")));
+
+        let free = DiscordChannelControls {
+            free_response_channels: ["*"].into_iter().map(String::from).collect(),
+            ..DiscordChannelControls::default()
+        };
+        assert!(free.allows_free_response(&DiscordChannelContext::server("900")));
+        assert!(free.allows_free_response(&DiscordChannelContext::thread("901", "900")));
+        assert!(!free.should_auto_thread(&DiscordChannelContext::server("900")));
+    }
+
+    #[test]
+    fn discord_component_auth_user_or_role_matches_and_fails_closed() {
+        let policy = DiscordInteractionAuthPolicy {
+            allowed_user_ids: ["11111"].into_iter().map(String::from).collect(),
+            allowed_role_ids: ["42"].into_iter().map(String::from).collect(),
+            ..DiscordInteractionAuthPolicy::default()
+        };
+
+        assert!(policy.component_allows(&DiscordInteractionSubject::user("11111")));
+        assert!(policy.component_allows(&DiscordInteractionSubject {
+            user_id: Some("99999".into()),
+            role_ids: ["42"].into_iter().map(String::from).collect(),
+            role_guild_id: None,
+        }));
+        assert!(!policy.component_allows(&DiscordInteractionSubject {
+            user_id: Some("99999".into()),
+            role_ids: ["7"].into_iter().map(String::from).collect(),
+            role_guild_id: None,
+        }));
+        assert!(!policy.component_allows(&DiscordInteractionSubject::default()));
+        assert!(DiscordInteractionAuthPolicy::default()
+            .component_allows(&DiscordInteractionSubject::default()));
+    }
+
+    #[test]
+    fn discord_slash_auth_matches_channel_and_identity_policy() {
+        let policy = DiscordInteractionAuthPolicy {
+            allowed_user_ids: ["100200300"].into_iter().map(String::from).collect(),
+            allowed_channels: ["1111", "2222"].into_iter().map(String::from).collect(),
+            ignored_channels: ["9999"].into_iter().map(String::from).collect(),
+            ..DiscordInteractionAuthPolicy::default()
+        };
+        let subject = DiscordInteractionSubject::user("100200300");
+
+        assert_eq!(
+            policy.authorize_slash(
+                &subject,
+                Some(&DiscordChannelContext::server("1111")),
+                Some("guild-1"),
+                None,
+            ),
+            DiscordAuthDecision::Allow
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &subject,
+                Some(&DiscordChannelContext::server("3333")),
+                Some("guild-1"),
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedChannels)
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &subject,
+                Some(&DiscordChannelContext::server("9999")),
+                Some("guild-1"),
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::IgnoredChannels)
+        );
+        assert_eq!(
+            policy.authorize_slash(&subject, None, Some("guild-1"), None),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedChannels)
+        );
+        let identity_only_policy = DiscordInteractionAuthPolicy {
+            allowed_user_ids: ["100200300"].into_iter().map(String::from).collect(),
+            ..DiscordInteractionAuthPolicy::default()
+        };
+        assert_eq!(
+            identity_only_policy.authorize_slash(
+                &DiscordInteractionSubject::user("other"),
+                None,
+                Some("guild-1"),
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
+        );
+        assert_eq!(
+            identity_only_policy.authorize_slash(&subject, None, Some("guild-1"), None),
+            DiscordAuthDecision::Allow
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &DiscordInteractionSubject::user("other"),
+                Some(&DiscordChannelContext::server("1111")),
+                Some("guild-1"),
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &DiscordInteractionSubject::default(),
+                Some(&DiscordChannelContext::dm("dm-1")),
+                None,
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
+        );
+    }
+
+    #[test]
+    fn discord_slash_auth_scopes_roles_to_origin_guild_or_dm_opt_in() {
+        let policy = DiscordInteractionAuthPolicy {
+            allowed_role_ids: ["5555"].into_iter().map(String::from).collect(),
+            ..DiscordInteractionAuthPolicy::default()
+        };
+        let foreign_role = DiscordInteractionSubject::member("42", ["5555"], "guild-a");
+        let in_scope_role = DiscordInteractionSubject::member("42", ["5555"], "guild-b");
+
+        assert_eq!(
+            policy.authorize_slash(
+                &foreign_role,
+                Some(&DiscordChannelContext::server("9999")),
+                Some("guild-b"),
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &in_scope_role,
+                Some(&DiscordChannelContext::server("9999")),
+                Some("guild-b"),
+                None,
+            ),
+            DiscordAuthDecision::Allow
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &foreign_role,
+                Some(&DiscordChannelContext::dm("dm-1")),
+                None,
+                None,
+            ),
+            DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
+        );
+        assert_eq!(
+            policy.authorize_slash(
+                &foreign_role,
+                Some(&DiscordChannelContext::dm("dm-1")),
+                None,
+                Some("guild-a"),
+            ),
+            DiscordAuthDecision::Allow
+        );
+    }
+
+    #[test]
+    fn discord_mention_policy_covers_free_response_and_participated_threads() {
+        let controls = DiscordChannelControls {
+            free_response_channels: ["222"].into_iter().map(String::from).collect(),
+            ..DiscordChannelControls::default()
+        };
+        assert!(!discord_allows_message_without_mention(
+            true,
+            &controls,
+            &DiscordChannelContext::server("111"),
+            false,
+            false,
+        ));
+        assert!(discord_allows_message_without_mention(
+            true,
+            &controls,
+            &DiscordChannelContext::server("222"),
+            false,
+            false,
+        ));
+        assert!(discord_allows_message_without_mention(
+            true,
+            &controls,
+            &DiscordChannelContext::thread("333", "222"),
+            false,
+            false,
+        ));
+        assert!(discord_allows_message_without_mention(
+            true,
+            &controls,
+            &DiscordChannelContext::thread("444", "111"),
+            true,
+            false,
+        ));
+        let strict_threads = DiscordChannelControls {
+            thread_require_mention: true,
+            ..DiscordChannelControls::default()
+        };
+        assert!(!discord_allows_message_without_mention(
+            true,
+            &strict_threads,
+            &DiscordChannelContext::thread("444", "111"),
+            true,
+            false,
+        ));
+        assert!(discord_allows_message_without_mention(
+            true,
+            &controls,
+            &DiscordChannelContext::server("111"),
+            false,
+            true,
+        ));
+    }
+
+    #[test]
+    fn discord_unauthorized_notify_soft_fail_falls_through() {
+        assert!(!discord_notify_result_counts_delivered(Some(false)));
+        assert!(discord_notify_result_counts_delivered(Some(true)));
+        assert!(discord_notify_result_counts_delivered(None));
+    }
+
+    #[test]
+    fn discord_skill_slash_auth_gates_autocomplete_and_handler_before_lookup() {
+        let policy = DiscordInteractionAuthPolicy {
+            allowed_user_ids: ["100200300"].into_iter().map(String::from).collect(),
+            ..DiscordInteractionAuthPolicy::default()
+        };
+        let entries = vec![
+            DiscordSkillCommandEntry {
+                name: "alpha".into(),
+                description: "First skill".into(),
+                command_key: "/alpha".into(),
+            },
+            DiscordSkillCommandEntry {
+                name: "beta".into(),
+                description: "Search documents".into(),
+                command_key: "/beta".into(),
+            },
+        ];
+        let channel = DiscordChannelContext::server("1111");
+
+        let unauthorized = DiscordInteractionSubject::user("999999999");
+        assert!(discord_skill_autocomplete_choices(
+            &policy,
+            &unauthorized,
+            Some(&channel),
+            Some("guild-1"),
+            None,
+            &entries,
+            ""
+        )
+        .is_empty());
+        assert_eq!(
+            discord_skill_command_decision(
+                &policy,
+                &unauthorized,
+                Some(&channel),
+                Some("guild-1"),
+                None,
+                &entries,
+                "alpha",
+                "extra"
+            ),
+            DiscordSkillCommandDecision::Unauthorized
+        );
+        assert_eq!(
+            discord_skill_command_decision(
+                &policy,
+                &unauthorized,
+                Some(&channel),
+                Some("guild-1"),
+                None,
+                &entries,
+                "definitely-not-a-skill",
+                ""
+            ),
+            DiscordSkillCommandDecision::Unauthorized
+        );
+
+        let authorized = DiscordInteractionSubject::user("100200300");
+        assert_eq!(
+            discord_skill_autocomplete_choices(
+                &policy,
+                &authorized,
+                Some(&channel),
+                Some("guild-1"),
+                None,
+                &entries,
+                "doc"
+            ),
+            vec!["beta".to_string()]
+        );
+        assert_eq!(
+            discord_skill_command_decision(
+                &policy,
+                &authorized,
+                Some(&channel),
+                Some("guild-1"),
+                None,
+                &entries,
+                "alpha",
+                "extra args"
+            ),
+            DiscordSkillCommandDecision::Dispatch {
+                text: "/alpha extra args".into()
+            }
+        );
+        assert_eq!(
+            discord_skill_command_decision(
+                &policy,
+                &authorized,
+                Some(&channel),
+                Some("guild-1"),
+                None,
+                &entries,
+                "missing",
+                ""
+            ),
+            DiscordSkillCommandDecision::UnknownSkill {
+                requested_name: "missing".into()
+            }
+        );
+    }
+
+    #[test]
     fn discord_channel_skill_bindings_resolve_exact_parent_and_deduped_skills() {
         let bindings = DiscordChannelSkillBinding::list_from_json(Some(&serde_json::json!([
             {"id": "100", "skills": ["a", "b", "a", "c", "b"]},
@@ -3574,6 +4221,7 @@ mod tests {
         let cmd = SlashCommand {
             name: "greet".into(),
             description: "Say hello".into(),
+            default_member_permissions: None,
             command_type: 1,
             options: Some(vec![
                 SlashCommandOption {
@@ -3611,6 +4259,23 @@ mod tests {
         let choices = options[1]["choices"].as_array().unwrap();
         assert_eq!(choices.len(), 2);
         assert_eq!(choices[0]["name"], "Formal");
+    }
+
+    #[test]
+    fn slash_owner_only_visibility_sets_zero_permissions() {
+        let mut commands = vec![SlashCommand {
+            name: "restart".into(),
+            description: "Restart Hermes".into(),
+            options: None,
+            default_member_permissions: None,
+            command_type: 1,
+        }];
+
+        apply_owner_only_slash_visibility(&mut commands);
+
+        assert_eq!(commands[0].default_member_permissions.as_deref(), Some("0"));
+        let json = serde_json::to_value(&commands[0]).unwrap();
+        assert_eq!(json["default_member_permissions"], "0");
     }
 
     // -- Emoji encoding tests -----------------------------------------------

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T08:17:55.647701+00:00",
+  "generated_at_utc": "2026-05-30T08:46:49.435761+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "25cfd0b9dd2d95fcb1eb5fb6eb7417a1da6a69d5",
+    "local_sha": "397bfdb4d67885994d1252c6682c606cbf34de94",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 849,
+    "commits_ahead": 851,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 708,
+    "local_patch_unique": 709,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 388977
+    "tree_deletions": 389430
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 708,
+    "local_patch_unique": 709,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T08:17:55.647701+00:00`
+Generated: `2026-05-30T08:46:49.435761+00:00`
 
 ## Scope
 
-- Local ref: `main` (`25cfd0b9dd2d95fcb1eb5fb6eb7417a1da6a69d5`)
+- Local ref: `main` (`397bfdb4d67885994d1252c6682c606cbf34de94`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T08:17:55.647701+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 849 |
+| Commits ahead local (`local` ancestry only) | 851 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 708 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 709 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 388977 |
+| Deletions (`local` vs `upstream`) | 389430 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T08:17:55.647701+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `708`
+- Local unique by patch-id: `709`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3766,16 +3766,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_component_auth.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "5758e82561e041f436c39543717fb826a2da2230",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_component_auth.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "95d746b80ee9b05ae888e6ef2e76f86cb7799c5c",
       "workstream": "WS6"
@@ -3811,16 +3811,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_free_response.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "91b23bd860294c94fe7e7d3e0c36092ee97f01b7",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_free_response.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e2133d56c3585995e94f8cffb282cf1f726b797c",
       "workstream": "WS6"
@@ -3931,16 +3931,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_roles_dm_scope.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0f10ba79ae1fa96feba43c8ddb839c5c81ebee74",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_roles_dm_scope.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "19d65a5998c39e5dff1f77381232da6307daf5ae",
       "workstream": "WS6"
@@ -3961,16 +3961,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_discord_slash_auth.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e51f240e3aa5703e26620bb51d2e25b83e0a51b4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_discord_slash_auth.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "39d06ba74fb8246453853aa392dae9dd551440c6",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T08:17:53.629547+00:00",
+  "generated_at_utc": "2026-05-30T08:46:47.522814+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "25cfd0b9dd2d95fcb1eb5fb6eb7417a1da6a69d5",
+    "local_sha": "397bfdb4d67885994d1252c6682c606cbf34de94",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 727,
-      "intentional_divergence": 122,
+      "functional": 723,
+      "intentional_divergence": 126,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 291,
-      "rust_equivalent_or_contract_test_required": 648,
+      "not_required_for_runtime": 295,
+      "rust_equivalent_or_contract_test_required": 644,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 122,
+      "cleared_intentional_divergence": 126,
       "cleared_non_runtime": 169,
-      "pending_review": 727
+      "pending_review": 723
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 122,
+    "cleared_intentional_divergence": 126,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 727,
+    "pending_review": 723,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T08:17:53.629547+00:00`
+Generated: `2026-05-30T08:46:47.522814+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `727`
+- Pending functional review: `723`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `122`
+- Cleared intentional divergence: `126`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 122 |
+| `cleared_intentional_divergence` | 126 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 727 |
+| `pending_review` | 723 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T08:17:53.629547+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 159 |
+| `tests/gateway` | 155 |
 | `tests/tools` | 137 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -171,6 +171,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_component_auth.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord component user-or-role authorization and fail-closed behavior is covered by Rust DiscordInteractionAuthPolicy component checks for empty allowlists, user matches, role-only matches, missing role data, and missing users.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_channel_controls.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord ignored_channels and no_thread_channels behavior is covered by Rust DiscordChannelControls tests for CSV/YAML parsing, DM bypass, thread-parent matching, auto-thread suppression, config env bridging, and config-to-env hydration precedence.",
@@ -181,6 +188,13 @@
       "path": "tests/gateway/test_discord_channel_skills.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord channel_skill_bindings resolver intent is covered by Rust DiscordChannelSkillBinding parsing and DiscordAdapter::resolve_channel_skills tests for channel matches, parent matches, single-skill shorthand, no-match, and ordered deduplication.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_free_response.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord free-response and mention-gating behavior is covered by Rust DiscordChannelControls and discord_allows_message_without_mention tests for DM bypass, channel and wildcard free-response lists, forum/thread parents, participated threads, reply auto-thread suppression, and voice-linked text channels.",
       "owner": "sheawinkler",
       "ticket": 25
     },
@@ -213,9 +227,23 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_discord_roles_dm_scope.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord role allowlist scoping is covered by Rust DiscordInteractionAuthPolicy tests that reject cross-guild guild and DM role matches, require dm_role_auth_guild opt-in for DMs, allow same-guild role matches, and preserve user-ID allowlist behavior.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_send.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord send retry and forum-post behavior is covered by Rust hermes-gateway reply-reference retry classifiers, chunk reference-mode payload tests, forum thread payload contracts, and DiscordAdapter forum send outcome handling.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_discord_slash_auth.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Discord slash authorization is covered by Rust DiscordInteractionAuthPolicy and gateway access-policy tests for user/role/channel allowlists, ignored-channel precedence, wildcard channels, malformed context fail-closed behavior, owner-only visibility semantics, notification soft-failure handling, and /skill autocomplete/handler auth-before-lookup decisions.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- add Rust Discord interaction auth policy helpers for component, slash, and `/skill` gates
- wire Discord channel allow/ignore policy through config/env into gateway routing
- classify the covered upstream Discord auth/free-response/role-scope tests as intentional Rust parity divergences and regenerate parity docs

## Local verification
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-runtime-placeholders.sh`
- `bash scripts/check-rust-runtime-no-python.sh`
- `rg "max_shared_different|max-shared-different|max shared different" . --glob '!target/**' --glob '!**/.git/**'` expected no matches
- `cargo test -p hermes-gateway --features discord`
- `cargo test -p hermes-config`
- `cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests`
- `python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main`
- `cargo build -p hermes-cli`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md`
