### PR TITLE
Add file tool security parity contracts

### DIFF
--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -263,7 +263,16 @@ fn lookup_home_for_username(username: &str) -> Option<PathBuf> {
 
 fn resolve_path(input: &str) -> Result<PathBuf, AgentError> {
     if !input.starts_with('~') {
-        return Ok(PathBuf::from(input));
+        let path = PathBuf::from(input);
+        if path.is_absolute() {
+            return Ok(path);
+        }
+        if let Some(cwd) = std::env::var_os("TERMINAL_CWD") {
+            if !cwd.is_empty() {
+                return Ok(PathBuf::from(cwd).join(path));
+            }
+        }
+        return Ok(path);
     }
 
     let rest = &input[1..];
@@ -1216,6 +1225,33 @@ mod tests {
         // Cleanup
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_relative_file_paths_use_terminal_cwd() {
+        let td = tempdir().unwrap();
+        let terminal_cwd = td.path().join("worktree");
+        std::fs::create_dir_all(&terminal_cwd).unwrap();
+        let _cwd_guard = EnvGuard::set("TERMINAL_CWD", terminal_cwd.to_string_lossy().as_ref());
+        let backend = LocalBackend::default();
+
+        backend
+            .write_file("nested/file.txt", "from terminal cwd")
+            .await
+            .unwrap();
+
+        let expected = terminal_cwd.join("nested/file.txt");
+        assert_eq!(
+            std::fs::read_to_string(&expected).unwrap(),
+            "from terminal cwd"
+        );
+        assert_eq!(
+            backend
+                .read_file("nested/file.txt", None, None)
+                .await
+                .unwrap(),
+            "from terminal cwd"
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/backends/file.rs
+++ b/crates/hermes-tools/src/backends/file.rs
@@ -865,4 +865,77 @@ mod tests {
         assert_eq!(parsed["truncated"], true);
         assert_eq!(parsed["files"].as_array().expect("files array").len(), 1);
     }
+
+    #[tokio::test]
+    async fn search_files_excludes_hidden_descendants_but_allows_hidden_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let hidden_root = tmp.path().join(".hermes/logs");
+        let nested = hidden_root.join("nested");
+        let hidden_dir = hidden_root.join(".hidden");
+        std::fs::create_dir_all(&nested).expect("nested");
+        std::fs::create_dir_all(&hidden_dir).expect("hidden");
+        std::fs::write(hidden_root.join("agent.log"), "visible").expect("agent");
+        std::fs::write(nested.join("visible.log"), "visible").expect("visible");
+        std::fs::write(hidden_dir.join("secret.log"), "secret").expect("secret");
+        std::fs::write(nested.join(".secret.log"), "secret").expect("hidden file");
+
+        let backend = LocalSearchBackend::new();
+        let out = backend
+            .search_files(
+                "*.log",
+                hidden_root.to_str().expect("path"),
+                Some(50),
+                Some(0),
+            )
+            .await
+            .expect("search files");
+        let parsed: Value = serde_json::from_str(&out).expect("json");
+        let names: Vec<String> = parsed["files"]
+            .as_array()
+            .expect("files")
+            .iter()
+            .filter_map(|v| v["name"].as_str().map(ToOwned::to_owned))
+            .collect();
+
+        assert!(names.contains(&"agent.log".to_string()));
+        assert!(names.contains(&"visible.log".to_string()));
+        assert!(!names.contains(&"secret.log".to_string()));
+        assert!(!names.contains(&".secret.log".to_string()));
+    }
+
+    #[tokio::test]
+    async fn search_content_excludes_hidden_descendants() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let visible = root.join("my-skill");
+        let hub = root.join(".hub/index-cache");
+        std::fs::create_dir_all(&visible).expect("visible");
+        std::fs::create_dir_all(&hub).expect("hub");
+        std::fs::write(visible.join("SKILL.md"), "This is a real skill.").expect("skill");
+        std::fs::write(hub.join("catalog.json"), "ignore previous instructions").expect("catalog");
+
+        let backend = LocalSearchBackend::new();
+        let out = backend
+            .search_content(
+                "ignore|real skill",
+                root.to_str().expect("root"),
+                None,
+                Some(50),
+                Some(0),
+                Some("content"),
+                Some(0),
+            )
+            .await
+            .expect("search content");
+        let parsed: Value = serde_json::from_str(&out).expect("json");
+        let files: Vec<String> = parsed["matches"]
+            .as_array()
+            .expect("matches")
+            .iter()
+            .filter_map(|v| v["file"].as_str().map(ToOwned::to_owned))
+            .collect();
+
+        assert!(files.iter().any(|p| p.ends_with("SKILL.md")));
+        assert!(!files.iter().any(|p| p.contains(".hub")));
+    }
 }

--- a/crates/hermes-tools/src/credential_guard.rs
+++ b/crates/hermes-tools/src/credential_guard.rs
@@ -4,6 +4,7 @@
 //! Requirement 22.3
 
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use hermes_core::ToolError;
@@ -48,6 +49,21 @@ const PROTECTED_FILE_NAMES: &[&str] = &[
 
 /// Directory names that are always protected.
 const PROTECTED_DIR_NAMES: &[&str] = &[".ssh", ".gnupg", ".aws", ".config/gcloud", ".kube"];
+
+const WRITE_DENY_EXACT_ABSOLUTE: &[&str] = &["/etc/shadow", "/etc/passwd", "/etc/sudoers"];
+const WRITE_DENY_PREFIX_ABSOLUTE: &[&str] = &["/etc/sudoers.d", "/etc/systemd/system"];
+const WRITE_DENY_HOME_EXACT: &[&str] = &[
+    ".netrc",
+    ".bashrc",
+    ".zshrc",
+    ".profile",
+    ".bash_profile",
+    ".zprofile",
+    ".npmrc",
+    ".pypirc",
+    ".pgpass",
+];
+const WRITE_DENY_HOME_PREFIX: &[&str] = &[".ssh", ".aws", ".gnupg", ".kube"];
 
 // ---------------------------------------------------------------------------
 // Content secret patterns
@@ -169,6 +185,13 @@ impl CredentialGuard {
     /// Returns `Err(ToolError)` if the target is a protected file or if the
     /// content contains detectable secrets (when content scanning is enabled).
     pub fn check_write_access(&self, path: &Path, content: &str) -> Result<(), ToolError> {
+        if is_write_denied(path) {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Write denied: '{}' is a protected system or credential path",
+                path.display()
+            )));
+        }
+
         // Check path first
         if self.is_protected_file(path) {
             return Err(ToolError::ExecutionFailed(format!(
@@ -205,6 +228,98 @@ impl Default for CredentialGuard {
 /// (using the built-in pattern list only).
 pub fn is_protected_file(path: &Path) -> bool {
     is_protected_file_with_extra(path, &[])
+}
+
+/// Check whether a file path is write-denied even if it is not a credential
+/// file by name. This covers sensitive system files, shell profiles, package
+/// manager credential files, and profile-aware `$HERMES_HOME/.env`.
+pub fn is_write_denied(path: &Path) -> bool {
+    is_write_denied_with_roots(
+        path,
+        std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+        std::env::var_os("HERMES_HOME")
+            .map(PathBuf::from)
+            .as_deref(),
+    )
+}
+
+fn expand_home(path: &Path, home: Option<&Path>) -> PathBuf {
+    let raw = path.to_string_lossy();
+    if raw == "~" {
+        return home
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf());
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        if let Some(home) = home {
+            return home.join(rest);
+        }
+    }
+    path.to_path_buf()
+}
+
+fn path_has_component_prefix(path: &Path, root: &Path, prefix: &str) -> bool {
+    let rel = match path.strip_prefix(root) {
+        Ok(rel) => rel,
+        Err(_) => return false,
+    };
+    let Some(first) = rel.components().next().and_then(|c| match c {
+        std::path::Component::Normal(os) => os.to_str(),
+        _ => None,
+    }) else {
+        return false;
+    };
+    first == prefix
+}
+
+/// Root-injected form for deterministic tests and callers that already know
+/// the active profile/home roots.
+pub fn is_write_denied_with_roots(
+    path: &Path,
+    home: Option<&Path>,
+    hermes_home: Option<&Path>,
+) -> bool {
+    let expanded = expand_home(path, home);
+    let normalized = expanded.to_string_lossy();
+
+    if WRITE_DENY_EXACT_ABSOLUTE
+        .iter()
+        .any(|candidate| normalized == *candidate)
+    {
+        return true;
+    }
+    if WRITE_DENY_PREFIX_ABSOLUTE
+        .iter()
+        .any(|prefix| normalized == *prefix || normalized.starts_with(&format!("{prefix}/")))
+    {
+        return true;
+    }
+
+    if let Some(home) = home {
+        if let Ok(rel) = expanded.strip_prefix(home) {
+            let rel_str = rel.to_string_lossy();
+            if WRITE_DENY_HOME_EXACT
+                .iter()
+                .any(|candidate| rel_str == *candidate)
+            {
+                return true;
+            }
+            if WRITE_DENY_HOME_PREFIX
+                .iter()
+                .any(|prefix| path_has_component_prefix(&expanded, home, prefix))
+            {
+                return true;
+            }
+        }
+    }
+
+    if let Some(hermes_home) = hermes_home {
+        if expanded == hermes_home.join(".env") {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn is_protected_file_with_extra(path: &Path, extra: &[String]) -> bool {
@@ -347,6 +462,9 @@ mod tests {
         assert!(guard
             .check_write_access(Path::new(".env"), "hello")
             .is_err());
+        assert!(guard
+            .check_write_access(Path::new("/etc/passwd"), "root:x:0:0")
+            .is_err());
     }
 
     #[test]
@@ -418,5 +536,94 @@ mod tests {
         assert!(is_protected_file(Path::new("Credentials.JSON")));
         assert!(is_protected_file(Path::new("ID_RSA")));
         assert!(is_protected_file(Path::new("Server.KEY")));
+    }
+
+    #[test]
+    fn write_deny_matches_upstream_sensitive_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let hermes_home = tmp.path().join("profile");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&hermes_home).expect("profile");
+
+        for path in ["/etc/shadow", "/etc/passwd", "/etc/sudoers"] {
+            assert!(is_write_denied_with_roots(
+                Path::new(path),
+                Some(&home),
+                Some(&hermes_home)
+            ));
+        }
+        assert!(is_write_denied_with_roots(
+            Path::new("/etc/sudoers.d/custom"),
+            Some(&home),
+            Some(&hermes_home)
+        ));
+        assert!(is_write_denied_with_roots(
+            Path::new("/etc/systemd/system/evil.service"),
+            Some(&home),
+            Some(&hermes_home)
+        ));
+
+        for rel in [
+            ".ssh/authorized_keys",
+            ".ssh/id_ed25519",
+            ".aws/credentials",
+            ".gnupg/secring.gpg",
+            ".kube/config",
+            ".netrc",
+            ".bashrc",
+            ".zshrc",
+            ".profile",
+            ".bash_profile",
+            ".zprofile",
+            ".npmrc",
+            ".pypirc",
+            ".pgpass",
+        ] {
+            assert!(is_write_denied_with_roots(
+                &home.join(rel),
+                Some(&home),
+                Some(&hermes_home)
+            ));
+        }
+
+        assert!(is_write_denied_with_roots(
+            &hermes_home.join(".env"),
+            Some(&home),
+            Some(&hermes_home)
+        ));
+        assert!(!is_write_denied_with_roots(
+            &hermes_home.join("config.yaml"),
+            Some(&home),
+            Some(&hermes_home)
+        ));
+        assert!(!is_write_denied_with_roots(
+            Path::new("/tmp/safe_file.txt"),
+            Some(&home),
+            Some(&hermes_home)
+        ));
+        assert!(!is_write_denied_with_roots(
+            Path::new("/home/user/project/main.py"),
+            Some(&home),
+            Some(&hermes_home)
+        ));
+    }
+
+    #[test]
+    fn write_deny_expands_tilde_against_home_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(&home).expect("home");
+
+        assert!(is_write_denied_with_roots(
+            Path::new("~/.ssh/id_rsa"),
+            Some(&home),
+            None
+        ));
+        assert!(is_write_denied_with_roots(
+            Path::new("~/.netrc"),
+            Some(&home),
+            None
+        ));
     }
 }

--- a/crates/hermes-tools/src/tools/credential_files.rs
+++ b/crates/hermes-tools/src/tools/credential_files.rs
@@ -1,10 +1,129 @@
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
 
 use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
 
 pub struct CredentialFilesHandler;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialFileMount {
+    pub host_path: PathBuf,
+    pub container_path: String,
+}
+
+fn entry_path(entry: &Value) -> Option<&str> {
+    match entry {
+        Value::String(path) => Some(path.as_str()),
+        Value::Object(map) => map
+            .get("path")
+            .and_then(Value::as_str)
+            .or_else(|| map.get("name").and_then(Value::as_str)),
+        _ => None,
+    }
+}
+
+fn normalize_container_base(container_base: &str) -> &str {
+    container_base.trim_end_matches('/')
+}
+
+pub fn credential_file_mount_for_entry(
+    hermes_home: &Path,
+    container_base: &str,
+    entry: &Value,
+) -> Result<Option<CredentialFileMount>, String> {
+    let Some(raw_path) = entry_path(entry).map(str::trim).filter(|p| !p.is_empty()) else {
+        return Ok(None);
+    };
+
+    let rel = Path::new(raw_path);
+    if rel.is_absolute() {
+        return Err("credential file path must be relative to HERMES_HOME".to_string());
+    }
+    if rel.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        )
+    }) {
+        return Err("credential file path escapes HERMES_HOME".to_string());
+    }
+
+    let home = hermes_home
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve HERMES_HOME: {e}"))?;
+    let host_path = home.join(rel);
+    if !host_path.exists() {
+        return Ok(None);
+    }
+    let resolved = host_path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve credential file: {e}"))?;
+    if resolved.strip_prefix(&home).is_err() {
+        return Err("credential file symlink escapes HERMES_HOME".to_string());
+    }
+
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    Ok(Some(CredentialFileMount {
+        host_path: resolved,
+        container_path: format!(
+            "{}/{}",
+            normalize_container_base(container_base),
+            rel_str.trim_start_matches('/')
+        ),
+    }))
+}
+
+pub fn credential_file_mounts(
+    hermes_home: &Path,
+    container_base: &str,
+    entries: &[Value],
+) -> (Vec<CredentialFileMount>, Vec<String>, Vec<String>) {
+    let mut mounts = Vec::new();
+    let mut missing = Vec::new();
+    let mut rejected = Vec::new();
+
+    for entry in entries {
+        let label = entry_path(entry).unwrap_or("").to_string();
+        match credential_file_mount_for_entry(hermes_home, container_base, entry) {
+            Ok(Some(mount)) => mounts.push(mount),
+            Ok(None) => {
+                if !label.is_empty() {
+                    missing.push(label);
+                }
+            }
+            Err(_) => {
+                if !label.is_empty() {
+                    rejected.push(label);
+                }
+            }
+        }
+    }
+
+    (mounts, missing, rejected)
+}
+
+pub fn path_contains_filtered_hidden_component(path: &Path) -> bool {
+    let native_match = path.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::Normal(part)
+                if matches!(part.to_str(), Some(".git" | ".github" | ".hub"))
+        )
+    });
+    native_match
+        || path
+            .to_string_lossy()
+            .split(['/', '\\'])
+            .any(|part| matches!(part, ".git" | ".github" | ".hub"))
+}
+
+pub fn resolved_path_escapes_root(resolved: &Path, root: &Path) -> bool {
+    resolved.strip_prefix(root).is_err()
+}
 
 #[async_trait]
 impl ToolHandler for CredentialFilesHandler {
@@ -25,5 +144,132 @@ impl ToolHandler for CredentialFilesHandler {
             "Check credential file existence/metadata.",
             JsonSchema::object(props, vec!["path".into()]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credential_mount_accepts_path_name_and_string_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join(".hermes");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::write(home.join("token.json"), "{}").expect("token");
+        std::fs::write(home.join("google_token.json"), "{}").expect("google");
+        std::fs::write(home.join("secret.key"), "key").expect("key");
+
+        let entries = vec![
+            json!({"path": "token.json"}),
+            json!({"name": "google_token.json", "description": "OAuth token"}),
+            json!("secret.key"),
+        ];
+        let (mounts, missing, rejected) = credential_file_mounts(&home, "/root/.hermes", &entries);
+
+        assert!(missing.is_empty());
+        assert!(rejected.is_empty());
+        let container_paths: Vec<&str> = mounts.iter().map(|m| m.container_path.as_str()).collect();
+        assert_eq!(
+            container_paths,
+            vec![
+                "/root/.hermes/token.json",
+                "/root/.hermes/google_token.json",
+                "/root/.hermes/secret.key"
+            ]
+        );
+    }
+
+    #[test]
+    fn credential_mount_reports_missing_and_prefers_path_over_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join(".hermes");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::write(home.join("real.json"), "{}").expect("real");
+
+        let entries = vec![
+            json!({"name": "does_not_exist.json"}),
+            json!({"path": "real.json", "name": "wrong.json"}),
+        ];
+        let (mounts, missing, rejected) = credential_file_mounts(&home, "/root/.hermes", &entries);
+
+        assert_eq!(missing, vec!["does_not_exist.json"]);
+        assert!(rejected.is_empty());
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].container_path, "/root/.hermes/real.json");
+    }
+
+    #[test]
+    fn credential_mount_rejects_traversal_absolute_and_symlink_escape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join(".hermes");
+        std::fs::create_dir_all(&home).expect("home");
+        let outside = tmp.path().join("sensitive.json");
+        std::fs::write(&outside, "{}").expect("outside");
+
+        for entry in [
+            json!("../sensitive.json"),
+            json!("../../.ssh/id_rsa"),
+            json!(outside.to_string_lossy().to_string()),
+        ] {
+            assert!(
+                credential_file_mount_for_entry(&home, "/root/.hermes", &entry).is_err(),
+                "{entry}"
+            );
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            symlink(&outside, home.join("evil_link.json")).expect("symlink");
+            assert!(credential_file_mount_for_entry(
+                &home,
+                "/root/.hermes",
+                &json!("evil_link.json")
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn hidden_component_filter_is_component_based() {
+        assert!(path_contains_filtered_hidden_component(Path::new(
+            "/home/user/.hermes/skills/.hub/quarantine/evil/SKILL.md"
+        )));
+        assert!(path_contains_filtered_hidden_component(Path::new(
+            "/home/user/.hermes/skills/.git/hooks/SKILL.md"
+        )));
+        assert!(path_contains_filtered_hidden_component(Path::new(
+            r"C:\Users\me\.hermes\skills\.hub\quarantine\evil-skill\SKILL.md"
+        )));
+        assert!(path_contains_filtered_hidden_component(Path::new(
+            "/home/user/.hermes/skills/.github/workflows/SKILL.md"
+        )));
+        assert!(!path_contains_filtered_hidden_component(Path::new(
+            "/home/user/.hermes/skills/.my-hidden-skill/SKILL.md"
+        )));
+        assert!(!path_contains_filtered_hidden_component(Path::new(
+            "/home/user/.hermes/skills/my-hub-skill/SKILL.md"
+        )));
+    }
+
+    #[test]
+    fn resolved_path_escape_check_respects_directory_boundaries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills = tmp.path().join("skills");
+        let skill_dir = skills.join("axolotl");
+        let sibling = skills.join("axolotl-backdoor");
+        std::fs::create_dir_all(&skill_dir).expect("skill");
+        std::fs::create_dir_all(&sibling).expect("sibling");
+
+        assert!(!resolved_path_escapes_root(
+            &skill_dir.join("utils/helper.py"),
+            &skill_dir
+        ));
+        assert!(resolved_path_escapes_root(
+            &sibling.join("evil.py"),
+            &skill_dir
+        ));
+        assert!(!resolved_path_escapes_root(&skill_dir, &skill_dir));
     }
 }

--- a/crates/hermes-tools/src/tools/file.rs
+++ b/crates/hermes-tools/src/tools/file.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 use hermes_core::{tool_schema, JsonSchema, TerminalBackend, ToolError, ToolHandler, ToolSchema};
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use crate::credential_guard::CredentialGuard;
@@ -16,6 +16,9 @@ const DEFAULT_READ_LIMIT: i64 = 500;
 const MAX_READ_LIMIT: i64 = 2000;
 const DEFAULT_SEARCH_OFFSET: i64 = 0;
 const DEFAULT_SEARCH_LIMIT: i64 = 50;
+pub const DEFAULT_MAX_READ_CHARS: usize = 200_000;
+pub const READ_DEDUP_STATUS_MESSAGE: &str =
+    "File unchanged since last read; content omitted. Use offset/limit or edit only from known content.";
 
 fn parse_int_param(raw: Option<&Value>, default: i64) -> i64 {
     let Some(v) = raw else {
@@ -57,6 +60,101 @@ fn normalize_search_pagination(
     (offset, limit)
 }
 
+pub fn is_blocked_device_path(path: &Path) -> bool {
+    let raw = path.to_string_lossy();
+    matches!(
+        raw.as_ref(),
+        "/dev/zero"
+            | "/dev/random"
+            | "/dev/urandom"
+            | "/dev/stdin"
+            | "/dev/stdout"
+            | "/dev/stderr"
+            | "/dev/tty"
+            | "/dev/console"
+            | "/dev/fd/0"
+            | "/dev/fd/1"
+            | "/dev/fd/2"
+    ) || matches!(
+        raw.as_ref(),
+        "/proc/self/fd/0" | "/proc/self/fd/1" | "/proc/self/fd/2"
+    ) || RegexLikeProcFd::matches(&raw)
+}
+
+struct RegexLikeProcFd;
+
+impl RegexLikeProcFd {
+    fn matches(raw: &str) -> bool {
+        let Some(rest) = raw.strip_prefix("/proc/") else {
+            return false;
+        };
+        let Some((pid, fd)) = rest.split_once("/fd/") else {
+            return false;
+        };
+        !pid.is_empty() && pid.chars().all(|c| c.is_ascii_digit()) && matches!(fd, "0" | "1" | "2")
+    }
+}
+
+fn expand_user_path(path: &str) -> Option<PathBuf> {
+    if path == "~" {
+        return std::env::var_os("HOME").map(PathBuf::from);
+    }
+    path.strip_prefix("~/").and_then(|rest| {
+        std::env::var_os("HOME").map(|home| {
+            let mut expanded = PathBuf::from(home);
+            expanded.push(rest);
+            expanded
+        })
+    })
+}
+
+fn clean_path(path: PathBuf) -> PathBuf {
+    let mut cleaned = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                cleaned.pop();
+            }
+            Component::Normal(part) => cleaned.push(part),
+            Component::RootDir | Component::Prefix(_) => cleaned.push(component.as_os_str()),
+        }
+    }
+    if cleaned.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        cleaned
+    }
+}
+
+/// Resolve file-tool paths the same way the Python tool facade did:
+/// user expansion first, absolute paths unchanged, then live terminal cwd,
+/// then `TERMINAL_CWD`, then process cwd for relative paths.
+pub fn resolve_tool_path(
+    input: &str,
+    terminal_cwd: Option<&Path>,
+    live_cwd: Option<&Path>,
+) -> PathBuf {
+    let expanded = expand_user_path(input).unwrap_or_else(|| PathBuf::from(input));
+    if expanded.is_absolute() {
+        return clean_path(expanded);
+    }
+
+    let base = live_cwd
+        .or(terminal_cwd)
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    clean_path(base.join(expanded))
+}
+
+pub fn content_looks_like_internal_read_status(content: &str) -> bool {
+    if !content.contains(READ_DEDUP_STATUS_MESSAGE) {
+        return false;
+    }
+    content.chars().count() <= READ_DEDUP_STATUS_MESSAGE.chars().count() + 128
+}
+
 // ---------------------------------------------------------------------------
 // ReadFileHandler
 // ---------------------------------------------------------------------------
