### PR TITLE
Add media tool parity contracts

### DIFF
--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -88,6 +88,16 @@ pub struct GatewayConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub auxiliary: BTreeMap<String, AuxiliaryTaskConfig>,
 
+    /// Upstream-compatible TTS configuration block.
+    ///
+    /// Kept as structured JSON because upstream accepts provider-specific
+    /// nested maps (`tts.openai`, `tts.providers.<name>`, `tts.piper`, etc.).
+    /// Runtime consumers validate the subkeys they understand and ignore the
+    /// rest so future upstream TTS knobs do not get dropped during config
+    /// round-trips.
+    #[serde(default, skip_serializing_if = "is_json_null")]
+    pub tts: serde_json::Value,
+
     /// Optional HTTP/SOCKS proxy settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy: Option<ProxyConfig>,
@@ -145,6 +155,7 @@ impl Default for GatewayConfig {
             fallback_models: Vec::new(),
             smart_model_routing: SmartModelRoutingConfig::default(),
             auxiliary: BTreeMap::new(),
+            tts: serde_json::Value::Null,
             proxy: None,
             approval: ApprovalConfig::default(),
             security: SecurityConfig::default(),
@@ -156,6 +167,10 @@ impl Default for GatewayConfig {
             home_dir: None,
         }
     }
+}
+
+fn is_json_null(value: &serde_json::Value) -> bool {
+    value.is_null()
 }
 
 /// User-facing override for one auxiliary side task.
@@ -843,6 +858,7 @@ mod tests {
         assert!(!cfg.tools.is_empty());
         assert!(cfg.model.is_none());
         assert!(cfg.auxiliary.is_empty());
+        assert!(cfg.tts.is_null());
         assert!(cfg.proxy.is_none());
         assert_eq!(
             cfg.platform_toolsets
@@ -871,11 +887,16 @@ mod tests {
                 ..Default::default()
             },
         );
+        cfg.tts = serde_json::json!({
+            "provider": "piper",
+            "piper": {"voice": "en_US-lessac-medium"}
+        });
         let json = serde_json::to_string(&cfg).unwrap();
         let back: GatewayConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.max_turns, cfg.max_turns);
         assert_eq!(back.tools, cfg.tools);
         assert_eq!(back.auxiliary["vision"].model, "google/gemini-2.5-flash");
+        assert_eq!(back.tts["provider"], "piper");
     }
 
     #[test]

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -126,6 +126,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 fallback_models: Vec::new(),
                 smart_model_routing: SmartModelRoutingConfig::default(),
                 auxiliary: Default::default(),
+                tts: serde_json::Value::Null,
                 proxy: None,
                 approval: ApprovalConfig::default(),
                 security: SecurityConfig::default(),

--- a/crates/hermes-tools/src/backends/tts.rs
+++ b/crates/hermes-tools/src/backends/tts.rs
@@ -5,11 +5,16 @@
 //! ONNX models via the forthcoming `LocalOnnxTtsBackend` (Sprint 6) or
 //! OpenAI's cheap `tts-1` endpoint.
 
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
 use async_trait::async_trait;
 use reqwest::Client;
-use serde_json::json;
+use serde_json::{json, Value};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+use tokio::time::timeout;
 
 use crate::tools::tts::TtsBackend;
 use crate::tts_streaming::minimax::MiniMaxTtsBackend;
@@ -18,6 +23,403 @@ use hermes_config::managed_gateway::{
     ResolveOptions,
 };
 use hermes_core::ToolError;
