### PR TITLE
parity(memory): secure provider config setup

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/config_io.rs
+++ b/crates/hermes-agent/src/memory_plugins/config_io.rs
@@ -1,0 +1,225 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Map, Value};
+
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+const DEFAULT_HOME_DIR: &str = ".hermes-agent-ultra";
+const LEGACY_HOME_DIR: &str = ".hermes";
+
+pub(crate) fn default_hermes_home() -> PathBuf {
+    if let Some(home) = env_var_path("HERMES_HOME") {
+        return home;
+    }
+    if let Some(home) = env_var_path("HERMES_AGENT_ULTRA_HOME") {
+        return home;
+    }
+
+    let home_dir = user_home_dir();
+    let primary = home_dir.join(DEFAULT_HOME_DIR);
+    let legacy = home_dir.join(LEGACY_HOME_DIR);
+    if primary.exists() || !legacy.exists() {
+        primary
+    } else {
+        legacy
+    }
+}
+
+fn env_var_path(var: &str) -> Option<PathBuf> {
+    std::env::var(var)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn user_home_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home)
+    } else if let Ok(home) = std::env::var("USERPROFILE") {
+        PathBuf::from(home)
+    } else {
+        PathBuf::from(".")
+    }
+}
+
+pub(crate) fn read_json_object(path: &Path) -> Map<String, Value> {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return Map::new();
+    };
+    serde_json::from_str::<Value>(&raw)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default()
+}
+
+pub(crate) fn json_file_has_nonempty_string(path: &Path, keys: &[&str]) -> bool {
+    let object = read_json_object(path);
+    keys.iter().any(|key| {
+        object
+            .get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
+pub(crate) fn merge_and_write_owner_only(path: &Path, values: &Value) -> Result<(), String> {
+    let incoming = values
+        .as_object()
+        .ok_or_else(|| "config must be a JSON object".to_string())?;
+    let mut existing = read_json_object(path);
+    merge_object_values(&mut existing, incoming);
+    write_owner_only_atomic(path, &Value::Object(existing))
+}
+
+fn merge_object_values(existing: &mut Map<String, Value>, incoming: &Map<String, Value>) {
+    for (key, value) in incoming {
+        match (existing.get_mut(key), value) {
+            (Some(Value::Object(existing_child)), Value::Object(incoming_child)) => {
+                merge_object_values(existing_child, incoming_child);
+            }
+            _ => {
+                existing.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+pub(crate) fn write_owner_only_atomic(path: &Path, value: &Value) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("config path {} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.json");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let tmp_path = parent.join(format!(".{file_name}.tmp.{}.{}", std::process::id(), nonce));
+    let raw = serde_json::to_vec_pretty(value).map_err(|e| format!("serialize config: {e}"))?;
+
+    let result = (|| -> Result<(), String> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let mut file = options
+            .open(&tmp_path)
+            .map_err(|e| format!("create {}: {e}", tmp_path.display()))?;
+        file.write_all(&raw)
+            .map_err(|e| format!("write {}: {e}", tmp_path.display()))?;
+        file.write_all(b"\n")
+            .map_err(|e| format!("write {}: {e}", tmp_path.display()))?;
+        file.sync_all()
+            .map_err(|e| format!("fsync {}: {e}", tmp_path.display()))?;
+        drop(file);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("chmod {}: {e}", tmp_path.display()))?;
+        }
+
+        fs::rename(&tmp_path, path)
+            .map_err(|e| format!("rename {} -> {}: {e}", tmp_path.display(), path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+        }
+
+        let _ = fs::File::open(parent).and_then(|dir| dir.sync_all());
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn owner_only_atomic_write_creates_private_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("secret.json");
+
+        write_owner_only_atomic(&path, &json!({"api_key": "secret"})).expect("write config");
+
+        let parsed: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read")).expect("json");
+        assert_eq!(parsed["api_key"], "secret");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).expect("metadata").permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn default_home_matches_ultra_home_precedence() {
+        let _guard = TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::remove("HERMES_HOME");
+        let _ultra = EnvGuard::remove("HERMES_AGENT_ULTRA_HOME");
+        let _userprofile = EnvGuard::remove("USERPROFILE");
+        let _home_dir = EnvGuard::set("HOME", tmp.path());
+
+        assert_eq!(default_hermes_home(), tmp.path().join(DEFAULT_HOME_DIR));
+
+        let ultra_override = tmp.path().join("custom-ultra-home");
+        let _ultra = EnvGuard::set("HERMES_AGENT_ULTRA_HOME", &ultra_override);
+        assert_eq!(default_hermes_home(), ultra_override);
+    }
+}

--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -20,6 +20,7 @@ use reqwest::blocking::Client;
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
+use crate::memory_plugins::config_io;
 
 const DEFAULT_API_URL: &str = "https://api.hindsight.vectorize.io";
 const DEFAULT_LOCAL_URL: &str = "http://localhost:8888";
@@ -294,7 +295,14 @@ impl MemoryProviderPlugin for HindsightPlugin {
             return true;
         }
         // Cloud mode requires credentials (or explicit API URL for self-hosted).
-        !api_key.is_empty() || !api_url.is_empty()
+        !api_key.is_empty()
+            || !api_url.is_empty()
+            || config_io::json_file_has_nonempty_string(
+                &config_io::default_hermes_home()
+                    .join("hindsight")
+                    .join("config.json"),
+                &["api_key", "apiKey", "api_url"],
+            )
     }
 
     fn initialize(&self, session_id: &str, hermes_home: &str) {
@@ -639,9 +647,10 @@ impl MemoryProviderPlugin for HindsightPlugin {
     }
 
     fn save_config(&self, config: &Value) -> Result<(), String> {
-        // Would write to $HERMES_HOME/hindsight/config.json
-        let _ = config;
-        Ok(())
+        let path = config_io::default_hermes_home()
+            .join("hindsight")
+            .join("config.json");
+        config_io::merge_and_write_owner_only(&path, config)
     }
 }
 
@@ -876,6 +885,28 @@ fn hindsight_retain(
 mod tests {
     use super::*;
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn test_hindsight_plugin_name() {
         let plugin = HindsightPlugin::new();
@@ -972,6 +1003,36 @@ mod tests {
         assert_eq!(body["budget"], "mid");
         assert_eq!(body["max_tokens"], 4096);
         assert_eq!(body["types"], json!(["observation"]));
+    }
+
+    #[test]
+    fn test_hindsight_save_config_writes_owner_only() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let path = tmp.path().join("hindsight").join("config.json");
+
+        HindsightPlugin::new()
+            .save_config(&json!({"api_key":"hd-secret"}))
+            .expect("save config");
+
+        let parsed: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(parsed["api_key"], "hd-secret");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/honcho.rs
+++ b/crates/hermes-agent/src/memory_plugins/honcho.rs
@@ -21,8 +21,10 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::memory_manager::MemoryProviderPlugin;
+use crate::memory_plugins::config_io;
 
 const HOST: &str = "hermes";
+const DEFAULT_BASE_URL: &str = "https://api.honcho.dev";
 const PEER_ID_HASH_ESCALATION_LENGTHS: &[usize] = &[8, 12, 16, 24, 32, 64];
 
 // ---------------------------------------------------------------------------
@@ -106,10 +108,17 @@ struct HonchoConfig {
 }
 
 impl HonchoConfig {
+    fn config_path(hermes_home: &str) -> std::path::PathBuf {
+        std::path::Path::new(hermes_home).join("honcho.json")
+    }
+
+    fn default_config_path() -> std::path::PathBuf {
+        config_io::default_hermes_home().join("honcho.json")
+    }
+
     fn from_env() -> Self {
         let api_key = std::env::var("HONCHO_API_KEY").unwrap_or_default();
-        let base_url = std::env::var("HONCHO_BASE_URL")
-            .unwrap_or_else(|_| "https://api.honcho.dev".to_string());
+        let base_url = std::env::var("HONCHO_BASE_URL").unwrap_or_default();
         let timeout_secs = std::env::var("HONCHO_TIMEOUT_SECS")
             .ok()
             .and_then(|s| s.parse::<f64>().ok())
@@ -131,7 +140,7 @@ impl HonchoConfig {
             }
         }
         Self {
-            enabled: !api_key.is_empty() || !base_url.trim().is_empty(),
+            enabled: !api_key.trim().is_empty() || !base_url.trim().is_empty(),
             api_key,
             base_url,
             recall_mode: "hybrid".to_string(),
@@ -152,7 +161,7 @@ impl HonchoConfig {
         let host = active_host();
         config.workspace_id = host.clone();
         config.ai_peer = host.clone();
-        let config_path = std::path::Path::new(hermes_home).join("honcho.json");
+        let config_path = Self::config_path(hermes_home);
         if let Ok(content) = std::fs::read_to_string(&config_path) {
             if let Ok(raw) = serde_json::from_str::<Value>(&content) {
                 Self::apply_config_value(&mut config, &raw);
@@ -162,6 +171,9 @@ impl HonchoConfig {
             }
         }
         config.base_url = config.base_url.trim_end_matches('/').to_string();
+        if config.base_url.is_empty() {
+            config.base_url = DEFAULT_BASE_URL.to_string();
+        }
         config
     }
 
@@ -173,7 +185,11 @@ impl HonchoConfig {
     }
 
     fn apply_config_value(config: &mut Self, raw: &Value) {
-        if let Some(key) = raw.get("apiKey").and_then(|v| v.as_str()) {
+        if let Some(key) = raw
+            .get("apiKey")
+            .or_else(|| raw.get("api_key"))
+            .and_then(|v| v.as_str())
+        {
             if !key.is_empty() {
                 config.api_key = key.to_string();
             }
@@ -239,7 +255,8 @@ impl HonchoConfig {
         if let Some(enabled) = raw.get("enabled").and_then(|v| v.as_bool()) {
             config.enabled = enabled;
         } else {
-            config.enabled = !config.api_key.is_empty() || !config.base_url.trim().is_empty();
+            config.enabled =
+                !config.api_key.trim().is_empty() || !config.base_url.trim().is_empty();
         }
         if let Some(map) = raw.get("endpoints").and_then(|v| v.as_object()) {
             for (key, value) in map {
@@ -474,7 +491,8 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
     }
 
     fn is_available(&self) -> bool {
-        let config = HonchoConfig::from_env();
+        let hermes_home = config_io::default_hermes_home();
+        let config = HonchoConfig::from_config_file(&hermes_home.to_string_lossy());
         config.enabled
     }
 
@@ -831,10 +849,17 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
     }
 
     fn save_config(&self, config: &Value) -> Result<(), String> {
-        if !config.is_object() {
-            return Err("config must be a JSON object".into());
+        let mut normalized = config
+            .as_object()
+            .cloned()
+            .ok_or_else(|| "config must be a JSON object".to_string())?;
+        if let Some(value) = normalized.remove("api_key") {
+            normalized.entry("apiKey".to_string()).or_insert(value);
         }
-        Ok(())
+        config_io::merge_and_write_owner_only(
+            &HonchoConfig::default_config_path(),
+            &Value::Object(normalized),
+        )
     }
 }
 
@@ -935,10 +960,99 @@ fn generated_runtime_peer_id(config: &HonchoConfig, prefix: &str, runtime_id: &s
 mod tests {
     use super::*;
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn test_honcho_plugin_name() {
         let plugin = HonchoMemoryPlugin::new();
         assert_eq!(plugin.name(), "honcho");
+    }
+
+    #[test]
+    fn test_honcho_is_not_available_without_explicit_config() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("HONCHO_API_KEY");
+        let _url = EnvGuard::remove("HONCHO_BASE_URL");
+
+        assert!(!HonchoMemoryPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_honcho_config_file_activates_provider_without_env() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("HONCHO_API_KEY");
+        let _url = EnvGuard::remove("HONCHO_BASE_URL");
+        std::fs::write(
+            tmp.path().join("honcho.json"),
+            r#"{"baseUrl":"http://localhost:8000","enabled":true}"#,
+        )
+        .expect("write config");
+
+        assert!(HonchoMemoryPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_honcho_save_config_normalizes_key_and_writes_owner_only() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let path = tmp.path().join("honcho.json");
+        std::fs::write(&path, r#"{"workspace":"existing"}"#).expect("write existing");
+
+        HonchoMemoryPlugin::new()
+            .save_config(&json!({"api_key":"hc-secret","baseUrl":"http://localhost:8000"}))
+            .expect("save config");
+
+        let parsed: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(parsed["workspace"], "existing");
+        assert_eq!(parsed["apiKey"], "hc-secret");
+        assert!(parsed.get("api_key").is_none());
+        assert_eq!(parsed["baseUrl"], "http://localhost:8000");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/mem0.rs
+++ b/crates/hermes-agent/src/memory_plugins/mem0.rs
@@ -19,6 +19,7 @@ use reqwest::Method;
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
+use crate::memory_plugins::config_io;
 
 const BREAKER_THRESHOLD: u32 = 5;
 const BREAKER_COOLDOWN_SECS: u64 = 120;
@@ -80,6 +81,18 @@ struct Mem0Config {
 }
 
 impl Mem0Config {
+    fn config_path(hermes_home: &str) -> std::path::PathBuf {
+        std::path::Path::new(hermes_home).join("mem0.json")
+    }
+
+    fn default_config_path() -> std::path::PathBuf {
+        config_io::default_hermes_home().join("mem0.json")
+    }
+
+    fn configured_api_key_at(path: &std::path::Path) -> bool {
+        config_io::json_file_has_nonempty_string(path, &["api_key"])
+    }
+
     fn load(hermes_home: &str) -> Self {
         let mut config = Self {
             api_key: std::env::var("MEM0_API_KEY").unwrap_or_default(),
@@ -91,7 +104,7 @@ impl Mem0Config {
             rerank: true,
         };
 
-        let config_path = std::path::Path::new(hermes_home).join("mem0.json");
+        let config_path = Self::config_path(hermes_home);
         if let Ok(content) = std::fs::read_to_string(&config_path) {
             if let Ok(raw) = serde_json::from_str::<Value>(&content) {
                 if let Some(key) = raw.get("api_key").and_then(|v| v.as_str()) {
@@ -354,7 +367,11 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
     }
 
     fn is_available(&self) -> bool {
-        !std::env::var("MEM0_API_KEY").unwrap_or_default().is_empty()
+        !std::env::var("MEM0_API_KEY")
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+            || Mem0Config::configured_api_key_at(&Mem0Config::default_config_path())
     }
 
     fn initialize(&self, session_id: &str, hermes_home: &str) {
@@ -594,16 +611,41 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
     }
 
     fn save_config(&self, config: &Value) -> Result<(), String> {
-        if !config.is_object() {
-            return Err("config must be a JSON object".into());
-        }
-        Ok(())
+        config_io::merge_and_write_owner_only(&Mem0Config::default_config_path(), config)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn test_mem0_plugin_name() {
@@ -650,5 +692,50 @@ mod tests {
             Mem0MemoryPlugin::extract_memory_text(&item2).as_deref(),
             Some("world")
         );
+    }
+
+    #[test]
+    fn test_mem0_config_file_activates_provider() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("MEM0_API_KEY");
+        std::fs::write(tmp.path().join("mem0.json"), r#"{"api_key":"m0-secret"}"#)
+            .expect("write config");
+
+        assert!(Mem0MemoryPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_mem0_save_config_merges_and_writes_owner_only() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let path = tmp.path().join("mem0.json");
+        std::fs::write(&path, r#"{"agent_id":"existing"}"#).expect("write existing");
+
+        Mem0MemoryPlugin::new()
+            .save_config(&json!({"api_key":"m0-secret","user_id":"operator"}))
+            .expect("save config");
+
+        let parsed: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(parsed["agent_id"], "existing");
+        assert_eq!(parsed["api_key"], "m0-secret");
+        assert_eq!(parsed["user_id"], "operator");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
     }
 }

--- a/crates/hermes-agent/src/memory_plugins/mod.rs
+++ b/crates/hermes-agent/src/memory_plugins/mod.rs
@@ -5,6 +5,7 @@
 //! External providers are additive and can run side-by-side.
 
 pub mod byterover;
+mod config_io;
 pub mod contextlattice;
 pub mod hindsight;
 pub mod holographic;

--- a/crates/hermes-agent/src/memory_plugins/supermemory.rs
+++ b/crates/hermes-agent/src/memory_plugins/supermemory.rs
@@ -14,6 +14,7 @@ use reqwest::Method;
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
+use crate::memory_plugins::config_io;
 
 const DEFAULT_CONTAINER_TAG: &str = "hermes";
 const DEFAULT_MAX_RECALL: usize = 10;
@@ -468,7 +469,12 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
     fn is_available(&self) -> bool {
         !std::env::var("SUPERMEMORY_API_KEY")
             .unwrap_or_default()
+            .trim()
             .is_empty()
+            || config_io::json_file_has_nonempty_string(
+                &config_io::default_hermes_home().join("supermemory.json"),
+                &["api_key"],
+            )
     }
 
     fn initialize(&self, session_id: &str, hermes_home: &str) {
@@ -767,11 +773,44 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
             {"key": "search_mode", "description": "hybrid|memories|documents", "default": "hybrid"}
         ]))
     }
+
+    fn save_config(&self, config: &Value) -> Result<(), String> {
+        let path = config_io::default_hermes_home().join("supermemory.json");
+        config_io::merge_and_write_owner_only(&path, config)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn test_supermemory_plugin_name() {
@@ -803,5 +842,50 @@ mod tests {
         );
         assert!(out.contains("User Profile"));
         assert!(out.contains("Relevant Memories"));
+    }
+
+    #[test]
+    fn test_supermemory_config_file_activates_provider() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("SUPERMEMORY_API_KEY");
+        std::fs::write(
+            tmp.path().join("supermemory.json"),
+            r#"{"api_key":"sm-secret"}"#,
+        )
+        .expect("write config");
+
+        assert!(SupermemoryMemoryPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_supermemory_save_config_writes_owner_only() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let path = tmp.path().join("supermemory.json");
+
+        SupermemoryMemoryPlugin::new()
+            .save_config(&json!({"api_key":"sm-secret"}))
+            .expect("save config");
+
+        let parsed: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(parsed["api_key"], "sm-secret");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
     }
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -15,6 +15,7 @@ use std::{
 
 use bytes::Bytes;
 use hermes_agent::plugins::PluginManifest;
+use hermes_agent::MemoryProviderPlugin;
 use hermes_core::AgentError;
 use hermes_intelligence::model_metadata::{get_model_context_length, get_model_info};
 use hermes_intelligence::models_dev::default_client;
@@ -22037,6 +22038,314 @@ pub async fn handle_cli_plugins(
     Ok(())
 }
 
+fn prompt_memory_setup_value(
+    label: &str,
+    default: Option<&str>,
+    yes: bool,
+) -> Result<String, AgentError> {
+    if yes {
+        return Ok(default.unwrap_or_default().to_string());
+    }
+    match default {
+        Some(value) if !value.is_empty() && memory_setup_label_is_secret(label) => {
+            print!("{label} [set]: ");
+        }
+        Some(value) if !value.is_empty() => {
+            print!("{label} [{value}]: ");
+        }
+        _ => {
+            print!("{label}: ");
+        }
+    }
+    std::io::stdout()
+        .flush()
+        .map_err(|e| AgentError::Io(format!("flush stdout: {e}")))?;
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .map_err(|e| AgentError::Io(format!("read setup input: {e}")))?;
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        Ok(default.unwrap_or_default().to_string())
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
+fn memory_setup_label_is_secret(label: &str) -> bool {
+    let lower = label.to_ascii_lowercase();
+    lower.contains("api key")
+        || lower.contains("jwt")
+        || lower.contains("token")
+        || lower.contains("secret")
+}
+
+fn active_honcho_host_key_for_cli() -> String {
+    if let Ok(explicit) = std::env::var("HERMES_HONCHO_HOST") {
+        let explicit = explicit.trim();
+        if !explicit.is_empty() {
+            return explicit.to_string();
+        }
+    }
+    let profile = std::env::var("HERMES_PROFILE").unwrap_or_default();
+    let profile = profile.trim();
+    if profile.is_empty() || matches!(profile, "default" | "custom") {
+        "hermes".to_string()
+    } else if profile == "hermes" || profile.starts_with("hermes.") {
+        profile.to_string()
+    } else {
+        format!("hermes.{profile}")
+    }
+}
+
+fn honcho_ai_peer_for_host(host: &str) -> String {
+    host.strip_prefix("hermes.")
+        .filter(|profile| !profile.trim().is_empty())
+        .unwrap_or(host)
+        .to_string()
+}
+
+fn parse_honcho_aliases(raw: &str) -> serde_json::Map<String, serde_json::Value> {
+    let mut aliases = serde_json::Map::new();
+    for entry in raw.split(',') {
+        let Some((key, value)) = entry.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if !key.is_empty() && !value.is_empty() {
+            aliases.insert(
+                key.to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+        }
+    }
+    aliases
+}
+
+struct HonchoSetupConfigInput<'a> {
+    host: &'a str,
+    deployment: &'a str,
+    api_key: &'a str,
+    base_url: &'a str,
+    peer_name: &'a str,
+    shape: &'a str,
+    runtime_peer_prefix: &'a str,
+    aliases: &'a serde_json::Map<String, serde_json::Value>,
+}
+
+fn build_honcho_setup_config(input: HonchoSetupConfigInput<'_>) -> serde_json::Value {
+    let mut root = serde_json::Map::new();
+    let mut host_block = serde_json::Map::new();
+
+    root.insert("enabled".to_string(), serde_json::Value::Bool(true));
+    if input.deployment == "local" {
+        root.insert(
+            "baseUrl".to_string(),
+            serde_json::Value::String(input.base_url.to_string()),
+        );
+        if !input.api_key.trim().is_empty() {
+            host_block.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String(input.api_key.to_string()),
+            );
+        }
+    } else if !input.api_key.trim().is_empty() {
+        root.insert(
+            "apiKey".to_string(),
+            serde_json::Value::String(input.api_key.to_string()),
+        );
+    }
+
+    host_block.insert("enabled".to_string(), serde_json::Value::Bool(true));
+    host_block.insert(
+        "workspace".to_string(),
+        serde_json::Value::String("hermes".to_string()),
+    );
+    host_block.insert(
+        "aiPeer".to_string(),
+        serde_json::Value::String(honcho_ai_peer_for_host(input.host)),
+    );
+    if !input.peer_name.trim().is_empty() {
+        host_block.insert(
+            "peerName".to_string(),
+            serde_json::Value::String(input.peer_name.to_string()),
+        );
+    }
+
+    match input.shape {
+        "single" => {
+            host_block.insert("pinUserPeer".to_string(), serde_json::Value::Bool(true));
+        }
+        "hybrid" => {
+            host_block.insert("pinUserPeer".to_string(), serde_json::Value::Bool(false));
+            if !input.aliases.is_empty() {
+                host_block.insert(
+                    "userPeerAliases".to_string(),
+                    serde_json::Value::Object(input.aliases.clone()),
+                );
+            }
+            if !input.runtime_peer_prefix.trim().is_empty() {
+                host_block.insert(
+                    "runtimePeerPrefix".to_string(),
+                    serde_json::Value::String(input.runtime_peer_prefix.to_string()),
+                );
+            }
+        }
+        _ => {
+            host_block.insert("pinUserPeer".to_string(), serde_json::Value::Bool(false));
+            if !input.runtime_peer_prefix.trim().is_empty() {
+                host_block.insert(
+                    "runtimePeerPrefix".to_string(),
+                    serde_json::Value::String(input.runtime_peer_prefix.to_string()),
+                );
+            }
+        }
+    }
+
+    let mut hosts = serde_json::Map::new();
+    hosts.insert(
+        input.host.to_string(),
+        serde_json::Value::Object(host_block),
+    );
+    root.insert("hosts".to_string(), serde_json::Value::Object(hosts));
+    serde_json::Value::Object(root)
+}
+
+fn setup_mem0_provider(yes: bool) -> Result<PathBuf, AgentError> {
+    let api_key_default = std::env::var("MEM0_API_KEY").unwrap_or_default();
+    let user_id_default =
+        std::env::var("MEM0_USER_ID").unwrap_or_else(|_| "hermes-user".to_string());
+    let agent_id_default = std::env::var("MEM0_AGENT_ID").unwrap_or_else(|_| "hermes".to_string());
+    let base_url_default =
+        std::env::var("MEM0_BASE_URL").unwrap_or_else(|_| "https://api.mem0.ai/v1".to_string());
+
+    let api_key = prompt_memory_setup_value("Mem0 API key", Some(&api_key_default), yes)?;
+    if api_key.trim().is_empty() {
+        return Err(AgentError::Config(
+            "Mem0 setup requires MEM0_API_KEY or an API key entered at the prompt.".into(),
+        ));
+    }
+    let user_id = prompt_memory_setup_value("Mem0 user_id", Some(&user_id_default), yes)?;
+    let agent_id = prompt_memory_setup_value("Mem0 agent_id", Some(&agent_id_default), yes)?;
+    let base_url = prompt_memory_setup_value("Mem0 base_url", Some(&base_url_default), yes)?;
+
+    let config = serde_json::json!({
+        "api_key": api_key,
+        "user_id": user_id,
+        "agent_id": agent_id,
+        "base_url": base_url,
+        "rerank": true
+    });
+    hermes_agent::memory_plugins::mem0::Mem0MemoryPlugin::new()
+        .save_config(&config)
+        .map_err(AgentError::Config)?;
+    Ok(hermes_config::hermes_home().join("mem0.json"))
+}
+
+fn setup_honcho_provider(yes: bool) -> Result<PathBuf, AgentError> {
+    let env_api_key = std::env::var("HONCHO_API_KEY").unwrap_or_default();
+    let env_base_url = std::env::var("HONCHO_BASE_URL").unwrap_or_default();
+    let default_deployment =
+        if env_base_url.trim().is_empty() || env_base_url.contains("api.honcho.dev") {
+            "cloud"
+        } else {
+            "local"
+        };
+    let deployment = prompt_memory_setup_value(
+        "Honcho deployment (cloud|local)",
+        Some(default_deployment),
+        yes,
+    )?
+    .to_ascii_lowercase();
+    let deployment = if deployment == "local" {
+        "local"
+    } else {
+        "cloud"
+    };
+
+    let base_url_default = if deployment == "local" {
+        if env_base_url.trim().is_empty() {
+            "http://localhost:8000".to_string()
+        } else {
+            env_base_url.clone()
+        }
+    } else {
+        env_base_url.clone()
+    };
+    let base_url = if deployment == "local" {
+        prompt_memory_setup_value("Honcho local baseUrl", Some(&base_url_default), yes)?
+    } else {
+        base_url_default
+    };
+    let api_label = if deployment == "local" {
+        "Honcho local JWT/API key (blank for no-auth local)"
+    } else {
+        "Honcho API key"
+    };
+    let api_key = prompt_memory_setup_value(api_label, Some(&env_api_key), yes)?;
+    if deployment == "cloud" && api_key.trim().is_empty() {
+        return Err(AgentError::Config(
+            "Honcho cloud setup requires HONCHO_API_KEY or an API key entered at the prompt."
+                .into(),
+        ));
+    }
+
+    let host = active_honcho_host_key_for_cli();
+    let peer_default = std::env::var("HERMES_USER").unwrap_or_default();
+    let peer_name = prompt_memory_setup_value("Honcho peerName", Some(&peer_default), yes)?;
+    let shape_input = prompt_memory_setup_value(
+        "Deployment shape (single|multi|hybrid)",
+        Some("single"),
+        yes,
+    )?
+    .to_ascii_lowercase();
+    let shape = match shape_input.as_str() {
+        "single" | "hybrid" => shape_input,
+        _ => "multi".to_string(),
+    };
+    let runtime_peer_prefix = if shape == "multi" || shape == "hybrid" {
+        prompt_memory_setup_value("Runtime peer prefix", Some(""), yes)?
+    } else {
+        String::new()
+    };
+    let alias_raw = if shape == "hybrid" {
+        prompt_memory_setup_value(
+            "Runtime aliases (comma key=peer, blank for none)",
+            Some(""),
+            yes,
+        )?
+    } else {
+        String::new()
+    };
+    let aliases = parse_honcho_aliases(&alias_raw);
+    let config = build_honcho_setup_config(HonchoSetupConfigInput {
+        host: &host,
+        deployment,
+        api_key: &api_key,
+        base_url: &base_url,
+        peer_name: &peer_name,
+        shape: &shape,
+        runtime_peer_prefix: &runtime_peer_prefix,
+        aliases: &aliases,
+    });
+
+    hermes_agent::memory_plugins::honcho::HonchoMemoryPlugin::new()
+        .save_config(&config)
+        .map_err(AgentError::Config)?;
+    Ok(hermes_config::hermes_home().join("honcho.json"))
+}
+
+fn setup_memory_provider_target(provider: &str, yes: bool) -> Result<PathBuf, AgentError> {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "mem0" => setup_mem0_provider(yes),
+        "honcho" => setup_honcho_provider(yes),
+        other => Err(AgentError::Config(format!(
+            "Unsupported memory provider setup target '{other}'. Supported: honcho, mem0"
+        ))),
+    }
+}
+
 /// Handle `hermes memory [action]`.
 pub async fn handle_cli_memory(
     action: Option<String>,
@@ -22094,6 +22403,19 @@ pub async fn handle_cli_memory(
             }
         }
         "setup" => {
+            if let Some(provider) = target
+                .as_deref()
+                .map(str::trim)
+                .filter(|provider| !provider.is_empty())
+            {
+                let path = setup_memory_provider_target(provider, yes)?;
+                println!("Configured memory provider '{}'.", provider);
+                println!("  Config: {}", path.display());
+                println!(
+                    "Memory provider config is owner-only and activates on subsequent sessions."
+                );
+                return Ok(());
+            }
             println!("Memory Provider Setup");
             println!("---------------------");
             std::fs::create_dir_all(&memories_dir)
@@ -24582,6 +24904,61 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Python plugin command dispatch is disabled"));
+    }
+
+    #[test]
+    fn memory_honcho_setup_config_stores_local_jwt_under_host_block() {
+        let aliases = serde_json::Map::new();
+        let cfg = build_honcho_setup_config(HonchoSetupConfigInput {
+            host: "hermes",
+            deployment: "local",
+            api_key: "local-jwt",
+            base_url: "http://localhost:8000",
+            peer_name: "operator",
+            shape: "single",
+            runtime_peer_prefix: "",
+            aliases: &aliases,
+        });
+
+        assert_eq!(cfg["baseUrl"], "http://localhost:8000");
+        assert!(cfg.get("apiKey").is_none());
+        assert_eq!(cfg["hosts"]["hermes"]["apiKey"], "local-jwt");
+        assert_eq!(cfg["hosts"]["hermes"]["pinUserPeer"], true);
+    }
+
+    #[test]
+    fn memory_honcho_setup_config_keeps_gateway_aliases_for_hybrid_shape() {
+        let aliases = parse_honcho_aliases("telegram-1=operator, discord-2=operator");
+        let cfg = build_honcho_setup_config(HonchoSetupConfigInput {
+            host: "hermes.coder",
+            deployment: "cloud",
+            api_key: "cloud-key",
+            base_url: "",
+            peer_name: "operator",
+            shape: "hybrid",
+            runtime_peer_prefix: "gateway_",
+            aliases: &aliases,
+        });
+
+        assert_eq!(cfg["apiKey"], "cloud-key");
+        assert_eq!(cfg["hosts"]["hermes.coder"]["aiPeer"], "coder");
+        assert_eq!(cfg["hosts"]["hermes.coder"]["pinUserPeer"], false);
+        assert_eq!(
+            cfg["hosts"]["hermes.coder"]["userPeerAliases"]["telegram-1"],
+            "operator"
+        );
+        assert_eq!(
+            cfg["hosts"]["hermes.coder"]["runtimePeerPrefix"],
+            "gateway_"
+        );
+    }
+
+    #[test]
+    fn memory_setup_prompt_classifies_secret_labels() {
+        assert!(memory_setup_label_is_secret("Mem0 API key"));
+        assert!(memory_setup_label_is_secret("Honcho local JWT/API key"));
+        assert!(!memory_setup_label_is_secret("Mem0 base_url"));
+        assert!(!memory_setup_label_is_secret("Deployment shape"));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T01:47:31.808831+00:00",
+  "generated_at_utc": "2026-05-31T09:38:06.283824+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T01:47:31.808831+00:00`
+Generated: `2026-05-31T09:38:06.283824+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -721,17 +721,17 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/honcho/README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "dbe3eebc9a56d1910a111800666634dbb1810273",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/honcho/README.md",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "3774747d05a7ba858585e9a154403bc824824a5b",
       "workstream": "WS3"
     },
@@ -796,17 +796,17 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/mem0/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "32d1f6ff700237a50e246a97759d549dc8248fb5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/mem0/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "332b3ac9412957eee3a8cfd46a0503f00288098b",
       "workstream": "WS3"
     },
@@ -7936,32 +7936,32 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/plugins",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/plugins/memory/test_hindsight_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "fcda46e56b09175017ba3b6c54677ef3323de631",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/plugins/memory/test_hindsight_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "f49c227611ae2bbaad90952034bd9e3fc1fdb520",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/plugins",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/plugins/memory/test_mem0_v2.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "6f60771f5c48970d622ff4a98143c411f2825618",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/plugins/memory/test_mem0_v2.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "a9a8667645237e3a3615e4ee4b98bf0a31dd8264",
       "workstream": "WS6"
     },
@@ -7981,17 +7981,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/plugins",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/plugins/memory/test_supermemory_provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0aee459757f4ada65bbfc860504c81332588d7d3",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/plugins/memory/test_supermemory_provider.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "d5f1c5bb17400ddfb86dd52e32892f4fbf7d1571",
       "workstream": "WS6"
     },
@@ -9391,17 +9391,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/test_honcho_client_config.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "feb0eb41d7c2fb5a986297920d68bf7254a6ebe8",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/test_honcho_client_config.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 304,
       "upstream_blob": "f7b1efa151ccd5452aec4f6370fa7617ac9792e3",
       "workstream": "WS6"
     },
@@ -15466,30 +15466,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T01:47:24.738287+00:00",
+  "generated_at_utc": "2026-05-31T09:38:06.180340+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "cd313d674d9d42b21ef9c625690bdd76f0667add",
+    "local_ref": "HEAD",
+    "local_sha": "fe145f8a2b574f66af38e0e0db3797839d3b49f0",
     "upstream_ref": "upstream/main",
     "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 609,
-      "intentional_divergence": 252,
+      "functional": 603,
+      "intentional_divergence": 258,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 422,
-      "rust_equivalent_or_contract_test_required": 526,
-      "rust_native_runtime_parity_required_if_needed": 2,
+      "not_required_for_runtime": 428,
+      "rust_equivalent_or_contract_test_required": 522,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 252,
+      "cleared_intentional_divergence": 258,
       "cleared_non_runtime": 170,
-      "pending_review": 609
+      "pending_review": 603
     },
     "by_workstream": {
       "WS3": 56,
@@ -15498,10 +15497,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 252,
+    "cleared_intentional_divergence": 258,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 609,
+    "pending_review": 603,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T01:47:24.738287+00:00`
+Generated: `2026-05-31T09:38:06.180340+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `609`
+- Pending functional review: `603`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `252`
+- Cleared intentional divergence: `258`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 252 |
+| `cleared_intentional_divergence` | 258 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 609 |
+| `pending_review` | 603 |
 
 ## Workstream Counts
 
@@ -42,11 +42,11 @@ Generated: `2026-05-31T01:47:24.738287+00:00`
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
-| `tests` | 40 |
+| `tests` | 39 |
 | `tests/cli` | 28 |
 | `tests/agent` | 21 |
 | `ui-tui/packages` | 18 |
-| `tests/plugins` | 17 |
+| `tests/plugins` | 14 |
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |
@@ -54,5 +54,4 @@ Generated: `2026-05-31T01:47:24.738287+00:00`
 | `tests/tui_gateway` | 4 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
-| `plugins/memory` | 2 |
 | `tests/e2e` | 2 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -136,6 +136,34 @@
       "ticket": 25
     },
     {
+      "path": "tests/test_honcho_client_config.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Python Honcho config permission coverage is mapped to Rust tests for owner-only atomic honcho.json writes and explicit config-file activation in crates/hermes-agent/src/memory_plugins/honcho.rs.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
+      "path": "tests/plugins/memory/test_hindsight_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Hindsight recall-type defaults and secure config writes are covered by Rust memory plugin tests, including observation-only recall payloads and owner-only $HERMES_HOME/hindsight/config.json writes.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
+      "path": "tests/plugins/memory/test_mem0_v2.py",
+      "classification": "intentional_divergence",
+      "rationale": "Mem0 v2 behavior and secure config persistence are covered by Rust memory plugin tests for result normalization, owner-only atomic mem0.json writes, merge semantics, and config-file activation.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
+      "path": "tests/plugins/memory/test_supermemory_provider.py",
+      "classification": "intentional_divergence",
+      "rationale": "Supermemory provider setup persistence is covered by Rust tests for owner-only atomic supermemory.json writes and config-file activation; the Python test file is retained as upstream reference.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
       "path": "tests/gateway",
       "classification": "functional",
       "rationale": "Gateway test deltas exercise platform adapter behavior and must be reviewed as runtime parity coverage.",
@@ -1081,6 +1109,13 @@
       "ticket": 25
     },
     {
+      "path": "plugins/memory/honcho/README.md",
+      "classification": "intentional_divergence",
+      "rationale": "Ultra documents the Rust-native `hermes memory setup honcho` path and dot-separated profile host keys used by crates/hermes-agent/src/memory_plugins/honcho.rs; legacy Python `hermes honcho ...` command dispatch remains disabled.",
+      "owner": "sheawinkler",
+      "ticket": 304
+    },
+    {
       "path": "plugins/memory/byterover/__init__.py",
       "classification": "policy_only",
       "rationale": "The shared diff is behavior-equivalent tuple membership for action and role guards; no ByteRover runtime behavior is missing.",
@@ -1121,6 +1156,13 @@
       "rationale": "Ultra supersedes the upstream Python Honcho gateway identity resolver with the Rust Honcho memory provider resolver in crates/hermes-agent/src/memory_plugins/honcho.rs, including pinUserPeer, userPeerAliases, runtimePeerPrefix, and hash-escalated collision handling.",
       "owner": "sheawinkler",
       "ticket": 25
+    },
+    {
+      "path": "plugins/memory/mem0/__init__.py",
+      "classification": "intentional_divergence",
+      "rationale": "The remaining Python Mem0 diff is legacy save_config write mechanics; Ultra implements Rust-native owner-only atomic config writes, merge semantics, and config-file activation in crates/hermes-agent/src/memory_plugins/mem0.rs.",
+      "owner": "sheawinkler",
+      "ticket": 304
     },
     {
       "path": "plugins/memory/supermemory/__init__.py",

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -12,8 +12,8 @@ AI-native cross-session user modeling with multi-pass dialectic reasoning, sessi
 ## Setup
 
 ```bash
-hermes honcho setup    # full interactive wizard (cloud or local)
-hermes memory setup    # generic picker, also works
+hermes memory setup honcho   # configure Honcho directly (cloud or local)
+hermes memory setup          # initialize the file memory backend
 ```
 
 Or manually:
@@ -21,6 +21,9 @@ Or manually:
 hermes config set memory.provider honcho
 echo "HONCHO_API_KEY=***" >> ~/.hermes/.env
 ```
+
+> `hermes honcho setup` is not used by the Rust runtime: Python plugin command
+> dispatch is disabled. Use `hermes memory setup honcho` on a fresh install.
 
 ## Architecture Overview
 
@@ -154,7 +157,7 @@ In gateway deployments (Telegram, Discord, Slack, etc.) each user arrives with a
 
 **Host vs root semantics.** All three keys are accepted at both root and `hosts.<host>` levels. Host-level wins. For maps and prefixes, host-level *replaces* the root value as a whole (not merge), so a host can intentionally own its identity universe or wipe it with `userPeerAliases: {}` / `runtimePeerPrefix: ""`.
 
-**Deployment shapes** (`hermes honcho setup` asks one prompt to set these):
+**Deployment shapes** (`hermes memory setup honcho` asks one prompt to set these):
 
 - **Single-operator** — `pinUserPeer: true`. All gateway users → `peerName`. Recommended for personal use where you connect Hermes to your own Telegram/Discord/etc.
 - **Multi-user gateway** — `pinUserPeer: false`, optional `runtimePeerPrefix`. Each runtime user → own peer. Recommended for bots serving many humans.
@@ -305,18 +308,14 @@ Presets:
 
 ## CLI Commands
 
+The Rust runtime currently supports direct setup and chat tools. Legacy
+`hermes honcho ...` Python plugin commands are not dispatched in Ultra.
+
 | Command | Description |
 |---------|-------------|
-| `hermes honcho setup` | Full interactive setup wizard |
-| `hermes honcho status` | Show resolved config for active profile |
-| `hermes honcho enable` / `disable` | Toggle Honcho for active profile |
-| `hermes honcho mode <mode>` | Change recall or observation mode |
-| `hermes honcho peer --user <name>` | Update user peer name |
-| `hermes honcho peer --ai <name>` | Update AI peer name |
-| `hermes honcho tokens --context <N>` | Set context token budget |
-| `hermes honcho tokens --dialectic <N>` | Set dialectic max chars |
-| `hermes honcho map <name>` | Map current directory to a session name |
-| `hermes honcho sync` | Create host blocks for all Hermes profiles |
+| `hermes memory setup honcho` | Configure Honcho directly for the Rust runtime |
+| `hermes memory status` | Show whether the file memory backend is initialized |
+| Honcho chat tools | `honcho_profile`, `honcho_search`, `honcho_context`, `honcho_conclude` |
 
 ## Example Config
 


### PR DESCRIPTION
## Summary
- add Rust owner-only atomic config persistence shared by memory providers
- wire Mem0, Honcho, Hindsight, and Supermemory availability/setup to secure config files
- add Rust `hermes memory setup honcho|mem0` paths and mask secret prompt defaults
- clear six WS3/WS6 memory-provider parity backlog items; pending review 609 -> 603, WS3 pending -> 0

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p hermes-agent memory_plugins -- --nocapture`
- `cargo test -p hermes-cli memory_ -- --nocapture`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-parity-tests --test global_parity_governance`
- `scripts/clippy-warning-gate.sh --check` (new=0; stale=2 pre-existing)
- `cargo build --workspace`
- `cargo test --workspace`