### PR TITLE
parity(skills): port hub sync provenance contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ dependencies = [
  "ed25519-dalek",
  "hermes-core",
  "jsonwebtoken",
+ "md5",
  "minijinja",
  "regex",
  "reqwest",

--- a/crates/hermes-skills/Cargo.toml
+++ b/crates/hermes-skills/Cargo.toml
@@ -25,6 +25,7 @@ base64 = { workspace = true }
 ed25519-dalek = "2"
 regex = { workspace = true }
 directories = { workspace = true }
+md5 = "0.7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/hermes-skills/src/hub.rs
+++ b/crates/hermes-skills/src/hub.rs
@@ -3,6 +3,8 @@
 use base64::Engine;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
 use tracing::{debug, instrument};
 
 use hermes_core::types::{Skill, SkillMeta};
@@ -75,6 +77,33 @@ pub struct SkillUpdate {
     pub changelog: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistrySkillMeta {
+    pub name: String,
+    pub description: String,
+    pub source: String,
+    pub identifier: String,
+    pub trust_level: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClawHubBundle {
+    pub name: String,
+    pub version: Option<String>,
+    pub files: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClawHubFileRef {
+    pub path: String,
+    pub content: Option<String>,
+    pub raw_url: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 struct UploadRequest {
     name: String,
@@ -88,6 +117,204 @@ struct UploadRequest {
 #[derive(Debug, Deserialize)]
 struct UploadResponse {
     id: String,
+}
+
+fn value_str<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+}
+
+fn clawhub_tags(value: &Value) -> Vec<String> {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|tag| !tag.is_empty())
+            .map(ToString::to_string)
+            .collect(),
+        Value::Object(map) => {
+            let mut tags: Vec<String> = map
+                .keys()
+                .filter(|key| key.as_str() != "latest")
+                .cloned()
+                .collect();
+            tags.sort();
+            tags
+        }
+        _ => Vec::new(),
+    }
+}
+
+pub fn clawhub_meta_from_payload(
+    payload: &Value,
+    fallback_slug: &str,
+) -> Option<RegistrySkillMeta> {
+    let skill = payload.get("skill").unwrap_or(payload);
+    let identifier = value_str(skill, &["slug", "id", "identifier"])
+        .unwrap_or(fallback_slug)
+        .trim();
+    if identifier.is_empty() {
+        return None;
+    }
+    let name = value_str(skill, &["displayName", "display_name", "name", "slug"])
+        .unwrap_or(identifier)
+        .trim()
+        .to_string();
+    let description = value_str(skill, &["summary", "description"])
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let version = payload
+        .get("latestVersion")
+        .and_then(|v| value_str(v, &["version"]))
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string);
+    Some(RegistrySkillMeta {
+        name,
+        description,
+        source: "clawhub".to_string(),
+        identifier: identifier.to_string(),
+        trust_level: "community".to_string(),
+        tags: skill.get("tags").map(clawhub_tags).unwrap_or_default(),
+        version,
+    })
+}
+
+pub fn clawhub_metas_from_listing(payload: &Value) -> Vec<RegistrySkillMeta> {
+    payload
+        .get("items")
+        .or_else(|| payload.get("skills"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            let fallback = value_str(item, &["slug", "id", "identifier"]).unwrap_or("");
+            clawhub_meta_from_payload(item, fallback)
+        })
+        .collect()
+}
+
+fn normalize_search_key(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn clawhub_score(meta: &RegistrySkillMeta, query: &str) -> i32 {
+    let q = normalize_search_key(query);
+    if q.is_empty() {
+        return 1;
+    }
+    let id = normalize_search_key(&meta.identifier);
+    let name = normalize_search_key(&meta.name);
+    let desc = meta.description.to_ascii_lowercase();
+    if id == q || name == q {
+        1000
+    } else if id.starts_with(&q) || name.starts_with(&q) {
+        800
+    } else if id.contains(&q) || name.contains(&q) {
+        650
+    } else if desc.contains(&query.to_ascii_lowercase()) {
+        250
+    } else {
+        0
+    }
+}
+
+pub fn clawhub_finalize_search_results(
+    query: &str,
+    mut candidates: Vec<RegistrySkillMeta>,
+    exact_slug: Option<RegistrySkillMeta>,
+    limit: usize,
+) -> Vec<RegistrySkillMeta> {
+    let q = normalize_search_key(query);
+    let best_score = candidates
+        .iter()
+        .map(|meta| clawhub_score(meta, query))
+        .max()
+        .unwrap_or(0);
+    if let Some(exact) = exact_slug {
+        let exact_id = normalize_search_key(&exact.identifier);
+        if !q.is_empty() && (exact_id == q || best_score == 0) {
+            if best_score == 0 {
+                candidates = vec![exact];
+            } else {
+                candidates.retain(|meta| meta.identifier != exact.identifier);
+                candidates.insert(0, exact);
+            }
+        }
+    }
+    candidates.sort_by(|a, b| {
+        clawhub_score(b, query)
+            .cmp(&clawhub_score(a, query))
+            .then_with(|| a.identifier.cmp(&b.identifier))
+    });
+    candidates.dedup_by(|a, b| a.identifier == b.identifier);
+    candidates.truncate(limit);
+    candidates
+}
+
+pub fn clawhub_latest_version(payload: &Value) -> Option<String> {
+    payload
+        .get("latestVersion")
+        .and_then(|v| value_str(v, &["version"]))
+        .or_else(|| value_str(payload, &["version"]))
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            payload
+                .get("versions")
+                .and_then(Value::as_array)
+                .and_then(|items| items.first())
+                .and_then(|v| value_str(v, &["version"]))
+                .map(ToString::to_string)
+        })
+}
+
+pub fn clawhub_file_refs(payload: &Value) -> Vec<ClawHubFileRef> {
+    let Some(files) = payload.get("files") else {
+        return Vec::new();
+    };
+    match files {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                let path = value_str(item, &["path", "name"])?.trim();
+                if path.is_empty() {
+                    return None;
+                }
+                Some(ClawHubFileRef {
+                    path: path.to_string(),
+                    content: value_str(item, &["content"]).map(ToString::to_string),
+                    raw_url: value_str(item, &["rawUrl", "raw_url"]).map(ToString::to_string),
+                })
+            })
+            .collect(),
+        Value::Object(map) => map
+            .iter()
+            .filter_map(|(path, content)| {
+                if path.trim().is_empty() {
+                    return None;
+                }
+                Some(ClawHubFileRef {
+                    path: path.clone(),
+                    content: content.as_str().map(ToString::to_string),
+                    raw_url: None,
+                })
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -615,6 +842,95 @@ mod tests {
         let hex = raw.iter().map(|b| format!("{:02x}", b)).collect::<String>();
         let got = decode_base64_or_hex_32(&hex).unwrap();
         assert_eq!(got, raw);
+    }
+
+    #[test]
+    fn clawhub_listing_maps_display_name_summary_and_tags() {
+        let payload = serde_json::json!({
+            "items": [
+                {
+                    "slug": "caldav-calendar",
+                    "displayName": "CalDAV Calendar",
+                    "summary": "Calendar integration",
+                    "tags": ["calendar", "productivity"]
+                }
+            ]
+        });
+        let metas = clawhub_metas_from_listing(&payload);
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].identifier, "caldav-calendar");
+        assert_eq!(metas[0].name, "CalDAV Calendar");
+        assert_eq!(metas[0].description, "Calendar integration");
+        assert_eq!(metas[0].tags, vec!["calendar", "productivity"]);
+    }
+
+    #[test]
+    fn clawhub_nested_detail_payload_excludes_latest_tag() {
+        let payload = serde_json::json!({
+            "skill": {
+                "slug": "self-improving-agent",
+                "displayName": "self-improving-agent",
+                "summary": "Captures learnings and errors for continuous improvement.",
+                "tags": {"latest": "3.0.2", "automation": "3.0.2"}
+            },
+            "latestVersion": {"version": "3.0.2"}
+        });
+        let meta = clawhub_meta_from_payload(&payload, "self-improving-agent").unwrap();
+        assert_eq!(meta.identifier, "self-improving-agent");
+        assert_eq!(meta.version.as_deref(), Some("3.0.2"));
+        assert_eq!(meta.tags, vec!["automation"]);
+        assert!(meta.description.contains("continuous improvement"));
+    }
+
+    #[test]
+    fn clawhub_finalize_repairs_irrelevant_cached_results_with_exact_slug() {
+        let poisoned = RegistrySkillMeta {
+            name: "Apple Music DJ".to_string(),
+            description: "Unrelated".to_string(),
+            source: "clawhub".to_string(),
+            identifier: "apple-music-dj".to_string(),
+            trust_level: "community".to_string(),
+            tags: Vec::new(),
+            version: None,
+        };
+        let exact = RegistrySkillMeta {
+            name: "self-improving-agent".to_string(),
+            description: "Captures learnings and errors for continuous improvement.".to_string(),
+            source: "clawhub".to_string(),
+            identifier: "self-improving-agent".to_string(),
+            trust_level: "community".to_string(),
+            tags: vec!["automation".to_string()],
+            version: None,
+        };
+        let results =
+            clawhub_finalize_search_results("self improving", vec![poisoned], Some(exact), 5);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "self-improving-agent");
+    }
+
+    #[test]
+    fn clawhub_version_and_files_support_inline_and_raw_refs() {
+        let detail = serde_json::json!({"latestVersion": {"version": "1.0.1"}});
+        assert_eq!(clawhub_latest_version(&detail).as_deref(), Some("1.0.1"));
+        let version_payload = serde_json::json!({
+            "files": [
+                {"path": "SKILL.md", "rawUrl": "https://files.example/skill-md"},
+                {"path": "README.md", "content": "hello"}
+            ]
+        });
+        let refs = clawhub_file_refs(&version_payload);
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].path, "SKILL.md");
+        assert_eq!(
+            refs[0].raw_url.as_deref(),
+            Some("https://files.example/skill-md")
+        );
+        assert_eq!(refs[1].content.as_deref(), Some("hello"));
+
+        let object_payload = serde_json::json!({"files": {"SKILL.md": "# Skill"}});
+        let refs = clawhub_file_refs(&object_payload);
+        assert_eq!(refs[0].path, "SKILL.md");
+        assert_eq!(refs[0].content.as_deref(), Some("# Skill"));
     }
 
     #[test]

