### PR TITLE
parity(tools): port yolo session approval guards

### DIFF
--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -451,6 +451,7 @@ impl Gateway {
         if let Some(state) = states.get_mut(session_key) {
             state.yolo = false;
         }
+        hermes_tools::approval::clear_session(session_key);
     }
 
     fn reaction_lifecycle_plan(
@@ -1017,6 +1018,11 @@ impl Gateway {
                 let mut states = self.runtime_state.write().await;
                 let state = states.entry(session_key.to_string()).or_default();
                 state.yolo = !state.yolo;
+                if state.yolo {
+                    hermes_tools::approval::enable_session_yolo(session_key);
+                } else {
+                    hermes_tools::approval::disable_session_yolo(session_key);
+                }
                 let reply = format!("🤠 YOLO mode: {}", if state.yolo { "ON" } else { "OFF" });
                 drop(states);
                 self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
@@ -3379,16 +3385,18 @@ mod tests {
         let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
         gw.register_adapter("test", adapter).await;
 
-        let session_key_1 = gw
-            .session_manager
-            .compose_session_key("test", "chat1", "user1");
-        let session_key_2 = gw
-            .session_manager
-            .compose_session_key("test", "chat2", "user1");
+        let session_key_1 =
+            gw.session_manager
+                .compose_session_key("test", "chat-yolo-new-1", "user1");
+        let session_key_2 =
+            gw.session_manager
+                .compose_session_key("test", "chat-yolo-new-2", "user1");
+        hermes_tools::approval::clear_session(&session_key_1);
+        hermes_tools::approval::clear_session(&session_key_2);
 
         let yolo_chat1 = IncomingMessage {
             platform: "test".into(),
-            chat_id: "chat1".into(),
+            chat_id: "chat-yolo-new-1".into(),
             user_id: "user1".into(),
             text: "/yolo".into(),
             message_id: None,
@@ -3398,7 +3406,7 @@ mod tests {
 
         let yolo_chat2 = IncomingMessage {
             platform: "test".into(),
-            chat_id: "chat2".into(),
+            chat_id: "chat-yolo-new-2".into(),
             user_id: "user1".into(),
             text: "/yolo".into(),
             message_id: None,
@@ -3411,10 +3419,16 @@ mod tests {
             assert_eq!(states.get(&session_key_1).map(|s| s.yolo), Some(true));
             assert_eq!(states.get(&session_key_2).map(|s| s.yolo), Some(true));
         }
+        assert!(hermes_tools::approval::is_session_yolo_enabled(
+            &session_key_1
+        ));
+        assert!(hermes_tools::approval::is_session_yolo_enabled(
+            &session_key_2
+        ));
 
         let reset_chat1 = IncomingMessage {
             platform: "test".into(),
-            chat_id: "chat1".into(),
+            chat_id: "chat-yolo-new-1".into(),
             user_id: "user1".into(),
             text: "/new".into(),
             message_id: None,
@@ -3425,6 +3439,13 @@ mod tests {
         let states = gw.runtime_state.read().await;
         assert_eq!(states.get(&session_key_1).map(|s| s.yolo), Some(false));
         assert_eq!(states.get(&session_key_2).map(|s| s.yolo), Some(true));
+        assert!(!hermes_tools::approval::is_session_yolo_enabled(
+            &session_key_1
+        ));
+        assert!(hermes_tools::approval::is_session_yolo_enabled(
+            &session_key_2
+        ));
+        hermes_tools::approval::clear_session(&session_key_2);
     }
 
     #[tokio::test]
@@ -3440,16 +3461,17 @@ mod tests {
         let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
         gw.register_adapter("test", adapter).await;
 
-        let current_key = gw
-            .session_manager
-            .compose_session_key("test", "chat1", "user1");
-        let target_key = gw
-            .session_manager
-            .compose_session_key("test", "chat2", "user1");
+        let current_key =
+            gw.session_manager
+                .compose_session_key("test", "chat-yolo-switch-current", "user1");
+        let target_key =
+            gw.session_manager
+                .compose_session_key("test", "chat-yolo-switch-target", "user1");
+        hermes_tools::approval::clear_session(&current_key);
 
         let _ = gw
             .session_manager
-            .get_or_create_session("test", "chat2", "user1")
+            .get_or_create_session("test", "chat-yolo-switch-target", "user1")
             .await;
         gw.session_manager
             .add_message(&target_key, Message::user("history from another session"))
@@ -3457,7 +3479,7 @@ mod tests {
 
         let yolo_chat1 = IncomingMessage {
             platform: "test".into(),
-            chat_id: "chat1".into(),
+            chat_id: "chat-yolo-switch-current".into(),
             user_id: "user1".into(),
             text: "/yolo".into(),
             message_id: None,
@@ -3468,10 +3490,13 @@ mod tests {
             let states = gw.runtime_state.read().await;
             assert_eq!(states.get(&current_key).map(|s| s.yolo), Some(true));
         }
+        assert!(hermes_tools::approval::is_session_yolo_enabled(
+            &current_key
+        ));
 
         let switch = IncomingMessage {
             platform: "test".into(),
-            chat_id: "chat1".into(),
+            chat_id: "chat-yolo-switch-current".into(),
             user_id: "user1".into(),
             text: format!("/sessions {}", target_key),
             message_id: None,
@@ -3481,6 +3506,9 @@ mod tests {
 
         let states = gw.runtime_state.read().await;
         assert_eq!(states.get(&current_key).map(|s| s.yolo), Some(false));
+        assert!(!hermes_tools::approval::is_session_yolo_enabled(
+            &current_key
+        ));
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/approval.rs
+++ b/crates/hermes-tools/src/approval.rs
@@ -4,7 +4,8 @@
 //! before execution, based on dangerous command patterns.
 
 use regex::Regex;
-use std::sync::LazyLock;
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
 
 // ---------------------------------------------------------------------------
 // ApprovalDecision
@@ -153,6 +154,12 @@ static DELETE_FROM: LazyLock<Regex> =
 
 static CONTAINER_BACKENDS: &[&str] = &["docker", "singularity", "modal", "daytona"];
 
+static SESSION_YOLO: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
 fn collapse_command(command: &str) -> String {
     command
         .replace("\\\n", " ")
@@ -172,6 +179,60 @@ fn yolo_mode_from_env() -> bool {
             matches!(v.as_str(), "1" | "true" | "yes" | "on")
         })
         .unwrap_or(false)
+}
+
+fn current_session_key_from_env() -> Option<String> {
+    std::env::var("HERMES_SESSION_KEY")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn current_session_yolo_from_env() -> bool {
+    current_session_key_from_env()
+        .map(|session_key| is_session_yolo_enabled(&session_key))
+        .unwrap_or(false)
+}
+
+/// Enable yolo approval bypass for a single session key.
+pub fn enable_session_yolo(session_key: &str) {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return;
+    }
+    SESSION_YOLO
+        .lock()
+        .expect("session yolo lock poisoned")
+        .insert(session_key.to_string());
+}
+
+/// Disable yolo approval bypass for a single session key.
+pub fn disable_session_yolo(session_key: &str) {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return;
+    }
+    SESSION_YOLO
+        .lock()
+        .expect("session yolo lock poisoned")
+        .remove(session_key);
+}
+
+/// Remove approval state associated with a session boundary.
+pub fn clear_session(session_key: &str) {
+    disable_session_yolo(session_key);
+}
+
+/// Return whether yolo approval bypass is enabled for this session key.
+pub fn is_session_yolo_enabled(session_key: &str) -> bool {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return false;
+    }
+    SESSION_YOLO
+        .lock()
+        .expect("session yolo lock poisoned")
+        .contains(session_key)
 }
 
 fn environment_bypasses_host_guards(environment: &str) -> bool {
@@ -281,7 +342,7 @@ impl ApprovalManager {
         self.check_approval_with_context(
             command,
             environment,
-            yolo_mode_from_env(),
+            yolo_mode_from_env() || current_session_yolo_from_env(),
             has_sudo_password_env(),
         )
     }
@@ -359,6 +420,35 @@ pub fn check_approval(command: &str) -> ApprovalDecision {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct EnvGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn remove(key: &'static str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, old }
+        }
+
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(old) = &self.old {
+                std::env::set_var(self.key, old);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     #[test]
     fn test_approved_commands() {
@@ -598,6 +688,113 @@ mod tests {
                 "yolo must not bypass hardline for {command:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_yolo_env_truthy_values_bypass_recoverable_confirmations() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let manager = ApprovalManager::new();
+
+        for value in ["1", "true", "yes", "on"] {
+            let _yolo = EnvGuard::set("HERMES_YOLO_MODE", value);
+            assert_eq!(
+                manager.check_approval_from_env("rm -rf /tmp/stuff", "local"),
+                ApprovalDecision::Approved,
+                "truthy HERMES_YOLO_MODE={value:?} should bypass recoverable approval"
+            );
+        }
+    }
+
+    #[test]
+    fn test_yolo_env_false_like_values_do_not_bypass() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let manager = ApprovalManager::new();
+
+        for value in ["", "false", "False", "0", "off", "no"] {
+            let _yolo = EnvGuard::set("HERMES_YOLO_MODE", value);
+            assert_eq!(
+                manager.check_approval_from_env("rm -rf /tmp/stuff", "local"),
+                ApprovalDecision::RequiresConfirmation,
+                "false-like HERMES_YOLO_MODE={value:?} must not bypass approval"
+            );
+        }
+    }
+
+    #[test]
+    fn test_session_scoped_yolo_only_bypasses_current_session() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let manager = ApprovalManager::new();
+
+        clear_session("session-a");
+        clear_session("session-b");
+        enable_session_yolo("session-a");
+
+        assert!(is_session_yolo_enabled("session-a"));
+        assert!(!is_session_yolo_enabled("session-b"));
+
+        {
+            let _session = EnvGuard::set("HERMES_SESSION_KEY", "session-a");
+            assert_eq!(
+                manager.check_approval_from_env("rm -rf /tmp/stuff", "local"),
+                ApprovalDecision::Approved,
+                "session-a yolo should bypass recoverable approval"
+            );
+        }
+
+        {
+            let _session = EnvGuard::set("HERMES_SESSION_KEY", "session-b");
+            assert_eq!(
+                manager.check_approval_from_env("rm -rf /tmp/stuff", "local"),
+                ApprovalDecision::RequiresConfirmation,
+                "session-b must not inherit session-a yolo"
+            );
+        }
+
+        clear_session("session-a");
+        clear_session("session-b");
+    }
+
+    #[test]
+    fn test_session_scoped_yolo_does_not_bypass_hardline_or_sudo_floor() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let _session = EnvGuard::set("HERMES_SESSION_KEY", "session-a");
+        let manager = ApprovalManager::new();
+
+        clear_session("session-a");
+        enable_session_yolo("session-a");
+
+        for command in ["rm -rf /", "mkfs.ext4 /dev/sda", "shutdown now"] {
+            assert_eq!(
+                manager.check_approval_from_env(command, "local"),
+                ApprovalDecision::Denied,
+                "session yolo must not bypass hardline denial for {command:?}"
+            );
+        }
+        assert_eq!(
+            manager.check_approval_from_env("sudo -S whoami", "local"),
+            ApprovalDecision::Denied,
+            "session yolo must not bypass sudo stdin/askpass denial"
+        );
+
+        clear_session("session-a");
+    }
+
+    #[test]
+    fn test_clear_session_removes_session_yolo_state() {
+        enable_session_yolo("session-a");
+        assert!(is_session_yolo_enabled("session-a"));
+
+        clear_session("session-a");
+
+        assert!(!is_session_yolo_enabled("session-a"));
     }
 
     #[test]

--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -479,10 +479,8 @@ impl ToolHandler for ProcessHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::approval::TEST_ENV_LOCK;
     use hermes_core::AgentError;
-    use std::sync::{LazyLock, Mutex};
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     struct EnvGuard {
         key: &'static str,
@@ -622,8 +620,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_terminal_handler_execute() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let result = handler
@@ -635,8 +634,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_terminal_handler_execute_with_stdin_data() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let result = handler
@@ -648,8 +648,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_terminal_handler_denies_confirmation_without_consent() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let err = handler
@@ -665,8 +666,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_terminal_handler_yolo_bypasses_recoverable_confirmation() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::set("HERMES_YOLO_MODE", "1");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let result = handler
@@ -678,8 +680,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_terminal_handler_yolo_does_not_bypass_hardline() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::set("HERMES_YOLO_MODE", "1");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let err = handler
@@ -687,6 +690,25 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("denied by security policy"));
+    }
+
+    #[tokio::test]
+    async fn test_terminal_handler_session_yolo_bypasses_recoverable_confirmation() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::set("HERMES_SESSION_KEY", "terminal-session-yolo");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        crate::approval::clear_session("terminal-session-yolo");
+        crate::approval::enable_session_yolo("terminal-session-yolo");
+
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+        let result = handler
+            .execute(json!({"command": "rm -rf /tmp/hermes-safe-test"}))
+            .await
+            .unwrap();
+        assert!(result.contains("rm -rf /tmp/hermes-safe-test"));
+
+        crate::approval::clear_session("terminal-session-yolo");
     }
 
     #[tokio::test]

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-30T15:08:17.069050+00:00",
+  "generated_at_utc": "2026-05-30T15:38:09.268684+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T15:08:23.562093+00:00",
+  "generated_at_utc": "2026-05-30T15:37:22.861106+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T15:08:23.562093+00:00`
+Generated: `2026-05-30T15:37:22.861106+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T15:08:12.661310+00:00",
+  "generated_at_utc": "2026-05-30T15:37:22.785476+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "e1a19d8a2152c3579d6a4c72c1c07aadec0320e1",
+    "local_sha": "21da3f1e8ffe7bef1a67c1be1e4765ed1e4bfb68",
     "upstream_ref": "upstream/main",
     "upstream_sha": "6a72af044c44c9a05137bc448bc65ecf0ace5a89",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4493,
-    "commits_ahead": 875,
+    "commits_ahead": 877,
     "upstream_patch_missing": 4373,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 721,
+    "local_patch_unique": 722,
     "files_only_upstream": 1493,
     "files_only_local": 574,
     "files_shared_identical": 1688,
     "files_shared_different": 1031,
     "tree_files_changed": 3098,
     "tree_insertions": 750036,
-    "tree_deletions": 399969
+    "tree_deletions": 400696
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4373,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 721,
+    "local_patch_unique": 722,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T15:08:12.661310+00:00`
+Generated: `2026-05-30T15:37:22.785476+00:00`
 
 ## Scope
 
-- Local ref: `main` (`e1a19d8a2152c3579d6a4c72c1c07aadec0320e1`)
+- Local ref: `main` (`21da3f1e8ffe7bef1a67c1be1e4765ed1e4bfb68`)
 - Upstream ref: `upstream/main` (`6a72af044c44c9a05137bc448bc65ecf0ace5a89`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T15:08:12.661310+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4493 |
-| Commits ahead local (`local` ancestry only) | 875 |
+| Commits ahead local (`local` ancestry only) | 877 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4373 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 721 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 722 |
 | Files only in upstream tree | 1493 |
 | Files only in local tree | 574 |
 | Shared files identical content | 1688 |
 | Shared files different content | 1031 |
 | Total files changed (`local` vs `upstream`) | 3098 |
 | Insertions (`local` vs `upstream`) | 750036 |
-| Deletions (`local` vs `upstream`) | 399969 |
+| Deletions (`local` vs `upstream`) | 400696 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T15:08:12.661310+00:00`
 
 - Upstream missing by patch-id: `4373`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `721`
+- Local unique by patch-id: `722`
 - Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -11881,16 +11881,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_yolo_mode.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "29a68f07ae07b191b4245649e0aab6e455d2d7bd",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_yolo_mode.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "ebd3c8ddceda7dfb8884d9295f35a1570d63635e",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T15:08:20.181640+00:00",
+  "generated_at_utc": "2026-05-30T15:37:19.851035+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "e1a19d8a2152c3579d6a4c72c1c07aadec0320e1",
+    "local_sha": "21da3f1e8ffe7bef1a67c1be1e4765ed1e4bfb68",
     "upstream_ref": "upstream/main",
     "upstream_sha": "6a72af044c44c9a05137bc448bc65ecf0ace5a89"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 650,
-      "intentional_divergence": 211,
+      "functional": 649,
+      "intentional_divergence": 212,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 381,
-      "rust_equivalent_or_contract_test_required": 566,
+      "not_required_for_runtime": 382,
+      "rust_equivalent_or_contract_test_required": 565,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 211,
+      "cleared_intentional_divergence": 212,
       "cleared_non_runtime": 170,
-      "pending_review": 650
+      "pending_review": 649
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 211,
+    "cleared_intentional_divergence": 212,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 650,
+    "pending_review": 649,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T15:08:20.181640+00:00`
+Generated: `2026-05-30T15:37:19.851035+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `650`
+- Pending functional review: `649`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `211`
+- Cleared intentional divergence: `212`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 211 |
+| `cleared_intentional_divergence` | 212 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 650 |
+| `pending_review` | 649 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-05-30T15:08:20.181640+00:00`
 | --- | ---: |
 | `tests/gateway` | 147 |
 | `tests/hermes_cli` | 127 |
-| `tests/tools` | 97 |
+| `tests/tools` | 96 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1396,6 +1396,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_yolo_mode.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream yolo approval-bypass intent is covered by Rust hermes-tools and hermes-gateway contracts for truthy and false-like HERMES_YOLO_MODE handling, recoverable-command bypass, hardline and sudo-stdin floors, session-scoped /yolo state, terminal handler session bypass, and session cleanup. Python's combined Tirith hook path is not a separate Rust runtime boundary.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/tools/test_skill_env_passthrough.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream skill required-environment metadata normalization is covered by Rust skill_utils required-env parsing while Ultra exposes env_passthrough as an explicit Rust tool instead of Python's implicit global registry.",


### PR DESCRIPTION
## Summary
- add Rust-native session-scoped yolo approval state in `hermes-tools::approval`
- wire gateway `/yolo`, `/new`, and session switch cleanup into the shared approval state
- cover upstream `tests/tools/test_yolo_mode.py` intent with Rust approval, terminal, and gateway contracts
- refresh parity docs/backlog; pending review moves 650 -> 649

## Local Verification
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-runtime-placeholders.sh`
- `bash scripts/check-rust-runtime-no-python.sh`
- `rg -n "max_shared_different|max-shared-different|max shared different" . --glob '!target/**' --glob '!**/.git/**'` (no matches)
- `cargo test -p hermes-tools approval -- --nocapture`
- `cargo test -p hermes-tools terminal_handler -- --nocapture`
- `cargo test -p hermes-gateway yolo -- --nocapture`
- `python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --local-ref HEAD --upstream-ref upstream/main --json`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json`
- `python3 scripts/validate-intentional-divergence.py --check --allow-warnings`
- `cargo test -p hermes-parity-tests --test global_parity_governance`
- `cargo test --workspace`
- `cargo build --workspace`
