### PR TITLE
parity(gateway): port blocking command approvals

### DIFF
--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -60,6 +60,11 @@ pub enum GatewayCommandResult {
     ApproveUser { user_id: String },
     /// Deny and revoke a user from DM access.
     DenyUser { user_id: String },
+    /// Resolve a blocked command approval for this gateway session.
+    ResolveCommandApproval {
+        choice: hermes_tools::approval::ApprovalChoice,
+        resolve_all: bool,
+    },
     /// Reload MCP server registry/state.
     ReloadMcp,
     /// Switch active provider.
@@ -317,8 +322,32 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         "/retry" => GatewayCommandResult::Retry,
         "/undo" => GatewayCommandResult::Undo,
         "/approve" => {
-            if args.is_empty() {
-                GatewayCommandResult::Reply("Usage: /approve <user_id>".to_string())
+            let words = args.split_whitespace().collect::<Vec<_>>();
+            if words.is_empty() {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Once,
+                    resolve_all: false,
+                }
+            } else if words.as_slice() == ["all"] {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Once,
+                    resolve_all: true,
+                }
+            } else if words.as_slice() == ["all", "session"] {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Session,
+                    resolve_all: true,
+                }
+            } else if words.as_slice() == ["session"] {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Session,
+                    resolve_all: false,
+                }
+            } else if words.as_slice() == ["always"] {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Always,
+                    resolve_all: false,
+                }
             } else {
                 GatewayCommandResult::ApproveUser {
                     user_id: args.clone(),
@@ -326,8 +355,17 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
             }
         }
         "/deny" => {
-            if args.is_empty() {
-                GatewayCommandResult::Reply("Usage: /deny <user_id>".to_string())
+            let words = args.split_whitespace().collect::<Vec<_>>();
+            if words.is_empty() {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Deny,
+                    resolve_all: false,
+                }
+            } else if words.as_slice() == ["all"] {
+                GatewayCommandResult::ResolveCommandApproval {
+                    choice: hermes_tools::approval::ApprovalChoice::Deny,
+                    resolve_all: true,
+                }
             } else {
                 GatewayCommandResult::DenyUser {
                     user_id: args.clone(),
@@ -606,6 +644,40 @@ mod tests {
         match handle_command("/deny bob") {
             GatewayCommandResult::DenyUser { user_id } => assert_eq!(user_id, "bob"),
             other => panic!("Expected DenyUser, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_command_approval_resolution_commands() {
+        match handle_command("/approve") {
+            GatewayCommandResult::ResolveCommandApproval {
+                choice,
+                resolve_all,
+            } => {
+                assert_eq!(choice, hermes_tools::approval::ApprovalChoice::Once);
+                assert!(!resolve_all);
+            }
+            other => panic!("Expected ResolveCommandApproval, got {:?}", other),
+        }
+        match handle_command("/approve all session") {
+            GatewayCommandResult::ResolveCommandApproval {
+                choice,
+                resolve_all,
+            } => {
+                assert_eq!(choice, hermes_tools::approval::ApprovalChoice::Session);
+                assert!(resolve_all);
+            }
+            other => panic!("Expected ResolveCommandApproval, got {:?}", other),
+        }
+        match handle_command("/deny all") {
+            GatewayCommandResult::ResolveCommandApproval {
+                choice,
+                resolve_all,
+            } => {
+                assert_eq!(choice, hermes_tools::approval::ApprovalChoice::Deny);
+                assert!(resolve_all);
+            }
+            other => panic!("Expected ResolveCommandApproval, got {:?}", other),
         }
     }
 

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -1029,6 +1029,39 @@ impl Gateway {
                     .await?;
                 Ok(true)
             }
+            GatewayCommandResult::ResolveCommandApproval {
+                choice,
+                resolve_all,
+            } => {
+                let count = hermes_tools::approval::resolve_gateway_approval(
+                    session_key,
+                    choice,
+                    resolve_all,
+                );
+                let reply = if count == 0 {
+                    "No pending command approval for this session.".to_string()
+                } else if choice == hermes_tools::approval::ApprovalChoice::Deny {
+                    if count == 1 {
+                        "Denied pending command. The blocked agent will resume with a denial."
+                            .to_string()
+                    } else {
+                        format!("Denied {count} pending commands.")
+                    }
+                } else if count == 1 {
+                    format!(
+                        "Approved pending command with `{}` scope. Resuming.",
+                        choice.as_str()
+                    )
+                } else {
+                    format!(
+                        "Approved {count} pending commands with `{}` scope.",
+                        choice.as_str()
+                    )
+                };
+                self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
+                    .await?;
+                Ok(true)
+            }
             GatewayCommandResult::SetHome { path, reply } => {
                 let target = std::path::Path::new(&path);
                 let response = if target.exists() && target.is_dir() {
@@ -2276,6 +2309,8 @@ mod tests {
         seen: Arc<Mutex<Vec<(String, serde_json::Value)>>>,
     }
 
+    struct FailingHook;
+
     #[async_trait]
     impl HookHandler for RecordingHook {
         async fn handle(&self, event: &HookEvent) -> Result<(), String> {
@@ -2288,6 +2323,17 @@ mod tests {
 
         fn name(&self) -> &str {
             "recording-hook"
+        }
+    }
+
+    #[async_trait]
+    impl HookHandler for FailingHook {
+        async fn handle(&self, _event: &HookEvent) -> Result<(), String> {
+            Err("boom".to_string())
+        }
+
+        fn name(&self) -> &str {
+            "failing-hook"
         }
     }
 
@@ -3393,6 +3439,8 @@ mod tests {
                 .compose_session_key("test", "chat-yolo-new-2", "user1");
         hermes_tools::approval::clear_session(&session_key_1);
         hermes_tools::approval::clear_session(&session_key_2);
+        hermes_tools::approval::approve_session(&session_key_1, "recursive delete");
+        hermes_tools::approval::approve_session(&session_key_2, "recursive delete");
 
         let yolo_chat1 = IncomingMessage {
             platform: "test".into(),
@@ -3425,6 +3473,14 @@ mod tests {
         assert!(hermes_tools::approval::is_session_yolo_enabled(
             &session_key_2
         ));
+        assert!(hermes_tools::approval::is_approved(
+            &session_key_1,
+            "recursive delete"
+        ));
+        assert!(hermes_tools::approval::is_approved(
+            &session_key_2,
+            "recursive delete"
+        ));
 
         let reset_chat1 = IncomingMessage {
             platform: "test".into(),
@@ -3444,6 +3500,14 @@ mod tests {
         ));
         assert!(hermes_tools::approval::is_session_yolo_enabled(
             &session_key_2
+        ));
+        assert!(!hermes_tools::approval::is_approved(
+            &session_key_1,
+            "recursive delete"
+        ));
+        assert!(hermes_tools::approval::is_approved(
+            &session_key_2,
+            "recursive delete"
         ));
         hermes_tools::approval::clear_session(&session_key_2);
     }
@@ -3468,6 +3532,7 @@ mod tests {
             gw.session_manager
                 .compose_session_key("test", "chat-yolo-switch-target", "user1");
         hermes_tools::approval::clear_session(&current_key);
+        hermes_tools::approval::approve_session(&current_key, "recursive delete");
 
         let _ = gw
             .session_manager
@@ -3493,6 +3558,10 @@ mod tests {
         assert!(hermes_tools::approval::is_session_yolo_enabled(
             &current_key
         ));
+        assert!(hermes_tools::approval::is_approved(
+            &current_key,
+            "recursive delete"
+        ));
 
         let switch = IncomingMessage {
             platform: "test".into(),
@@ -3509,6 +3578,229 @@ mod tests {
         assert!(!hermes_tools::approval::is_session_yolo_enabled(
             &current_key
         ));
+        assert!(!hermes_tools::approval::is_approved(
+            &current_key,
+            "recursive delete"
+        ));
+    }
+
+    #[tokio::test]
+    async fn gateway_approve_resolves_oldest_blocking_command() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+
+        let session_key =
+            gw.session_manager
+                .compose_session_key("test", "chat-approve-command", "user1");
+        hermes_tools::approval::clear_session(&session_key);
+        let (tx, rx) = std::sync::mpsc::channel();
+        hermes_tools::approval::register_gateway_notify(&session_key, move |request| {
+            tx.send(request).expect("approval request should send");
+        });
+
+        let session_for_thread = session_key.clone();
+        let handle = std::thread::spawn(move || {
+            hermes_tools::approval::check_all_command_guards_with_context(
+                "rm -rf /tmp/gateway-approve-command",
+                "local",
+                hermes_tools::approval::CommandGuardContext {
+                    gateway: true,
+                    ask: true,
+                    session_key: Some(session_for_thread),
+                    gateway_approval_timeout: std::time::Duration::from_secs(5),
+                    tirith_result: Ok(Some(hermes_tools::approval::TirithResult::allow())),
+                    ..hermes_tools::approval::CommandGuardContext::default()
+                },
+                None,
+            )
+            .expect("approval guard should return")
+        });
+
+        let request = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("gateway approval notify should fire");
+        assert_eq!(request.command, "rm -rf /tmp/gateway-approve-command");
+        assert!(hermes_tools::approval::has_blocking_approval(&session_key));
+
+        let approve = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-approve-command".into(),
+            user_id: "user1".into(),
+            text: "/approve".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&approve).await.is_ok());
+
+        let result = handle.join().expect("approval guard thread should join");
+        assert!(result.approved);
+        assert!(result.user_approved);
+        assert!(!hermes_tools::approval::has_blocking_approval(&session_key));
+
+        let replies = sent.lock().unwrap();
+        assert!(replies.iter().any(|(_, text)| {
+            text.to_ascii_lowercase().contains("approved") && text.contains("Resuming")
+        }));
+        hermes_tools::approval::unregister_gateway_notify(&session_key);
+        hermes_tools::approval::clear_session(&session_key);
+    }
+
+    #[tokio::test]
+    async fn gateway_deny_all_resolves_all_blocking_commands() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+
+        let session_key =
+            gw.session_manager
+                .compose_session_key("test", "chat-deny-all-command", "user1");
+        hermes_tools::approval::clear_session(&session_key);
+        let (tx, rx) = std::sync::mpsc::channel();
+        hermes_tools::approval::register_gateway_notify(&session_key, move |request| {
+            tx.send(request).expect("approval request should send");
+        });
+
+        let mut handles = Vec::new();
+        for suffix in ["a", "b"] {
+            let session_for_thread = session_key.clone();
+            handles.push(std::thread::spawn(move || {
+                hermes_tools::approval::check_all_command_guards_with_context(
+                    &format!("rm -rf /tmp/gateway-deny-{suffix}"),
+                    "local",
+                    hermes_tools::approval::CommandGuardContext {
+                        gateway: true,
+                        ask: true,
+                        session_key: Some(session_for_thread),
+                        gateway_approval_timeout: std::time::Duration::from_secs(5),
+                        tirith_result: Ok(Some(hermes_tools::approval::TirithResult::allow())),
+                        ..hermes_tools::approval::CommandGuardContext::default()
+                    },
+                    None,
+                )
+                .expect("approval guard should return")
+            }));
+        }
+
+        for _ in 0..2 {
+            rx.recv_timeout(std::time::Duration::from_secs(2))
+                .expect("gateway approval notify should fire");
+        }
+        assert_eq!(
+            hermes_tools::approval::pending_gateway_approval_count(&session_key),
+            2
+        );
+
+        let deny = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-deny-all-command".into(),
+            user_id: "user1".into(),
+            text: "/deny all".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&deny).await.is_ok());
+
+        let results = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("approval guard thread should join"))
+            .collect::<Vec<_>>();
+        assert!(results.iter().all(|result| !result.approved));
+        assert!(results.iter().all(|result| {
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("User denied")
+        }));
+        assert!(!hermes_tools::approval::has_blocking_approval(&session_key));
+
+        let replies = sent.lock().unwrap();
+        assert!(replies
+            .iter()
+            .any(|(_, text)| text.contains("Denied 2 pending commands")));
+        hermes_tools::approval::unregister_gateway_notify(&session_key);
+        hermes_tools::approval::clear_session(&session_key);
+    }
+
+    #[tokio::test]
+    async fn gateway_new_denies_blocked_approval_for_target_session() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+
+        let session_key =
+            gw.session_manager
+                .compose_session_key("test", "chat-boundary-approval", "user1");
+        hermes_tools::approval::clear_session(&session_key);
+        let (tx, rx) = std::sync::mpsc::channel();
+        hermes_tools::approval::register_gateway_notify(&session_key, move |request| {
+            tx.send(request).expect("approval request should send");
+        });
+
+        let session_for_thread = session_key.clone();
+        let handle = std::thread::spawn(move || {
+            hermes_tools::approval::check_all_command_guards_with_context(
+                "rm -rf /tmp/gateway-boundary-approval",
+                "local",
+                hermes_tools::approval::CommandGuardContext {
+                    gateway: true,
+                    ask: true,
+                    session_key: Some(session_for_thread),
+                    gateway_approval_timeout: std::time::Duration::from_secs(5),
+                    tirith_result: Ok(Some(hermes_tools::approval::TirithResult::allow())),
+                    ..hermes_tools::approval::CommandGuardContext::default()
+                },
+                None,
+            )
+            .expect("approval guard should return")
+        });
+
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("gateway approval notify should fire");
+        assert!(hermes_tools::approval::has_blocking_approval(&session_key));
+
+        let reset = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-boundary-approval".into(),
+            user_id: "user1".into(),
+            text: "/new".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&reset).await.is_ok());
+
+        let result = handle.join().expect("approval guard thread should join");
+        assert!(!result.approved);
+        assert!(result
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("User denied"));
+        assert!(!hermes_tools::approval::has_blocking_approval(&session_key));
+        hermes_tools::approval::unregister_gateway_notify(&session_key);
+        hermes_tools::approval::clear_session(&session_key);
     }
 
     #[tokio::test]
@@ -4151,6 +4443,9 @@ mod tests {
             Box::pin(async move { Ok("assistant".to_string()) })
         }))
         .await;
+        let session_key = gw
+            .session_manager
+            .compose_session_key("test", "chat1", "user1");
 
         let normal = IncomingMessage {
             platform: "test".into(),
@@ -4174,7 +4469,57 @@ mod tests {
 
         let events = hook_seen.lock().unwrap();
         let names: Vec<String> = events.iter().map(|(name, _)| name.clone()).collect();
-        assert!(names.contains(&"session:end".to_string()));
-        assert!(names.contains(&"session:reset".to_string()));
+        assert_eq!(
+            names,
+            vec![
+                "session:start".to_string(),
+                "session:end".to_string(),
+                "session:reset".to_string()
+            ]
+        );
+        let end_payload = events
+            .iter()
+            .find(|(name, _)| name == "session:end")
+            .map(|(_, ctx)| ctx.clone())
+            .expect("session:end payload should exist");
+        let reset_payload = events
+            .iter()
+            .find(|(name, _)| name == "session:reset")
+            .map(|(_, ctx)| ctx.clone())
+            .expect("session:reset payload should exist");
+        assert_eq!(end_payload["session_id"], serde_json::json!(session_key));
+        assert_eq!(reset_payload["session_id"], serde_json::json!(session_key));
+    }
+
+    #[tokio::test]
+    async fn gateway_hook_error_does_not_break_reset_command() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let mut hooks = HookRegistry::new();
+        hooks.register_in_process("session:*", Arc::new(FailingHook));
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.set_hook_registry(Arc::new(hooks)).await;
+        gw.register_adapter("test", adapter).await;
+
+        let reset = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-hook-error".into(),
+            user_id: "user1".into(),
+            text: "/new".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&reset).await.is_ok());
+
+        let replies = sent.lock().unwrap();
+        assert!(replies.iter().any(|(_, text)| {
+            text.contains("New conversation") || text.contains("Session reset")
+        }));
     }
 }