@@ -80,14 +178,31 @@ impl ToolHandler for ReadFileHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'path' parameter".into()))?;
 
+        if is_blocked_device_path(Path::new(path)) {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Refusing to read device file '{}'",
+                path
+            )));
+        }
+
         CredentialGuard::new().check_read_access(Path::new(path))?;
 
         let (offset, limit) = normalize_read_pagination(params.get("offset"), params.get("limit"));
 
-        self.backend
+        let content = self
+            .backend
             .read_file(path, offset, limit)
             .await
-            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        if limit.is_none() && content.chars().count() > DEFAULT_MAX_READ_CHARS {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Read safety limit exceeded for '{}'; use offset and limit to read smaller chunks",
+                path
+            )));
+        }
+
+        Ok(content)
     }
 
     fn schema(&self) -> ToolSchema {
@@ -149,6 +264,12 @@ impl ToolHandler for WriteFileHandler {
             .get("content")
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'content' parameter".into()))?;
+
+        if content_looks_like_internal_read_status(content) {
+            return Err(ToolError::ExecutionFailed(
+                "Write denied: content appears to be internal read_file status text".into(),
+            ));
+        }
 
         CredentialGuard::new().check_write_access(Path::new(path), content)?;
 
@@ -545,5 +666,143 @@ mod tests {
         let (offset, limit) = normalize_search_pagination(Some(&json!(3)), Some(&json!(0)));
         assert_eq!(offset, Some(3));
         assert_eq!(limit, Some(1));
+    }
+
+    #[test]
+    fn blocked_device_detection_matches_python_guard() {
+        for path in [
+            "/dev/zero",
+            "/dev/random",
+            "/dev/urandom",
+            "/dev/stdin",
+            "/dev/tty",
+            "/dev/console",
+            "/dev/stdout",
+            "/dev/stderr",
+            "/dev/fd/0",
+            "/dev/fd/1",
+            "/dev/fd/2",
+            "/proc/self/fd/0",
+            "/proc/12345/fd/2",
+        ] {
+            assert!(is_blocked_device_path(Path::new(path)), "{path}");
+        }
+
+        for path in [
+            "/dev/null",
+            "/dev/sda1",
+            "/proc/self/fd/3",
+            "/proc/self/maps",
+            "/tmp/test.py",
+            "/home/user/.bashrc",
+        ] {
+            assert!(!is_blocked_device_path(Path::new(path)), "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn read_file_handler_rejects_device_paths_before_backend_io() {
+        let handler = ReadFileHandler::new(Arc::new(MockBackend));
+        let err = handler
+            .execute(json!({"path": "/dev/zero"}))
+            .await
+            .expect_err("device path should be rejected");
+        assert!(err.to_string().contains("device file"));
+    }
+
+    #[tokio::test]
+    async fn read_file_handler_rejects_oversized_unbounded_reads() {
+        struct BigBackend;
+        #[async_trait]
+        impl TerminalBackend for BigBackend {
+            async fn execute_command(
+                &self,
+                _cmd: &str,
+                _timeout: Option<u64>,
+                _workdir: Option<&str>,
+                _bg: bool,
+                _pty: bool,
+            ) -> Result<CommandOutput, AgentError> {
+                unreachable!()
+            }
+            async fn read_file(
+                &self,
+                _path: &str,
+                _offset: Option<u64>,
+                _limit: Option<u64>,
+            ) -> Result<String, AgentError> {
+                Ok("x".repeat(DEFAULT_MAX_READ_CHARS + 1))
+            }
+            async fn write_file(&self, _path: &str, _content: &str) -> Result<(), AgentError> {
+                unreachable!()
+            }
+            async fn file_exists(&self, _path: &str) -> Result<bool, AgentError> {
+                Ok(true)
+            }
+        }
+
+        let handler = ReadFileHandler::new(Arc::new(BigBackend));
+        let err = handler
+            .execute(json!({"path": "/tmp/huge.txt"}))
+            .await
+            .expect_err("oversized read should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("safety limit"));
+        assert!(msg.contains("offset and limit"));
+
+        let bounded = handler
+            .execute(json!({"path": "/tmp/huge.txt", "limit": 1}))
+            .await
+            .expect("explicit limit delegates to backend");
+        assert_eq!(bounded.len(), DEFAULT_MAX_READ_CHARS + 1);
+    }
+
+    #[test]
+    fn internal_read_status_write_guard_is_status_dominated_only() {
+        assert!(content_looks_like_internal_read_status(
+            READ_DEDUP_STATUS_MESSAGE
+        ));
+        assert!(content_looks_like_internal_read_status(&format!(
+            "Note: {READ_DEDUP_STATUS_MESSAGE}\n\n(continuing.)"
+        )));
+        let documented = format!(
+            "# Skill reference\n\n    {READ_DEDUP_STATUS_MESSAGE}\n\n{}",
+            "This is documentation content. ".repeat(200)
+        );
+        assert!(!content_looks_like_internal_read_status(&documented));
+    }
+
+    #[tokio::test]
+    async fn write_file_handler_rejects_internal_read_status_text() {
+        let handler = WriteFileHandler::new(Arc::new(MockBackend));
+        let err = handler
+            .execute(json!({"path": "/tmp/out.txt", "content": READ_DEDUP_STATUS_MESSAGE}))
+            .await
+            .expect_err("status text should be rejected");
+        assert!(err.to_string().contains("internal read_file status text"));
+    }
+
+    #[test]
+    fn resolve_tool_path_prefers_live_cwd_then_terminal_cwd() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let start = tmp.path().join("start");
+        let live = tmp.path().join("worktree");
+        std::fs::create_dir_all(&start).expect("start");
+        std::fs::create_dir_all(&live).expect("live");
+
+        assert_eq!(
+            resolve_tool_path("nested/file.txt", Some(&start), Some(&live)),
+            live.join("nested/file.txt")
+        );
+        assert_eq!(
+            resolve_tool_path("a/../b/file.txt", Some(&start), None),
+            start.join("b/file.txt")
+        );
+
+        let absolute = tmp.path().join("already-absolute.txt");
+        assert_eq!(
+            resolve_tool_path(absolute.to_str().unwrap(), Some(&start), Some(&live)),
+            absolute
+        );
     }
 }

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T09:23:35.591500+00:00",
+  "generated_at_utc": "2026-05-30T09:51:22.516485+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "88283364599dc26b85ef93d0345fcc8fb2dace07",
+    "local_sha": "51096a1a8016770af8ece117d6ae92afec19e099",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4403,
-    "commits_ahead": 855,
+    "commits_ahead": 857,
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 711,
+    "local_patch_unique": 712,
     "files_only_upstream": 1474,
     "files_only_local": 570,
     "files_shared_identical": 1701,
     "files_shared_different": 1018,
     "tree_files_changed": 3062,
     "tree_insertions": 740489,
-    "tree_deletions": 390342
+    "tree_deletions": 391368
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4285,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 711,
+    "local_patch_unique": 712,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T09:23:35.591500+00:00`
+Generated: `2026-05-30T09:51:22.516485+00:00`
 
 ## Scope
 
-- Local ref: `main` (`88283364599dc26b85ef93d0345fcc8fb2dace07`)
+- Local ref: `main` (`51096a1a8016770af8ece117d6ae92afec19e099`)
 - Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T09:23:35.591500+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 855 |
+| Commits ahead local (`local` ancestry only) | 857 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 711 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 712 |
 | Files only in upstream tree | 1474 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1701 |
 | Shared files different content | 1018 |
 | Total files changed (`local` vs `upstream`) | 3062 |
 | Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 390342 |
+| Deletions (`local` vs `upstream`) | 391368 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T09:23:35.591500+00:00`
 
 - Upstream missing by patch-id: `4285`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `711`
+- Local unique by patch-id: `712`
 - Intentional divergence tracked items: `8` (covered files: `900`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -10096,16 +10096,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_credential_files.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e0ec46a8563ee592d9cdec7a5481846eeb6966e2",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_credential_files.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "32b4c7664dfe83d00b2c13b7ef998a811d5f2587",
       "workstream": "WS6"
@@ -10291,46 +10291,46 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_file_operations.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "9e9ffa8ad33e11d9db6b72a37041d504baf3ef34",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_file_operations.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f809ea5d9129ec6db269846363fa3c7081b55e17",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_file_ops_cwd_tracking.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "3b9e6be4c0a0d14a7511aea691e521d21d09b48a",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_file_ops_cwd_tracking.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "9df366a6e11c0333f0355a3991c42472e04b5c65",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_file_read_guards.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ccb82daa7340246f1f09c005b52821ea4be13365",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_file_read_guards.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "fbe09f360bc613abf15bfa4f1b5bcaa28c2e7093",
       "workstream": "WS6"
@@ -10351,16 +10351,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_file_tools.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a951ed25cb74d7ddb509035c5916b6ecf5017914",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_file_tools.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "ac28e41ce89be610893d53608b3cc36cb227fbc4",
       "workstream": "WS6"
@@ -10426,16 +10426,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_hidden_dir_filter.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d7c10846bea62af09aa444f9b1a7138e177df078",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_hidden_dir_filter.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c72a8fab6bcaa11e7d731f2337a96a4f9e1cf8be",
       "workstream": "WS6"
@@ -10891,16 +10891,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_resolve_path.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "cd4d868961f937e578e899560777dd333bd92345",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_resolve_path.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "4c9cbe30ab65b7084553b96bbb6d7fd23260b1cb",
       "workstream": "WS6"
@@ -10921,16 +10921,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_search_hidden_dirs.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ac963ab1b71b4d3b9ba2bb90551bf9b1621ad779",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_search_hidden_dirs.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0c214c1583a4779bb5a6ee93601e0db3465835c5",
       "workstream": "WS6"
@@ -11206,16 +11206,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_symlink_prefix_confusion.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c0a7cd7c55ff39f30eafaeb577dd364752560fbb",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_symlink_prefix_confusion.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "05a9e281cd1a83dda264333a7ce21ac903994634",
       "workstream": "WS6"
@@ -11716,16 +11716,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_write_deny.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "7d264525336614cb55b67422293f477704c9678e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_write_deny.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6fe6c802aced90ae5b27e12dcbbb8c1fe429fb1b",
       "workstream": "WS6"
@@ -15271,29 +15271,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T09:23:33.522119+00:00",
+  "generated_at_utc": "2026-05-30T09:51:28.970397+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "88283364599dc26b85ef93d0345fcc8fb2dace07",
+    "local_sha": "51096a1a8016770af8ece117d6ae92afec19e099",
     "upstream_ref": "upstream/main",
     "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 715,
-      "intentional_divergence": 134,
+      "functional": 705,
+      "intentional_divergence": 144,
       "policy_only": 168
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 303,
-      "rust_equivalent_or_contract_test_required": 636,
+      "not_required_for_runtime": 313,
+      "rust_equivalent_or_contract_test_required": 626,
       "rust_primary_ux_or_documented_divergence_required": 79
     },
     "by_status": {
-      "cleared_intentional_divergence": 134,
+      "cleared_intentional_divergence": 144,
       "cleared_non_runtime": 169,
-      "pending_review": 715
+      "pending_review": 705
     },
     "by_workstream": {
       "WS3": 53,
@@ -15302,10 +15302,10 @@
       "WS6": 683,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 134,
+    "cleared_intentional_divergence": 144,
     "cleared_non_runtime": 169,
     "pending_classification": 0,
-    "pending_review": 715,
+    "pending_review": 705,
     "total_shared_different": 1018
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T09:23:33.522119+00:00`
+Generated: `2026-05-30T09:51:28.970397+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1018`
 - Pending classification: `0`
-- Pending functional review: `715`
+- Pending functional review: `705`
 - Cleared non-runtime: `169`
-- Cleared intentional divergence: `134`
+- Cleared intentional divergence: `144`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 134 |
+| `cleared_intentional_divergence` | 144 |
 | `cleared_non_runtime` | 169 |
-| `pending_review` | 715 |
+| `pending_review` | 705 |
 
 ## Workstream Counts
 
@@ -38,7 +38,7 @@ Generated: `2026-05-30T09:23:33.522119+00:00`
 | Classification Path | Count |
 | --- | ---: |
 | `tests/gateway` | 147 |
-| `tests/tools` | 137 |
+| `tests/tools` | 127 |
 | `tests/hermes_cli` | 126 |
 | `ui-tui/src` | 58 |
 | `tests/run_agent` | 55 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -318,6 +318,76 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_credential_files.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream credential-file mount behavior is covered by Rust credential file contracts for path/name/string entries, missing reporting, path precedence, traversal rejection, absolute-path rejection, symlink escape rejection, filtered hidden skill components, and component-boundary symlink checks.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_file_operations.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream file operation safety behavior is covered by Rust file-tool contracts for pagination normalization, sensitive write-deny paths, hidden descendant search exclusion, hidden-root visible file search, and JSON search output modes.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_file_ops_cwd_tracking.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream live-cwd behavior is covered by Rust LocalBackend and file-tool path contracts that resolve relative file operations against TERMINAL_CWD or the live terminal cwd before process cwd.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_file_read_guards.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream read safety guards are covered by Rust contracts for device-path rejection before backend I/O, unbounded read size limits with offset/limit guidance, and internal read_file status text write rejection.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_file_tools.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream file tool facade behavior is covered by Rust handler contracts for read/write schemas, missing parameter errors, normalized read/search pagination, patch backend behavior, search output modes, and status-dominated write rejection.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_hidden_dir_filter.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream hidden directory filtering is covered by Rust component-based hidden path contracts that catch .git, .github, and .hub on Unix and Windows-style paths without rejecting unrelated dotted skill names.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_resolve_path.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream path resolution behavior is covered by Rust resolve_tool_path and LocalBackend contracts for absolute paths, tilde expansion, relative TERMINAL_CWD joins, live cwd precedence, and lexical parent cleanup.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_search_hidden_dirs.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream hidden search exclusion is covered by Rust LocalSearchBackend contracts that skip .hub/.git-style hidden descendants while preserving visible files under a hidden root and visible skill content.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_symlink_prefix_confusion.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream symlink prefix-confusion regression is covered by Rust root-boundary contracts using Path strip_prefix semantics so sibling directories sharing a prefix escape while real subpaths and the root itself pass.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_write_deny.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream write-deny behavior is covered by Rust CredentialGuard contracts for /etc sensitive files, sudoers/systemd prefixes, SSH/AWS/GnuPG/Kube home prefixes, shell/package credential files, profile-aware HERMES_HOME/.env, and allowed project/config paths.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "website/docs",
       "classification": "policy_only",
       "rationale": "Documentation-site content differs by project positioning and release policy; runtime behavior is unaffected.",


### PR DESCRIPTION
## Summary
- add Rust file-tool safety contracts for device-file reads, read size guidance, internal read status write protection, hidden search exclusion, and file path cwd resolution
- extend credential/write guards for sensitive system paths, shell/package credential files, profile-aware HERMES_HOME/.env, credential mount traversal, and symlink boundary checks
- classify 10 upstream file-tools Python test references as covered by Rust-native parity contracts and regenerate parity docs

## Local verification
- cargo fmt
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg guard for max_shared_different/max-shared-different/max shared different
- cargo test -p hermes-tools file
- cargo test -p hermes-environments relative_file_paths_use_terminal_cwd
- cargo test -p hermes-tools
- cargo test -p hermes-environments
- cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests
- cargo test -p hermes-gateway --features discord
- cargo test -p hermes-config
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main
- cargo build -p hermes-cli
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md

Note: one attempted focused cargo test command used two test filters and failed argument parsing; it was rerun correctly with separate filters.