### PR TITLE
parity(cli): cover API key provider registry

### DIFF
--- a/crates/hermes-acp/src/auth.rs
+++ b/crates/hermes-acp/src/auth.rs
@@ -179,13 +179,19 @@ fn provider_env_key_names(provider: &str) -> &'static [&'static str] {
         "kimi" => &["MOONSHOT_API_KEY"],
         "minimax" => &["MINIMAX_API_KEY"],
         "nous" => &["NOUS_API_KEY", "HERMES_NOUS_API_KEY"],
-        "copilot" | "copilot-acp" => &["GITHUB_COPILOT_TOKEN"],
+        "copilot" | "copilot-acp" => &[
+            "COPILOT_GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "GITHUB_COPILOT_TOKEN",
+        ],
         "stepfun" => &["STEPFUN_API_KEY"],
         "ai-gateway" => &["AI_GATEWAY_API_KEY"],
         "novita" => &["NOVITA_API_KEY"],
         "xai" => &["XAI_API_KEY"],
         "nvidia" => &["NVIDIA_API_KEY"],
         "kilocode" => &["KILOCODE_API_KEY"],
+        "gmi" => &["GMI_API_KEY"],
         "huggingface" => &["HF_TOKEN", "HUGGINGFACE_API_KEY"],
         "zai" => &["ZAI_API_KEY"],
         "arcee" => &["ARCEE_API_KEY"],
@@ -311,6 +317,19 @@ mod tests {
         assert_eq!(
             detect_provider_from_config(&config).as_deref(),
             Some("kimi")
+        );
+    }
+
+    #[test]
+    fn copilot_credentials_accept_upstream_env_aliases() {
+        assert_eq!(
+            provider_env_key_names("copilot"),
+            &[
+                "COPILOT_GITHUB_TOKEN",
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+                "GITHUB_COPILOT_TOKEN"
+            ]
         );
     }
 }

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -2673,8 +2673,14 @@ impl AgentLoop {
             "nous" => std::env::var("NOUS_API_KEY")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
-            "copilot" | "copilot-acp" => std::env::var("GITHUB_COPILOT_TOKEN")
+            "copilot" | "copilot-acp" => std::env::var("COPILOT_GITHUB_TOKEN")
                 .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("GH_TOKEN").ok())
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("GITHUB_TOKEN").ok())
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("GITHUB_COPILOT_TOKEN").ok())
                 .filter(|v| !v.trim().is_empty()),
             _ => None,
         }
@@ -2709,6 +2715,8 @@ impl AgentLoop {
                     Some("cloudcode-pa://google".to_string())
                 } else if provider == "stepfun" {
                     Some("https://api.stepfun.ai/step_plan/v1".to_string())
+                } else if provider == "copilot" {
+                    Some("https://api.githubcopilot.com".to_string())
                 } else {
                     None
                 }
