### PR TITLE
parity(tools): port security guard contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,6 +2034,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -313,8 +313,75 @@ fn resolve_path(input: &str) -> Result<PathBuf, AgentError> {
 }
 
 const SUBPROCESS_ENV_BLOCKLIST_EXACT: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "BROWSERBASE_PROJECT_ID",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "COHERE_API_KEY",
+    "DAYTONA_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "DISCORD_REQUIRE_MENTION",
+    "EMAIL_ADDRESS",
+    "EMAIL_HOME_ADDRESS",
+    "EMAIL_HOME_ADDRESS_NAME",
+    "EMAIL_IMAP_HOST",
+    "EMAIL_PASSWORD",
+    "EMAIL_SMTP_HOST",
+    "ELEVENLABS_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "FIREWORKS_API_KEY",
+    "GATEWAY_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GH_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "GITHUB_TOKEN",
+    "GLM_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "HASS_TOKEN",
+    "HASS_URL",
+    "HELICONE_API_KEY",
     "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
     "HERMES_POLICY_ADMIN_TOKEN",
+    "KIMI_API_KEY",
+    "LLM_MODEL",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "MISTRAL_API_KEY",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "NVIDIA_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENROUTER_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_IGNORE_STORIES",
+    "SLACK_ALLOWED_USERS",
+    "SLACK_APP_TOKEN",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "TOGETHER_API_KEY",
+    "WHATSAPP_ALLOWED_USERS",
+    "WHATSAPP_ENABLED",
+    "WHATSAPP_MODE",
+    "XAI_API_KEY",
+    "ZAI_API_KEY",
+    "Z_AI_API_KEY",
 ];
 
 const SUBPROCESS_ENV_BLOCKLIST_PREFIXES: &[&str] = &[
@@ -324,6 +391,18 @@ const SUBPROCESS_ENV_BLOCKLIST_PREFIXES: &[&str] = &[
     "HERMES_HTTP_",
 ];
 
+const SUBPROCESS_ENV_FORCE_PREFIX: &str = "_HERMES_FORCE_";
+
+const SANE_PATH_ENTRIES: &[&str] = &[
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+];
+
 fn should_strip_subprocess_env(key: &str) -> bool {
     SUBPROCESS_ENV_BLOCKLIST_EXACT.contains(&key)
         || SUBPROCESS_ENV_BLOCKLIST_PREFIXES
@@ -331,26 +410,98 @@ fn should_strip_subprocess_env(key: &str) -> bool {
             .any(|prefix| key.starts_with(prefix))
 }
 
+fn normalize_subprocess_path(path: Option<&str>) -> String {
+    let Some(path) = path.filter(|value| !value.trim().is_empty()) else {
+        return SANE_PATH_ENTRIES.join(":");
+    };
+    if std::env::split_paths(path).any(|entry| entry == std::path::Path::new("/usr/bin")) {
+        return path.to_string();
+    }
+
+    let mut entries: Vec<String> = std::env::split_paths(path)
+        .map(|entry| entry.to_string_lossy().to_string())
+        .filter(|entry| !entry.is_empty())
+        .collect();
+    for sane in SANE_PATH_ENTRIES {
+        if !entries.iter().any(|entry| entry == sane) {
+            entries.push((*sane).to_string());
+        }
+    }
+    entries.join(":")
+}
+
+fn shell_env_cleanup_snippet() -> String {
+    let mut snippet = String::new();
+    if !SUBPROCESS_ENV_BLOCKLIST_PREFIXES.is_empty() {
+        snippet
+            .push_str("for __hermes_env in $(env | sed 's/=.*//'); do case \"$__hermes_env\" in ");
+        for (idx, prefix) in SUBPROCESS_ENV_BLOCKLIST_PREFIXES.iter().enumerate() {
+            if idx > 0 {
+                snippet.push('|');
+            }
+            snippet.push_str(prefix);
+            snippet.push('*');
+        }
+        snippet.push_str(") unset \"$__hermes_env\" ;; esac; done; unset __hermes_env; ");
+    }
+    for key in SUBPROCESS_ENV_BLOCKLIST_EXACT {
+        snippet.push_str("case \" ${HERMES_SUBPROCESS_FORCE_TARGETS:-} \" in *\" ");
+        snippet.push_str(key);
+        snippet.push_str(" \"*) ;; *) unset ");
+        snippet.push_str(key);
+        snippet.push_str(" ;; esac; ");
+    }
+    snippet.push_str("unset HERMES_SUBPROCESS_FORCE_TARGETS; ");
+    snippet
+}
+
 fn scrub_subprocess_env(cmd: &mut TokioCommand) {
+    let mut forced = Vec::new();
     for (key, _) in std::env::vars() {
         if should_strip_subprocess_env(&key) {
             cmd.env_remove(key);
+        } else if let Some(target) = key.strip_prefix(SUBPROCESS_ENV_FORCE_PREFIX) {
+            cmd.env_remove(&key);
+            if !target.is_empty() && should_strip_subprocess_env(target) {
+                if let Ok(value) = std::env::var(&key) {
+                    forced.push((target.to_string(), value));
+                }
+            }
         }
     }
+    for (target, value) in forced {
+        cmd.env(target, value);
+    }
+    let forced_targets: Vec<String> = std::env::vars()
+        .filter_map(|(key, _)| {
+            key.strip_prefix(SUBPROCESS_ENV_FORCE_PREFIX)
+                .filter(|target| !target.is_empty() && should_strip_subprocess_env(target))
+                .map(ToString::to_string)
+        })
+        .collect();
+    if forced_targets.is_empty() {
+        cmd.env_remove("HERMES_SUBPROCESS_FORCE_TARGETS");
+    } else {
+        cmd.env("HERMES_SUBPROCESS_FORCE_TARGETS", forced_targets.join(" "));
+    }
+
+    let normalized_path = normalize_subprocess_path(std::env::var("PATH").ok().as_deref());
+    cmd.env("PATH", normalized_path);
 }
 
 fn with_login_profile_sources(command: &str) -> String {
     #[cfg(unix)]
     {
+        let cleanup = shell_env_cleanup_snippet();
         fn shell_single_quote(value: &str) -> String {
             format!("'{}'", value.replace('\'', "'\\''"))
         }
 
         let bash_command = shell_single_quote(&format!(
-            "[ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; [ -f \"$HOME/.bash_profile\" ] && . \"$HOME/.bash_profile\"; {command}"
+            "[ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; [ -f \"$HOME/.bash_profile\" ] && . \"$HOME/.bash_profile\"; {cleanup}{command}"
         ));
         let zsh_command = shell_single_quote(&format!(
-            "[ -f \"$HOME/.zshenv\" ] && . \"$HOME/.zshenv\"; [ -f \"$HOME/.zprofile\" ] && . \"$HOME/.zprofile\"; [ -f \"$HOME/.zshrc\" ] && . \"$HOME/.zshrc\"; [ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; {command}"
+            "[ -f \"$HOME/.zshenv\" ] && . \"$HOME/.zshenv\"; [ -f \"$HOME/.zprofile\" ] && . \"$HOME/.zprofile\"; [ -f \"$HOME/.zshrc\" ] && . \"$HOME/.zshrc\"; [ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; {cleanup}{command}"
         ));
         let preferred_shell = std::env::var("SHELL")
             .ok()
@@ -1082,6 +1233,8 @@ mod tests {
     use std::path::Path;
     use tempfile::tempdir;
 
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     struct EnvGuard {
         key: &'static str,
         original: Option<OsString>,
@@ -1305,6 +1458,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_command_strips_gateway_env_vars() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _token_guard = EnvGuard::set("TOOL_GATEWAY_USER_TOKEN", "should-not-leak");
         let _managed_guard = EnvGuard::set("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
         let _http_guard = EnvGuard::set("HERMES_HTTP_API_KEY", "secret-http-key");
@@ -1324,6 +1478,139 @@ mod tests {
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.stdout, "|||ok");
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_strips_provider_tool_and_gateway_env_vars() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _openai_key = EnvGuard::set("OPENAI_API_KEY", "sk-should-not-leak");
+        let _openai_base = EnvGuard::set("OPENAI_BASE_URL", "http://localhost:8000/v1");
+        let _bedrock_bearer = EnvGuard::set("AWS_BEARER_TOKEN_BEDROCK", "bedrock-secret");
+        let _github = EnvGuard::set("GITHUB_TOKEN", "ghp-secret");
+        let _modal = EnvGuard::set("MODAL_TOKEN_SECRET", "modal-secret");
+        let _gateway = EnvGuard::set("GATEWAY_ALLOWED_USERS", "alice,bob");
+        let _safe_guard = EnvGuard::set("SAFE_PASSTHRU_TEST", "ok");
+        let backend = LocalBackend::default();
+
+        let output = backend
+            .execute_command(
+                "printf '%s|%s|%s|%s|%s|%s|%s' \"${OPENAI_API_KEY:-}\" \"${OPENAI_BASE_URL:-}\" \"${AWS_BEARER_TOKEN_BEDROCK:-}\" \"${GITHUB_TOKEN:-}\" \"${MODAL_TOKEN_SECRET:-}\" \"${GATEWAY_ALLOWED_USERS:-}\" \"${SAFE_PASSTHRU_TEST:-}\"",
+                None,
+                None,
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "||||||ok");
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_preserves_general_aws_credentials() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _access_key = EnvGuard::set("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+        let _secret_key = EnvGuard::set("AWS_SECRET_ACCESS_KEY", "aws-secret");
+        let _session = EnvGuard::set("AWS_SESSION_TOKEN", "aws-session");
+        let backend = LocalBackend::default();
+
+        let output = backend
+            .execute_command(
+                "printf '%s|%s|%s' \"${AWS_ACCESS_KEY_ID:-}\" \"${AWS_SECRET_ACCESS_KEY:-}\" \"${AWS_SESSION_TOKEN:-}\"",
+                None,
+                None,
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "AKIAIOSFODNN7EXAMPLE|aws-secret|aws-session");
+        for var in [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_PROFILE",
+            "AWS_DEFAULT_REGION",
+            "AWS_REGION",
+            "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_CONFIG_FILE",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_ROLE_ARN",
+        ] {
+            assert!(
+                !should_strip_subprocess_env(var),
+                "{var} must not be in the Hermes subprocess blocklist"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_force_prefix_reinjects_blocked_var() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _blocked = EnvGuard::set("OPENAI_API_KEY", "sk-should-not-leak");
+        let _forced = EnvGuard::set("_HERMES_FORCE_OPENAI_API_KEY", "sk-explicit");
+        let backend = LocalBackend::default();
+
+        let output = backend
+            .execute_command(
+                "printf '%s|%s' \"${OPENAI_API_KEY:-}\" \"${_HERMES_FORCE_OPENAI_API_KEY:-}\"",
+                None,
+                None,
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "sk-explicit|");
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_cleans_profile_reintroduced_blocked_vars() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let td = tempdir().unwrap();
+        std::fs::write(
+            td.path().join(".profile"),
+            "export OPENAI_API_KEY=from-profile\nexport SAFE_PASSTHRU_TEST=ok\n",
+        )
+        .unwrap();
+        let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
+        let backend = LocalBackend::default();
+
+        let output = backend
+            .execute_command(
+                "printf '%s|%s' \"${OPENAI_API_KEY:-}\" \"${SAFE_PASSTHRU_TEST:-}\"",
+                None,
+                None,
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "|ok");
+    }
+
+    #[test]
+    fn test_subprocess_path_appends_homebrew_when_path_is_minimal() {
+        let normalized = normalize_subprocess_path(Some("/some/custom/bin"));
+        assert!(normalized.contains("/some/custom/bin"));
+        assert!(normalized.contains("/usr/bin"));
+        assert!(normalized.contains("/opt/homebrew/bin"));
+        assert!(normalized.contains("/opt/homebrew/sbin"));
+    }
+
+    #[test]
+    fn test_subprocess_path_preserves_full_path() {
+        assert_eq!(
+            normalize_subprocess_path(Some("/usr/bin:/bin")),
+            "/usr/bin:/bin"
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/Cargo.toml
+++ b/crates/hermes-tools/Cargo.toml
@@ -25,6 +25,7 @@ indexmap = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 serde_yaml = { workspace = true }
+url = { workspace = true }
 rand = "0.8"
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/hermes-tools/src/tools/url_safety.rs
+++ b/crates/hermes-tools/src/tools/url_safety.rs
@@ -1,10 +1,245 @@
+use std::fmt::Display;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
+use std::str::FromStr;
+use std::sync::Mutex;
+
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use serde_json::{json, Value};
+use url::Url;
 
 use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
 
+const METADATA_HOSTNAMES: [&str; 3] = [
+    "metadata.google.internal",
+    "metadata.goog",
+    "metadata.internal",
+];
+const QQ_MULTIMEDIA_HOST: &str = "multimedia.nt.qq.com.cn";
+
+static ALLOW_PRIVATE_URLS_CACHE: Mutex<Option<bool>> = Mutex::new(None);
+
 pub struct UrlSafetyHandler;
+
+fn parse_bool_like(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn config_allow_private_urls() -> bool {
+    false
+}
+
+#[cfg(not(test))]
+fn config_allow_private_urls() -> bool {
+    match hermes_config::load_config(None) {
+        Ok(cfg) => {
+            if cfg.security.allow_private_urls {
+                return true;
+            }
+            cfg.tools_config
+                .per_tool
+                .get("browser")
+                .and_then(|v| v.get("allow_private_urls"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        }
+        Err(_) => false,
+    }
+}
+
+fn global_allow_private_urls() -> bool {
+    let mut guard = ALLOW_PRIVATE_URLS_CACHE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(v) = *guard {
+        return v;
+    }
+
+    let resolved = std::env::var("HERMES_ALLOW_PRIVATE_URLS")
+        .ok()
+        .and_then(|v| parse_bool_like(&v))
+        .unwrap_or_else(config_allow_private_urls);
+    *guard = Some(resolved);
+    resolved
+}
+
+#[cfg(test)]
+fn reset_allow_private_cache_for_tests() {
+    let mut guard = ALLOW_PRIVATE_URLS_CACHE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = None;
+}
+
+fn is_benchmark_ipv4(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 198 && (18..=19).contains(&octets[1])
+}
+
+fn is_blocked_ipv4(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 10
+        || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+        || (octets[0] == 192 && octets[1] == 168)
+        || octets[0] == 127
+        || (octets[0] == 169 && octets[1] == 254)
+        || octets[0] == 0
+        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        || is_benchmark_ipv4(ip)
+        || ip.is_multicast()
+        || ip.is_broadcast()
+}
+
+fn mapped_ipv4(ip: &Ipv6Addr) -> Option<Ipv4Addr> {
+    ip.to_ipv4_mapped()
+}
+
+fn is_blocked_ipv6(ip: &Ipv6Addr) -> bool {
+    if let Some(v4) = mapped_ipv4(ip) {
+        return is_blocked_ipv4(&v4);
+    }
+
+    let segments = ip.segments();
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || (segments[0] & 0xffc0) == 0xfe80
+        || (segments[0] & 0xfe00) == 0xfc00
+}
+
+fn is_blocked_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        IpAddr::V6(v6) => is_blocked_ipv6(v6),
+    }
+}
+
+fn is_always_blocked_ipv4(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    (octets[0] == 169 && octets[1] == 254) || octets == [100, 100, 100, 200]
+}
+
+fn is_always_blocked_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_always_blocked_ipv4(v4),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = mapped_ipv4(v6) {
+                return is_always_blocked_ipv4(&v4);
+            }
+            *v6 == Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254)
+        }
+    }
+}
+
+fn is_metadata_hostname(host: &str) -> bool {
+    METADATA_HOSTNAMES.contains(&host)
+}
+
+fn qq_multimedia_benchmark_exception(host: &str, scheme: &str, ip: &IpAddr) -> bool {
+    if host != QQ_MULTIMEDIA_HOST || scheme != "https" {
+        return false;
+    }
+    match ip {
+        IpAddr::V4(v4) => is_benchmark_ipv4(v4),
+        IpAddr::V6(v6) => mapped_ipv4(v6).as_ref().is_some_and(is_benchmark_ipv4),
+    }
+}
+
+fn resolve_host_ips(host: &str, port: u16) -> Result<Vec<IpAddr>, std::io::Error> {
+    let ips: Vec<IpAddr> = (host, port)
+        .to_socket_addrs()?
+        .map(|addr| addr.ip())
+        .collect();
+    if ips.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "host resolved to no addresses",
+        ));
+    }
+    Ok(ips)
+}
+
+fn ip_allowed(host: &str, scheme: &str, ip: &IpAddr, allow_private_urls: bool) -> bool {
+    if is_always_blocked_ip(ip) {
+        return false;
+    }
+    allow_private_urls || !is_blocked_ip(ip) || qq_multimedia_benchmark_exception(host, scheme, ip)
+}
+
+fn is_safe_url_with_resolver<F, E>(url: &str, mut resolver: F) -> bool
+where
+    F: FnMut(&str, u16) -> Result<Vec<IpAddr>, E>,
+    E: Display,
+{
+    let parsed = match Url::parse(url) {
+        Ok(parsed) => parsed,
+        Err(_) => return false,
+    };
+    let scheme = parsed.scheme();
+    if !matches!(scheme, "http" | "https") {
+        return false;
+    }
+
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let host = host.to_ascii_lowercase();
+    if is_metadata_hostname(&host) {
+        return false;
+    }
+
+    let allow_private_urls = global_allow_private_urls();
+    if let Ok(ip) = IpAddr::from_str(&host) {
+        return ip_allowed(&host, scheme, &ip, allow_private_urls);
+    }
+
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let ips = match resolver(&host, port) {
+        Ok(ips) if !ips.is_empty() => ips,
+        Ok(_) | Err(_) => return false,
+    };
+    ips.iter()
+        .all(|ip| ip_allowed(&host, scheme, ip, allow_private_urls))
+}
+
+pub fn is_safe_url(url: &str) -> bool {
+    is_safe_url_with_resolver(url, resolve_host_ips)
+}
+
+fn is_always_blocked_url_with_resolver<F, E>(url: &str, mut resolver: F) -> bool
+where
+    F: FnMut(&str, u16) -> Result<Vec<IpAddr>, E>,
+    E: Display,
+{
+    let parsed = match Url::parse(url) {
+        Ok(parsed) => parsed,
+        Err(_) => return false,
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let host = host.to_ascii_lowercase();
+    if is_metadata_hostname(&host) {
+        return true;
+    }
+    if let Ok(ip) = IpAddr::from_str(&host) {
+        return is_always_blocked_ip(&ip);
+    }
+
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    resolver(&host, port)
+        .map(|ips| ips.iter().any(is_always_blocked_ip))
+        .unwrap_or(false)
+}
+
+pub fn is_always_blocked_url(url: &str) -> bool {
+    is_always_blocked_url_with_resolver(url, resolve_host_ips)
+}
 
 #[async_trait]
 impl ToolHandler for UrlSafetyHandler {
@@ -13,11 +248,16 @@ impl ToolHandler for UrlSafetyHandler {
         if url.is_empty() {
             return Err(ToolError::InvalidParams("Missing 'url'".into()));
         }
-        let risky = url.starts_with("http://");
-        Ok(
-            json!({"url":url,"safe":!risky,"reason":if risky {"non_https"} else {"ok"}})
-                .to_string(),
-        )
+
+        let safe = is_safe_url(url);
+        let reason = if safe {
+            "ok"
+        } else if is_always_blocked_url(url) {
+            "always_blocked"
+        } else {
+            "blocked_or_invalid"
+        };
+        Ok(json!({"url":url,"safe":safe,"reason":reason}).to_string())
     }
 
     fn schema(&self) -> ToolSchema {
@@ -28,5 +268,269 @@ impl ToolHandler for UrlSafetyHandler {
             "Check whether a URL is safe to access.",
             JsonSchema::object(props, vec!["url".into()]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            reset_allow_private_cache_for_tests();
+            Self { key, old }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::remove_var(key);
+            reset_allow_private_cache_for_tests();
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+            reset_allow_private_cache_for_tests();
+        }
+    }
+
+    fn ips(values: &[&str]) -> Vec<IpAddr> {
+        values
+            .iter()
+            .map(|value| value.parse().expect("valid ip"))
+            .collect()
+    }
+
+    fn with_ips(
+        values: &'static [&'static str],
+    ) -> impl FnMut(&str, u16) -> Result<Vec<IpAddr>, String> {
+        move |_, _| Ok(ips(values))
+    }
+
+    fn with_ip(value: &'static str) -> impl FnMut(&str, u16) -> Result<Vec<IpAddr>, String> {
+        move |_, _| Ok(ips(&[value]))
+    }
+
+    fn resolver_err(_: &str, _: u16) -> Result<Vec<IpAddr>, String> {
+        Err("dns failure".to_string())
+    }
+
+    #[test]
+    fn safe_url_allows_public_http_and_https_only() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::remove("HERMES_ALLOW_PRIVATE_URLS");
+        assert!(is_safe_url_with_resolver(
+            "https://example.com/image.png",
+            with_ips(&["93.184.216.34"])
+        ));
+        assert!(is_safe_url_with_resolver(
+            "http://example.com/image.png",
+            with_ips(&["93.184.216.34"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "ftp://example.com/file.txt",
+            with_ips(&["93.184.216.34"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "example.com/path",
+            with_ips(&["93.184.216.34"])
+        ));
+        assert!(!is_safe_url_with_resolver("http://", with_ips(&[])));
+        assert!(!is_safe_url_with_resolver("", with_ips(&[])));
+    }
+
+    #[test]
+    fn safe_url_blocks_private_reserved_and_metadata_ips() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::remove("HERMES_ALLOW_PRIVATE_URLS");
+        for ip in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "0.0.0.0",
+            "100.64.0.1",
+            "100.127.255.254",
+            "198.18.0.23",
+            "224.0.0.251",
+            "255.255.255.255",
+            "::1",
+            "fe80::1",
+            "fd12::1",
+            "ff02::1",
+            "::ffff:127.0.0.1",
+            "::ffff:169.254.169.254",
+            "::ffff:100.100.100.200",
+        ] {
+            let parsed: IpAddr = ip.parse().expect("valid ip");
+            assert!(is_blocked_ip(&parsed), "{ip} should be blocked");
+            assert!(!is_safe_url_with_resolver(
+                "https://resolved.example/file",
+                with_ip(ip)
+            ));
+        }
+    }
+
+    #[test]
+    fn safe_url_allows_public_and_non_cgnat_100_addresses() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::remove("HERMES_ALLOW_PRIVATE_URLS");
+        for ip in [
+            "8.8.8.8",
+            "93.184.216.34",
+            "1.1.1.1",
+            "100.0.0.1",
+            "2606:4700::1",
+            "2001:4860:4860::8888",
+            "::ffff:8.8.8.8",
+        ] {
+            let parsed: IpAddr = ip.parse().expect("valid ip");
+            assert!(!is_blocked_ip(&parsed), "{ip} should be allowed");
+            assert!(is_safe_url_with_resolver(
+                "https://resolved.example/file",
+                with_ip(ip)
+            ));
+        }
+    }
+
+    #[test]
+    fn qq_multimedia_exact_https_exception_allows_benchmark_ip() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::remove("HERMES_ALLOW_PRIVATE_URLS");
+        assert!(is_safe_url_with_resolver(
+            "https://multimedia.nt.qq.com.cn/download?id=123",
+            with_ips(&["198.18.0.23"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "https://sub.multimedia.nt.qq.com.cn/download?id=123",
+            with_ips(&["198.18.0.23"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "http://multimedia.nt.qq.com.cn/download?id=123",
+            with_ips(&["198.18.0.23"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "https://multimedia.nt.qq.com.cn/download?id=123",
+            resolver_err
+        ));
+    }
+
+    #[test]
+    fn safe_url_blocks_metadata_hostnames_without_dns() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::set("HERMES_ALLOW_PRIVATE_URLS", "true");
+        assert!(!is_safe_url_with_resolver(
+            "http://metadata.google.internal/computeMetadata/v1/",
+            resolver_err
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "http://metadata.goog/computeMetadata/v1/",
+            resolver_err
+        ));
+    }
+
+    #[test]
+    fn allow_private_toggle_permits_private_but_not_metadata() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::set("HERMES_ALLOW_PRIVATE_URLS", "true");
+        assert!(is_safe_url_with_resolver(
+            "http://router.local",
+            with_ips(&["192.168.1.1"])
+        ));
+        assert!(is_safe_url_with_resolver(
+            "http://tailscale-peer.example",
+            with_ips(&["100.100.100.100"])
+        ));
+        assert!(is_safe_url_with_resolver(
+            "http://localhost:8080/api",
+            with_ips(&["127.0.0.1"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "http://169.254.169.254/latest/meta-data/",
+            with_ips(&["169.254.169.254"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "http://[fd00:ec2::254]/latest/",
+            with_ips(&["fd00:ec2::254"])
+        ));
+        assert!(!is_safe_url_with_resolver(
+            "https://nonexistent.example.com",
+            resolver_err
+        ));
+    }
+
+    #[test]
+    fn env_toggle_false_values_keep_private_blocked_and_cache_result() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _env = EnvVarGuard::set("HERMES_ALLOW_PRIVATE_URLS", "false");
+        assert!(!is_safe_url_with_resolver(
+            "http://router.local",
+            with_ips(&["192.168.1.1"])
+        ));
+        std::env::set_var("HERMES_ALLOW_PRIVATE_URLS", "true");
+        assert!(!is_safe_url_with_resolver(
+            "http://router.local",
+            with_ips(&["192.168.1.1"])
+        ));
+    }
+
+    #[test]
+    fn always_blocked_url_floor_is_metadata_only() {
+        assert!(is_always_blocked_url_with_resolver(
+            "http://169.254.169.254/latest/meta-data/",
+            with_ips(&["8.8.8.8"])
+        ));
+        assert!(is_always_blocked_url_with_resolver(
+            "http://metadata.google.internal/",
+            resolver_err
+        ));
+        assert!(is_always_blocked_url_with_resolver(
+            "http://attacker.example/",
+            with_ips(&["169.254.42.1"])
+        ));
+        assert!(!is_always_blocked_url_with_resolver(
+            "http://127.0.0.1:8080/",
+            with_ips(&["127.0.0.1"])
+        ));
+        assert!(!is_always_blocked_url_with_resolver(
+            "http://100.64.0.1/",
+            with_ips(&["100.64.0.1"])
+        ));
+        assert!(!is_always_blocked_url_with_resolver(
+            "http://nonexistent.example.com/",
+            resolver_err
+        ));
+        assert!(!is_always_blocked_url_with_resolver("", resolver_err));
+    }
+
+    #[tokio::test]
+    async fn url_safety_handler_reports_safe_and_blocked_urls() {
+        let handler = UrlSafetyHandler;
+        let blocked = handler
+            .execute(json!({"url":"http://169.254.169.254/latest/meta-data/"}))
+            .await
+            .expect("handler result");
+        let blocked: Value = serde_json::from_str(&blocked).expect("json");
+        assert_eq!(blocked["safe"], false);
+        assert_eq!(blocked["reason"], "always_blocked");
+
+        let missing = handler.execute(json!({})).await;
+        assert!(matches!(missing, Err(ToolError::InvalidParams(_))));
     }
 }

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-30T13:47:25.793998+00:00",
+  "generated_at_utc": "2026-05-30T14:26:49.077079+00:00",
   "items": [
     {
       "errors": [],
@@ -185,7 +185,7 @@
   "summary": {
     "errors": 0,
     "items": 8,
-    "local_paths": 3292,
+    "local_paths": 3293,
     "review_overdue": 0,
     "unowned": 0,
     "upstream_paths": 4203,

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,13 +2,13 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 4469.0,
+        "actual": 4473.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "status": "pass"
       },
       {
-        "actual": 4351.0,
+        "actual": 4353.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "status": "pass"
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T13:47:36.693860+00:00",
+  "generated_at_utc": "2026-05-30T14:26:05.893551+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -60,12 +60,12 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 4469.0,
+    "max_commits_behind": 4473.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 1484.0,
     "max_queue_pending_commits": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 4351.0,
+    "max_upstream_patch_missing": 4353.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T13:47:36.693860+00:00`
+Generated: `2026-05-30T14:26:05.893551+00:00`
 
 ## Gate Status
 
@@ -13,8 +13,8 @@ Generated: `2026-05-30T13:47:36.693860+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 4469.0 |
-| `max_upstream_patch_missing` | 4351.0 |
+| `max_commits_behind` | 4473.0 |
+| `max_upstream_patch_missing` | 4353.0 |
 | `max_files_only_upstream` | 1484.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T13:47:27.064383+00:00",
+  "generated_at_utc": "2026-05-30T14:26:04.682475+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b644f01012a3ebd0b0593691561c6cc70c4c3329",
+    "local_sha": "72597f7c28b599838240eee4a67b7579867c3309",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "44f3e5186502167e68b6073b4f7bdfae7bfb4fbe",
+    "upstream_sha": "10dec7c6dc3e1e051a2a3c8a6e60eac2532449b3",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4469,
-    "commits_ahead": 871,
-    "upstream_patch_missing": 4351,
+    "commits_behind": 4473,
+    "commits_ahead": 873,
+    "upstream_patch_missing": 4353,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 719,
+    "local_patch_unique": 720,
     "files_only_upstream": 1484,
-    "files_only_local": 573,
-    "files_shared_identical": 1691,
-    "files_shared_different": 1028,
-    "tree_files_changed": 3085,
-    "tree_insertions": 746713,
-    "tree_deletions": 398480
+    "files_only_local": 574,
+    "files_shared_identical": 1690,
+    "files_shared_different": 1029,
+    "tree_files_changed": 3087,
+    "tree_insertions": 746950,
+    "tree_deletions": 399132
   },
   "top_upstream_only": [
     {
@@ -189,12 +189,12 @@
       "count": 172
     },
     {
-      "path": "website/docs",
+      "path": "tests/tools",
       "count": 139
     },
     {
-      "path": "tests/tools",
-      "count": 138
+      "path": "website/docs",
+      "count": 139
     },
     {
       "path": "tests/hermes_cli",
@@ -388,7 +388,7 @@
     },
     {
       "path": "crates/hermes-core",
-      "count": 11
+      "count": 12
     },
     {
       "path": "crates/hermes-acp",
@@ -712,7 +712,7 @@
     },
     {
       "path": "crates/hermes-core",
-      "count": 11
+      "count": 12
     },
     {
       "path": "crates/hermes-acp",
@@ -837,7 +837,7 @@
       "issue": 10,
       "name": "Tests and CI parity",
       "upstream_only": 329,
-      "shared_different": 687,
+      "shared_different": 688,
       "local_only": 34,
       "risk": "critical",
       "effort": "XL"
@@ -858,7 +858,7 @@
       "name": "Compatibility and divergence policy",
       "upstream_only": 393,
       "shared_different": 12,
-      "local_only": 198,
+      "local_only": 199,
       "risk": "high",
       "effort": "XL"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4351,
+    "upstream_patch_missing": 4353,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 719,
+    "local_patch_unique": 720,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,29 +1,29 @@
 # Parity Matrix
 
-Generated: `2026-05-30T13:47:27.064383+00:00`
+Generated: `2026-05-30T14:26:04.682475+00:00`
 
 ## Scope
 
-- Local ref: `main` (`b644f01012a3ebd0b0593691561c6cc70c4c3329`)
-- Upstream ref: `upstream/main` (`44f3e5186502167e68b6073b4f7bdfae7bfb4fbe`)
+- Local ref: `main` (`72597f7c28b599838240eee4a67b7579867c3309`)
+- Upstream ref: `upstream/main` (`10dec7c6dc3e1e051a2a3c8a6e60eac2532449b3`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4469 |
-| Commits ahead local (`local` ancestry only) | 871 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4351 |
+| Commits behind local (`upstream` ancestry only) | 4473 |
+| Commits ahead local (`local` ancestry only) | 873 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4353 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 719 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 720 |
 | Files only in upstream tree | 1484 |
-| Files only in local tree | 573 |
-| Shared files identical content | 1691 |
-| Shared files different content | 1028 |
-| Total files changed (`local` vs `upstream`) | 3085 |
-| Insertions (`local` vs `upstream`) | 746713 |
-| Deletions (`local` vs `upstream`) | 398480 |
+| Files only in local tree | 574 |
+| Shared files identical content | 1690 |
+| Shared files different content | 1029 |
+| Total files changed (`local` vs `upstream`) | 3087 |
+| Insertions (`local` vs `upstream`) | 746950 |
+| Deletions (`local` vs `upstream`) | 399132 |
 
 ## Top 40 upstream-only buckets
 
@@ -75,8 +75,8 @@ Generated: `2026-05-30T13:47:27.064383+00:00`
 | Bucket | Files |
 | --- | ---: |
 | `tests/gateway` | 172 |
+| `tests/tools` | 139 |
 | `website/docs` | 139 |
-| `tests/tools` | 138 |
 | `tests/hermes_cli` | 127 |
 | `ui-tui/src` | 60 |
 | `tests/agent` | 58 |
@@ -129,7 +129,7 @@ Generated: `2026-05-30T13:47:27.064383+00:00`
 | `crates/hermes-eval` | 15 |
 | `crates/hermes-parity-tests` | 15 |
 | `crates/hermes-environments` | 13 |
-| `crates/hermes-core` | 11 |
+| `crates/hermes-core` | 12 |
 | `crates/hermes-acp` | 10 |
 | `crates/hermes-skills` | 10 |
 | `crates/hermes-cron` | 9 |
@@ -164,7 +164,7 @@ Generated: `2026-05-30T13:47:27.064383+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 329 | 687 | critical | XL |
+| `WS6` | #10 | Tests and CI parity | 329 | 688 | critical | XL |
 | `WS5` | #9 | UX parity | 493 | 234 | high | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 393 | 12 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 114 | 55 | high | L |
@@ -174,9 +174,9 @@ Generated: `2026-05-30T13:47:27.064383+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4351`
+- Upstream missing by patch-id: `4353`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `719`
+- Local unique by patch-id: `720`
 - Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -657,7 +657,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "9aa780e621305998217163e6b115792d8d9144b8",
+      "upstream_blob": "841890c51e1142cdd3d9b70943093f41f7058414",
       "workstream": "WS3"
     },
     {
@@ -10392,7 +10392,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b5f06248f5a1c090858d573711361e7439f69821",
+      "upstream_blob": "225b005cfe874636f8d45fcff769767f081e21b3",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "bad72f4b6d4bd6d8e3ee452121011fca70c8b544",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_operations_edge_cases.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "0e275d5a4a943f54ec9c74dedd8adc35207a2da4",
       "workstream": "WS6"
     },
     {
@@ -10636,16 +10651,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_local_env_blocklist.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e3e7c310c5e3eb591fb249261415619ad4859f58",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_local_env_blocklist.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0e0520387e1044751b223b07f778d5c47a16d68d",
       "workstream": "WS6"
@@ -11596,16 +11611,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_url_safety.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "38d27d40af3ca7ad8927f71b8c78ee1430090778",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_url_safety.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8513a848be0103c92c237b8aaaed21edb7708253",
       "workstream": "WS6"
@@ -15421,42 +15436,42 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T13:47:36.763313+00:00",
+  "generated_at_utc": "2026-05-30T14:26:05.787861+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b644f01012a3ebd0b0593691561c6cc70c4c3329",
+    "local_sha": "72597f7c28b599838240eee4a67b7579867c3309",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "5f84c9144a2c1f1248e92f53eeb2ea8146ad0883"
+    "upstream_sha": "10dec7c6dc3e1e051a2a3c8a6e60eac2532449b3"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 651,
-      "intentional_divergence": 207,
+      "functional": 650,
+      "intentional_divergence": 209,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 377,
-      "rust_equivalent_or_contract_test_required": 568,
+      "not_required_for_runtime": 379,
+      "rust_equivalent_or_contract_test_required": 567,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 207,
+      "cleared_intentional_divergence": 209,
       "cleared_non_runtime": 170,
-      "pending_review": 651
+      "pending_review": 650
     },
     "by_workstream": {
       "WS3": 55,
       "WS4": 40,
       "WS5": 233,
-      "WS6": 687,
+      "WS6": 688,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 207,
+    "cleared_intentional_divergence": 209,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 651,
-    "total_shared_different": 1028
+    "pending_review": 650,
+    "total_shared_different": 1029
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T13:47:36.763313+00:00`
+Generated: `2026-05-30T14:26:05.787861+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1028`
+- Total shared-different paths: `1029`
 - Pending classification: `0`
-- Pending functional review: `651`
+- Pending functional review: `650`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `207`
+- Cleared intentional divergence: `209`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 207 |
+| `cleared_intentional_divergence` | 209 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 651 |
+| `pending_review` | 650 |
 
 ## Workstream Counts
 
@@ -25,7 +25,7 @@ Generated: `2026-05-30T13:47:36.763313+00:00`
 | `WS3` | 55 |
 | `WS4` | 40 |
 | `WS5` | 233 |
-| `WS6` | 687 |
+| `WS6` | 688 |
 | `WS8` | 13 |
 
 ## Pending Classification
@@ -39,7 +39,7 @@ Generated: `2026-05-30T13:47:36.763313+00:00`
 | --- | ---: |
 | `tests/gateway` | 147 |
 | `tests/hermes_cli` | 127 |
-| `tests/tools` | 99 |
+| `tests/tools` | 98 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1368,6 +1368,20 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_local_env_blocklist.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream LocalEnvironment subprocess env-scrubbing intent is covered by Rust hermes-environments contracts for Hermes-managed provider, tool, gateway, GitHub, Modal, Daytona, and Bedrock bearer-token stripping; explicit _HERMES_FORCE_ reinjection; general AWS credential-chain passthrough; and Homebrew PATH fallback preservation.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_url_safety.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream URL safety/SSRF intent is covered by Rust hermes-tools url_safety contracts for http/https-only parsing, DNS fail-closed behavior, private/reserved IPv4 and IPv6 blocking including CGNAT, benchmark, multicast, and IPv4-mapped IPv6 ranges, metadata hostname/IP always-blocking, allow_private_urls toggle semantics, and the exact QQ multimedia benchmark-IP exception.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/tools/test_skill_env_passthrough.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream skill required-environment metadata normalization is covered by Rust skill_utils required-env parsing while Ultra exposes env_passthrough as an explicit Rust tool instead of Python's implicit global registry.",


### PR DESCRIPTION
## Summary
- port upstream URL safety / SSRF contracts into Rust url_safety tool behavior
- harden local subprocess env scrubbing for provider/tool/gateway secrets, force-prefix opt-in, profile reintroduced vars, and Homebrew PATH fallback
- classify the covered upstream test files and regenerate parity artifacts

## Local verification
- cargo fmt --check
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- rg max_shared_different check (no matches)
- python3 scripts/validate-intentional-divergence.py --check --allow-warnings
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --local-ref HEAD --upstream-ref upstream/main --json
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- cargo test -p hermes-environments
- cargo test -p hermes-tools
- cargo test --workspace
- cargo build --workspace