### PR TITLE
Isolate approval session-state tests

### DIFF
--- a/crates/hermes-tools/src/approval.rs
+++ b/crates/hermes-tools/src/approval.rs
@@ -1683,6 +1683,8 @@ mod tests {
 
     #[test]
     fn test_session_scoped_yolo_only_bypasses_current_session() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
@@ -1715,10 +1717,13 @@ mod tests {
 
         clear_session("session-a");
         clear_session("session-b");
+        reset_approval_state_unlocked();
     }
 
     #[test]
     fn test_session_scoped_yolo_does_not_bypass_hardline_or_sudo_floor() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
@@ -1742,6 +1747,7 @@ mod tests {
         );
 
         clear_session("session-a");
+        reset_approval_state_unlocked();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- serialize session-scoped yolo tests on the approval-state lock
- reset shared approval/session state before and after those mutations

## Local verification
- cargo fmt --all
- git diff --check
- cargo test -p hermes-tools approval::tests -- --nocapture
- cargo test -p hermes-tools --lib

Hosted GitHub CI is intentionally optional for this repo; local gates above are the required checks.