--- a/crates/hermes-tools/src/approval.rs
+++ b/crates/hermes-tools/src/approval.rs
@@ -4,8 +4,9 @@
 //! before execution, based on dangerous command patterns.
 
 use regex::Regex;
-use std::collections::{HashMap, HashSet};
-use std::sync::{LazyLock, Mutex};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Condvar, LazyLock, Mutex};
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // ApprovalDecision
@@ -31,6 +32,17 @@ pub enum ApprovalChoice {
     Always,
 }
 
+impl ApprovalChoice {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Deny => "deny",
+            Self::Once => "once",
+            Self::Session => "session",
+            Self::Always => "always",
+        }
+    }
+}
+
 /// Human-facing prompt data for a combined command guard warning.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApprovalPrompt {
@@ -50,6 +62,8 @@ pub struct CommandGuardResult {
     pub description: Option<String>,
     pub user_approved: bool,
     pub outcome: Option<String>,
+    pub status: Option<String>,
+    pub approval_pending: bool,
 }
 
 impl CommandGuardResult {
@@ -61,6 +75,8 @@ impl CommandGuardResult {
             description: None,
             user_approved: false,
             outcome: None,
+            status: None,
+            approval_pending: false,
         }
     }
 
@@ -72,6 +88,25 @@ impl CommandGuardResult {
             description,
             user_approved: false,
             outcome: Some("denied".to_string()),
+            status: None,
+            approval_pending: false,
+        }
+    }
+
+    fn pending_approval(
+        message: String,
+        pattern_key: Option<String>,
+        description: Option<String>,
+    ) -> Self {
+        Self {
+            approved: false,
+            message: Some(message),
+            pattern_key,
+            description,
+            user_approved: false,
+            outcome: Some("pending_approval".to_string()),
+            status: Some("pending_approval".to_string()),
+            approval_pending: true,
         }
     }
 }
