### PR TITLE
Drop obsolete shared-different workflow metric

### DIFF
--- a/.github/workflows/parity-audit.yml
+++ b/.github/workflows/parity-audit.yml
@@ -88,7 +88,6 @@ jobs:
               print(f"- commits_behind: `{metrics.get('max_commits_behind')}`")
               print(f"- upstream_patch_missing: `{metrics.get('max_upstream_patch_missing')}`")
               print(f"- files_only_upstream: `{metrics.get('max_files_only_upstream')}`")
-              print(f"- shared_different: `{metrics.get('max_shared_different')}`")
               if backlog_summary:
                   print(f"- shared_diff_pending_classification: `{backlog_summary.get('pending_classification')}`")
                   print(f"- shared_diff_pending_review: `{backlog_summary.get('pending_review')}`")


### PR DESCRIPTION
## Summary
- remove the stale max_shared_different failure-comment metric from the parity audit workflow
- leave the shared-diff backlog summary metrics as the source of truth

## Local verification
- rg -n "max_shared_different|max-shared-different" . -g '!target'
- git diff --check

Hosted GitHub CI is intentionally optional for this repo; local gates are the required checks.