### PR TITLE
Cover Telegram adapter parity contracts

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -25226,9 +25226,9 @@ mod tests {
         let usage = latest_ui_assistant_text(&app);
         assert!(usage.contains("Usage: /handoff <platform>"));
 
-        handle_handoff_command(&mut app, &["telegram"]).expect("handoff unknown platform");
+        handle_handoff_command(&mut app, &["pagerduty"]).expect("handoff unknown platform");
         let unknown = latest_ui_assistant_text(&app);
-        assert!(unknown.contains("Unknown platform 'telegram'"));
+        assert!(unknown.contains("Unknown platform 'pagerduty'"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4048,11 +4048,17 @@ fn build_telegram_config(
     TelegramConfig {
         token,
         webhook_url: platform_cfg.webhook_url.clone(),
+        webhook_secret: extra_string(platform_cfg, "webhook_secret")
+            .or_else(|| std::env::var("TELEGRAM_WEBHOOK_SECRET").ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
         polling,
         proxy: Default::default(),
         parse_markdown,
         parse_html,
         poll_timeout,
+        reply_to_mode: reply_to_mode_string(platform_cfg).unwrap_or_else(|| "first".to_string()),
+        reactions: extra_bool(platform_cfg, "reactions", false),
         bot_username: None,
     }
 }
@@ -4122,6 +4128,10 @@ fn extra_string_set(platform_cfg: &PlatformConfig, key: &str) -> HashSet<String>
 }
 
 fn discord_reply_to_mode_string(platform_cfg: &PlatformConfig) -> Option<String> {
+    reply_to_mode_string(platform_cfg)
+}
+
+fn reply_to_mode_string(platform_cfg: &PlatformConfig) -> Option<String> {
     let raw = platform_cfg.extra.get("reply_to_mode")?;
     let candidate = match raw {
         serde_json::Value::String(value) => value.trim().to_ascii_lowercase(),
@@ -14224,6 +14234,49 @@ mod tests {
     }
 
     #[test]
+    fn build_telegram_config_reads_reply_secret_and_reactions() {
+        let _guard = env_lock();
+        let previous_secret = std::env::var("TELEGRAM_WEBHOOK_SECRET").ok();
+        std::env::set_var("TELEGRAM_WEBHOOK_SECRET", "env-secret");
+
+        let mut platform = PlatformConfig {
+            webhook_url: Some("https://hooks.example.com/tg".to_string()),
+            ..PlatformConfig::default()
+        };
+        platform
+            .extra
+            .insert("reply_to_mode".to_string(), serde_json::json!("all"));
+        platform
+            .extra
+            .insert("reactions".to_string(), serde_json::json!(true));
+
+        let cfg = build_telegram_config(&platform, "token".to_string());
+        assert_eq!(
+            cfg.webhook_url.as_deref(),
+            Some("https://hooks.example.com/tg")
+        );
+        assert_eq!(cfg.webhook_secret.as_deref(), Some("env-secret"));
+        assert_eq!(cfg.reply_to_mode, "all");
+        assert!(cfg.reactions);
+
+        match previous_secret {
+            Some(value) => std::env::set_var("TELEGRAM_WEBHOOK_SECRET", value),
+            None => std::env::remove_var("TELEGRAM_WEBHOOK_SECRET"),
+        }
+    }
+
+    #[test]
+    fn build_telegram_config_maps_yaml_boolean_off_reply_mode() {
+        let mut platform = PlatformConfig::default();
+        platform
+            .extra
+            .insert("reply_to_mode".to_string(), serde_json::json!(false));
+
+        let cfg = build_telegram_config(&platform, "token".to_string());
+        assert_eq!(cfg.reply_to_mode, "off");
+    }
+
+    #[test]
     fn gateway_platform_access_policy_reads_discord_channel_lists() {
         let mut config = hermes_config::GatewayConfig::default();
         let mut discord = PlatformConfig {
@@ -15116,6 +15169,9 @@ max_turns: 50
         telegram
             .extra
             .insert("polling".to_string(), serde_json::json!(false));
+        telegram
+            .extra
+            .insert("webhook_secret".to_string(), serde_json::json!("tg-secret"));
         config.platforms.insert("telegram".to_string(), telegram);
 
         let mut weixin = make_platform(true, Some("wx-token"));

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -26,7 +26,7 @@ fn env_bool(raw: &str) -> bool {
     matches!(raw.to_lowercase().as_str(), "1" | "true" | "yes" | "on")
 }
 
-fn discord_reply_to_mode(raw: &str) -> Option<&'static str> {
+fn reply_to_mode(raw: &str) -> Option<&'static str> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "off" => Some("off"),
         "first" => Some("first"),
@@ -37,6 +37,52 @@ fn discord_reply_to_mode(raw: &str) -> Option<&'static str> {
 
 fn set_extra(pc: &mut PlatformConfig, key: &str, val: Value) {
     pc.extra.insert(key.to_string(), val);
+}
+
+fn apply_telegram_env(config: &mut GatewayConfig) {
+    let token = env_nonempty("TELEGRAM_BOT_TOKEN");
+    let webhook_url = env_nonempty("TELEGRAM_WEBHOOK_URL");
+    let webhook_secret = env_nonempty("TELEGRAM_WEBHOOK_SECRET");
+    let reply_mode = env_nonempty("TELEGRAM_REPLY_TO_MODE").and_then(|v| reply_to_mode(&v));
+    let reactions = env_nonempty("TELEGRAM_REACTIONS");
+
+    if token.is_none()
+        && webhook_url.is_none()
+        && webhook_secret.is_none()
+        && reply_mode.is_none()
+        && reactions.is_none()
+    {
+        return;
+    }
+
+    let telegram = config
+        .platforms
+        .entry("telegram".into())
+        .or_insert_with(PlatformConfig::default);
+
+    if let Some(token) = token {
+        let enabled_was_explicit = telegram
+            .extra
+            .remove("_enabled_explicit")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !telegram.enabled && !enabled_was_explicit {
+            telegram.enabled = true;
+        }
+        telegram.token = Some(token);
+    }
+    if let Some(v) = webhook_url {
+        telegram.webhook_url = Some(v);
+    }
+    if let Some(v) = webhook_secret {
+        set_extra(telegram, "webhook_secret", json!(v));
+    }
+    if let Some(mode) = reply_mode {
+        set_extra(telegram, "reply_to_mode", json!(mode));
+    }
+    if let Some(v) = reactions {
+        set_extra(telegram, "reactions", json!(env_bool(&v)));
+    }
 }
 
 fn apply_weixin_env(config: &mut GatewayConfig) {
@@ -184,7 +230,7 @@ fn apply_discord_env(config: &mut GatewayConfig) {
         set_extra(discord, "reactions", json!(env_bool(&v)));
     }
     if let Some(v) = env_nonempty("DISCORD_REPLY_TO_MODE") {
-        if let Some(mode) = discord_reply_to_mode(&v) {
+        if let Some(mode) = reply_to_mode(&v) {
             set_extra(discord, "reply_to_mode", json!(mode));
         }
     }
@@ -222,6 +268,7 @@ fn apply_discord_env(config: &mut GatewayConfig) {
 
 /// 应用与 Python 文档一致的平台环境变量到 `platforms`。
 pub fn apply_python_named_platform_env(config: &mut GatewayConfig) {
+    apply_telegram_env(config);
     apply_discord_env(config);
     apply_weixin_env(config);
     apply_dingtalk_env(config);
@@ -273,6 +320,74 @@ mod tests {
             std::env::remove_var("WEIXIN_TOKEN");
             std::env::remove_var("WEIXIN_DM_POLICY");
             std::env::remove_var("WEIXIN_ALLOWED_USERS");
+        }
+    }
+
+    #[test]
+    fn telegram_env_sets_reply_reactions_webhook_secret_and_token() {
+        let _env = env_lock();
+        unsafe {
+            std::env::set_var("TELEGRAM_BOT_TOKEN", "telegram-token");
+            std::env::set_var("TELEGRAM_WEBHOOK_URL", "https://hooks.example.com/tg");
+            std::env::set_var("TELEGRAM_WEBHOOK_SECRET", "telegram-secret");
+            std::env::set_var("TELEGRAM_REPLY_TO_MODE", "ALL");
+            std::env::set_var("TELEGRAM_REACTIONS", "1");
+        }
+        let mut cfg = GatewayConfig::default();
+        apply_python_named_platform_env(&mut cfg);
+        let telegram = cfg.platforms.get("telegram").expect("telegram block");
+        assert!(telegram.enabled);
+        assert_eq!(telegram.token.as_deref(), Some("telegram-token"));
+        assert_eq!(
+            telegram.webhook_url.as_deref(),
+            Some("https://hooks.example.com/tg")
+        );
+        assert_eq!(
+            telegram
+                .extra
+                .get("webhook_secret")
+                .and_then(|v| v.as_str()),
+            Some("telegram-secret")
+        );
+        assert_eq!(
+            telegram.extra.get("reply_to_mode").and_then(|v| v.as_str()),
+            Some("all")
+        );
+        assert_eq!(
+            telegram.extra.get("reactions").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        unsafe {
+            std::env::remove_var("TELEGRAM_BOT_TOKEN");
+            std::env::remove_var("TELEGRAM_WEBHOOK_URL");
+            std::env::remove_var("TELEGRAM_WEBHOOK_SECRET");
+            std::env::remove_var("TELEGRAM_REPLY_TO_MODE");
+            std::env::remove_var("TELEGRAM_REACTIONS");
+        }
+    }
+
+    #[test]
+    fn telegram_reply_to_mode_env_ignores_invalid_values() {
+        let _env = env_lock();
+        unsafe {
+            std::env::set_var("TELEGRAM_REPLY_TO_MODE", "banana");
+        }
+        let mut cfg = GatewayConfig::default();
+        cfg.platforms
+            .entry("telegram".into())
+            .or_default()
+            .extra
+            .insert("reply_to_mode".into(), json!("off"));
+
+        apply_python_named_platform_env(&mut cfg);
+        let telegram = cfg.platforms.get("telegram").expect("telegram block");
+        assert_eq!(
+            telegram.extra.get("reply_to_mode").and_then(|v| v.as_str()),
+            Some("off")
+        );
+
+        unsafe {
+            std::env::remove_var("TELEGRAM_REPLY_TO_MODE");
         }
     }
 

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -494,6 +494,18 @@ impl Gateway {
                 error: "❌",
             });
         }
+        if incoming.platform.eq_ignore_ascii_case("telegram")
+            && matches!(
+                access_policy.and_then(|policy| policy.reactions_enabled),
+                Some(true)
+            )
+        {
+            return Some(ReactionLifecyclePlan {
+                start: "👀",
+                success: "👍",
+                error: "👎",
+            });
+        }
         None
     }
 
@@ -4003,6 +4015,57 @@ mod tests {
         };
         assert!(gw.route_message(&incoming).await.is_ok());
         assert!(reactions.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn gateway_telegram_reactions_require_explicit_policy_enable() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let reactions = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(ReactionTestAdapter {
+            messages: sent.clone(),
+            reactions: reactions.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("telegram", adapter).await;
+        gw.set_message_handler(Arc::new(|_messages| {
+            Box::pin(async { Ok("done".to_string()) })
+        }))
+        .await;
+
+        let incoming = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "123".into(),
+            user_id: "user1".into(),
+            text: "hello".into(),
+            message_id: Some("456".into()),
+            is_dm: true,
+        };
+        assert!(gw.route_message(&incoming).await.is_ok());
+        assert!(reactions.lock().unwrap().is_empty());
+
+        let mut policies = HashMap::new();
+        policies.insert(
+            "telegram".to_string(),
+            PlatformAccessPolicy {
+                reactions_enabled: Some(true),
+                ..PlatformAccessPolicy::default()
+            },
+        );
+        gw.set_platform_access_policies(policies).await;
+
+        assert!(gw.route_message(&incoming).await.is_ok());
+        assert_eq!(
+            reactions.lock().unwrap().clone(),
+            vec![
+                "add:123:456:👀".to_string(),
+                "remove:123:456:👀".to_string(),
+                "add:123:456:👍".to_string()
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -40,7 +40,9 @@ const RATE_LIMIT_MAX_RETRIES: u32 = 3;
 const TELEGRAM_MAX_DOCUMENT_SIZE_BYTES: u64 = 20 * 1024 * 1024;
 
 /// Supported document extensions for Telegram document processing.
-const SUPPORTED_DOCUMENT_EXTENSIONS: &[&str] = &["pdf", "md", "txt", "docx", "xlsx", "pptx"];
+const SUPPORTED_DOCUMENT_EXTENSIONS: &[&str] = &[
+    "pdf", "md", "txt", "docx", "xlsx", "pptx", "zip", "png", "jpg", "jpeg",
+];
 
 // ---------------------------------------------------------------------------
 // TelegramConfig
@@ -55,6 +57,10 @@ pub struct TelegramConfig {
     /// Optional webhook URL for receiving updates.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub webhook_url: Option<String>,
+
+    /// Secret token required for webhook delivery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub webhook_secret: Option<String>,
 
     /// Whether to use polling (true) or webhooks (false) for updates.
     #[serde(default = "default_true")]
@@ -76,6 +82,14 @@ pub struct TelegramConfig {
     #[serde(default = "default_poll_timeout")]
     pub poll_timeout: u64,
 
+    /// Reply threading behavior for split replies: off, first, or all.
+    #[serde(default = "default_reply_to_mode")]
+    pub reply_to_mode: String,
+
+    /// Whether Telegram message reactions are enabled.
+    #[serde(default)]
+    pub reactions: bool,
+
     /// Bot username (without @), used for mention filtering in groups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bot_username: Option<String>,
@@ -87,6 +101,36 @@ fn default_true() -> bool {
 
 fn default_poll_timeout() -> u64 {
     DEFAULT_POLL_TIMEOUT
+}
+
+fn default_reply_to_mode() -> String {
+    "first".to_string()
+}
+
+/// Effective behavior for Telegram reply anchors across split chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelegramReplyToMode {
+    Off,
+    First,
+    All,
+}
+
+impl TelegramReplyToMode {
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(mode) if mode.eq_ignore_ascii_case("off") => Self::Off,
+            Some(mode) if mode.eq_ignore_ascii_case("all") => Self::All,
+            _ => Self::First,
+        }
+    }
+
+    pub fn references_chunk(self, chunk_index: usize) -> bool {
+        match self {
+            Self::Off => false,
+            Self::First => chunk_index == 0,
+            Self::All => true,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +416,8 @@ pub struct TelegramAdapter {
 impl TelegramAdapter {
     /// Create a new Telegram adapter with the given configuration.
     pub fn new(config: TelegramConfig) -> Result<Self, GatewayError> {
+        Self::validate_webhook_secret(&config)?;
+
         let base = BasePlatformAdapter::new(&config.token).with_proxy(config.proxy.clone());
 
         base.validate_token()?;
@@ -395,6 +441,67 @@ impl TelegramAdapter {
     /// Get a reference to the configuration.
     pub fn config(&self) -> &TelegramConfig {
         &self.config
+    }
+
+    fn validate_webhook_secret(config: &TelegramConfig) -> Result<(), GatewayError> {
+        let webhook_url = config.webhook_url.as_deref().map(str::trim);
+        let webhook_enabled = webhook_url.filter(|s| !s.is_empty()).is_some() || !config.polling;
+        if !webhook_enabled {
+            return Ok(());
+        }
+
+        let has_secret = config
+            .webhook_secret
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_some();
+        if has_secret {
+            return Ok(());
+        }
+
+        Err(GatewayError::Auth(
+            "Telegram webhook mode requires TELEGRAM_WEBHOOK_SECRET / webhook_secret; \
+             generate one with `openssl rand -hex 32` and set it before enabling webhooks \
+             (GHSA-3vpc-7q5r-276h)"
+                .to_string(),
+        ))
+    }
+
+    pub fn reply_to_mode(&self) -> TelegramReplyToMode {
+        TelegramReplyToMode::parse(Some(&self.config.reply_to_mode))
+    }
+
+    pub fn should_thread_reply(
+        &self,
+        reply_to_message_id: Option<i64>,
+        chunk_index: usize,
+    ) -> bool {
+        reply_to_message_id.is_some() && self.reply_to_mode().references_chunk(chunk_index)
+    }
+
+    /// Merge media captions without using substring checks that drop distinct captions.
+    pub fn merge_caption(existing: Option<&str>, caption: &str) -> String {
+        let caption = caption.trim();
+        let existing = existing.unwrap_or("").trim();
+
+        if existing.is_empty() {
+            return caption.to_string();
+        }
+        if caption.is_empty() {
+            return existing.to_string();
+        }
+
+        let seen = existing
+            .split("\n\n")
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .any(|part| part == caption);
+        if seen {
+            existing.to_string()
+        } else {
+            format!("{existing}\n\n{caption}")
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -461,8 +568,7 @@ impl TelegramAdapter {
                 body["message_thread_id"] = serde_json::Value::Number(thread_id.into());
             }
 
-            // Only reply to the original message for the first chunk.
-            if i == 0 {
+            if self.should_thread_reply(reply_to_message_id, i) {
                 if let Some(reply_id) = reply_to_message_id {
                     body["reply_to_message_id"] = serde_json::Value::Number(reply_id.into());
                 }
@@ -987,7 +1093,7 @@ impl TelegramAdapter {
     pub fn document_exceeds_size_limit(doc: &Document) -> bool {
         doc.file_size
             .map(|sz| sz > TELEGRAM_MAX_DOCUMENT_SIZE_BYTES)
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     fn extract_extension(name: &str) -> Option<String> {
@@ -1003,6 +1109,9 @@ impl TelegramAdapter {
             "application/pdf" => Some("pdf".to_string()),
             "text/markdown" => Some("md".to_string()),
             "text/plain" => Some("txt".to_string()),
+            "application/zip" => Some("zip".to_string()),
+            "image/png" => Some("png".to_string()),
+            "image/jpeg" => Some("jpg".to_string()),
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => {
                 Some("docx".to_string())
             }
@@ -1014,6 +1123,35 @@ impl TelegramAdapter {
             }
             _ => None,
         }
+    }
+
+    async fn set_message_reaction(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        reaction: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        if !self.config.reactions {
+            return Ok(());
+        }
+
+        let message_id = message_id.parse::<i64>().map_err(|_| {
+            GatewayError::SendFailed(format!(
+                "Invalid Telegram message_id for reaction: {message_id}"
+            ))
+        })?;
+        let reaction_value = match reaction {
+            Some(emoji) => serde_json::json!([{ "type": "emoji", "emoji": emoji }]),
+            None => serde_json::json!([]),
+        };
+        let body = serde_json::json!({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "reaction": reaction_value,
+        });
+        let url = format!("{}/setMessageReaction", self.api_base);
+        let _resp: TelegramResponse<bool> = self.post_json(&url, &body).await?;
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1227,6 +1365,25 @@ impl PlatformAdapter for TelegramAdapter {
         Ok(())
     }
 
+    async fn add_reaction(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> Result<(), GatewayError> {
+        self.set_message_reaction(chat_id, message_id, Some(emoji))
+            .await
+    }
+
+    async fn remove_reaction(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        _emoji: &str,
+    ) -> Result<(), GatewayError> {
+        self.set_message_reaction(chat_id, message_id, None).await
+    }
+
     fn is_running(&self) -> bool {
         self.base.is_running()
     }
@@ -1274,6 +1431,29 @@ fn split_message(text: &str, max_len: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_config() -> TelegramConfig {
+        TelegramConfig {
+            token: "fake_token_12345".into(),
+            webhook_url: None,
+            webhook_secret: None,
+            polling: true,
+            proxy: AdapterProxyConfig::default(),
+            parse_markdown: false,
+            parse_html: false,
+            poll_timeout: 30,
+            reply_to_mode: "first".into(),
+            reactions: false,
+            bot_username: None,
+        }
+    }
+
+    fn test_adapter(config: TelegramConfig) -> TelegramAdapter {
+        TelegramAdapter::new(config).unwrap()
+    }
 
     // -----------------------------------------------------------------------
     // split_message tests (original)
@@ -1309,6 +1489,148 @@ mod tests {
         let chunks = split_message(&text, 4096);
         assert_eq!(chunks.len(), 2);
         assert!(chunks[0].ends_with('\n'));
+    }
+
+    #[test]
+    fn telegram_reply_to_mode_parse_and_chunk_policy() {
+        assert_eq!(TelegramReplyToMode::parse(None), TelegramReplyToMode::First);
+        assert_eq!(
+            TelegramReplyToMode::parse(Some("off")),
+            TelegramReplyToMode::Off
+        );
+        assert_eq!(
+            TelegramReplyToMode::parse(Some("ALL")),
+            TelegramReplyToMode::All
+        );
+        assert_eq!(
+            TelegramReplyToMode::parse(Some("invalid")),
+            TelegramReplyToMode::First
+        );
+
+        assert!(!TelegramReplyToMode::Off.references_chunk(0));
+        assert!(TelegramReplyToMode::First.references_chunk(0));
+        assert!(!TelegramReplyToMode::First.references_chunk(1));
+        assert!(TelegramReplyToMode::All.references_chunk(10));
+    }
+
+    #[test]
+    fn telegram_should_thread_reply_respects_reply_mode() {
+        let mut cfg = test_config();
+        cfg.reply_to_mode = "off".into();
+        let adapter = test_adapter(cfg);
+        assert!(!adapter.should_thread_reply(Some(99), 0));
+
+        let mut cfg = test_config();
+        cfg.reply_to_mode = "first".into();
+        let adapter = test_adapter(cfg);
+        assert!(adapter.should_thread_reply(Some(99), 0));
+        assert!(!adapter.should_thread_reply(Some(99), 1));
+        assert!(!adapter.should_thread_reply(None, 0));
+
+        let mut cfg = test_config();
+        cfg.reply_to_mode = "all".into();
+        let adapter = test_adapter(cfg);
+        assert!(adapter.should_thread_reply(Some(99), 0));
+        assert!(adapter.should_thread_reply(Some(99), 2));
+    }
+
+    #[test]
+    fn telegram_merge_caption_uses_exact_dedupe() {
+        assert_eq!(TelegramAdapter::merge_caption(None, "Hello"), "Hello");
+        assert_eq!(
+            TelegramAdapter::merge_caption(Some("Revenue"), "Revenue  "),
+            "Revenue"
+        );
+        assert_eq!(
+            TelegramAdapter::merge_caption(Some("Meeting agenda"), "Meeting"),
+            "Meeting agenda\n\nMeeting"
+        );
+        assert_eq!(
+            TelegramAdapter::merge_caption(Some("Revenue"), "Revenue and Profit"),
+            "Revenue\n\nRevenue and Profit"
+        );
+        let merged = TelegramAdapter::merge_caption(Some("A\n\nB"), "A");
+        assert_eq!(merged, "A\n\nB");
+    }
+
+    #[test]
+    fn telegram_webhook_secret_required_only_for_webhook_mode() {
+        let polling = test_config();
+        assert!(TelegramAdapter::new(polling).is_ok());
+
+        let mut webhook = test_config();
+        webhook.webhook_url = Some("https://hooks.example.com/tg".into());
+        let err = match TelegramAdapter::new(webhook) {
+            Ok(_) => panic!("webhook mode without secret must fail"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("TELEGRAM_WEBHOOK_SECRET"));
+        assert!(err.contains("GHSA-3vpc-7q5r-276h"));
+        assert!(err.contains("openssl rand"));
+
+        let mut webhook = test_config();
+        webhook.webhook_url = Some("https://hooks.example.com/tg".into());
+        webhook.webhook_secret = Some("secret-token".into());
+        assert!(TelegramAdapter::new(webhook).is_ok());
+    }
+
+    #[tokio::test]
+    async fn telegram_reactions_call_set_message_reaction_when_enabled() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/setMessageReaction"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": true
+            })))
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.reactions = true;
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        adapter.add_reaction("123", "456", "👀").await.unwrap();
+        adapter.remove_reaction("123", "456", "👀").await.unwrap();
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 2);
+        let add_json: Value = serde_json::from_slice(&requests[0].body).expect("add json");
+        assert_eq!(
+            add_json.pointer("/chat_id").and_then(|v| v.as_str()),
+            Some("123")
+        );
+        assert_eq!(
+            add_json.pointer("/message_id").and_then(|v| v.as_i64()),
+            Some(456)
+        );
+        assert_eq!(
+            add_json
+                .pointer("/reaction/0/emoji")
+                .and_then(|v| v.as_str()),
+            Some("👀")
+        );
+        let remove_json: Value = serde_json::from_slice(&requests[1].body).expect("remove json");
+        assert_eq!(
+            remove_json
+                .pointer("/reaction")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn telegram_reactions_are_noop_when_disabled() {
+        let server = MockServer::start().await;
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        adapter.add_reaction("123", "456", "👀").await.unwrap();
+
+        let requests = server.received_requests().await.expect("requests");
+        assert!(requests.is_empty());
     }
 
     // -----------------------------------------------------------------------
@@ -1972,6 +2294,24 @@ mod tests {
             file_size: Some(1024),
         };
         assert!(!TelegramAdapter::is_supported_document(&doc_unsupported));
+
+        let zip_doc = Document {
+            file_id: "d4".into(),
+            file_unique_id: None,
+            file_name: Some("archive.zip".into()),
+            mime_type: Some("application/zip".into()),
+            file_size: Some(1024),
+        };
+        assert!(TelegramAdapter::is_supported_document(&zip_doc));
+
+        let png_doc_from_mime = Document {
+            file_id: "d5".into(),
+            file_unique_id: None,
+            file_name: None,
+            mime_type: Some("image/png".into()),
+            file_size: Some(1024),
+        };
+        assert!(TelegramAdapter::is_supported_document(&png_doc_from_mime));
     }
 
     #[test]
@@ -1993,6 +2333,15 @@ mod tests {
             file_size: Some(TELEGRAM_MAX_DOCUMENT_SIZE_BYTES + 1),
         };
         assert!(TelegramAdapter::document_exceeds_size_limit(&large));
+
+        let unknown_size = Document {
+            file_id: "d3".into(),
+            file_unique_id: None,
+            file_name: Some("unknown.pdf".into()),
+            mime_type: Some("application/pdf".into()),
+            file_size: None,
+        };
+        assert!(TelegramAdapter::document_exceeds_size_limit(&unknown_size));
     }
 
     // -----------------------------------------------------------------------
@@ -2000,16 +2349,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn make_adapter_with_bot_username(username: Option<&str>) -> TelegramAdapter {
-        let config = TelegramConfig {
-            token: "fake_token_12345".into(),
-            webhook_url: None,
-            polling: true,
-            proxy: AdapterProxyConfig::default(),
-            parse_markdown: false,
-            parse_html: false,
-            poll_timeout: 30,
-            bot_username: username.map(|s| s.to_string()),
-        };
+        let mut config = test_config();
+        config.bot_username = username.map(|s| s.to_string());
         TelegramAdapter::new(config).unwrap()
     }
 
@@ -2083,6 +2424,9 @@ mod tests {
         assert!(!cfg.parse_markdown);
         assert!(!cfg.parse_html);
         assert_eq!(cfg.poll_timeout, DEFAULT_POLL_TIMEOUT);
+        assert_eq!(cfg.reply_to_mode, "first");
+        assert!(cfg.webhook_secret.is_none());
+        assert!(!cfg.reactions);
         assert!(cfg.bot_username.is_none());
     }
 
@@ -2091,5 +2435,19 @@ mod tests {
         let json = r#"{"token": "abc", "bot_username": "mybot"}"#;
         let cfg: TelegramConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.bot_username, Some("mybot".into()));
+    }
+
+    #[test]
+    fn config_with_reply_mode_webhook_secret_and_reactions() {
+        let json = r#"{
+            "token": "abc",
+            "webhook_secret": "secret",
+            "reply_to_mode": "all",
+            "reactions": true
+        }"#;
+        let cfg: TelegramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.webhook_secret.as_deref(), Some("secret"));
+        assert_eq!(cfg.reply_to_mode, "all");
+        assert!(cfg.reactions);
     }
 }

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -5326,16 +5326,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_telegram_caption_merge.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "09cfd8c3d7ef0a8d873d706787bb0580651235b6",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_telegram_caption_merge.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f5d4390f48378b236606f9636464c08ac71076f2",
       "workstream": "WS6"
@@ -5431,31 +5431,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_telegram_reactions.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "143161e9b7105d13356acc61a337890156723b82",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_telegram_reactions.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8b3b0686bb415a629fa41c532ea4e5d7006749e4",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_telegram_reply_mode.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1389736fe9212520c4eec3459297c34b336cfd68",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_telegram_reply_mode.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f036dc6b785f671217c168302646d9098d628de4",
       "workstream": "WS6"
@@ -5506,16 +5506,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_telegram_webhook_secret.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0f1e786367a9f5e26c4ef95d04a1fc2b462f7f2e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_telegram_webhook_secret.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "268a52e327ee29b5e82bcc56ae5ee3a60f9e0847",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T18:13:55.708786+00:00",
+  "generated_at_utc": "2026-05-30T19:26:25.939028+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "19f552e2a75b1428eeb3e9cf140bc15548fab1dc",
+    "local_ref": "HEAD",
+    "local_sha": "e8df3c5409c13bd96954940833d537b3b35d54dd",
     "upstream_ref": "upstream/main",
     "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 634,
-      "intentional_divergence": 227,
+      "functional": 630,
+      "intentional_divergence": 231,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 397,
-      "rust_equivalent_or_contract_test_required": 550,
+      "not_required_for_runtime": 401,
+      "rust_equivalent_or_contract_test_required": 546,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 227,
+      "cleared_intentional_divergence": 231,
       "cleared_non_runtime": 170,
-      "pending_review": 634
+      "pending_review": 630
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 227,
+    "cleared_intentional_divergence": 231,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 634,
+    "pending_review": 630,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T18:13:55.708786+00:00`
+Generated: `2026-05-30T19:26:25.939028+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `634`
+- Pending functional review: `630`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `227`
+- Cleared intentional divergence: `231`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 227 |
+| `cleared_intentional_divergence` | 231 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 634 |
+| `pending_review` | 630 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-30T18:13:55.708786+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 145 |
+| `tests/gateway` | 141 |
 | `tests/hermes_cli` | 127 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -164,6 +164,34 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_telegram_caption_merge.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Telegram caption exact-dedupe intent is covered by Rust TelegramAdapter::merge_caption tests for empty captions, whitespace-normalized exact duplicates, substring regressions, and multi-caption albums.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_telegram_reactions.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Telegram reaction lifecycle intent is covered by Rust Telegram adapter setMessageReaction contracts, disabled-by-default no-op behavior, config/env reaction hydration, and gateway lifecycle tests requiring explicit Telegram reactions policy.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_telegram_reply_mode.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Telegram reply_to_mode behavior is covered by Rust Telegram reply-mode parsing, chunk-reference policy tests for off/first/all/invalid modes, CLI config hydration, and env/YAML boolean-off bridging.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_telegram_webhook_secret.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Telegram webhook-secret guard is covered by Rust TelegramConfig webhook validation requiring webhook_secret/TELEGRAM_WEBHOOK_SECRET with GHSA remediation text while leaving polling mode unaffected.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/gateway/test_discord_allowed_mentions.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Discord allowed_mentions safe-default intent is covered by Rust hermes-gateway DiscordAllowedMentions payload construction and env-style parsing tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- add Telegram webhook secret enforcement for webhook/non-polling mode
- add Telegram reply-to modes, caption exact-dedupe, document size/mime coverage, and reaction API support
- hydrate Telegram env/config through the Rust config and CLI path
- gate gateway reaction lifecycle behind explicit platform policy
- classify covered Telegram shared-different fixtures and refresh the parity backlog

## Local verification
- cargo fmt --all
- cargo test -p hermes-gateway --features telegram telegram_ -- --nocapture
- cargo test -p hermes-config telegram_ -- --nocapture
- cargo test -p hermes-cli build_telegram_config -- --nocapture
- cargo test -p hermes-gateway --features telegram
- cargo test -p hermes-parity-tests
- cargo test --workspace
- cargo build --workspace