--- a/crates/hermes-skills/src/lib.rs
+++ b/crates/hermes-skills/src/lib.rs
@@ -6,8 +6,11 @@
 
 mod guard;
 mod hub;
+mod provenance;
 mod skill;
 mod store;
+mod sync;
+mod usage;
 mod version;
 
 pub use guard::{
@@ -16,7 +19,27 @@ pub use guard::{
     SkillScanFinding, SkillScanReport, SkillScanVerdict, SkillTrustLevel,
     MAX_SINGLE_SKILL_FILE_BYTES, MAX_SKILL_FILE_COUNT,
 };
-pub use hub::{SkillUpdate, SkillsHubClient};
+pub use hub::{
+    clawhub_file_refs, clawhub_finalize_search_results, clawhub_latest_version,
+    clawhub_meta_from_payload, clawhub_metas_from_listing, ClawHubBundle, ClawHubFileRef,
+    RegistrySkillMeta, SkillUpdate, SkillsHubClient,
+};
+pub use provenance::{
+    get_current_write_origin, is_background_review, normalize_write_origin,
+    set_current_write_origin, WriteOriginGuard, ASSISTANT_TOOL, BACKGROUND_REVIEW, FOREGROUND,
+};
 pub use skill::{SkillError, SkillManager, MAX_SKILL_CONTENT_CHARS};
 pub use store::{FileSkillStore, SkillStore, MAX_SKILL_NAME_LENGTH};
+pub use sync::{
+    compute_relative_dest, dir_hash, discover_bundled_skills, read_manifest, read_skill_name,
+    reset_bundled_skill, restore_official_optional_skill, sync_skills, write_manifest,
+    BundledSkill, OfficialOptionalRestoreResult, SkillResetResult, SkillSyncConfig,
+    SkillSyncResult,
+};
+pub use usage::{
+    agent_created_report, archive_skill, bump_patch, bump_use, bump_view, forget, get_record,
+    is_agent_created, is_protected_skill, list_agent_created_skill_names, load_usage,
+    mark_agent_created, restore_skill, save_usage, set_pinned, set_state, usage_file,
+    SkillUsageRecord, SkillUsageReportRow, STATE_ACTIVE, STATE_ARCHIVED, STATE_STALE,
+};
 pub use version::{compare_versions, compute_version, track_change, SkillChange, SkillVersion};

--- a/crates/hermes-skills/src/provenance.rs
+++ b/crates/hermes-skills/src/provenance.rs
@@ -1,0 +1,95 @@
+//! Skill write provenance tracking.
+//!
+//! Python upstream uses a `ContextVar`; Rust keeps the same nested-scope
+//! contract with thread-local state and a guard that restores the prior origin
+//! on drop.
+
+use std::cell::RefCell;
+
+pub const FOREGROUND: &str = "foreground";
+pub const ASSISTANT_TOOL: &str = "assistant_tool";
+pub const BACKGROUND_REVIEW: &str = "background_review";
+
+thread_local! {
+    static CURRENT_WRITE_ORIGIN: RefCell<String> = RefCell::new(FOREGROUND.to_string());
+}
+
+#[derive(Debug)]
+pub struct WriteOriginGuard {
+    previous: String,
+}
+
+impl Drop for WriteOriginGuard {
+    fn drop(&mut self) {
+        CURRENT_WRITE_ORIGIN.with(|origin| {
+            *origin.borrow_mut() = self.previous.clone();
+        });
+    }
+}
+
+pub fn normalize_write_origin(origin: &str) -> String {
+    let trimmed = origin.trim();
+    if trimmed.is_empty() {
+        FOREGROUND.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+pub fn set_current_write_origin(origin: &str) -> WriteOriginGuard {
+    CURRENT_WRITE_ORIGIN.with(|current| {
+        let previous = current.borrow().clone();
+        *current.borrow_mut() = normalize_write_origin(origin);
+        WriteOriginGuard { previous }
+    })
+}
+
+pub fn get_current_write_origin() -> String {
+    CURRENT_WRITE_ORIGIN.with(|origin| origin.borrow().clone())
+}
+
+pub fn is_background_review() -> bool {
+    get_current_write_origin() == BACKGROUND_REVIEW
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_and_get_origin() {
+        let _guard = set_current_write_origin(BACKGROUND_REVIEW);
+        assert_eq!(get_current_write_origin(), BACKGROUND_REVIEW);
+    }
+
+    #[test]
+    fn nested_guard_restores_prior_origin() {
+        let outer = set_current_write_origin(ASSISTANT_TOOL);
+        {
+            let _inner = set_current_write_origin(BACKGROUND_REVIEW);
+            assert!(is_background_review());
+        }
+        assert_eq!(get_current_write_origin(), ASSISTANT_TOOL);
+        drop(outer);
+        assert_eq!(get_current_write_origin(), FOREGROUND);
+    }
+
+    #[test]
+    fn empty_origin_falls_back_to_foreground() {
+        let _guard = set_current_write_origin("");
+        assert_eq!(get_current_write_origin(), FOREGROUND);
+    }
+
+    #[test]
+    fn origin_is_thread_isolated() {
+        let _guard = set_current_write_origin(ASSISTANT_TOOL);
+        let inside = std::thread::spawn(|| {
+            let _guard = set_current_write_origin(BACKGROUND_REVIEW);
+            get_current_write_origin()
+        })
+        .join()
+        .unwrap();
+        assert_eq!(inside, BACKGROUND_REVIEW);
+        assert_eq!(get_current_write_origin(), ASSISTANT_TOOL);
+    }
+}

--- a/crates/hermes-skills/src/sync.rs
+++ b/crates/hermes-skills/src/sync.rs
@@ -1,0 +1,906 @@
+//! Bundled and official skill synchronization.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::skill::SkillError;
+use crate::usage::{read_skill_name_from_dir, read_skill_name_from_file};
+
+#[derive(Debug, Clone)]
+pub struct SkillSyncConfig {
+    pub bundled_dir: PathBuf,
+    pub optional_dir: PathBuf,
+    pub skills_dir: PathBuf,
+    pub manifest_file: PathBuf,
+}
+
+impl SkillSyncConfig {
+    pub fn new(bundled_dir: PathBuf, optional_dir: PathBuf, skills_dir: PathBuf) -> Self {
+        let manifest_file = skills_dir.join(".bundled_manifest");
+        Self {
+            bundled_dir,
+            optional_dir,
+            skills_dir,
+            manifest_file,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BundledSkill {
+    pub name: String,
+    pub path: PathBuf,
+    pub relative_dest: PathBuf,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillSyncResult {
+    pub copied: Vec<String>,
+    pub updated: Vec<String>,
+    pub skipped: usize,
+    pub user_modified: Vec<String>,
+    pub cleaned: Vec<String>,
+    pub total_bundled: usize,
+    pub optional_provenance_backfilled: Vec<String>,
+    #[serde(default)]
+    pub collisions: Vec<String>,
+    #[serde(default)]
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillResetResult {
+    pub ok: bool,
+    pub action: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synced: Option<SkillSyncResult>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OfficialOptionalRestoreResult {
+    pub ok: bool,
+    pub restored: Vec<String>,
+    pub backfilled: Vec<String>,
+    pub backed_up: Vec<String>,
+    pub backup_dir: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SkillHubInstalledEntry {
+    name: String,
+    source: String,
+    identifier: String,
+    trust_level: String,
+    scan_verdict: String,
+    content_hash: String,
+    install_path: String,
+    #[serde(default)]
+    files: Vec<String>,
+    #[serde(default)]
+    metadata: Value,
+    installed_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SkillsHubLockFile {
+    #[serde(default = "default_lock_version")]
+    version: u32,
+    #[serde(default)]
+    installed: Vec<SkillHubInstalledEntry>,
+}
+
+fn default_lock_version() -> u32 {
+    1
+}
+
+pub fn read_manifest(path: &Path) -> BTreeMap<String, String> {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return BTreeMap::new();
+    };
+    raw.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let (name, hash) = line
+                .split_once(':')
+                .map(|(name, hash)| (name.trim(), hash.trim()))
+                .unwrap_or((line, ""));
+            if name.is_empty() {
+                None
+            } else {
+                Some((name.to_string(), hash.to_string()))
+            }
+        })
+        .collect()
+}
+
+pub fn write_manifest(path: &Path, entries: &BTreeMap<String, String>) -> Result<(), SkillError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut out = String::new();
+    for (name, hash) in entries {
+        if hash.is_empty() {
+            out.push_str(name);
+        } else {
+            out.push_str(name);
+            out.push(':');
+            out.push_str(hash);
+        }
+        out.push('\n');
+    }
+    fs::write(path, out)?;
+    Ok(())
+}
+
+pub fn dir_hash(dir: &Path) -> String {
+    let mut files = Vec::new();
+    collect_files(dir, dir, &mut files);
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut ctx = md5::Context::new();
+    for (rel, path) in files {
+        ctx.consume(rel.as_bytes());
+        ctx.consume([0]);
+        if let Ok(bytes) = fs::read(path) {
+            ctx.consume(bytes);
+        }
+        ctx.consume([0xff]);
+    }
+    format!("{:x}", ctx.compute())
+}
+
+fn collect_files(root: &Path, dir: &Path, files: &mut Vec<(String, PathBuf)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|v| v.to_str()) else {
+            continue;
+        };
+        if name == ".git" || name.starts_with(".DS_Store") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_files(root, &path, files);
+        } else if path.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((rel, path));
+        }
+    }
+}
+
+pub fn read_skill_name(skill_md: &Path, fallback: &str) -> String {
+    read_skill_name_from_file(skill_md, fallback)
+}
+
+pub fn compute_relative_dest(skill_dir: &Path, bundled_dir: &Path) -> PathBuf {
+    skill_dir
+        .strip_prefix(bundled_dir)
+        .unwrap_or(skill_dir)
+        .to_path_buf()
+}
+
+pub fn discover_bundled_skills(bundled_dir: &Path) -> Vec<BundledSkill> {
+    let mut out = Vec::new();
+    if !bundled_dir.exists() {
+        return out;
+    }
+    let mut stack = vec![bundled_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|v| v.to_str()) else {
+                continue;
+            };
+            if name.starts_with('.') || name == "node_modules" || name == "__pycache__" {
+                continue;
+            }
+            if !path.is_dir() {
+                continue;
+            }
+            let skill_md = path.join("SKILL.md");
+            if skill_md.exists() {
+                out.push(BundledSkill {
+                    name: read_skill_name(&skill_md, name),
+                    relative_dest: compute_relative_dest(&path, bundled_dir),
+                    path,
+                });
+            } else {
+                stack.push(path);
+            }
+        }
+    }
+    out.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.relative_dest.cmp(&b.relative_dest))
+    });
+    out
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), SkillError> {
+    fs::create_dir_all(dst)?;
+    let entries = fs::read_dir(src)?;
+    for entry in entries.flatten() {
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else if src_path.is_file() {
+            if let Some(parent) = dst_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn replace_dir_atomic(src: &Path, dst: &Path) -> Result<(), SkillError> {
+    let parent = dst.parent().ok_or_else(|| {
+        SkillError::Io(format!("Missing destination parent for {}", dst.display()))
+    })?;
+    fs::create_dir_all(parent)?;
+    let staging = parent.join(format!(
+        ".{}.sync-{}",
+        dst.file_name().and_then(|v| v.to_str()).unwrap_or("skill"),
+        std::process::id()
+    ));
+    if staging.exists() {
+        fs::remove_dir_all(&staging)?;
+    }
+    copy_dir_recursive(src, &staging)?;
+    if dst.exists() {
+        let backup = parent.join(format!(
+            ".{}.backup-{}",
+            dst.file_name().and_then(|v| v.to_str()).unwrap_or("skill"),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::rename(dst, &backup)?;
+        match fs::rename(&staging, dst) {
+            Ok(()) => {
+                let _ = fs::remove_dir_all(backup);
+            }
+            Err(err) => {
+                let _ = fs::rename(&backup, dst);
+                let _ = fs::remove_dir_all(&staging);
+                return Err(err.into());
+            }
+        }
+    } else {
+        fs::rename(&staging, dst)?;
+    }
+    Ok(())
+}
+
+fn copy_parent_descriptions(
+    skill: &BundledSkill,
+    config: &SkillSyncConfig,
+) -> Result<(), SkillError> {
+    let rel_parent = skill
+        .relative_dest
+        .parent()
+        .unwrap_or_else(|| Path::new(""));
+    let mut current = PathBuf::new();
+    for component in rel_parent.components() {
+        current.push(component.as_os_str());
+        let src = config.bundled_dir.join(&current).join("DESCRIPTION.md");
+        if src.exists() {
+            let dst = config.skills_dir.join(&current).join("DESCRIPTION.md");
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            if !dst.exists() {
+                fs::copy(src, dst)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn sync_skills(config: &SkillSyncConfig, quiet: bool) -> Result<SkillSyncResult, SkillError> {
+    if !config.bundled_dir.exists() {
+        return Ok(SkillSyncResult::default());
+    }
+    fs::create_dir_all(&config.skills_dir)?;
+    let mut result = SkillSyncResult::default();
+    let mut manifest = read_manifest(&config.manifest_file);
+    let bundled = discover_bundled_skills(&config.bundled_dir);
+    result.total_bundled = bundled.len();
+
+    let bundled_names: BTreeSet<String> = bundled.iter().map(|s| s.name.clone()).collect();
+    let stale: Vec<String> = manifest
+        .keys()
+        .filter(|name| !bundled_names.contains(*name))
+        .cloned()
+        .collect();
+    for name in stale {
+        manifest.remove(&name);
+        result.cleaned.push(name);
+    }
+
+    for skill in &bundled {
+        let bundled_hash = dir_hash(&skill.path);
+        let dest = config.skills_dir.join(&skill.relative_dest);
+        let manifest_hash = manifest.get(&skill.name).cloned();
+
+        if let Some(origin_hash) = manifest_hash {
+            if !dest.exists() {
+                result.skipped += 1;
+                continue;
+            }
+            let user_hash = dir_hash(&dest);
+            if origin_hash.is_empty() {
+                manifest.insert(skill.name.clone(), user_hash);
+                result.skipped += 1;
+            } else if user_hash == origin_hash {
+                if user_hash == bundled_hash {
+                    result.skipped += 1;
+                } else {
+                    match replace_dir_atomic(&skill.path, &dest) {
+                        Ok(()) => {
+                            manifest.insert(skill.name.clone(), bundled_hash);
+                            result.updated.push(skill.name.clone());
+                            copy_parent_descriptions(skill, config)?;
+                        }
+                        Err(err) => result
+                            .errors
+                            .push(format!("Failed to update {}: {}", skill.name, err)),
+                    }
+                }
+            } else {
+                result.user_modified.push(skill.name.clone());
+            }
+            continue;
+        }
+
+        if dest.exists() {
+            result.collisions.push(skill.name.clone());
+            if !quiet {
+                println!(
+                    "Bundled skill '{}' is shadowed by an existing local copy. Run `hermes skills reset {}` to accept bundled.",
+                    skill.name, skill.name
+                );
+            }
+            continue;
+        }
+
+        match copy_dir_recursive(&skill.path, &dest) {
+            Ok(()) => {
+                manifest.insert(skill.name.clone(), bundled_hash);
+                result.copied.push(skill.name.clone());
+                copy_parent_descriptions(skill, config)?;
+            }
+            Err(err) => result
+                .errors
+                .push(format!("Failed to copy {}: {}", skill.name, err)),
+        }
+    }
+
+    let backfilled = backfill_optional_provenance(config)?;
+    result.optional_provenance_backfilled = backfilled;
+    write_manifest(&config.manifest_file, &manifest)?;
+    result.copied.sort();
+    result.updated.sort();
+    result.user_modified.sort();
+    result.cleaned.sort();
+    result.collisions.sort();
+    Ok(result)
+}
+
+fn skills_hub_lock_path(skills_dir: &Path) -> PathBuf {
+    skills_dir.join(".hub").join("lock.json")
+}
+
+fn read_hub_lock(skills_dir: &Path) -> SkillsHubLockFile {
+    let Ok(raw) = fs::read_to_string(skills_hub_lock_path(skills_dir)) else {
+        return SkillsHubLockFile {
+            version: 1,
+            installed: Vec::new(),
+        };
+    };
+    serde_json::from_str::<SkillsHubLockFile>(&raw).unwrap_or(SkillsHubLockFile {
+        version: 1,
+        installed: Vec::new(),
+    })
+}
+
+fn write_hub_lock(skills_dir: &Path, lock: &SkillsHubLockFile) -> Result<(), SkillError> {
+    let path = skills_hub_lock_path(skills_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string_pretty(lock)
+        .map_err(|e| SkillError::Parse(format!("Failed to encode hub lock: {e}")))?;
+    fs::write(path, raw)?;
+    Ok(())
+}
+
+fn record_official_lock(
+    config: &SkillSyncConfig,
+    name: &str,
+    rel_dest: &Path,
+    skill_dir: &Path,
+) -> Result<(), SkillError> {
+    let mut lock = read_hub_lock(&config.skills_dir);
+    let install_path = rel_dest.to_string_lossy().replace('\\', "/");
+    let now = Utc::now().to_rfc3339();
+    lock.installed.retain(|entry| entry.name != name);
+    lock.installed.push(SkillHubInstalledEntry {
+        name: name.to_string(),
+        source: "official".to_string(),
+        identifier: format!("official/{install_path}"),
+        trust_level: "builtin".to_string(),
+        scan_verdict: "clean".to_string(),
+        content_hash: format!("md5:{}", dir_hash(skill_dir)),
+        install_path,
+        files: Vec::new(),
+        metadata: Value::Null,
+        installed_at: now.clone(),
+        updated_at: now,
+    });
+    lock.installed.sort_by(|a, b| a.name.cmp(&b.name));
+    write_hub_lock(&config.skills_dir, &lock)
+}
+
+fn discover_optional_skills(optional_dir: &Path) -> Vec<BundledSkill> {
+    discover_bundled_skills(optional_dir)
+}
+
+fn backfill_optional_provenance(config: &SkillSyncConfig) -> Result<Vec<String>, SkillError> {
+    let mut out = Vec::new();
+    if !config.optional_dir.exists() {
+        return Ok(out);
+    }
+    let lock = read_hub_lock(&config.skills_dir);
+    let existing: BTreeSet<String> = lock.installed.into_iter().map(|entry| entry.name).collect();
+    for skill in discover_optional_skills(&config.optional_dir) {
+        if existing.contains(&skill.name) {
+            continue;
+        }
+        let active = config.skills_dir.join(&skill.relative_dest);
+        if active.exists() && dir_hash(&active) == dir_hash(&skill.path) {
+            record_official_lock(config, &skill.name, &skill.relative_dest, &active)?;
+            out.push(
+                skill
+                    .relative_dest
+                    .file_name()
+                    .and_then(|v| v.to_str())
+                    .unwrap_or(skill.name.as_str())
+                    .to_string(),
+            );
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn find_bundled_by_name(root: &Path, name: &str) -> Option<BundledSkill> {
+    discover_bundled_skills(root).into_iter().find(|skill| {
+        skill.name == name || skill.relative_dest.file_name().and_then(|v| v.to_str()) == Some(name)
+    })
+}
+
+pub fn reset_bundled_skill(
+    config: &SkillSyncConfig,
+    skill_name: &str,
+    restore: bool,
+) -> Result<SkillResetResult, SkillError> {
+    let name = skill_name.trim();
+    let mut manifest = read_manifest(&config.manifest_file);
+    let Some(skill) = find_bundled_by_name(&config.bundled_dir, name) else {
+        return Ok(SkillResetResult {
+            ok: false,
+            action: "not_in_manifest".to_string(),
+            message: format!("Skill '{name}' is not a tracked bundled skill."),
+            synced: None,
+        });
+    };
+    let dest = config.skills_dir.join(&skill.relative_dest);
+    if restore {
+        if dest.exists() {
+            if let Err(err) = fs::remove_dir_all(&dest) {
+                return Ok(SkillResetResult {
+                    ok: false,
+                    action: "not_reset".to_string(),
+                    message: format!(
+                        "Failed to remove '{}': {}. Manifest entry preserved.",
+                        dest.display(),
+                        err
+                    ),
+                    synced: None,
+                });
+            }
+        }
+        manifest.remove(&skill.name);
+        write_manifest(&config.manifest_file, &manifest)?;
+        let synced = sync_skills(config, true)?;
+        return Ok(SkillResetResult {
+            ok: true,
+            action: "restored".to_string(),
+            message: format!("Skill '{}' restored from bundled copy.", skill.name),
+            synced: Some(synced),
+        });
+    }
+
+    if !manifest.contains_key(&skill.name) && !dest.exists() {
+        return Ok(SkillResetResult {
+            ok: false,
+            action: "not_in_manifest".to_string(),
+            message: format!("Skill '{name}' is not a tracked bundled skill."),
+            synced: None,
+        });
+    }
+    manifest.insert(skill.name.clone(), dir_hash(&skill.path));
+    write_manifest(&config.manifest_file, &manifest)?;
+    Ok(SkillResetResult {
+        ok: true,
+        action: "manifest_cleared".to_string(),
+        message: format!("Skill '{}' re-baselined to bundled hash.", skill.name),
+        synced: None,
+    })
+}
+
+fn find_active_skill_dirs_by_frontmatter(skills_dir: &Path, declared_name: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![skills_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|v| v.to_str()) else {
+                continue;
+            };
+            if name.starts_with('.') || !path.is_dir() {
+                continue;
+            }
+            if path.join("SKILL.md").exists() {
+                if read_skill_name_from_dir(&path) == declared_name {
+                    out.push(path);
+                }
+            } else {
+                stack.push(path);
+            }
+        }
+    }
+    out
+}
+
+pub fn restore_official_optional_skill(
+    config: &SkillSyncConfig,
+    skill_name: &str,
+    restore: bool,
+) -> Result<OfficialOptionalRestoreResult, SkillError> {
+    let Some(skill) = discover_optional_skills(&config.optional_dir)
+        .into_iter()
+        .find(|skill| {
+            skill.name == skill_name
+                || skill.relative_dest.file_name().and_then(|v| v.to_str()) == Some(skill_name)
+        })
+    else {
+        return Ok(OfficialOptionalRestoreResult {
+            ok: false,
+            message: format!("Official optional skill '{skill_name}' not found."),
+            ..Default::default()
+        });
+    };
+
+    let canonical = config.skills_dir.join(&skill.relative_dest);
+    let mut result = OfficialOptionalRestoreResult {
+        ok: true,
+        backup_dir: config
+            .skills_dir
+            .join(".archive")
+            .join(format!(
+                "official-restore-{}",
+                Utc::now().format("%Y%m%d%H%M%S")
+            ))
+            .to_string_lossy()
+            .to_string(),
+        ..Default::default()
+    };
+
+    if canonical.exists() && dir_hash(&canonical) == dir_hash(&skill.path) {
+        record_official_lock(config, &skill.name, &skill.relative_dest, &canonical)?;
+        result.backfilled.push(
+            skill
+                .relative_dest
+                .file_name()
+                .and_then(|v| v.to_str())
+                .unwrap_or(skill.name.as_str())
+                .to_string(),
+        );
+        return Ok(result);
+    }
+
+    if !restore {
+        return Ok(result);
+    }
+
+    let backup_root = PathBuf::from(&result.backup_dir);
+    let canonical_rel = skill.relative_dest.to_string_lossy().replace('\\', "/");
+    for active in find_active_skill_dirs_by_frontmatter(&config.skills_dir, &skill.name) {
+        if active == canonical {
+            continue;
+        }
+        let rel = active
+            .strip_prefix(&config.skills_dir)
+            .unwrap_or(&active)
+            .to_path_buf();
+        let backup_dest = backup_root.join(&rel);
+        if let Some(parent) = backup_dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(&active, &backup_dest)?;
+        result
+            .backed_up
+            .push(rel.to_string_lossy().replace('\\', "/"));
+    }
+
+    if canonical.exists() {
+        let backup_dest = backup_root.join(&skill.relative_dest);
+        if let Some(parent) = backup_dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(&canonical, &backup_dest)?;
+        result.backed_up.push(canonical_rel.clone());
+    }
+    copy_dir_recursive(&skill.path, &canonical)?;
+    record_official_lock(config, &skill.name, &skill.relative_dest, &canonical)?;
+    result.restored.push(
+        skill
+            .relative_dest
+            .file_name()
+            .and_then(|v| v.to_str())
+            .unwrap_or(skill.name.as_str())
+            .to_string(),
+    );
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn setup_bundled(root: &Path) -> PathBuf {
+        let bundled = root.join("bundled");
+        let new_skill = bundled.join("category").join("new-skill");
+        fs::create_dir_all(&new_skill).unwrap();
+        fs::write(new_skill.join("SKILL.md"), "# New").unwrap();
+        fs::write(new_skill.join("main.rs"), "fn main() {}").unwrap();
+        fs::write(bundled.join("category").join("DESCRIPTION.md"), "Category").unwrap();
+        let old_skill = bundled.join("old-skill");
+        fs::create_dir_all(&old_skill).unwrap();
+        fs::write(old_skill.join("SKILL.md"), "# Old").unwrap();
+        bundled
+    }
+
+    fn config(root: &Path, bundled: PathBuf) -> SkillSyncConfig {
+        let skills_dir = root.join("skills");
+        SkillSyncConfig::new(bundled, root.join("optional-skills"), skills_dir)
+    }
+
+    #[test]
+    fn manifest_read_write_v1_v2_and_sorted() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".bundled_manifest");
+        fs::write(&path, "old-skill\nnew-skill:abc\n\n").unwrap();
+        let data = read_manifest(&path);
+        assert_eq!(data.get("old-skill").map(String::as_str), Some(""));
+        assert_eq!(data.get("new-skill").map(String::as_str), Some("abc"));
+        let mut entries = BTreeMap::new();
+        entries.insert("zebra".to_string(), "1".to_string());
+        entries.insert("alpha".to_string(), "2".to_string());
+        write_manifest(&path, &entries).unwrap();
+        assert!(fs::read_to_string(path)
+            .unwrap()
+            .starts_with("alpha:2\nzebra:1"));
+    }
+
+    #[test]
+    fn dir_hash_is_stable_and_sensitive() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        for path in [&a, &b] {
+            fs::create_dir_all(path).unwrap();
+            fs::write(path.join("SKILL.md"), "# Skill").unwrap();
+        }
+        assert_eq!(dir_hash(&a), dir_hash(&b));
+        fs::write(b.join("extra.md"), "x").unwrap();
+        assert_ne!(dir_hash(&a), dir_hash(&b));
+        assert_eq!(dir_hash(&dir.path().join("missing")).len(), 32);
+    }
+
+    #[test]
+    fn discover_uses_frontmatter_and_ignores_hidden_dirs() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("mlops").join("axolotl")).unwrap();
+        fs::write(
+            root.join("mlops").join("axolotl").join("SKILL.md"),
+            "---\nname: axolotl-skill\n---\n# body",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join(".git").join("fake")).unwrap();
+        fs::write(root.join(".git").join("fake").join("SKILL.md"), "# fake").unwrap();
+        let skills = discover_bundled_skills(root);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "axolotl-skill");
+        assert_eq!(
+            compute_relative_dest(&skills[0].path, root),
+            PathBuf::from("mlops/axolotl")
+        );
+    }
+
+    #[test]
+    fn fresh_sync_copies_records_hashes_and_category_description() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled);
+        let result = sync_skills(&cfg, true).unwrap();
+        assert_eq!(result.total_bundled, 2);
+        assert_eq!(result.copied, vec!["new-skill", "old-skill"]);
+        assert!(cfg.skills_dir.join("category/new-skill/SKILL.md").exists());
+        assert!(cfg.skills_dir.join("category/DESCRIPTION.md").exists());
+        let manifest = read_manifest(&cfg.manifest_file);
+        assert_eq!(manifest["new-skill"].len(), 32);
+    }
+
+    #[test]
+    fn sync_updates_unmodified_and_preserves_user_modified() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled.clone());
+        fs::create_dir_all(cfg.skills_dir.join("old-skill")).unwrap();
+        fs::write(cfg.skills_dir.join("old-skill/SKILL.md"), "# Old v1").unwrap();
+        let old_hash = dir_hash(&cfg.skills_dir.join("old-skill"));
+        fs::create_dir_all(&cfg.skills_dir).unwrap();
+        fs::write(&cfg.manifest_file, format!("old-skill:{old_hash}\n")).unwrap();
+        let result = sync_skills(&cfg, true).unwrap();
+        assert_eq!(result.updated, vec!["old-skill"]);
+        assert_eq!(
+            fs::read_to_string(cfg.skills_dir.join("old-skill/SKILL.md")).unwrap(),
+            "# Old"
+        );
+
+        fs::write(cfg.skills_dir.join("old-skill/SKILL.md"), "# My custom").unwrap();
+        let result = sync_skills(&cfg, true).unwrap();
+        assert_eq!(result.user_modified, vec!["old-skill"]);
+        assert_eq!(
+            fs::read_to_string(cfg.skills_dir.join("old-skill/SKILL.md")).unwrap(),
+            "# My custom"
+        );
+    }
+
+    #[test]
+    fn collision_does_not_poison_manifest_or_flag_second_sync() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled);
+        let dest = cfg.skills_dir.join("category/new-skill");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(dest.join("SKILL.md"), "# unrelated").unwrap();
+        let first = sync_skills(&cfg, true).unwrap();
+        assert_eq!(first.collisions, vec!["new-skill"]);
+        assert!(!read_manifest(&cfg.manifest_file).contains_key("new-skill"));
+        let second = sync_skills(&cfg, true).unwrap();
+        assert!(!second.user_modified.contains(&"new-skill".to_string()));
+    }
+
+    #[test]
+    fn v1_manifest_migrates_to_user_baseline_then_detects_update() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled.clone());
+        fs::create_dir_all(cfg.skills_dir.join("old-skill")).unwrap();
+        fs::write(cfg.skills_dir.join("old-skill/SKILL.md"), "# Old").unwrap();
+        fs::write(&cfg.manifest_file, "old-skill\n").unwrap();
+        sync_skills(&cfg, true).unwrap();
+        assert_eq!(read_manifest(&cfg.manifest_file)["old-skill"].len(), 32);
+        fs::write(bundled.join("old-skill/SKILL.md"), "# Old v2").unwrap();
+        let result = sync_skills(&cfg, true).unwrap();
+        assert_eq!(result.updated, vec!["old-skill"]);
+    }
+
+    #[test]
+    fn reset_rebaselines_or_restores_without_manifest_limbo() {
+        let dir = tempdir().unwrap();
+        let bundled = dir.path().join("bundled");
+        let skill = bundled.join("productivity/google-workspace");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: google-workspace\n---\n# upstream\n",
+        )
+        .unwrap();
+        let cfg = config(dir.path(), bundled);
+        let dest = cfg.skills_dir.join("productivity/google-workspace");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(
+            dest.join("SKILL.md"),
+            "---\nname: google-workspace\n---\n# upstream\n",
+        )
+        .unwrap();
+        fs::write(&cfg.manifest_file, "google-workspace:STALE\n").unwrap();
+        assert_eq!(
+            sync_skills(&cfg, true).unwrap().user_modified,
+            vec!["google-workspace"]
+        );
+        let reset = reset_bundled_skill(&cfg, "google-workspace", false).unwrap();
+        assert!(reset.ok);
+        assert_eq!(reset.action, "manifest_cleared");
+        let restored = reset_bundled_skill(&cfg, "google-workspace", true).unwrap();
+        assert!(restored.ok);
+        assert_eq!(restored.action, "restored");
+        assert!(restored
+            .synced
+            .unwrap()
+            .copied
+            .contains(&"google-workspace".to_string()));
+    }
+
+    #[test]
+    fn optional_provenance_backfill_and_restore_with_backup() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled);
+        let optional = cfg.optional_dir.join("mlops/training/trl-fine-tuning");
+        fs::create_dir_all(&optional).unwrap();
+        fs::write(
+            optional.join("SKILL.md"),
+            "---\nname: fine-tuning-with-trl\n---\n# official\n",
+        )
+        .unwrap();
+        let active = cfg.skills_dir.join("mlops/training/trl-fine-tuning");
+        fs::create_dir_all(&active).unwrap();
+        fs::write(
+            active.join("SKILL.md"),
+            "---\nname: fine-tuning-with-trl\n---\n# official\n",
+        )
+        .unwrap();
+        let result = sync_skills(&cfg, true).unwrap();
+        assert_eq!(
+            result.optional_provenance_backfilled,
+            vec!["trl-fine-tuning"]
+        );
+
+        let wrong = cfg.skills_dir.join("mlops/trl-fine-tuning");
+        fs::create_dir_all(&wrong).unwrap();
+        fs::write(
+            wrong.join("SKILL.md"),
+            "---\nname: fine-tuning-with-trl\n---\n# wrong\n",
+        )
+        .unwrap();
+        fs::write(active.join("SKILL.md"), "# modified\n").unwrap();
+        let repair = restore_official_optional_skill(&cfg, "fine-tuning-with-trl", true).unwrap();
+        assert!(repair.ok);
+        assert_eq!(repair.restored, vec!["trl-fine-tuning"]);
+        assert!(repair
+            .backed_up
+            .contains(&"mlops/trl-fine-tuning".to_string()));
+        assert!(fs::read_to_string(active.join("SKILL.md"))
+            .unwrap()
+            .contains("official"));
+    }
+}