@@ -3266,7 +3274,7 @@ impl AgentLoop {
             }
             "copilot" | "copilot-acp" => {
                 let p = CopilotProvider::new(
-                    base_url.unwrap_or_else(|| "https://api.github.com/copilot".to_string()),
+                    base_url.unwrap_or_else(|| "https://api.githubcopilot.com".to_string()),
                     &api_key,
                 )
                 .with_model(model_name);
@@ -9152,6 +9160,12 @@ mod tests {
             std::env::set_var(key, value);
             Self { key, previous }
         }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
     }
 
     impl Drop for EnvVarGuard {
@@ -13037,6 +13051,7 @@ mod tests {
     #[test]
     fn test_runtime_provider_stepfun_env_key_and_base_url_defaults() {
         use futures::stream::BoxStream;
+        let _guard = env_test_lock();
 
         struct DummyProvider;
         #[async_trait::async_trait]
@@ -13077,14 +13092,69 @@ mod tests {
             Arc::new(DummyProvider),
         );
 
-        std::env::remove_var("HERMES_STEPFUN_API_KEY");
-        std::env::set_var("STEPFUN_API_KEY", "stepfun-secret");
+        let _hermes_stepfun = EnvVarGuard::remove("HERMES_STEPFUN_API_KEY");
+        let _stepfun = EnvVarGuard::set("STEPFUN_API_KEY", "stepfun-secret");
         let resolved = agent.resolve_runtime_api_key("stepfun", None, None);
         assert_eq!(resolved.as_deref(), Some("stepfun-secret"));
-        std::env::remove_var("STEPFUN_API_KEY");
 
         let base = agent.resolve_runtime_base_url("stepfun", None);
         assert_eq!(base.as_deref(), Some("https://api.stepfun.ai/step_plan/v1"));
+    }
+
+    #[test]
+    fn test_runtime_provider_copilot_env_aliases_and_base_url_default() {
+        use futures::stream::BoxStream;
+        let _guard = env_test_lock();
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let _copilot_github = EnvVarGuard::remove("COPILOT_GITHUB_TOKEN");
+        let _gh = EnvVarGuard::remove("GH_TOKEN");
+        let _github_token = EnvVarGuard::remove("GITHUB_TOKEN");
+        let _legacy = EnvVarGuard::remove("GITHUB_COPILOT_TOKEN");
+        let agent = AgentLoop::new(
+            AgentConfig::default(),
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+
+        let _github_token_override = EnvVarGuard::set("GITHUB_TOKEN", "gh-env-secret");
+        let resolved = agent.resolve_runtime_api_key("copilot", None, None);
+        assert_eq!(resolved.as_deref(), Some("gh-env-secret"));
+
+        let base = agent.resolve_runtime_base_url("copilot", None);
+        assert_eq!(base.as_deref(), Some("https://api.githubcopilot.com"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4679,10 +4679,46 @@ mod tests {
 
     #[test]
     fn test_provider_api_key_from_env_supports_extended_registry() {
+        let _guard = env_test_lock();
+        let env_vars = [
+            "AI_GATEWAY_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "HF_TOKEN",
+            "KILOCODE_API_KEY",
+            "NVIDIA_API_KEY",
+            "OLLAMA_LOCAL_API_KEY",
+            "LLAMA_CPP_API_KEY",
+            "VLLM_API_KEY",
+            "MLX_API_KEY",
+            "APPLE_ANE_API_KEY",
+            "SGLANG_API_KEY",
+            "TGI_API_KEY",
+            "NOVITA_API_KEY",
+            "OPENCODE_GO_API_KEY",
+            "OPENCODE_ZEN_API_KEY",
+            "XAI_API_KEY",
+            "XIAOMI_API_KEY",
+            "GLM_API_KEY",
+            "ZAI_API_KEY",
+            "Z_AI_API_KEY",
+            "GMI_API_KEY",
+            "MINIMAX_CN_API_KEY",
+            "COPILOT_GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "GITHUB_COPILOT_TOKEN",
+        ];
+        for env_var in env_vars {
+            std::env::remove_var(env_var);
+        }
         let checks = [
             ("AI_GATEWAY_API_KEY", "ai-gateway"),
+            ("AI_GATEWAY_API_KEY", "vercel"),
             ("DEEPSEEK_API_KEY", "deepseek"),
             ("HF_TOKEN", "huggingface"),
+            ("HF_TOKEN", "hf"),
+            ("HF_TOKEN", "hugging-face"),
+            ("HF_TOKEN", "huggingface-hub"),
             ("KILOCODE_API_KEY", "kilocode"),
             ("NVIDIA_API_KEY", "nvidia"),
             ("OLLAMA_LOCAL_API_KEY", "ollama-local"),
@@ -4698,15 +4734,28 @@ mod tests {
             ("XAI_API_KEY", "xai"),
             ("XIAOMI_API_KEY", "xiaomi"),
             ("GLM_API_KEY", "zai"),
+            ("GLM_API_KEY", "glm"),
+            ("ZAI_API_KEY", "z-ai"),
+            ("Z_AI_API_KEY", "zhipu"),
+            ("GMI_API_KEY", "gmi-cloud"),
+            ("MINIMAX_CN_API_KEY", "minimax_cn"),
+            ("COPILOT_GITHUB_TOKEN", "github-copilot"),
+            ("GH_TOKEN", "github-models"),
+            ("GITHUB_TOKEN", "copilot"),
+            ("GITHUB_COPILOT_TOKEN", "copilot"),
         ];
         for (env_var, provider) in checks {
-            std::env::remove_var(env_var);
+            for env_var in env_vars {
+                std::env::remove_var(env_var);
+            }
             let expected = format!("token-for-{provider}");
             std::env::set_var(env_var, expected.clone());
             assert_eq!(
                 provider_api_key_from_env(provider).as_deref(),
                 Some(expected.as_str())
             );
+        }
+        for env_var in env_vars {
             std::env::remove_var(env_var);
         }
     }
@@ -4730,6 +4779,110 @@ mod tests {
         assert_eq!(normalize_runtime_provider_name("llvm"), "vllm");
         assert_eq!(normalize_runtime_provider_name("mlx-lm"), "mlx");
         assert_eq!(normalize_runtime_provider_name("ane"), "apple-ane");
+        assert_eq!(normalize_runtime_provider_name("glm"), "zai");
+        assert_eq!(normalize_runtime_provider_name("z-ai"), "zai");
+        assert_eq!(normalize_runtime_provider_name("zhipu"), "zai");
+        assert_eq!(normalize_runtime_provider_name("github-copilot"), "copilot");
+        assert_eq!(normalize_runtime_provider_name("github-models"), "copilot");
+        assert_eq!(
+            normalize_runtime_provider_name("github-copilot-acp"),
+            "copilot-acp"
+        );
+        assert_eq!(
+            normalize_runtime_provider_name("copilot-acp-agent"),
+            "copilot-acp"
+        );
+        assert_eq!(normalize_runtime_provider_name("hf"), "huggingface");
+        assert_eq!(
+            normalize_runtime_provider_name("hugging-face"),
+            "huggingface"
+        );
+        assert_eq!(
+            normalize_runtime_provider_name("huggingface-hub"),
+            "huggingface"
+        );
+        assert_eq!(normalize_runtime_provider_name("aigateway"), "ai-gateway");
+        assert_eq!(normalize_runtime_provider_name("vercel"), "ai-gateway");
+        assert_eq!(normalize_runtime_provider_name("gmi-cloud"), "gmi");
+    }
+
+    #[test]
+    fn test_provider_base_url_from_env_supports_api_provider_aliases() {
+        let _guard = env_test_lock();
+        let env_vars = [
+            "COPILOT_API_BASE_URL",
+            "GLM_BASE_URL",
+            "KIMI_BASE_URL",
+            "MINIMAX_CN_BASE_URL",
+            "GMI_BASE_URL",
+            "HF_BASE_URL",
+            "AI_GATEWAY_BASE_URL",
+        ];
+        for env_var in env_vars {
+            std::env::remove_var(env_var);
+        }
+
+        std::env::set_var("COPILOT_API_BASE_URL", "https://copilot.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("github-copilot").as_deref(),
+            Some("https://copilot.example/v1")
+        );
+        std::env::set_var("GLM_BASE_URL", "https://glm.example/v4");
+        assert_eq!(
+            provider_base_url_from_env("z-ai").as_deref(),
+            Some("https://glm.example/v4")
+        );
+        std::env::set_var("KIMI_BASE_URL", "https://kimi.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("moonshot").as_deref(),
+            Some("https://kimi.example/v1")
+        );
+        std::env::set_var("MINIMAX_CN_BASE_URL", "https://minimax-cn.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("minimax_cn").as_deref(),
+            Some("https://minimax-cn.example/v1")
+        );
+        std::env::set_var("GMI_BASE_URL", "https://gmi.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("gmi-cloud").as_deref(),
+            Some("https://gmi.example/v1")
+        );
+        std::env::set_var("HF_BASE_URL", "https://hf.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("huggingface-hub").as_deref(),
+            Some("https://hf.example/v1")
+        );
+        std::env::set_var("AI_GATEWAY_BASE_URL", "https://gateway.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("vercel").as_deref(),
+            Some("https://gateway.example/v1")
+        );
+
+        for env_var in env_vars {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    #[test]
+    fn test_provider_default_base_url_supports_upstream_aliases() {
+        assert_eq!(
+            provider_default_base_url("github-copilot"),
+            Some(COPILOT_BASE_URL)
+        );
+        assert_eq!(provider_default_base_url("glm"), Some(ZAI_BASE_URL));
+        assert_eq!(
+            provider_default_base_url("minimax_cn"),
+            Some(MINIMAX_CN_BASE_URL)
+        );
+        assert_eq!(
+            provider_default_base_url("huggingface-hub"),
+            Some(HUGGINGFACE_BASE_URL)
+        );
+        assert_eq!(
+            provider_default_base_url("vercel"),
+            Some(AI_GATEWAY_BASE_URL)
+        );
+        assert_eq!(provider_default_base_url("gmi-cloud"), Some(GMI_BASE_URL));
     }
 
     #[test]
@@ -5480,10 +5633,12 @@ const MINIMAX_CN_BASE_URL: &str = "https://api.minimaxi.com/anthropic";
 const NOVITA_BASE_URL: &str = "https://api.novita.ai/openai/v1";
 const XAI_BASE_URL: &str = "https://api.x.ai/v1";
 const NVIDIA_BASE_URL: &str = "https://integrate.api.nvidia.com/v1";
+const COPILOT_BASE_URL: &str = "https://api.githubcopilot.com";
 const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
 const KILOCODE_BASE_URL: &str = "https://api.kilo.ai/api/gateway";
 const HUGGINGFACE_BASE_URL: &str = "https://router.huggingface.co/v1";
+const GMI_BASE_URL: &str = "https://api.gmi-serving.com/v1";
 const XIAOMI_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
 const ZAI_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
 const ARCEE_BASE_URL: &str = "https://api.arcee.ai/api/v1";
@@ -5509,6 +5664,12 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
         "minimax-cn" => "minimax".to_string(),
         "novita-ai" | "novitaai" => "novita".to_string(),
+        "glm" | "z-ai" | "z_ai" | "zhipu" => "zai".to_string(),
+        "aigateway" | "vercel" => "ai-gateway".to_string(),
+        "github-copilot" | "github-models" => "copilot".to_string(),
+        "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
+        "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
+        "gmi-cloud" => "gmi".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
@@ -5530,19 +5691,21 @@ fn provider_default_base_url(provider: &str) -> Option<&'static str> {
         "qwen" | "alibaba" => Some(QWEN_BASE_URL),
         "alibaba-coding-plan" => Some(ALIBABA_CODING_PLAN_BASE_URL),
         "stepfun" | "step" | "step-plan" => Some(STEPFUN_BASE_URL),
-        "ai-gateway" => Some(AI_GATEWAY_BASE_URL),
+        "ai-gateway" | "aigateway" | "vercel" => Some(AI_GATEWAY_BASE_URL),
         "kimi-coding" => Some(KIMI_CODING_BASE_URL),
         "kimi-coding-cn" | "moonshot" | "kimi" => Some(KIMI_CODING_CN_BASE_URL),
-        "minimax-cn" => Some(MINIMAX_CN_BASE_URL),
+        "minimax-cn" | "minimax_cn" => Some(MINIMAX_CN_BASE_URL),
         "novita" | "novita-ai" | "novitaai" => Some(NOVITA_BASE_URL),
         "xai" => Some(XAI_BASE_URL),
         "nvidia" => Some(NVIDIA_BASE_URL),
+        "copilot" | "github-copilot" | "github-models" => Some(COPILOT_BASE_URL),
         "opencode-go" => Some(OPENCODE_GO_BASE_URL),
         "opencode-zen" | "opencode" => Some(OPENCODE_ZEN_BASE_URL),
         "kilocode" | "kilo" => Some(KILOCODE_BASE_URL),
-        "huggingface" => Some(HUGGINGFACE_BASE_URL),
+        "huggingface" | "hf" | "hugging-face" | "huggingface-hub" => Some(HUGGINGFACE_BASE_URL),
+        "gmi" | "gmi-cloud" => Some(GMI_BASE_URL),
         "xiaomi" => Some(XIAOMI_BASE_URL),
-        "zai" => Some(ZAI_BASE_URL),
+        "zai" | "glm" | "z-ai" | "z_ai" | "zhipu" => Some(ZAI_BASE_URL),
         "arcee" => Some(ARCEE_BASE_URL),
         "ollama-cloud" => Some(OLLAMA_CLOUD_BASE_URL),
         "ollama-local" | "ollama" => Some(OLLAMA_LOCAL_BASE_URL),
@@ -5732,15 +5895,44 @@ fn default_rtk_raw_mode() -> bool {
 }
 
 fn provider_base_url_from_env(provider: &str) -> Option<String> {
-    let env_var = match provider.trim().to_ascii_lowercase().as_str() {
-        "ollama-local" | "ollama" => "OLLAMA_BASE_URL",
-        "llama-cpp" | "llama.cpp" | "llamacpp" => "LLAMA_CPP_BASE_URL",
-        "vllm" | "ollvm" | "llvm" => "VLLM_BASE_URL",
-        "mlx" | "mlx-lm" | "apple-mlx" => "MLX_BASE_URL",
-        "apple-ane" | "ane" | "apple-neural-engine" => "APPLE_ANE_BASE_URL",
-        "sglang" => "SGLANG_BASE_URL",
-        "tgi" | "text-generation-inference" => "TGI_BASE_URL",
-        _ => return None,
+    let raw_provider = provider.trim().to_ascii_lowercase();
+    let normalized_provider = normalize_runtime_provider_name(raw_provider.as_str());
+    let env_var = match raw_provider.as_str() {
+        "minimax-cn" | "minimax_cn" => "MINIMAX_CN_BASE_URL",
+        _ => match normalized_provider.as_str() {
+            "openai" => "OPENAI_BASE_URL",
+            "openai-codex" | "codex" => "HERMES_OPENAI_CODEX_BASE_URL",
+            "anthropic" => "ANTHROPIC_BASE_URL",
+            "google-gemini-cli" => "HERMES_GEMINI_BASE_URL",
+            "gemini" | "google" => "GEMINI_BASE_URL",
+            "qwen" => "DASHSCOPE_BASE_URL",
+            "qwen-oauth" => "HERMES_QWEN_BASE_URL",
+            "stepfun" => "STEPFUN_BASE_URL",
+            "ai-gateway" => "AI_GATEWAY_BASE_URL",
+            "kimi" => "KIMI_BASE_URL",
+            "minimax" => "MINIMAX_BASE_URL",
+            "novita" => "NOVITA_BASE_URL",
+            "xai" => "XAI_BASE_URL",
+            "nvidia" => "NVIDIA_BASE_URL",
+            "copilot" => "COPILOT_API_BASE_URL",
+            "opencode-go" => "OPENCODE_GO_BASE_URL",
+            "opencode-zen" => "OPENCODE_ZEN_BASE_URL",
+            "kilocode" => "KILOCODE_BASE_URL",
+            "huggingface" => "HF_BASE_URL",
+            "gmi" => "GMI_BASE_URL",
+            "xiaomi" => "XIAOMI_BASE_URL",
+            "zai" => "GLM_BASE_URL",
+            "arcee" => "ARCEE_BASE_URL",
+            "deepseek" => "DEEPSEEK_BASE_URL",
+            "ollama-local" | "ollama" => "OLLAMA_BASE_URL",
+            "llama-cpp" | "llama.cpp" | "llamacpp" => "LLAMA_CPP_BASE_URL",
+            "vllm" | "ollvm" | "llvm" => "VLLM_BASE_URL",
+            "mlx" | "mlx-lm" | "apple-mlx" => "MLX_BASE_URL",
+            "apple-ane" | "ane" | "apple-neural-engine" => "APPLE_ANE_BASE_URL",
+            "sglang" => "SGLANG_BASE_URL",
+            "tgi" | "text-generation-inference" => "TGI_BASE_URL",
+            _ => return None,
+        },
     };
     std::env::var(env_var)
         .ok()
@@ -5798,7 +5990,15 @@ fn url_is_local_or_private(base_url: &str) -> bool {
 
 /// Resolve API key / token for a named LLM provider from well-known environment variables.
 pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
-    let provider = normalize_runtime_provider_name(provider);
+    let raw_provider = provider.trim().to_ascii_lowercase();
+    if matches!(raw_provider.as_str(), "minimax-cn" | "minimax_cn") {
+        return std::env::var("MINIMAX_CN_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+            .filter(|s| !s.trim().is_empty());
+    }
+    let provider = normalize_runtime_provider_name(raw_provider.as_str());
     match provider.as_str() {
         "openai" => std::env::var("HERMES_OPENAI_API_KEY")
             .ok()
@@ -5860,8 +6060,14 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
         "nous" => std::env::var("NOUS_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
-        "copilot" => std::env::var("GITHUB_COPILOT_TOKEN")
+        "copilot" => std::env::var("COPILOT_GITHUB_TOKEN")
             .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("GH_TOKEN").ok())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("GITHUB_TOKEN").ok())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| std::env::var("GITHUB_COPILOT_TOKEN").ok())
             .filter(|s| !s.trim().is_empty()),
         "ai-gateway" => std::env::var("AI_GATEWAY_API_KEY")
             .ok()
@@ -5875,6 +6081,9 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
             .ok()
             .filter(|s| !s.trim().is_empty()),
         "huggingface" => std::env::var("HF_TOKEN")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "gmi" => std::env::var("GMI_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
         "kilocode" => std::env::var("KILOCODE_API_KEY")
@@ -6055,7 +6264,7 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         }
         "copilot" => {
             let p = CopilotProvider::new(
-                base_url.unwrap_or_else(|| "https://api.github.com/copilot".to_string()),
+                base_url.unwrap_or_else(|| COPILOT_BASE_URL.to_string()),
                 &api_key,
             )
             .with_model(model_name.as_str());

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -5231,11 +5231,13 @@ fn normalize_auth_provider(provider: &str) -> String {
         "glm" | "z-ai" | "z.ai" | "zhipu" => "zai".to_string(),
         "nim" | "nvidia-nim" | "build-nvidia" | "nemotron" => "nvidia".to_string(),
         "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
+        "gmi-cloud" => "gmi".to_string(),
         "api-server" => "api_server".to_string(),
         "home-assistant" => "homeassistant".to_string(),
         "wecom-callback" => "wecom_callback".to_string(),
         "mm" => "mattermost".to_string(),
-        "github-copilot" => "copilot".to_string(),
+        "github-copilot" | "github-models" => "copilot".to_string(),
+        "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
         other => other.to_string(),
     }
 }
@@ -5267,7 +5269,8 @@ fn gateway_platform_provider_key(provider: &str) -> Option<&'static str> {
 fn normalize_secret_provider(provider: &str) -> String {
     let p = provider.trim().to_ascii_lowercase();
     match p.as_str() {
-        "github-copilot" => "copilot".to_string(),
+        "github-copilot" | "github-models" => "copilot".to_string(),
+        "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
         "claude" | "claude-code" => "anthropic".to_string(),
         "codex" => "openai-codex".to_string(),
         "openai-oauth" | "openai-cli" => "openai".to_string(),
@@ -5286,6 +5289,7 @@ fn normalize_secret_provider(provider: &str) -> String {
         "glm" | "z-ai" | "z.ai" | "zhipu" => "zai".to_string(),
         "nim" | "nvidia-nim" | "build-nvidia" | "nemotron" => "nvidia".to_string(),
         "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
+        "gmi-cloud" => "gmi".to_string(),
         "dashscope" | "aliyun" | "alibaba-cloud" => "alibaba".to_string(),
         "alibaba_coding" | "alibaba-coding" | "alibaba_coding_plan" => {
             "alibaba-coding-plan".to_string()
@@ -5308,7 +5312,11 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
         ],
         "kimi-coding-cn" => vec!["kimi-coding-cn".to_string()],
         "stepfun" => vec!["stepfun".to_string(), "step".to_string()],
-        "copilot" => vec!["copilot".to_string(), "github-copilot".to_string()],
+        "copilot" => vec![
+            "copilot".to_string(),
+            "github-copilot".to_string(),
+            "github-models".to_string(),
+        ],
         "openai-codex" => vec!["openai-codex".to_string(), "codex".to_string()],
         "google-gemini-cli" => vec![
             "google-gemini-cli".to_string(),
@@ -5333,6 +5341,7 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
             "nim".to_string(),
         ],
         "huggingface" => vec!["huggingface".to_string(), "hf".to_string()],
+        "gmi" => vec!["gmi".to_string(), "gmi-cloud".to_string()],
         "ai-gateway" => vec!["ai-gateway".to_string(), "aigateway".to_string()],
         "opencode-zen" => vec!["opencode-zen".to_string(), "opencode".to_string()],
         "kilocode" => vec!["kilocode".to_string(), "kilo".to_string()],
@@ -5372,11 +5381,12 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "minimax-cn" => Some("MINIMAX_CN_API_KEY"),
         "stepfun" => Some("STEPFUN_API_KEY"),
         "nous" => Some("NOUS_API_KEY"),
-        "copilot" => Some("GITHUB_COPILOT_TOKEN"),
+        "copilot" => Some("COPILOT_GITHUB_TOKEN"),
         "ai-gateway" => Some("AI_GATEWAY_API_KEY"),
         "arcee" => Some("ARCEEAI_API_KEY"),
         "deepseek" => Some("DEEPSEEK_API_KEY"),
         "huggingface" => Some("HF_TOKEN"),
+        "gmi" => Some("GMI_API_KEY"),
         "kilocode" => Some("KILOCODE_API_KEY"),
         "nvidia" => Some("NVIDIA_API_KEY"),
         "ollama-cloud" => Some("OLLAMA_API_KEY"),
@@ -5566,6 +5576,7 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
         ("MINIMAX_CN_API_KEY", "minimax-cn"),
         ("STEPFUN_API_KEY", "stepfun"),
         ("NOUS_API_KEY", "nous"),
+        ("COPILOT_GITHUB_TOKEN", "copilot"),
         ("GITHUB_COPILOT_TOKEN", "copilot"),
         ("AI_GATEWAY_API_KEY", "ai-gateway"),
         ("ARCEEAI_API_KEY", "arcee"),
@@ -7952,7 +7963,7 @@ async fn run_auth(
                     })
                     .await?;
                 println!("GitHub device login complete; credential saved as provider 'copilot'.");
-                println!("Ensure GITHUB_COPILOT_TOKEN is set for the agent (see printed instructions above).");
+                println!("Ensure COPILOT_GITHUB_TOKEN is set for the agent (see printed instructions above).");
                 return Ok(());
             }
 
@@ -9282,11 +9293,12 @@ const SETUP_MINIMAX_ENV_KEYS: &[&str] = &["MINIMAX_API_KEY"];
 const SETUP_MINIMAX_CN_ENV_KEYS: &[&str] = &["MINIMAX_CN_API_KEY"];
 const SETUP_NOVITA_ENV_KEYS: &[&str] = &["NOVITA_API_KEY"];
 const SETUP_STEPFUN_ENV_KEYS: &[&str] = &["HERMES_STEPFUN_API_KEY", "STEPFUN_API_KEY"];
-const SETUP_COPILOT_ENV_KEYS: &[&str] = &["GITHUB_COPILOT_TOKEN"];
+const SETUP_COPILOT_ENV_KEYS: &[&str] = &["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 const SETUP_AI_GATEWAY_ENV_KEYS: &[&str] = &["AI_GATEWAY_API_KEY"];
 const SETUP_ARCEE_ENV_KEYS: &[&str] = &["ARCEEAI_API_KEY", "ARCEE_API_KEY"];
 const SETUP_DEEPSEEK_ENV_KEYS: &[&str] = &["DEEPSEEK_API_KEY"];
 const SETUP_HUGGINGFACE_ENV_KEYS: &[&str] = &["HF_TOKEN"];
+const SETUP_GMI_ENV_KEYS: &[&str] = &["GMI_API_KEY"];
 const SETUP_KILOCODE_ENV_KEYS: &[&str] = &["KILOCODE_API_KEY"];
 const SETUP_NVIDIA_ENV_KEYS: &[&str] = &["NVIDIA_API_KEY"];
 const SETUP_OLLAMA_CLOUD_ENV_KEYS: &[&str] = &["OLLAMA_API_KEY"];
@@ -9446,6 +9458,11 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
         provider: "kilocode",
         model: "kilocode:openai/gpt-5.4",
         label: "KiloCode",
+    },
+    SetupModelOption {
+        provider: "gmi",
+        model: "gmi:gpt-oss-120b",
+        label: "GMI Cloud",
     },
     SetupModelOption {
         provider: "ai-gateway",
@@ -9620,6 +9637,7 @@ fn setup_provider_display(provider: &str) -> &'static str {
         "copilot" => "GitHub Copilot",
         "huggingface" => "Hugging Face",
         "kilocode" => "KiloCode",
+        "gmi" => "GMI Cloud",
         "nvidia" => "NVIDIA NIM",
         "ollama-cloud" => "Ollama Cloud",
         "ollama-local" => "Ollama Local",
@@ -9663,6 +9681,7 @@ fn setup_provider_env_keys(provider: &str) -> &'static [&'static str] {
         "copilot" => SETUP_COPILOT_ENV_KEYS,
         "huggingface" => SETUP_HUGGINGFACE_ENV_KEYS,
         "kilocode" => SETUP_KILOCODE_ENV_KEYS,
+        "gmi" => SETUP_GMI_ENV_KEYS,
         "nvidia" => SETUP_NVIDIA_ENV_KEYS,
         "ollama-cloud" => SETUP_OLLAMA_CLOUD_ENV_KEYS,
         "ollama-local" => SETUP_OLLAMA_LOCAL_ENV_KEYS,
@@ -9696,8 +9715,10 @@ fn setup_provider_default_base_url(provider: &str) -> Option<&'static str> {
         "stepfun" => Some("https://api.stepfun.ai/step_plan/v1"),
         "ai-gateway" => Some("https://ai-gateway.vercel.sh/v1"),
         "arcee" => Some("https://api.arcee.ai/api/v1"),
+        "copilot" => Some("https://api.githubcopilot.com"),
         "huggingface" => Some("https://router.huggingface.co/v1"),
         "kilocode" => Some("https://api.kilo.ai/api/gateway"),
+        "gmi" => Some("https://api.gmi-serving.com/v1"),
         "nvidia" => Some("https://integrate.api.nvidia.com/v1"),
         "ollama-cloud" => Some("https://ollama.com/v1"),
         "ollama-local" => Some("http://127.0.0.1:11434/v1"),
@@ -14105,6 +14126,8 @@ mod tests {
         assert_eq!(normalize_auth_provider("z-ai"), "zai");
         assert_eq!(normalize_auth_provider("grok"), "xai");
         assert_eq!(normalize_auth_provider("hf"), "huggingface");
+        assert_eq!(normalize_auth_provider("github-models"), "copilot");
+        assert_eq!(normalize_auth_provider("copilot-acp-agent"), "copilot-acp");
         assert_eq!(normalize_auth_provider("ollama"), "ollama-local");
         assert_eq!(normalize_auth_provider("llama.cpp"), "llama-cpp");
         assert_eq!(normalize_auth_provider("ollvm"), "vllm");
@@ -14318,6 +14341,13 @@ mod tests {
             provider_env_var("qwen-oauth"),
             Some("HERMES_QWEN_OAUTH_API_KEY")
         );
+        assert_eq!(provider_env_var("copilot"), Some("COPILOT_GITHUB_TOKEN"));
+        assert_eq!(
+            secret_provider_aliases("copilot"),
+            vec!["copilot", "github-copilot", "github-models"]
+        );
+        assert_eq!(provider_env_var("gmi-cloud"), Some("GMI_API_KEY"));
+        assert_eq!(secret_provider_aliases("gmi"), vec!["gmi", "gmi-cloud"]);
         assert_eq!(
             provider_env_var("google-gemini-cli"),
             Some("HERMES_GEMINI_OAUTH_API_KEY")
@@ -14587,6 +14617,20 @@ mod tests {
         assert_eq!(
             setup_provider_env_keys("google-gemini-cli"),
             &["HERMES_GEMINI_OAUTH_API_KEY"]
+        );
+        assert_eq!(
+            setup_provider_env_keys("copilot"),
+            &["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+        );
+        assert_eq!(
+            setup_provider_default_base_url("copilot"),
+            Some("https://api.githubcopilot.com")
+        );
+        assert_eq!(setup_provider_display("gmi"), "GMI Cloud");
+        assert_eq!(setup_provider_env_keys("gmi"), &["GMI_API_KEY"]);
+        assert_eq!(
+            setup_provider_default_base_url("gmi"),
+            Some("https://api.gmi-serving.com/v1")
         );
         assert_eq!(
             setup_provider_default_base_url("ai-gateway"),

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -26,6 +26,7 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "deepseek",
     "huggingface",
     "kilocode",
+    "gmi",
     "nvidia",
     "ollama-cloud",
     "ollama-local",
@@ -95,8 +96,14 @@ pub fn canonical_provider_id(provider: &str) -> String {
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
-        "minimax-cn" => "minimax".to_string(),
+        "minimax_cn" => "minimax-cn".to_string(),
         "novita-ai" | "novitaai" => "novita".to_string(),
+        "glm" | "z-ai" | "z_ai" | "zhipu" => "zai".to_string(),
+        "aigateway" | "vercel" => "ai-gateway".to_string(),
+        "github-copilot" | "github-models" => "copilot".to_string(),
+        "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
+        "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
+        "gmi-cloud" => "gmi".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
@@ -268,5 +275,19 @@ mod tests {
         assert_eq!(canonical_provider_id("ollama"), "ollama-local");
         assert_eq!(canonical_provider_id("llama.cpp"), "llama-cpp");
         assert_eq!(canonical_provider_id("llvm"), "vllm");
+        assert_eq!(canonical_provider_id("glm"), "zai");
+        assert_eq!(canonical_provider_id("z-ai"), "zai");
+        assert_eq!(canonical_provider_id("zhipu"), "zai");
+        assert_eq!(canonical_provider_id("github-copilot"), "copilot");
+        assert_eq!(canonical_provider_id("github-models"), "copilot");
+        assert_eq!(canonical_provider_id("github-copilot-acp"), "copilot-acp");
+        assert_eq!(canonical_provider_id("copilot-acp-agent"), "copilot-acp");
+        assert_eq!(canonical_provider_id("hf"), "huggingface");
+        assert_eq!(canonical_provider_id("hugging-face"), "huggingface");
+        assert_eq!(canonical_provider_id("huggingface-hub"), "huggingface");
+        assert_eq!(canonical_provider_id("aigateway"), "ai-gateway");
+        assert_eq!(canonical_provider_id("vercel"), "ai-gateway");
+        assert_eq!(canonical_provider_id("gmi-cloud"), "gmi");
+        assert_eq!(canonical_provider_id("minimax_cn"), "minimax-cn");
     }
 }

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -855,7 +855,8 @@ pub fn load_from_json(path: &Path) -> Result<GatewayConfig, ConfigError> {
 ///   MOONSHOT_API_KEY           -> llm_providers["kimi"].api_key
 ///   MINIMAX_API_KEY            -> llm_providers["minimax"].api_key
 ///   NOUS_API_KEY               -> llm_providers["nous"].api_key
-///   GITHUB_COPILOT_TOKEN       -> llm_providers["copilot"].api_key
+///   COPILOT_GITHUB_TOKEN/GITHUB_COPILOT_TOKEN
+///                              -> llm_providers["copilot"].api_key
 ///   HERMES_BASE_URL            -> all llm_providers[*].base_url
 ///
 /// 另见 [`crate::python_platform_env::apply_python_named_platform_env`]：
@@ -937,6 +938,7 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
             .or_insert_with(LlmProviderConfig::default)
             .api_key = Some(v);
     }
+    let mut env_overridden_providers = std::collections::HashSet::new();
     for (env_var, provider_name) in [
         ("ANTHROPIC_API_KEY", "anthropic"),
         ("OPENROUTER_API_KEY", "openrouter"),
@@ -946,10 +948,15 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
         ("MOONSHOT_API_KEY", "kimi"),
         ("MINIMAX_API_KEY", "minimax"),
         ("NOUS_API_KEY", "nous"),
+        ("GMI_API_KEY", "gmi"),
+        ("COPILOT_GITHUB_TOKEN", "copilot"),
         ("GITHUB_COPILOT_TOKEN", "copilot"),
     ] {
         if let Ok(v) = std::env::var(env_var) {
             if v.trim().is_empty() {
+                continue;
+            }
+            if !env_overridden_providers.insert(provider_name) {
                 continue;
             }
             config
@@ -1474,6 +1481,60 @@ auxiliary:
         unsafe {
             std::env::remove_var("HERMES_OPENAI_CODEX_API_KEY");
             std::env::remove_var("HERMES_QWEN_OAUTH_API_KEY");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_supports_copilot_env_var_precedence() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::set_var("COPILOT_GITHUB_TOKEN", "copilot-primary");
+            std::env::set_var("GITHUB_COPILOT_TOKEN", "legacy-fallback");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_env_overrides(&mut cfg);
+
+        assert_eq!(
+            cfg.llm_providers
+                .get("copilot")
+                .and_then(|p| p.api_key.as_deref()),
+            Some("copilot-primary")
+        );
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("COPILOT_GITHUB_TOKEN");
+            std::env::remove_var("GITHUB_COPILOT_TOKEN");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_ignores_generic_github_tokens_for_copilot() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("COPILOT_GITHUB_TOKEN");
+            std::env::remove_var("GITHUB_COPILOT_TOKEN");
+            std::env::set_var("GH_TOKEN", "generic-gh-token");
+            std::env::set_var("GITHUB_TOKEN", "generic-github-token");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_env_overrides(&mut cfg);
+
+        assert!(
+            !cfg.llm_providers.contains_key("copilot"),
+            "generic GitHub tokens should not auto-configure the Copilot provider"
+        );
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("GH_TOKEN");
+            std::env::remove_var("GITHUB_TOKEN");
         }
     }
 

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -49,6 +49,7 @@ use serde_json::Value;
 
 pub const HTTP_PLATFORM: &str = "http";
 const SESSION_KEY_HEADER: &str = "x-hermes-session-key";
+const COPILOT_BASE_URL: &str = "https://api.githubcopilot.com";
 
 #[derive(Clone, Default)]
 pub struct ChatOutboundBuffer {
@@ -791,7 +792,7 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         "nous" => Arc::new(NousProvider::new(&api_key).with_model(model_name)),
         "copilot" => Arc::new(
             CopilotProvider::new(
-                base_url.unwrap_or_else(|| "https://api.github.com/copilot".to_string()),
+                base_url.unwrap_or_else(|| COPILOT_BASE_URL.to_string()),
                 &api_key,
             )
             .with_model(model_name),

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -5911,16 +5911,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_api_key_providers.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "291b8b70d464742b5b54cd420fa7324eda1435bb",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_api_key_providers.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "af576ed299520a0cdb6fc4f424398a7fe46ab00e",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T20:07:17.874172+00:00",
+  "generated_at_utc": "2026-05-30T21:28:33.552427+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "23b35632cd6d3c9abac7c1682ff2f0ac82caad8c",
+    "local_sha": "67cd153e695e570d9f7ada2f2208d16f6462edc9",
     "upstream_ref": "upstream/main",
     "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 620,
-      "intentional_divergence": 241,
+      "functional": 619,
+      "intentional_divergence": 242,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 411,
-      "rust_equivalent_or_contract_test_required": 536,
+      "not_required_for_runtime": 412,
+      "rust_equivalent_or_contract_test_required": 535,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 241,
+      "cleared_intentional_divergence": 242,
       "cleared_non_runtime": 170,
-      "pending_review": 620
+      "pending_review": 619
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 241,
+    "cleared_intentional_divergence": 242,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 620,
+    "pending_review": 619,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T20:07:17.874172+00:00`
+Generated: `2026-05-30T21:28:33.552427+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `620`
+- Pending functional review: `619`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `241`
+- Cleared intentional divergence: `242`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 241 |
+| `cleared_intentional_divergence` | 242 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 620 |
+| `pending_review` | 619 |
 
 ## Workstream Counts
 
@@ -38,7 +38,7 @@ Generated: `2026-05-30T20:07:17.874172+00:00`
 | Classification Path | Count |
 | --- | ---: |
 | `tests/gateway` | 131 |
-| `tests/hermes_cli` | 127 |
+| `tests/hermes_cli` | 126 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -633,6 +633,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/hermes_cli/test_api_key_providers.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream API-key provider registry behavior is covered by Rust provider canonicalization, CLI setup metadata, config env hydration, ACP auth discovery, and runtime provider tests for Copilot, Z.AI/GLM, Hugging Face, AI Gateway, MiniMax CN, GMI, and local backend aliases.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "ui-tui",
       "classification": "functional",
       "rationale": "TUI package and documentation deltas can affect distributed interactive UX behavior and must be reviewed against Hermes Ultra's Rust-primary UX surface.",


### PR DESCRIPTION
## Summary
- port upstream API-key provider aliases and defaults into Rust CLI/provider resolution
- align Copilot env/base URL handling across CLI, agent loop, ACP auth, config, and HTTP gateway construction
- add GMI provider registry/setup/env coverage and regenerate shared-diff parity backlog

## Local verification
- cargo fmt --all --check
- git diff --check
- cargo test -p hermes-cli provider -- --nocapture
- cargo test -p hermes-agent runtime_provider -- --nocapture
- cargo test -p hermes-config apply_env_overrides -- --nocapture
- cargo test -p hermes-acp copilot_credentials_accept_upstream_env_aliases -- --nocapture
- cargo check -p hermes-http
- cargo test -p hermes-parity-tests

Hosted GitHub CI is optional for this repo; local gates above are authoritative for this PR.