+
+pub const FALLBACK_MAX_TEXT_LENGTH: usize = 4_000;
+pub const DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH: usize = 15_000;
+pub const DEFAULT_COMMAND_TTS_OUTPUT_FORMAT: &str = "mp3";
+pub const DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS: u64 = 60;
+pub const COMMAND_TTS_OUTPUT_FORMATS: &[&str] = &["mp3", "wav", "ogg", "flac"];
+
+const BUILTIN_TTS_PROVIDERS: &[&str] = &[
+    "elevenlabs",
+    "openai",
+    "minimax",
+    "piper",
+    // Reserved upstream/Python provider names. Hermes Agent Ultra must not
+    // let a command provider silently shadow names that are built in upstream
+    // or intentionally unsupported by the Rust-only runtime.
+    "edge",
+    "edge_tts",
+    "edge-tts",
+    "neutts",
+    "kittentts",
+    "mistral",
+    "gemini",
+    "xai",
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CommandTtsProviderConfig {
+    pub name: String,
+    pub command: String,
+    pub config: Value,
+}
+
+fn normalize_provider_name(provider: Option<&str>) -> Option<String> {
+    provider
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase())
+}
+
+fn find_object_key_case_insensitive<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<(&'a str, &'a Value)> {
+    object
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(k, v)| (k.as_str(), v))
+}
+
+fn named_tts_provider_config<'a>(tts_config: &'a Value, provider: &str) -> Option<&'a Value> {
+    let object = tts_config.as_object()?;
+    if let Some(providers) = object.get("providers").and_then(|v| v.as_object()) {
+        if let Some((_name, value)) = find_object_key_case_insensitive(providers, provider) {
+            return Some(value);
+        }
+    }
+    find_object_key_case_insensitive(object, provider).map(|(_name, value)| value)
+}
+
+fn is_reserved_tts_provider(provider: &str) -> bool {
+    BUILTIN_TTS_PROVIDERS
+        .iter()
+        .any(|known| known.eq_ignore_ascii_case(provider))
+}
+
+pub(crate) fn is_command_provider_config(value: &Value) -> bool {
+    let object = match value.as_object() {
+        Some(object) => object,
+        None => return false,
+    };
+    let command = object
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .unwrap_or("");
+    if command.is_empty() {
+        return false;
+    }
+    let kind = object
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("command");
+    kind.eq_ignore_ascii_case("command")
+}
+
+pub(crate) fn resolve_command_provider_config(
+    provider: &str,
+    tts_config: &Value,
+) -> Option<CommandTtsProviderConfig> {
+    if is_reserved_tts_provider(provider) {
+        return None;
+    }
+    let (name, value) = {
+        let object = tts_config.as_object()?;
+        if let Some(providers) = object.get("providers").and_then(|v| v.as_object()) {
+            if let Some((name, value)) = find_object_key_case_insensitive(providers, provider) {
+                (name.to_string(), value)
+            } else if let Some((name, value)) = find_object_key_case_insensitive(object, provider) {
+                (name.to_string(), value)
+            } else {
+                return None;
+            }
+        } else if let Some((name, value)) = find_object_key_case_insensitive(object, provider) {
+            (name.to_string(), value)
+        } else {
+            return None;
+        }
+    };
+    if !is_command_provider_config(value) {
+        return None;
+    }
+    let command = value
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?
+        .to_string();
+    Some(CommandTtsProviderConfig {
+        name,
+        command,
+        config: value.clone(),
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn iter_command_providers(tts_config: &Value) -> Vec<CommandTtsProviderConfig> {
+    let mut providers = BTreeMap::new();
+    if let Some(object) = tts_config.as_object() {
+        if let Some(block) = object.get("providers").and_then(|v| v.as_object()) {
+            for (name, value) in block {
+                if let Some(cfg) = resolve_command_provider_config(name, tts_config) {
+                    providers.insert(name.to_ascii_lowercase(), cfg);
+                } else if !is_reserved_tts_provider(name) && is_command_provider_config(value) {
+                    // Unreachable for normal values, but keeps the helper
+                    // robust if lookup semantics change.
+                    let command = value["command"].as_str().unwrap_or("").trim().to_string();
+                    providers.insert(
+                        name.to_ascii_lowercase(),
+                        CommandTtsProviderConfig {
+                            name: name.clone(),
+                            command,
+                            config: value.clone(),
+                        },
+                    );
+                }
+            }
+        }
+        for (name, value) in object {
+            if name == "providers"
+                || is_reserved_tts_provider(name)
+                || !is_command_provider_config(value)
+            {
+                continue;
+            }
+            providers
+                .entry(name.to_ascii_lowercase())
+                .or_insert_with(|| CommandTtsProviderConfig {
+                    name: name.clone(),
+                    command: value["command"].as_str().unwrap_or("").trim().to_string(),
+                    config: value.clone(),
+                });
+        }
+    }
+    providers.into_values().collect()
+}
+
+fn positive_usize(value: Option<&Value>) -> Option<usize> {
+    match value? {
+        Value::Number(n) => n
+            .as_u64()
+            .and_then(|v| usize::try_from(v).ok())
+            .filter(|v| *v > 0),
+        _ => None,
+    }
+}
+
+pub(crate) fn resolve_max_text_length(provider: Option<&str>, tts_config: &Value) -> usize {
+    let provider = match normalize_provider_name(provider) {
+        Some(provider) => provider,
+        None => return FALLBACK_MAX_TEXT_LENGTH,
+    };
+    if let Some(cfg) = named_tts_provider_config(tts_config, &provider) {
+        if let Some(v) = positive_usize(cfg.get("max_text_length")) {
+            return v;
+        }
+    }
+    if resolve_command_provider_config(&provider, tts_config).is_some() {
+        return DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH;
+    }
+    match provider.as_str() {
+        "openai" => 4_096,
+        "xai" => 15_000,
+        "minimax" => 10_000,
+        "mistral" => 10_000,
+        "gemini" => 32_000,
+        "piper" => 5_000,
+        "kittentts" => 5_000,
+        "edge" | "edge_tts" | "edge-tts" | "neutts" => FALLBACK_MAX_TEXT_LENGTH,
+        "elevenlabs" => elevenlabs_max_text_length(tts_config),
+        _ => FALLBACK_MAX_TEXT_LENGTH,
+    }
+}
+
+fn elevenlabs_max_text_length(tts_config: &Value) -> usize {
+    let cfg = named_tts_provider_config(tts_config, "elevenlabs");
+    if let Some(v) = cfg.and_then(|cfg| positive_usize(cfg.get("max_text_length"))) {
+        return v;
+    }
+    let model = cfg
+        .and_then(|cfg| cfg.get("model_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("eleven_multilingual_v2");
+    match model {
+        "eleven_flash_v2_5" => 40_000,
+        "eleven_flash_v2" => 30_000,
+        "eleven_v3" => 5_000,
+        "eleven_multilingual_v2" => 10_000,
+        _ => 10_000,
+    }
+}
+
+fn number_from_config(value: Option<&Value>) -> Option<f64> {
+    match value? {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+pub(crate) fn tts_speed_for_provider(
+    provider: &str,
+    tts_config: &Value,
+    explicit_speed: Option<f64>,
+) -> Option<f64> {
+    let raw = explicit_speed
+        .or_else(|| {
+            named_tts_provider_config(tts_config, provider)
+                .and_then(|cfg| number_from_config(cfg.get("speed")))
+        })
+        .or_else(|| number_from_config(tts_config.get("speed")));
+    raw.map(|speed| speed.clamp(0.25, 4.0))
+}
+
+fn command_tts_timeout(config: &Value) -> Duration {
+    let seconds = number_from_config(config.get("timeout_seconds"))
+        .or_else(|| number_from_config(config.get("timeout")))
+        .filter(|v| *v > 0.0)
+        .unwrap_or(DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS as f64);
+    Duration::from_secs_f64(seconds)
+}
+
+fn command_tts_output_format(config: &Value, output_path: Option<&Path>) -> &'static str {
+    if let Some(path) = output_path {
+        if let Some(ext) = path
+            .extension()
+            .and_then(|v| v.to_str())
+            .map(|v| v.to_ascii_lowercase())
+        {
+            if let Some(format) = COMMAND_TTS_OUTPUT_FORMATS
+                .iter()
+                .copied()
+                .find(|format| *format == ext)
+            {
+                return format;
+            }
+        }
+    }
+    config
+        .get("output_format")
+        .or_else(|| config.get("format"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .and_then(|v| {
+            COMMAND_TTS_OUTPUT_FORMATS
+                .iter()
+                .copied()
+                .find(|format| format.eq_ignore_ascii_case(v))
+        })
+        .unwrap_or(DEFAULT_COMMAND_TTS_OUTPUT_FORMAT)
+}
+
+fn command_tts_voice_compatible(config: &Value) -> bool {
+    match config.get("voice_compatible") {
+        Some(Value::Bool(v)) => *v,
+        Some(Value::String(s)) => matches!(
+            s.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        _ => false,
+    }
+}
+
+pub(crate) fn shell_quote_context(template: &str, placeholder_start: usize) -> Option<char> {
+    let mut single = false;
+    let mut double = false;
+    let mut escape = false;
+    for (idx, ch) in template.char_indices() {
+        if idx >= placeholder_start {
+            break;
+        }
+        if escape {
+            escape = false;
+            continue;
+        }
+        if ch == '\\' && double {
+            escape = true;
+            continue;
+        }
+        match ch {
+            '\'' if !double => single = !single,
+            '"' if !single => double = !double,
+            _ => {}
+        }
+    }
+    if single {
+        Some('\'')
+    } else if double {
+        Some('"')
+    } else {
+        None
+    }
+}
+
+fn posix_shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    let safe = value.bytes().all(|b| {
+        b.is_ascii_alphanumeric()
+            || matches!(b, b'_' | b'-' | b'.' | b'/' | b':' | b'=' | b',' | b'@')
+    });
+    if safe {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn quote_placeholder_for_context(template: &str, start: usize, value: &str) -> String {
+    match shell_quote_context(template, start) {
+        Some('\'') => value.replace('\'', "'\\''"),
+        Some('"') => value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('$', "\\$")
+            .replace('`', "\\`"),
+        _ => posix_shell_quote(value),
+    }
+}
+
+pub(crate) fn render_command_tts_template(
+    template: &str,
+    placeholders: &BTreeMap<&str, String>,
+) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut idx = 0;
+    while idx < template.len() {
+        let rest = &template[idx..];
+        if rest.starts_with("{{") {
+            out.push('{');
+            idx += 2;
+            continue;
+        }
+        if rest.starts_with("}}") {
+            out.push('}');
+            idx += 2;
+            continue;
+        }
+        if rest.starts_with('{') {
+            if let Some(close) = rest.find('}') {
+                let key = &rest[1..close];
+                if let Some(value) = placeholders.get(key) {
+                    out.push_str(&quote_placeholder_for_context(template, idx, value));
+                    idx += close + 1;
+                    continue;
+                }
+            }
+        }
+        let ch = rest.chars().next().expect("non-empty rest");
+        out.push(ch);
+        idx += ch.len_utf8();
+    }
+    out
+}
+
+fn load_tts_config_from_env_or_file() -> Value {
+    if let Ok(raw) = std::env::var("HERMES_TTS_CONFIG_JSON") {
+        if let Ok(value) = serde_json::from_str::<Value>(&raw) {
+            return value;
+        }
+    }
+    hermes_config::load_config(None)
+        .map(|cfg| cfg.tts)
+        .unwrap_or(Value::Null)
+}
 
 /// TTS backend that dispatches to ElevenLabs, OpenAI, or MiniMax based on
 /// the `provider` argument. Defaults to `openai` when no API keys hint at a
@@ -28,6 +430,7 @@ pub struct MultiTtsBackend {
     openai_base_url: String,
     minimax: MiniMaxTtsBackend,
     minimax_available: bool,
+    tts_config: Value,
 }
 
 impl MultiTtsBackend {
@@ -43,10 +446,24 @@ impl MultiTtsBackend {
                 .unwrap_or_else(|_| "https://api.openai.com/v1".to_string()),
             minimax: MiniMaxTtsBackend::from_env(),
             minimax_available,
+            tts_config: load_tts_config_from_env_or_file(),
         }
     }
 
-    async fn elevenlabs_tts(&self, text: &str, voice: &str) -> Result<String, ToolError> {
+    #[cfg(test)]
+    fn with_tts_config(tts_config: Value) -> Self {
+        Self {
+            tts_config,
+            ..Self::new()
+        }
+    }
+
+    async fn elevenlabs_tts(
+        &self,
+        text: &str,
+        voice: &str,
+        output_path: Option<&str>,
+    ) -> Result<String, ToolError> {
         let api_key = self
             .elevenlabs_key
             .as_ref()
@@ -83,8 +500,9 @@ impl MultiTtsBackend {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read audio: {}", e)))?;
 
-        let output_path =
-            std::env::temp_dir().join(format!("hermes_tts_{}.mp3", uuid::Uuid::new_v4()));
+        let output_path = output_path.map(PathBuf::from).unwrap_or_else(|| {
+            std::env::temp_dir().join(format!("hermes_tts_{}.mp3", uuid::Uuid::new_v4()))
+        });
         tokio::fs::write(&output_path, &bytes)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to write audio: {}", e)))?;
@@ -98,7 +516,13 @@ impl MultiTtsBackend {
         .to_string())
     }
 
-    async fn openai_tts(&self, text: &str, voice: &str) -> Result<String, ToolError> {
+    async fn openai_tts(
+        &self,
+        text: &str,
+        voice: &str,
+        output_path: Option<&str>,
+        speed: Option<f64>,
+    ) -> Result<String, ToolError> {
         // Resolve transport in priority order:
         // 1. Managed Nous gateway (HERMES_ENABLE_NOUS_MANAGED_TOOLS + Nous token)
         // 2. Direct OpenAI with VOICE_TOOLS_OPENAI_KEY override, then
@@ -123,11 +547,14 @@ impl MultiTtsBackend {
             }
         };
 
-        let body = json!({
+        let mut body = json!({
             "model": "tts-1",
             "input": text,
             "voice": voice,
         });
+        if let Some(speed) = tts_speed_for_provider("openai", &self.tts_config, speed) {
+            body["speed"] = json!(speed);
+        }
 
         let resp = self
             .client
@@ -152,8 +579,9 @@ impl MultiTtsBackend {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read audio: {}", e)))?;
 
-        let output_path =
-            std::env::temp_dir().join(format!("hermes_tts_{}.mp3", uuid::Uuid::new_v4()));
+        let output_path = output_path.map(PathBuf::from).unwrap_or_else(|| {
+            std::env::temp_dir().join(format!("hermes_tts_{}.mp3", uuid::Uuid::new_v4()))
+        });
         tokio::fs::write(&output_path, &bytes)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to write audio: {}", e)))?;
@@ -168,7 +596,12 @@ impl MultiTtsBackend {
         .to_string())
     }
 
-    async fn piper_tts(&self, text: &str, voice: Option<&str>) -> Result<String, ToolError> {
+    async fn piper_tts(
+        &self,
+        text: &str,
+        voice: Option<&str>,
+        output_path: Option<&str>,
+    ) -> Result<String, ToolError> {
         let binary = std::env::var("PIPER_BINARY")
             .ok()
             .map(|v| v.trim().to_string())
@@ -193,8 +626,9 @@ impl MultiTtsBackend {
                 )
             })?;
 
-        let output_path =
-            std::env::temp_dir().join(format!("hermes_tts_{}.wav", uuid::Uuid::new_v4()));
+        let output_path = output_path.map(PathBuf::from).unwrap_or_else(|| {
+            std::env::temp_dir().join(format!("hermes_tts_{}.wav", uuid::Uuid::new_v4()))
+        });
         let mut cmd = Command::new(&binary);
         cmd.arg("--model")
             .arg(&model)
@@ -286,6 +720,127 @@ impl MultiTtsBackend {
         .to_string())
     }
 
+    async fn command_tts(
+        &self,
+        text: &str,
+        voice: Option<&str>,
+        provider: &CommandTtsProviderConfig,
+        output_path: Option<&str>,
+        speed: Option<f64>,
+    ) -> Result<String, ToolError> {
+        let output_hint = output_path.map(PathBuf::from);
+        let format = command_tts_output_format(&provider.config, output_hint.as_deref());
+        let output_path = output_hint.unwrap_or_else(|| {
+            std::env::temp_dir().join(format!("hermes_tts_{}.{}", uuid::Uuid::new_v4(), format))
+        });
+        let input_path =
+            std::env::temp_dir().join(format!("hermes_tts_input_{}.txt", uuid::Uuid::new_v4()));
+        tokio::fs::write(&input_path, text)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("write TTS command input: {e}")))?;
+
+        let mut placeholders = BTreeMap::new();
+        placeholders.insert("input_path", input_path.display().to_string());
+        placeholders.insert("text_path", input_path.display().to_string());
+        placeholders.insert("output_path", output_path.display().to_string());
+        placeholders.insert("format", format.to_string());
+        placeholders.insert("voice", voice.unwrap_or("").to_string());
+        placeholders.insert(
+            "model",
+            provider
+                .config
+                .get("model")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        );
+        placeholders.insert(
+            "speed",
+            speed
+                .or_else(|| tts_speed_for_provider(&provider.name, &self.tts_config, None))
+                .unwrap_or(1.0)
+                .to_string(),
+        );
+
+        let rendered = render_command_tts_template(&provider.command, &placeholders);
+        let mut cmd = if cfg!(windows) {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/C").arg(&rendered);
+            cmd
+        } else {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(&rendered);
+            cmd
+        };
+        cmd.stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
+
+        let duration = command_tts_timeout(&provider.config);
+        let output = match timeout(duration, cmd.output()).await {
+            Ok(result) => result.map_err(|e| {
+                ToolError::ExecutionFailed(format!(
+                    "TTS command provider '{}' failed to start: {e}",
+                    provider.name
+                ))
+            })?,
+            Err(_) => {
+                let _ = tokio::fs::remove_file(&input_path).await;
+                return Err(ToolError::ExecutionFailed(format!(
+                    "TTS command provider '{}' timed out after {:.1}s",
+                    provider.name,
+                    duration.as_secs_f64()
+                )));
+            }
+        };
+        let _ = tokio::fs::remove_file(&input_path).await;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(ToolError::ExecutionFailed(format!(
+                "TTS command provider '{}' exited with code {}{}",
+                provider.name,
+                output.status.code().unwrap_or(-1),
+                if stderr.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {}", stderr)
+                }
+            )));
+        }
+
+        let metadata = tokio::fs::metadata(&output_path).await.map_err(|e| {
+            ToolError::ExecutionFailed(format!(
+                "TTS command provider '{}' produced no output at {}: {e}",
+                provider.name,
+                output_path.display()
+            ))
+        })?;
+        if metadata.len() == 0 {
+            return Err(ToolError::ExecutionFailed(format!(
+                "TTS command provider '{}' produced no output",
+                provider.name
+            )));
+        }
+
+        let voice_compatible = command_tts_voice_compatible(&provider.config);
+        Ok(json!({
+            "provider": provider.name,
+            "transport": "command",
+            "file": output_path.display().to_string(),
+            "file_path": output_path.display().to_string(),
+            "format": format,
+            "voice": voice.unwrap_or(""),
+            "bytes": metadata.len(),
+            "voice_compatible": voice_compatible,
+            "media_tag": if voice_compatible {
+                format!("[[audio_as_voice]]{}", output_path.display())
+            } else {
+                format!("[[audio]]{}", output_path.display())
+            },
+        })
+        .to_string())
+    }
+
     /// Compose the OpenAI-audio gateway endpoint + bearer for a resolved
     /// managed config. Public visibility kept tight (`pub(crate)`) so the
     /// `tts_premium` handler can reuse it later if needed.
@@ -307,7 +862,7 @@ impl MultiTtsBackend {
         text: &str,
         voice: &str,
     ) -> Result<String, ToolError> {
-        self.elevenlabs_tts(text, voice).await
+        self.elevenlabs_tts(text, voice, None).await
     }
 }
 
@@ -324,42 +879,82 @@ impl TtsBackend for MultiTtsBackend {
         text: &str,
         voice: Option<&str>,
         provider: Option<&str>,
+        output_path: Option<&str>,
+        speed: Option<f64>,
     ) -> Result<String, ToolError> {
         // Default provider preference:
         // 1. ELEVENLABS_API_KEY set → elevenlabs (highest quality)
         // 2. Otherwise OpenAI (cheapest HTTP-only path)
         // Zero-Python: edge_tts removed entirely — callers asking for
         // "edge_tts" receive a clear migration error.
-        let resolved_provider = provider.unwrap_or_else(|| {
-            if self.elevenlabs_key.is_some() {
-                "elevenlabs"
-            } else {
-                "openai"
-            }
-        });
+        let configured_provider = self
+            .tts_config
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let resolved_provider_raw = provider
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .or(configured_provider)
+            .unwrap_or_else(|| {
+                if self.elevenlabs_key.is_some() {
+                    "elevenlabs"
+                } else {
+                    "openai"
+                }
+            });
+        let resolved_provider_key = resolved_provider_raw.to_ascii_lowercase();
+        let resolved_provider = resolved_provider_key.as_str();
+
+        let max_len = resolve_max_text_length(Some(resolved_provider), &self.tts_config);
+        let text_buf;
+        let text = if text.chars().count() > max_len {
+            tracing::warn!(
+                provider = resolved_provider,
+                max_text_length = max_len,
+                "truncating TTS input to provider limit"
+            );
+            text_buf = text.chars().take(max_len).collect::<String>();
+            text_buf.as_str()
+        } else {
+            text
+        };
+
+        if let Some(command_provider) =
+            resolve_command_provider_config(resolved_provider, &self.tts_config)
+        {
+            return self
+                .command_tts(text, voice, &command_provider, output_path, speed)
+                .await;
+        }
 
         match resolved_provider {
             "elevenlabs" => {
                 let voice = voice.unwrap_or("21m00Tcm4TlvDq8ikWAM"); // Rachel
-                self.elevenlabs_tts(text, voice).await
+                self.elevenlabs_tts(text, voice, output_path).await
             }
             "openai" => {
                 let voice = voice.unwrap_or("alloy");
-                self.openai_tts(text, voice).await
+                self.openai_tts(text, voice, output_path, speed).await
             }
             "minimax" => {
                 if !self.minimax_available {
                     return Err(ToolError::ExecutionFailed("MINIMAX_API_KEY not set".into()));
                 }
-                self.minimax.synthesize(text, voice, provider).await
+                self.minimax
+                    .synthesize(text, voice, Some(resolved_provider), output_path, speed)
+                    .await
             }
-            "piper" => self.piper_tts(text, voice).await,
-            "edge_tts" | "edge-tts" | "neutts" => Err(ToolError::InvalidParams(format!(
+            "piper" => self.piper_tts(text, voice, output_path).await,
+            "edge" | "edge_tts" | "edge-tts" | "neutts" | "kittentts" => Err(
+                ToolError::InvalidParams(format!(
                 "{resolved_provider} is not supported in hermes-agent-rust (zero-Python). \
                  Use provider='openai' (HERMES_OPENAI_API_KEY or OPENAI_API_KEY), \
                  'elevenlabs' (ELEVENLABS_API_KEY), 'minimax' (MINIMAX_API_KEY), \
                  or 'piper' (local piper binary + PIPER_MODEL)."
-            ))),
+            )),
+            ),
             other => Err(ToolError::InvalidParams(format!(
                 "Unknown TTS provider: '{other}'. Use 'openai', 'elevenlabs', 'minimax', or 'piper'.",
             ))),
@@ -388,11 +983,146 @@ mod tests {
         assert_eq!(transport, "managed");
     }
 
+    #[test]
+    fn command_provider_resolution_matches_upstream_contracts() {
+        let cfg = json!({
+            "providers": {
+                "openai": {"type": "command", "command": "echo no"},
+                "piper": {"type": "command", "command": "echo no"},
+                "piper-cli": {"command": "piper-cli foo"},
+                "broken": {"type": "command", "command": "   "}
+            },
+            "voxcpm": {"type": "command", "command": "voxcpm"}
+        });
+
+        assert!(resolve_command_provider_config("openai", &cfg).is_none());
+        assert!(resolve_command_provider_config("piper", &cfg).is_none());
+        assert!(resolve_command_provider_config("broken", &cfg).is_none());
+        assert_eq!(
+            resolve_command_provider_config("PIPER-CLI", &cfg)
+                .unwrap()
+                .command,
+            "piper-cli foo"
+        );
+        let names: Vec<_> = iter_command_providers(&cfg)
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        assert_eq!(names, vec!["piper-cli".to_string(), "voxcpm".to_string()]);
+    }
+
+    #[test]
+    fn tts_max_text_length_is_provider_and_model_specific() {
+        assert_eq!(resolve_max_text_length(Some("OpenAI"), &json!({})), 4_096);
+        assert_eq!(resolve_max_text_length(Some("xai"), &json!({})), 15_000);
+        assert_eq!(resolve_max_text_length(Some("minimax"), &json!({})), 10_000);
+        assert_eq!(
+            resolve_max_text_length(
+                Some("elevenlabs"),
+                &json!({"elevenlabs": {"model_id": "eleven_flash_v2_5"}})
+            ),
+            40_000
+        );
+        assert_eq!(
+            resolve_max_text_length(
+                Some("elevenlabs"),
+                &json!({"elevenlabs": {"model_id": "eleven_v3"}})
+            ),
+            5_000
+        );
+        assert_eq!(
+            resolve_max_text_length(Some("openai"), &json!({"openai": {"max_text_length": 99}})),
+            99
+        );
+        assert_eq!(
+            resolve_max_text_length(
+                Some("cmd"),
+                &json!({"providers": {"cmd": {"command": "cp {input_path} {output_path}"}}})
+            ),
+            DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH
+        );
+        assert_eq!(
+            resolve_max_text_length(None, &json!({})),
+            FALLBACK_MAX_TEXT_LENGTH
+        );
+    }
+
+    #[test]
+    fn command_template_rendering_quotes_placeholders_by_context() {
+        let mut placeholders = BTreeMap::new();
+        placeholders.insert("input_path", "/tmp/Jane Doe/in.txt".to_string());
+        placeholders.insert("output_path", "/tmp/out; rm -rf /".to_string());
+        placeholders.insert("voice", "$(whoami)".to_string());
+
+        assert_eq!(shell_quote_context("tts '{output_path}'", 5), Some('\''));
+        assert_eq!(shell_quote_context("tts \"{output_path}\"", 5), Some('"'));
+
+        let rendered = render_command_tts_template(
+            "tts --voice {voice} --in {input_path} --out {output_path} '{{literal}}'",
+            &placeholders,
+        );
+        assert!(rendered.contains("'$(whoami)'"));
+        assert!(rendered.contains("'/tmp/Jane Doe/in.txt'"));
+        assert!(rendered.contains("'/tmp/out; rm -rf /'"));
+        assert!(rendered.contains("'{literal}'"));
+
+        let rendered = render_command_tts_template("tts --voice \"{voice}\"", &placeholders);
+        assert!(rendered.contains("\"\\$(whoami)\""));
+    }
+
+    #[tokio::test]
+    async fn command_provider_writes_output_and_reports_voice_compatibility() {
+        let tmp = tempfile::tempdir().unwrap();
+        let output = tmp.path().join("clip.ogg");
+        let backend = MultiTtsBackend::with_tts_config(json!({
+            "provider": "copy-tts",
+            "providers": {
+                "copy-tts": {
+                    "type": "command",
+                    "command": "cp {input_path} {output_path}",
+                    "output_format": "ogg",
+                    "voice_compatible": true
+                }
+            }
+        }));
+
+        let out = backend
+            .synthesize(
+                "hello command",
+                Some("voice-a"),
+                None,
+                Some(output.to_str().unwrap()),
+                Some(1.2),
+            )
+            .await
+            .unwrap();
+        let data: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(data["provider"], "copy-tts");
+        assert_eq!(data["transport"], "command");
+        assert_eq!(data["voice_compatible"], true);
+        assert!(data["media_tag"]
+            .as_str()
+            .unwrap()
+            .starts_with("[[audio_as_voice]]"));
+        assert_eq!(std::fs::read_to_string(output).unwrap(), "hello command");
+    }
+
+    #[test]
+    fn tts_speed_prefers_provider_then_global_and_clamps() {
+        let cfg = json!({"speed": 1.5, "openai": {"speed": 10.0}});
+        assert_eq!(tts_speed_for_provider("openai", &cfg, None), Some(4.0));
+        assert_eq!(tts_speed_for_provider("piper", &cfg, None), Some(1.5));
+        assert_eq!(
+            tts_speed_for_provider("openai", &cfg, Some(0.1)),
+            Some(0.25)
+        );
+    }
+
     #[tokio::test]
     async fn test_edge_tts_returns_migration_error() {
         let backend = MultiTtsBackend::new();
         let err = backend
-            .synthesize("hello", None, Some("edge_tts"))
+            .synthesize("hello", None, Some("edge_tts"), None, None)
             .await
             .unwrap_err();
         let msg = err.to_string();
@@ -404,7 +1134,7 @@ mod tests {
     async fn test_neutts_returns_migration_error() {
         let backend = MultiTtsBackend::new();
         let err = backend
-            .synthesize("hi", None, Some("neutts"))
+            .synthesize("hi", None, Some("neutts"), None, None)
             .await
             .unwrap_err();
         let msg = err.to_string();
@@ -415,7 +1145,7 @@ mod tests {
     async fn test_unknown_provider_errors() {
         let backend = MultiTtsBackend::new();
         let err = backend
-            .synthesize("hello", None, Some("bogus"))
+            .synthesize("hello", None, Some("bogus"), None, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("Unknown"));
@@ -427,7 +1157,7 @@ mod tests {
         let _guard = EnvVarGuard::new("PIPER_MODEL");
         std::env::remove_var("PIPER_MODEL");
         let err = backend
-            .synthesize("hello", None, Some("piper"))
+            .synthesize("hello", None, Some("piper"), None, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("PIPER_MODEL"));

--- a/crates/hermes-tools/src/backends/video.rs
+++ b/crates/hermes-tools/src/backends/video.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+#[cfg(test)]
+use base64::Engine;
 use tokio::process::Command;
 
 use crate::tools::video::VideoBackend;
@@ -48,6 +50,12 @@ impl VisionFrameSamplingVideoBackend {
             if !path.exists() {
                 return Err(ToolError::ExecutionFailed(format!(
                     "video path does not exist: {}",
+                    path.display()
+                )));
+            }
+            if detect_video_mime_type(&path).is_none() {
+                return Err(ToolError::ExecutionFailed(format!(
+                    "unsupported video format: {}",
                     path.display()
                 )));
             }
@@ -102,6 +110,39 @@ impl VisionFrameSamplingVideoBackend {
         }
         Ok(frames)
     }
+}
+
+pub(crate) fn detect_video_mime_type(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|v| v.to_str())
+        .map(|v| v.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("mp4") => Some("video/mp4"),
+        Some("webm") => Some("video/webm"),
+        Some("mov") => Some("video/mov"),
+        Some("mpeg") | Some("mpg") => Some("video/mpeg"),
+        Some("avi") | Some("mkv") => Some("video/mp4"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn video_to_base64_data_url(
+    path: &Path,
+    mime_type: Option<&str>,
+) -> Result<String, ToolError> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        ToolError::ExecutionFailed(format!("failed to read video {}: {e}", path.display()))
+    })?;
+    let mime = mime_type
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .or_else(|| detect_video_mime_type(path))
+        .unwrap_or("video/mp4");
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(format!("data:{mime};base64,{encoded}"))
 }
 
 #[async_trait]
@@ -162,5 +203,63 @@ impl VideoBackend for VisionFrameSamplingVideoBackend {
         // Best-effort cleanup.
         let _ = tokio::fs::remove_dir_all(&work_dir).await;
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_video_mime_type_matches_upstream_extension_table() {
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.mp4")),
+            Some("video/mp4")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.MP4")),
+            Some("video/mp4")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.webm")),
+            Some("video/webm")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.mov")),
+            Some("video/mov")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.mpeg")),
+            Some("video/mpeg")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.mpg")),
+            Some("video/mpeg")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.avi")),
+            Some("video/mp4")
+        );
+        assert_eq!(
+            detect_video_mime_type(Path::new("clip.mkv")),
+            Some("video/mp4")
+        );
+        assert_eq!(detect_video_mime_type(Path::new("clip.flv")), None);
+    }
+
+    #[test]
+    fn video_data_url_uses_detected_or_custom_mime_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mp4 = tmp.path().join("demo.mp4");
+        std::fs::write(&mp4, [0_u8, 1, 2, 3]).unwrap();
+        assert!(video_to_base64_data_url(&mp4, None)
+            .unwrap()
+            .starts_with("data:video/mp4;base64,"));
+
+        let webm = tmp.path().join("demo.webm");
+        std::fs::write(&webm, [0_u8, 1, 2, 3]).unwrap();
+        assert!(video_to_base64_data_url(&webm, Some("video/webm"))
+            .unwrap()
+            .starts_with("data:video/webm;base64,"));
     }
 }

--- a/crates/hermes-tools/src/backends/vision.rs
+++ b/crates/hermes-tools/src/backends/vision.rs
@@ -1,6 +1,10 @@
 //! Real vision backend: call OpenAI-compatible multimodal API.
 
+use std::net::IpAddr;
+use std::path::Path;
+
 use async_trait::async_trait;
+use base64::Engine;
 use reqwest::Client;
 use serde_json::{json, Value};
 
@@ -37,35 +41,104 @@ impl OpenAiVisionBackend {
             })?;
         let base_url = std::env::var("OPENAI_BASE_URL")
             .unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
-        let model = std::env::var("VISION_MODEL").unwrap_or_else(|_| "gpt-4o".to_string());
+        let model = std::env::var("AUXILIARY_VISION_MODEL")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or_else(|| std::env::var("VISION_MODEL").ok())
+            .unwrap_or_else(|| "gpt-4o".to_string());
         Ok(Self::new(api_key, base_url, model))
     }
 
     async fn encode_image_if_local(&self, image_url: &str) -> Result<Value, ToolError> {
         if image_url.starts_with("http://") || image_url.starts_with("https://") {
+            if !validate_image_url_for_vision(image_url) {
+                return Err(ToolError::InvalidParams(format!(
+                    "Image URL is blocked by vision URL safety policy: {image_url}"
+                )));
+            }
             Ok(json!({"type": "image_url", "image_url": {"url": image_url}}))
         } else {
             // Local file - read and base64 encode
             let data = tokio::fs::read(image_url).await.map_err(|e| {
                 ToolError::ExecutionFailed(format!("Failed to read image '{}': {}", image_url, e))
             })?;
-            use base64::Engine;
             let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
-            let mime = if image_url.ends_with(".png") {
-                "image/png"
-            } else if image_url.ends_with(".gif") {
-                "image/gif"
-            } else if image_url.ends_with(".webp") {
-                "image/webp"
-            } else {
-                "image/jpeg"
-            };
+            let mime = determine_image_mime_type(Path::new(image_url));
             Ok(json!({
                 "type": "image_url",
                 "image_url": {"url": format!("data:{};base64,{}", mime, encoded)}
             }))
         }
     }
+}
+
+pub(crate) fn determine_image_mime_type(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|v| v.to_str())
+        .map(|v| v.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => "image/png",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        _ => "image/jpeg",
+    }
+}
+
+fn is_blocked_image_host(host: &str) -> bool {
+    let host = host.trim().trim_matches(['[', ']']).to_ascii_lowercase();
+    if host.is_empty()
+        || host == "localhost"
+        || host == "metadata.google.internal"
+        || host == "metadata.goog"
+        || host == "metadata.internal"
+    {
+        return true;
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return match ip {
+            IpAddr::V4(v4) => {
+                let o = v4.octets();
+                v4.is_loopback()
+                    || v4.is_private()
+                    || v4.is_link_local()
+                    || v4.is_unspecified()
+                    || v4.is_multicast()
+                    || (o[0] == 100 && (64..=127).contains(&o[1]))
+                    || (o[0] == 198 && (18..=19).contains(&o[1]))
+            }
+            IpAddr::V6(v6) => {
+                v6.is_loopback()
+                    || v6.is_unspecified()
+                    || v6.is_multicast()
+                    || (v6.segments()[0] & 0xffc0) == 0xfe80
+                    || (v6.segments()[0] & 0xfe00) == 0xfc00
+                    || v6.to_ipv4_mapped().is_some_and(|v4| {
+                        let o = v4.octets();
+                        v4.is_loopback()
+                            || v4.is_private()
+                            || v4.is_link_local()
+                            || (o[0] == 100 && (64..=127).contains(&o[1]))
+                    })
+            }
+        };
+    }
+    false
+}
+
+pub(crate) fn validate_image_url_for_vision(image_url: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(image_url.trim()) else {
+        return false;
+    };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return false;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    !is_blocked_image_host(host)
 }
 
 #[async_trait]
@@ -115,5 +188,58 @@ impl VisionBackend for OpenAiVisionBackend {
             .unwrap_or("No analysis available");
 
         Ok(content.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_mime_type_matches_upstream_defaults() {
+        assert_eq!(
+            determine_image_mime_type(Path::new("photo.jpg")),
+            "image/jpeg"
+        );
+        assert_eq!(
+            determine_image_mime_type(Path::new("photo.jpeg")),
+            "image/jpeg"
+        );
+        assert_eq!(
+            determine_image_mime_type(Path::new("image.png")),
+            "image/png"
+        );
+        assert_eq!(
+            determine_image_mime_type(Path::new("anim.gif")),
+            "image/gif"
+        );
+        assert_eq!(
+            determine_image_mime_type(Path::new("modern.webp")),
+            "image/webp"
+        );
+        assert_eq!(
+            determine_image_mime_type(Path::new("unknown.bin")),
+            "image/jpeg"
+        );
+    }
+
+    #[test]
+    fn image_url_validation_blocks_unsafe_schemes_and_hosts() {
+        assert!(validate_image_url_for_vision(
+            "https://example.com/image.jpg"
+        ));
+        assert!(validate_image_url_for_vision("http://cdn.example.org/pic"));
+        assert!(!validate_image_url_for_vision(
+            "ftp://example.com/image.jpg"
+        ));
+        assert!(!validate_image_url_for_vision("file:///etc/passwd"));
+        assert!(!validate_image_url_for_vision(
+            "http://localhost:8080/image.png"
+        ));
+        assert!(!validate_image_url_for_vision("http://127.0.0.1/admin"));
+        assert!(!validate_image_url_for_vision(
+            "http://169.254.169.254/latest"
+        ));
+        assert!(!validate_image_url_for_vision("http://[::1]/"));
     }
 }

--- a/crates/hermes-tools/src/tools/transcription.rs
+++ b/crates/hermes-tools/src/tools/transcription.rs
@@ -46,6 +46,31 @@ fn audio_extension_format(path: &str) -> &'static str {
         .unwrap_or("wav")
 }
 
+pub(crate) fn transcription_response_format_for_model(model: &str) -> &'static str {
+    if model.trim().eq_ignore_ascii_case("whisper-1") {
+        "text"
+    } else {
+        "json"
+    }
+}
+
+pub(crate) fn parse_transcription_response(
+    body: &str,
+    response_format: &str,
+) -> Result<String, ToolError> {
+    if response_format.eq_ignore_ascii_case("text") {
+        return Ok(body.trim().to_string());
+    }
+    let json: Value = serde_json::from_str(body)
+        .map_err(|e| ToolError::ExecutionFailed(format!("Whisper JSON: {e}")))?;
+    Ok(json
+        .get("text")
+        .and_then(|t| t.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string())
+}
+
 /// Compose the (endpoint, bearer, transport_label) tuple for a Whisper
 /// request. Pure helper so it can be unit-tested without touching the
 /// network.
@@ -99,6 +124,18 @@ impl ToolHandler for TranscriptionHandler {
             .map_err(|e| ToolError::ExecutionFailed(format!("Cannot read audio file: {e}")))?;
 
         let fmt = audio_extension_format(path);
+        let model = params
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("whisper-1");
+        let response_format = params
+            .get("response_format")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| transcription_response_format_for_model(model));
         let client = reqwest::Client::new();
         let part = reqwest::multipart::Part::bytes(bytes)
             .file_name(format!("audio.{fmt}"))
@@ -107,7 +144,8 @@ impl ToolHandler for TranscriptionHandler {
 
         let form = reqwest::multipart::Form::new()
             .part("file", part)
-            .text("model", "whisper-1");
+            .text("model", model.to_string())
+            .text("response_format", response_format.to_string());
 
         let resp = client
             .post(&endpoint)
@@ -125,19 +163,17 @@ impl ToolHandler for TranscriptionHandler {
             )));
         }
 
-        let json: Value = resp
-            .json()
+        let body = resp
+            .text()
             .await
-            .map_err(|e| ToolError::ExecutionFailed(format!("Whisper JSON: {e}")))?;
-        let text = json
-            .get("text")
-            .and_then(|t| t.as_str())
-            .unwrap_or("")
-            .to_string();
+            .map_err(|e| ToolError::ExecutionFailed(format!("Whisper read body: {e}")))?;
+        let text = parse_transcription_response(&body, response_format)?;
 
         Ok(json!({
             "audio_path": path,
+            "model": model,
             "text": text,
+            "response_format": response_format,
             "transport": transport,
             "status": "transcribed",
         })
@@ -225,6 +261,27 @@ mod tests {
         assert_eq!(audio_extension_format("a.xyz"), "wav");
         assert_eq!(audio_extension_format("noext"), "wav");
         assert_eq!(audio_extension_format(""), "wav");
+    }
+
+    #[test]
+    fn response_format_matches_openai_audio_model_contract() {
+        assert_eq!(transcription_response_format_for_model("whisper-1"), "text");
+        assert_eq!(
+            transcription_response_format_for_model("gpt-4o-mini-transcribe"),
+            "json"
+        );
+    }
+
+    #[test]
+    fn parse_transcription_response_handles_text_and_json_shapes() {
+        assert_eq!(
+            parse_transcription_response("  hello from whisper\n", "text").unwrap(),
+            "hello from whisper"
+        );
+        assert_eq!(
+            parse_transcription_response(r#"{"text":"hello from gpt-4o"}"#, "json").unwrap(),
+            "hello from gpt-4o"
+        );
     }
 
     #[test]

--- a/crates/hermes-tools/src/tools/tts.rs
+++ b/crates/hermes-tools/src/tools/tts.rs
@@ -21,6 +21,8 @@ pub trait TtsBackend: Send + Sync {
         text: &str,
         voice: Option<&str>,
         provider: Option<&str>,
+        output_path: Option<&str>,
+        speed: Option<f64>,
     ) -> Result<String, ToolError>;
 }
 
@@ -49,8 +51,12 @@ impl ToolHandler for TextToSpeechHandler {
 
         let voice = params.get("voice").and_then(|v| v.as_str());
         let provider = params.get("provider").and_then(|v| v.as_str());
+        let output_path = params.get("output_path").and_then(|v| v.as_str());
+        let speed = params.get("speed").and_then(|v| v.as_f64());
 
-        self.backend.synthesize(text, voice, provider).await
+        self.backend
+            .synthesize(text, voice, provider, output_path, speed)
+            .await
     }
 
     fn schema(&self) -> ToolSchema {
@@ -78,6 +84,20 @@ impl ToolHandler for TextToSpeechHandler {
                 "default": "openai"
             }),
         );
+        props.insert(
+            "output_path".into(),
+            json!({
+                "type": "string",
+                "description": "Optional output file path. Defaults to a temporary audio file."
+            }),
+        );
+        props.insert(
+            "speed".into(),
+            json!({
+                "type": "number",
+                "description": "Optional provider-specific speech speed multiplier."
+            }),
+        );
 
         tool_schema(
             "text_to_speech",
@@ -99,6 +119,8 @@ mod tests {
             text: &str,
             _voice: Option<&str>,
             _provider: Option<&str>,
+            _output_path: Option<&str>,
+            _speed: Option<f64>,
         ) -> Result<String, ToolError> {
             Ok(format!("Audio for: {}", text))
         }

--- a/crates/hermes-tools/src/tts_streaming/minimax.rs
+++ b/crates/hermes-tools/src/tts_streaming/minimax.rs
@@ -176,6 +176,8 @@ impl TtsBackend for MiniMaxTtsBackend {
         text: &str,
         voice: Option<&str>,
         _provider: Option<&str>,
+        output_path: Option<&str>,
+        _speed: Option<f64>,
     ) -> Result<String, ToolError> {
         let audio = self.synthesize_to_bytes(text, voice).await?;
         let suffix = match self.settings.format.as_str() {
@@ -183,8 +185,12 @@ impl TtsBackend for MiniMaxTtsBackend {
             "flac" => "flac",
             _ => "mp3",
         };
-        let path =
-            std::env::temp_dir().join(format!("hermes_minimax_{}.{suffix}", uuid::Uuid::new_v4()));
+        let path = output_path
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| {
+                std::env::temp_dir()
+                    .join(format!("hermes_minimax_{}.{suffix}", uuid::Uuid::new_v4()))
+            });
         tokio::fs::write(&path, &audio)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("write audio: {e}")))?;
@@ -367,7 +373,10 @@ mod tests {
             model: "m".into(),
             settings: MiniMaxVoiceSettings::default(),
         };
-        let err = backend.synthesize("hello", None, None).await.unwrap_err();
+        let err = backend
+            .synthesize("hello", None, None, None, None)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("MINIMAX_API_KEY"));
     }
 }

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T09:51:22.516485+00:00",
+  "generated_at_utc": "2026-05-30T10:26:04.996490+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "51096a1a8016770af8ece117d6ae92afec19e099",
+    "local_sha": "4c993b1011827da6eb6059783b6e9a678f296c8a",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625",
+    "upstream_sha": "61268ff7a9be93673361e433cbf2e775798a13ae",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4403,
-    "commits_ahead": 857,
-    "upstream_patch_missing": 4285,
+    "commits_behind": 4466,
+    "commits_ahead": 859,
+    "upstream_patch_missing": 4346,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 712,
-    "files_only_upstream": 1474,
+    "local_patch_unique": 713,
+    "files_only_upstream": 1484,
     "files_only_local": 570,
-    "files_shared_identical": 1701,
-    "files_shared_different": 1018,
-    "tree_files_changed": 3062,
-    "tree_insertions": 740489,
-    "tree_deletions": 391368
+    "files_shared_identical": 1691,
+    "files_shared_different": 1028,
+    "tree_files_changed": 3082,
+    "tree_insertions": 746550,
+    "tree_deletions": 392534
   },
   "top_upstream_only": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 86
+      "count": 90
     },
     {
       "path": "web/src",
@@ -36,11 +36,11 @@
     },
     {
       "path": "tests/agent",
-      "count": 53
+      "count": 54
     },
     {
       "path": "tests/gateway",
-      "count": 40
+      "count": 41
     },
     {
       "path": "gateway/platforms",
@@ -68,7 +68,7 @@
     },
     {
       "path": "tests/run_agent",
-      "count": 19
+      "count": 20
     },
     {
       "path": "ui-tui/src",
@@ -76,7 +76,7 @@
     },
     {
       "path": "tests/cli",
-      "count": 17
+      "count": 18
     },
     {
       "path": ".github/workflows",
@@ -190,27 +190,27 @@
     },
     {
       "path": "website/docs",
-      "count": 138
+      "count": 139
     },
     {
       "path": "tests/tools",
-      "count": 137
+      "count": 138
     },
     {
       "path": "tests/hermes_cli",
-      "count": 126
+      "count": 127
+    },
+    {
+      "path": "ui-tui/src",
+      "count": 60
     },
     {
       "path": "tests/agent",
       "count": 58
     },
     {
-      "path": "ui-tui/src",
-      "count": 58
-    },
-    {
       "path": "tests/run_agent",
-      "count": 56
+      "count": 57
     },
     {
       "path": "tests/cli",
@@ -222,7 +222,7 @@
     },
     {
       "path": "tests/plugins",
-      "count": 16
+      "count": 17
     },
     {
       "path": "skills/creative",
@@ -237,16 +237,16 @@
       "count": 9
     },
     {
+      "path": "plugins/memory",
+      "count": 9
+    },
+    {
       "path": "plugins/platforms",
       "count": 9
     },
     {
       "path": "tests/acp",
       "count": 8
-    },
-    {
-      "path": "plugins/memory",
-      "count": 7
     },
     {
       "path": "skills/productivity",
@@ -514,7 +514,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 86
+      "count": 90
     },
     {
       "path": "web/src",
@@ -522,11 +522,11 @@
     },
     {
       "path": "tests/agent",
-      "count": 53
+      "count": 54
     },
     {
       "path": "tests/gateway",
-      "count": 40
+      "count": 41
     },
     {
       "path": "gateway/platforms",
@@ -554,7 +554,7 @@
     },
     {
       "path": "tests/run_agent",
-      "count": 19
+      "count": 20
     },
     {
       "path": "ui-tui/src",
@@ -562,7 +562,7 @@
     },
     {
       "path": "tests/cli",
-      "count": 17
+      "count": 18
     },
     {
       "path": ".github/workflows",
@@ -836,8 +836,8 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 320,
-      "shared_different": 683,
+      "upstream_only": 329,
+      "shared_different": 687,
       "local_only": 34,
       "risk": "critical",
       "effort": "XL"
@@ -847,7 +847,7 @@
       "issue": 9,
       "name": "UX parity",
       "upstream_only": 493,
-      "shared_different": 231,
+      "shared_different": 234,
       "local_only": 72,
       "risk": "high",
       "effort": "XL"
@@ -856,7 +856,7 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 392,
+      "upstream_only": 393,
       "shared_different": 12,
       "local_only": 195,
       "risk": "high",
@@ -867,7 +867,7 @@
       "issue": 7,
       "name": "Tools and adapters parity",
       "upstream_only": 114,
-      "shared_different": 53,
+      "shared_different": 55,
       "local_only": 104,
       "risk": "high",
       "effort": "L"
@@ -877,7 +877,7 @@
       "issue": 8,
       "name": "Skills parity",
       "upstream_only": 93,
-      "shared_different": 39,
+      "shared_different": 40,
       "local_only": 14,
       "risk": "medium",
       "effort": "L"
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4285,
+    "upstream_patch_missing": 4346,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 712,
+    "local_patch_unique": 713,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",
@@ -960,7 +960,7 @@
       "6b69de4772eac5f982c097553dc6bcfeb60350e6"
     ],
     "intentional_divergence_items": 8,
-    "intentional_divergence_covered_files": 900
+    "intentional_divergence_covered_files": 904
   },
   "intentional_divergence": [
     {
@@ -1005,11 +1005,12 @@
       "status": "approved",
       "workstream": "WS4",
       "summary": "Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring).",
-      "matched_files": 146,
+      "matched_files": 147,
       "matched_sample": [
         "optional-skills/autonomous-ai-agents/antigravity-cli/SKILL.md",
         "optional-skills/autonomous-ai-agents/antigravity-cli/references/cli-docs.md",
         "optional-skills/autonomous-ai-agents/grok/SKILL.md",
+        "optional-skills/autonomous-ai-agents/honcho/SKILL.md",
         "optional-skills/autonomous-ai-agents/openhands/SKILL.md",
         "optional-skills/blockchain/base/SKILL.md",
         "optional-skills/blockchain/base/scripts/base_client.py",
@@ -1025,8 +1026,7 @@
         "optional-skills/devops/pinggy-tunnel/SKILL.md",
         "optional-skills/devops/watchers/scripts/watch_rss.py",
         "optional-skills/finance/SKILL.md",
-        "optional-skills/finance/dcf-model/scripts/validate_dcf.py",
-        "optional-skills/finance/scripts/stocks_client.py"
+        "optional-skills/finance/dcf-model/scripts/validate_dcf.py"
       ]
     },
     {
@@ -1077,7 +1077,7 @@
       "status": "approved",
       "workstream": "WS5",
       "summary": "Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported.",
-      "matched_files": 728,
+      "matched_files": 731,
       "matched_sample": [
         "ui-tui/README.md",
         "ui-tui/babel.compiler.config.cjs",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,48 +1,48 @@
 # Parity Matrix
 
-Generated: `2026-05-30T09:51:22.516485+00:00`
+Generated: `2026-05-30T10:26:04.996490+00:00`
 
 ## Scope
 
-- Local ref: `main` (`51096a1a8016770af8ece117d6ae92afec19e099`)
-- Upstream ref: `upstream/main` (`bcc83010006c7059ee4d0be63fe74afc74867625`)
+- Local ref: `main` (`4c993b1011827da6eb6059783b6e9a678f296c8a`)
+- Upstream ref: `upstream/main` (`61268ff7a9be93673361e433cbf2e775798a13ae`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4403 |
-| Commits ahead local (`local` ancestry only) | 857 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4285 |
+| Commits behind local (`upstream` ancestry only) | 4466 |
+| Commits ahead local (`local` ancestry only) | 859 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4346 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 712 |
-| Files only in upstream tree | 1474 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 713 |
+| Files only in upstream tree | 1484 |
 | Files only in local tree | 570 |
-| Shared files identical content | 1701 |
-| Shared files different content | 1018 |
-| Total files changed (`local` vs `upstream`) | 3062 |
-| Insertions (`local` vs `upstream`) | 740489 |
-| Deletions (`local` vs `upstream`) | 391368 |
+| Shared files identical content | 1691 |
+| Shared files different content | 1028 |
+| Total files changed (`local` vs `upstream`) | 3082 |
+| Insertions (`local` vs `upstream`) | 746550 |
+| Deletions (`local` vs `upstream`) | 392534 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
 | `website/i18n` | 332 |
-| `tests/hermes_cli` | 86 |
+| `tests/hermes_cli` | 90 |
 | `web/src` | 77 |
-| `tests/agent` | 53 |
-| `tests/gateway` | 40 |
+| `tests/agent` | 54 |
+| `tests/gateway` | 41 |
 | `gateway/platforms` | 39 |
 | `skills/creative` | 36 |
 | `tests/tools` | 34 |
 | `website/docs` | 34 |
 | `optional-skills/research` | 33 |
 | `tests/plugins` | 21 |
-| `tests/run_agent` | 19 |
+| `tests/run_agent` | 20 |
 | `ui-tui/src` | 19 |
-| `tests/cli` | 17 |
+| `tests/cli` | 18 |
 | `.github/workflows` | 15 |
 | `tests/docker` | 12 |
 | `agent/lsp` | 11 |
@@ -75,21 +75,21 @@ Generated: `2026-05-30T09:51:22.516485+00:00`
 | Bucket | Files |
 | --- | ---: |
 | `tests/gateway` | 172 |
-| `website/docs` | 138 |
-| `tests/tools` | 137 |
-| `tests/hermes_cli` | 126 |
+| `website/docs` | 139 |
+| `tests/tools` | 138 |
+| `tests/hermes_cli` | 127 |
+| `ui-tui/src` | 60 |
 | `tests/agent` | 58 |
-| `ui-tui/src` | 58 |
-| `tests/run_agent` | 56 |
+| `tests/run_agent` | 57 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |
-| `tests/plugins` | 16 |
+| `tests/plugins` | 17 |
 | `skills/creative` | 11 |
 | `tests/cron` | 11 |
 | `plugins/google_meet` | 9 |
+| `plugins/memory` | 9 |
 | `plugins/platforms` | 9 |
 | `tests/acp` | 8 |
-| `plugins/memory` | 7 |
 | `skills/productivity` | 7 |
 | `tests/skills` | 6 |
 | `plugins/model-providers` | 5 |
@@ -164,20 +164,20 @@ Generated: `2026-05-30T09:51:22.516485+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 320 | 683 | critical | XL |
-| `WS5` | #9 | UX parity | 493 | 231 | high | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 392 | 12 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 114 | 53 | high | L |
-| `WS4` | #8 | Skills parity | 93 | 39 | medium | L |
+| `WS6` | #10 | Tests and CI parity | 329 | 687 | critical | XL |
+| `WS5` | #9 | UX parity | 493 | 234 | high | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 393 | 12 | high | XL |
+| `WS3` | #7 | Tools and adapters parity | 114 | 55 | high | L |
+| `WS4` | #8 | Skills parity | 93 | 40 | medium | L |
 | `WS2` | #6 | Core runtime parity | 62 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4285`
+- Upstream missing by patch-id: `4346`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `712`
-- Intentional divergence tracked items: `8` (covered files: `900`)
+- Local unique by patch-id: `713`
+- Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -187,11 +187,11 @@ Generated: `2026-05-30T09:51:22.516485+00:00`
 | `ultra-contextlattice-memory-plugin` | approved | WS3 | 2 | Keep ContextLattice native memory plugin and provider discovery in the Rust agent runtime. |
 | `ultra-webhook-queue-backends` | approved | WS7 | 4 | Preserve webhook-driven sync queue worker architecture with sqlite, SQS, and Kafka support. |
 | `ultra-launchd-webhook-lifecycle` | approved | WS7 | 4 | Preserve launchd-based interactive dev lifecycle management for webhook listener and worker. |
-| `rust-skills-catalog-governance` | approved | WS4 | 146 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
+| `rust-skills-catalog-governance` | approved | WS4 | 147 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
 | `rust-gateway-platform-plugin-parity` | approved | WS3 | 5 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
 | `upstream-python-plugin-backend-drift-20260527` | temporary | WS3 | 10 | Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes. |
 | `upstream-s6-plan-doc-archive` | approved | WS7 | 1 | Do not import upstream implementation-plan archive documents unless they change local runtime or release behavior. |
-| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 728 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
+| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 731 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
 
 
 ## Notes

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -185,6 +185,21 @@
       "classification": "intentional_divergence",
       "classification_path": "optional-skills",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "865d844df26e8439193abc8f6fe11d8437a90e9e",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills/autonomous-ai-agents/honcho/SKILL.md",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "b4a24a46e25d743426f524c29f865d49cdf5a002",
+      "workstream": "WS4"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "optional-skills",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "288c38383677ca0b14837d1b4abd024596777d71",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
@@ -687,7 +702,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "ef8fcafb88a2d883f705c0decb61c7d67d49e488",
+      "upstream_blob": "2f94c08da383321afec997bcbf17f2ac21933b1c",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/memory",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "dbe3eebc9a56d1910a111800666634dbb1810273",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/README.md",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "3774747d05a7ba858585e9a154403bc824824a5b",
       "workstream": "WS3"
     },
     {
@@ -702,7 +732,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "bbff0d0e6281db8a707d5174d6970d130138a548",
+      "upstream_blob": "6e6f39b8cd7f18819a4a8a4b928bce798fa98876",
       "workstream": "WS3"
     },
     {
@@ -717,7 +747,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "9227bf95ab8c3ecd87812fc2c53bb6bbba2d7b84",
+      "upstream_blob": "ce2af8a08b2a6e86a0b8a7933b7bfc3c8adb6fcd",
       "workstream": "WS3"
     },
     {
@@ -732,7 +762,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "3d31bd7a1fb83832ba71318c6528465547e025f5",
+      "upstream_blob": "ae837a0b1157cccb640633d2e75b4b2d275ce9c7",
       "workstream": "WS3"
     },
     {
@@ -751,6 +781,21 @@
       "workstream": "WS3"
     },
     {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/memory",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "32d1f6ff700237a50e246a97759d549dc8248fb5",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/mem0/__init__.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "332b3ac9412957eee3a8cfd46a0503f00288098b",
+      "workstream": "WS3"
+    },
+    {
       "action": "No runtime implementation; keep rationale current.",
       "classification": "policy_only",
       "classification_path": "plugins/memory/supermemory/__init__.py",
@@ -762,7 +807,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "35b5b6fd649e2fc4c0c5cdf8821f32cc336eb7ae",
+      "upstream_blob": "a21ae53cc06f7e400ee2571bddd96385b674d873",
       "workstream": "WS3"
     },
     {
@@ -1197,7 +1242,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "7d1df04124ec3db109f3bb7bbdec11a314714390",
+      "upstream_blob": "bf96b93c6d0c8f2efa39fc7a4550da8518342d0a",
       "workstream": "WS8"
     },
     {
@@ -1452,7 +1497,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "231b1b6849fc9e9e821670a80872c0119927dc17",
+      "upstream_blob": "27855a5158eb5497bfc37a8d7f17c48e0a9b5864",
       "workstream": "WS4"
     },
     {
@@ -1887,7 +1932,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0d7aa81f41fdc64f11ad1352be9a0ad10586bf1d",
+      "upstream_blob": "5ce753864c908c13d51560c245bcfa43a3c33e79",
       "workstream": "WS6"
     },
     {
@@ -2217,7 +2262,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "3f9fd56d140fa192ca2aecdcd1016e710a23b175",
+      "upstream_blob": "5b1abfd32d059b415bb30c133f42821d91d52afd",
       "workstream": "WS6"
     },
     {
@@ -2247,7 +2292,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "41fb4463ec806eadbca56a0110ee31f34fec9234",
+      "upstream_blob": "b4bbbf753dfa57c51726ffebd29c4d3179a91657",
       "workstream": "WS6"
     },
     {
@@ -3282,7 +3327,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0c6e2df3bd9038d1319a119b4b3fd8c8d72e5acf",
+      "upstream_blob": "37f8b51a458d489d78c57d6e416ed60bd70480e8",
       "workstream": "WS6"
     },
     {
@@ -5157,7 +5202,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "01222597224ea676d9ccd9c6fea0e9628b469be7",
+      "upstream_blob": "0b88d271808d81a2c76565f68e5492c6bda97871",
       "workstream": "WS6"
     },
     {
@@ -6147,7 +6192,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0cb8d033eb8200f8b7dcf7bbb4f0dde60953ea7f",
+      "upstream_blob": "ed9033ffce2fccf9f213edacf466868e1c5fa8c3",
       "workstream": "WS6"
     },
     {
@@ -6283,6 +6328,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "3d0b0bdeb722f781b6dd3ddeb5898fa64d785bbe",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "e414687bce755b7ccb7b39056c0f1c875620a8ca",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_copilot_in_model_list.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "83832b0c332fa22c7f976f739d967c3247f166e7",
       "workstream": "WS6"
     },
     {
@@ -6522,7 +6582,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "2c2f146ed85aa947f6d731b63b99177e435313ac",
+      "upstream_blob": "86aaf699bf60251e9d730337c92281dce569f62a",
       "workstream": "WS6"
     },
     {
@@ -6627,7 +6687,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "020ad4fb4255b1509da8b303995febda1ca60c47",
+      "upstream_blob": "b2510855ea25610e800bf9f3ddece5b2d7e05a92",
       "workstream": "WS6"
     },
     {
@@ -6822,7 +6882,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "91fc4e50d009b4e1218ee8e69b95b0dbcd6509ae",
+      "upstream_blob": "89465b6c6c7538e5f27ddf878aab10b0bd0589d7",
       "workstream": "WS6"
     },
     {
@@ -6837,7 +6897,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "db96a6558d7d877ab2ff1ccf7ca9e206da0b747a",
+      "upstream_blob": "f965f361decd0dab1fcf8af9f23af148900b100e",
       "workstream": "WS6"
     },
     {
@@ -6882,7 +6942,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "2c89d245301599cf17ff57818c142fd025868a00",
+      "upstream_blob": "561602c0ac691ed51802813b42d37ce775d66e38",
       "workstream": "WS6"
     },
     {
@@ -6912,7 +6972,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "e62aa899ff81198e4cd7c1df09023344369c0197",
+      "upstream_blob": "ad7e3a0b9d90e08ac386fe98b814e10e6cb163a8",
       "workstream": "WS6"
     },
     {
@@ -7047,7 +7107,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "22e36d42123d0ccc7a580229e7848bb8230ea90f",
+      "upstream_blob": "dd336030928eae89223925729b13ebde75ed97d5",
       "workstream": "WS6"
     },
     {
@@ -7527,7 +7587,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "cfef9c3b46ac328cbc54fb62b51fbf1cd49206b3",
+      "upstream_blob": "e93ad8fcaf30a8f331c79463f91a05b7bd9ccf40",
       "workstream": "WS6"
     },
     {
@@ -7707,7 +7767,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "97f4f7306d5ce45e1a6d7f8c08730ef1ef4c2d48",
+      "upstream_blob": "e1f2f5ea97b438a8cf7d6335275d435fd1f79338",
       "workstream": "WS6"
     },
     {
@@ -7722,7 +7782,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "8244badc2f664f414040bff0706803e3b6f525e4",
+      "upstream_blob": "74b7e1bc34e761f8f172f8d6a55fe0ca2d7d6c14",
       "workstream": "WS6"
     },
     {
@@ -7737,7 +7797,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "a02e6937a3468cc587b828617a3e091ef27876c6",
+      "upstream_blob": "929df4283f6a9c3f3b9afc948052babe7421b9e5",
       "workstream": "WS6"
     },
     {
@@ -7752,7 +7812,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "ef3a215f32991a26b24f8caaedff923ab158fdb6",
+      "upstream_blob": "1e72bc97d1a45218f7e0066f14fdc621543a1512",
       "workstream": "WS6"
     },
     {
@@ -7872,7 +7932,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "bc62b7f2c8fc5821577955a11844784aa580678f",
+      "upstream_blob": "f49c227611ae2bbaad90952034bd9e3fc1fdb520",
       "workstream": "WS6"
     },
     {
@@ -7887,7 +7947,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "1ef85499b54eee976813679c3e4ce02801779a61",
+      "upstream_blob": "a9a8667645237e3a3615e4ee4b98bf0a31dd8264",
       "workstream": "WS6"
     },
     {
@@ -7903,6 +7963,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "3f609cd1d67aee01f530115d5dfb74dea642385d",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/plugins",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "0aee459757f4ada65bbfc860504c81332588d7d3",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/plugins/memory/test_supermemory_provider.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "d5f1c5bb17400ddfb86dd52e32892f4fbf7d1571",
       "workstream": "WS6"
     },
     {
@@ -8157,7 +8232,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "6695d6c275ea8608a7a4c3f555baf5e151d4b932",
+      "upstream_blob": "cadb26c449b3f2b94a82561cccbc1e0ee0e4b770",
       "workstream": "WS6"
     },
     {
@@ -8413,6 +8488,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "c8c322191ffca044297b8717d1a47ea845d18a97",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/run_agent",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "61ee6fc5c28b9eaa15f8b85ac900b5ccf9d44adc",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_dict_tool_call_args.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "ac249919fa1f01fa610ab6826642d07154aa5e46",
       "workstream": "WS6"
     },
     {
@@ -8727,7 +8817,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "07ff74930b0f5ab4cbf7c514cea714f6fb9161eb",
+      "upstream_blob": "2bef65887da1dad1b63fbc129656621e86d7f7dd",
       "workstream": "WS6"
     },
     {
@@ -8967,7 +9057,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "30a1441d634b4935d7a7450b01568f901a0a82e1",
+      "upstream_blob": "ffb56ce3cb58bc645bc252c7ac5f5eb0bb3774e9",
       "workstream": "WS6"
     },
     {
@@ -9267,7 +9357,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "cec3c13f0da76c807e833d8140a04a2dbfd967ff",
+      "upstream_blob": "8fec76aa6b96ff95bf1b89683283ce718c51dd8f",
       "workstream": "WS6"
     },
     {
@@ -9297,7 +9387,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "d4c62d610e99585de85ccbe286c2d80e636c2d68",
+      "upstream_blob": "f7b1efa151ccd5452aec4f6370fa7617ac9792e3",
       "workstream": "WS6"
     },
     {
@@ -9477,7 +9567,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "d72c0224a692e31cf3a789a5695fe87d20965f17",
+      "upstream_blob": "fadb022f31f6a03618e272892092cf111eafd6f5",
       "workstream": "WS6"
     },
     {
@@ -10302,7 +10392,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f809ea5d9129ec6db269846363fa3c7081b55e17",
+      "upstream_blob": "b5f06248f5a1c090858d573711361e7439f69821",
       "workstream": "WS6"
     },
     {
@@ -10378,6 +10468,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "641e7dc6a0a813ddcf96d79954f4c960787bdddc",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "e2eef17ab1dbd3f336e8aa5ada1cb52493da05f1",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_write_safety.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "a2bb05dd13a9103501bbb8bf0538c06d6d07c0bd",
       "workstream": "WS6"
     },
     {
@@ -10591,16 +10696,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_managed_media_gateways.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "4468dfe94d7c4ab29db2afc549e2effc40021de0",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_managed_media_gateways.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "d8b60d1644dbd0df52bfbec4109d0eff126ee017",
       "workstream": "WS6"
@@ -10707,7 +10812,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "1dd76959854c6bd388ad9903d00b840eb03b1bbe",
+      "upstream_blob": "2c3734274d88902ee8b63d333596ab84cadfa6b9",
       "workstream": "WS6"
     },
     {
@@ -10962,7 +11067,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "3a6ad11fdea18212f22c7de1ed2bc20f5d561176",
+      "upstream_blob": "10a4868655b3f3e097f01b8dd51ad96ae3ea493a",
       "workstream": "WS6"
     },
     {
@@ -10981,16 +11086,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_signal_media.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ee483c0819336b962adc605171d49f727c3e807b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_signal_media.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6d1bc2112ebd000a1b87bca996e96547e9984433",
       "workstream": "WS6"
@@ -11172,7 +11277,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "1813f4c50e753e9a3fe105c309d7fc1286b3f4ec",
+      "upstream_blob": "c13ed18727a527bfeb8b1cac043031223c2a9ccd",
       "workstream": "WS6"
     },
     {
@@ -11356,136 +11461,136 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_transcription.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e56577ca55694dc69846be2f6f7b40098c99dbc1",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_transcription.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "84f6c9679af6df2b03ac3c1d2ccea98918f71d2e",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_transcription_dotenv_fallback.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "39f5ca108e3c8f8a9eb39c46789771368c367807",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_transcription_dotenv_fallback.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e764ac0b42609b2f4210e1442892cd639d45e1e4",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_transcription_tools.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e5b27d9e4d4b255455456ce2cb809b44b17a878c",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_transcription_tools.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f3c0cf29c8355d926eeb785a5d3580abc9fd5917",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tts_command_providers.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "583abcb588b54162f6eaf77fa5a231f4670bdab7",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tts_command_providers.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e3242274a005184abfd4294c069b3792dd8df2bd",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tts_dotenv_fallback.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "05083208709ed160e752ca126e47337a1f300e10",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tts_dotenv_fallback.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0a4ea5a8ac2e75c33fe97a6f1445e81bccba3440",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tts_kittentts.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ab841f59f4ad75caf17bb823fd152d43731c8d67",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tts_kittentts.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f4918df4496ba0c0975339e40df5544bcae3cfbc",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tts_max_text_length.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "38a763ea78caaec17175e1f3a3f607aec675e003",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tts_max_text_length.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "49ae5ca2f4b9624e0152255f2d33c7c56542bb73",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tts_piper.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ef7330a18c9944bc742ea55a5b0987cba48eee26",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tts_piper.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c30b26dc9b9460470a6c89027780416bb9f19147",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tts_speed.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8a3866aaa8a3b19bc67493bc4e7a125b7a9896c6",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tts_speed.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "d9274bb84d794a95231abac488d7b788957c62ff",
       "workstream": "WS6"
@@ -11506,76 +11611,76 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_video_analyze.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "62987d96b208bc305e0436b3ee218fe3a3acfece",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_video_analyze.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1294ab8f55813b1b4a1491f05e47480fed4b38e6",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_vision_native_fast_path.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "fce3772de8ec7127fd586b345d6d4edc8cfd25bf",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_vision_native_fast_path.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "9916ca369d504c52ca919b82758c4f92de3861ea",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_vision_tools.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d8977f84927fb3ffb49503c0d3be64295a3d6106",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_vision_tools.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e3bff50d56f760fa863cc0b51ac57fee2682c9e9",
+      "upstream_blob": "7a50a4b4630c610a8fb95c1c313aebd08c083859",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_voice_cli_integration.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "93dffa649a7b708c18970191c58e4a5137d35be7",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_voice_cli_integration.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f43eb97c96de99ae7f2a8330097c126fb4f09dc5",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_voice_mode.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1d35c48625f661354617da49624d04dd1bc25dec",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_voice_mode.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "2a2b77bae2ee43f22de76549bfeea9db10b8436e",
       "workstream": "WS6"
@@ -12140,6 +12245,21 @@
       "classification": "functional",
       "classification_path": "ui-tui/src",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "b0646ee488e8862401ee337c5ca7bfea33ba5077",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/__tests__/clipboard.test.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "93feb009d870885f90f7fec9543c6f4bb80a704f",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d74976d195eddb5157cc3568d784e2acbcb47c57",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -12147,7 +12267,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0a3e4227396425f0c26e7f4fbc4c593fb19d0dae",
+      "upstream_blob": "897875b2c032bb7b56a2914d0b8e048836abc252",
       "workstream": "WS5"
     },
     {
@@ -12387,7 +12507,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "26d6cfacd0c2401d7990c7dbe0fb38fef118731e",
+      "upstream_blob": "70264b0c7f93e54bc21ccaffd279802774c5a0de",
       "workstream": "WS5"
     },
     {
@@ -12777,7 +12897,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0d9ecee87c9f2d080e12460df73c8bd46ba7aa22",
+      "upstream_blob": "ce90cca21386269b2c24b4e0b3904c2f2cd7b980",
       "workstream": "WS5"
     },
     {
@@ -12867,7 +12987,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "ae1f38e9b38482f6ed01825ecd27c1c3983bee50",
+      "upstream_blob": "447dec3ea49209a58bc44d7da66a7b1848f0946a",
       "workstream": "WS5"
     },
     {
@@ -12883,6 +13003,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "592d20e9a07d22969bffd5d7c2ab3131bb7129a3",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "587e8986c3ebd813cdc1bd12f5f6bea91c77b9c5",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/lib/clipboard.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "4a5387ae2d22c27a588f07b57f1200465f89154d",
       "workstream": "WS5"
     },
     {
@@ -13137,7 +13272,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "4b51175618194cf117c17416c72b1ef8a172600d",
+      "upstream_blob": "55641b16f278eab60f7f9467cb80e0276da65f10",
       "workstream": "WS5"
     },
     {
@@ -13782,7 +13917,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "5882d4aaac31c8845d12a5c3b9ff83b118a080fe",
+      "upstream_blob": "b8b41a621e01407cafb12caa8314bad77a076342",
       "workstream": "WS5"
     },
     {
@@ -14210,6 +14345,21 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "61dd73e8f2e0885fe49aff498f7bbe58c5f44e4c",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "website/docs/user-guide/features/honcho.md",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "b971bea272d3ea83fd74a00922b33074515a8e39",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "website/docs",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b71c10a6465e1dc858d54e5a181c625f52284a01",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
@@ -14292,7 +14442,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f584c7288a83580579c49c0a015396c1157063c5",
+      "upstream_blob": "00f2555d620c806fad47de63ab7bda76b91cda4f",
       "workstream": "WS5"
     },
     {
@@ -15271,41 +15421,42 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T09:51:28.970397+00:00",
+  "generated_at_utc": "2026-05-30T10:26:05.130629+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "51096a1a8016770af8ece117d6ae92afec19e099",
+    "local_sha": "4c993b1011827da6eb6059783b6e9a678f296c8a",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "bcc83010006c7059ee4d0be63fe74afc74867625"
+    "upstream_sha": "61268ff7a9be93673361e433cbf2e775798a13ae"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 705,
-      "intentional_divergence": 144,
-      "policy_only": 168
+      "functional": 697,
+      "intentional_divergence": 161,
+      "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 313,
-      "rust_equivalent_or_contract_test_required": 626,
-      "rust_primary_ux_or_documented_divergence_required": 79
+      "not_required_for_runtime": 331,
+      "rust_equivalent_or_contract_test_required": 614,
+      "rust_native_runtime_parity_required_if_needed": 2,
+      "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 144,
-      "cleared_non_runtime": 169,
-      "pending_review": 705
+      "cleared_intentional_divergence": 161,
+      "cleared_non_runtime": 170,
+      "pending_review": 697
     },
     "by_workstream": {
-      "WS3": 53,
-      "WS4": 39,
-      "WS5": 230,
-      "WS6": 683,
+      "WS3": 55,
+      "WS4": 40,
+      "WS5": 233,
+      "WS6": 687,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 144,
-    "cleared_non_runtime": 169,
+    "cleared_intentional_divergence": 161,
+    "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 705,
-    "total_shared_different": 1018
+    "pending_review": 697,
+    "total_shared_different": 1028
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,31 +1,31 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T09:51:28.970397+00:00`
+Generated: `2026-05-30T10:26:05.130629+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1018`
+- Total shared-different paths: `1028`
 - Pending classification: `0`
-- Pending functional review: `705`
-- Cleared non-runtime: `169`
-- Cleared intentional divergence: `144`
+- Pending functional review: `697`
+- Cleared non-runtime: `170`
+- Cleared intentional divergence: `161`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 144 |
-| `cleared_non_runtime` | 169 |
-| `pending_review` | 705 |
+| `cleared_intentional_divergence` | 161 |
+| `cleared_non_runtime` | 170 |
+| `pending_review` | 697 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 53 |
-| `WS4` | 39 |
-| `WS5` | 230 |
-| `WS6` | 683 |
+| `WS3` | 55 |
+| `WS4` | 40 |
+| `WS5` | 233 |
+| `WS6` | 687 |
 | `WS8` | 13 |
 
 ## Pending Classification
@@ -38,15 +38,15 @@ Generated: `2026-05-30T09:51:28.970397+00:00`
 | Classification Path | Count |
 | --- | ---: |
 | `tests/gateway` | 147 |
-| `tests/tools` | 127 |
-| `tests/hermes_cli` | 126 |
-| `ui-tui/src` | 58 |
-| `tests/run_agent` | 55 |
+| `tests/hermes_cli` | 127 |
+| `tests/tools` | 112 |
+| `ui-tui/src` | 60 |
+| `tests/run_agent` | 56 |
 | `tests/agent` | 46 |
 | `tests` | 40 |
 | `tests/cli` | 29 |
 | `ui-tui/packages` | 18 |
-| `tests/plugins` | 16 |
+| `tests/plugins` | 17 |
 | `tests/cron` | 11 |
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
@@ -55,4 +55,5 @@ Generated: `2026-05-30T09:51:28.970397+00:00`
 | `tests/tui_gateway` | 4 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
+| `plugins/memory` | 2 |
 | `tests/e2e` | 2 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -388,6 +388,118 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_managed_media_gateways.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream managed media gateway behavior is covered by Rust OpenAI-audio managed endpoint contracts for TTS and transcription plus FAL managed video-generation contracts; direct keys still override managed gateways where required.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_signal_media.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Signal media behavior is covered by Rust gateway SignalAdapter attachment upload, image-url download, text fallback, and platform registration contracts; the Python send_message_tool tests remain reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_transcription.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream transcription behavior is covered by Rust transcription handler contracts for audio extension mapping, credential/gateway endpoint resolution, missing-path errors, and model-specific response parsing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_transcription_dotenv_fallback.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream transcription key fallback behavior is covered by Rust openai-audio credential resolution contracts that prefer VOICE_TOOLS_OPENAI_KEY before HERMES_OPENAI_API_KEY and legacy OPENAI_API_KEY.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_transcription_tools.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream STT provider semantics are covered by Rust transcription contracts for explicit OpenAI-audio routing, managed/direct credential order, extension MIME mapping, and whisper text versus GPT transcribe JSON response formats.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tts_command_providers.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream command-provider TTS behavior is covered by Rust MultiTtsBackend contracts for provider lookup, reserved built-in names, command template quoting, timeout/output validation, output format, voice-compatible media tags, and max_text_length.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tts_dotenv_fallback.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream TTS credential fallback behavior is covered by Rust openai-audio contracts that prefer VOICE_TOOLS_OPENAI_KEY, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY, with Nous-managed audio gateway support.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tts_kittentts.py",
+      "classification": "intentional_divergence",
+      "rationale": "KittenTTS remains an intentional Python-provider divergence in Hermes Agent Ultra; Rust TTS contracts reject Python-only providers with migration guidance while retaining Rust-native OpenAI, ElevenLabs, MiniMax, Piper, and command-provider paths.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tts_max_text_length.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream per-provider TTS length behavior is covered by Rust resolve_max_text_length contracts for OpenAI, xAI, MiniMax, ElevenLabs model-specific limits, Piper, command providers, overrides, and fallback limits.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tts_piper.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Piper behavior is covered by Rust-native Piper contracts using the local piper binary and PIPER_MODEL/PIPER_* knobs, with model-required errors and zero-Python runtime enforcement.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tts_speed.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream TTS speed behavior is covered by Rust contracts for provider/global speed precedence, OpenAI speed clamping, command-provider speed placeholder rendering, and MiniMax raw-audio payload shape without legacy voice_setting.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_video_analyze.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream video analysis behavior is covered by Rust VideoAnalyzeHandler and VisionFrameSamplingVideoBackend contracts for schema/aliases, safe prompt defaults, max frame clamping, MIME detection, data-url encoding, unsupported formats, and frame-sampled vision synthesis.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_vision_native_fast_path.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream native-vision intent is covered by Rust ACP/provider multimodal contracts and OpenAI-compatible vision backend contracts for data URLs, image MIME detection, unsafe URL rejection, and auxiliary vision model selection.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_vision_tools.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream vision tool behavior is covered by Rust VisionAnalyzeHandler and OpenAiVisionBackend contracts for schemas, question forwarding, AUXILIARY_VISION_MODEL precedence, local image base64 data URLs, MIME detection, and URL safety.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_voice_cli_integration.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream CLI voice integration is covered by Rust voice_mode toggle, TTS streaming pipeline, markdown/think scrubbing, CLI /voice status, and tool-preview contracts; Python microphone-loop tests remain reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_voice_mode.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream voice-mode behavior is covered by Rust voice_mode state contracts plus gateway voice manager STT/TTS join/leave/VAD contracts; local Python audio-stack detection is intentionally not part of the Rust runtime.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "website/docs",
       "classification": "policy_only",
       "rationale": "Documentation-site content differs by project positioning and release policy; runtime behavior is unaffected.",


### PR DESCRIPTION
## Summary
- add Rust-native media tool parity coverage for TTS provider config, command-provider dispatch, speed/max-length handling, output path routing, transcription model/response parsing, vision URL/MIME safety, and video MIME validation
- preserve upstream-compatible `gateway.tts` config as structured JSON while keeping runtime Rust-only
- classify 16 upstream media-tool Python test references as intentional divergence with Rust contracts and regenerate parity docs

## Local verification
- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-runtime-placeholders.sh`
- `bash scripts/check-rust-runtime-no-python.sh`
- `cargo test -p hermes-config`
- `cargo test -p hermes-tools`
- `cargo test -p hermes-gateway --features signal`
- `cargo test -p hermes-gateway --features discord`
- `cargo test -p hermes-agent -p hermes-cli -p hermes-parity-tests`
- `python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --upstream-ref upstream/main`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main`
- `cargo build -p hermes-cli`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release --out-json /tmp/hermes-agent-ultra-global-parity-proof.json --out-md /tmp/hermes-agent-ultra-global-parity-proof.md`

## Parity notes
- refreshed against `upstream/main` at `61268ff7a`
- shared-diff backlog after this batch: `pending_review=697`, `cleared_intentional_divergence=161`, `total_shared_different=1028`
- GitHub CI is optional for this repo; local gates above are the authoritative checks for this batch