@@ -168,6 +203,7 @@ pub struct CommandGuardContext {
     pub cron_approval_deny: bool,
     pub session_key: Option<String>,
     pub tirith_result: Result<Option<TirithResult>, CommandGuardError>,
+    pub gateway_approval_timeout: Duration,
 }
 
 impl CommandGuardContext {
@@ -183,6 +219,7 @@ impl CommandGuardContext {
             cron_approval_deny: false,
             session_key: current_session_key_from_env().or_else(|| Some("default".to_string())),
             tirith_result: Ok(None),
+            gateway_approval_timeout: Duration::from_secs(300),
         }
     }
 
@@ -221,7 +258,65 @@ impl Default for CommandGuardContext {
             cron_approval_deny: false,
             session_key: Some("default".to_string()),
             tirith_result: Ok(None),
+            gateway_approval_timeout: Duration::from_secs(300),
         }
+    }
+}
+
+/// Approval payload queued for gateway-visible command confirmation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayApprovalRequest {
+    pub session_key: String,
+    pub command: String,
+    pub description: String,
+    pub pattern_key: String,
+    pub pattern_keys: Vec<String>,
+    pub allow_permanent: bool,
+}
+
+#[derive(Debug)]
+pub struct GatewayApprovalEntry {
+    request: GatewayApprovalRequest,
+    result: Mutex<Option<ApprovalChoice>>,
+    resolved: Condvar,
+}
+
+impl GatewayApprovalEntry {
+    pub fn new(request: GatewayApprovalRequest) -> Self {
+        Self {
+            request,
+            result: Mutex::new(None),
+            resolved: Condvar::new(),
+        }
+    }
+
+    pub fn request(&self) -> &GatewayApprovalRequest {
+        &self.request
+    }
+
+    pub fn result(&self) -> Option<ApprovalChoice> {
+        *self.result.lock().expect("gateway approval lock poisoned")
+    }
+
+    pub fn is_resolved(&self) -> bool {
+        self.result().is_some()
+    }
+
+    fn resolve(&self, choice: ApprovalChoice) {
+        let mut result = self.result.lock().expect("gateway approval lock poisoned");
+        if result.is_none() {
+            *result = Some(choice);
+            self.resolved.notify_all();
+        }
+    }
+
+    pub fn wait(&self, timeout: Duration) -> Option<ApprovalChoice> {
+        let result = self.result.lock().expect("gateway approval lock poisoned");
+        let (result, _) = self
+            .resolved
+            .wait_timeout_while(result, timeout, |choice| choice.is_none())
+            .expect("gateway approval condvar poisoned");
+        *result
     }
 }
 
