### PR TITLE
parity(browser): add Browser Use Rust backend

### DIFF
--- a/crates/hermes-agent/src/bedrock.rs
+++ b/crates/hermes-agent/src/bedrock.rs
@@ -170,15 +170,18 @@ impl LlmProvider for BedrockProvider {
                 .unwrap_or_else(|_| Client::new());
             client.post(url.as_str()).body(body_bytes.clone())
         };
+        let anthropic_beta = bedrock_anthropic_beta_header(effective_model);
         for (key, value) in bedrock_request_headers(
-            "POST",
-            url.as_str(),
-            &self.region,
-            "bedrock",
-            &body_bytes,
+            BedrockHeaderRequest {
+                method: "POST",
+                url: url.as_str(),
+                region: &self.region,
+                service: "bedrock",
+                body: &body_bytes,
+                anthropic_beta: anthropic_beta.as_deref(),
+                now: Utc::now(),
+            },
             &auth,
-            bedrock_anthropic_beta_header(effective_model).as_deref(),
-            Utc::now(),
         )? {
             request = request.header(key, value);
         }
@@ -252,15 +255,18 @@ impl LlmProvider for BedrockProvider {
                     return;
                 }
             };
+            let anthropic_beta = bedrock_anthropic_beta_header(&effective_model);
             let headers = match bedrock_request_headers(
-                "POST",
-                url.as_str(),
-                &provider.region,
-                "bedrock",
-                &body_bytes,
+                BedrockHeaderRequest {
+                    method: "POST",
+                    url: url.as_str(),
+                    region: &provider.region,
+                    service: "bedrock",
+                    body: &body_bytes,
+                    anthropic_beta: anthropic_beta.as_deref(),
+                    now: Utc::now(),
+                },
                 &auth,
-                bedrock_anthropic_beta_header(&effective_model).as_deref(),
-                Utc::now(),
             ) {
                 Ok(headers) => headers,
                 Err(err) => {
@@ -448,11 +454,21 @@ async fn fetch_bedrock_catalog_endpoint(
     region: &str,
     auth: &BedrockAuth,
 ) -> Vec<String> {
-    let headers =
-        match bedrock_request_headers("GET", url, region, "bedrock", b"", auth, None, Utc::now()) {
-            Ok(headers) => headers,
-            Err(_) => return Vec::new(),
-        };
+    let headers = match bedrock_request_headers(
+        BedrockHeaderRequest {
+            method: "GET",
+            url,
+            region,
+            service: "bedrock",
+            body: b"",
+            anthropic_beta: None,
+            now: Utc::now(),
+        },
+        auth,
+    ) {
+        Ok(headers) => headers,
+        Err(_) => return Vec::new(),
+    };
     let client = Client::new();
     let mut request = client.get(url);
     for (key, value) in headers {
@@ -1912,22 +1928,31 @@ fn parse_ini_section(raw: &str, profile: &str) -> HashMap<String, String> {
     out
 }
 
-fn bedrock_request_headers(
-    method: &str,
-    url: &str,
-    region: &str,
-    service: &str,
-    body: &[u8],
-    auth: &BedrockAuth,
-    anthropic_beta: Option<&str>,
+#[derive(Clone, Copy)]
+struct BedrockHeaderRequest<'a> {
+    method: &'a str,
+    url: &'a str,
+    region: &'a str,
+    service: &'a str,
+    body: &'a [u8],
+    anthropic_beta: Option<&'a str>,
     now: DateTime<Utc>,
+}
+
+fn bedrock_request_headers(
+    request: BedrockHeaderRequest<'_>,
+    auth: &BedrockAuth,
 ) -> Result<BTreeMap<String, String>, AgentError> {
     let mut headers = BTreeMap::new();
     headers.insert("accept".to_string(), "application/json".to_string());
-    if method != "GET" {
+    if request.method != "GET" {
         headers.insert("content-type".to_string(), "application/json".to_string());
     }
-    if let Some(beta) = anthropic_beta.map(str::trim).filter(|s| !s.is_empty()) {
+    if let Some(beta) = request
+        .anthropic_beta
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         headers.insert("anthropic-beta".to_string(), beta.to_string());
     }
     match auth {
@@ -1935,37 +1960,23 @@ fn bedrock_request_headers(
             headers.insert("authorization".to_string(), format!("Bearer {token}"));
             Ok(headers)
         }
-        BedrockAuth::SigV4(credentials) => sign_sigv4_headers(
-            method,
-            url,
-            region,
-            service,
-            body,
-            credentials,
-            headers,
-            now,
-        ),
+        BedrockAuth::SigV4(credentials) => sign_sigv4_headers(request, credentials, headers),
     }
 }
 
 fn sign_sigv4_headers(
-    method: &str,
-    url: &str,
-    region: &str,
-    service: &str,
-    body: &[u8],
+    request: BedrockHeaderRequest<'_>,
     credentials: &AwsCredentials,
     mut headers: BTreeMap<String, String>,
-    now: DateTime<Utc>,
 ) -> Result<BTreeMap<String, String>, AgentError> {
-    let url = reqwest::Url::parse(url)
+    let url = reqwest::Url::parse(request.url)
         .map_err(|err| AgentError::Config(format!("invalid Bedrock URL for SigV4: {err}")))?;
     let host = url
         .host_str()
         .ok_or_else(|| AgentError::Config("Bedrock SigV4 URL missing host".to_string()))?;
-    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
-    let short_date = now.format("%Y%m%d").to_string();
-    let payload_hash = hex::encode(Sha256::digest(body));
+    let amz_date = request.now.format("%Y%m%dT%H%M%SZ").to_string();
+    let short_date = request.now.format("%Y%m%d").to_string();
+    let payload_hash = hex::encode(Sha256::digest(request.body));
 
     headers.insert("host".to_string(), host.to_string());
     headers.insert("x-amz-date".to_string(), amz_date.clone());
@@ -1991,7 +2002,7 @@ fn sign_sigv4_headers(
     let canonical_query = canonical_query_string(&url);
     let canonical_request = format!(
         "{}\n{}\n{}\n{}\n{}\n{}",
-        method.to_ascii_uppercase(),
+        request.method.to_ascii_uppercase(),
         canonical_uri(&url),
         canonical_query,
         canonical_headers,
@@ -2001,8 +2012,8 @@ fn sign_sigv4_headers(
     let scope = format!(
         "{}/{}/{}/aws4_request",
         short_date,
-        normalized_region_or_default(region),
-        service
+        normalized_region_or_default(request.region),
+        request.service
     );
     let string_to_sign = format!(
         "AWS4-HMAC-SHA256\n{}\n{}\n{}",
@@ -2013,8 +2024,8 @@ fn sign_sigv4_headers(
     let signing_key = sigv4_signing_key(
         credentials.secret_access_key.as_bytes(),
         short_date.as_bytes(),
-        normalized_region_or_default(region).as_bytes(),
-        service.as_bytes(),
+        normalized_region_or_default(request.region).as_bytes(),
+        request.service.as_bytes(),
     )?;
     let signature = hmac_sha256_hex(&signing_key, string_to_sign.as_bytes())?;
     headers.insert(
@@ -2848,16 +2859,18 @@ mod tests {
         };
         let auth = BedrockAuth::SigV4(creds);
         let headers = bedrock_request_headers(
-            "POST",
-            "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude%3A0/converse",
-            "us-east-1",
-            "bedrock",
-            br#"{"messages":[]}"#,
+            BedrockHeaderRequest {
+                method: "POST",
+                url: "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude%3A0/converse",
+                region: "us-east-1",
+                service: "bedrock",
+                body: br#"{"messages":[]}"#,
+                anthropic_beta: Some(CONTEXT_1M_BETA),
+                now: DateTime::parse_from_rfc3339("2026-05-30T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            },
             &auth,
-            Some(CONTEXT_1M_BETA),
-            DateTime::parse_from_rfc3339("2026-05-30T00:00:00Z")
-                .unwrap()
-                .with_timezone(&Utc),
         )
         .expect("headers");
         assert_eq!(

--- a/crates/hermes-agent/src/compression.rs
+++ b/crates/hermes-agent/src/compression.rs
@@ -278,8 +278,7 @@ impl ContextCompressor {
             .filter_map(|msg| msg.content.as_deref())
             .filter_map(summary_body_from_handoff)
             .map(|body| body.trim().to_string())
-            .filter(|body| !body.is_empty())
-            .last();
+            .rfind(|body| !body.is_empty());
     }
 
     // ------------------------------------------------------------------

--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -436,13 +436,15 @@ impl MemoryProviderPlugin for HindsightPlugin {
             } else {
                 match hindsight_recall(
                     &client,
-                    &base,
-                    &bank,
-                    &cfg.api_key,
-                    &q,
-                    &cfg.budget,
-                    cfg.recall_max_tokens,
-                    &cfg.recall_types,
+                    HindsightRecallRequest {
+                        base: &base,
+                        bank: &bank,
+                        api_key: &cfg.api_key,
+                        query: &q,
+                        budget: &cfg.budget,
+                        max_tokens: cfg.recall_max_tokens,
+                        recall_types: &cfg.recall_types,
+                    },
                 ) {
                     Ok(t) => t,
                     Err(e) => {
@@ -580,13 +582,15 @@ impl MemoryProviderPlugin for HindsightPlugin {
                 }
                 match hindsight_recall(
                     &client,
-                    &base,
-                    &bank,
-                    &cfg.api_key,
-                    query,
-                    &cfg.budget,
-                    cfg.recall_max_tokens,
-                    &cfg.recall_types,
+                    HindsightRecallRequest {
+                        base: &base,
+                        bank: &bank,
+                        api_key: &cfg.api_key,
+                        query,
+                        budget: &cfg.budget,
+                        max_tokens: cfg.recall_max_tokens,
+                        recall_types: &cfg.recall_types,
+                    },
                 ) {
                     Ok(text) if !text.is_empty() => json!({"result": text}).to_string(),
                     Ok(_) => json!({"result": "No relevant memories found."}).to_string(),
@@ -749,21 +753,33 @@ fn hindsight_recall_body(
     })
 }
 
+struct HindsightRecallRequest<'a> {
+    base: &'a str,
+    bank: &'a str,
+    api_key: &'a str,
+    query: &'a str,
+    budget: &'a str,
+    max_tokens: usize,
+    recall_types: &'a [String],
+}
+
 fn hindsight_recall(
     client: &Client,
-    base: &str,
-    bank: &str,
-    api_key: &str,
-    query: &str,
-    budget: &str,
-    max_tokens: usize,
-    recall_types: &[String],
+    request: HindsightRecallRequest<'_>,
 ) -> Result<String, String> {
-    let url = format!("{}/v1/default/banks/{}/memories/recall", base, bank);
-    let body = hindsight_recall_body(query, budget, max_tokens, recall_types);
+    let url = format!(
+        "{}/v1/default/banks/{}/memories/recall",
+        request.base, request.bank
+    );
+    let body = hindsight_recall_body(
+        request.query,
+        request.budget,
+        request.max_tokens,
+        request.recall_types,
+    );
     let mut req = client.post(&url).json(&body);
-    if !api_key.is_empty() {
-        req = req.bearer_auth(api_key);
+    if !request.api_key.is_empty() {
+        req = req.bearer_auth(request.api_key);
     }
     let resp = req.send().map_err(|e| e.to_string())?;
     if !resp.status().is_success() {

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -1291,6 +1291,9 @@ mod tests {
 
     #[tokio::test]
     async fn local_provider_catalog_returns_curated_without_network_dependency() {
+        let _guard = env_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = ScopedCatalogEnv::new(tmp.path());
         let client = seeded_client(json!({}));
         let out = provider_model_ids_with_client("ollama-local", &client).await;
         let expected: Vec<String> = provider_curated_models("ollama-local")
@@ -1308,6 +1311,9 @@ mod tests {
 
     #[tokio::test]
     async fn provider_model_ids_normalizes_provider_aliases() {
+        let _guard = env_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = ScopedCatalogEnv::new(tmp.path());
         let client = seeded_client(json!({}));
         let aliased = provider_model_ids_with_client("ollama", &client).await;
         let canonical = provider_model_ids_with_client("ollama-local", &client).await;

--- a/crates/hermes-core/src/schema_sanitizer.rs
+++ b/crates/hermes-core/src/schema_sanitizer.rs
@@ -48,9 +48,7 @@ fn default_object_schema() -> Value {
 
 fn schema_for_type(kind: &str) -> Value {
     let kind = kind.trim();
-    if kind == "object" {
-        default_object_schema()
-    } else if kind.is_empty() {
+    if kind == "object" || kind.is_empty() {
         default_object_schema()
     } else {
         serde_json::json!({"type": kind})

--- a/crates/hermes-cron/src/runner.rs
+++ b/crates/hermes-cron/src/runner.rs
@@ -803,6 +803,14 @@ mod tests {
 
     static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
     #[test]
     fn test_filtered_tool_schemas_excludes_cronjob() {
         // Create a minimal tool registry with a cronjob tool
@@ -940,8 +948,8 @@ mod tests {
         assert_eq!(reply.trim(), "watchdog-ok");
     }
 
-    #[tokio::test]
-    async fn test_no_agent_script_path_runs_relative_to_hermes_scripts() {
+    #[test]
+    fn test_no_agent_script_path_runs_relative_to_hermes_scripts() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let home = tempfile::tempdir().unwrap();
         let scripts = home.path().join("scripts");
@@ -957,7 +965,7 @@ mod tests {
         job.no_agent = true;
         job.script = Some("watchdog.sh".to_string());
 
-        let result = runner.run_job(&job).await.expect("script-only result");
+        let result = block_on(runner.run_job(&job)).expect("script-only result");
         let reply = result
             .messages
             .iter()
@@ -967,8 +975,8 @@ mod tests {
         assert_eq!(reply.trim(), "scripts-ok");
     }
 
-    #[tokio::test]
-    async fn test_no_agent_script_path_blocks_traversal() {
+    #[test]
+    fn test_no_agent_script_path_blocks_traversal() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let home = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(home.path().join("scripts")).unwrap();
@@ -982,7 +990,7 @@ mod tests {
         job.no_agent = true;
         job.script = Some("../../etc/passwd".to_string());
 
-        let err = runner.run_job(&job).await.expect_err("blocked");
+        let err = block_on(runner.run_job(&job)).expect_err("blocked");
         assert!(err.to_string().contains("blocked cron script path"));
     }
 

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -1235,6 +1235,14 @@ mod tests {
 
     static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
     struct EnvGuard {
         key: &'static str,
         original: Option<OsString>,
@@ -1456,8 +1464,8 @@ mod tests {
         assert_eq!(content, "ok");
     }
 
-    #[tokio::test]
-    async fn test_execute_command_strips_gateway_env_vars() {
+    #[test]
+    fn test_execute_command_strips_gateway_env_vars() {
         let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _token_guard = EnvGuard::set("TOOL_GATEWAY_USER_TOKEN", "should-not-leak");
         let _managed_guard = EnvGuard::set("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
@@ -1465,23 +1473,21 @@ mod tests {
         let _safe_guard = EnvGuard::set("SAFE_PASSTHRU_TEST", "ok");
         let backend = LocalBackend::default();
 
-        let output = backend
-            .execute_command(
+        let output = block_on(backend.execute_command(
                 "printf '%s|%s|%s|%s' \"${TOOL_GATEWAY_USER_TOKEN:-}\" \"${HERMES_ENABLE_NOUS_MANAGED_TOOLS:-}\" \"${HERMES_HTTP_API_KEY:-}\" \"${SAFE_PASSTHRU_TEST:-}\"",
                 None,
                 None,
                 false,
                 false,
-            )
-            .await
-            .unwrap();
+        ))
+        .unwrap();
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.stdout, "|||ok");
     }
 
-    #[tokio::test]
-    async fn test_execute_command_strips_provider_tool_and_gateway_env_vars() {
+    #[test]
+    fn test_execute_command_strips_provider_tool_and_gateway_env_vars() {
         let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _openai_key = EnvGuard::set("OPENAI_API_KEY", "sk-should-not-leak");
         let _openai_base = EnvGuard::set("OPENAI_BASE_URL", "http://localhost:8000/v1");
@@ -1492,39 +1498,35 @@ mod tests {
         let _safe_guard = EnvGuard::set("SAFE_PASSTHRU_TEST", "ok");
         let backend = LocalBackend::default();
 
-        let output = backend
-            .execute_command(
+        let output = block_on(backend.execute_command(
                 "printf '%s|%s|%s|%s|%s|%s|%s' \"${OPENAI_API_KEY:-}\" \"${OPENAI_BASE_URL:-}\" \"${AWS_BEARER_TOKEN_BEDROCK:-}\" \"${GITHUB_TOKEN:-}\" \"${MODAL_TOKEN_SECRET:-}\" \"${GATEWAY_ALLOWED_USERS:-}\" \"${SAFE_PASSTHRU_TEST:-}\"",
                 None,
                 None,
                 false,
                 false,
-            )
-            .await
-            .unwrap();
+        ))
+        .unwrap();
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.stdout, "||||||ok");
     }
 
-    #[tokio::test]
-    async fn test_execute_command_preserves_general_aws_credentials() {
+    #[test]
+    fn test_execute_command_preserves_general_aws_credentials() {
         let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _access_key = EnvGuard::set("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
         let _secret_key = EnvGuard::set("AWS_SECRET_ACCESS_KEY", "aws-secret");
         let _session = EnvGuard::set("AWS_SESSION_TOKEN", "aws-session");
         let backend = LocalBackend::default();
 
-        let output = backend
-            .execute_command(
+        let output = block_on(backend.execute_command(
                 "printf '%s|%s|%s' \"${AWS_ACCESS_KEY_ID:-}\" \"${AWS_SECRET_ACCESS_KEY:-}\" \"${AWS_SESSION_TOKEN:-}\"",
                 None,
                 None,
                 false,
                 false,
-            )
-            .await
-            .unwrap();
+        ))
+        .unwrap();
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.stdout, "AKIAIOSFODNN7EXAMPLE|aws-secret|aws-session");
@@ -1547,30 +1549,28 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_execute_command_force_prefix_reinjects_blocked_var() {
+    #[test]
+    fn test_execute_command_force_prefix_reinjects_blocked_var() {
         let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _blocked = EnvGuard::set("OPENAI_API_KEY", "sk-should-not-leak");
         let _forced = EnvGuard::set("_HERMES_FORCE_OPENAI_API_KEY", "sk-explicit");
         let backend = LocalBackend::default();
 
-        let output = backend
-            .execute_command(
-                "printf '%s|%s' \"${OPENAI_API_KEY:-}\" \"${_HERMES_FORCE_OPENAI_API_KEY:-}\"",
-                None,
-                None,
-                false,
-                false,
-            )
-            .await
-            .unwrap();
+        let output = block_on(backend.execute_command(
+            "printf '%s|%s' \"${OPENAI_API_KEY:-}\" \"${_HERMES_FORCE_OPENAI_API_KEY:-}\"",
+            None,
+            None,
+            false,
+            false,
+        ))
+        .unwrap();
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.stdout, "sk-explicit|");
     }
 
-    #[tokio::test]
-    async fn test_execute_command_cleans_profile_reintroduced_blocked_vars() {
+    #[test]
+    fn test_execute_command_cleans_profile_reintroduced_blocked_vars() {
         let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let td = tempdir().unwrap();
         std::fs::write(
@@ -1581,16 +1581,14 @@ mod tests {
         let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
         let backend = LocalBackend::default();
 
-        let output = backend
-            .execute_command(
-                "printf '%s|%s' \"${OPENAI_API_KEY:-}\" \"${SAFE_PASSTHRU_TEST:-}\"",
-                None,
-                None,
-                false,
-                false,
-            )
-            .await
-            .unwrap();
+        let output = block_on(backend.execute_command(
+            "printf '%s|%s' \"${OPENAI_API_KEY:-}\" \"${SAFE_PASSTHRU_TEST:-}\"",
+            None,
+            None,
+            false,
+            false,
+        ))
+        .unwrap();
 
         assert_eq!(output.exit_code, 0);
         assert_eq!(output.stdout, "|ok");

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -461,15 +461,11 @@ impl Gateway {
         if incoming.text.trim_start().starts_with('/') {
             return None;
         }
-        if incoming
+        incoming
             .message_id
             .as_deref()
             .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .is_none()
-        {
-            return None;
-        }
+            .filter(|s| !s.is_empty())?;
         if matches!(
             access_policy.and_then(|policy| policy.reactions_enabled),
             Some(false)

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -798,6 +798,12 @@ pub enum DiscordSkillCommandDecision {
     Dispatch { text: String },
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct DiscordSkillCommandRequest<'a> {
+    pub requested_name: &'a str,
+    pub args: &'a str,
+}
+
 pub fn discord_skill_autocomplete_choices(
     policy: &DiscordInteractionAuthPolicy,
     subject: &DiscordInteractionSubject,
@@ -833,8 +839,7 @@ pub fn discord_skill_command_decision(
     guild_id: Option<&str>,
     dm_role_auth_guild: Option<&str>,
     entries: &[DiscordSkillCommandEntry],
-    requested_name: &str,
-    args: &str,
+    request: DiscordSkillCommandRequest<'_>,
 ) -> DiscordSkillCommandDecision {
     if policy.authorize_slash(subject, channel_context, guild_id, dm_role_auth_guild)
         != DiscordAuthDecision::Allow
@@ -842,7 +847,7 @@ pub fn discord_skill_command_decision(
         return DiscordSkillCommandDecision::Unauthorized;
     }
 
-    let requested = requested_name.trim();
+    let requested = request.requested_name.trim();
     let Some(entry) = entries
         .iter()
         .find(|entry| entry.name.eq_ignore_ascii_case(requested))
@@ -852,7 +857,7 @@ pub fn discord_skill_command_decision(
         };
     };
 
-    let args = args.trim();
+    let args = request.args.trim();
     let text = if args.is_empty() {
         entry.command_key.clone()
     } else {
@@ -1434,7 +1439,7 @@ pub fn discord_command_fingerprint(commands: &[serde_json::Value]) -> String {
         .iter()
         .map(normalize_command_payload)
         .collect::<Vec<_>>();
-    normalized.sort_by(|a, b| command_key(a).cmp(&command_key(b)));
+    normalized.sort_by_key(command_key);
     serde_json::to_string(&normalized).unwrap_or_default()
 }
 
@@ -4116,8 +4121,10 @@ mod tests {
                 Some("guild-1"),
                 None,
                 &entries,
-                "alpha",
-                "extra"
+                DiscordSkillCommandRequest {
+                    requested_name: "alpha",
+                    args: "extra",
+                }
             ),
             DiscordSkillCommandDecision::Unauthorized
         );
@@ -4129,8 +4136,10 @@ mod tests {
                 Some("guild-1"),
                 None,
                 &entries,
-                "definitely-not-a-skill",
-                ""
+                DiscordSkillCommandRequest {
+                    requested_name: "definitely-not-a-skill",
+                    args: "",
+                }
             ),
             DiscordSkillCommandDecision::Unauthorized
         );
@@ -4156,8 +4165,10 @@ mod tests {
                 Some("guild-1"),
                 None,
                 &entries,
-                "alpha",
-                "extra args"
+                DiscordSkillCommandRequest {
+                    requested_name: "alpha",
+                    args: "extra args",
+                }
             ),
             DiscordSkillCommandDecision::Dispatch {
                 text: "/alpha extra args".into()
@@ -4171,8 +4182,10 @@ mod tests {
                 Some("guild-1"),
                 None,
                 &entries,
-                "missing",
-                ""
+                DiscordSkillCommandRequest {
+                    requested_name: "missing",
+                    args: "",
+                }
             ),
             DiscordSkillCommandDecision::UnknownSkill {
                 requested_name: "missing".into()

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -529,7 +529,8 @@ impl TelegramTextBatcher {
         let ready_keys = self
             .pending
             .iter()
-            .filter_map(|(key, batch)| (batch.ready_at <= now).then(|| key.clone()))
+            .filter(|(_, batch)| batch.ready_at <= now)
+            .map(|(key, _)| key.clone())
             .collect::<Vec<_>>();
 
         ready_keys
@@ -652,7 +653,7 @@ impl TelegramTopicBindingStore {
             .filter(|binding| binding.chat_id == chat_id)
             .cloned()
             .collect::<Vec<_>>();
-        rows.sort_by(|a, b| b.touched_seq.cmp(&a.touched_seq));
+        rows.sort_by_key(|row| std::cmp::Reverse(row.touched_seq));
         rows
     }
 
@@ -716,6 +717,31 @@ pub struct TelegramAdapter {
     /// Inline approval callback IDs mapped to gateway session keys.
     approval_state: Mutex<HashMap<u64, String>>,
     approval_counter: AtomicU64,
+}
+
+#[derive(Clone, Copy)]
+struct TelegramMultipartRequest<'a> {
+    chat_id: &'a str,
+    file_path: &'a str,
+    caption: Option<&'a str>,
+    method: &'a str,
+    field_name: &'a str,
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+}
+
+impl TelegramMultipartRequest<'_> {
+    fn has_thread_context(self) -> bool {
+        self.reply_to_message_id.is_some() || self.message_thread_id.is_some()
+    }
+
+    fn without_thread_context(self) -> Self {
+        Self {
+            reply_to_message_id: None,
+            message_thread_id: None,
+            ..self
+        }
+    }
 }
 
 impl TelegramAdapter {
@@ -952,11 +978,7 @@ impl TelegramAdapter {
                 continue;
             };
             match entity.entity_type.as_str() {
-                "mention" | "text_mention" => {
-                    if token.eq_ignore_ascii_case(&mention) {
-                        return true;
-                    }
-                }
+                "mention" | "text_mention" if token.eq_ignore_ascii_case(&mention) => return true,
                 "bot_command" if is_command => {
                     if let Some((_, addressed_to)) = token.split_once('@') {
                         return addressed_to.eq_ignore_ascii_case(bot_username);
@@ -1264,15 +1286,15 @@ impl TelegramAdapter {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<i64, GatewayError> {
-        self.send_multipart_with_options(
+        self.send_multipart_with_options(TelegramMultipartRequest {
             chat_id,
             file_path,
             caption,
-            "sendDocument",
-            "document",
-            None,
-            None,
-        )
+            method: "sendDocument",
+            field_name: "document",
+            reply_to_message_id: None,
+            message_thread_id: None,
+        })
         .await
     }
 
@@ -1284,15 +1306,15 @@ impl TelegramAdapter {
         reply_to_message_id: Option<i64>,
         message_thread_id: Option<i64>,
     ) -> Result<i64, GatewayError> {
-        self.send_multipart_with_options(
+        self.send_multipart_with_options(TelegramMultipartRequest {
             chat_id,
             file_path,
             caption,
-            "sendDocument",
-            "document",
+            method: "sendDocument",
+            field_name: "document",
             reply_to_message_id,
             message_thread_id,
-        )
+        })
         .await
     }
 
@@ -1303,15 +1325,15 @@ impl TelegramAdapter {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<i64, GatewayError> {
-        self.send_multipart_with_options(
+        self.send_multipart_with_options(TelegramMultipartRequest {
             chat_id,
             file_path,
             caption,
-            "sendPhoto",
-            "photo",
-            None,
-            None,
-        )
+            method: "sendPhoto",
+            field_name: "photo",
+            reply_to_message_id: None,
+            message_thread_id: None,
+        })
         .await
     }
 
@@ -1323,15 +1345,15 @@ impl TelegramAdapter {
         reply_to_message_id: Option<i64>,
         message_thread_id: Option<i64>,
     ) -> Result<i64, GatewayError> {
-        self.send_multipart_with_options(
+        self.send_multipart_with_options(TelegramMultipartRequest {
             chat_id,
             file_path,
             caption,
-            "sendPhoto",
-            "photo",
+            method: "sendPhoto",
+            field_name: "photo",
             reply_to_message_id,
             message_thread_id,
-        )
+        })
         .await
     }
 
@@ -1416,43 +1438,30 @@ impl TelegramAdapter {
         method: &str,
         field_name: &str,
     ) -> Result<i64, GatewayError> {
-        self.send_multipart_with_options(
-            chat_id, file_path, caption, method, field_name, None, None,
-        )
+        self.send_multipart_with_options(TelegramMultipartRequest {
+            chat_id,
+            file_path,
+            caption,
+            method,
+            field_name,
+            reply_to_message_id: None,
+            message_thread_id: None,
+        })
         .await
     }
 
     async fn send_multipart_with_options(
         &self,
-        chat_id: &str,
-        file_path: &str,
-        caption: Option<&str>,
-        method: &str,
-        field_name: &str,
-        reply_to_message_id: Option<i64>,
-        message_thread_id: Option<i64>,
+        request: TelegramMultipartRequest<'_>,
     ) -> Result<i64, GatewayError> {
-        match self
-            .send_multipart_once(
-                chat_id,
-                file_path,
-                caption,
-                method,
-                field_name,
-                reply_to_message_id,
-                message_thread_id,
-            )
-            .await
-        {
+        match self.send_multipart_once(request).await {
             Ok(id) => Ok(id),
             Err(err)
                 if Self::gateway_error_thread_or_reply_missing(&err)
-                    && (reply_to_message_id.is_some() || message_thread_id.is_some()) =>
+                    && request.has_thread_context() =>
             {
-                self.send_multipart_once(
-                    chat_id, file_path, caption, method, field_name, None, None,
-                )
-                .await
+                self.send_multipart_once(request.without_thread_context())
+                    .await
             }
             Err(err) => Err(err),
         }
@@ -1460,21 +1469,15 @@ impl TelegramAdapter {
 
     async fn send_multipart_once(
         &self,
-        chat_id: &str,
-        file_path: &str,
-        caption: Option<&str>,
-        method: &str,
-        field_name: &str,
-        reply_to_message_id: Option<i64>,
-        message_thread_id: Option<i64>,
+        request: TelegramMultipartRequest<'_>,
     ) -> Result<i64, GatewayError> {
-        let url = format!("{}/{}", self.api_base, method);
+        let url = format!("{}/{}", self.api_base, request.method);
 
-        let file_bytes = tokio::fs::read(file_path).await.map_err(|e| {
-            GatewayError::SendFailed(format!("Failed to read file {}: {}", file_path, e))
+        let file_bytes = tokio::fs::read(request.file_path).await.map_err(|e| {
+            GatewayError::SendFailed(format!("Failed to read file {}: {}", request.file_path, e))
         })?;
 
-        let file_name = std::path::Path::new(file_path)
+        let file_name = std::path::Path::new(request.file_path)
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("file")
@@ -1483,19 +1486,19 @@ impl TelegramAdapter {
         let part = reqwest::multipart::Part::bytes(file_bytes).file_name(file_name);
 
         let mut form = reqwest::multipart::Form::new()
-            .text("chat_id", chat_id.to_string())
-            .part(field_name.to_string(), part);
+            .text("chat_id", request.chat_id.to_string())
+            .part(request.field_name.to_string(), part);
 
-        if let Some(cap) = caption.map(str::trim).filter(|s| !s.is_empty()) {
+        if let Some(cap) = request.caption.map(str::trim).filter(|s| !s.is_empty()) {
             let truncated: String = cap.chars().take(MAX_CAPTION_LENGTH).collect();
             form = form.text("caption", truncated);
         }
 
-        if let Some(reply_id) = reply_to_message_id {
+        if let Some(reply_id) = request.reply_to_message_id {
             form = form.text("reply_to_message_id", reply_id.to_string());
         }
 
-        if let Some(thread_id) = message_thread_id {
+        if let Some(thread_id) = request.message_thread_id {
             form = form.text("message_thread_id", thread_id.to_string());
         }
 
@@ -1505,19 +1508,22 @@ impl TelegramAdapter {
             .multipart(form)
             .send()
             .await
-            .map_err(|e| GatewayError::SendFailed(format!("{} failed: {}", method, e)))?;
+            .map_err(|e| GatewayError::SendFailed(format!("{} failed: {}", request.method, e)))?;
 
         let status = resp.status();
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             let body_text = resp.text().await.unwrap_or_default();
             return Err(GatewayError::SendFailed(format!(
                 "Rate limited on {}: {}",
-                method, body_text
+                request.method, body_text
             )));
         }
 
         let result: TelegramResponse<SentMessage> = resp.json().await.map_err(|e| {
-            GatewayError::SendFailed(format!("Failed to parse {} response: {}", method, e))
+            GatewayError::SendFailed(format!(
+                "Failed to parse {} response: {}",
+                request.method, e
+            ))
         })?;
 
         if result.ok {
@@ -1525,14 +1531,14 @@ impl TelegramAdapter {
                 GatewayError::SendFailed(
                     result
                         .description
-                        .unwrap_or_else(|| format!("{} returned no message", method)),
+                        .unwrap_or_else(|| format!("{} returned no message", request.method)),
                 )
             })
         } else {
             Err(GatewayError::SendFailed(
                 result
                     .description
-                    .unwrap_or_else(|| format!("{} failed", method)),
+                    .unwrap_or_else(|| format!("{} failed", request.method)),
             ))
         }
     }

--- a/crates/hermes-skills/src/guard.rs
+++ b/crates/hermes-skills/src/guard.rs
@@ -294,15 +294,15 @@ pub fn content_hash(content: impl AsRef<[u8]>) -> String {
     out
 }
 
-static SCAN_PATTERNS: LazyLock<
-    Vec<(
-        Regex,
-        &'static str,
-        &'static str,
-        &'static str,
-        &'static str,
-    )>,
-> = LazyLock::new(|| {
+type ScanPattern = (
+    Regex,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+);
+
+static SCAN_PATTERNS: LazyLock<Vec<ScanPattern>> = LazyLock::new(|| {
     [
         (
             r"(?i)\bcurl\b[^\n]*(\$\{?[A-Z_][A-Z0-9_]*\}?)",

--- a/crates/hermes-tools/src/backends/browser.rs
+++ b/crates/hermes-tools/src/backends/browser.rs
@@ -4,7 +4,12 @@
 //! and provides browser automation capabilities.
 
 use async_trait::async_trait;
+use hermes_config::{
+    cli_config_path, config_path, managed_nous_tools_enabled, resolve_managed_tool_gateway,
+    ManagedToolGatewayConfig, ResolveOptions,
+};
 use serde_json::{json, Value};
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -14,19 +19,31 @@ use hermes_core::ToolError;
 
 const BROWSERBASE_BASE_URL_DEFAULT: &str = "https://api.browserbase.com";
 const BROWSERBASE_MAX_SESSION_TIMEOUT_SECS: u64 = 21_600;
+const BROWSER_USE_BASE_URL_DEFAULT: &str = "https://api.browser-use.com/api/v3";
+const BROWSER_USE_MANAGED_TIMEOUT_MINUTES: u64 = 5;
+const BROWSER_USE_MANAGED_PROXY_COUNTRY_CODE: &str = "us";
 
 /// Resolve the default browser backend from environment.
 ///
 /// Selection order:
+/// - `HERMES_BROWSER_BACKEND=browser-use` / `BROWSER_CLOUD_PROVIDER=browser-use`
 /// - `HERMES_BROWSER_BACKEND=browserbase` / `BROWSER_CLOUD_PROVIDER=browserbase`
 /// - Browserbase credentials (`BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID`)
+/// - Browser Use direct or managed gateway configuration
 /// - `HERMES_BROWSER_BACKEND=camofox`
 /// - local CDP (`CHROME_CDP_URL` or localhost default)
 pub fn browser_backend_from_env() -> Arc<dyn BrowserBackend> {
     match browser_backend_choice_from_env() {
+        "browser-use" => match BrowserUseBrowserBackend::from_env() {
+            Ok(backend) => Arc::new(backend),
+            Err(err) if explicit_browser_use_requested_from_env_or_config() => {
+                Arc::new(UnavailableBrowserBackend::new(err.to_string()))
+            }
+            Err(_) => Arc::new(CdpBrowserBackend::from_env()),
+        },
         "browserbase" => match BrowserbaseBrowserBackend::from_env() {
             Ok(backend) => Arc::new(backend),
-            Err(err) if explicit_browserbase_requested_from_env() => {
+            Err(err) if explicit_browserbase_requested_from_env_or_config() => {
                 Arc::new(UnavailableBrowserBackend::new(err.to_string()))
             }
             Err(_) => Arc::new(CdpBrowserBackend::from_env()),
@@ -36,22 +53,34 @@ pub fn browser_backend_from_env() -> Arc<dyn BrowserBackend> {
     }
 }
 
-fn explicit_browserbase_requested_from_env() -> bool {
+fn explicit_browser_use_requested_from_env_or_config() -> bool {
     for key in [
         "HERMES_BROWSER_BACKEND",
         "BROWSER_CLOUD_PROVIDER",
         "BROWSER_PROVIDER",
     ] {
         if let Some(value) = env_optional_nonempty(key) {
-            if matches!(
-                value.to_ascii_lowercase().as_str(),
-                "browserbase" | "browser-base"
-            ) {
+            if normalize_browser_provider(&value) == Some("browser-use") {
                 return true;
             }
         }
     }
-    false
+    matches!(configured_browser_cloud_provider(), Some("browser-use"))
+}
+
+fn explicit_browserbase_requested_from_env_or_config() -> bool {
+    for key in [
+        "HERMES_BROWSER_BACKEND",
+        "BROWSER_CLOUD_PROVIDER",
+        "BROWSER_PROVIDER",
+    ] {
+        if let Some(value) = env_optional_nonempty(key) {
+            if normalize_browser_provider(&value) == Some("browserbase") {
+                return true;
+            }
+        }
+    }
+    matches!(configured_browser_cloud_provider(), Some("browserbase"))
 }
 
 fn browser_backend_choice_from_env() -> &'static str {
@@ -61,19 +90,34 @@ fn browser_backend_choice_from_env() -> &'static str {
         "BROWSER_PROVIDER",
     ] {
         if let Some(value) = env_optional_nonempty(key) {
-            match value.to_ascii_lowercase().as_str() {
-                "browserbase" | "browser-base" => return "browserbase",
-                "camofox" | "camo" => return "camofox",
-                "cdp" | "chrome" | "chromium" | "local" => return "cdp",
-                _ => {}
+            if let Some(provider) = normalize_browser_provider(&value) {
+                return provider;
             }
         }
     }
 
+    if let Some(provider) = configured_browser_cloud_provider() {
+        return provider;
+    }
+
     if BrowserbaseConfig::is_configured_from_env() {
         "browserbase"
+    } else if BrowserUseConfig::is_configured_from_env_or_managed() {
+        "browser-use"
     } else {
         "cdp"
+    }
+}
+
+fn normalize_browser_provider(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "browser-use" | "browser_use" | "browseruse" | "managed-browser" | "managed_browser" => {
+            Some("browser-use")
+        }
+        "browserbase" | "browser-base" => Some("browserbase"),
+        "camofox" | "camo" => Some("camofox"),
+        "cdp" | "chrome" | "chromium" | "local" => Some("cdp"),
+        _ => None,
     }
 }
 
@@ -96,11 +140,93 @@ fn env_bool(name: &str, default: bool) -> bool {
 }
 
 fn normalize_base_url(raw: &str) -> String {
+    normalize_base_url_with_default(raw, BROWSERBASE_BASE_URL_DEFAULT)
+}
+
+fn normalize_base_url_with_default(raw: &str, default: &str) -> String {
     let trimmed = raw.trim().trim_end_matches('/');
     if trimmed.is_empty() {
-        BROWSERBASE_BASE_URL_DEFAULT.to_string()
+        default.to_string()
     } else {
         trimmed.to_string()
+    }
+}
+
+fn configured_browser_cloud_provider() -> Option<&'static str> {
+    for path in [cli_config_path(), config_path()] {
+        if let Some(provider) = browser_provider_from_yaml_path(&path) {
+            return Some(provider);
+        }
+    }
+    None
+}
+
+fn browser_provider_from_yaml_path(path: &Path) -> Option<&'static str> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&text).ok()?;
+    let provider = value
+        .get("browser")
+        .and_then(|browser| browser.get("cloud_provider"))
+        .and_then(yaml_scalar_as_string)?;
+    normalize_browser_provider(&provider)
+}
+
+fn browser_use_prefers_gateway_from_config() -> bool {
+    for path in [cli_config_path(), config_path()] {
+        if let Some(prefer) = browser_use_gateway_preference_from_yaml_path(&path) {
+            return prefer;
+        }
+    }
+    false
+}
+
+fn browser_use_gateway_preference_from_yaml_path(path: &Path) -> Option<bool> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&text).ok()?;
+
+    if let Some(raw) = value
+        .get("browser")
+        .and_then(|browser| browser.get("use_gateway"))
+    {
+        return Some(yaml_truthy(raw));
+    }
+    if let Some(raw) = value
+        .get("tool_gateway")
+        .and_then(|gateway| gateway.get("browser"))
+    {
+        return Some(yaml_gateway_route(raw));
+    }
+    None
+}
+
+fn yaml_scalar_as_string(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(s) => Some(s.clone()),
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+fn yaml_truthy(value: &serde_yaml::Value) -> bool {
+    match value {
+        serde_yaml::Value::Bool(b) => *b,
+        serde_yaml::Value::Number(n) => n.as_i64().map(|v| v != 0).unwrap_or(false),
+        serde_yaml::Value::String(s) => matches!(
+            s.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on" | "gateway" | "managed"
+        ),
+        _ => false,
+    }
+}
+
+fn yaml_gateway_route(value: &serde_yaml::Value) -> bool {
+    match value {
+        serde_yaml::Value::String(s) => matches!(
+            s.trim().to_ascii_lowercase().as_str(),
+            "gateway" | "managed" | "nous" | "true" | "1" | "yes" | "on"
+        ),
+        _ => yaml_truthy(value),
     }
 }
 
@@ -164,6 +290,34 @@ pub struct BrowserbaseBrowserBackend {
     session: Mutex<Option<BrowserbaseSession>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserUseConfig {
+    api_key: String,
+    base_url: String,
+    managed_mode: bool,
+    task_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BrowserUseSession {
+    session_name: String,
+    bb_session_id: String,
+    cdp_url: String,
+    external_call_id: Option<String>,
+}
+
+/// Browser Use cloud browser backend.
+///
+/// Supports both direct `BROWSER_USE_API_KEY` and the Nous-managed Browser Use
+/// gateway. Managed mode preserves upstream's idempotency-key behavior for
+/// in-flight or retryable session creation.
+pub struct BrowserUseBrowserBackend {
+    config: BrowserUseConfig,
+    client: reqwest::Client,
+    session: Mutex<Option<BrowserUseSession>>,
+    pending_create_key: Mutex<Option<String>>,
+}
+
 impl UnavailableBrowserBackend {
     fn new(message: String) -> Self {
         Self { message }
@@ -223,6 +377,72 @@ impl BrowserbaseConfig {
 
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+}
+
+impl BrowserUseConfig {
+    pub fn new_direct(api_key: String) -> Self {
+        Self {
+            api_key,
+            base_url: BROWSER_USE_BASE_URL_DEFAULT.to_string(),
+            managed_mode: false,
+            task_id: "rust".to_string(),
+        }
+    }
+
+    pub fn from_env() -> Result<Self, ToolError> {
+        let direct_api_key = env_optional_nonempty("BROWSER_USE_API_KEY");
+        if let Some(api_key) = direct_api_key {
+            if !browser_use_prefers_gateway_from_config() {
+                let mut cfg = Self::new_direct(api_key);
+                if let Some(task_id) = env_optional_nonempty("HERMES_TASK_ID") {
+                    cfg.task_id = task_id;
+                }
+                return Ok(cfg);
+            }
+        }
+
+        if let Some(managed) =
+            resolve_managed_tool_gateway("browser-use", ResolveOptions::default())
+        {
+            let mut cfg = Self::from_managed(&managed);
+            if let Some(task_id) = env_optional_nonempty("HERMES_TASK_ID") {
+                cfg.task_id = task_id;
+            }
+            return Ok(cfg);
+        }
+
+        let message = if managed_nous_tools_enabled() {
+            "Browser Use requires either a direct BROWSER_USE_API_KEY credential or a managed Browser Use gateway configuration."
+        } else {
+            "Browser Use requires a direct BROWSER_USE_API_KEY credential."
+        };
+        Err(ToolError::ExecutionFailed(message.into()))
+    }
+
+    pub fn from_managed(cfg: &ManagedToolGatewayConfig) -> Self {
+        Self {
+            api_key: cfg.nous_user_token.clone(),
+            base_url: normalize_base_url_with_default(
+                &cfg.gateway_origin,
+                BROWSER_USE_BASE_URL_DEFAULT,
+            ),
+            managed_mode: true,
+            task_id: "rust".to_string(),
+        }
+    }
+
+    pub fn is_configured_from_env_or_managed() -> bool {
+        env_optional_nonempty("BROWSER_USE_API_KEY").is_some()
+            || resolve_managed_tool_gateway("browser-use", ResolveOptions::default()).is_some()
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn managed_mode(&self) -> bool {
+        self.managed_mode
     }
 }
 
@@ -297,11 +517,8 @@ impl BrowserbaseBrowserBackend {
                 ToolError::ExecutionFailed("Browserbase response missing connectUrl".into())
             })?
             .to_string();
-        let session_name = format!(
-            "hermes_{}_{}",
-            self.config.task_id,
-            Uuid::new_v4().simple().to_string()[..8].to_string()
-        );
+        let suffix = Uuid::new_v4().simple().to_string();
+        let session_name = format!("hermes_{}_{}", self.config.task_id, &suffix[..8]);
         let features = BrowserbaseFeatures {
             basic_stealth: true,
             proxies: self.config.proxies && !proxies_fallback,
@@ -392,6 +609,222 @@ impl BrowserbaseBrowserBackend {
             }
         }))
     }
+}
+
+impl BrowserUseBrowserBackend {
+    pub fn new(config: BrowserUseConfig) -> Self {
+        Self {
+            config,
+            client: reqwest::Client::new(),
+            session: Mutex::new(None),
+            pending_create_key: Mutex::new(None),
+        }
+    }
+
+    pub fn from_env() -> Result<Self, ToolError> {
+        Ok(Self::new(BrowserUseConfig::from_env()?))
+    }
+
+    pub fn config(&self) -> &BrowserUseConfig {
+        &self.config
+    }
+
+    async fn ensure_session(&self) -> Result<BrowserUseSession, ToolError> {
+        let mut guard = self.session.lock().await;
+        if let Some(session) = guard.as_ref() {
+            return Ok(session.clone());
+        }
+        let session = self.create_session().await?;
+        *guard = Some(session.clone());
+        Ok(session)
+    }
+
+    async fn create_session(&self) -> Result<BrowserUseSession, ToolError> {
+        let idempotency_key = if self.config.managed_mode {
+            Some(self.get_or_create_pending_create_key().await)
+        } else {
+            None
+        };
+
+        let response = self.post_session(idempotency_key.as_deref()).await?;
+        let status = response.status();
+        let external_call_id = if self.config.managed_mode {
+            response
+                .headers()
+                .get("x-external-call-id")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.to_string())
+        } else {
+            None
+        };
+        let text = response.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to read Browser Use response: {e}"))
+        })?;
+
+        if !status.is_success() {
+            if self.config.managed_mode
+                && !browser_use_should_preserve_pending_create_key(status, &text)
+            {
+                self.clear_pending_create_key().await;
+            }
+            return Err(ToolError::ExecutionFailed(format!(
+                "Failed to create Browser Use session: {status} {text}"
+            )));
+        }
+
+        let data: Value = serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to parse Browser Use response: {e}"))
+        })?;
+        if self.config.managed_mode {
+            self.clear_pending_create_key().await;
+        }
+        let bb_session_id = data
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                ToolError::ExecutionFailed("Browser Use response missing session id".into())
+            })?
+            .to_string();
+        let cdp_url = data
+            .get("cdpUrl")
+            .or_else(|| data.get("connectUrl"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let suffix = Uuid::new_v4().simple().to_string();
+        let session_name = format!("hermes_{}_{}", self.config.task_id, &suffix[..8]);
+        tracing::info!(
+            session_id = %bb_session_id,
+            session_name = %session_name,
+            managed = self.config.managed_mode,
+            "created Browser Use session"
+        );
+        Ok(BrowserUseSession {
+            session_name,
+            bb_session_id,
+            cdp_url,
+            external_call_id,
+        })
+    }
+
+    async fn post_session(
+        &self,
+        idempotency_key: Option<&str>,
+    ) -> Result<reqwest::Response, ToolError> {
+        let mut request = self
+            .client
+            .post(format!("{}/browsers", self.config.base_url))
+            .json(&browser_use_session_payload(self.config.managed_mode));
+        for (name, value) in browser_use_headers(&self.config, idempotency_key) {
+            request = request.header(name, value);
+        }
+        request.send().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Browser Use API connection failed: {e}"))
+        })
+    }
+
+    async fn get_or_create_pending_create_key(&self) -> String {
+        let mut guard = self.pending_create_key.lock().await;
+        if let Some(existing) = guard.as_ref() {
+            return existing.clone();
+        }
+        let created = format!("browser-use-session-create:{}", Uuid::new_v4().simple());
+        *guard = Some(created.clone());
+        created
+    }
+
+    async fn clear_pending_create_key(&self) {
+        let mut guard = self.pending_create_key.lock().await;
+        *guard = None;
+    }
+
+    pub async fn close_active_session(&self) -> Result<bool, ToolError> {
+        let mut guard = self.session.lock().await;
+        let Some(session) = guard.take() else {
+            return Ok(false);
+        };
+        self.close_session(&session.bb_session_id).await
+    }
+
+    async fn close_session(&self, session_id: &str) -> Result<bool, ToolError> {
+        let mut request = self
+            .client
+            .patch(format!("{}/browsers/{session_id}", self.config.base_url))
+            .json(&json!({"action": "stop"}));
+        for (name, value) in browser_use_headers(&self.config, None) {
+            request = request.header(name, value);
+        }
+        let resp = request
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Browser Use close failed: {e}")))?;
+        Ok(matches!(
+            resp.status(),
+            reqwest::StatusCode::OK
+                | reqwest::StatusCode::CREATED
+                | reqwest::StatusCode::NO_CONTENT
+        ))
+    }
+
+    async fn browser_use_command(&self, method: &str, params: Value) -> Result<Value, ToolError> {
+        let session = self.ensure_session().await?;
+        Ok(json!({
+            "method": method,
+            "params": params,
+            "target": session.cdp_url,
+            "status": "sent",
+            "browser_use": {
+                "session_name": session.session_name,
+                "bb_session_id": session.bb_session_id,
+                "features": {"browser_use": true},
+                "managed_mode": self.config.managed_mode,
+                "external_call_id": session.external_call_id,
+            }
+        }))
+    }
+}
+
+fn browser_use_headers(
+    config: &BrowserUseConfig,
+    idempotency_key: Option<&str>,
+) -> Vec<(&'static str, String)> {
+    let mut headers = vec![
+        ("Content-Type", "application/json".to_string()),
+        ("X-Browser-Use-API-Key", config.api_key.clone()),
+    ];
+    if let Some(key) = idempotency_key {
+        headers.push(("X-Idempotency-Key", key.to_string()));
+    }
+    headers
+}
+
+fn browser_use_session_payload(managed_mode: bool) -> Value {
+    if managed_mode {
+        json!({
+            "timeout": BROWSER_USE_MANAGED_TIMEOUT_MINUTES,
+            "proxyCountryCode": BROWSER_USE_MANAGED_PROXY_COUNTRY_CODE,
+        })
+    } else {
+        json!({})
+    }
+}
+
+fn browser_use_should_preserve_pending_create_key(status: reqwest::StatusCode, body: &str) -> bool {
+    if status.as_u16() >= 500 {
+        return true;
+    }
+    if status != reqwest::StatusCode::CONFLICT {
+        return false;
+    }
+    let Ok(payload) = serde_json::from_str::<Value>(body) else {
+        return false;
+    };
+    payload
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(|message| message.as_str())
+        .map(|message| message.to_ascii_lowercase().contains("already in progress"))
+        .unwrap_or(false)
 }
 
 fn browserbase_session_payload(
@@ -583,6 +1016,145 @@ impl BrowserBackend for BrowserbaseBrowserBackend {
             "clear" => {
                 let result = self
                     .browserbase_command(
+                        "Runtime.evaluate",
+                        json!({"expression": "console.clear(); 'cleared'"}),
+                    )
+                    .await?;
+                Ok(json!({"status": "console_cleared", "cdp": result}).to_string())
+            }
+            other => Err(ToolError::InvalidParams(format!(
+                "Unknown console action: {}",
+                other
+            ))),
+        }
+    }
+}
+
+#[async_trait]
+impl BrowserBackend for BrowserUseBrowserBackend {
+    async fn navigate(&self, url: &str) -> Result<String, ToolError> {
+        let result = self
+            .browser_use_command("Page.navigate", json!({"url": url}))
+            .await?;
+        Ok(json!({"status": "navigated", "url": url, "cdp": result}).to_string())
+    }
+
+    async fn snapshot(&self) -> Result<String, ToolError> {
+        let result = self
+            .browser_use_command("Accessibility.getFullAXTree", json!({}))
+            .await?;
+        Ok(json!({"status": "snapshot", "cdp": result}).to_string())
+    }
+
+    async fn click(&self, selector: &str) -> Result<String, ToolError> {
+        let js = format!(
+            "document.querySelector('{}')?.click(); 'clicked'",
+            selector.replace('\'', "\\'")
+        );
+        let result = self
+            .browser_use_command("Runtime.evaluate", json!({"expression": js}))
+            .await?;
+        Ok(json!({"status": "clicked", "selector": selector, "cdp": result}).to_string())
+    }
+
+    async fn r#type(&self, selector: &str, text: &str) -> Result<String, ToolError> {
+        let js = format!(
+            "let el = document.querySelector('{}'); if(el) {{ el.value = '{}'; el.dispatchEvent(new Event('input')); 'typed' }} else {{ 'not found' }}",
+            selector.replace('\'', "\\'"),
+            text.replace('\'', "\\'")
+        );
+        let result = self
+            .browser_use_command("Runtime.evaluate", json!({"expression": js}))
+            .await?;
+        Ok(
+            json!({"status": "typed", "selector": selector, "text": text, "cdp": result})
+                .to_string(),
+        )
+    }
+
+    async fn scroll(&self, direction: &str, amount: Option<u32>) -> Result<String, ToolError> {
+        let px = amount.unwrap_or(500) as i32;
+        let (x, y) = match direction {
+            "up" => (0, -px),
+            "down" => (0, px),
+            "left" => (-px, 0),
+            "right" => (px, 0),
+            _ => (0, px),
+        };
+        let js = format!("window.scrollBy({}, {}); 'scrolled'", x, y);
+        let result = self
+            .browser_use_command("Runtime.evaluate", json!({"expression": js}))
+            .await?;
+        Ok(
+            json!({"status": "scrolled", "direction": direction, "amount": px, "cdp": result})
+                .to_string(),
+        )
+    }
+
+    async fn go_back(&self) -> Result<String, ToolError> {
+        let result = self
+            .browser_use_command(
+                "Runtime.evaluate",
+                json!({"expression": "history.back(); 'back'"}),
+            )
+            .await?;
+        Ok(json!({"status": "navigated_back", "cdp": result}).to_string())
+    }
+
+    async fn press(&self, key: &str) -> Result<String, ToolError> {
+        let result = self
+            .browser_use_command(
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "keyDown",
+                    "key": key,
+                }),
+            )
+            .await?;
+        Ok(json!({"status": "key_pressed", "key": key, "cdp": result}).to_string())
+    }
+
+    async fn get_images(&self, selector: Option<&str>) -> Result<String, ToolError> {
+        let sel = selector.unwrap_or("img");
+        let js = format!(
+            "JSON.stringify(Array.from(document.querySelectorAll('{}')).map(img => ({{src: img.src, alt: img.alt, width: img.width, height: img.height}})))",
+            sel.replace('\'', "\\'")
+        );
+        let result = self
+            .browser_use_command(
+                "Runtime.evaluate",
+                json!({"expression": js, "returnByValue": true}),
+            )
+            .await?;
+        Ok(json!({"status": "images_found", "selector": sel, "cdp": result}).to_string())
+    }
+
+    async fn vision(&self, instruction: &str) -> Result<String, ToolError> {
+        let result = self
+            .browser_use_command("Page.captureScreenshot", json!({"format": "png"}))
+            .await?;
+        Ok(json!({
+            "status": "vision_analysis",
+            "instruction": instruction,
+            "screenshot": result,
+            "note": "Screenshot captured; vision analysis requires LLM integration"
+        })
+        .to_string())
+    }
+
+    async fn console(&self, action: &str) -> Result<String, ToolError> {
+        match action {
+            "read" => {
+                let result = self
+                    .browser_use_command("Runtime.evaluate", json!({
+                        "expression": "'Console messages require Runtime.consoleAPICalled event listener'"
+                    }))
+                    .await?;
+                Ok(json!({"status": "console_read", "cdp": result}).to_string())
+            }
+            "clear" => {
+                let result = self
+                    .browser_use_command(
                         "Runtime.evaluate",
                         json!({"expression": "console.clear(); 'cleared'"}),
                     )
@@ -865,7 +1437,15 @@ mod tests {
                 "BROWSERBASE_ADVANCED_STEALTH",
                 "BROWSERBASE_KEEP_ALIVE",
                 "BROWSERBASE_SESSION_TIMEOUT",
+                "BROWSER_USE_API_KEY",
+                "BROWSER_USE_GATEWAY_URL",
+                "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
                 "HERMES_TASK_ID",
+                "HERMES_HOME",
+                "HERMES_AGENT_ULTRA_HOME",
+                "TOOL_GATEWAY_USER_TOKEN",
+                "TOOL_GATEWAY_DOMAIN",
+                "TOOL_GATEWAY_SCHEME",
                 "CAMOFOX_CDP_URL",
                 "CHROME_CDP_URL",
             ];
@@ -886,6 +1466,213 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn browser_use_config_prefers_direct_key_unless_gateway_is_requested() {
+        let _scope = EnvScope::new();
+        std::env::set_var("BROWSER_USE_API_KEY", "direct-key");
+        std::env::set_var("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+        std::env::set_var("TOOL_GATEWAY_USER_TOKEN", "nous-token");
+        std::env::set_var("BROWSER_USE_GATEWAY_URL", "http://127.0.0.1:3009/");
+        std::env::set_var("HERMES_TASK_ID", "task-browser-use");
+
+        let cfg = BrowserUseConfig::from_env().expect("browser use direct config");
+
+        assert_eq!(cfg.api_key, "direct-key");
+        assert_eq!(cfg.base_url(), BROWSER_USE_BASE_URL_DEFAULT);
+        assert!(!cfg.managed_mode());
+        assert_eq!(cfg.task_id, "task-browser-use");
+    }
+
+    #[test]
+    fn browser_use_config_honors_browser_use_gateway_preference() {
+        let _scope = EnvScope::new();
+        let home = tempfile::tempdir().expect("temp hermes home");
+        std::fs::write(
+            home.path().join("config.yaml"),
+            "browser:\n  cloud_provider: browser-use\n  use_gateway: true\n",
+        )
+        .expect("write config");
+        std::env::set_var("HERMES_HOME", home.path());
+        std::env::set_var("BROWSER_USE_API_KEY", "direct-key");
+        std::env::set_var("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+        std::env::set_var("TOOL_GATEWAY_USER_TOKEN", "nous-token");
+        std::env::set_var("BROWSER_USE_GATEWAY_URL", "http://127.0.0.1:3009/");
+
+        let cfg = BrowserUseConfig::from_env().expect("browser use managed config");
+
+        assert_eq!(cfg.api_key, "nous-token");
+        assert_eq!(cfg.base_url(), "http://127.0.0.1:3009");
+        assert!(cfg.managed_mode());
+    }
+
+    #[test]
+    fn browser_use_payload_and_idempotency_rules_match_provider_contract() {
+        let cfg = BrowserUseConfig {
+            api_key: "key".into(),
+            base_url: BROWSER_USE_BASE_URL_DEFAULT.into(),
+            managed_mode: true,
+            task_id: "task".into(),
+        };
+
+        assert_eq!(browser_use_session_payload(false), json!({}));
+        assert_eq!(
+            browser_use_session_payload(true),
+            json!({"timeout": 5, "proxyCountryCode": "us"})
+        );
+        assert_eq!(
+            browser_use_headers(&cfg, Some("browser-use-session-create:abc")),
+            vec![
+                ("Content-Type", "application/json".to_string()),
+                ("X-Browser-Use-API-Key", "key".to_string()),
+                (
+                    "X-Idempotency-Key",
+                    "browser-use-session-create:abc".to_string()
+                ),
+            ]
+        );
+        assert!(browser_use_should_preserve_pending_create_key(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            ""
+        ));
+        assert!(browser_use_should_preserve_pending_create_key(
+            reqwest::StatusCode::CONFLICT,
+            r#"{"error":{"message":"Managed Browser Use session creation is already in progress"}}"#
+        ));
+        assert!(!browser_use_should_preserve_pending_create_key(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"bad request"}}"#
+        ));
+    }
+
+    #[tokio::test]
+    async fn browser_use_create_session_sends_managed_gateway_contract() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut buf = Vec::new();
+            let mut tmp = [0_u8; 1024];
+            loop {
+                let n = stream.read(&mut tmp).await.expect("read request");
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&tmp[..n]);
+                let text = String::from_utf8_lossy(&buf);
+                if text.contains("\r\n\r\n") && text.contains(r#""proxyCountryCode":"us""#) {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&buf).to_string();
+            let _ = tx.send(request);
+            let body =
+                r#"{"id":"bu_local_session_1","connectUrl":"wss://browser-use.example/session"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nx-external-call-id: call-browser-use-1\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let cfg = BrowserUseConfig {
+            api_key: "nous-token".into(),
+            base_url: format!("http://{addr}"),
+            managed_mode: true,
+            task_id: "task-browser-use-managed".into(),
+        };
+        let backend = BrowserUseBrowserBackend::new(cfg);
+        let session = backend.create_session().await.expect("create session");
+        let request = rx.await.expect("captured request").to_ascii_lowercase();
+
+        assert!(request.starts_with("post /browsers "));
+        assert!(request.contains("x-browser-use-api-key: nous-token"));
+        assert!(request.contains("x-idempotency-key: browser-use-session-create:"));
+        assert!(request.contains(r#""timeout":5"#));
+        assert!(request.contains(r#""proxycountrycode":"us""#));
+        assert_eq!(session.bb_session_id, "bu_local_session_1");
+        assert_eq!(session.cdp_url, "wss://browser-use.example/session");
+        assert_eq!(
+            session.external_call_id.as_deref(),
+            Some("call-browser-use-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn browser_use_close_session_sends_stop_patch() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut buf = Vec::new();
+            let mut tmp = [0_u8; 1024];
+            loop {
+                let n = stream.read(&mut tmp).await.expect("read request");
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&tmp[..n]);
+                let text = String::from_utf8_lossy(&buf);
+                if text.contains("\r\n\r\n") && text.contains(r#""action":"stop""#) {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&buf).to_string();
+            let _ = tx.send(request);
+            stream
+                .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .expect("write response");
+        });
+
+        let cfg = BrowserUseConfig {
+            api_key: "direct-key".into(),
+            base_url: format!("http://{addr}"),
+            managed_mode: false,
+            task_id: "task-browser-use-close".into(),
+        };
+        let backend = BrowserUseBrowserBackend::new(cfg);
+
+        assert!(backend
+            .close_session("bu_local_session_close")
+            .await
+            .expect("close session"));
+        let request = rx.await.expect("captured request").to_ascii_lowercase();
+        assert!(request.starts_with("patch /browsers/bu_local_session_close "));
+        assert!(request.contains("x-browser-use-api-key: direct-key"));
+        assert!(request.contains(r#""action":"stop""#));
+    }
+
+    #[test]
+    fn browser_backend_choice_accepts_browser_use_env_and_config() {
+        let _scope = EnvScope::new();
+        std::env::set_var("BROWSER_CLOUD_PROVIDER", "browser_use");
+        assert_eq!(browser_backend_choice_from_env(), "browser-use");
+
+        std::env::remove_var("BROWSER_CLOUD_PROVIDER");
+        let home = tempfile::tempdir().expect("temp hermes home");
+        std::fs::write(
+            home.path().join("config.yaml"),
+            "browser:\n  cloud_provider: managed-browser\n",
+        )
+        .expect("write config");
+        std::env::set_var("HERMES_HOME", home.path());
+        assert_eq!(browser_backend_choice_from_env(), "browser-use");
     }
 
     #[test]
@@ -962,6 +1749,24 @@ mod tests {
     async fn explicit_browserbase_without_credentials_fails_at_runtime() {
         let _scope = EnvScope::new();
         std::env::set_var("HERMES_BROWSER_BACKEND", "browserbase");
+        let backend = browser_backend_from_env();
+        let err = backend.navigate("https://example.com").await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID"));
+    }
+
+    #[tokio::test]
+    async fn configured_browserbase_without_credentials_fails_at_runtime() {
+        let _scope = EnvScope::new();
+        let home = tempfile::tempdir().expect("temp hermes home");
+        std::fs::write(
+            home.path().join("config.yaml"),
+            "browser:\n  cloud_provider: browserbase\n",
+        )
+        .expect("write config");
+        std::env::set_var("HERMES_HOME", home.path());
+
         let backend = browser_backend_from_env();
         let err = backend.navigate("https://example.com").await.unwrap_err();
         assert!(err

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -100,8 +100,8 @@ pub use tools::web::{
 
 // Re-export real backend implementations
 pub use backends::browser::{
-    browser_backend_from_env, BrowserbaseBrowserBackend, BrowserbaseConfig, CamoFoxBrowserBackend,
-    CdpBrowserBackend,
+    browser_backend_from_env, BrowserUseBrowserBackend, BrowserUseConfig,
+    BrowserbaseBrowserBackend, BrowserbaseConfig, CamoFoxBrowserBackend, CdpBrowserBackend,
 };
 pub use backends::clarify::SignalClarifyBackend;
 pub use backends::code_execution::LocalCodeExecutionBackend;

--- a/crates/hermes-tools/src/tools/dashboard_control.rs
+++ b/crates/hermes-tools/src/tools/dashboard_control.rs
@@ -230,49 +230,58 @@ mod tests {
             .expect("env lock poisoned")
     }
 
-    #[tokio::test]
-    async fn enable_status_disable_roundtrip() {
-        let _guard = env_lock();
-        let temp = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", temp.path());
-
-        let handler = DashboardControlHandler;
-        let enabled = handler
-            .execute(json!({"action":"enable","host":"127.0.0.1","port":9191}))
-            .await
-            .expect("enable");
-        let enabled_json: Value = serde_json::from_str(&enabled).expect("json");
-        assert_eq!(enabled_json["enabled"], true);
-        assert_eq!(enabled_json["port"], 9191);
-
-        let status = handler
-            .execute(json!({"action":"status"}))
-            .await
-            .expect("status");
-        let status_json: Value = serde_json::from_str(&status).expect("json");
-        assert_eq!(status_json["enabled"], true);
-        assert_eq!(status_json["host"], "127.0.0.1");
-        assert_eq!(status_json["port"], 9191);
-
-        let disabled = handler
-            .execute(json!({"action":"disable"}))
-            .await
-            .expect("disable");
-        let disabled_json: Value = serde_json::from_str(&disabled).expect("json");
-        assert_eq!(disabled_json["enabled"], false);
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
     }
 
-    #[tokio::test]
-    async fn rejects_non_local_without_insecure() {
+    #[test]
+    fn enable_status_disable_roundtrip() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", temp.path());
+
+        block_on(async {
+            let handler = DashboardControlHandler;
+            let enabled = handler
+                .execute(json!({"action":"enable","host":"127.0.0.1","port":9191}))
+                .await
+                .expect("enable");
+            let enabled_json: Value = serde_json::from_str(&enabled).expect("json");
+            assert_eq!(enabled_json["enabled"], true);
+            assert_eq!(enabled_json["port"], 9191);
+
+            let status = handler
+                .execute(json!({"action":"status"}))
+                .await
+                .expect("status");
+            let status_json: Value = serde_json::from_str(&status).expect("json");
+            assert_eq!(status_json["enabled"], true);
+            assert_eq!(status_json["host"], "127.0.0.1");
+            assert_eq!(status_json["port"], 9191);
+
+            let disabled = handler
+                .execute(json!({"action":"disable"}))
+                .await
+                .expect("disable");
+            let disabled_json: Value = serde_json::from_str(&disabled).expect("json");
+            assert_eq!(disabled_json["enabled"], false);
+        });
+    }
+
+    #[test]
+    fn rejects_non_local_without_insecure() {
         let _guard = env_lock();
         let temp = tempfile::tempdir().expect("tempdir");
         std::env::set_var("HERMES_HOME", temp.path());
 
         let handler = DashboardControlHandler;
-        let err = handler
-            .execute(json!({"action":"enable","host":"0.0.0.0","port":8080}))
-            .await
-            .expect_err("non-local should fail");
+        let err =
+            block_on(handler.execute(json!({"action":"enable","host":"0.0.0.0","port":8080})))
+                .expect_err("non-local should fail");
         match err {
             ToolError::InvalidParams(msg) => assert!(msg.contains("non-localhost")),
             other => panic!("unexpected error: {other:?}"),

--- a/crates/hermes-tools/src/tools/disk_cleanup.rs
+++ b/crates/hermes-tools/src/tools/disk_cleanup.rs
@@ -443,17 +443,14 @@ impl DiskCleanup {
             if parts.len() == 1 && PROTECTED_EMPTY_TOP_LEVEL.contains(&parts[0]) {
                 continue;
             }
-            match fs::read_dir(&dir) {
-                Ok(mut entries) => {
-                    if entries.next().is_some() {
-                        continue;
-                    }
-                    if fs::remove_dir(&dir).is_ok() {
-                        removed += 1;
-                        self.audit_log(&format!("DELETED: {} (empty dir)", dir.display()));
-                    }
+            if let Ok(mut entries) = fs::read_dir(&dir) {
+                if entries.next().is_some() {
+                    continue;
                 }
-                _ => {}
+                if fs::remove_dir(&dir).is_ok() {
+                    removed += 1;
+                    self.audit_log(&format!("DELETED: {} (empty dir)", dir.display()));
+                }
             }
         }
         removed
@@ -833,7 +830,7 @@ fn extract_absolute_like_paths(text: &str) -> Vec<String> {
 }
 
 fn trim_path_token(token: &str) -> &str {
-    token.trim_end_matches(|c: char| matches!(c, ',' | ';' | ':' | ')' | ']' | '}'))
+    token.trim_end_matches([',', ';', ':', ')', ']', '}'])
 }
 
 fn expand_user(path: String) -> PathBuf {

--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -511,6 +511,14 @@ mod tests {
         }
     }
 
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
     struct MockBackend;
     #[async_trait]
     impl TerminalBackend for MockBackend {
@@ -618,45 +626,37 @@ mod tests {
         assert_eq!(schema.name, "terminal");
     }
 
-    #[tokio::test]
-    async fn test_terminal_handler_execute() {
+    #[test]
+    fn test_terminal_handler_execute() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
         let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
-        let result = handler
-            .execute(json!({"command": "echo hello"}))
-            .await
-            .unwrap();
+        let result = block_on(handler.execute(json!({"command": "echo hello"}))).unwrap();
         assert!(result.contains("echo hello"));
     }
 
-    #[tokio::test]
-    async fn test_terminal_handler_execute_with_stdin_data() {
+    #[test]
+    fn test_terminal_handler_execute_with_stdin_data() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
         let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
-        let result = handler
-            .execute(json!({"command": "cat", "stdin_data": "abc123"}))
-            .await
-            .unwrap();
+        let result =
+            block_on(handler.execute(json!({"command": "cat", "stdin_data": "abc123"}))).unwrap();
         assert!(result.contains("stdin=abc123"));
     }
 
-    #[tokio::test]
-    async fn test_terminal_handler_denies_confirmation_without_consent() {
+    #[test]
+    fn test_terminal_handler_denies_confirmation_without_consent() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
         let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
-        let err = handler
-            .execute(json!({"command": "sudo apt update"}))
-            .await
-            .unwrap_err();
+        let err = block_on(handler.execute(json!({"command": "sudo apt update"}))).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Do NOT retry"));
         assert!(msg.contains("rephrase"));
@@ -664,36 +664,31 @@ mod tests {
         assert!(msg.contains("Silence is not consent"));
     }
 
-    #[tokio::test]
-    async fn test_terminal_handler_yolo_bypasses_recoverable_confirmation() {
+    #[test]
+    fn test_terminal_handler_yolo_bypasses_recoverable_confirmation() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::set("HERMES_YOLO_MODE", "1");
         let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
-        let result = handler
-            .execute(json!({"command": "rm -rf /tmp/hermes-safe-test"}))
-            .await
-            .unwrap();
+        let result =
+            block_on(handler.execute(json!({"command": "rm -rf /tmp/hermes-safe-test"}))).unwrap();
         assert!(result.contains("rm -rf /tmp/hermes-safe-test"));
     }
 
-    #[tokio::test]
-    async fn test_terminal_handler_yolo_does_not_bypass_hardline() {
+    #[test]
+    fn test_terminal_handler_yolo_does_not_bypass_hardline() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::set("HERMES_YOLO_MODE", "1");
         let _session = EnvGuard::remove("HERMES_SESSION_KEY");
         let _sudo = EnvGuard::remove("SUDO_PASSWORD");
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
-        let err = handler
-            .execute(json!({"command": "rm -rf /"}))
-            .await
-            .unwrap_err();
+        let err = block_on(handler.execute(json!({"command": "rm -rf /"}))).unwrap_err();
         assert!(err.to_string().contains("denied by security policy"));
     }
 
-    #[tokio::test]
-    async fn test_terminal_handler_session_yolo_bypasses_recoverable_confirmation() {
+    #[test]
+    fn test_terminal_handler_session_yolo_bypasses_recoverable_confirmation() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
         let _session = EnvGuard::set("HERMES_SESSION_KEY", "terminal-session-yolo");
@@ -702,10 +697,8 @@ mod tests {
         crate::approval::enable_session_yolo("terminal-session-yolo");
 
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
-        let result = handler
-            .execute(json!({"command": "rm -rf /tmp/hermes-safe-test"}))
-            .await
-            .unwrap();
+        let result =
+            block_on(handler.execute(json!({"command": "rm -rf /tmp/hermes-safe-test"}))).unwrap();
         assert!(result.contains("rm -rf /tmp/hermes-safe-test"));
 
         crate::approval::clear_session("terminal-session-yolo");

--- a/crates/hermes-tools/tests/upstream_core_tool_contracts.rs
+++ b/crates/hermes-tools/tests/upstream_core_tool_contracts.rs
@@ -77,8 +77,10 @@ async fn clarify_contract_trims_question_and_normalizes_choices() {
 
 #[derive(Default)]
 struct CaptureCodeBackend {
-    calls: Mutex<Vec<(String, Option<String>, Option<u64>)>>,
+    calls: Mutex<Vec<CodeExecutionCall>>,
 }
+
+type CodeExecutionCall = (String, Option<String>, Option<u64>);
 
 #[async_trait]
 impl CodeExecutionBackend for CaptureCodeBackend {
@@ -217,12 +219,13 @@ async fn cronjob_contract_forwards_extended_create_fields_and_rejects_bad_action
             .expect("create"),
         "created"
     );
-    let calls = backend.calls.lock().expect("calls");
-    assert_eq!(calls.len(), 1);
-    assert!(calls[0].contains("create:daily:0 9 * * *:summarize"));
-    assert!(calls[0].contains("Some(\"web\")"));
-    assert!(calls[0].contains("Some(true)"));
-    drop(calls);
+    {
+        let calls = backend.calls.lock().expect("calls");
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].contains("create:daily:0 9 * * *:summarize"));
+        assert!(calls[0].contains("Some(\"web\")"));
+        assert!(calls[0].contains("Some(true)"));
+    }
 
     assert_err_contains(
         handler.execute(json!({"action": "explode"})).await,
@@ -507,8 +510,10 @@ async fn messaging_contract_accepts_all_gateway_platform_schema_names() {
 
 #[derive(Default)]
 struct CaptureSessionSearchBackend {
-    calls: Mutex<Vec<(Option<String>, Option<String>, usize, Option<String>)>>,
+    calls: Mutex<Vec<SessionSearchCall>>,
 }
+
+type SessionSearchCall = (Option<String>, Option<String>, usize, Option<String>);
 
 #[async_trait]
 impl SessionSearchBackend for CaptureSessionSearchBackend {

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-30T18:13:54.789675+00:00",
+  "generated_at_utc": "2026-05-31T01:47:31.808831+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-30T18:13:54.789675+00:00`
+Generated: `2026-05-31T01:47:31.808831+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -406,16 +406,16 @@
       "workstream": "WS8"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/browser/browser_use/provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "3d371bdd88a7f8922148a3f00df2f1f0ca78499c",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/browser/browser_use/provider.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "46a220333446afea4d969c59a6a3021657a2f10f",
       "workstream": "WS3"
@@ -10407,7 +10407,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "225b005cfe874636f8d45fcff769767f081e21b3",
+      "upstream_blob": "a66a818286ba86565bd57d94cb11f34d7f1d0c3b",
       "workstream": "WS6"
     },
     {
@@ -15466,30 +15466,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-30T23:25:49.862543+00:00",
+  "generated_at_utc": "2026-05-31T01:47:24.738287+00:00",
   "refs": {
-    "local_ref": "HEAD",
-    "local_sha": "d4898938cf9acd1cc072c91da3c485241f95547c",
+    "local_ref": "main",
+    "local_sha": "cd313d674d9d42b21ef9c625690bdd76f0667add",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "5921d667855880b0aa2083a50f001748aed52f3e"
+    "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 610,
-      "intentional_divergence": 251,
+      "functional": 609,
+      "intentional_divergence": 252,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 421,
+      "not_required_for_runtime": 422,
       "rust_equivalent_or_contract_test_required": 526,
-      "rust_native_runtime_parity_required_if_needed": 3,
+      "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 251,
+      "cleared_intentional_divergence": 252,
       "cleared_non_runtime": 170,
-      "pending_review": 610
+      "pending_review": 609
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15498,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 251,
+    "cleared_intentional_divergence": 252,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 610,
+    "pending_review": 609,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-30T23:25:49.862543+00:00`
+Generated: `2026-05-31T01:47:24.738287+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `610`
+- Pending functional review: `609`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `251`
+- Cleared intentional divergence: `252`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 251 |
+| `cleared_intentional_divergence` | 252 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 610 |
+| `pending_review` | 609 |
 
 ## Workstream Counts
 
@@ -56,4 +56,3 @@ Generated: `2026-05-30T23:25:49.862543+00:00`
 | `ui-tui` | 3 |
 | `plugins/memory` | 2 |
 | `tests/e2e` | 2 |
-| `plugins/browser/browser_use/provider.py` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1866,8 +1866,8 @@
     },
     {
       "path": "plugins/browser/browser_use/provider.py",
-      "classification": "functional",
-      "rationale": "Browser Use cloud-provider plugin affects runtime browser session creation, direct-vs-managed gateway auth resolution, and managed idempotency semantics; port or cover with Rust-native browser provider contracts before clearing.",
+      "classification": "intentional_divergence",
+      "rationale": "Browser Use runtime behavior is now covered by the Rust-native browser backend, including browser-use provider selection, direct BROWSER_USE_API_KEY auth, managed Nous gateway fallback/preference, managed timeout/proxy payload, idempotency-key retry preservation, external-call-id capture, and stop-session PATCH; the Python plugin remains reference-only compatibility material.",
       "owner": "sheawinkler",
       "ticket": 25
     },


### PR DESCRIPTION
## Summary
- add a Rust-native Browser Use browser backend with direct API-key auth and Nous-managed gateway resolution
- honor browser provider/gateway config, managed payload/idempotency semantics, external-call-id capture, and stop-session close behavior
- clear the Browser Use shared-diff parity item and regenerate parity proof/backlog
- clean local clippy-gate warning deltas and isolate provider-model cache tests

## Local verification
- cargo fmt --all --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- git diff --check
- scripts/clippy-warning-gate.sh --check
- cargo build --workspace
- cargo test --workspace

GitHub CI is optional for this repo; local deterministic gates were run before push.