### PR TITLE
parity(tools): port schema sanitizer contracts

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -567,7 +567,7 @@ impl GenericProvider {
     }
 
     fn format_tools_for_openai_api(tools: &[ToolSchema]) -> Value {
-        Value::Array(
+        let formatted = Value::Array(
             tools
                 .iter()
                 .map(|tool| {
@@ -581,7 +581,8 @@ impl GenericProvider {
                     })
                 })
                 .collect(),
-        )
+        );
+        hermes_core::sanitize_tool_schemas(Some(&formatted)).unwrap_or(formatted)
     }
 
     fn build_request(

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! used across the hermes-agent-rust workspace.
 
 pub mod errors;
+pub mod schema_sanitizer;
 pub mod tool_call_parser;
 pub mod tool_schema;
 pub mod traits;
@@ -25,6 +26,11 @@ pub use types::{
 
 // Re-export tool schema types
 pub use tool_schema::{tool_schema, JsonSchema, ToolSchema};
+
+// Re-export schema sanitizer helpers
+pub use schema_sanitizer::{
+    sanitize_tool_parameters, sanitize_tool_schemas, strip_pattern_and_format, strip_slash_enum,
+};
 
 // Re-export trait definitions
 pub use traits::{

--- a/crates/hermes-core/src/schema_sanitizer.rs
+++ b/crates/hermes-core/src/schema_sanitizer.rs
@@ -1,0 +1,631 @@
+use serde_json::{Map, Value};
+
+const TOP_LEVEL_FORBIDDEN_KEYS: &[&str] = &["allOf", "oneOf", "anyOf", "enum", "not"];
+
+pub fn sanitize_tool_schemas(tools: Option<&Value>) -> Option<Value> {
+    let mut out = tools?.clone();
+    for_each_tool_parameters_mut(&mut out, true, |params| {
+        *params = sanitize_tool_parameters(params);
+    });
+    Some(out)
+}
+
+pub fn sanitize_tool_parameters(params: &Value) -> Value {
+    let mut root = match params {
+        Value::Object(obj) => Value::Object(obj.clone()),
+        Value::String(kind) => schema_for_type(kind),
+        _ => default_object_schema(),
+    };
+    sanitize_schema_node(&mut root, true);
+    root
+}
+
+pub fn strip_pattern_and_format(tools: Option<&mut Value>) -> usize {
+    let Some(tools) = tools else {
+        return 0;
+    };
+    let mut stripped = 0;
+    for_each_tool_parameters_mut(tools, false, |params| {
+        stripped += strip_schema_keywords(params, &["pattern", "format"]);
+    });
+    stripped
+}
+
+pub fn strip_slash_enum(tools: Option<&mut Value>) -> usize {
+    let Some(tools) = tools else {
+        return 0;
+    };
+    let mut stripped = 0;
+    for_each_tool_parameters_mut(tools, false, |params| {
+        stripped += strip_slash_enum_in_schema(params);
+    });
+    stripped
+}
+
+fn default_object_schema() -> Value {
+    serde_json::json!({"type": "object", "properties": {}})
+}
+
+fn schema_for_type(kind: &str) -> Value {
+    let kind = kind.trim();
+    if kind == "object" {
+        default_object_schema()
+    } else if kind.is_empty() {
+        default_object_schema()
+    } else {
+        serde_json::json!({"type": kind})
+    }
+}
+
+fn for_each_tool_parameters_mut<F>(tools: &mut Value, insert_missing: bool, mut f: F)
+where
+    F: FnMut(&mut Value),
+{
+    let Some(items) = tools.as_array_mut() else {
+        return;
+    };
+    for tool in items {
+        if let Some(function) = tool.get_mut("function").and_then(Value::as_object_mut) {
+            if insert_missing {
+                let params = function
+                    .entry("parameters".to_string())
+                    .or_insert_with(default_object_schema);
+                f(params);
+            } else if let Some(params) = function.get_mut("parameters") {
+                f(params);
+            }
+            continue;
+        }
+
+        if let Some(obj) = tool.as_object_mut() {
+            if let Some(params) = obj.get_mut("parameters") {
+                f(params);
+            }
+        }
+    }
+}
+
+fn sanitize_schema_node(node: &mut Value, top_level: bool) {
+    match node {
+        Value::String(kind) => {
+            *node = schema_for_type(kind);
+        }
+        Value::Object(_) => {}
+        _ if top_level => {
+            *node = default_object_schema();
+        }
+        _ => return,
+    }
+
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+
+    if top_level {
+        for key in TOP_LEVEL_FORBIDDEN_KEYS {
+            obj.remove(*key);
+        }
+    }
+
+    collapse_nullable_type_array(obj);
+    coerce_object_type(obj);
+
+    if let Some(props) = obj.get_mut("properties").and_then(Value::as_object_mut) {
+        for value in props.values_mut() {
+            sanitize_schema_node(value, false);
+        }
+    }
+
+    if let Some(items) = obj.get_mut("items") {
+        sanitize_schema_node(items, false);
+    }
+
+    if let Some(additional) = obj.get_mut("additionalProperties") {
+        if additional.is_object() || additional.is_string() {
+            sanitize_schema_node(additional, false);
+        }
+    }
+
+    for key in ["anyOf"] {
+        if let Some(branches) = obj.get_mut(key).and_then(Value::as_array_mut) {
+            for branch in branches {
+                sanitize_schema_node(branch, false);
+            }
+        }
+    }
+
+    if let Some(defs) = obj.get_mut("$defs").and_then(Value::as_object_mut) {
+        for value in defs.values_mut() {
+            sanitize_schema_node(value, false);
+        }
+    }
+
+    prune_required(obj);
+}
+
+fn collapse_nullable_type_array(obj: &mut Map<String, Value>) {
+    let Some(types) = obj.get("type").and_then(Value::as_array) else {
+        return;
+    };
+    let mut saw_null = false;
+    let mut first_non_null = None;
+    for typ in types {
+        match typ.as_str() {
+            Some("null") => saw_null = true,
+            Some(other) if first_non_null.is_none() => first_non_null = Some(other.to_string()),
+            _ => {}
+        }
+    }
+    if let Some(kind) = first_non_null {
+        obj.insert("type".to_string(), Value::String(kind));
+        if saw_null {
+            obj.insert("nullable".to_string(), Value::Bool(true));
+        }
+    }
+}
+
+fn coerce_object_type(obj: &mut Map<String, Value>) {
+    let has_properties = obj.get("properties").is_some();
+    let missing_or_null_type = obj
+        .get("type")
+        .is_none_or(|value| value.is_null() || value.as_str() == Some(""));
+    if has_properties && missing_or_null_type {
+        obj.insert("type".to_string(), Value::String("object".to_string()));
+    }
+
+    if obj.get("type").and_then(Value::as_str) == Some("object") {
+        let needs_properties = !obj.get("properties").is_some_and(Value::is_object);
+        if needs_properties {
+            obj.insert("properties".to_string(), Value::Object(Map::new()));
+        }
+    }
+}
+
+fn prune_required(obj: &mut Map<String, Value>) {
+    let Some(required) = obj.get("required").and_then(Value::as_array) else {
+        return;
+    };
+    let Some(props) = obj.get("properties").and_then(Value::as_object) else {
+        obj.remove("required");
+        return;
+    };
+    let kept: Vec<Value> = required
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|name| props.contains_key(*name))
+        .map(|name| Value::String(name.to_string()))
+        .collect();
+    if kept.is_empty() {
+        obj.remove("required");
+    } else {
+        obj.insert("required".to_string(), Value::Array(kept));
+    }
+}
+
+fn strip_schema_keywords(node: &mut Value, keywords: &[&str]) -> usize {
+    let Some(obj) = node.as_object_mut() else {
+        return 0;
+    };
+    let mut stripped = 0;
+    for key in keywords {
+        if obj.remove(*key).is_some() {
+            stripped += 1;
+        }
+    }
+    stripped += recurse_schema_children(obj, |child| strip_schema_keywords(child, keywords));
+    stripped
+}
+
+fn strip_slash_enum_in_schema(node: &mut Value) -> usize {
+    let Some(obj) = node.as_object_mut() else {
+        return 0;
+    };
+    let mut stripped = 0;
+    let enum_has_slash = obj
+        .get("enum")
+        .and_then(Value::as_array)
+        .is_some_and(|values| {
+            values
+                .iter()
+                .any(|value| value.as_str().is_some_and(|s| s.contains('/')))
+        });
+    if enum_has_slash {
+        obj.remove("enum");
+        stripped += 1;
+    }
+    stripped += recurse_schema_children(obj, strip_slash_enum_in_schema);
+    stripped
+}
+
+fn recurse_schema_children<F>(obj: &mut Map<String, Value>, mut f: F) -> usize
+where
+    F: FnMut(&mut Value) -> usize,
+{
+    let mut count = 0;
+    if let Some(props) = obj.get_mut("properties").and_then(Value::as_object_mut) {
+        for value in props.values_mut() {
+            count += f(value);
+        }
+    }
+    if let Some(items) = obj.get_mut("items") {
+        count += f(items);
+    }
+    if let Some(additional) = obj.get_mut("additionalProperties") {
+        if additional.is_object() {
+            count += f(additional);
+        }
+    }
+    for key in ["anyOf", "oneOf", "allOf"] {
+        if let Some(branches) = obj.get_mut(key).and_then(Value::as_array_mut) {
+            for branch in branches {
+                count += f(branch);
+            }
+        }
+    }
+    if let Some(defs) = obj.get_mut("$defs").and_then(Value::as_object_mut) {
+        for value in defs.values_mut() {
+            count += f(value);
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tool(name: &str, parameters: Value) -> Value {
+        json!({"type": "function", "function": {"name": name, "parameters": parameters}})
+    }
+
+    fn responses_tool(name: &str, parameters: Value) -> Value {
+        json!({"type": "function", "name": name, "parameters": parameters})
+    }
+
+    fn sanitize(tools: Value) -> Value {
+        sanitize_tool_schemas(Some(&tools)).expect("sanitized tools")
+    }
+
+    #[test]
+    fn object_without_properties_gets_empty_properties() {
+        let out = sanitize(json!([tool("t", json!({"type": "object"}))]));
+        assert_eq!(
+            out[0]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn nested_object_without_properties_gets_empty_properties() {
+        let out = sanitize(json!([tool(
+            "t",
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "arguments": {"type": "object", "description": "free-form"}
+                },
+                "required": ["name"]
+            })
+        )]));
+        let args = &out[0]["function"]["parameters"]["properties"]["arguments"];
+        assert_eq!(args["type"], "object");
+        assert_eq!(args["properties"], json!({}));
+        assert_eq!(args["description"], "free-form");
+    }
+
+    #[test]
+    fn bare_string_property_values_are_replaced_with_schema_dicts() {
+        let out = sanitize(json!([tool(
+            "t",
+            json!({"type": "object", "properties": {"payload": "object", "name": "string"}})
+        )]));
+        assert_eq!(
+            out[0]["function"]["parameters"]["properties"]["payload"],
+            json!({"type": "object", "properties": {}})
+        );
+        assert_eq!(
+            out[0]["function"]["parameters"]["properties"]["name"],
+            json!({"type": "string"})
+        );
+    }
+
+    #[test]
+    fn nullable_type_array_collapses_to_single_string() {
+        let out = sanitize(json!([tool(
+            "t",
+            json!({"type": "object", "properties": {"maybe_name": {"type": ["string", "null"]}}})
+        )]));
+        let prop = &out[0]["function"]["parameters"]["properties"]["maybe_name"];
+        assert_eq!(prop["type"], "string");
+        assert_eq!(prop["nullable"], true);
+    }
+
+    #[test]
+    fn anyof_nested_objects_are_sanitized() {
+        let out = sanitize(json!([tool(
+            "t",
+            json!({
+                "type": "object",
+                "properties": {
+                    "opt": {"anyOf": [{"type": "object"}, {"type": "string"}]}
+                }
+            })
+        )]));
+        let variants = &out[0]["function"]["parameters"]["properties"]["opt"]["anyOf"];
+        assert_eq!(variants[0], json!({"type": "object", "properties": {}}));
+        assert_eq!(variants[1], json!({"type": "string"}));
+    }
+
+    #[test]
+    fn missing_or_non_dict_parameters_get_default_object_schema() {
+        let tools = json!([
+            {"type": "function", "function": {"name": "missing"}},
+            tool("string_params", json!("object"))
+        ]);
+        let out = sanitize(tools);
+        assert_eq!(
+            out[0]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+        assert_eq!(
+            out[1]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn required_fields_are_pruned_to_existing_properties() {
+        let out = sanitize(json!([tool(
+            "t",
+            json!({
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name", "missing_field"]
+            })
+        )]));
+        assert_eq!(
+            out[0]["function"]["parameters"]["required"],
+            json!(["name"])
+        );
+
+        let out = sanitize(json!([tool(
+            "t",
+            json!({"type": "object", "properties": {}, "required": ["x", "y"]})
+        )]));
+        assert!(out[0]["function"]["parameters"].get("required").is_none());
+    }
+
+    #[test]
+    fn well_formed_schema_and_additional_properties_are_preserved_or_sanitized() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path"},
+                "payload": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "dict_field": {
+                    "type": "object",
+                    "additionalProperties": {"type": "object"}
+                }
+            },
+            "required": ["path"]
+        });
+        let out = sanitize(json!([tool("read_file", schema)]));
+        let params = &out[0]["function"]["parameters"];
+        assert_eq!(params["properties"]["path"]["description"], "File path");
+        assert_eq!(
+            params["properties"]["payload"]["additionalProperties"],
+            true
+        );
+        assert_eq!(
+            params["properties"]["dict_field"]["additionalProperties"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn sanitize_does_not_mutate_input() {
+        let original = json!([tool(
+            "t",
+            json!({"type": "object", "properties": {"x": {"type": "object"}}})
+        )]);
+        let _ = sanitize_tool_schemas(Some(&original));
+        assert!(original[0]["function"]["parameters"]["properties"]["x"]
+            .get("properties")
+            .is_none());
+    }
+
+    #[test]
+    fn items_and_nested_required_are_sanitized() {
+        let out = sanitize(json!([tool(
+            "t",
+            json!({
+                "type": "object",
+                "properties": {
+                    "bag": {"type": "array", "items": {"type": "object"}},
+                    "filter": {
+                        "type": "object",
+                        "properties": {"field": {"type": "string"}},
+                        "required": ["field", "missing"]
+                    }
+                }
+            })
+        )]));
+        assert_eq!(
+            out[0]["function"]["parameters"]["properties"]["bag"]["items"],
+            json!({"type": "object", "properties": {}})
+        );
+        assert_eq!(
+            out[0]["function"]["parameters"]["properties"]["filter"]["required"],
+            json!(["field"])
+        );
+    }
+
+    #[test]
+    fn empty_and_none_tools_are_stable() {
+        assert_eq!(sanitize_tool_schemas(Some(&json!([]))), Some(json!([])));
+        assert_eq!(sanitize_tool_schemas(None), None);
+    }
+
+    #[test]
+    fn strip_pattern_and_format_removes_schema_keywords_only() {
+        let mut tools = json!([tool(
+            "search_files",
+            json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Regex pattern"},
+                    "date": {"type": "string", "pattern": "\\d+", "format": "date-time"}
+                },
+                "required": ["pattern"]
+            })
+        )]);
+        let stripped = strip_pattern_and_format(Some(&mut tools));
+        assert_eq!(stripped, 2);
+        let params = &tools[0]["function"]["parameters"];
+        assert!(params["properties"].get("pattern").is_some());
+        assert_eq!(params["properties"]["pattern"]["type"], "string");
+        assert!(params["properties"]["date"].get("pattern").is_none());
+        assert!(params["properties"]["date"].get("format").is_none());
+    }
+
+    #[test]
+    fn strip_pattern_and_format_recurses_and_is_idempotent() {
+        let mut tools = json!([tool(
+            "t",
+            json!({
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "anyOf": [
+                            {"type": "string", "pattern": "[A-Z]+", "format": "uuid"},
+                            {"type": "integer"}
+                        ]
+                    }
+                }
+            })
+        )]);
+        assert_eq!(strip_pattern_and_format(Some(&mut tools)), 2);
+        assert_eq!(strip_pattern_and_format(Some(&mut tools)), 0);
+        let variants = &tools[0]["function"]["parameters"]["properties"]["value"]["anyOf"];
+        assert!(variants[0].get("pattern").is_none());
+        assert!(variants[0].get("format").is_none());
+    }
+
+    #[test]
+    fn strip_pattern_and_format_handles_responses_and_mixed_formats() {
+        let mut tools = json!([
+            tool(
+                "search",
+                json!({"type": "object", "properties": {"query": {"type": "string", "pattern": "^[a-z]+$"}}})
+            ),
+            responses_tool(
+                "get_time",
+                json!({"type": "object", "properties": {"tz": {"type": "string", "format": "date-time"}}})
+            )
+        ]);
+        assert_eq!(strip_pattern_and_format(Some(&mut tools)), 2);
+        assert!(tools[0]["function"]["parameters"]["properties"]["query"]
+            .get("pattern")
+            .is_none());
+        assert!(tools[1]["parameters"]["properties"]["tz"]
+            .get("format")
+            .is_none());
+    }
+
+    #[test]
+    fn strip_pattern_and_format_empty_and_none_return_zero() {
+        let mut empty = json!([]);
+        assert_eq!(strip_pattern_and_format(Some(&mut empty)), 0);
+        assert_eq!(strip_pattern_and_format(None), 0);
+    }
+
+    #[test]
+    fn top_level_forbidden_combinators_are_stripped_but_nested_allof_survives() {
+        let out = sanitize(json!([tool(
+            "memory",
+            json!({
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["add", "replace"]},
+                    "config": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string"}},
+                        "allOf": [{"required": ["mode"]}]
+                    }
+                },
+                "required": ["action"],
+                "allOf": [{"then": {"required": ["content"]}}],
+                "oneOf": [{"required": ["action"]}],
+                "anyOf": [{"required": ["action"]}],
+                "enum": ["bogus-top-level"],
+                "not": {"required": ["y"]}
+            })
+        )]));
+        let params = &out[0]["function"]["parameters"];
+        for key in TOP_LEVEL_FORBIDDEN_KEYS {
+            assert!(params.get(*key).is_none(), "{key} should be stripped");
+        }
+        assert_eq!(params["required"], json!(["action"]));
+        assert_eq!(
+            params["properties"]["config"]["allOf"],
+            json!([{"required": ["mode"]}])
+        );
+    }
+
+    #[test]
+    fn strip_slash_enum_removes_enums_containing_slashes() {
+        let mut tools = json!([
+            tool(
+                "train",
+                json!({"type": "object", "properties": {"model": {"type": "string", "enum": ["Qwen/Qwen3.5", "local"]}}})
+            ),
+            responses_tool(
+                "pick",
+                json!({"type": "object", "properties": {"mode": {"type": "string", "enum": ["fast", "slow"]}}})
+            )
+        ]);
+        assert_eq!(strip_slash_enum(Some(&mut tools)), 1);
+        assert!(tools[0]["function"]["parameters"]["properties"]["model"]
+            .get("enum")
+            .is_none());
+        assert_eq!(
+            tools[1]["parameters"]["properties"]["mode"]["enum"],
+            json!(["fast", "slow"])
+        );
+    }
+
+    #[test]
+    fn strip_slash_enum_recurses_and_is_idempotent() {
+        let mut tools = json!([tool(
+            "t",
+            json!({
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "anyOf": [
+                            {"type": "string", "enum": ["owner/repo"]},
+                            {"type": "null"}
+                        ]
+                    }
+                }
+            })
+        )]);
+        assert_eq!(strip_slash_enum(Some(&mut tools)), 1);
+        assert_eq!(strip_slash_enum(Some(&mut tools)), 0);
+        let variants = &tools[0]["function"]["parameters"]["properties"]["value"]["anyOf"];
+        assert!(variants[0].get("enum").is_none());
+    }
+
+    #[test]
+    fn strip_slash_enum_empty_and_none_return_zero() {
+        let mut empty = json!([]);
+        assert_eq!(strip_slash_enum(Some(&mut empty)), 0);
+        assert_eq!(strip_slash_enum(None), 0);
+    }
+}

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-30T13:16:25.504315+00:00",
+  "generated_at_utc": "2026-05-30T13:47:25.793998+00:00",
   "items": [
     {
       "errors": [],
@@ -185,7 +185,7 @@
   "summary": {
     "errors": 0,
     "items": 8,
-    "local_paths": 3289,
+    "local_paths": 3292,
     "review_overdue": 0,
     "unowned": 0,
     "upstream_paths": 4203,

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -8,7 +8,7 @@
         "status": "pass"
       },
       {
-        "actual": 4349.0,
+        "actual": 4351.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "status": "pass"
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T13:16:25.578166+00:00",
+  "generated_at_utc": "2026-05-30T13:47:36.693860+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -65,7 +65,7 @@
     "max_files_only_upstream": 1484.0,
     "max_queue_pending_commits": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 4349.0,
+    "max_upstream_patch_missing": 4351.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T13:16:25.578166+00:00`
+Generated: `2026-05-30T13:47:36.693860+00:00`
 
 ## Gate Status
 
@@ -14,7 +14,7 @@ Generated: `2026-05-30T13:16:25.578166+00:00`
 | Metric | Value |
 | --- | ---: |
 | `max_commits_behind` | 4469.0 |
-| `max_upstream_patch_missing` | 4349.0 |
+| `max_upstream_patch_missing` | 4351.0 |
 | `max_files_only_upstream` | 1484.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T13:16:13.680097+00:00",
+  "generated_at_utc": "2026-05-30T13:47:27.064383+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "eff4cb7a106c89eb11b9123c77fcd417d2fecce9",
+    "local_sha": "b644f01012a3ebd0b0593691561c6cc70c4c3329",
     "upstream_ref": "upstream/main",
     "upstream_sha": "44f3e5186502167e68b6073b4f7bdfae7bfb4fbe",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4469,
-    "commits_ahead": 869,
-    "upstream_patch_missing": 4349,
+    "commits_ahead": 871,
+    "upstream_patch_missing": 4351,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 718,
+    "local_patch_unique": 719,
     "files_only_upstream": 1484,
-    "files_only_local": 570,
+    "files_only_local": 573,
     "files_shared_identical": 1691,
     "files_shared_different": 1028,
-    "tree_files_changed": 3082,
+    "tree_files_changed": 3085,
     "tree_insertions": 746713,
-    "tree_deletions": 396453
+    "tree_deletions": 398480
   },
   "top_upstream_only": [
     {
@@ -395,6 +395,10 @@
       "count": 10
     },
     {
+      "path": "crates/hermes-skills",
+      "count": 10
+    },
+    {
       "path": "crates/hermes-cron",
       "count": 9
     },
@@ -408,10 +412,6 @@
     },
     {
       "path": "crates/hermes-mcp",
-      "count": 7
-    },
-    {
-      "path": "crates/hermes-skills",
       "count": 7
     },
     {
@@ -719,6 +719,10 @@
       "count": 10
     },
     {
+      "path": "crates/hermes-skills",
+      "count": 10
+    },
+    {
       "path": "crates/hermes-cron",
       "count": 9
     },
@@ -732,10 +736,6 @@
     },
     {
       "path": "crates/hermes-mcp",
-      "count": 7
-    },
-    {
-      "path": "crates/hermes-skills",
       "count": 7
     },
     {
@@ -858,7 +858,7 @@
       "name": "Compatibility and divergence policy",
       "upstream_only": 393,
       "shared_different": 12,
-      "local_only": 195,
+      "local_only": 198,
       "risk": "high",
       "effort": "XL"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4349,
+    "upstream_patch_missing": 4351,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 718,
+    "local_patch_unique": 719,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T13:16:13.680097+00:00`
+Generated: `2026-05-30T13:47:27.064383+00:00`
 
 ## Scope
 
-- Local ref: `main` (`eff4cb7a106c89eb11b9123c77fcd417d2fecce9`)
+- Local ref: `main` (`b644f01012a3ebd0b0593691561c6cc70c4c3329`)
 - Upstream ref: `upstream/main` (`44f3e5186502167e68b6073b4f7bdfae7bfb4fbe`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T13:16:13.680097+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4469 |
-| Commits ahead local (`local` ancestry only) | 869 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4349 |
+| Commits ahead local (`local` ancestry only) | 871 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4351 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 718 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 719 |
 | Files only in upstream tree | 1484 |
-| Files only in local tree | 570 |
+| Files only in local tree | 573 |
 | Shared files identical content | 1691 |
 | Shared files different content | 1028 |
-| Total files changed (`local` vs `upstream`) | 3082 |
+| Total files changed (`local` vs `upstream`) | 3085 |
 | Insertions (`local` vs `upstream`) | 746713 |
-| Deletions (`local` vs `upstream`) | 396453 |
+| Deletions (`local` vs `upstream`) | 398480 |
 
 ## Top 40 upstream-only buckets
 
@@ -131,11 +131,11 @@ Generated: `2026-05-30T13:16:13.680097+00:00`
 | `crates/hermes-environments` | 13 |
 | `crates/hermes-core` | 11 |
 | `crates/hermes-acp` | 10 |
+| `crates/hermes-skills` | 10 |
 | `crates/hermes-cron` | 9 |
 | `docs/implementation` | 9 |
 | `docs/roadmaps` | 8 |
 | `crates/hermes-mcp` | 7 |
-| `crates/hermes-skills` | 7 |
 | `optional-skills/creative` | 6 |
 | `crates/hermes-http` | 5 |
 | `docs/releases` | 5 |
@@ -174,9 +174,9 @@ Generated: `2026-05-30T13:16:13.680097+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4349`
+- Upstream missing by patch-id: `4351`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `718`
+- Local unique by patch-id: `719`
 - Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -10482,7 +10482,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "a2bb05dd13a9103501bbb8bf0538c06d6d07c0bd",
+      "upstream_blob": "ac44dd1bc6b342bfbbdb7d363f2b034b21a13627",
       "workstream": "WS6"
     },
     {
@@ -11011,16 +11011,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_schema_sanitizer.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "89fbcd91d2b119e85961ec4b86a7702a21e6e8c0",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_schema_sanitizer.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "b856440ef4088bdad6e8b99286648baa625a20aa",
       "workstream": "WS6"
@@ -15421,30 +15421,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T13:16:24.565936+00:00",
+  "generated_at_utc": "2026-05-30T13:47:36.763313+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "eff4cb7a106c89eb11b9123c77fcd417d2fecce9",
+    "local_sha": "b644f01012a3ebd0b0593691561c6cc70c4c3329",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "44f3e5186502167e68b6073b4f7bdfae7bfb4fbe"
+    "upstream_sha": "5f84c9144a2c1f1248e92f53eeb2ea8146ad0883"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 652,
-      "intentional_divergence": 206,
+      "functional": 651,
+      "intentional_divergence": 207,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 376,
-      "rust_equivalent_or_contract_test_required": 569,
+      "not_required_for_runtime": 377,
+      "rust_equivalent_or_contract_test_required": 568,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 206,
+      "cleared_intentional_divergence": 207,
       "cleared_non_runtime": 170,
-      "pending_review": 652
+      "pending_review": 651
     },
     "by_workstream": {
       "WS3": 55,
@@ -15453,10 +15453,10 @@
       "WS6": 687,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 206,
+    "cleared_intentional_divergence": 207,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 652,
+    "pending_review": 651,
     "total_shared_different": 1028
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T13:16:24.565936+00:00`
+Generated: `2026-05-30T13:47:36.763313+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1028`
 - Pending classification: `0`
-- Pending functional review: `652`
+- Pending functional review: `651`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `206`
+- Cleared intentional divergence: `207`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 206 |
+| `cleared_intentional_divergence` | 207 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 652 |
+| `pending_review` | 651 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-05-30T13:16:24.565936+00:00`
 | --- | ---: |
 | `tests/gateway` | 147 |
 | `tests/hermes_cli` | 127 |
-| `tests/tools` | 100 |
+| `tests/tools` | 99 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1361,6 +1361,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_schema_sanitizer.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream tool schema sanitizer intent is covered by Rust hermes-core schema sanitizer contracts for OpenAI and Responses tool formats, object/default-property repair, nullable type collapse, required pruning, nested anyOf/items/additionalProperties, reactive pattern/format stripping, slash-enum stripping, and provider formatting integration.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/tools/test_skill_env_passthrough.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream skill required-environment metadata normalization is covered by Rust skill_utils required-env parsing while Ultra exposes env_passthrough as an explicit Rust tool instead of Python's implicit global registry.",


### PR DESCRIPTION
## Summary
- add a Rust shared schema sanitizer in hermes-core for OpenAI and Responses tool schema formats
- apply the sanitizer to OpenAI-compatible provider tool formatting so malformed tool schemas are repaired at runtime
- classify upstream tests/tools/test_schema_sanitizer.py as covered by Rust contracts and regenerate parity artifacts

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different gate check
- cargo test -p hermes-core
- cargo test -p hermes-agent provider::tests::test_format_tools_for_openai_api_shape
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --local-ref HEAD --upstream-ref upstream/main --json
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- cargo test --workspace
- cargo build --workspace