@@ -509,6 +604,11 @@ static SESSION_APPROVED: LazyLock<Mutex<HashMap<String, HashSet<String>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static PERMANENT_APPROVED: LazyLock<Mutex<HashSet<String>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
+type GatewayNotifyCallback = Arc<dyn Fn(GatewayApprovalRequest) + Send + Sync + 'static>;
+static GATEWAY_QUEUES: LazyLock<Mutex<HashMap<String, VecDeque<Arc<GatewayApprovalEntry>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static GATEWAY_NOTIFY_CBS: LazyLock<Mutex<HashMap<String, GatewayNotifyCallback>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(test)]
 pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -608,6 +708,149 @@ pub fn is_approved(session_key: &str, pattern_key: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Register a gateway callback that receives newly blocked command approvals.
+pub fn register_gateway_notify<F>(session_key: &str, callback: F)
+where
+    F: Fn(GatewayApprovalRequest) + Send + Sync + 'static,
+{
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return;
+    }
+    GATEWAY_NOTIFY_CBS
+        .lock()
+        .expect("gateway notify lock poisoned")
+        .insert(session_key.to_string(), Arc::new(callback));
+}
+
+/// Remove a gateway callback and deny any blocked approval waiters for that session.
+pub fn unregister_gateway_notify(session_key: &str) {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return;
+    }
+    GATEWAY_NOTIFY_CBS
+        .lock()
+        .expect("gateway notify lock poisoned")
+        .remove(session_key);
+    cancel_gateway_approvals(session_key, ApprovalChoice::Deny);
+}
+
+/// Return whether a session currently has blocked gateway approvals.
+pub fn has_blocking_approval(session_key: &str) -> bool {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return false;
+    }
+    GATEWAY_QUEUES
+        .lock()
+        .expect("gateway queue lock poisoned")
+        .get(session_key)
+        .map(|entries| !entries.is_empty())
+        .unwrap_or(false)
+}
+
+/// Number of pending gateway approval entries for a session.
+pub fn pending_gateway_approval_count(session_key: &str) -> usize {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return 0;
+    }
+    GATEWAY_QUEUES
+        .lock()
+        .expect("gateway queue lock poisoned")
+        .get(session_key)
+        .map(VecDeque::len)
+        .unwrap_or(0)
+}
+
+/// Resolve pending gateway approvals. Without `resolve_all`, this resolves the oldest entry.
+pub fn resolve_gateway_approval(
+    session_key: &str,
+    choice: ApprovalChoice,
+    resolve_all: bool,
+) -> usize {
+    let session_key = session_key.trim();
+    if session_key.is_empty() {
+        return 0;
+    }
+
+    let resolved = {
+        let mut queues = GATEWAY_QUEUES.lock().expect("gateway queue lock poisoned");
+        let Some(queue) = queues.get_mut(session_key) else {
+            return 0;
+        };
+        let entries = if resolve_all {
+            queue.drain(..).collect::<Vec<_>>()
+        } else {
+            queue.pop_front().into_iter().collect::<Vec<_>>()
+        };
+        let remove_queue = queue.is_empty();
+        if remove_queue {
+            queues.remove(session_key);
+        }
+        entries
+    };
+
+    for entry in &resolved {
+        entry.resolve(choice);
+    }
+    resolved.len()
+}
+
+fn cancel_gateway_approvals(session_key: &str, choice: ApprovalChoice) -> usize {
+    resolve_gateway_approval(session_key, choice, true)
+}
+
+fn gateway_notify_callback(session_key: &str) -> Option<GatewayNotifyCallback> {
+    GATEWAY_NOTIFY_CBS
+        .lock()
+        .expect("gateway notify lock poisoned")
+        .get(session_key)
+        .cloned()
+}
+
+enum GatewayApprovalWaitOutcome {
+    NoListener,
+    Resolved(ApprovalChoice),
+    TimedOut,
+}
+
+fn submit_gateway_approval_and_wait(
+    request: GatewayApprovalRequest,
+    timeout: Duration,
+) -> GatewayApprovalWaitOutcome {
+    let Some(callback) = gateway_notify_callback(&request.session_key) else {
+        return GatewayApprovalWaitOutcome::NoListener;
+    };
+
+    let session_key = request.session_key.clone();
+    let entry = Arc::new(GatewayApprovalEntry::new(request.clone()));
+    {
+        let mut queues = GATEWAY_QUEUES.lock().expect("gateway queue lock poisoned");
+        queues
+            .entry(session_key.clone())
+            .or_default()
+            .push_back(entry.clone());
+    }
+
+    callback(request);
+
+    if let Some(choice) = entry.wait(timeout) {
+        GatewayApprovalWaitOutcome::Resolved(choice)
+    } else {
+        let mut queues = GATEWAY_QUEUES.lock().expect("gateway queue lock poisoned");
+        if let Some(queue) = queues.get_mut(&session_key) {
+            queue.retain(|candidate| !Arc::ptr_eq(candidate, &entry));
+            let remove_queue = queue.is_empty();
+            if remove_queue {
+                queues.remove(&session_key);
+            }
+        }
+        GatewayApprovalWaitOutcome::TimedOut
+    }
+}
+
 /// Enable yolo approval bypass for a single session key.
 pub fn enable_session_yolo(session_key: &str) {
     let session_key = session_key.trim();
@@ -643,6 +886,7 @@ pub fn clear_session(session_key: &str) {
         .lock()
         .expect("session approval lock poisoned")
         .remove(session_key);
+    cancel_gateway_approvals(session_key, ApprovalChoice::Deny);
 }
 
 /// Return whether yolo approval bypass is enabled for this session key.
@@ -895,14 +1139,47 @@ pub fn check_all_command_guards_with_context(
         .collect::<Vec<_>>();
     let allow_permanent = !warnings.iter().any(|warning| warning.is_tirith);
 
+    let prompt = ApprovalPrompt {
+        command: command.to_string(),
+        description: combined_desc.clone(),
+        pattern_key: primary_key.clone(),
+        pattern_keys,
+        allow_permanent,
+    };
+
     let choice = if let Some(callback) = approval_callback.as_mut() {
-        callback(ApprovalPrompt {
+        callback(prompt)
+    } else if context.gateway || context.ask {
+        let request = GatewayApprovalRequest {
+            session_key: session_key.clone(),
             command: command.to_string(),
             description: combined_desc.clone(),
             pattern_key: primary_key.clone(),
-            pattern_keys,
+            pattern_keys: warnings
+                .iter()
+                .map(|warning| warning.pattern_key.clone())
+                .collect(),
             allow_permanent,
-        })
+        };
+        match submit_gateway_approval_and_wait(request, context.gateway_approval_timeout) {
+            GatewayApprovalWaitOutcome::Resolved(choice) => choice,
+            GatewayApprovalWaitOutcome::TimedOut => {
+                return Ok(CommandGuardResult::blocked(
+                    "BLOCKED: Command approval timed out waiting for a gateway response."
+                        .to_string(),
+                    Some(primary_key),
+                    Some(combined_desc),
+                ));
+            }
+            GatewayApprovalWaitOutcome::NoListener => {
+                return Ok(CommandGuardResult::pending_approval(
+                    "Command requires approval, but no gateway approval listener is registered."
+                        .to_string(),
+                    Some(primary_key),
+                    Some(combined_desc),
+                ));
+            }
+        }
     } else {
         ApprovalChoice::Deny
     };
@@ -919,6 +1196,8 @@ pub fn check_all_command_guards_with_context(
         description: Some(combined_desc),
         user_approved: true,
         outcome: None,
+        status: None,
+        approval_pending: false,
     })
 }
 
