### PR TITLE
parity(providers): cover tokenhub direct provider parity

### DIFF
--- a/crates/hermes-acp/src/auth.rs
+++ b/crates/hermes-acp/src/auth.rs
@@ -70,12 +70,17 @@ fn normalize_provider_name(provider: &str) -> String {
         "claude" | "claude-code" => "anthropic".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
         "minimax-cn" => "minimax".to_string(),
         "novita-ai" | "novitaai" => "novita".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
+        "gmi-cloud" | "gmicloud" => "gmi".to_string(),
+        "arcee-ai" | "arceeai" => "arcee".to_string(),
+        "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
         "ollama" => "ollama-local".to_string(),
@@ -194,7 +199,9 @@ fn provider_env_key_names(provider: &str) -> &'static [&'static str] {
         "gmi" => &["GMI_API_KEY"],
         "huggingface" => &["HF_TOKEN", "HUGGINGFACE_API_KEY"],
         "zai" => &["ZAI_API_KEY"],
-        "arcee" => &["ARCEE_API_KEY"],
+        "arcee" => &["ARCEEAI_API_KEY", "ARCEE_API_KEY"],
+        "xiaomi" => &["XIAOMI_API_KEY"],
+        "tencent-tokenhub" => &["TOKENHUB_API_KEY"],
         "ollama-cloud" => &["OLLAMA_API_KEY"],
         _ => &[],
     }
@@ -330,6 +337,23 @@ mod tests {
                 "GITHUB_TOKEN",
                 "GITHUB_COPILOT_TOKEN"
             ]