--- a/crates/hermes-skills/src/usage.rs
+++ b/crates/hermes-skills/src/usage.rs
@@ -1,0 +1,657 @@
+//! Skill usage sidecar and curator provenance filters.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::skill::SkillError;
+
+pub const STATE_ACTIVE: &str = "active";
+pub const STATE_STALE: &str = "stale";
+pub const STATE_ARCHIVED: &str = "archived";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillUsageRecord {
+    #[serde(default)]
+    pub use_count: u64,
+    #[serde(default)]
+    pub view_count: u64,
+    #[serde(default)]
+    pub patch_count: u64,
+    #[serde(default = "default_state")]
+    pub state: String,
+    #[serde(default)]
+    pub pinned: bool,
+    #[serde(default)]
+    pub archived_at: Option<String>,
+    #[serde(default)]
+    pub last_used_at: Option<String>,
+    #[serde(default)]
+    pub last_viewed_at: Option<String>,
+    #[serde(default)]
+    pub last_patched_at: Option<String>,
+    #[serde(default)]
+    pub agent_created: bool,
+}
+
+impl Default for SkillUsageRecord {
+    fn default() -> Self {
+        Self {
+            use_count: 0,
+            view_count: 0,
+            patch_count: 0,
+            state: STATE_ACTIVE.to_string(),
+            pinned: false,
+            archived_at: None,
+            last_used_at: None,
+            last_viewed_at: None,
+            last_patched_at: None,
+            agent_created: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillUsageReportRow {
+    pub name: String,
+    pub use_count: u64,
+    pub view_count: u64,
+    pub patch_count: u64,
+    pub activity_count: u64,
+    pub state: String,
+    pub pinned: bool,
+    pub archived_at: Option<String>,
+    pub last_activity_at: Option<String>,
+}
+
+fn default_state() -> String {
+    STATE_ACTIVE.to_string()
+}
+
+fn now_iso() -> String {
+    Utc::now().to_rfc3339()
+}
+
+pub fn usage_file(skills_dir: &Path) -> PathBuf {
+    skills_dir.join(".usage.json")
+}
+
+fn usage_lock_file(skills_dir: &Path) -> PathBuf {
+    skills_dir.join(".usage.lock")
+}
+
+struct UsageLock {
+    path: PathBuf,
+}
+
+impl Drop for UsageLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn acquire_usage_lock(skills_dir: &Path) -> Result<UsageLock, SkillError> {
+    fs::create_dir_all(skills_dir)?;
+    let path = usage_lock_file(skills_dir);
+    let start = Instant::now();
+    loop {
+        match fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                let _ = writeln!(file, "pid={}", std::process::id());
+                return Ok(UsageLock { path });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                if start.elapsed() > Duration::from_secs(20) {
+                    return Err(SkillError::Io(format!(
+                        "Timed out waiting for usage sidecar lock: {}",
+                        path.display()
+                    )));
+                }
+                thread::sleep(Duration::from_millis(15));
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+}
+
+pub fn load_usage(skills_dir: &Path) -> BTreeMap<String, SkillUsageRecord> {
+    let path = usage_file(skills_dir);
+    let Ok(raw) = fs::read_to_string(path) else {
+        return BTreeMap::new();
+    };
+    serde_json::from_str::<BTreeMap<String, SkillUsageRecord>>(&raw).unwrap_or_default()
+}
+
+pub fn save_usage(
+    skills_dir: &Path,
+    usage: &BTreeMap<String, SkillUsageRecord>,
+) -> Result<(), SkillError> {
+    fs::create_dir_all(skills_dir)?;
+    let path = usage_file(skills_dir);
+    let tmp = skills_dir.join(format!(".usage_{}.tmp", std::process::id()));
+    let body = serde_json::to_string_pretty(usage)
+        .map_err(|e| SkillError::Parse(format!("Failed to encode usage sidecar: {e}")))?;
+    fs::write(&tmp, body)?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn mutate_usage<F>(skills_dir: &Path, skill_name: &str, mut f: F) -> Result<(), SkillError>
+where
+    F: FnMut(&mut SkillUsageRecord),
+{
+    let name = skill_name.trim();
+    if name.is_empty() || is_protected_skill(skills_dir, name) {
+        return Ok(());
+    }
+    let _lock = acquire_usage_lock(skills_dir)?;
+    let mut usage = load_usage(skills_dir);
+    let rec = usage.entry(name.to_string()).or_default();
+    f(rec);
+    save_usage(skills_dir, &usage)
+}
+
+pub fn get_record(skills_dir: &Path, skill_name: &str) -> SkillUsageRecord {
+    load_usage(skills_dir)
+        .get(skill_name)
+        .cloned()
+        .unwrap_or_default()
+}
+
+pub fn bump_view(skills_dir: &Path, skill_name: &str) -> Result<(), SkillError> {
+    mutate_usage(skills_dir, skill_name, |rec| {
+        rec.view_count += 1;
+        rec.last_viewed_at = Some(now_iso());
+    })
+}
+
+pub fn bump_use(skills_dir: &Path, skill_name: &str) -> Result<(), SkillError> {
+    mutate_usage(skills_dir, skill_name, |rec| {
+        rec.use_count += 1;
+        rec.last_used_at = Some(now_iso());
+    })
+}
+
+pub fn bump_patch(skills_dir: &Path, skill_name: &str) -> Result<(), SkillError> {
+    mutate_usage(skills_dir, skill_name, |rec| {
+        rec.patch_count += 1;
+        rec.last_patched_at = Some(now_iso());
+    })
+}
+
+pub fn mark_agent_created(skills_dir: &Path, skill_name: &str) -> Result<(), SkillError> {
+    mutate_usage(skills_dir, skill_name, |rec| {
+        rec.agent_created = true;
+    })
+}
+
+pub fn set_state(skills_dir: &Path, skill_name: &str, state: &str) -> Result<(), SkillError> {
+    if !matches!(state, STATE_ACTIVE | STATE_STALE | STATE_ARCHIVED) {
+        return Ok(());
+    }
+    mutate_usage(skills_dir, skill_name, |rec| {
+        rec.state = state.to_string();
+        rec.archived_at = if state == STATE_ARCHIVED {
+            Some(now_iso())
+        } else {
+            None
+        };
+    })
+}
+
+pub fn set_pinned(skills_dir: &Path, skill_name: &str, pinned: bool) -> Result<(), SkillError> {
+    mutate_usage(skills_dir, skill_name, |rec| {
+        rec.pinned = pinned;
+    })
+}
+
+pub fn forget(skills_dir: &Path, skill_name: &str) -> Result<(), SkillError> {
+    let name = skill_name.trim();
+    if name.is_empty() {
+        return Ok(());
+    }
+    let _lock = acquire_usage_lock(skills_dir)?;
+    let mut usage = load_usage(skills_dir);
+    usage.remove(name);
+    save_usage(skills_dir, &usage)
+}
+
+pub(crate) fn read_skill_name_from_file(path: &Path, fallback: &str) -> String {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return fallback.to_string();
+    };
+    let trimmed = raw.trim_start();
+    if !trimmed.starts_with("---") {
+        return fallback.to_string();
+    }
+    let after_first = &trimmed[3..];
+    let Some(end_idx) = after_first.find("\n---") else {
+        return fallback.to_string();
+    };
+    let yaml = &after_first[..end_idx];
+    let parsed = serde_yaml::from_str::<Value>(yaml).ok();
+    parsed
+        .as_ref()
+        .and_then(|v| v.get("name"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+pub(crate) fn read_skill_name_from_dir(skill_dir: &Path) -> String {
+    let fallback = skill_dir
+        .file_name()
+        .and_then(|v| v.to_str())
+        .unwrap_or("skill");
+    read_skill_name_from_file(&skill_dir.join("SKILL.md"), fallback)
+}
+
+fn bundled_skill_names(skills_dir: &Path) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let Ok(raw) = fs::read_to_string(skills_dir.join(".bundled_manifest")) else {
+        return names;
+    };
+    for line in raw.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        let name = line.split_once(':').map(|(name, _)| name).unwrap_or(line);
+        if !name.trim().is_empty() {
+            names.insert(name.trim().to_string());
+        }
+    }
+    names
+}
+
+#[derive(Debug, Deserialize)]
+struct HubLock {
+    #[serde(default)]
+    installed: HubInstalledCollection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum HubInstalledCollection {
+    Vec(Vec<HubInstalledEntry>),
+    Map(BTreeMap<String, HubInstalledEntry>),
+}
+
+impl Default for HubInstalledCollection {
+    fn default() -> Self {
+        Self::Vec(Vec::new())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct HubInstalledEntry {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    install_path: String,
+    #[serde(flatten)]
+    _rest: BTreeMap<String, Value>,
+}
+
+fn hub_installed_names(skills_dir: &Path) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let Ok(raw) = fs::read_to_string(skills_dir.join(".hub").join("lock.json")) else {
+        return names;
+    };
+    let Ok(lock) = serde_json::from_str::<HubLock>(&raw) else {
+        return names;
+    };
+    let entries: Vec<(Option<String>, HubInstalledEntry)> = match lock.installed {
+        HubInstalledCollection::Vec(entries) => {
+            entries.into_iter().map(|entry| (None, entry)).collect()
+        }
+        HubInstalledCollection::Map(entries) => entries
+            .into_iter()
+            .map(|(name, entry)| (Some(name), entry))
+            .collect(),
+    };
+    for (key, entry) in entries {
+        if let Some(key) = key.filter(|v| !v.trim().is_empty()) {
+            names.insert(key);
+        }
+        if !entry.name.trim().is_empty() {
+            names.insert(entry.name.trim().to_string());
+        }
+        if !entry.install_path.trim().is_empty() {
+            let path = Path::new(entry.install_path.trim());
+            if let Some(base) = path.file_name().and_then(|v| v.to_str()) {
+                names.insert(base.to_string());
+            }
+            let skill_dir = skills_dir.join(path);
+            if skill_dir.join("SKILL.md").exists() {
+                names.insert(read_skill_name_from_dir(&skill_dir));
+            }
+        }
+    }
+    names
+}
+
+pub fn is_protected_skill(skills_dir: &Path, skill_name: &str) -> bool {
+    let name = skill_name.trim();
+    if name.is_empty() {
+        return false;
+    }
+    bundled_skill_names(skills_dir).contains(name) || hub_installed_names(skills_dir).contains(name)
+}
+
+pub fn is_agent_created(skills_dir: &Path, skill_name: &str) -> bool {
+    !skill_name.trim().is_empty() && !is_protected_skill(skills_dir, skill_name)
+}
+
+fn find_skill_dir(skills_dir: &Path, skill_name: &str) -> Option<PathBuf> {
+    let mut stack = vec![skills_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|v| v.to_str()) else {
+                continue;
+            };
+            if name.starts_with('.') {
+                continue;
+            }
+            if !path.is_dir() {
+                continue;
+            }
+            if path.join("SKILL.md").exists() {
+                let declared = read_skill_name_from_dir(&path);
+                if name == skill_name || declared == skill_name {
+                    return Some(path);
+                }
+            } else {
+                stack.push(path);
+            }
+        }
+    }
+    None
+}
+
+pub fn list_agent_created_skill_names(skills_dir: &Path) -> Vec<String> {
+    let usage = load_usage(skills_dir);
+    let mut names: Vec<String> = usage
+        .iter()
+        .filter_map(|(name, rec)| {
+            if rec.agent_created && is_agent_created(skills_dir, name) {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+pub fn agent_created_report(skills_dir: &Path) -> Vec<SkillUsageReportRow> {
+    let usage = load_usage(skills_dir);
+    let mut rows = Vec::new();
+    for name in list_agent_created_skill_names(skills_dir) {
+        let rec = usage.get(&name).cloned().unwrap_or_default();
+        let last_activity_at = [
+            rec.last_used_at.clone(),
+            rec.last_viewed_at.clone(),
+            rec.last_patched_at.clone(),
+        ]
+        .into_iter()
+        .flatten()
+        .max();
+        rows.push(SkillUsageReportRow {
+            name,
+            use_count: rec.use_count,
+            view_count: rec.view_count,
+            patch_count: rec.patch_count,
+            activity_count: rec.use_count + rec.view_count + rec.patch_count,
+            state: rec.state,
+            pinned: rec.pinned,
+            archived_at: rec.archived_at,
+            last_activity_at,
+        });
+    }
+    rows
+}
+
+pub fn archive_skill(skills_dir: &Path, skill_name: &str) -> Result<(bool, String), SkillError> {
+    let name = skill_name.trim();
+    if name.is_empty() {
+        return Ok((false, "Skill name is required.".to_string()));
+    }
+    if is_protected_skill(skills_dir, name) {
+        return Ok((
+            false,
+            format!("Skill '{name}' is bundled or hub-installed and cannot be archived."),
+        ));
+    }
+    let Some(src) = find_skill_dir(skills_dir, name) else {
+        return Ok((false, format!("Skill '{name}' not found.")));
+    };
+    let archive_root = skills_dir.join(".archive");
+    fs::create_dir_all(&archive_root)?;
+    let mut dest = archive_root.join(name);
+    if dest.exists() {
+        dest = archive_root.join(format!("{}-{}", name, Utc::now().format("%Y%m%d%H%M%S")));
+    }
+    fs::rename(&src, &dest)?;
+    set_state(skills_dir, name, STATE_ARCHIVED)?;
+    Ok((true, format!("Skill '{name}' archived.")))
+}
+
+fn find_archived_skill_dir(skills_dir: &Path, skill_name: &str) -> Option<PathBuf> {
+    let archive_root = skills_dir.join(".archive");
+    let mut stack = vec![archive_root];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if path.join("SKILL.md").exists() {
+                let dir_name = path.file_name().and_then(|v| v.to_str()).unwrap_or("");
+                let declared = read_skill_name_from_dir(&path);
+                if declared == skill_name
+                    || dir_name == skill_name
+                    || dir_name.starts_with(&format!("{skill_name}-"))
+                {
+                    return Some(path);
+                }
+            } else {
+                stack.push(path);
+            }
+        }
+    }
+    None
+}
+
+pub fn restore_skill(skills_dir: &Path, skill_name: &str) -> Result<(bool, String), SkillError> {
+    let name = skill_name.trim();
+    if name.is_empty() {
+        return Ok((false, "Skill name is required.".to_string()));
+    }
+    if is_protected_skill(skills_dir, name) || find_skill_dir(skills_dir, name).is_some() {
+        return Ok((
+            false,
+            format!("Refusing to restore '{name}' because it would shadow an existing bundled, hub, or local skill."),
+        ));
+    }
+    let Some(src) = find_archived_skill_dir(skills_dir, name) else {
+        return Ok((false, format!("Archived skill '{name}' not found.")));
+    };
+    let dest = skills_dir.join(name);
+    fs::rename(&src, &dest)?;
+    set_state(skills_dir, name, STATE_ACTIVE)?;
+    Ok((true, format!("Skill '{name}' restored.")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_skill(skills_dir: &Path, name: &str, category: Option<&str>) -> PathBuf {
+        let dir = category
+            .map(|cat| skills_dir.join(cat).join(name))
+            .unwrap_or_else(|| skills_dir.join(name));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: test\n---\n# body\n"),
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn save_load_and_missing_defaults() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        assert!(load_usage(skills).is_empty());
+        let mut data = BTreeMap::new();
+        data.insert(
+            "skill-a".to_string(),
+            SkillUsageRecord {
+                use_count: 3,
+                ..Default::default()
+            },
+        );
+        save_usage(skills, &data).unwrap();
+        assert_eq!(get_record(skills, "skill-a").use_count, 3);
+        assert_eq!(get_record(skills, "missing").state, STATE_ACTIVE);
+        assert!(!usage_file(skills)
+            .parent()
+            .unwrap()
+            .join(".usage_")
+            .exists());
+    }
+
+    #[test]
+    fn bump_counters_and_forget() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        bump_view(skills, "x").unwrap();
+        bump_use(skills, "x").unwrap();
+        bump_patch(skills, "x").unwrap();
+        let rec = get_record(skills, "x");
+        assert_eq!(rec.view_count, 1);
+        assert_eq!(rec.use_count, 1);
+        assert_eq!(rec.patch_count, 1);
+        assert!(rec.last_viewed_at.is_some());
+        forget(skills, "x").unwrap();
+        assert!(load_usage(skills).is_empty());
+    }
+
+    #[test]
+    fn protected_skills_do_not_get_usage_records() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        fs::create_dir_all(skills.join(".hub")).unwrap();
+        fs::write(skills.join(".bundled_manifest"), "bundled:abc\n").unwrap();
+        fs::write(
+            skills.join(".hub").join("lock.json"),
+            r#"{"installed":[{"name":"hubbed","install_path":"hubbed"}]}"#,
+        )
+        .unwrap();
+
+        bump_view(skills, "bundled").unwrap();
+        bump_use(skills, "hubbed").unwrap();
+        set_state(skills, "bundled", STATE_ARCHIVED).unwrap();
+        assert!(load_usage(skills).is_empty());
+        assert!(!is_agent_created(skills, "bundled"));
+        assert!(!is_agent_created(skills, "hubbed"));
+        assert!(is_agent_created(skills, "mine"));
+    }
+
+    #[test]
+    fn hub_lock_install_path_frontmatter_name_is_protected() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        let skill_dir = skills.join("productivity").join("getnote");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: get-note-display\n---\n# body\n",
+        )
+        .unwrap();
+        fs::create_dir_all(skills.join(".hub")).unwrap();
+        fs::write(
+            skills.join(".hub").join("lock.json"),
+            r#"{"installed":{"getnote":{"source":"taps/main","install_path":"productivity/getnote"}}}"#,
+        )
+        .unwrap();
+        assert!(is_protected_skill(skills, "getnote"));
+        assert!(is_protected_skill(skills, "get-note-display"));
+    }
+
+    #[test]
+    fn agent_created_report_requires_marker_and_excludes_protected() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        write_skill(skills, "mine", None);
+        write_skill(skills, "manual", None);
+        mark_agent_created(skills, "mine").unwrap();
+        bump_view(skills, "mine").unwrap();
+        bump_view(skills, "manual").unwrap();
+
+        let names = list_agent_created_skill_names(skills);
+        assert_eq!(names, vec!["mine"]);
+        let report = agent_created_report(skills);
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].view_count, 1);
+        assert_eq!(report[0].activity_count, 1);
+    }
+
+    #[test]
+    fn archive_restore_and_collision_suffix() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        write_skill(skills, "dup", None);
+        let (ok, _) = archive_skill(skills, "dup").unwrap();
+        assert!(ok);
+        write_skill(skills, "dup", None);
+        let (ok, _) = archive_skill(skills, "dup").unwrap();
+        assert!(ok);
+        let archived = fs::read_dir(skills.join(".archive"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert!(archived.iter().any(|name| name == "dup"));
+        assert!(archived.iter().any(|name| name.starts_with("dup-")));
+
+        let (ok, _) = restore_skill(skills, "dup").unwrap();
+        assert!(ok);
+        assert!(skills.join("dup").join("SKILL.md").exists());
+    }
+
+    #[test]
+    fn archive_refuses_protected_and_restore_refuses_shadowing() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path();
+        write_skill(skills, "shared", None);
+        archive_skill(skills, "shared").unwrap();
+        write_skill(skills, "shared", None);
+        fs::write(skills.join(".bundled_manifest"), "shared:abc\n").unwrap();
+        let (ok, msg) = restore_skill(skills, "shared").unwrap();
+        assert!(!ok);
+        assert!(msg.contains("shadow"));
+        let (ok, _) = archive_skill(skills, "shared").unwrap();
+        assert!(!ok);
+    }
+}

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-30T12:39:37.465067+00:00",
+  "generated_at_utc": "2026-05-30T13:16:25.504315+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T12:39:36.615184+00:00",
+  "generated_at_utc": "2026-05-30T13:16:25.578166+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T12:39:36.615184+00:00`
+Generated: `2026-05-30T13:16:25.578166+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T12:38:10.386905+00:00",
+  "generated_at_utc": "2026-05-30T13:16:13.680097+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "3656758c30a8c13aee3468ba024c144175571a45",
+    "local_sha": "eff4cb7a106c89eb11b9123c77fcd417d2fecce9",
     "upstream_ref": "upstream/main",
     "upstream_sha": "44f3e5186502167e68b6073b4f7bdfae7bfb4fbe",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4469,
-    "commits_ahead": 867,
+    "commits_ahead": 869,
     "upstream_patch_missing": 4349,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 717,
+    "local_patch_unique": 718,
     "files_only_upstream": 1484,
     "files_only_local": 570,
     "files_shared_identical": 1691,
     "files_shared_different": 1028,
     "tree_files_changed": 3082,
     "tree_insertions": 746713,
-    "tree_deletions": 395609
+    "tree_deletions": 396453
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4349,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 717,
+    "local_patch_unique": 718,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T12:38:10.386905+00:00`
+Generated: `2026-05-30T13:16:13.680097+00:00`
 
 ## Scope
 
-- Local ref: `main` (`3656758c30a8c13aee3468ba024c144175571a45`)
+- Local ref: `main` (`eff4cb7a106c89eb11b9123c77fcd417d2fecce9`)
 - Upstream ref: `upstream/main` (`44f3e5186502167e68b6073b4f7bdfae7bfb4fbe`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T12:38:10.386905+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4469 |
-| Commits ahead local (`local` ancestry only) | 867 |
+| Commits ahead local (`local` ancestry only) | 869 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4349 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 717 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 718 |
 | Files only in upstream tree | 1484 |
 | Files only in local tree | 570 |
 | Shared files identical content | 1691 |
 | Shared files different content | 1028 |
 | Total files changed (`local` vs `upstream`) | 3082 |
 | Insertions (`local` vs `upstream`) | 746713 |
-| Deletions (`local` vs `upstream`) | 395609 |
+| Deletions (`local` vs `upstream`) | 396453 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T12:38:10.386905+00:00`
 
 - Upstream missing by patch-id: `4349`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `717`
+- Local unique by patch-id: `718`
 - Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -11161,16 +11161,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_skill_provenance.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8cbecc000bc54a6565e5ccfc765ea7587d980ba4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_skill_provenance.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6c1aedef771f2cfc58d630a1cc35c4d9378c7e96",
       "workstream": "WS6"
@@ -11191,16 +11191,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_skill_usage.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8251e6099934586d34098ba532ab2c9293501544",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_skill_usage.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "ad306b9c512abaf10c429fd3855587e09205d580",
       "workstream": "WS6"
@@ -11251,31 +11251,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_skills_hub_clawhub.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2b2863498a3165e2fe4a9ed3fadcd3d72ac4442d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_skills_hub_clawhub.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6b45d081d094f4fd02eadf0e2eced909e8c8d1c0",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_skills_sync.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "347366e6a6ffa10aa9af0a371adf4d14517c18ad",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_skills_sync.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c13ed18727a527bfeb8b1cac043031223c2a9ccd",
       "workstream": "WS6"
@@ -15421,30 +15421,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T12:38:07.274680+00:00",
+  "generated_at_utc": "2026-05-30T13:16:24.565936+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "3656758c30a8c13aee3468ba024c144175571a45",
+    "local_sha": "eff4cb7a106c89eb11b9123c77fcd417d2fecce9",
     "upstream_ref": "upstream/main",
     "upstream_sha": "44f3e5186502167e68b6073b4f7bdfae7bfb4fbe"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 656,
-      "intentional_divergence": 202,
+      "functional": 652,
+      "intentional_divergence": 206,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 372,
-      "rust_equivalent_or_contract_test_required": 573,
+      "not_required_for_runtime": 376,
+      "rust_equivalent_or_contract_test_required": 569,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 202,
+      "cleared_intentional_divergence": 206,
       "cleared_non_runtime": 170,
-      "pending_review": 656
+      "pending_review": 652
     },
     "by_workstream": {
       "WS3": 55,
@@ -15453,10 +15453,10 @@
       "WS6": 687,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 202,
+    "cleared_intentional_divergence": 206,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 656,
+    "pending_review": 652,
     "total_shared_different": 1028
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T12:38:07.274680+00:00`
+Generated: `2026-05-30T13:16:24.565936+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1028`
 - Pending classification: `0`
-- Pending functional review: `656`
+- Pending functional review: `652`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `202`
+- Cleared intentional divergence: `206`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 202 |
+| `cleared_intentional_divergence` | 206 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 656 |
+| `pending_review` | 652 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-05-30T12:38:07.274680+00:00`
 | --- | ---: |
 | `tests/gateway` | 147 |
 | `tests/hermes_cli` | 127 |
-| `tests/tools` | 104 |
+| `tests/tools` | 100 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1382,9 +1382,23 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_skill_provenance.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream skill write-origin ContextVar intent is covered by Rust write-origin provenance guards with foreground fallback, nested restoration, background-review detection, and thread-isolated scope tests.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/tools/test_skill_size_limits.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream managed skill content-size guard intent is covered by Rust SkillManager MAX_SKILL_CONTENT_CHARS tests while hand-placed skill files remain loadable through the store path.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_skill_usage.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream skill usage sidecar, curator provenance filtering, protected bundled/hub exclusions, archiving, restore, pin/state, and agent-created reporting intent is covered by Rust SkillUsageRecord and usage module contract tests.",
       "owner": "sheawinkler",
       "ticket": 25
     },
@@ -1406,6 +1420,20 @@
       "path": "tests/tools/test_skills_hub.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream skills hub trust, content hashing, and remote skill integrity intent is covered by Rust SkillsHubClient search/download/upload/update contracts, Ed25519 signature verification, trusted source resolution, and scan-before-use policy; Python source-adapter breadth remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_skills_hub_clawhub.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ClawHub listing/detail/search repair/version/file mapping intent is covered by Rust ClawHub registry metadata parsing, exact-slug repair, hyphenated query normalization, latest-version extraction, and inline/raw file reference contracts.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_skills_sync.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream bundled skill manifest sync/reset/optional provenance intent is covered by Rust sync contracts for v1/v2 manifests, stable hashes, category-preserving copy, collision non-poisoning, user-modified protection, reset/restore, and official optional lock backfill.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- port skill write-origin provenance, usage sidecar, bundled skill sync/reset, and ClawHub parsing contracts into hermes-skills Rust modules
- classify the covered upstream Python tests as intentional divergence after Rust parity implementation
- regenerate parity matrix, shared diff backlog, divergence validation, and global parity proof artifacts

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different gate check
- cargo test -p hermes-skills
- cargo test -p hermes-tools skill
- cargo test -p hermes-cli skills
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --local-ref HEAD --upstream-ref upstream/main --json
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- cargo test --workspace
- cargo build --workspace