@@ -1064,6 +1343,14 @@ pub fn check_approval(command: &str) -> ApprovalDecision {
 mod tests {
     use super::*;
 
+    static TEST_STATE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn lock_test_state() -> std::sync::MutexGuard<'static, ()> {
+        TEST_STATE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     struct EnvGuard {
         key: &'static str,
         old: Option<String>,
@@ -1093,7 +1380,7 @@ mod tests {
         }
     }
 
-    fn reset_approval_state() {
+    fn reset_approval_state_unlocked() {
         SESSION_APPROVED
             .lock()
             .expect("session approval lock poisoned")
@@ -1105,6 +1392,14 @@ mod tests {
         PERMANENT_APPROVED
             .lock()
             .expect("permanent approval lock poisoned")
+            .clear();
+        GATEWAY_QUEUES
+            .lock()
+            .expect("gateway queue lock poisoned")
+            .clear();
+        GATEWAY_NOTIFY_CBS
+            .lock()
+            .expect("gateway notify lock poisoned")
             .clear();
     }
 
@@ -1461,7 +1756,8 @@ mod tests {
 
     #[test]
     fn test_clear_session_removes_pattern_approval_state() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         approve_session("session-a", "recursive delete");
         approve_session("session-b", "recursive delete");
 
@@ -1472,7 +1768,232 @@ mod tests {
 
         assert!(!is_approved("session-a", "recursive delete"));
         assert!(is_approved("session-b", "recursive delete"));
-        reset_approval_state();
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_gateway_approval_resolve_single_is_fifo() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let session = "gateway-fifo";
+        let first = Arc::new(GatewayApprovalEntry::new(GatewayApprovalRequest {
+            session_key: session.to_string(),
+            command: "cmd1".to_string(),
+            description: "first".to_string(),
+            pattern_key: "first".to_string(),
+            pattern_keys: vec!["first".to_string()],
+            allow_permanent: true,
+        }));
+        let second = Arc::new(GatewayApprovalEntry::new(GatewayApprovalRequest {
+            session_key: session.to_string(),
+            command: "cmd2".to_string(),
+            description: "second".to_string(),
+            pattern_key: "second".to_string(),
+            pattern_keys: vec!["second".to_string()],
+            allow_permanent: true,
+        }));
+        GATEWAY_QUEUES
+            .lock()
+            .expect("gateway queue lock poisoned")
+            .insert(
+                session.to_string(),
+                VecDeque::from([first.clone(), second.clone()]),
+            );
+
+        let count = resolve_gateway_approval(session, ApprovalChoice::Once, false);
+
+        assert_eq!(count, 1);
+        assert_eq!(first.result(), Some(ApprovalChoice::Once));
+        assert_eq!(second.result(), None);
+        assert_eq!(pending_gateway_approval_count(session), 1);
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_gateway_approval_resolve_all_unblocks_entries() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let session = "gateway-all";
+        let first = Arc::new(GatewayApprovalEntry::new(GatewayApprovalRequest {
+            session_key: session.to_string(),
+            command: "cmd1".to_string(),
+            description: "first".to_string(),
+            pattern_key: "first".to_string(),
+            pattern_keys: vec!["first".to_string()],
+            allow_permanent: true,
+        }));
+        let second = Arc::new(GatewayApprovalEntry::new(GatewayApprovalRequest {
+            session_key: session.to_string(),
+            command: "cmd2".to_string(),
+            description: "second".to_string(),
+            pattern_key: "second".to_string(),
+            pattern_keys: vec!["second".to_string()],
+            allow_permanent: true,
+        }));
+        GATEWAY_QUEUES
+            .lock()
+            .expect("gateway queue lock poisoned")
+            .insert(
+                session.to_string(),
+                VecDeque::from([first.clone(), second.clone()]),
+            );
+
+        let count = resolve_gateway_approval(session, ApprovalChoice::Session, true);
+
+        assert_eq!(count, 2);
+        assert_eq!(first.result(), Some(ApprovalChoice::Session));
+        assert_eq!(second.result(), Some(ApprovalChoice::Session));
+        assert!(!has_blocking_approval(session));
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_clear_session_denies_and_signals_gateway_entries() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let session = "gateway-boundary-cleanup";
+        let first = Arc::new(GatewayApprovalEntry::new(GatewayApprovalRequest {
+            session_key: session.to_string(),
+            command: "cmd1".to_string(),
+            description: "first".to_string(),
+            pattern_key: "first".to_string(),
+            pattern_keys: vec!["first".to_string()],
+            allow_permanent: true,
+        }));
+        let second = Arc::new(GatewayApprovalEntry::new(GatewayApprovalRequest {
+            session_key: session.to_string(),
+            command: "cmd2".to_string(),
+            description: "second".to_string(),
+            pattern_key: "second".to_string(),
+            pattern_keys: vec!["second".to_string()],
+            allow_permanent: true,
+        }));
+        GATEWAY_QUEUES
+            .lock()
+            .expect("gateway queue lock poisoned")
+            .insert(
+                session.to_string(),
+                VecDeque::from([first.clone(), second.clone()]),
+            );
+
+        clear_session(session);
+
+        assert_eq!(first.result(), Some(ApprovalChoice::Deny));
+        assert_eq!(second.result(), Some(ApprovalChoice::Deny));
+        assert!(!has_blocking_approval(session));
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_combined_guards_gateway_blocks_until_resolved() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let session = "gateway-e2e";
+        let (tx, rx) = std::sync::mpsc::channel();
+        register_gateway_notify(session, move |request| {
+            tx.send(request).expect("notify request should send");
+        });
+
+        let session_for_thread = session.to_string();
+        let handle = std::thread::spawn(move || {
+            check_all_command_guards_with_context(
+                "echo gateway-e2e",
+                "local",
+                CommandGuardContext {
+                    gateway: true,
+                    ask: true,
+                    session_key: Some(session_for_thread),
+                    gateway_approval_timeout: Duration::from_secs(5),
+                    tirith_result: Ok(Some(TirithResult::warn(
+                        "gateway_unique_e2e",
+                        "gateway warning",
+                    ))),
+                    ..CommandGuardContext::default()
+                },
+                None,
+            )
+            .expect("gateway guard should return")
+        });
+
+        let request = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("gateway notify should fire");
+        assert_eq!(request.command, "echo gateway-e2e");
+        assert_eq!(request.pattern_key, "tirith:gateway_unique_e2e");
+        assert!(has_blocking_approval(session));
+
+        assert_eq!(
+            resolve_gateway_approval(session, ApprovalChoice::Session, false),
+            1
+        );
+        let result = handle.join().expect("gateway guard thread should join");
+        assert!(result.approved);
+        assert!(result.user_approved);
+        assert!(is_approved(session, "tirith:gateway_unique_e2e"));
+        unregister_gateway_notify(session);
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_combined_guards_gateway_timeout_blocks() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let session = "gateway-timeout";
+        register_gateway_notify(session, |_request| {});
+
+        let result = check_all_command_guards_with_context(
+            "echo gateway-timeout",
+            "local",
+            CommandGuardContext {
+                gateway: true,
+                ask: true,
+                session_key: Some(session.to_string()),
+                gateway_approval_timeout: Duration::from_millis(10),
+                tirith_result: Ok(Some(TirithResult::warn(
+                    "gateway_unique_timeout",
+                    "gateway warning",
+                ))),
+                ..CommandGuardContext::default()
+            },
+            None,
+        )
+        .expect("gateway guard should return");
+
+        assert!(!result.approved);
+        assert!(result
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("timed out"));
+        assert!(!has_blocking_approval(session));
+        unregister_gateway_notify(session);
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_combined_guards_gateway_without_listener_returns_pending() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let result = check_all_command_guards_with_context(
+            "echo gateway-pending",
+            "local",
+            CommandGuardContext {
+                ask: true,
+                session_key: Some("gateway-no-listener".to_string()),
+                tirith_result: Ok(Some(TirithResult::warn(
+                    "gateway_unique_pending",
+                    "gateway warning",
+                ))),
+                ..CommandGuardContext::default()
+            },
+            None,
+        )
+        .expect("gateway guard should return");
+
+        assert!(!result.approved);
+        assert_eq!(result.status.as_deref(), Some("pending_approval"));
+        assert!(result.approval_pending);
+        reset_approval_state_unlocked();
     }
 
     #[test]
@@ -1499,7 +2020,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_allow_safe_command() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let result = check_all_command_guards_with_context(
             "echo hello",
             "local",
@@ -1531,7 +2053,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_block_prompts_as_approvable_warning() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let result = check_all_command_guards_with_context(
             "curl http://homograph.test",
             "local",
@@ -1551,7 +2074,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_block_plus_dangerous_prompt_combines() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let mut prompts = Vec::new();
         let mut callback = |prompt: ApprovalPrompt| {
             prompts.push(prompt);
@@ -1574,7 +2098,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_dangerous_only_cli_deny_allows_permanent_prompt() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let mut prompts = Vec::new();
         let mut callback = |prompt: ApprovalPrompt| {
             prompts.push(prompt);
@@ -1596,7 +2121,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_warn_safe_prompts_without_permanent() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let mut prompts = Vec::new();
         let mut callback = |prompt: ApprovalPrompt| {
             prompts.push(prompt);
@@ -1621,7 +2147,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_warn_session_approval_skips_prompt() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         approve_session("session-a", "tirith:shortened_url");
         let mut callback = |_prompt: ApprovalPrompt| ApprovalChoice::Deny;
 
@@ -1642,7 +2169,7 @@ mod tests {
         .unwrap();
 
         assert!(result.approved);
-        reset_approval_state();
+        reset_approval_state_unlocked();
     }
 
     #[test]
@@ -1666,7 +2193,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_warn_and_dangerous_session_approves_both() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let mut prompts = Vec::new();
         let mut callback = |prompt: ApprovalPrompt| {
             prompts.push(prompt);
@@ -1693,12 +2221,13 @@ mod tests {
             "session-combined",
             "pipe remote content to shell"
         ));
-        reset_approval_state();
+        reset_approval_state_unlocked();
     }
 
     #[test]
     fn test_combined_guards_dangerous_only_always_approves_permanent() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let mut prompts = Vec::new();
         let mut callback = |prompt: ApprovalPrompt| {
             prompts.push(prompt);
@@ -1716,7 +2245,7 @@ mod tests {
         assert_eq!(prompts.len(), 1);
         assert!(prompts[0].allow_permanent);
         assert!(is_approved("another-session", "recursive delete"));
-        reset_approval_state();
+        reset_approval_state_unlocked();
     }
 
     #[test]
@@ -1738,7 +2267,8 @@ mod tests {
 
     #[test]
     fn test_combined_guards_tirith_warn_empty_findings_prompts() {
-        reset_approval_state();
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let mut prompts = Vec::new();
         let mut callback = |prompt: ApprovalPrompt| {
             prompts.push(prompt);

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-30T16:10:54.268491+00:00",
+  "generated_at_utc": "2026-05-30T16:53:27.439849+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T16:07:54.570989+00:00",
+  "generated_at_utc": "2026-05-30T16:52:58.965397+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T16:07:54.570989+00:00`
+Generated: `2026-05-30T16:52:58.965397+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T16:07:51.917087+00:00",
+  "generated_at_utc": "2026-05-30T16:52:51.516130+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b6ff2c78afea1c884bf823e42b7252c8ad03d6e0",
+    "local_sha": "d3afd74cd74e4ce7c1ab6dae5b08de647e131bc0",
     "upstream_ref": "upstream/main",
     "upstream_sha": "6a72af044c44c9a05137bc448bc65ecf0ace5a89",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 4493,
-    "commits_ahead": 879,
+    "commits_ahead": 881,
     "upstream_patch_missing": 4373,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 723,
+    "local_patch_unique": 724,
     "files_only_upstream": 1493,
     "files_only_local": 574,
     "files_shared_identical": 1688,
     "files_shared_different": 1031,
     "tree_files_changed": 3098,
     "tree_insertions": 750036,
-    "tree_deletions": 400950
+    "tree_deletions": 401943
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 4373,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 723,
+    "local_patch_unique": 724,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-05-30T16:07:51.917087+00:00`
+Generated: `2026-05-30T16:52:51.516130+00:00`
 
 ## Scope
 
-- Local ref: `main` (`b6ff2c78afea1c884bf823e42b7252c8ad03d6e0`)
+- Local ref: `main` (`d3afd74cd74e4ce7c1ab6dae5b08de647e131bc0`)
 - Upstream ref: `upstream/main` (`6a72af044c44c9a05137bc448bc65ecf0ace5a89`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-05-30T16:07:51.917087+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 4493 |
-| Commits ahead local (`local` ancestry only) | 879 |
+| Commits ahead local (`local` ancestry only) | 881 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4373 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 723 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 724 |
 | Files only in upstream tree | 1493 |
 | Files only in local tree | 574 |
 | Shared files identical content | 1688 |
 | Shared files different content | 1031 |
 | Total files changed (`local` vs `upstream`) | 3098 |
 | Insertions (`local` vs `upstream`) | 750036 |
-| Deletions (`local` vs `upstream`) | 400950 |
+| Deletions (`local` vs `upstream`) | 401943 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-05-30T16:07:51.917087+00:00`
 
 - Upstream missing by patch-id: `4373`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `723`
+- Local unique by patch-id: `724`
 - Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3451,16 +3451,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_approve_deny_commands.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ebe4d59172adc38ed98838ad0e9e57b174489f2f",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_approve_deny_commands.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1c996b2baee0452e2f0905bf70bdd2d6e336cfbb",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T16:07:45.836489+00:00",
+  "generated_at_utc": "2026-05-30T16:52:49.484472+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b6ff2c78afea1c884bf823e42b7252c8ad03d6e0",
+    "local_sha": "d3afd74cd74e4ce7c1ab6dae5b08de647e131bc0",
     "upstream_ref": "upstream/main",
     "upstream_sha": "6a72af044c44c9a05137bc448bc65ecf0ace5a89"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 648,
-      "intentional_divergence": 213,
+      "functional": 647,
+      "intentional_divergence": 214,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 383,
-      "rust_equivalent_or_contract_test_required": 564,
+      "not_required_for_runtime": 384,
+      "rust_equivalent_or_contract_test_required": 563,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 213,
+      "cleared_intentional_divergence": 214,
       "cleared_non_runtime": 170,
-      "pending_review": 648
+      "pending_review": 647
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 213,
+    "cleared_intentional_divergence": 214,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 648,
+    "pending_review": 647,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T16:07:45.836489+00:00`
+Generated: `2026-05-30T16:52:49.484472+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `648`
+- Pending functional review: `647`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `213`
+- Cleared intentional divergence: `214`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 213 |
+| `cleared_intentional_divergence` | 214 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 648 |
+| `pending_review` | 647 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T16:07:45.836489+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 147 |
+| `tests/gateway` | 146 |
 | `tests/hermes_cli` | 127 |
 | `tests/tools` | 95 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -150,6 +150,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_approve_deny_commands.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream blocking command approvals are covered by Rust hermes-tools gateway approval queue contracts and hermes-gateway slash command tests for FIFO resolution, resolve-all behavior, timeout/no-listener fallback, /approve and /deny command resolution, and session-boundary denial; Python-only stale _pending_approvals cleanup has no Rust runtime equivalent.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_allowed_mentions.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord allowed_mentions safe-default intent is covered by Rust hermes-gateway DiscordAllowedMentions payload construction and env-style parsing tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- add Rust-native blocking gateway approval queue with approve/deny/always/all resolution
- wire /approve and /deny slash commands to pending command approvals
- harden reset/session-boundary cleanup and hook coverage
- classify the upstream approve/deny gateway test as an intentional Rust runtime divergence and regenerate parity docs

## Local verification
- cargo fmt
- cargo fmt --check
- cargo test -p hermes-tools gateway -- --nocapture
- cargo test -p hermes-tools approval -- --nocapture
- cargo test -p hermes-gateway approval -- --nocapture
- cargo test -p hermes-gateway hook -- --nocapture
- cargo test -p hermes-gateway commands::tests::test_command_approval_resolution_commands -- --nocapture
- python3 scripts/generate-shared-diff-backlog.py --repo-root .
- python3 scripts/generate-parity-matrix.py --repo-root .
- python3 scripts/generate-global-parity-proof.py --repo-root .
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --local-ref HEAD --upstream-ref upstream/main --json
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- python3 scripts/validate-intentional-divergence.py --check --allow-warnings
- git diff --check
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- cargo test -p hermes-parity-tests --test global_parity_governance
- cargo test --workspace
- cargo build --workspace