+        );
+    }
+
+    #[test]
+    fn direct_provider_credentials_accept_upstream_aliases() {
+        assert_eq!(normalize_provider_name("google-ai-studio"), "gemini");
+        assert_eq!(normalize_provider_name("gmicloud"), "gmi");
+        assert_eq!(normalize_provider_name("arcee-ai"), "arcee");
+        assert_eq!(normalize_provider_name("mimo"), "xiaomi");
+        assert_eq!(normalize_provider_name("tokenhub"), "tencent-tokenhub");
+        assert_eq!(
+            provider_env_key_names("arcee"),
+            &["ARCEEAI_API_KEY", "ARCEE_API_KEY"]
+        );
+        assert_eq!(
+            provider_env_key_names("tencent-tokenhub"),
+            &["TOKENHUB_API_KEY"]
         );
     }
 }

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -2646,6 +2646,29 @@ impl AgentLoop {
                 .filter(|v| !v.trim().is_empty());
         }
         match provider {
+            "gemini" | "google" | "google-gemini" | "google-ai-studio" => {
+                std::env::var("GEMINI_API_KEY")
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+                    .or_else(|| std::env::var("GOOGLE_API_KEY").ok())
+                    .filter(|v| !v.trim().is_empty())
+            }
+            "gmi" | "gmi-cloud" | "gmicloud" => std::env::var("GMI_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "arcee" | "arcee-ai" | "arceeai" => std::env::var("ARCEEAI_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("ARCEE_API_KEY").ok())
+                .filter(|v| !v.trim().is_empty()),
+            "xiaomi" | "mimo" | "xiaomi-mimo" => std::env::var("XIAOMI_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "tencent-tokenhub" | "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => {
+                std::env::var("TOKENHUB_API_KEY")
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+            }
             "anthropic" | "claude" | "claude-code" => std::env::var("ANTHROPIC_API_KEY")
                 .ok()
                 .filter(|v| !v.trim().is_empty())
@@ -2717,6 +2740,22 @@ impl AgentLoop {
                     Some("https://api.stepfun.ai/step_plan/v1".to_string())
                 } else if provider == "copilot" {
                     Some("https://api.githubcopilot.com".to_string())
+                } else if matches!(
+                    provider,
+                    "gemini" | "google" | "google-gemini" | "google-ai-studio"
+                ) {
+                    Some("https://generativelanguage.googleapis.com/v1beta/openai".to_string())
+                } else if matches!(provider, "gmi" | "gmi-cloud" | "gmicloud") {
+                    Some("https://api.gmi-serving.com/v1".to_string())
+                } else if matches!(provider, "arcee" | "arcee-ai" | "arceeai") {
+                    Some("https://api.arcee.ai/api/v1".to_string())
+                } else if matches!(provider, "xiaomi" | "mimo" | "xiaomi-mimo") {
+                    Some("https://api.xiaomimimo.com/v1".to_string())
+                } else if matches!(
+                    provider,
+                    "tencent-tokenhub" | "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas"
+                ) {
+                    Some("https://tokenhub.tencentmaas.com/v1".to_string())
                 } else {
                     None
                 }
@@ -13155,6 +13194,117 @@ mod tests {
 
         let base = agent.resolve_runtime_base_url("copilot", None);
         assert_eq!(base.as_deref(), Some("https://api.githubcopilot.com"));
+    }
+
+    #[test]
+    fn test_runtime_provider_direct_env_keys_and_base_url_defaults() {
+        use futures::stream::BoxStream;
+        let _guard = env_test_lock();
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let _gemini = EnvVarGuard::remove("GEMINI_API_KEY");
+        let _google = EnvVarGuard::remove("GOOGLE_API_KEY");
+        let _gmi = EnvVarGuard::remove("GMI_API_KEY");
+        let _arceeai = EnvVarGuard::remove("ARCEEAI_API_KEY");
+        let _arcee = EnvVarGuard::remove("ARCEE_API_KEY");
+        let _xiaomi = EnvVarGuard::remove("XIAOMI_API_KEY");
+        let _tokenhub = EnvVarGuard::remove("TOKENHUB_API_KEY");
+
+        let agent = AgentLoop::new(
+            AgentConfig::default(),
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+
+        let _google_key = EnvVarGuard::set("GOOGLE_API_KEY", "google-secret");
+        assert_eq!(
+            agent.resolve_runtime_api_key("google-ai-studio", None, None),
+            Some("google-secret".to_string())
+        );
+        drop(_google_key);
+
+        let _gmi_key = EnvVarGuard::set("GMI_API_KEY", "gmi-secret");
+        assert_eq!(
+            agent.resolve_runtime_api_key("gmicloud", None, None),
+            Some("gmi-secret".to_string())
+        );
+
+        let _arcee_key = EnvVarGuard::set("ARCEE_API_KEY", "arcee-secret");
+        assert_eq!(
+            agent.resolve_runtime_api_key("arcee-ai", None, None),
+            Some("arcee-secret".to_string())
+        );
+
+        let _xiaomi_key = EnvVarGuard::set("XIAOMI_API_KEY", "xiaomi-secret");
+        assert_eq!(
+            agent.resolve_runtime_api_key("mimo", None, None),
+            Some("xiaomi-secret".to_string())
+        );
+
+        let _tokenhub_key = EnvVarGuard::set("TOKENHUB_API_KEY", "tokenhub-secret");
+        assert_eq!(
+            agent.resolve_runtime_api_key("tencent", None, None),
+            Some("tokenhub-secret".to_string())
+        );
+
+        assert_eq!(
+            agent
+                .resolve_runtime_base_url("google-gemini", None)
+                .as_deref(),
+            Some("https://generativelanguage.googleapis.com/v1beta/openai")
+        );
+        assert_eq!(
+            agent.resolve_runtime_base_url("gmi-cloud", None).as_deref(),
+            Some("https://api.gmi-serving.com/v1")
+        );
+        assert_eq!(
+            agent.resolve_runtime_base_url("arceeai", None).as_deref(),
+            Some("https://api.arcee.ai/api/v1")
+        );
+        assert_eq!(
+            agent
+                .resolve_runtime_base_url("xiaomi-mimo", None)
+                .as_deref(),
+            Some("https://api.xiaomimimo.com/v1")
+        );
+        assert_eq!(
+            agent
+                .resolve_runtime_base_url("tencentmaas", None)
+                .as_deref(),
+            Some("https://tokenhub.tencentmaas.com/v1")
+        );
     }
 
     #[test]

--- a/crates/hermes-agent/src/auxiliary_builder.rs
+++ b/crates/hermes-agent/src/auxiliary_builder.rs
@@ -30,6 +30,8 @@ mod default_models {
     pub const KIMI: &str = "kimi-k2-turbo-preview";
     pub const MINIMAX: &str = "MiniMax-M2.7";
     pub const GEMINI: &str = "gemini-3-flash-preview";
+    pub const GMI: &str = "google/gemini-3.1-flash-lite-preview";
+    pub const TENCENT_TOKENHUB: &str = "hy3-preview";
 }
 
 mod default_base_urls {
@@ -39,11 +41,13 @@ mod default_base_urls {
     pub const GEMINI: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
     pub const XAI: &str = "https://api.x.ai/v1";
     pub const XIAOMI: &str = "https://api.xiaomimimo.com/v1";
+    pub const GMI: &str = "https://api.gmi-serving.com/v1";
     pub const HUGGINGFACE: &str = "https://router.huggingface.co/v1";
     pub const ZAI: &str = "https://api.z.ai/api/paas/v4";
     pub const NOVITA: &str = "https://api.novita.ai/openai/v1";
     pub const NVIDIA: &str = "https://integrate.api.nvidia.com/v1";
     pub const ARCEE: &str = "https://api.arcee.ai/api/v1";
+    pub const TENCENT_TOKENHUB: &str = "https://tokenhub.tencentmaas.com/v1";
     pub const OLLAMA_LOCAL: &str = "http://127.0.0.1:11434/v1";
     pub const LLAMA_CPP: &str = "http://127.0.0.1:8080/v1";
     pub const VLLM: &str = "http://127.0.0.1:8000/v1";
@@ -261,6 +265,24 @@ pub fn build_auxiliary_client_with_main_runtime(
         default_models::GEMINI,
         main_label.as_deref(),
     );
+    register_direct_key(
+        &mut builder,
+        &mut summary,
+        "GMI_API_KEY",
+        "gmi",
+        default_base_urls::GMI,
+        default_models::GMI,
+        main_label.as_deref(),
+    );
+    register_direct_key(
+        &mut builder,
+        &mut summary,
+        "TOKENHUB_API_KEY",
+        "tencent-tokenhub",
+        default_base_urls::TENCENT_TOKENHUB,
+        default_models::TENCENT_TOKENHUB,
+        main_label.as_deref(),
+    );
 
     let client = builder.build();
     (client, summary)
@@ -385,6 +407,11 @@ fn canonical_provider_label(provider: &str) -> String {
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
+        "gmi-cloud" | "gmicloud" => "gmi".to_string(),
+        "arcee-ai" | "arceeai" => "arcee".to_string(),
+        "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
         "ollama" => "ollama-local".to_string(),
         "llama.cpp" | "llamacpp" => "llama-cpp".to_string(),
         "ollvm" | "llvm" => "vllm".to_string(),
@@ -447,6 +474,8 @@ fn provider_api_key_from_env(label: &str) -> Option<String> {
         "gemini" | "google" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
         "xai" => &["XAI_API_KEY"],
         "xiaomi" => &["XIAOMI_API_KEY"],
+        "gmi" => &["GMI_API_KEY"],
+        "tencent-tokenhub" => &["TOKENHUB_API_KEY"],
         "huggingface" => &["HF_TOKEN", "HUGGINGFACE_API_KEY"],
         "zai" => &["GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"],
         "novita" => &["NOVITA_API_KEY"],
@@ -478,6 +507,8 @@ fn default_base_url(label: &str) -> Option<&'static str> {
         "gemini" | "google" => Some(default_base_urls::GEMINI),
         "xai" => Some(default_base_urls::XAI),
         "xiaomi" => Some(default_base_urls::XIAOMI),
+        "gmi" => Some(default_base_urls::GMI),
+        "tencent-tokenhub" => Some(default_base_urls::TENCENT_TOKENHUB),
         "huggingface" => Some(default_base_urls::HUGGINGFACE),
         "zai" => Some(default_base_urls::ZAI),
         "novita" => Some(default_base_urls::NOVITA),
@@ -562,6 +593,8 @@ mod tests {
         "ANTHROPIC_TOKEN",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "NOUS_API_KEY",
+        "GMI_API_KEY",
+        "TOKENHUB_API_KEY",
         "DEEPSEEK_API_KEY",
         "DASHSCOPE_API_KEY",
         "GITHUB_COPILOT_TOKEN",
@@ -700,11 +733,20 @@ mod tests {
         std::env::set_var("OPENAI_API_KEY", "sk-oa-legacy");
         std::env::set_var("ANTHROPIC_API_KEY", "sk-an");
         std::env::set_var("ZAI_API_KEY", "z");
+        std::env::set_var("GMI_API_KEY", "sk-gmi");
+        std::env::set_var("TOKENHUB_API_KEY", "sk-tokenhub");
         {
             let (client, _) = build_default_auxiliary_client(AuxiliaryConfig::default());
             assert_eq!(
                 client.chain_labels(),
-                vec!["openrouter", "custom", "anthropic", "zai"]
+                vec![
+                    "openrouter",
+                    "custom",
+                    "anthropic",
+                    "zai",
+                    "gmi",
+                    "tencent-tokenhub"
+                ]
             );
         }
     }

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4698,6 +4698,8 @@ mod tests {
             "OPENCODE_ZEN_API_KEY",
             "XAI_API_KEY",
             "XIAOMI_API_KEY",
+            "ARCEEAI_API_KEY",
+            "ARCEE_API_KEY",
             "GLM_API_KEY",
             "ZAI_API_KEY",
             "Z_AI_API_KEY",
@@ -4707,6 +4709,7 @@ mod tests {
             "GH_TOKEN",
             "GITHUB_TOKEN",
             "GITHUB_COPILOT_TOKEN",
+            "TOKENHUB_API_KEY",
         ];
         for env_var in env_vars {
             std::env::remove_var(env_var);
@@ -4738,6 +4741,14 @@ mod tests {
             ("ZAI_API_KEY", "z-ai"),
             ("Z_AI_API_KEY", "zhipu"),
             ("GMI_API_KEY", "gmi-cloud"),
+            ("GMI_API_KEY", "gmicloud"),
+            ("ARCEEAI_API_KEY", "arcee-ai"),
+            ("ARCEEAI_API_KEY", "arceeai"),
+            ("XIAOMI_API_KEY", "mimo"),
+            ("XIAOMI_API_KEY", "xiaomi-mimo"),
+            ("TOKENHUB_API_KEY", "tencent-tokenhub"),
+            ("TOKENHUB_API_KEY", "tencent"),
+            ("TOKENHUB_API_KEY", "tokenhub"),
             ("MINIMAX_CN_API_KEY", "minimax_cn"),
             ("COPILOT_GITHUB_TOKEN", "github-copilot"),
             ("GH_TOKEN", "github-models"),
@@ -4804,6 +4815,23 @@ mod tests {
         assert_eq!(normalize_runtime_provider_name("aigateway"), "ai-gateway");
         assert_eq!(normalize_runtime_provider_name("vercel"), "ai-gateway");
         assert_eq!(normalize_runtime_provider_name("gmi-cloud"), "gmi");
+        assert_eq!(normalize_runtime_provider_name("gmicloud"), "gmi");
+        assert_eq!(
+            normalize_runtime_provider_name("google-ai-studio"),
+            "gemini"
+        );
+        assert_eq!(normalize_runtime_provider_name("arcee-ai"), "arcee");
+        assert_eq!(normalize_runtime_provider_name("arceeai"), "arcee");
+        assert_eq!(normalize_runtime_provider_name("mimo"), "xiaomi");
+        assert_eq!(normalize_runtime_provider_name("xiaomi-mimo"), "xiaomi");
+        assert_eq!(
+            normalize_runtime_provider_name("tencent-cloud"),
+            "tencent-tokenhub"
+        );
+        assert_eq!(
+            normalize_runtime_provider_name("tokenhub"),
+            "tencent-tokenhub"
+        );
     }
 
     #[test]
@@ -4817,6 +4845,9 @@ mod tests {
             "GMI_BASE_URL",
             "HF_BASE_URL",
             "AI_GATEWAY_BASE_URL",
+            "TOKENHUB_BASE_URL",
+            "ARCEE_BASE_URL",
+            "XIAOMI_BASE_URL",
         ];
         for env_var in env_vars {
             std::env::remove_var(env_var);
@@ -4847,6 +4878,10 @@ mod tests {
             provider_base_url_from_env("gmi-cloud").as_deref(),
             Some("https://gmi.example/v1")
         );
+        assert_eq!(
+            provider_base_url_from_env("gmicloud").as_deref(),
+            Some("https://gmi.example/v1")
+        );
         std::env::set_var("HF_BASE_URL", "https://hf.example/v1");
         assert_eq!(
             provider_base_url_from_env("huggingface-hub").as_deref(),
@@ -4856,6 +4891,21 @@ mod tests {
         assert_eq!(
             provider_base_url_from_env("vercel").as_deref(),
             Some("https://gateway.example/v1")
+        );
+        std::env::set_var("TOKENHUB_BASE_URL", "https://tokenhub.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("tencent").as_deref(),
+            Some("https://tokenhub.example/v1")
+        );
+        std::env::set_var("ARCEE_BASE_URL", "https://arcee.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("arcee-ai").as_deref(),
+            Some("https://arcee.example/v1")
+        );
+        std::env::set_var("XIAOMI_BASE_URL", "https://mimo.example/v1");
+        assert_eq!(
+            provider_base_url_from_env("mimo").as_deref(),
+            Some("https://mimo.example/v1")
         );
 
         for env_var in env_vars {
@@ -4883,6 +4933,13 @@ mod tests {
             Some(AI_GATEWAY_BASE_URL)
         );
         assert_eq!(provider_default_base_url("gmi-cloud"), Some(GMI_BASE_URL));
+        assert_eq!(provider_default_base_url("gmicloud"), Some(GMI_BASE_URL));
+        assert_eq!(provider_default_base_url("arcee-ai"), Some(ARCEE_BASE_URL));
+        assert_eq!(provider_default_base_url("mimo"), Some(XIAOMI_BASE_URL));
+        assert_eq!(
+            provider_default_base_url("tencent"),
+            Some(TENCENT_TOKENHUB_BASE_URL)
+        );
     }
 
     #[test]
@@ -5642,6 +5699,7 @@ const GMI_BASE_URL: &str = "https://api.gmi-serving.com/v1";
 const XIAOMI_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
 const ZAI_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
 const ARCEE_BASE_URL: &str = "https://api.arcee.ai/api/v1";
+const TENCENT_TOKENHUB_BASE_URL: &str = "https://tokenhub.tencentmaas.com/v1";
 const OLLAMA_CLOUD_BASE_URL: &str = "https://ollama.com/v1";
 const DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/v1";
 const OLLAMA_LOCAL_BASE_URL: &str = "http://127.0.0.1:11434/v1";
@@ -5659,6 +5717,7 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
         "claude" | "claude-code" => "anthropic".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
@@ -5669,7 +5728,10 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
         "github-copilot" | "github-models" => "copilot".to_string(),
         "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
         "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
-        "gmi-cloud" => "gmi".to_string(),
+        "gmi-cloud" | "gmicloud" => "gmi".to_string(),
+        "arcee-ai" | "arceeai" => "arcee".to_string(),
+        "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
@@ -5687,7 +5749,7 @@ fn provider_default_base_url(provider: &str) -> Option<&'static str> {
     match provider.trim().to_ascii_lowercase().as_str() {
         "openai-codex" | "codex" => Some(OPENAI_CODEX_BASE_URL),
         "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => Some(GOOGLE_GEMINI_CLI_BASE_URL),
-        "gemini" | "google" => Some(GEMINI_BASE_URL),
+        "gemini" | "google" | "google-gemini" | "google-ai-studio" => Some(GEMINI_BASE_URL),
         "qwen" | "alibaba" => Some(QWEN_BASE_URL),
         "alibaba-coding-plan" => Some(ALIBABA_CODING_PLAN_BASE_URL),
         "stepfun" | "step" | "step-plan" => Some(STEPFUN_BASE_URL),
@@ -5703,10 +5765,13 @@ fn provider_default_base_url(provider: &str) -> Option<&'static str> {
         "opencode-zen" | "opencode" => Some(OPENCODE_ZEN_BASE_URL),
         "kilocode" | "kilo" => Some(KILOCODE_BASE_URL),
         "huggingface" | "hf" | "hugging-face" | "huggingface-hub" => Some(HUGGINGFACE_BASE_URL),
-        "gmi" | "gmi-cloud" => Some(GMI_BASE_URL),
-        "xiaomi" => Some(XIAOMI_BASE_URL),
+        "gmi" | "gmi-cloud" | "gmicloud" => Some(GMI_BASE_URL),
+        "xiaomi" | "mimo" | "xiaomi-mimo" => Some(XIAOMI_BASE_URL),
         "zai" | "glm" | "z-ai" | "z_ai" | "zhipu" => Some(ZAI_BASE_URL),
-        "arcee" => Some(ARCEE_BASE_URL),
+        "arcee" | "arcee-ai" | "arceeai" => Some(ARCEE_BASE_URL),
+        "tencent-tokenhub" | "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => {
+            Some(TENCENT_TOKENHUB_BASE_URL)
+        }
         "ollama-cloud" => Some(OLLAMA_CLOUD_BASE_URL),
         "ollama-local" | "ollama" => Some(OLLAMA_LOCAL_BASE_URL),
         "llama-cpp" | "llama.cpp" | "llamacpp" => Some(LLAMA_CPP_BASE_URL),
@@ -5923,6 +5988,7 @@ fn provider_base_url_from_env(provider: &str) -> Option<String> {
             "xiaomi" => "XIAOMI_BASE_URL",
             "zai" => "GLM_BASE_URL",
             "arcee" => "ARCEE_BASE_URL",
+            "tencent-tokenhub" => "TOKENHUB_BASE_URL",
             "deepseek" => "DEEPSEEK_BASE_URL",
             "ollama-local" | "ollama" => "OLLAMA_BASE_URL",
             "llama-cpp" | "llama.cpp" | "llamacpp" => "LLAMA_CPP_BASE_URL",
@@ -6130,6 +6196,9 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
             .ok()
             .filter(|s| !s.trim().is_empty()),
         "xiaomi" => std::env::var("XIAOMI_API_KEY")
+            .ok()
+            .filter(|s| !s.trim().is_empty()),
+        "tencent-tokenhub" => std::env::var("TOKENHUB_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
         "zai" => std::env::var("GLM_API_KEY")

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -5211,6 +5211,7 @@ fn normalize_auth_provider(provider: &str) -> String {
         "openai-oauth" | "openai-cli" => "openai".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi" => "kimi-coding".to_string(),
         "minimax-cn" | "minimax_cn" | "minimax-china" => "minimax-cn".to_string(),
@@ -5231,7 +5232,10 @@ fn normalize_auth_provider(provider: &str) -> String {
         "glm" | "z-ai" | "z.ai" | "zhipu" => "zai".to_string(),
         "nim" | "nvidia-nim" | "build-nvidia" | "nemotron" => "nvidia".to_string(),
         "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
-        "gmi-cloud" => "gmi".to_string(),
+        "gmi-cloud" | "gmicloud" => "gmi".to_string(),
+        "arcee-ai" | "arceeai" => "arcee".to_string(),
+        "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
         "api-server" => "api_server".to_string(),
         "home-assistant" => "homeassistant".to_string(),
         "wecom-callback" => "wecom_callback".to_string(),
@@ -5275,6 +5279,7 @@ fn normalize_secret_provider(provider: &str) -> String {
         "codex" => "openai-codex".to_string(),
         "openai-oauth" | "openai-cli" => "openai".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "moonshot" | "kimi" => "kimi-coding".to_string(),
         "aigateway" | "vercel" | "vercel-ai-gateway" => "ai-gateway".to_string(),
         "opencode" | "zen" => "opencode-zen".to_string(),
@@ -5289,7 +5294,10 @@ fn normalize_secret_provider(provider: &str) -> String {
         "glm" | "z-ai" | "z.ai" | "zhipu" => "zai".to_string(),
         "nim" | "nvidia-nim" | "build-nvidia" | "nemotron" => "nvidia".to_string(),
         "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
-        "gmi-cloud" => "gmi".to_string(),
+        "gmi-cloud" | "gmicloud" => "gmi".to_string(),
+        "arcee-ai" | "arceeai" => "arcee".to_string(),
+        "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
         "dashscope" | "aliyun" | "alibaba-cloud" => "alibaba".to_string(),
         "alibaba_coding" | "alibaba-coding" | "alibaba_coding_plan" => {
             "alibaba-coding-plan".to_string()
@@ -5341,7 +5349,28 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
             "nim".to_string(),
         ],
         "huggingface" => vec!["huggingface".to_string(), "hf".to_string()],
-        "gmi" => vec!["gmi".to_string(), "gmi-cloud".to_string()],
+        "gmi" => vec![
+            "gmi".to_string(),
+            "gmi-cloud".to_string(),
+            "gmicloud".to_string(),
+        ],
+        "arcee" => vec![
+            "arcee".to_string(),
+            "arcee-ai".to_string(),
+            "arceeai".to_string(),
+        ],
+        "xiaomi" => vec![
+            "xiaomi".to_string(),
+            "mimo".to_string(),
+            "xiaomi-mimo".to_string(),
+        ],
+        "tencent-tokenhub" => vec![
+            "tencent-tokenhub".to_string(),
+            "tencent".to_string(),
+            "tokenhub".to_string(),
+            "tencent-cloud".to_string(),
+            "tencentmaas".to_string(),
+        ],
         "ai-gateway" => vec!["ai-gateway".to_string(), "aigateway".to_string()],
         "opencode-zen" => vec!["opencode-zen".to_string(), "opencode".to_string()],
         "kilocode" => vec!["kilocode".to_string(), "kilo".to_string()],
@@ -5401,6 +5430,7 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "opencode-zen" => Some("OPENCODE_ZEN_API_KEY"),
         "xai" => Some("XAI_API_KEY"),
         "xiaomi" => Some("XIAOMI_API_KEY"),
+        "tencent-tokenhub" => Some("TOKENHUB_API_KEY"),
         "zai" => Some("GLM_API_KEY"),
         _ => None,
     }
@@ -5597,6 +5627,7 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
         ("OPENCODE_ZEN_API_KEY", "opencode-zen"),
         ("XAI_API_KEY", "xai"),
         ("XIAOMI_API_KEY", "xiaomi"),
+        ("TOKENHUB_API_KEY", "tencent-tokenhub"),
         ("GLM_API_KEY", "zai"),
         ("ZAI_API_KEY", "zai"),
         ("Z_AI_API_KEY", "zai"),
@@ -9313,6 +9344,7 @@ const SETUP_OPENCODE_GO_ENV_KEYS: &[&str] = &["OPENCODE_GO_API_KEY"];
 const SETUP_OPENCODE_ZEN_ENV_KEYS: &[&str] = &["OPENCODE_ZEN_API_KEY"];
 const SETUP_XAI_ENV_KEYS: &[&str] = &["XAI_API_KEY"];
 const SETUP_XIAOMI_ENV_KEYS: &[&str] = &["XIAOMI_API_KEY"];
+const SETUP_TENCENT_TOKENHUB_ENV_KEYS: &[&str] = &["TOKENHUB_API_KEY"];
 const SETUP_ZAI_ENV_KEYS: &[&str] = &["GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"];
 const SETUP_BEDROCK_ENV_KEYS: &[&str] = &[
     "AWS_ACCESS_KEY_ID",
@@ -9478,6 +9510,11 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
         provider: "xiaomi",
         model: "xiaomi:mimo-v2.5-pro",
         label: "Xiaomi MiMo",
+    },
+    SetupModelOption {
+        provider: "tencent-tokenhub",
+        model: "tencent-tokenhub:hy3-preview",
+        label: "Tencent TokenHub",
     },
     SetupModelOption {
         provider: "ollama-cloud",
@@ -9651,6 +9688,7 @@ fn setup_provider_display(provider: &str) -> &'static str {
         "opencode-zen" => "OpenCode Zen",
         "xai" => "xAI",
         "xiaomi" => "Xiaomi MiMo",
+        "tencent-tokenhub" => "Tencent TokenHub",
         "zai" => "Z.AI / GLM",
         _ => "Provider",
     }
@@ -9695,6 +9733,7 @@ fn setup_provider_env_keys(provider: &str) -> &'static [&'static str] {
         "opencode-zen" => SETUP_OPENCODE_ZEN_ENV_KEYS,
         "xai" => SETUP_XAI_ENV_KEYS,
         "xiaomi" => SETUP_XIAOMI_ENV_KEYS,
+        "tencent-tokenhub" => SETUP_TENCENT_TOKENHUB_ENV_KEYS,
         "zai" => SETUP_ZAI_ENV_KEYS,
         _ => &[],
     }
@@ -9732,6 +9771,7 @@ fn setup_provider_default_base_url(provider: &str) -> Option<&'static str> {
         "opencode-zen" => Some("https://opencode.ai/zen/v1"),
         "xai" => Some("https://api.x.ai/v1"),
         "xiaomi" => Some("https://api.xiaomimimo.com/v1"),
+        "tencent-tokenhub" => Some("https://tokenhub.tencentmaas.com/v1"),
         "zai" => Some("https://api.z.ai/api/paas/v4"),
         _ => None,
     }
@@ -14120,6 +14160,7 @@ mod tests {
         assert_eq!(normalize_auth_provider("openai-oauth"), "openai");
         assert_eq!(normalize_auth_provider("qwen-cli"), "qwen-oauth");
         assert_eq!(normalize_auth_provider("gemini-cli"), "google-gemini-cli");
+        assert_eq!(normalize_auth_provider("google-ai-studio"), "gemini");
         assert_eq!(normalize_auth_provider("step-plan"), "stepfun");
         assert_eq!(normalize_auth_provider("aigateway"), "ai-gateway");
         assert_eq!(normalize_auth_provider("moonshot"), "kimi-coding");
@@ -14128,6 +14169,10 @@ mod tests {
         assert_eq!(normalize_auth_provider("hf"), "huggingface");
         assert_eq!(normalize_auth_provider("github-models"), "copilot");
         assert_eq!(normalize_auth_provider("copilot-acp-agent"), "copilot-acp");
+        assert_eq!(normalize_auth_provider("gmicloud"), "gmi");
+        assert_eq!(normalize_auth_provider("arcee-ai"), "arcee");
+        assert_eq!(normalize_auth_provider("mimo"), "xiaomi");
+        assert_eq!(normalize_auth_provider("tencent-cloud"), "tencent-tokenhub");
         assert_eq!(normalize_auth_provider("ollama"), "ollama-local");
         assert_eq!(normalize_auth_provider("llama.cpp"), "llama-cpp");
         assert_eq!(normalize_auth_provider("ollvm"), "vllm");
@@ -14347,7 +14392,31 @@ mod tests {
             vec!["copilot", "github-copilot", "github-models"]
         );
         assert_eq!(provider_env_var("gmi-cloud"), Some("GMI_API_KEY"));
-        assert_eq!(secret_provider_aliases("gmi"), vec!["gmi", "gmi-cloud"]);
+        assert_eq!(
+            secret_provider_aliases("gmi"),
+            vec!["gmi", "gmi-cloud", "gmicloud"]
+        );
+        assert_eq!(provider_env_var("arcee-ai"), Some("ARCEEAI_API_KEY"));
+        assert_eq!(
+            secret_provider_aliases("arcee"),
+            vec!["arcee", "arcee-ai", "arceeai"]
+        );
+        assert_eq!(provider_env_var("mimo"), Some("XIAOMI_API_KEY"));
+        assert_eq!(
+            secret_provider_aliases("xiaomi"),
+            vec!["xiaomi", "mimo", "xiaomi-mimo"]
+        );
+        assert_eq!(provider_env_var("tokenhub"), Some("TOKENHUB_API_KEY"));
+        assert_eq!(
+            secret_provider_aliases("tencent"),
+            vec![
+                "tencent-tokenhub",
+                "tencent",
+                "tokenhub",
+                "tencent-cloud",
+                "tencentmaas"
+            ]
+        );
         assert_eq!(
             provider_env_var("google-gemini-cli"),
             Some("HERMES_GEMINI_OAUTH_API_KEY")
@@ -14631,6 +14700,18 @@ mod tests {
         assert_eq!(
             setup_provider_default_base_url("gmi"),
             Some("https://api.gmi-serving.com/v1")
+        );
+        assert_eq!(
+            setup_provider_display("tencent-tokenhub"),
+            "Tencent TokenHub"
+        );
+        assert_eq!(
+            setup_provider_env_keys("tencent-tokenhub"),
+            &["TOKENHUB_API_KEY"]
+        );
+        assert_eq!(
+            setup_provider_default_base_url("tencent-tokenhub"),
+            Some("https://tokenhub.tencentmaas.com/v1")
         );
         assert_eq!(
             setup_provider_default_base_url("ai-gateway"),

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -32,6 +32,8 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
             "moonshotai/kimi-k2.6",
             "anthropic/claude-opus-4.7",
             "openai/gpt-5.4",
+            "tencent/hy3-preview:free",
+            "tencent/hy3-preview",
         ],
     ),
     (
@@ -61,6 +63,7 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
             "nousresearch/hermes-4-405b",
             "nousresearch/hermes-4-70b",
             "xiaomi/mimo-v2.5-pro",
+            "tencent/hy3-preview",
             "anthropic/claude-sonnet-4.5",
         ],
     ),
@@ -204,6 +207,34 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
             "deepseek-ai/DeepSeek-V3.2",
         ],
     ),
+    (
+        "gmi",
+        &[
+            "zai-org/GLM-5.1-FP8",
+            "deepseek-ai/DeepSeek-V3.2",
+            "moonshotai/Kimi-K2.5",
+            "anthropic/claude-sonnet-4.6",
+        ],
+    ),
+    (
+        "arcee",
+        &[
+            "trinity-large-preview",
+            "trinity-large-thinking",
+            "trinity-mini",
+        ],
+    ),
+    (
+        "xiaomi",
+        &[
+            "mimo-v2.5-pro",
+            "mimo-v2.5",
+            "mimo-v2-pro",
+            "mimo-v2-omni",
+            "mimo-v2-flash",
+        ],
+    ),
+    ("tencent-tokenhub", &["hy3-preview"]),
     ("zai", &["glm-5.1", "glm-5.0", "glm-4.5-flash"]),
     (
         "gemini",
@@ -603,6 +634,44 @@ fn resolve_huggingface_catalog_endpoint_and_token() -> (String, Option<String>) 
     (base_url, token)
 }
 
+fn openai_compatible_catalog_credentials(provider: &str) -> Option<(String, String)> {
+    let (base_env, default_base, key_envs): (&str, &str, &[&str]) = match provider {
+        "gmi" => (
+            "GMI_BASE_URL",
+            "https://api.gmi-serving.com/v1",
+            &["GMI_API_KEY"],
+        ),
+        "arcee" => (
+            "ARCEE_BASE_URL",
+            "https://api.arcee.ai/api/v1",
+            &["ARCEEAI_API_KEY", "ARCEE_API_KEY"],
+        ),
+        "xiaomi" => (
+            "XIAOMI_BASE_URL",
+            "https://api.xiaomimimo.com/v1",
+            &["XIAOMI_API_KEY"],
+        ),
+        "tencent-tokenhub" => (
+            "TOKENHUB_BASE_URL",
+            "https://tokenhub.tencentmaas.com/v1",
+            &["TOKENHUB_API_KEY"],
+        ),
+        _ => return None,
+    };
+    let token = key_envs.iter().find_map(|name| {
+        std::env::var(name)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })?;
+    let base_url = std::env::var(base_env)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default_base.to_string());
+    Some((base_url, token))
+}
+
 async fn fetch_openai_compatible_live_models(base_url: &str, api_key: Option<&str>) -> Vec<String> {
     if cfg!(test) {
         return Vec::new();
@@ -836,6 +905,28 @@ pub async fn provider_model_ids_with_client(
             }
         }
         merged
+    } else if matches!(
+        normalized.as_str(),
+        "gmi" | "arcee" | "xiaomi" | "tencent-tokenhub"
+    ) {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut merged: Vec<String> = Vec::new();
+        if let Some((base_url, token)) = openai_compatible_catalog_credentials(&normalized) {
+            let live = fetch_openai_compatible_live_models(base_url.as_str(), Some(&token)).await;
+            for model in live {
+                let key = model.to_ascii_lowercase();
+                if seen.insert(key) {
+                    merged.push(model);
+                }
+            }
+        }
+        for model in curated {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                merged.push((*model).to_string());
+            }
+        }
+        merged
     } else if is_local_openai_compatible_provider(&normalized) {
         let mut seen: HashSet<String> = HashSet::new();
         let mut merged: Vec<String> = Vec::new();
@@ -1059,6 +1150,17 @@ mod tests {
         let models = provider_curated_models("openrouter");
         assert!(models.contains(&"openai/gpt-5.5"));
         assert!(models.contains(&"openai/gpt-5.5-pro"));
+        assert!(models.contains(&"tencent/hy3-preview:free"));
+        assert!(models.contains(&"tencent/hy3-preview"));
+    }
+
+    #[test]
+    fn direct_api_provider_curated_models_cover_upstream_provider_tests() {
+        assert!(provider_curated_models("gmi").contains(&"zai-org/GLM-5.1-FP8"));
+        assert!(provider_curated_models("gmicloud").contains(&"deepseek-ai/DeepSeek-V3.2"));
+        assert!(provider_curated_models("arcee-ai").contains(&"trinity-mini"));
+        assert!(provider_curated_models("mimo").contains(&"mimo-v2.5-pro"));
+        assert!(provider_curated_models("tokenhub").contains(&"hy3-preview"));
     }
 
     #[tokio::test]
@@ -1183,6 +1285,7 @@ mod tests {
                 "nousresearch/hermes-4-405b".to_string(),
                 "nousresearch/hermes-4-70b".to_string(),
                 "xiaomi/mimo-v2.5-pro".to_string(),
+                "tencent/hy3-preview".to_string(),
                 "anthropic/claude-sonnet-4.5".to_string()
             ]),
             "nous list should keep curated models first"

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -40,6 +40,7 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "opencode-zen",
     "xai",
     "xiaomi",
+    "tencent-tokenhub",
     "zai",
 ];
 
@@ -93,6 +94,7 @@ pub fn canonical_provider_id(provider: &str) -> String {
         "claude" | "claude-code" => "anthropic".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
@@ -103,7 +105,10 @@ pub fn canonical_provider_id(provider: &str) -> String {
         "github-copilot" | "github-models" => "copilot".to_string(),
         "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
         "hf" | "hugging-face" | "huggingface-hub" => "huggingface".to_string(),
-        "gmi-cloud" => "gmi".to_string(),
+        "gmi-cloud" | "gmicloud" => "gmi".to_string(),
+        "arcee-ai" | "arceeai" => "arcee".to_string(),
+        "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
@@ -288,6 +293,14 @@ mod tests {
         assert_eq!(canonical_provider_id("aigateway"), "ai-gateway");
         assert_eq!(canonical_provider_id("vercel"), "ai-gateway");
         assert_eq!(canonical_provider_id("gmi-cloud"), "gmi");
+        assert_eq!(canonical_provider_id("gmicloud"), "gmi");
+        assert_eq!(canonical_provider_id("google-ai-studio"), "gemini");
+        assert_eq!(canonical_provider_id("arcee-ai"), "arcee");
+        assert_eq!(canonical_provider_id("arceeai"), "arcee");
+        assert_eq!(canonical_provider_id("mimo"), "xiaomi");
+        assert_eq!(canonical_provider_id("xiaomi-mimo"), "xiaomi");
+        assert_eq!(canonical_provider_id("tencent-cloud"), "tencent-tokenhub");
+        assert_eq!(canonical_provider_id("tokenhub"), "tencent-tokenhub");
         assert_eq!(canonical_provider_id("minimax_cn"), "minimax-cn");
     }
 }

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -949,6 +949,10 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
         ("MINIMAX_API_KEY", "minimax"),
         ("NOUS_API_KEY", "nous"),
         ("GMI_API_KEY", "gmi"),
+        ("ARCEEAI_API_KEY", "arcee"),
+        ("ARCEE_API_KEY", "arcee"),
+        ("XIAOMI_API_KEY", "xiaomi"),
+        ("TOKENHUB_API_KEY", "tencent-tokenhub"),
         ("COPILOT_GITHUB_TOKEN", "copilot"),
         ("GITHUB_COPILOT_TOKEN", "copilot"),
     ] {
@@ -964,6 +968,23 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
                 .entry(provider_name.to_string())
                 .or_insert_with(LlmProviderConfig::default)
                 .api_key = Some(v);
+        }
+    }
+    for (env_var, provider_name) in [
+        ("GMI_BASE_URL", "gmi"),
+        ("ARCEE_BASE_URL", "arcee"),
+        ("XIAOMI_BASE_URL", "xiaomi"),
+        ("TOKENHUB_BASE_URL", "tencent-tokenhub"),
+    ] {
+        if let Ok(v) = std::env::var(env_var) {
+            if v.trim().is_empty() {
+                continue;
+            }
+            config
+                .llm_providers
+                .entry(provider_name.to_string())
+                .or_insert_with(LlmProviderConfig::default)
+                .base_url = Some(v);
         }
     }
 
@@ -1508,6 +1529,50 @@ auxiliary:
         unsafe {
             std::env::remove_var("COPILOT_GITHUB_TOKEN");
             std::env::remove_var("GITHUB_COPILOT_TOKEN");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_supports_direct_provider_env_vars() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        unsafe {
+            std::env::set_var("ARCEEAI_API_KEY", "arcee-token");
+            std::env::set_var("XIAOMI_API_KEY", "xiaomi-token");
+            std::env::set_var("TOKENHUB_API_KEY", "tokenhub-token");
+            std::env::set_var("TOKENHUB_BASE_URL", "https://tokenhub.example/v1");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_env_overrides(&mut cfg);
+
+        assert_eq!(
+            cfg.llm_providers
+                .get("arcee")
+                .and_then(|p| p.api_key.as_deref()),
+            Some("arcee-token")
+        );
+        assert_eq!(
+            cfg.llm_providers
+                .get("xiaomi")
+                .and_then(|p| p.api_key.as_deref()),
+            Some("xiaomi-token")
+        );
+        let tokenhub = cfg
+            .llm_providers
+            .get("tencent-tokenhub")
+            .expect("tokenhub provider");
+        assert_eq!(tokenhub.api_key.as_deref(), Some("tokenhub-token"));
+        assert_eq!(
+            tokenhub.base_url.as_deref(),
+            Some("https://tokenhub.example/v1")
+        );
+
+        unsafe {
+            std::env::remove_var("ARCEEAI_API_KEY");
+            std::env::remove_var("XIAOMI_API_KEY");
+            std::env::remove_var("TOKENHUB_API_KEY");
+            std::env::remove_var("TOKENHUB_BASE_URL");
         }
     }
 

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -50,6 +50,11 @@ use serde_json::Value;
 pub const HTTP_PLATFORM: &str = "http";
 const SESSION_KEY_HEADER: &str = "x-hermes-session-key";
 const COPILOT_BASE_URL: &str = "https://api.githubcopilot.com";
+const GEMINI_OPENAI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
+const GMI_BASE_URL: &str = "https://api.gmi-serving.com/v1";
+const ARCEE_BASE_URL: &str = "https://api.arcee.ai/api/v1";
+const XIAOMI_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
+const TENCENT_TOKENHUB_BASE_URL: &str = "https://tokenhub.tencentmaas.com/v1";
 
 #[derive(Clone, Default)]
 pub struct ChatOutboundBuffer {
@@ -756,8 +761,12 @@ pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
 }
 
 pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvider> {
-    let (provider_name, model_name) = model.split_once(':').unwrap_or(("openai", model));
-    let provider_config = config.llm_providers.get(provider_name);
+    let (raw_provider_name, model_name) = model.split_once(':').unwrap_or(("openai", model));
+    let provider_name = canonical_gateway_provider_name(raw_provider_name);
+    let provider_config = config
+        .llm_providers
+        .get(raw_provider_name)
+        .or_else(|| config.llm_providers.get(provider_name));
     let api_key = provider_config
         .and_then(|c| c.api_key.clone())
         .unwrap_or_default();
@@ -798,9 +807,33 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             .with_model(model_name),
         ),
         _ => {
-            let url = base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+            let url = base_url
+                .or_else(|| default_gateway_base_url(provider_name).map(str::to_string))
+                .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
             Arc::new(GenericProvider::new(url, &api_key, model_name))
         }
+    }
+}
+
+fn canonical_gateway_provider_name(provider: &str) -> &str {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "google" | "google-gemini" | "google-ai-studio" => "gemini",
+        "gmi-cloud" | "gmicloud" => "gmi",
+        "arcee-ai" | "arceeai" => "arcee",
+        "mimo" | "xiaomi-mimo" => "xiaomi",
+        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub",
+        _ => provider,
+    }
+}
+
+fn default_gateway_base_url(provider: &str) -> Option<&'static str> {
+    match provider {
+        "gemini" => Some(GEMINI_OPENAI_BASE_URL),
+        "gmi" => Some(GMI_BASE_URL),
+        "arcee" => Some(ARCEE_BASE_URL),
+        "xiaomi" => Some(XIAOMI_BASE_URL),
+        "tencent-tokenhub" => Some(TENCENT_TOKENHUB_BASE_URL),
+        _ => None,
     }
 }
 
@@ -884,5 +917,26 @@ fn resolve_model(default_model: &str, provider: Option<&str>, model: Option<&str
         }
         (None, Some(m)) => m.to_string(),
         (None, None) => default_model.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_provider_aliases_resolve_to_direct_provider_defaults() {
+        let cases = [
+            ("google-ai-studio", "gemini", GEMINI_OPENAI_BASE_URL),
+            ("gmicloud", "gmi", GMI_BASE_URL),
+            ("arcee-ai", "arcee", ARCEE_BASE_URL),
+            ("mimo", "xiaomi", XIAOMI_BASE_URL),
+            ("tencentmaas", "tencent-tokenhub", TENCENT_TOKENHUB_BASE_URL),
+        ];
+
+        for (alias, canonical, base_url) in cases {
+            assert_eq!(canonical_gateway_provider_name(alias), canonical);
+            assert_eq!(default_gateway_base_url(canonical), Some(base_url));
+        }
     }
 }

--- a/crates/hermes-intelligence/src/model_metadata.rs
+++ b/crates/hermes-intelligence/src/model_metadata.rs
@@ -96,6 +96,8 @@ static DEFAULT_CONTEXT_LENGTHS: &[(&str, u64)] = &[
     // Xiaomi MIMO
     ("mimo-v2.5-pro", 1_000_000),
     ("mimo-v2.5", 1_000_000),
+    // Tencent TokenHub
+    ("hy3-preview", 128_000),
 ];
 
 // ---------------------------------------------------------------------------
@@ -548,6 +550,13 @@ pub fn infer_provider_from_url(base_url: &str) -> Option<&'static str> {
         ("api.deepseek.com", "deepseek"),
         ("api.githubcopilot.com", "copilot"),
         ("api.x.ai", "xai"),
+        ("api.gmi-serving.com", "gmi"),
+        ("api.arcee.ai", "arcee"),
+        ("api.xiaomimimo.com", "xiaomi"),
+        ("token-plan-ams.xiaomimimo.com", "xiaomi"),
+        ("token-plan-cn.xiaomimimo.com", "xiaomi"),
+        ("token-plan-sgp.xiaomimimo.com", "xiaomi"),
+        ("tokenhub.tencentmaas.com", "tencent-tokenhub"),
     ];
 
     for (pattern, provider) in mappings {
@@ -630,6 +639,7 @@ mod tests {
         assert_eq!(get_model_context_length("gemini-2.0-flash"), 1_048_576);
         assert_eq!(get_model_context_length("gemma4:31b-cloud"), 256_000);
         assert_eq!(get_model_context_length("xiaomi/mimo-v2.5-pro"), 1_000_000);
+        assert!(get_model_context_length("hy3-preview") >= 4096);
         assert_eq!(
             get_model_context_length("unknown-model"),
             CONTEXT_PROBE_TIERS[0]
@@ -700,6 +710,26 @@ mod tests {
         assert_eq!(
             infer_provider_from_url("https://open.bigmodel.cn/api/paas/v4"),
             Some("zai")
+        );
+        assert_eq!(
+            infer_provider_from_url("https://api.gmi-serving.com/v1"),
+            Some("gmi")
+        );
+        assert_eq!(
+            infer_provider_from_url("https://api.arcee.ai/api/v1"),
+            Some("arcee")
+        );
+        assert_eq!(
+            infer_provider_from_url("https://api.xiaomimimo.com/v1"),
+            Some("xiaomi")
+        );
+        assert_eq!(
+            infer_provider_from_url("https://token-plan-ams.xiaomimimo.com/v1"),
+            Some("xiaomi")
+        );
+        assert_eq!(
+            infer_provider_from_url("https://tokenhub.tencentmaas.com/v1"),
+            Some("tencent-tokenhub")
         );
         assert_eq!(infer_provider_from_url("http://localhost:8080"), None);
     }

--- a/crates/hermes-intelligence/src/models_dev/mapping.rs
+++ b/crates/hermes-intelligence/src/models_dev/mapping.rs
@@ -26,6 +26,7 @@ const PAIRS: &[(&str, &str)] = &[
     ("huggingface", "huggingface"),
     ("gemini", "google"),
     ("google", "google"),
+    ("xiaomi", "xiaomi"),
     ("xai", "xai"),
     ("nvidia", "nvidia"),
     ("groq", "groq"),
@@ -85,6 +86,7 @@ mod tests {
         assert_eq!(to_models_dev("anthropic"), Some("anthropic"));
         assert_eq!(to_models_dev("kimi-coding"), Some("kimi-for-coding"));
         assert_eq!(to_models_dev("gemini"), Some("google"));
+        assert_eq!(to_models_dev("xiaomi"), Some("xiaomi"));
         assert_eq!(to_models_dev("nonexistent"), None);
     }
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -5941,16 +5941,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_arcee_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ac703153fa59714631342e15544410441227c08b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_arcee_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "a4953805dd9c4a2c7235e41abcdb5e99b69bffbc",
       "workstream": "WS6"
@@ -6571,31 +6571,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_gemini_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1daeb281f0e3d8649d6e34f5811aa51f40445fe4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_gemini_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "61d7bc48ebb738c3dec3711c9e755e8fdd2ba393",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_gmi_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "06863b6682696bb8a41d1cb70fc6ac0ec918aab1",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_gmi_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "86aaf699bf60251e9d730337c92281dce569f62a",
       "workstream": "WS6"
@@ -7531,16 +7531,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_tencent_tokenhub_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "eac3b760013b3e0c51ba5c6773b3f9c77a351eed",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_tencent_tokenhub_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "55ab42244c8226f4be06090c2ba632915dd689c5",
       "workstream": "WS6"
@@ -7756,16 +7756,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_xiaomi_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "73433338961e9ab575a5c50ddd27197b86558f0c",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_xiaomi_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "4a5a7724ad0439c8fc7e38b739a8dfd82470fe47",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T21:28:33.552427+00:00",
+  "generated_at_utc": "2026-05-30T22:18:41.644574+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "67cd153e695e570d9f7ada2f2208d16f6462edc9",
+    "local_sha": "b134515993f8292f38aea2a9843cdd6c6dad83a5",
     "upstream_ref": "upstream/main",
     "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 619,
-      "intentional_divergence": 242,
+      "functional": 614,
+      "intentional_divergence": 247,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 412,
-      "rust_equivalent_or_contract_test_required": 535,
+      "not_required_for_runtime": 417,
+      "rust_equivalent_or_contract_test_required": 530,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 242,
+      "cleared_intentional_divergence": 247,
       "cleared_non_runtime": 170,
-      "pending_review": 619
+      "pending_review": 614
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 242,
+    "cleared_intentional_divergence": 247,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 619,
+    "pending_review": 614,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T21:28:33.552427+00:00`
+Generated: `2026-05-30T22:18:41.644574+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `619`
+- Pending functional review: `614`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `242`
+- Cleared intentional divergence: `247`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 242 |
+| `cleared_intentional_divergence` | 247 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 619 |
+| `pending_review` | 614 |
 
 ## Workstream Counts
 
@@ -38,7 +38,7 @@ Generated: `2026-05-30T21:28:33.552427+00:00`
 | Classification Path | Count |
 | --- | ---: |
 | `tests/gateway` | 131 |
-| `tests/hermes_cli` | 126 |
+| `tests/hermes_cli` | 121 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -640,6 +640,41 @@
       "ticket": 25
     },
     {
+      "path": "tests/hermes_cli/test_arcee_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Arcee provider alias, ARCEEAI_API_KEY/ARCEE_API_KEY, base URL, model catalog, URL inference, config hydration, ACP auth, and runtime resolution intent is covered by Rust provider, CLI, config, ACP, intelligence, AgentLoop, and HTTP gateway tests.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_gemini_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Gemini provider alias and GOOGLE_API_KEY/GEMINI_API_KEY compatibility intent is covered by Rust provider canonicalization, CLI env/base-url resolution, config hydration, AgentLoop runtime defaults, and HTTP gateway alias tests.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_gmi_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream GMI provider aliases, GMI_API_KEY/GMI_BASE_URL handling, curated/live model catalog, auxiliary default, config hydration, ACP auth, and runtime/base URL resolution are covered by Rust CLI, config, ACP, auxiliary, AgentLoop, intelligence, and HTTP gateway tests.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_tencent_tokenhub_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Tencent TokenHub canonical provider, aliases, TOKENHUB_API_KEY/TOKENHUB_BASE_URL, hy3-preview catalog/default/context metadata, URL inference, config hydration, ACP auth, auxiliary default, and runtime/base URL resolution are covered by Rust provider, CLI, config, ACP, auxiliary, AgentLoop, intelligence, and HTTP gateway tests.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_xiaomi_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Xiaomi/MiMo aliases, XIAOMI_API_KEY/XIAOMI_BASE_URL handling, model catalog, URL inference, config hydration, ACP auth, and runtime/base URL resolution are covered by Rust provider, CLI, config, ACP, intelligence, AgentLoop, and HTTP gateway tests.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "ui-tui",
       "classification": "functional",
       "rationale": "TUI package and documentation deltas can affect distributed interactive UX behavior and must be reviewed against Hermes Ultra's Rust-primary UX surface.",


### PR DESCRIPTION
## Summary
- add Tencent TokenHub plus GMI/Arcee/Xiaomi/Gemini alias/env/base-url coverage across CLI, config, ACP, AgentLoop, auxiliary, HTTP, model catalog, and metadata surfaces
- add curated direct-provider models and OpenAI-compatible live catalog fallback for TokenHub/GMI/Arcee/Xiaomi
- clear five reviewed Hermes CLI provider parity backlog entries

## Local verification
- cargo fmt
- git diff --check
- cargo test -p hermes-agent build_default_auxiliary_client_scenarios
- cargo test -p hermes-agent test_runtime_provider_direct_env_keys_and_base_url_defaults
- cargo test -p hermes-http gateway_provider_aliases_resolve_to_direct_provider_defaults
- cargo test -p hermes-cli provider
- cargo test -p hermes-config apply_env_overrides_supports_direct_provider_env_vars
- cargo test -p hermes-acp direct_provider_credentials_accept_upstream_aliases
- cargo test -p hermes-intelligence provider
- cargo test -p hermes-intelligence test_get_model_context_length
- scripts/check-runtime-placeholders.sh
- scripts/check-rust-runtime-no-python.sh
- cargo test -p hermes-parity-tests
- cargo build --workspace
- cargo test --workspace

## Note
- scripts/clippy-warning-gate.sh --check currently fails on existing warnings outside this PR's touched files; no new warning was reported in this batch's changed files.