### PR TITLE
parity(gateway): port session lifecycle hooks

### DIFF
--- a/crates/hermes-agent/src/plugins.rs
+++ b/crates/hermes-agent/src/plugins.rs
@@ -318,7 +318,18 @@ impl PluginManager {
         let Some(callbacks) = self.context.hooks.get(&hook) else {
             return Vec::new();
         };
-        callbacks.iter().map(|cb| cb(context)).collect()
+        callbacks
+            .iter()
+            .filter_map(|cb| {
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| cb(context))) {
+                    Ok(result) => Some(result),
+                    Err(_) => {
+                        tracing::warn!(hook = hook.as_str(), "Plugin hook panicked");
+                        None
+                    }
+                }
+            })
+            .collect()
     }
 
     /// Get all tools registered via plugin contexts.
@@ -546,6 +557,32 @@ mod tests {
         }
     }
 
+    struct PanicHookPlugin;
+
+    #[async_trait::async_trait]
+    impl Plugin for PanicHookPlugin {
+        fn meta(&self) -> PluginMeta {
+            PluginMeta {
+                name: "panic_hook_test".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Panic hook test plugin".to_string(),
+                author: None,
+            }
+        }
+        async fn initialize(&self) -> Result<(), AgentError> {
+            Ok(())
+        }
+        async fn shutdown(&self) -> Result<(), AgentError> {
+            Ok(())
+        }
+        fn register(&self, ctx: &mut PluginContext) {
+            ctx.on(
+                HookType::OnSessionFinalize,
+                Arc::new(|_ctx| panic!("hook failed")),
+            );
+        }
+    }
+
     #[test]
     fn test_plugin_register() {
         let mut mgr = PluginManager::new();
@@ -571,6 +608,17 @@ mod tests {
     }
 
     #[test]
+    fn test_invoke_hook_contains_panics() {
+        let mut mgr = PluginManager::new();
+        mgr.register(Arc::new(PanicHookPlugin));
+        let results = mgr.invoke_hook(
+            HookType::OnSessionFinalize,
+            &serde_json::json!({"session_id": "test", "platform": "cli"}),
+        );
+        assert!(results.is_empty());
+    }
+
+    #[test]
     fn test_is_disabled() {
         let mgr = PluginManager::new();
         let disabled = vec!["foo".to_string(), "bar".to_string()];
@@ -592,6 +640,10 @@ mod tests {
     fn test_hook_type_as_str() {
         assert_eq!(HookType::PreToolCall.as_str(), "pre_tool_call");
         assert_eq!(HookType::OnSessionEnd.as_str(), "on_session_end");
+        assert_eq!(HookType::OnSessionFinalize.as_str(), "on_session_finalize");
+        assert_eq!(HookType::OnSessionReset.as_str(), "on_session_reset");
+        assert!(HookType::all().contains(&HookType::OnSessionFinalize));
+        assert!(HookType::all().contains(&HookType::OnSessionReset));
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use hermes_agent::agent_loop::ToolRegistry as AgentToolRegistry;
+use hermes_agent::plugins::HookType;
 use hermes_agent::provider::{
     openai_codex_provider, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
     OPENAI_CODEX_BASE_URL,
@@ -2292,6 +2293,8 @@ impl App {
 
     /// Create a new session, clearing all messages.
     pub fn new_session(&mut self) {
+        let old_session_id = self.session_id.clone();
+        self.invoke_session_lifecycle_hook(HookType::OnSessionFinalize, &old_session_id);
         self.session_id = Uuid::new_v4().to_string();
         self.messages.clear();
         self.ui_messages.clear();
@@ -2300,16 +2303,35 @@ impl App {
         self.input_history.clear();
         self.history_index = 0;
         self.ensure_session_stub_snapshot();
+        self.invoke_session_lifecycle_hook(HookType::OnSessionReset, &self.session_id);
     }
 
     /// Reset the current session (clear messages but keep session ID).
     pub fn reset_session(&mut self) {
+        let session_id = self.session_id.clone();
+        self.invoke_session_lifecycle_hook(HookType::OnSessionFinalize, &session_id);
         self.messages.clear();
         self.ui_messages.clear();
         self.pending_image_hint = None;
         self.session_objective = None;
         self.input_history.clear();
         self.history_index = 0;
+        self.invoke_session_lifecycle_hook(HookType::OnSessionReset, &session_id);
+    }
+
+    fn invoke_session_lifecycle_hook(&self, hook: HookType, session_id: &str) {
+        let Some(plugin_manager) = self.agent.plugin_manager.as_ref() else {
+            return;
+        };
+        let Ok(plugin_manager) = plugin_manager.lock() else {
+            tracing::warn!(hook = hook.as_str(), "Plugin manager lock poisoned");
+            return;
+        };
+        let context = serde_json::json!({
+            "session_id": session_id,
+            "platform": "cli",
+        });
+        let _ = plugin_manager.invoke_hook(hook, &context);
     }
 
     /// Set or clear a durable session objective.
@@ -3665,6 +3687,7 @@ mod tests {
         upsert_objective_contract,
     };
     use crate::test_env_lock;
+    use hermes_agent::plugins::{HookResult, Plugin, PluginContext, PluginManager};
     use hermes_config::LlmProviderConfig;
     use std::collections::HashMap;
 
@@ -3716,6 +3739,117 @@ mod tests {
             quorum_armed_once: false,
             pet_settings: PetSettings::default(),
         }
+    }
+
+    struct LifecycleHookPlugin {
+        seen: Arc<StdMutex<Vec<(String, String)>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Plugin for LifecycleHookPlugin {
+        fn meta(&self) -> hermes_agent::plugins::PluginMeta {
+            hermes_agent::plugins::PluginMeta {
+                name: "lifecycle-recorder".to_string(),
+                version: "0.1.0".to_string(),
+                description: "Lifecycle recorder".to_string(),
+                author: None,
+            }
+        }
+
+        async fn initialize(&self) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn shutdown(&self) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn register(&self, ctx: &mut PluginContext) {
+            let finalize_seen = self.seen.clone();
+            ctx.on(
+                HookType::OnSessionFinalize,
+                Arc::new(move |value| {
+                    let session_id = value
+                        .get("session_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    finalize_seen
+                        .lock()
+                        .unwrap()
+                        .push(("on_session_finalize".to_string(), session_id));
+                    HookResult::Ok
+                }),
+            );
+            let reset_seen = self.seen.clone();
+            ctx.on(
+                HookType::OnSessionReset,
+                Arc::new(move |value| {
+                    let session_id = value
+                        .get("session_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    reset_seen
+                        .lock()
+                        .unwrap()
+                        .push(("on_session_reset".to_string(), session_id));
+                    HookResult::Ok
+                }),
+            );
+        }
+    }
+
+    fn attach_lifecycle_recorder(app: &mut App, seen: Arc<StdMutex<Vec<(String, String)>>>) {
+        let mut plugin_manager = PluginManager::new();
+        plugin_manager.register(Arc::new(LifecycleHookPlugin { seen }));
+        let agent = AgentLoop::new(
+            app.agent.config.clone(),
+            app.agent.tool_registry.clone(),
+            app.agent.llm_provider.clone(),
+        )
+        .with_plugins(Arc::new(StdMutex::new(plugin_manager)));
+        app.agent = Arc::new(agent);
+    }
+
+    #[test]
+    fn app_new_session_invokes_session_lifecycle_hooks() {
+        let mut app = build_minimal_test_app();
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        attach_lifecycle_recorder(&mut app, seen.clone());
+        let old_session_id = app.session_id.clone();
+
+        app.new_session();
+
+        let events = seen.lock().unwrap().clone();
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0],
+            ("on_session_finalize".to_string(), old_session_id)
+        );
+        assert_eq!(events[1].0, "on_session_reset");
+        assert_eq!(events[1].1, app.session_id);
+        assert_ne!(events[0].1, events[1].1);
+    }
+
+    #[test]
+    fn app_reset_session_invokes_session_lifecycle_hooks() {
+        let mut app = build_minimal_test_app();
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        attach_lifecycle_recorder(&mut app, seen.clone());
+        let session_id = app.session_id.clone();
+
+        app.reset_session();
+
+        let events = seen.lock().unwrap().clone();
+        assert_eq!(
+            events,
+            vec![
+                ("on_session_finalize".to_string(), session_id.clone()),
+                ("on_session_reset".to_string(), session_id)
+            ]
+        );
+        assert_eq!(app.session_id, "test-session");
     }
 
     #[test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -25,7 +25,7 @@ use crate::commands::{handle_command, GatewayCommandResult};
 use crate::dm::{DmDecision, DmManager};
 use crate::hooks::{HookEvent, HookRegistry};
 use crate::platforms::helpers::extract_inline_images;
-use crate::session::SessionManager;
+use crate::session::{Session, SessionManager};
 use crate::stream::{StreamConfig, StreamManager};
 
 // ---------------------------------------------------------------------------
@@ -555,6 +555,51 @@ impl Gateway {
         }
     }
 
+    fn session_lifecycle_context(
+        session_key: &str,
+        session: &Session,
+        reason: &str,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "platform": session.platform,
+            "chat_id": session.chat_id,
+            "user_id": session.user_id,
+            "session_key": session_key,
+            "session_id": session.id,
+            "reason": reason,
+        })
+    }
+
+    async fn emit_session_finalize(&self, session_key: &str, session: &Session, reason: &str) {
+        self.emit_hook_event(
+            "on_session_finalize",
+            Self::session_lifecycle_context(session_key, session, reason),
+        )
+        .await;
+    }
+
+    async fn emit_session_reset_lifecycle(
+        &self,
+        session_key: &str,
+        session: &Session,
+        reason: &str,
+    ) {
+        self.emit_hook_event(
+            "on_session_reset",
+            Self::session_lifecycle_context(session_key, session, reason),
+        )
+        .await;
+    }
+
+    async fn finalize_active_sessions(&self, reason: &str) -> usize {
+        let sessions = self.session_manager.all_sessions().await;
+        for (session_key, session) in &sessions {
+            self.emit_session_finalize(session_key, session, reason)
+                .await;
+        }
+        sessions.len()
+    }
+
     /// Register a platform adapter under the given name.
     pub async fn register_adapter(
         &self,
@@ -587,6 +632,13 @@ impl Gateway {
 
     /// Stop all platform adapters gracefully.
     pub async fn stop_all(&self) -> Result<(), GatewayError> {
+        let finalized = self.finalize_active_sessions("shutdown").await;
+        if finalized > 0 {
+            info!(
+                finalized,
+                "Finalized active gateway sessions before shutdown"
+            );
+        }
         let adapters = self.adapters.read().await;
         for (name, adapter) in adapters.iter() {
             info!("Stopping platform adapter: {}", name);
@@ -872,29 +924,47 @@ impl Gateway {
                 Ok(true)
             }
             GatewayCommandResult::ResetSession(reply) => {
+                let current_session = self.session_manager.get_session(session_key).await;
                 self.emit_hook_event(
                     "session:end",
                     serde_json::json!({
                         "platform": incoming.platform,
                         "chat_id": incoming.chat_id,
                         "user_id": incoming.user_id,
-                        "session_id": session_key
+                        "session_id": session_key,
+                        "logical_session_id": current_session.as_ref().map(|s| s.id.clone())
                     }),
                 )
                 .await;
-                self.session_manager.reset_session(session_key).await;
+                if let Some(old_session) = current_session.as_ref() {
+                    self.emit_session_finalize(session_key, old_session, "reset")
+                        .await;
+                }
+                let reset_snapshot = self
+                    .session_manager
+                    .reset_session_with_snapshots(session_key)
+                    .await;
                 self.clear_session_boundary_security_state(session_key)
                     .await;
+                let reset_session = reset_snapshot
+                    .as_ref()
+                    .map(|(_, new_session)| new_session)
+                    .or(current_session.as_ref());
                 self.emit_hook_event(
                     "session:reset",
                     serde_json::json!({
                         "platform": incoming.platform,
                         "chat_id": incoming.chat_id,
                         "user_id": incoming.user_id,
-                        "session_id": session_key
+                        "session_id": session_key,
+                        "logical_session_id": reset_session.map(|s| s.id.clone())
                     }),
                 )
                 .await;
+                if let Some(new_session) = reset_session {
+                    self.emit_session_reset_lifecycle(session_key, new_session, "reset")
+                        .await;
+                }
                 self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
                     .await?;
                 Ok(true)
@@ -2144,11 +2214,22 @@ impl Gateway {
             tokio::time::interval(std::time::Duration::from_secs(interval_secs.max(30)));
         loop {
             ticker.tick().await;
-            let expired = self.session_manager.expire_idle_sessions().await;
+            let expired = self.expire_idle_sessions_once("idle_expiry").await;
             if expired > 0 {
                 tracing::info!(expired, "Expired idle sessions");
             }
         }
+    }
+
+    /// Expire idle sessions once and emit lifecycle finalization hooks for
+    /// each removed session using retained session snapshots.
+    pub async fn expire_idle_sessions_once(&self, reason: &str) -> usize {
+        let expired = self.session_manager.expire_idle_session_snapshots().await;
+        for (session_key, session) in &expired {
+            self.emit_session_finalize(session_key, session, reason)
+                .await;
+        }
+        expired.len()
     }
 
     /// Monitors adapter health and attempts reconnect through stop/start.
@@ -4489,6 +4570,173 @@ mod tests {
             .expect("session:reset payload should exist");
         assert_eq!(end_payload["session_id"], serde_json::json!(session_key));
         assert_eq!(reset_payload["session_id"], serde_json::json!(session_key));
+    }
+
+    #[tokio::test]
+    async fn gateway_emits_plugin_session_finalize_and_reset_for_reset_command() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let hook_seen = Arc::new(Mutex::new(Vec::new()));
+        let mut hooks = HookRegistry::new();
+        hooks.register_in_process(
+            "on_session_finalize",
+            Arc::new(RecordingHook {
+                seen: hook_seen.clone(),
+            }),
+        );
+        hooks.register_in_process(
+            "on_session_reset",
+            Arc::new(RecordingHook {
+                seen: hook_seen.clone(),
+            }),
+        );
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.set_hook_registry(Arc::new(hooks)).await;
+        gw.register_adapter("test", adapter).await;
+        gw.set_message_handler(Arc::new(|_messages| {
+            Box::pin(async move { Ok("assistant".to_string()) })
+        }))
+        .await;
+        let session_key =
+            gw.session_manager
+                .compose_session_key("test", "chat-plugin-reset", "user1");
+
+        let normal = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-plugin-reset".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&normal).await.is_ok());
+        let old_logical_id = gw
+            .session_manager
+            .get_session(&session_key)
+            .await
+            .expect("session should exist")
+            .id;
+
+        let reset = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-plugin-reset".into(),
+            user_id: "user1".into(),
+            text: "/reset".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&reset).await.is_ok());
+
+        let events = hook_seen.lock().unwrap();
+        let names: Vec<String> = events.iter().map(|(name, _)| name.clone()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "on_session_finalize".to_string(),
+                "on_session_reset".to_string()
+            ]
+        );
+        let finalize_payload = &events[0].1;
+        let reset_payload = &events[1].1;
+        assert_eq!(
+            finalize_payload["session_id"],
+            serde_json::json!(old_logical_id)
+        );
+        assert_eq!(
+            finalize_payload["session_key"],
+            serde_json::json!(session_key)
+        );
+        assert_eq!(finalize_payload["reason"], serde_json::json!("reset"));
+        assert_eq!(reset_payload["session_key"], serde_json::json!(session_key));
+        assert_eq!(reset_payload["reason"], serde_json::json!("reset"));
+        assert_ne!(reset_payload["session_id"], finalize_payload["session_id"]);
+    }
+
+    #[tokio::test]
+    async fn gateway_stop_all_finalizes_active_sessions() {
+        let hook_seen = Arc::new(Mutex::new(Vec::new()));
+        let mut hooks = HookRegistry::new();
+        hooks.register_in_process(
+            "on_session_finalize",
+            Arc::new(RecordingHook {
+                seen: hook_seen.clone(),
+            }),
+        );
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let first = session_mgr
+            .get_or_create_session("test", "stop-chat-a", "user1")
+            .await;
+        let second = session_mgr
+            .get_or_create_session("test", "stop-chat-b", "user2")
+            .await;
+        let gw = Gateway::new(
+            session_mgr,
+            DmManager::with_pair_behavior(),
+            GatewayConfig::default(),
+        );
+        gw.set_hook_registry(Arc::new(hooks)).await;
+
+        gw.stop_all().await.expect("stop should succeed");
+
+        let events = hook_seen.lock().unwrap();
+        let session_ids: HashSet<String> = events
+            .iter()
+            .filter(|(name, _)| name == "on_session_finalize")
+            .filter_map(|(_, ctx)| ctx["session_id"].as_str().map(ToOwned::to_owned))
+            .collect();
+        assert_eq!(
+            session_ids,
+            HashSet::from([first.id.clone(), second.id.clone()])
+        );
+        assert!(events
+            .iter()
+            .all(|(_, ctx)| ctx["reason"] == serde_json::json!("shutdown")));
+    }
+
+    #[tokio::test]
+    async fn gateway_idle_expiry_finalizes_removed_sessions() {
+        let hook_seen = Arc::new(Mutex::new(Vec::new()));
+        let mut hooks = HookRegistry::new();
+        hooks.register_in_process(
+            "on_session_finalize",
+            Arc::new(RecordingHook {
+                seen: hook_seen.clone(),
+            }),
+        );
+
+        let session_config = SessionConfig {
+            reset_policy: hermes_config::session::SessionResetPolicy::Idle { timeout_minutes: 0 },
+            ..SessionConfig::default()
+        };
+        let session_mgr = Arc::new(SessionManager::new(session_config));
+        let expired = session_mgr
+            .get_or_create_session("test", "idle-chat", "user1")
+            .await;
+        let session_key = session_mgr.compose_session_key("test", "idle-chat", "user1");
+        let gw = Gateway::new(
+            session_mgr.clone(),
+            DmManager::with_pair_behavior(),
+            GatewayConfig::default(),
+        );
+        gw.set_hook_registry(Arc::new(hooks)).await;
+
+        let expired_count = gw.expire_idle_sessions_once("idle_expiry").await;
+
+        assert_eq!(expired_count, 1);
+        assert!(session_mgr.get_session(&session_key).await.is_none());
+        let events = hook_seen.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "on_session_finalize");
+        assert_eq!(events[0].1["session_id"], serde_json::json!(expired.id));
+        assert_eq!(events[0].1["session_key"], serde_json::json!(session_key));
+        assert_eq!(events[0].1["reason"], serde_json::json!("idle_expiry"));
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/session.rs
+++ b/crates/hermes-gateway/src/session.rs
@@ -366,14 +366,27 @@ impl SessionManager {
         session_clone
     }
 
-    /// Reset a session by ID, clearing all messages.
-    pub async fn reset_session(&self, session_id: &str) {
+    /// Reset a session by key, clearing all messages and rotating the logical
+    /// session id. Returns the pre-reset and post-reset session snapshots.
+    pub async fn reset_session_with_snapshots(
+        &self,
+        session_id: &str,
+    ) -> Option<(Session, Session)> {
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(session_id) {
+            let old = session.clone();
             session.messages.clear();
+            session.id = Uuid::new_v4().to_string();
             session.created_at = Utc::now();
             session.last_active_at = Utc::now();
+            return Some((old, session.clone()));
         }
+        None
+    }
+
+    /// Reset a session by key, clearing all messages.
+    pub async fn reset_session(&self, session_id: &str) {
+        let _ = self.reset_session_with_snapshots(session_id).await;
     }
 
     /// Add a message to a session.
@@ -508,21 +521,50 @@ impl SessionManager {
         all
     }
 
+    /// Return all current session snapshots with their canonical keys.
+    pub async fn all_sessions(&self) -> Vec<(String, Session)> {
+        let sessions = self.sessions.read().await;
+        sessions
+            .iter()
+            .map(|(key, session)| (key.clone(), session.clone()))
+            .collect()
+    }
+
     /// Expire idle sessions according to their reset policy.
     ///
-    /// Returns the number of removed sessions.
-    pub async fn expire_idle_sessions(&self) -> usize {
+    /// Returns the removed session snapshots with their canonical keys.
+    pub async fn expire_idle_session_snapshots(&self) -> Vec<(String, Session)> {
         let mut sessions = self.sessions.write().await;
-        let before = sessions.len();
         let stale_ids: Vec<String> = sessions
             .iter()
             .filter(|(_, s)| s.should_reset())
             .map(|(id, _)| id.clone())
             .collect();
-        for id in &stale_ids {
-            sessions.remove(id);
+        let mut expired = Vec::new();
+        for id in stale_ids {
+            if let Some(session) = sessions.remove(&id) {
+                expired.push((id, session));
+            }
         }
-        before.saturating_sub(sessions.len())
+        drop(sessions);
+
+        if !expired.is_empty() {
+            let mut user_sessions = self.user_sessions.write().await;
+            for (id, session) in &expired {
+                if let Some(ids) = user_sessions.get_mut(&session.user_id) {
+                    ids.retain(|existing| existing != id);
+                }
+            }
+        }
+
+        expired
+    }
+
+    /// Expire idle sessions according to their reset policy.
+    ///
+    /// Returns the number of removed sessions.
+    pub async fn expire_idle_sessions(&self) -> usize {
+        self.expire_idle_session_snapshots().await.len()
     }
 
     /// Infer the session type from the chat_id format.
@@ -704,6 +746,52 @@ mod tests {
 
         manager.reset_session(&sid).await;
         assert!(manager.get_messages(&sid).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_manager_reset_returns_old_and_new_logical_ids() {
+        let config = SessionConfig::default();
+        let manager = SessionManager::new(config);
+        let session = manager
+            .get_or_create_session("telegram", "chat-reset-id", "user1")
+            .await;
+        let sid =
+            manager.compose_session_key(&session.platform, &session.chat_id, &session.user_id);
+        manager.add_message(&sid, Message::user("hello")).await;
+
+        let (old_session, new_session) = manager
+            .reset_session_with_snapshots(&sid)
+            .await
+            .expect("session should reset");
+
+        assert_eq!(old_session.id, session.id);
+        assert_ne!(new_session.id, old_session.id);
+        assert_eq!(new_session.platform, "telegram");
+        assert_eq!(new_session.chat_id, "chat-reset-id");
+        assert!(new_session.messages.is_empty());
+        assert!(manager.get_messages(&sid).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_manager_expire_returns_snapshots_and_cleans_user_index() {
+        let config = SessionConfig {
+            reset_policy: SessionResetPolicy::Idle { timeout_minutes: 0 },
+            ..SessionConfig::default()
+        };
+        let manager = SessionManager::new(config);
+        let session = manager
+            .get_or_create_session("telegram", "chat-expire", "user1")
+            .await;
+        let sid =
+            manager.compose_session_key(&session.platform, &session.chat_id, &session.user_id);
+
+        let expired = manager.expire_idle_session_snapshots().await;
+
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].0, sid);
+        assert_eq!(expired[0].1.id, session.id);
+        assert!(manager.get_session(&sid).await.is_none());
+        assert!(manager.get_user_sessions("user1").await.is_empty());
     }
 
     #[test]

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-05-30T16:53:27.439849+00:00",
+  "generated_at_utc": "2026-05-30T17:43:19.804214+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,13 +2,13 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 4493.0,
+        "actual": 4494.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "status": "pass"
       },
       {
-        "actual": 4373.0,
+        "actual": 4374.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "status": "pass"
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T16:52:58.965397+00:00",
+  "generated_at_utc": "2026-05-30T17:41:23.479937+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -60,12 +60,12 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 4493.0,
+    "max_commits_behind": 4494.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 1493.0,
     "max_queue_pending_commits": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 4373.0,
+    "max_upstream_patch_missing": 4374.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T16:52:58.965397+00:00`
+Generated: `2026-05-30T17:41:23.479937+00:00`
 
 ## Gate Status
 
@@ -13,8 +13,8 @@ Generated: `2026-05-30T16:52:58.965397+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 4493.0 |
-| `max_upstream_patch_missing` | 4373.0 |
+| `max_commits_behind` | 4494.0 |
+| `max_upstream_patch_missing` | 4374.0 |
 | `max_files_only_upstream` | 1493.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-05-30T16:52:51.516130+00:00",
+  "generated_at_utc": "2026-05-30T17:41:23.389573+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "d3afd74cd74e4ce7c1ab6dae5b08de647e131bc0",
+    "local_sha": "8c7e0cf78385928a5dd7f613e708c56c9bb2d4f1",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "6a72af044c44c9a05137bc448bc65ecf0ace5a89",
+    "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 4493,
-    "commits_ahead": 881,
-    "upstream_patch_missing": 4373,
+    "commits_behind": 4494,
+    "commits_ahead": 883,
+    "upstream_patch_missing": 4374,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 724,
+    "local_patch_unique": 725,
     "files_only_upstream": 1493,
     "files_only_local": 574,
     "files_shared_identical": 1688,
     "files_shared_different": 1031,
     "tree_files_changed": 3098,
-    "tree_insertions": 750036,
-    "tree_deletions": 401943
+    "tree_insertions": 750070,
+    "tree_deletions": 402897
   },
   "top_upstream_only": [
     {
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 4373,
+    "upstream_patch_missing": 4374,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 724,
+    "local_patch_unique": 725,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,29 +1,29 @@
 # Parity Matrix
 
-Generated: `2026-05-30T16:52:51.516130+00:00`
+Generated: `2026-05-30T17:41:23.389573+00:00`
 
 ## Scope
 
-- Local ref: `main` (`d3afd74cd74e4ce7c1ab6dae5b08de647e131bc0`)
-- Upstream ref: `upstream/main` (`6a72af044c44c9a05137bc448bc65ecf0ace5a89`)
+- Local ref: `main` (`8c7e0cf78385928a5dd7f613e708c56c9bb2d4f1`)
+- Upstream ref: `upstream/main` (`5921d667855880b0aa2083a50f001748aed52f3e`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 4493 |
-| Commits ahead local (`local` ancestry only) | 881 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4373 |
+| Commits behind local (`upstream` ancestry only) | 4494 |
+| Commits ahead local (`local` ancestry only) | 883 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 4374 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 724 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 725 |
 | Files only in upstream tree | 1493 |
 | Files only in local tree | 574 |
 | Shared files identical content | 1688 |
 | Shared files different content | 1031 |
 | Total files changed (`local` vs `upstream`) | 3098 |
-| Insertions (`local` vs `upstream`) | 750036 |
-| Deletions (`local` vs `upstream`) | 401943 |
+| Insertions (`local` vs `upstream`) | 750070 |
+| Deletions (`local` vs `upstream`) | 402897 |
 
 ## Top 40 upstream-only buckets
 
@@ -174,9 +174,9 @@ Generated: `2026-05-30T16:52:51.516130+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `4373`
+- Upstream missing by patch-id: `4374`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `724`
+- Local unique by patch-id: `725`
 - Intentional divergence tracked items: `8` (covered files: `904`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3001,16 +3001,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/cli/test_session_boundary_hooks.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "19de4cd97a32fcae3806a10cc6d04a28f5a851a2",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/cli/test_session_boundary_hooks.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "3fcab991e954758d29ae25744e5b39b75a91354b",
       "workstream": "WS6"
@@ -4906,16 +4906,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_session_boundary_hooks.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "255795492fc70defad466c3be4fc661d3ef26d05",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_session_boundary_hooks.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "30584513325a78cdc86bc0a5a8cf6b9a46143675",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T16:52:49.484472+00:00",
+  "generated_at_utc": "2026-05-30T17:41:19.343165+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "d3afd74cd74e4ce7c1ab6dae5b08de647e131bc0",
+    "local_sha": "8c7e0cf78385928a5dd7f613e708c56c9bb2d4f1",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "6a72af044c44c9a05137bc448bc65ecf0ace5a89"
+    "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 647,
-      "intentional_divergence": 214,
+      "functional": 645,
+      "intentional_divergence": 216,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 384,
-      "rust_equivalent_or_contract_test_required": 563,
+      "not_required_for_runtime": 386,
+      "rust_equivalent_or_contract_test_required": 561,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 214,
+      "cleared_intentional_divergence": 216,
       "cleared_non_runtime": 170,
-      "pending_review": 647
+      "pending_review": 645
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 214,
+    "cleared_intentional_divergence": 216,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 647,
+    "pending_review": 645,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T16:52:49.484472+00:00`
+Generated: `2026-05-30T17:41:19.343165+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `647`
+- Pending functional review: `645`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `214`
+- Cleared intentional divergence: `216`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 214 |
+| `cleared_intentional_divergence` | 216 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 647 |
+| `pending_review` | 645 |
 
 ## Workstream Counts
 
@@ -37,13 +37,13 @@ Generated: `2026-05-30T16:52:49.484472+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 146 |
+| `tests/gateway` | 145 |
 | `tests/hermes_cli` | 127 |
 | `tests/tools` | 95 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |
-| `tests/cli` | 29 |
+| `tests/cli` | 28 |
 | `tests/agent` | 24 |
 | `ui-tui/packages` | 18 |
 | `tests/plugins` | 17 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -157,6 +157,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_session_boundary_hooks.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream gateway session-boundary lifecycle intent is covered by Rust hermes-gateway contracts for reset ordering, old logical session finalize hooks, new logical session reset hooks, hook error containment, shutdown finalization for active sessions, and idle-expiry finalization before session removal.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_allowed_mentions.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord allowed_mentions safe-default intent is covered by Rust hermes-gateway DiscordAllowedMentions payload construction and env-style parsing tests; the Python test file remains reference-only.",
@@ -811,6 +818,13 @@
       "path": "tests/cli",
       "classification": "functional",
       "rationale": "CLI test deltas cover command contracts and user-visible runtime behavior.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/cli/test_session_boundary_hooks.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream CLI session-boundary hook intent is covered by Rust hermes-agent HookType registration and panic containment plus Rust hermes-cli App tests that invoke on_session_finalize and on_session_reset for /new-style session rotation and same-session reset.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- add Rust plugin lifecycle dispatch for session finalize/reset across gateway and CLI resets
- rotate logical gateway session IDs on reset while preserving canonical session keys
- finalize active/idle gateway sessions via lifecycle hooks and classify upstream session-boundary hook tests

## Local verification
- cargo fmt --check
- git diff --check
- python3 scripts/validate-intentional-divergence.py --check --allow-warnings
- python3 scripts/run-upstream-slash-parity-gate.py --repo-root . --local-ref HEAD --upstream-ref upstream/main --json
- python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --local-mode worktree --upstream-ref upstream/main --json
- bash scripts/check-runtime-placeholders.sh
- bash scripts/check-rust-runtime-no-python.sh
- cargo test -p hermes-parity-tests --test global_parity_governance
- cargo test --workspace
- cargo build --workspace
