### PR TITLE
parity(bedrock): add Rust Converse provider coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "hermes-intelligence",
  "hermes-skills",
  "hex",
+ "hmac",
  "lazy_static",
  "proptest",
  "regex",

--- a/crates/hermes-agent/Cargo.toml
+++ b/crates/hermes-agent/Cargo.toml
@@ -35,6 +35,7 @@ uuid = { workspace = true, features = ["v4"] }
 syn = { version = "2", features = ["full"] }
 sha2 = "0.10"
 hex = "0.4"
+hmac = "0.12"
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -29,6 +29,9 @@ use hermes_core::{
 };
 
 use crate::api_bridge::CodexProvider;
+use crate::bedrock::{
+    bedrock_runtime_base_url, resolve_bedrock_region, BedrockProvider, BEDROCK_AUTH_MARKER,
+};
 use crate::budget;
 use crate::code_index::CodeIndex;
 use crate::context::{
@@ -937,7 +940,11 @@ fn classify_error(err: &str) -> ErrorClass {
     let openrouter_privacy_guardrail =
         lower.contains("privacy guardrail") || lower.contains("openrouter privacy");
 
-    if lower.contains("rate limit") || lower.contains("429") || lower.contains("too many") {
+    if lower.contains("rate limit")
+        || lower.contains("429")
+        || lower.contains("too many")
+        || lower.contains("throttlingexception")
+    {
         ErrorClass::RateLimit
     } else if lower.contains("404") || lower.contains("not found") {
         if model_not_found || openrouter_privacy_guardrail {
@@ -949,6 +956,7 @@ fn classify_error(err: &str) -> ErrorClass {
         || lower.contains("maximum context")
         || lower.contains("token limit")
         || lower.contains("context_length_exceeded")
+        || lower.contains("input is too long")
     {
         ErrorClass::ContextOverflow
     } else if lower.contains("401")
@@ -2588,6 +2596,12 @@ impl AgentLoop {
         if provider == "copilot-acp" {
             return Some("copilot-acp".to_string());
         }
+        if matches!(
+            provider,
+            "bedrock" | "aws" | "aws-bedrock" | "amazon-bedrock" | "amazon"
+        ) {
+            return Some(BEDROCK_AUTH_MARKER.to_string());
+        }
         if let Some(token) = self.resolve_oauth_store_api_key(provider) {
             return Some(token);
         }
@@ -2736,6 +2750,15 @@ impl AgentLoop {
                     Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string())
                 } else if provider == "google-gemini-cli" {
                     Some("cloudcode-pa://google".to_string())
+                } else if matches!(
+                    provider,
+                    "bedrock" | "aws" | "aws-bedrock" | "amazon-bedrock" | "amazon"
+                ) {
+                    std::env::var("BEDROCK_BASE_URL")
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .or_else(|| Some(bedrock_runtime_base_url(&resolve_bedrock_region())))
                 } else if provider == "stepfun" {
                     Some("https://api.stepfun.ai/step_plan/v1".to_string())
                 } else if provider == "copilot" {
@@ -3306,6 +3329,15 @@ impl AgentLoop {
             }
             "nous" => {
                 let mut p = NousProvider::new(&api_key).with_model(model_name);
+                if let Some(url) = base_url {
+                    p = p.with_base_url(url);
+                }
+                Arc::new(p)
+            }
+            "bedrock" | "aws" | "aws-bedrock" | "amazon-bedrock" | "amazon" => {
+                let mut p = BedrockProvider::new()
+                    .with_region(resolve_bedrock_region())
+                    .with_model(model_name);
                 if let Some(url) = base_url {
                     p = p.with_base_url(url);
                 }

--- a/crates/hermes-agent/src/bedrock.rs
+++ b/crates/hermes-agent/src/bedrock.rs
@@ -1,0 +1,1281 @@
+//! AWS Bedrock Converse provider and catalog helpers.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use hmac::{Hmac, Mac};
+use reqwest::Client;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+
+use hermes_core::{
+    AgentError, FunctionCall, LlmProvider, LlmResponse, Message, MessageRole, StreamChunk,
+    StreamDelta, ToolCall, ToolSchema, UsageStats,
+};
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub const BEDROCK_AUTH_MARKER: &str = "aws-sdk";
+pub const BEDROCK_DEFAULT_REGION: &str = "us-east-1";
+pub const CONTEXT_1M_BETA: &str = "context-1m-2025-08-07";
+const INTERLEAVED_THINKING_BETA: &str = "interleaved-thinking-2025-05-14";
+const FINE_GRAINED_TOOL_STREAMING_BETA: &str = "fine-grained-tool-streaming-2025-05-14";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwsCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BedrockAuth {
+    Bearer(String),
+    SigV4(AwsCredentials),
+}
+
+#[derive(Debug, Clone)]
+pub struct BedrockProvider {
+    base_url: Option<String>,
+    region: String,
+    model: String,
+    client: Arc<Mutex<Client>>,
+}
+
+impl Default for BedrockProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BedrockProvider {
+    pub fn new() -> Self {
+        Self {
+            base_url: None,
+            region: resolve_bedrock_region(),
+            model: "anthropic.claude-3-5-sonnet-20241022-v2:0".to_string(),
+            client: Arc::new(Mutex::new(Client::new())),
+        }
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_region(mut self, region: impl Into<String>) -> Self {
+        let region = region.into();
+        if !region.trim().is_empty() {
+            self.region = region.trim().to_string();
+        }
+        self
+    }
+
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        let base_url = base_url.into();
+        if !base_url.trim().is_empty() {
+            self.base_url = Some(base_url.trim_end_matches('/').to_string());
+        }
+        self
+    }
+
+    fn effective_base_url(&self) -> String {
+        self.base_url
+            .clone()
+            .unwrap_or_else(|| bedrock_runtime_base_url(&self.region))
+    }
+}
+
+#[async_trait]
+impl LlmProvider for BedrockProvider {
+    async fn chat_completion(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: Option<u32>,
+        temperature: Option<f64>,
+        model: Option<&str>,
+        extra_body: Option<&Value>,
+    ) -> Result<LlmResponse, AgentError> {
+        let effective_model = model
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+            .unwrap_or(self.model.as_str());
+        let body = build_converse_body(
+            effective_model,
+            messages,
+            tools,
+            max_tokens,
+            temperature,
+            extra_body,
+        );
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|err| AgentError::Config(format!("serialize Bedrock request: {err}")))?;
+        let url = format!(
+            "{}/model/{}/converse",
+            self.effective_base_url().trim_end_matches('/'),
+            percent_encode_path_segment(effective_model)
+        );
+        let auth = resolve_bedrock_auth().ok_or_else(|| {
+            AgentError::AuthFailed(
+                "No AWS credentials for Bedrock; set AWS_BEARER_TOKEN_BEDROCK, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or a shared credentials profile".to_string(),
+            )
+        })?;
+        let mut request = {
+            let client = self
+                .client
+                .lock()
+                .map(|c| c.clone())
+                .unwrap_or_else(|_| Client::new());
+            client.post(url.as_str()).body(body_bytes.clone())
+        };
+        for (key, value) in bedrock_request_headers(
+            "POST",
+            url.as_str(),
+            &self.region,
+            "bedrock",
+            &body_bytes,
+            &auth,
+            bedrock_anthropic_beta_header(effective_model).as_deref(),
+            Utc::now(),
+        )? {
+            request = request.header(key, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|err| AgentError::LlmApi(format!("Bedrock Converse request failed: {err}")))?;
+        let status = response.status();
+        let payload = response
+            .text()
+            .await
+            .map_err(|err| AgentError::LlmApi(format!("Bedrock response read failed: {err}")))?;
+        if !status.is_success() {
+            return Err(map_bedrock_error(status.as_u16(), &payload));
+        }
+        let json: Value = serde_json::from_str(&payload).map_err(|err| {
+            AgentError::LlmApi(format!(
+                "Bedrock response JSON parse failed: {err}; body={payload}"
+            ))
+        })?;
+        parse_bedrock_response(&json, effective_model)
+    }
+
+    fn chat_completion_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: Option<u32>,
+        temperature: Option<f64>,
+        model: Option<&str>,
+        extra_body: Option<&Value>,
+    ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+        let provider = self.clone();
+        let messages = messages.to_vec();
+        let tools = tools.to_vec();
+        let model = model.map(str::to_string);
+        let extra_body = extra_body.cloned();
+        Box::pin(async_stream::stream! {
+            match provider
+                .chat_completion(
+                    &messages,
+                    &tools,
+                    max_tokens,
+                    temperature,
+                    model.as_deref(),
+                    extra_body.as_ref(),
+                )
+                .await
+            {
+                Ok(response) => {
+                    if let Some(content) = response.message.content.clone().filter(|s| !s.is_empty()) {
+                        yield Ok(StreamChunk {
+                            delta: Some(StreamDelta {
+                                content: Some(content),
+                                tool_calls: None,
+                                extra: None,
+                            }),
+                            finish_reason: None,
+                            usage: None,
+                        });
+                    }
+                    yield Ok(StreamChunk {
+                        delta: None,
+                        finish_reason: response.finish_reason,
+                        usage: response.usage,
+                    });
+                }
+                Err(err) => yield Err(err),
+            }
+        })
+    }
+}
+
+pub fn bedrock_runtime_base_url(region: &str) -> String {
+    format!(
+        "https://bedrock-runtime.{}.amazonaws.com",
+        normalized_region_or_default(region)
+    )
+}
+
+pub fn bedrock_control_base_url(region: &str) -> String {
+    format!(
+        "https://bedrock.{}.amazonaws.com",
+        normalized_region_or_default(region)
+    )
+}
+
+pub fn resolve_bedrock_region() -> String {
+    std::env::var("AWS_REGION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            std::env::var("AWS_DEFAULT_REGION")
+                .ok()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+        })
+        .or_else(resolve_region_from_aws_config)
+        .unwrap_or_else(|| BEDROCK_DEFAULT_REGION.to_string())
+}
+
+pub fn has_aws_credentials() -> bool {
+    std::env::var("AWS_BEARER_TOKEN_BEDROCK")
+        .ok()
+        .is_some_and(|v| !v.trim().is_empty())
+        || resolve_env_credentials().is_some()
+        || resolve_shared_credentials().is_some()
+        || std::env::var("AWS_PROFILE")
+            .ok()
+            .is_some_and(|v| !v.trim().is_empty())
+        || std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE")
+            .ok()
+            .is_some_and(|v| !v.trim().is_empty())
+        || std::env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+            .ok()
+            .is_some_and(|v| !v.trim().is_empty())
+        || std::env::var("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+            .ok()
+            .is_some_and(|v| !v.trim().is_empty())
+}
+
+pub fn curated_bedrock_models_for_region(region: &str) -> Vec<String> {
+    let anthropic_prefix = anthropic_inference_profile_prefix(region);
+    let amazon_prefix = amazon_inference_profile_prefix(region);
+    vec![
+        "anthropic.claude-sonnet-4-6".to_string(),
+        format!("{anthropic_prefix}.anthropic.claude-sonnet-4-6"),
+        "anthropic.claude-haiku-4-5-20251001-v1:0".to_string(),
+        format!("{anthropic_prefix}.anthropic.claude-haiku-4-5-20251001-v1:0"),
+        "anthropic.claude-3-5-sonnet-20241022-v2:0".to_string(),
+        "amazon.nova-pro-v1:0".to_string(),
+        format!("{amazon_prefix}.amazon.nova-pro-v1:0"),
+        "amazon.nova-micro-v1:0".to_string(),
+        format!("{amazon_prefix}.amazon.nova-micro-v1:0"),
+    ]
+}
+
+pub async fn discover_bedrock_model_ids(region: &str) -> Vec<String> {
+    if cfg!(test) {
+        return Vec::new();
+    }
+    let Some(auth) = resolve_bedrock_auth() else {
+        return Vec::new();
+    };
+    let region = normalized_region_or_default(region);
+    let base = bedrock_control_base_url(&region);
+    let mut ids = Vec::new();
+    ids.extend(
+        fetch_bedrock_catalog_endpoint(&format!("{base}/foundation-models"), &region, &auth).await,
+    );
+    ids.extend(
+        fetch_bedrock_catalog_endpoint(&format!("{base}/inference-profiles"), &region, &auth).await,
+    );
+    dedup_model_ids(ids)
+}
+
+async fn fetch_bedrock_catalog_endpoint(
+    url: &str,
+    region: &str,
+    auth: &BedrockAuth,
+) -> Vec<String> {
+    let headers =
+        match bedrock_request_headers("GET", url, region, "bedrock", b"", auth, None, Utc::now()) {
+            Ok(headers) => headers,
+            Err(_) => return Vec::new(),
+        };
+    let client = Client::new();
+    let mut request = client.get(url);
+    for (key, value) in headers {
+        request = request.header(key, value);
+    }
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(_) => return Vec::new(),
+    };
+    if !response.status().is_success() {
+        return Vec::new();
+    }
+    let payload: Value = match response.json().await {
+        Ok(value) => value,
+        Err(_) => return Vec::new(),
+    };
+    parse_bedrock_catalog_model_ids(&payload)
+}
+
+pub fn parse_bedrock_catalog_model_ids(payload: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    collect_model_ids(payload, "modelSummaries", "modelId", &mut ids);
+    collect_model_ids(
+        payload,
+        "inferenceProfileSummaries",
+        "inferenceProfileId",
+        &mut ids,
+    );
+    collect_model_ids(payload, "data", "id", &mut ids);
+    dedup_model_ids(ids)
+}
+
+fn collect_model_ids(payload: &Value, array_key: &str, id_key: &str, out: &mut Vec<String>) {
+    if let Some(rows) = payload.get(array_key).and_then(Value::as_array) {
+        for row in rows {
+            if let Some(id) = row
+                .get(id_key)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                out.push(id.to_string());
+            }
+        }
+    }
+}
+
+fn dedup_model_ids(ids: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut dedup = Vec::new();
+    for id in ids {
+        if seen.insert(id.to_ascii_lowercase()) {
+            dedup.push(id);
+        }
+    }
+    dedup
+}
+
+pub fn build_converse_body(
+    model: &str,
+    messages: &[Message],
+    tools: &[ToolSchema],
+    max_tokens: Option<u32>,
+    temperature: Option<f64>,
+    extra_body: Option<&Value>,
+) -> Value {
+    let (system, messages) = convert_messages_to_bedrock(messages);
+    let mut body = json!({
+        "messages": messages,
+    });
+    if !system.is_empty() {
+        body["system"] = Value::Array(system);
+    }
+    let mut inference = Map::new();
+    if let Some(max_tokens) = max_tokens {
+        inference.insert("maxTokens".to_string(), json!(max_tokens));
+    }
+    if let Some(temperature) = temperature {
+        inference.insert("temperature".to_string(), json!(temperature));
+    }
+    if !inference.is_empty() {
+        body["inferenceConfig"] = Value::Object(inference);
+    }
+    if !tools.is_empty() {
+        body["toolConfig"] = json!({
+            "tools": convert_tools_to_bedrock(tools),
+        });
+    }
+    if let Some(fields) = bedrock_additional_model_request_fields(model) {
+        body["additionalModelRequestFields"] = fields;
+    }
+    merge_bedrock_extra_body(&mut body, extra_body);
+    body
+}
+
+fn merge_bedrock_extra_body(body: &mut Value, extra_body: Option<&Value>) {
+    let Some(Value::Object(extra)) = extra_body else {
+        return;
+    };
+    for (key, value) in extra {
+        match key.as_str() {
+            "strict_api" | "strict_tool_calls" | "provider_strict" => {}
+            "additionalModelRequestFields" => {
+                if let (Some(target), Some(source)) = (
+                    body.get_mut("additionalModelRequestFields")
+                        .and_then(Value::as_object_mut),
+                    value.as_object(),
+                ) {
+                    for (field_key, field_value) in source {
+                        target.insert(field_key.clone(), field_value.clone());
+                    }
+                } else {
+                    body[key] = value.clone();
+                }
+            }
+            _ => {
+                body[key] = value.clone();
+            }
+        }
+    }
+}
+
+fn convert_messages_to_bedrock(messages: &[Message]) -> (Vec<Value>, Vec<Value>) {
+    let mut system = Vec::new();
+    let mut converted = Vec::new();
+    for message in messages {
+        match message.role {
+            MessageRole::System => {
+                if let Some(text) = message
+                    .content
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    system.push(json!({"text": text}));
+                }
+            }
+            MessageRole::User => {
+                converted.push(json!({
+                    "role": "user",
+                    "content": text_content_blocks(message.content.as_deref()),
+                }));
+            }
+            MessageRole::Assistant => {
+                let mut content = text_content_blocks(message.content.as_deref());
+                if let Some(reasoning) = message
+                    .reasoning_content
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    content.insert(0, json!({"reasoningContent": {"text": reasoning}}));
+                }
+                if let Some(tool_calls) = message.tool_calls.as_ref() {
+                    for call in tool_calls {
+                        let input: Value = serde_json::from_str(&call.function.arguments)
+                            .unwrap_or_else(|_| json!({ "arguments": call.function.arguments }));
+                        content.push(json!({
+                            "toolUse": {
+                                "toolUseId": call.id,
+                                "name": call.function.name,
+                                "input": input,
+                            }
+                        }));
+                    }
+                }
+                converted.push(json!({
+                    "role": "assistant",
+                    "content": content,
+                }));
+            }
+            MessageRole::Tool => {
+                converted.push(json!({
+                    "role": "user",
+                    "content": [{
+                        "toolResult": {
+                            "toolUseId": message.tool_call_id.clone().unwrap_or_default(),
+                            "content": text_content_blocks(message.content.as_deref()),
+                        }
+                    }],
+                }));
+            }
+        }
+    }
+    if converted.is_empty() {
+        converted.push(json!({
+            "role": "user",
+            "content": [{"text": ""}],
+        }));
+    }
+    (system, converted)
+}
+
+fn text_content_blocks(content: Option<&str>) -> Vec<Value> {
+    match content.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(text) => vec![json!({"text": text})],
+        None => Vec::new(),
+    }
+}
+
+pub fn convert_tools_to_bedrock(tools: &[ToolSchema]) -> Vec<Value> {
+    tools
+        .iter()
+        .map(|tool| {
+            let schema = serde_json::to_value(&tool.parameters).unwrap_or_else(|_| {
+                json!({
+                    "type": "object",
+                    "properties": {},
+                })
+            });
+            json!({
+                "toolSpec": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "inputSchema": {
+                        "json": schema,
+                    },
+                }
+            })
+        })
+        .collect()
+}
+
+pub fn validate_bedrock_response(value: &Value) -> bool {
+    value.get("output").and_then(|v| v.get("message")).is_some() && value.get("error").is_none()
+}
+
+pub fn map_bedrock_finish_reason(reason: Option<&str>) -> Option<String> {
+    Some(
+        match reason.unwrap_or("end_turn") {
+            "end_turn" => "stop",
+            "tool_use" => "tool_calls",
+            "max_tokens" => "length",
+            "guardrail_intervened" => "content_filter",
+            _ => "stop",
+        }
+        .to_string(),
+    )
+}
+
+pub fn parse_bedrock_response(json: &Value, model: &str) -> Result<LlmResponse, AgentError> {
+    if let Some(response) = parse_openai_like_response(json, model) {
+        return Ok(response);
+    }
+    if !validate_bedrock_response(json) {
+        return Err(AgentError::LlmApi(format!(
+            "Invalid Bedrock response shape: {}",
+            truncate_json(json, 600)
+        )));
+    }
+    let content_blocks = json
+        .get("output")
+        .and_then(|v| v.get("message"))
+        .and_then(|v| v.get("content"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut text_parts = Vec::new();
+    let mut reasoning_parts = Vec::new();
+    let mut tool_calls = Vec::new();
+    for block in content_blocks {
+        if let Some(text) = block.get("text").and_then(Value::as_str) {
+            if !text.is_empty() {
+                text_parts.push(text.to_string());
+            }
+        }
+        if let Some(text) = block
+            .get("reasoningContent")
+            .and_then(|v| v.get("text"))
+            .and_then(Value::as_str)
+        {
+            if !text.is_empty() {
+                reasoning_parts.push(text.to_string());
+            }
+        }
+        if let Some(tool_use) = block.get("toolUse") {
+            let id = tool_use
+                .get("toolUseId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let name = tool_use
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if name.is_empty() {
+                continue;
+            }
+            let arguments = tool_use
+                .get("input")
+                .cloned()
+                .unwrap_or_else(|| json!({}))
+                .to_string();
+            tool_calls.push(ToolCall {
+                id,
+                function: FunctionCall { name, arguments },
+                extra_content: None,
+            });
+        }
+    }
+    let usage = json.get("usage").map(|usage| UsageStats {
+        prompt_tokens: usage
+            .get("inputTokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        completion_tokens: usage
+            .get("outputTokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        total_tokens: usage
+            .get("totalTokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_else(|| {
+                usage
+                    .get("inputTokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_default()
+                    + usage
+                        .get("outputTokens")
+                        .and_then(Value::as_u64)
+                        .unwrap_or_default()
+            }),
+        estimated_cost: None,
+    });
+    Ok(LlmResponse {
+        message: Message {
+            role: MessageRole::Assistant,
+            content: Some(text_parts.join("\n")),
+            tool_calls: if tool_calls.is_empty() {
+                None
+            } else {
+                Some(tool_calls)
+            },
+            tool_call_id: None,
+            name: None,
+            reasoning_content: if reasoning_parts.is_empty() {
+                None
+            } else {
+                Some(reasoning_parts.join("\n"))
+            },
+            cache_control: None,
+        },
+        usage,
+        model: model.to_string(),
+        finish_reason: map_bedrock_finish_reason(json.get("stopReason").and_then(Value::as_str)),
+    })
+}
+
+fn parse_openai_like_response(json: &Value, fallback_model: &str) -> Option<LlmResponse> {
+    let choices = json.get("choices")?.as_array()?;
+    let choice = choices.first()?;
+    let message_obj = choice.get("message")?;
+    let content = message_obj
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let tool_calls = message_obj
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|tc| {
+                    let function = tc.get("function")?;
+                    Some(ToolCall {
+                        id: tc
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                        function: FunctionCall {
+                            name: function.get("name")?.as_str()?.to_string(),
+                            arguments: function
+                                .get("arguments")
+                                .and_then(Value::as_str)
+                                .unwrap_or("{}")
+                                .to_string(),
+                        },
+                        extra_content: None,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|calls| !calls.is_empty());
+    let usage = json.get("usage").map(|usage| UsageStats {
+        prompt_tokens: usage
+            .get("prompt_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        completion_tokens: usage
+            .get("completion_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        total_tokens: usage
+            .get("total_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        estimated_cost: None,
+    });
+    Some(LlmResponse {
+        message: Message {
+            role: MessageRole::Assistant,
+            content: Some(content),
+            tool_calls,
+            tool_call_id: None,
+            name: None,
+            reasoning_content: message_obj
+                .get("reasoning")
+                .or_else(|| message_obj.get("reasoning_content"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            cache_control: None,
+        },
+        usage,
+        model: json
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or(fallback_model)
+            .to_string(),
+        finish_reason: choice
+            .get("finish_reason")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    })
+}
+
+fn bedrock_additional_model_request_fields(model: &str) -> Option<Value> {
+    let betas = bedrock_anthropic_betas(model)?;
+    Some(json!({ "anthropic_beta": betas }))
+}
+
+pub fn bedrock_anthropic_betas(model: &str) -> Option<Vec<String>> {
+    if !is_bedrock_anthropic_model_id(model) {
+        return None;
+    }
+    Some(vec![
+        CONTEXT_1M_BETA.to_string(),
+        INTERLEAVED_THINKING_BETA.to_string(),
+        FINE_GRAINED_TOOL_STREAMING_BETA.to_string(),
+    ])
+}
+
+fn bedrock_anthropic_beta_header(model: &str) -> Option<String> {
+    bedrock_anthropic_betas(model).map(|betas| betas.join(","))
+}
+
+pub fn is_bedrock_anthropic_model_id(model: &str) -> bool {
+    let lower = model.trim().to_ascii_lowercase();
+    [
+        "anthropic.",
+        "us.anthropic.",
+        "eu.anthropic.",
+        "ap.anthropic.",
+        "global.anthropic.",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+}
+
+fn map_bedrock_error(status: u16, body: &str) -> AgentError {
+    let lower = body.to_ascii_lowercase();
+    if lower.contains("throttlingexception")
+        || lower.contains("too many requests")
+        || lower.contains("rate limit")
+        || status == 429
+    {
+        AgentError::RateLimited {
+            retry_after_secs: None,
+        }
+    } else if status == 401
+        || status == 403
+        || lower.contains("unauthorized")
+        || lower.contains("accessdenied")
+        || lower.contains("invalidsignature")
+    {
+        AgentError::AuthFailed(format!("Bedrock authorization failed: {body}"))
+    } else {
+        AgentError::LlmApi(format!("Bedrock API error {status}: {body}"))
+    }
+}
+
+fn resolve_bedrock_auth() -> Option<BedrockAuth> {
+    std::env::var("AWS_BEARER_TOKEN_BEDROCK")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .map(BedrockAuth::Bearer)
+        .or_else(|| resolve_env_credentials().map(BedrockAuth::SigV4))
+        .or_else(|| resolve_shared_credentials().map(BedrockAuth::SigV4))
+}
+
+fn resolve_env_credentials() -> Option<AwsCredentials> {
+    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())?;
+    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())?;
+    let session_token = std::env::var("AWS_SESSION_TOKEN")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    Some(AwsCredentials {
+        access_key_id,
+        secret_access_key,
+        session_token,
+    })
+}
+
+fn resolve_shared_credentials() -> Option<AwsCredentials> {
+    let path = aws_shared_credentials_path()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let profile = aws_profile_name();
+    let values = parse_ini_section(&raw, &profile);
+    let access_key_id = values.get("aws_access_key_id")?.trim().to_string();
+    let secret_access_key = values.get("aws_secret_access_key")?.trim().to_string();
+    if access_key_id.is_empty() || secret_access_key.is_empty() {
+        return None;
+    }
+    let session_token = values
+        .get("aws_session_token")
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    Some(AwsCredentials {
+        access_key_id,
+        secret_access_key,
+        session_token,
+    })
+}
+
+fn resolve_region_from_aws_config() -> Option<String> {
+    let path = aws_config_path()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let profile = aws_profile_name();
+    parse_ini_section(&raw, &profile)
+        .get("region")
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn aws_profile_name() -> String {
+    std::env::var("AWS_PROFILE")
+        .or_else(|_| std::env::var("AWS_DEFAULT_PROFILE"))
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn aws_shared_credentials_path() -> Option<PathBuf> {
+    std::env::var("AWS_SHARED_CREDENTIALS_FILE")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".aws").join("credentials")))
+}
+
+fn aws_config_path() -> Option<PathBuf> {
+    std::env::var("AWS_CONFIG_FILE")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".aws").join("config")))
+}
+
+fn parse_ini_section(raw: &str, profile: &str) -> HashMap<String, String> {
+    let mut current_matches = false;
+    let mut out = HashMap::new();
+    let profile_section = if profile == "default" {
+        "default".to_string()
+    } else {
+        format!("profile {profile}")
+    };
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let section = trimmed.trim_start_matches('[').trim_end_matches(']').trim();
+            current_matches = section == profile || section == profile_section;
+            continue;
+        }
+        if !current_matches {
+            continue;
+        }
+        if let Some((key, value)) = trimmed.split_once('=') {
+            out.insert(key.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+    out
+}
+
+fn bedrock_request_headers(
+    method: &str,
+    url: &str,
+    region: &str,
+    service: &str,
+    body: &[u8],
+    auth: &BedrockAuth,
+    anthropic_beta: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<BTreeMap<String, String>, AgentError> {
+    let mut headers = BTreeMap::new();
+    headers.insert("accept".to_string(), "application/json".to_string());
+    if method != "GET" {
+        headers.insert("content-type".to_string(), "application/json".to_string());
+    }
+    if let Some(beta) = anthropic_beta.map(str::trim).filter(|s| !s.is_empty()) {
+        headers.insert("anthropic-beta".to_string(), beta.to_string());
+    }
+    match auth {
+        BedrockAuth::Bearer(token) => {
+            headers.insert("authorization".to_string(), format!("Bearer {token}"));
+            Ok(headers)
+        }
+        BedrockAuth::SigV4(credentials) => sign_sigv4_headers(
+            method,
+            url,
+            region,
+            service,
+            body,
+            credentials,
+            headers,
+            now,
+        ),
+    }
+}
+
+fn sign_sigv4_headers(
+    method: &str,
+    url: &str,
+    region: &str,
+    service: &str,
+    body: &[u8],
+    credentials: &AwsCredentials,
+    mut headers: BTreeMap<String, String>,
+    now: DateTime<Utc>,
+) -> Result<BTreeMap<String, String>, AgentError> {
+    let url = reqwest::Url::parse(url)
+        .map_err(|err| AgentError::Config(format!("invalid Bedrock URL for SigV4: {err}")))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| AgentError::Config("Bedrock SigV4 URL missing host".to_string()))?;
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let short_date = now.format("%Y%m%d").to_string();
+    let payload_hash = hex::encode(Sha256::digest(body));
+
+    headers.insert("host".to_string(), host.to_string());
+    headers.insert("x-amz-date".to_string(), amz_date.clone());
+    headers.insert("x-amz-content-sha256".to_string(), payload_hash.clone());
+    if let Some(token) = credentials
+        .session_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        headers.insert("x-amz-security-token".to_string(), token.to_string());
+    }
+
+    let canonical_headers = headers
+        .iter()
+        .map(|(key, value)| format!("{}:{}\n", key.to_ascii_lowercase(), collapse_spaces(value)))
+        .collect::<String>();
+    let signed_headers = headers
+        .keys()
+        .map(|key| key.to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(";");
+    let canonical_query = canonical_query_string(&url);
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method.to_ascii_uppercase(),
+        canonical_uri(&url),
+        canonical_query,
+        canonical_headers,
+        signed_headers,
+        payload_hash
+    );
+    let scope = format!(
+        "{}/{}/{}/aws4_request",
+        short_date,
+        normalized_region_or_default(region),
+        service
+    );
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+        amz_date,
+        scope,
+        hex::encode(Sha256::digest(canonical_request.as_bytes()))
+    );
+    let signing_key = sigv4_signing_key(
+        credentials.secret_access_key.as_bytes(),
+        short_date.as_bytes(),
+        normalized_region_or_default(region).as_bytes(),
+        service.as_bytes(),
+    )?;
+    let signature = hmac_sha256_hex(&signing_key, string_to_sign.as_bytes())?;
+    headers.insert(
+        "authorization".to_string(),
+        format!(
+            "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+            credentials.access_key_id, scope, signed_headers, signature
+        ),
+    );
+    Ok(headers)
+}
+
+fn sigv4_signing_key(
+    secret: &[u8],
+    date: &[u8],
+    region: &[u8],
+    service: &[u8],
+) -> Result<Vec<u8>, AgentError> {
+    let k_secret = [b"AWS4".as_slice(), secret].concat();
+    let k_date = hmac_sha256(&k_secret, date)?;
+    let k_region = hmac_sha256(&k_date, region)?;
+    let k_service = hmac_sha256(&k_region, service)?;
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+fn hmac_sha256(key: &[u8], value: &[u8]) -> Result<Vec<u8>, AgentError> {
+    let mut mac = HmacSha256::new_from_slice(key)
+        .map_err(|err| AgentError::Config(format!("SigV4 HMAC init failed: {err}")))?;
+    mac.update(value);
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+fn hmac_sha256_hex(key: &[u8], value: &[u8]) -> Result<String, AgentError> {
+    Ok(hex::encode(hmac_sha256(key, value)?))
+}
+
+fn canonical_uri(url: &reqwest::Url) -> String {
+    let path = url.path();
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn canonical_query_string(url: &reqwest::Url) -> String {
+    let mut pairs = url
+        .query_pairs()
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                percent_encode_query_component(&key),
+                percent_encode_query_component(&value)
+            )
+        })
+        .collect::<Vec<_>>();
+    pairs.sort();
+    pairs.join("&")
+}
+
+fn collapse_spaces(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn normalized_region_or_default(region: &str) -> String {
+    let trimmed = region.trim();
+    if trimmed.is_empty() {
+        BEDROCK_DEFAULT_REGION.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn anthropic_inference_profile_prefix(region: &str) -> &'static str {
+    let region = normalized_region_or_default(region);
+    if region.starts_with("eu-") {
+        "eu"
+    } else if matches!(
+        region.as_str(),
+        "ap-southeast-2" | "ap-southeast-4" | "ap-southeast-6"
+    ) {
+        "au"
+    } else if matches!(region.as_str(), "ap-northeast-1" | "ap-northeast-3") {
+        "jp"
+    } else {
+        "us"
+    }
+}
+
+fn amazon_inference_profile_prefix(region: &str) -> &'static str {
+    let region = normalized_region_or_default(region);
+    if region.starts_with("eu-") {
+        "eu"
+    } else {
+        "us"
+    }
+}
+
+fn percent_encode_path_segment(input: &str) -> String {
+    percent_encode_bytes(input.as_bytes(), false)
+}
+
+fn percent_encode_query_component(input: &str) -> String {
+    percent_encode_bytes(input.as_bytes(), true)
+}
+
+fn percent_encode_bytes(input: &[u8], encode_tilde: bool) -> String {
+    let mut out = String::new();
+    for &byte in input {
+        let keep = byte.is_ascii_alphanumeric()
+            || matches!(byte, b'-' | b'_' | b'.')
+            || (!encode_tilde && byte == b'~');
+        if keep {
+            out.push(byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+fn truncate_json(value: &Value, max_chars: usize) -> String {
+    let raw = value.to_string();
+    if raw.chars().count() <= max_chars {
+        raw
+    } else {
+        raw.chars().take(max_chars).collect::<String>() + "..."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hermes_core::JsonSchema;
+
+    #[test]
+    fn build_converse_body_maps_messages_tools_and_1m_beta() {
+        let tools = vec![ToolSchema::new(
+            "terminal",
+            "Run commands",
+            JsonSchema::new("object"),
+        )];
+        let body = build_converse_body(
+            "global.anthropic.claude-opus-4-7",
+            &[Message::system("system"), Message::user("hello")],
+            &tools,
+            Some(8192),
+            Some(0.2),
+            None,
+        );
+        assert_eq!(body["system"][0]["text"], "system");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["inferenceConfig"]["maxTokens"], 8192);
+        assert_eq!(
+            body["toolConfig"]["tools"][0]["toolSpec"]["name"],
+            "terminal"
+        );
+        let betas = body["additionalModelRequestFields"]["anthropic_beta"]
+            .as_array()
+            .expect("anthropic betas");
+        assert!(betas.iter().any(|v| v == CONTEXT_1M_BETA));
+    }
+
+    #[test]
+    fn parse_bedrock_response_preserves_text_tool_reasoning_and_usage() {
+        let raw = json!({
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"reasoningContent": {"text": "Let me think..."}},
+                        {"text": "Answer."},
+                        {"toolUse": {
+                            "toolUseId": "tool_1",
+                            "name": "terminal",
+                            "input": {"command": "ls"}
+                        }}
+                    ]
+                }
+            },
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15}
+        });
+        let response = parse_bedrock_response(&raw, "anthropic.claude").expect("response");
+        assert_eq!(response.message.content.as_deref(), Some("Answer."));
+        assert_eq!(
+            response.message.reasoning_content.as_deref(),
+            Some("Let me think...")
+        );
+        assert_eq!(response.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(response.usage.expect("usage").total_tokens, 15);
+        let calls = response.message.tool_calls.expect("tool calls");
+        assert_eq!(calls[0].function.name, "terminal");
+        assert_eq!(calls[0].function.arguments, r#"{"command":"ls"}"#);
+    }
+
+    #[test]
+    fn finish_reason_mapping_matches_bedrock_transport_contract() {
+        assert_eq!(
+            map_bedrock_finish_reason(Some("end_turn")).as_deref(),
+            Some("stop")
+        );
+        assert_eq!(
+            map_bedrock_finish_reason(Some("tool_use")).as_deref(),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            map_bedrock_finish_reason(Some("max_tokens")).as_deref(),
+            Some("length")
+        );
+        assert_eq!(
+            map_bedrock_finish_reason(Some("guardrail_intervened")).as_deref(),
+            Some("content_filter")
+        );
+        assert_eq!(
+            map_bedrock_finish_reason(Some("unknown")).as_deref(),
+            Some("stop")
+        );
+    }
+
+    #[test]
+    fn catalog_parser_accepts_foundation_models_and_inference_profiles() {
+        let raw = json!({
+            "modelSummaries": [
+                {"modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0"}
+            ],
+            "inferenceProfileSummaries": [
+                {"inferenceProfileId": "eu.anthropic.claude-sonnet-4-6"}
+            ]
+        });
+        let ids = parse_bedrock_catalog_model_ids(&raw);
+        assert_eq!(ids.len(), 2);
+        assert!(ids.iter().any(|id| id.starts_with("eu.anthropic.")));
+    }
+
+    #[test]
+    fn sigv4_headers_include_required_bedrock_fields() {
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: Some("session".to_string()),
+        };
+        let auth = BedrockAuth::SigV4(creds);
+        let headers = bedrock_request_headers(
+            "POST",
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude%3A0/converse",
+            "us-east-1",
+            "bedrock",
+            br#"{"messages":[]}"#,
+            &auth,
+            Some(CONTEXT_1M_BETA),
+            DateTime::parse_from_rfc3339("2026-05-30T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .expect("headers");
+        assert_eq!(
+            headers.get("x-amz-date").map(String::as_str),
+            Some("20260530T000000Z")
+        );
+        assert_eq!(
+            headers.get("x-amz-security-token").map(String::as_str),
+            Some("session")
+        );
+        assert!(headers.get("authorization").expect("auth").starts_with(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260530/us-east-1/bedrock/aws4_request"
+        ));
+        assert_eq!(
+            headers.get("anthropic-beta").map(String::as_str),
+            Some(CONTEXT_1M_BETA)
+        );
+    }
+}

--- a/crates/hermes-agent/src/lib.rs
+++ b/crates/hermes-agent/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod agent_loop;
 pub mod api_bridge;
 pub mod auxiliary_builder;
+pub mod bedrock;
 pub mod budget;
 pub mod code_index;
 pub mod compression;
@@ -55,6 +56,7 @@ pub use auxiliary_builder::{
     build_auxiliary_client_with_main_runtime, build_default_auxiliary_client, AuxiliaryMainRuntime,
     AuxiliaryWiringSummary,
 };
+pub use bedrock::BedrockProvider;
 pub use provider::{AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider};
 pub use providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,

--- a/crates/hermes-agent/src/smart_model_routing.rs
+++ b/crates/hermes-agent/src/smart_model_routing.rs
@@ -93,6 +93,7 @@ pub enum ApiMode {
     ChatCompletions,
     AnthropicMessages,
     CodexResponses,
+    BedrockConverse,
 }
 
 impl Default for ApiMode {
@@ -342,6 +343,9 @@ where
 /// Heuristic from Python `_detect_api_mode_for_url` (OpenAI direct host → Codex/Responses).
 pub fn detect_api_mode_for_url(base_url: &str) -> Option<ApiMode> {
     let normalized = base_url.trim().to_lowercase();
+    if normalized.contains("bedrock-runtime.") || normalized.contains("bedrock-runtime-") {
+        return Some(ApiMode::BedrockConverse);
+    }
     if normalized.contains("api.openai.com") && !normalized.contains("openrouter") {
         return Some(ApiMode::CodexResponses);
     }
@@ -429,6 +433,14 @@ mod tests {
         assert!(
             choose_cheap_model_route(prompt, &cfg).is_none(),
             "jailbreak/tool-abuse language should never take cheap route"
+        );
+    }
+
+    #[test]
+    fn detects_bedrock_converse_api_mode_from_runtime_url() {
+        assert_eq!(
+            detect_api_mode_for_url("https://bedrock-runtime.us-east-1.amazonaws.com"),
+            Some(ApiMode::BedrockConverse)
         );
     }
 

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -14,6 +14,9 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use hermes_agent::agent_loop::ToolRegistry as AgentToolRegistry;
+use hermes_agent::bedrock::{
+    bedrock_runtime_base_url, resolve_bedrock_region, BedrockProvider, BEDROCK_AUTH_MARKER,
+};
 use hermes_agent::plugins::HookType;
 use hermes_agent::provider::{
     openai_codex_provider, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
@@ -4832,6 +4835,9 @@ mod tests {
             normalize_runtime_provider_name("tokenhub"),
             "tencent-tokenhub"
         );
+        assert_eq!(normalize_runtime_provider_name("aws"), "bedrock");
+        assert_eq!(normalize_runtime_provider_name("aws-bedrock"), "bedrock");
+        assert_eq!(normalize_runtime_provider_name("amazon"), "bedrock");
     }
 
     #[test]
@@ -4848,6 +4854,7 @@ mod tests {
             "TOKENHUB_BASE_URL",
             "ARCEE_BASE_URL",
             "XIAOMI_BASE_URL",
+            "BEDROCK_BASE_URL",
         ];
         for env_var in env_vars {
             std::env::remove_var(env_var);
@@ -4906,6 +4913,11 @@ mod tests {
         assert_eq!(
             provider_base_url_from_env("mimo").as_deref(),
             Some("https://mimo.example/v1")
+        );
+        std::env::set_var("BEDROCK_BASE_URL", "https://bedrock-runtime.example");
+        assert_eq!(
+            provider_base_url_from_env("aws").as_deref(),
+            Some("https://bedrock-runtime.example")
         );
 
         for env_var in env_vars {
@@ -5732,6 +5744,7 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
         "arcee-ai" | "arceeai" => "arcee".to_string(),
         "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
         "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
+        "aws" | "aws-bedrock" | "amazon-bedrock" | "amazon" => "bedrock".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
@@ -5968,6 +5981,7 @@ fn provider_base_url_from_env(provider: &str) -> Option<String> {
             "openai" => "OPENAI_BASE_URL",
             "openai-codex" | "codex" => "HERMES_OPENAI_CODEX_BASE_URL",
             "anthropic" => "ANTHROPIC_BASE_URL",
+            "bedrock" => "BEDROCK_BASE_URL",
             "google-gemini-cli" => "HERMES_GEMINI_BASE_URL",
             "gemini" | "google" => "GEMINI_BASE_URL",
             "qwen" => "DASHSCOPE_BASE_URL",
@@ -6016,6 +6030,8 @@ fn provider_is_local_backend(provider: &str) -> bool {
 fn allow_no_api_key(provider_name: &str, runtime_provider: &str, base_url: Option<&str>) -> bool {
     provider_is_local_backend(runtime_provider)
         || provider_is_local_backend(provider_name)
+        || runtime_provider == "bedrock"
+        || provider_name == "bedrock"
         || base_url.is_some_and(url_is_local_or_private)
 }
 
@@ -6081,6 +6097,7 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
             .filter(|s| !s.trim().is_empty())
             .or_else(|| std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok())
             .filter(|s| !s.trim().is_empty()),
+        "bedrock" => Some(BEDROCK_AUTH_MARKER.to_string()),
         "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => {
             std::env::var("HERMES_GEMINI_OAUTH_API_KEY")
                 .ok()
@@ -6291,6 +6308,17 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         "anthropic" => {
             let mut p = AnthropicProvider::new(&api_key).with_model(model_name.as_str());
             if let Some(url) = base_url {
+                p = p.with_base_url(url);
+            }
+            Arc::new(p)
+        }
+        "bedrock" => {
+            let mut p = BedrockProvider::new()
+                .with_region(resolve_bedrock_region())
+                .with_model(model_name.as_str());
+            if let Some(url) =
+                base_url.or_else(|| Some(bedrock_runtime_base_url(&resolve_bedrock_region())))
+            {
                 p = p.with_base_url(url);
             }
             Arc::new(p)

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -5298,6 +5298,7 @@ fn normalize_secret_provider(provider: &str) -> String {
         "arcee-ai" | "arceeai" => "arcee".to_string(),
         "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
         "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
+        "aws" | "aws-bedrock" | "amazon-bedrock" | "amazon" => "bedrock".to_string(),
         "dashscope" | "aliyun" | "alibaba-cloud" => "alibaba".to_string(),
         "alibaba_coding" | "alibaba-coding" | "alibaba_coding_plan" => {
             "alibaba-coding-plan".to_string()
@@ -5371,6 +5372,13 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
             "tencent-cloud".to_string(),
             "tencentmaas".to_string(),
         ],
+        "bedrock" => vec![
+            "bedrock".to_string(),
+            "aws".to_string(),
+            "aws-bedrock".to_string(),
+            "amazon-bedrock".to_string(),
+            "amazon".to_string(),
+        ],
         "ai-gateway" => vec!["ai-gateway".to_string(), "aigateway".to_string()],
         "opencode-zen" => vec!["opencode-zen".to_string(), "opencode".to_string()],
         "kilocode" => vec!["kilocode".to_string(), "kilo".to_string()],
@@ -5398,6 +5406,7 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "openai" => Some("HERMES_OPENAI_API_KEY"),
         "openai-codex" => Some("HERMES_OPENAI_CODEX_API_KEY"),
         "anthropic" => Some("ANTHROPIC_API_KEY"),
+        "bedrock" => None,
         "google-gemini-cli" => Some("HERMES_GEMINI_OAUTH_API_KEY"),
         "gemini" => Some("GOOGLE_API_KEY"),
         "openrouter" => Some("OPENROUTER_API_KEY"),
@@ -9382,6 +9391,11 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
         label: "Anthropic Claude (OAuth/API key)",
     },
     SetupModelOption {
+        provider: "bedrock",
+        model: "bedrock:anthropic.claude-sonnet-4-6",
+        label: "AWS Bedrock",
+    },
+    SetupModelOption {
         provider: "openrouter",
         model: "openrouter:auto",
         label: "OpenRouter auto (multi-provider)",
@@ -9780,7 +9794,7 @@ fn setup_provider_default_base_url(provider: &str) -> Option<&'static str> {
 fn setup_provider_requires_api_key(provider: &str) -> bool {
     !matches!(
         provider,
-        "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi"
+        "bedrock" | "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi"
     )
 }
 
@@ -14426,6 +14440,11 @@ mod tests {
             secret_provider_aliases("claude"),
             vec!["anthropic", "claude", "claude-code"]
         );
+        assert_eq!(provider_env_var("bedrock"), None);
+        assert_eq!(
+            secret_provider_aliases("aws-bedrock"),
+            vec!["bedrock", "aws", "aws-bedrock", "amazon-bedrock", "amazon"]
+        );
         assert_eq!(provider_env_var("ollama"), Some("OLLAMA_LOCAL_API_KEY"));
         assert_eq!(provider_env_var("llama.cpp"), Some("LLAMA_CPP_API_KEY"));
         assert_eq!(provider_env_var("ollvm"), Some("VLLM_API_KEY"));
@@ -14681,6 +14700,16 @@ mod tests {
         );
         assert!(!setup_provider_requires_api_key("ollama-local"));
         assert!(!setup_provider_requires_api_key("apple-ane"));
+        assert!(!setup_provider_requires_api_key("bedrock"));
+        assert_eq!(setup_provider_display("bedrock"), "AWS Bedrock");
+        assert_eq!(
+            setup_provider_env_keys("bedrock"),
+            &[
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN"
+            ]
+        );
         assert!(setup_provider_requires_api_key("openai"));
         assert_eq!(setup_provider_display("alibaba"), "Alibaba Cloud DashScope");
         assert_eq!(

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -3,6 +3,10 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
+use hermes_agent::bedrock::{
+    curated_bedrock_models_for_region, discover_bedrock_model_ids, has_aws_credentials,
+    resolve_bedrock_region,
+};
 use hermes_core::AgentError;
 use hermes_intelligence::models_dev::{default_client, ModelsDevClient};
 use hmac::{Hmac, Mac};
@@ -84,6 +88,20 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
             "claude-sonnet-4-6",
             "claude-sonnet-4-5",
             "claude-haiku-4-5",
+        ],
+    ),
+    (
+        "bedrock",
+        &[
+            "anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-sonnet-4-6",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "amazon.nova-pro-v1:0",
+            "us.amazon.nova-pro-v1:0",
+            "amazon.nova-micro-v1:0",
+            "us.amazon.nova-micro-v1:0",
         ],
     ),
     (
@@ -836,7 +854,32 @@ pub async fn provider_model_ids_with_client(
         }
     }
 
-    let computed = if normalized == "nous" {
+    let computed = if normalized == "bedrock" {
+        let region = resolve_bedrock_region();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut merged: Vec<String> = Vec::new();
+        if has_aws_credentials() {
+            for model in discover_bedrock_model_ids(region.as_str()).await {
+                let key = model.to_ascii_lowercase();
+                if seen.insert(key) {
+                    merged.push(model);
+                }
+            }
+        }
+        for model in curated_bedrock_models_for_region(region.as_str()) {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                merged.push(model);
+            }
+        }
+        for model in curated {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                merged.push((*model).to_string());
+            }
+        }
+        merged
+    } else if normalized == "nous" {
         // Nous model picker should always include curated compatibility picks
         // (including kimi-k2.6), then append live/models.dev discoveries.
         let mut seen: HashSet<String> = HashSet::new();
@@ -1161,6 +1204,19 @@ mod tests {
         assert!(provider_curated_models("arcee-ai").contains(&"trinity-mini"));
         assert!(provider_curated_models("mimo").contains(&"mimo-v2.5-pro"));
         assert!(provider_curated_models("tokenhub").contains(&"hy3-preview"));
+    }
+
+    #[tokio::test]
+    async fn bedrock_provider_models_include_region_aware_curated_fallback_and_aliases() {
+        let _guard = env_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = ScopedCatalogEnv::new(tmp.path());
+        std::env::set_var("AWS_REGION", "eu-central-1");
+        let client = seeded_client(json!({}));
+        let out = provider_model_ids_with_client("aws-bedrock", &client).await;
+        assert!(out.iter().any(|model| model.starts_with("eu.anthropic.")));
+        assert!(out.iter().any(|model| model.contains("amazon.nova")));
+        std::env::remove_var("AWS_REGION");
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -109,6 +109,7 @@ pub fn canonical_provider_id(provider: &str) -> String {
         "arcee-ai" | "arceeai" => "arcee".to_string(),
         "mimo" | "xiaomi-mimo" => "xiaomi".to_string(),
         "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub".to_string(),
+        "aws" | "aws-bedrock" | "amazon-bedrock" | "amazon" => "bedrock".to_string(),
         "kilo" | "kilo-code" | "kilo-gateway" => "kilocode".to_string(),
         "opencode" | "opencode-zen" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
@@ -301,6 +302,10 @@ mod tests {
         assert_eq!(canonical_provider_id("xiaomi-mimo"), "xiaomi");
         assert_eq!(canonical_provider_id("tencent-cloud"), "tencent-tokenhub");
         assert_eq!(canonical_provider_id("tokenhub"), "tencent-tokenhub");
+        assert_eq!(canonical_provider_id("aws"), "bedrock");
+        assert_eq!(canonical_provider_id("aws-bedrock"), "bedrock");
+        assert_eq!(canonical_provider_id("amazon-bedrock"), "bedrock");
+        assert_eq!(canonical_provider_id("amazon"), "bedrock");
         assert_eq!(canonical_provider_id("minimax_cn"), "minimax-cn");
     }
 }

--- a/crates/hermes-intelligence/src/anthropic_adapter.rs
+++ b/crates/hermes-intelligence/src/anthropic_adapter.rs
@@ -163,17 +163,32 @@ pub struct ReasoningConfig {
 // Model name normalization
 // ---------------------------------------------------------------------------
 
+/// Return true for AWS Bedrock model IDs where dots are semantic delimiters.
+pub fn is_bedrock_model_id(model: &str) -> bool {
+    let lower = model.trim().to_ascii_lowercase();
+    [
+        "anthropic.",
+        "us.anthropic.",
+        "eu.anthropic.",
+        "ap.anthropic.",
+        "global.anthropic.",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+}
+
 /// Normalize a model name for the Anthropic API.
 ///
 /// Strips `anthropic/` prefix and converts dots to hyphens unless
-/// `preserve_dots` is true.
+/// `preserve_dots` is true. AWS Bedrock model IDs keep dots because those
+/// dots are part of Bedrock's provider model identifier.
 pub fn normalize_model_name(model: &str, preserve_dots: bool) -> String {
     let mut result = model.to_string();
     let lower = result.to_lowercase();
     if lower.starts_with("anthropic/") {
         result = result[10..].to_string();
     }
-    if !preserve_dots {
+    if !preserve_dots && !is_bedrock_model_id(&result) {
         result = result.replace('.', "-");
     }
     result
@@ -924,6 +939,14 @@ mod tests {
         assert_eq!(
             normalize_model_name("claude-sonnet-4", false),
             "claude-sonnet-4"
+        );
+        assert_eq!(
+            normalize_model_name("global.anthropic.claude-opus-4-7", false),
+            "global.anthropic.claude-opus-4-7"
+        );
+        assert_eq!(
+            normalize_model_name("claude-opus-4.6", false),
+            "claude-opus-4-6"
         );
     }
 

--- a/crates/hermes-intelligence/src/model_metadata.rs
+++ b/crates/hermes-intelligence/src/model_metadata.rs
@@ -57,6 +57,21 @@ static DEFAULT_CONTEXT_LENGTHS: &[(&str, u64)] = &[
     ("claude-sonnet-4-6", 1_000_000),
     ("claude-opus-4.6", 1_000_000),
     ("claude-sonnet-4.6", 1_000_000),
+    ("global.anthropic.claude-opus-4-7", 1_000_000),
+    ("anthropic.claude-sonnet-4-6", 1_000_000),
+    ("global.anthropic.claude-sonnet-4-6", 1_000_000),
+    ("us.anthropic.claude-sonnet-4-6", 1_000_000),
+    ("eu.anthropic.claude-sonnet-4-6", 1_000_000),
+    ("au.anthropic.claude-sonnet-4-6", 1_000_000),
+    ("jp.anthropic.claude-sonnet-4-6", 1_000_000),
+    ("anthropic.claude-haiku-4-5", 200_000),
+    ("global.anthropic.claude-haiku-4-5", 200_000),
+    ("us.anthropic.claude-haiku-4-5", 200_000),
+    ("eu.anthropic.claude-haiku-4-5", 200_000),
+    ("au.anthropic.claude-haiku-4-5", 200_000),
+    ("jp.anthropic.claude-haiku-4-5", 200_000),
+    ("anthropic.claude-3-5-sonnet", 200_000),
+    ("amazon.nova", 300_000),
     // Older Claude
     ("claude", 200_000),
     // OpenAI
@@ -540,6 +555,7 @@ pub fn infer_provider_from_url(base_url: &str) -> Option<&'static str> {
         ("api.openai.com", "openai"),
         ("chatgpt.com", "openai"),
         ("api.anthropic.com", "anthropic"),
+        ("bedrock-runtime.", "bedrock"),
         ("api.z.ai", "zai"),
         ("open.bigmodel.cn", "zai"),
         ("api.moonshot.ai", "kimi-coding"),
@@ -636,6 +652,14 @@ mod tests {
     fn test_get_model_context_length() {
         assert_eq!(get_model_context_length("gpt-4o"), 128_000);
         assert_eq!(get_model_context_length("claude-opus-4-6"), 1_000_000);
+        assert_eq!(
+            get_model_context_length("us.anthropic.claude-sonnet-4-6"),
+            1_000_000
+        );
+        assert_eq!(
+            get_model_context_length("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            200_000
+        );
         assert_eq!(get_model_context_length("gemini-2.0-flash"), 1_048_576);
         assert_eq!(get_model_context_length("gemma4:31b-cloud"), 256_000);
         assert_eq!(get_model_context_length("xiaomi/mimo-v2.5-pro"), 1_000_000);
@@ -706,6 +730,10 @@ mod tests {
         assert_eq!(
             infer_provider_from_url("https://api.anthropic.com"),
             Some("anthropic")
+        );
+        assert_eq!(
+            infer_provider_from_url("https://bedrock-runtime.us-east-1.amazonaws.com"),
+            Some("bedrock")
         );
         assert_eq!(
             infer_provider_from_url("https://open.bigmodel.cn/api/paas/v4"),

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1861,16 +1861,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_bedrock_1m_context.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "7d9753831eddf1e8377db6e06b1b7022e70be8d5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_bedrock_1m_context.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c088bcc04732d575ebeea10b297668c307d3d121",
       "workstream": "WS6"
@@ -1891,16 +1891,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_bedrock_integration.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "954075ab722825ea43c2b692cf48286247b250c8",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_bedrock_integration.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "65df149e528d939d011df1ac2af165bd5787d693",
       "workstream": "WS6"
@@ -2566,16 +2566,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/agent",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent/transports/test_bedrock_transport.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "7a5301d84fc12a62847da9145f76ef4297b7d462",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/transports/test_bedrock_transport.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "2f43daf988d2005d64dd439200252220d475ecdd",
       "workstream": "WS6"
@@ -6166,16 +6166,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_bedrock_model_picker.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "3b2c4d5dc7b02237208a4fabae695f536b8570c4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_bedrock_model_picker.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0020341d4917b5cf8745e5cf1755e030ca8c662e",
       "workstream": "WS6"
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T22:18:41.644574+00:00",
+  "generated_at_utc": "2026-05-30T23:25:49.862543+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "b134515993f8292f38aea2a9843cdd6c6dad83a5",
+    "local_sha": "d4898938cf9acd1cc072c91da3c485241f95547c",
     "upstream_ref": "upstream/main",
     "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 614,
-      "intentional_divergence": 247,
+      "functional": 610,
+      "intentional_divergence": 251,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 417,
-      "rust_equivalent_or_contract_test_required": 530,
+      "not_required_for_runtime": 421,
+      "rust_equivalent_or_contract_test_required": 526,
       "rust_native_runtime_parity_required_if_needed": 3,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 247,
+      "cleared_intentional_divergence": 251,
       "cleared_non_runtime": 170,
-      "pending_review": 614
+      "pending_review": 610
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 247,
+    "cleared_intentional_divergence": 251,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 614,
+    "pending_review": 610,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T22:18:41.644574+00:00`
+Generated: `2026-05-30T23:25:49.862543+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `614`
+- Pending functional review: `610`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `247`
+- Cleared intentional divergence: `251`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 247 |
+| `cleared_intentional_divergence` | 251 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 614 |
+| `pending_review` | 610 |
 
 ## Workstream Counts
 
@@ -38,13 +38,13 @@ Generated: `2026-05-30T22:18:41.644574+00:00`
 | Classification Path | Count |
 | --- | ---: |
 | `tests/gateway` | 131 |
-| `tests/hermes_cli` | 121 |
+| `tests/hermes_cli` | 120 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 40 |
 | `tests/cli` | 28 |
-| `tests/agent` | 24 |
+| `tests/agent` | 21 |
 | `ui-tui/packages` | 18 |
 | `tests/plugins` | 17 |
 | `tests/skills` | 6 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -633,6 +633,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/hermes_cli/test_bedrock_model_picker.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Bedrock model-picker intent is covered by Rust provider canonicalization, region-aware curated fallback, best-effort signed live Bedrock catalog discovery, AWS credential-signal gating, and setup/model catalog tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/hermes_cli/test_api_key_providers.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream API-key provider registry behavior is covered by Rust provider canonicalization, CLI setup metadata, config env hydration, ACP auth discovery, and runtime provider tests for Copilot, Z.AI/GLM, Hugging Face, AI Gateway, MiniMax CN, GMI, and local backend aliases.",
@@ -692,6 +699,27 @@
       "path": "tests/agent",
       "classification": "functional",
       "rationale": "Agent tests cover model routing, provider, memory, and loop semantics.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/agent/test_bedrock_1m_context.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Bedrock 1M-context beta intent is covered by Rust Bedrock Converse request/header contracts and existing Anthropic/MiniMax beta filtering tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/agent/test_bedrock_integration.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Bedrock registry, alias, runtime-provider, auth-marker, base-URL, context, model-id normalization, and error-classification intent is covered by Rust hermes-cli provider/model tests, hermes-agent Bedrock provider contracts, and hermes-intelligence metadata/normalization tests; the Python test file remains reference-only.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/agent/transports/test_bedrock_transport.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Bedrock transport build-kwargs, tool conversion, response validation, finish-reason mapping, reasoningContent preservation, toolUse normalization, usage mapping, and SigV4 request contract are covered by Rust hermes-agent Bedrock provider tests; the Python test file remains reference-only.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- add a Rust Bedrock Converse provider with SigV4/bearer auth, Converse body/response mapping, catalog discovery, curated model fallbacks, and Bedrock error classification
- wire Bedrock aliases through runtime provider construction, setup/auth/model picker flows, API-mode detection, and model metadata
- mark the Bedrock shared-diff parity files covered and regenerate the parity backlog

## Local verification
- cargo fmt --check
- git diff --check
- scripts/check-runtime-placeholders.sh
- scripts/check-rust-runtime-no-python.sh
- cargo test -p hermes-agent bedrock
- cargo test -p hermes-cli bedrock
- cargo test -p hermes-intelligence model_metadata
- cargo test -p hermes-parity-tests
- cargo build --workspace
- cargo test --workspace

## Note
- cargo clippy --workspace --all-targets -- -D warnings currently fails on pre-existing unrelated workspace warning debt outside this Bedrock slice.