### PR TITLE
parity(gateway): add hook collect and HTTP pool contracts

### DIFF
--- a/crates/hermes-gateway/src/adapter.rs
+++ b/crates/hermes-gateway/src/adapter.rs
@@ -4,7 +4,9 @@
 //! `BasePlatformAdapter` with common fields (token, webhook_url, proxy)
 //! and helper methods shared by all platform adapters.
 
-use reqwest::Client;
+use std::time::Duration;
+
+use reqwest::{Client, ClientBuilder};
 use serde::{Deserialize, Serialize};
 
 use hermes_core::errors::GatewayError;
@@ -80,6 +82,62 @@ pub fn describe_secret(secret: &str) -> String {
     format!("len={}, fp={hash:016x}", trimmed.chars().count())
 }
 
+pub const DEFAULT_PLATFORM_HTTP_KEEPALIVE_EXPIRY_SECS: f64 = 2.0;
+pub const DEFAULT_PLATFORM_HTTP_MAX_KEEPALIVE: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PlatformHttpClientLimits {
+    pub keepalive_expiry: Duration,
+    pub max_keepalive_connections: usize,
+}
+
+impl Default for PlatformHttpClientLimits {
+    fn default() -> Self {
+        Self {
+            keepalive_expiry: Duration::from_secs_f64(DEFAULT_PLATFORM_HTTP_KEEPALIVE_EXPIRY_SECS),
+            max_keepalive_connections: DEFAULT_PLATFORM_HTTP_MAX_KEEPALIVE,
+        }
+    }
+}
+
+fn positive_env_f64(name: &str) -> Option<f64> {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value > 0.0)
+}
+
+fn positive_env_usize(name: &str) -> Option<usize> {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
+
+/// Shared HTTP pool limits for long-lived platform adapters.
+///
+/// The env names intentionally match upstream's Python/httpx helper so
+/// operator deployments can keep the same knobs while the implementation uses
+/// reqwest instead of httpx.
+pub fn platform_http_client_limits() -> PlatformHttpClientLimits {
+    PlatformHttpClientLimits {
+        keepalive_expiry: Duration::from_secs_f64(
+            positive_env_f64("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY")
+                .unwrap_or(DEFAULT_PLATFORM_HTTP_KEEPALIVE_EXPIRY_SECS),
+        ),
+        max_keepalive_connections: positive_env_usize("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE")
+            .unwrap_or(DEFAULT_PLATFORM_HTTP_MAX_KEEPALIVE),
+    }
+}
+
+/// Build a reqwest client builder with the shared platform-adapter pool limits.
+pub fn platform_http_client_builder() -> ClientBuilder {
+    let limits = platform_http_client_limits();
+    Client::builder()
+        .pool_idle_timeout(limits.keepalive_expiry)
+        .pool_max_idle_per_host(limits.max_keepalive_connections)
+}
+
 impl BasePlatformAdapter {
     /// Create a new `BasePlatformAdapter` with the given token.
     pub fn new(token: impl Into<String>) -> Self {
@@ -113,7 +171,7 @@ impl BasePlatformAdapter {
 
     /// Build a `reqwest::Client` configured with proxy settings if any.
     pub fn build_client(&self) -> Result<Client, GatewayError> {
-        let mut builder = Client::builder();
+        let mut builder = platform_http_client_builder();
 
         if let Some(ref http_proxy) = self.proxy.http_proxy {
             let proxy = reqwest::Proxy::all(http_proxy).map_err(|e| {
@@ -155,6 +213,9 @@ impl BasePlatformAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn base_adapter_validate_token_ok() {
@@ -172,6 +233,48 @@ mod tests {
     fn base_adapter_build_client_no_proxy() {
         let base = BasePlatformAdapter::new("token");
         assert!(base.build_client().is_ok());
+    }
+
+    #[test]
+    fn platform_http_client_limits_default_tightens_idle_pool() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY");
+        std::env::remove_var("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE");
+        let limits = platform_http_client_limits();
+        assert!(limits.keepalive_expiry > Duration::ZERO);
+        assert!(limits.keepalive_expiry < Duration::from_secs(5));
+        assert!((1..=50).contains(&limits.max_keepalive_connections));
+        assert!(platform_http_client_builder().build().is_ok());
+    }
+
+    #[test]
+    fn platform_http_client_limits_honor_env_overrides() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", "7.5");
+        std::env::set_var("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE", "25");
+        let limits = platform_http_client_limits();
+        assert_eq!(limits.keepalive_expiry, Duration::from_secs_f64(7.5));
+        assert_eq!(limits.max_keepalive_connections, 25);
+        std::env::remove_var("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY");
+        std::env::remove_var("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE");
+    }
+
+    #[test]
+    fn platform_http_client_limits_reject_garbage_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", "not-a-number");
+        std::env::set_var("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE", "0");
+        let limits = platform_http_client_limits();
+        assert_eq!(
+            limits.keepalive_expiry,
+            Duration::from_secs_f64(DEFAULT_PLATFORM_HTTP_KEEPALIVE_EXPIRY_SECS)
+        );
+        assert_eq!(
+            limits.max_keepalive_connections,
+            DEFAULT_PLATFORM_HTTP_MAX_KEEPALIVE
+        );
+        std::env::remove_var("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY");
+        std::env::remove_var("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE");
     }
 
     #[test]

--- a/crates/hermes-gateway/src/hooks.rs
+++ b/crates/hermes-gateway/src/hooks.rs
@@ -69,6 +69,14 @@ impl HookEvent {
             context,
         }
     }
+
+    /// Convenience constructor for hooks that do not need event context.
+    pub fn empty(event_type: impl Into<String>) -> Self {
+        Self {
+            event_type: event_type.into(),
+            context: json!({}),
+        }
+    }
 }
 
 /// In-process hook handler. Implementations should be cheap and
@@ -78,6 +86,16 @@ pub trait HookHandler: Send + Sync {
     /// Handle one event. Errors are logged but never propagate to the
     /// gateway pipeline.
     async fn handle(&self, event: &HookEvent) -> Result<(), String>;
+
+    /// Handle one event and optionally return a decision/result payload.
+    ///
+    /// Most hooks are fire-and-forget, so the default implementation delegates
+    /// to [`HookHandler::handle`] and returns no collected value. Decision
+    /// hooks can override this without changing the normal emit path.
+    async fn handle_collect(&self, event: &HookEvent) -> Result<Option<Value>, String> {
+        self.handle(event).await?;
+        Ok(None)
+    }
 
     /// Stable identifier used in logs. Need not be unique but should help
     /// operators correlate events with hooks.
@@ -286,38 +304,12 @@ impl HookRegistry {
     /// `scope:*` wildcard matches. Errors and panics are logged and
     /// swallowed.
     pub async fn emit(&self, event: &HookEvent) {
-        let mut to_call: Vec<Arc<dyn HookHandler>> = Vec::new();
-
-        if let Some(list) = self.handlers.get(&event.event_type) {
-            to_call.extend(list.iter().cloned());
-        }
-
-        if let Some((scope, _)) = event.event_type.split_once(':') {
-            let wildcard = format!("{scope}:*");
-            if wildcard != event.event_type {
-                if let Some(list) = self.handlers.get(&wildcard) {
-                    to_call.extend(list.iter().cloned());
-                }
-            }
-        }
-
-        for handler in to_call {
-            // Catch panics so a misbehaving hook can't kill the gateway.
+        for handler in self.matching_handlers(&event.event_type) {
             let name = handler.name().to_string();
             let evt_for_call = event.clone();
-            let result =
-                std::panic::AssertUnwindSafe(async move { handler.handle(&evt_for_call).await });
-            // Note: we deliberately don't use catch_unwind here because
-            // it doesn't compose with async; Tokio's spawn isolation +
-            // the per-handler error log below is sufficient containment
-            // for normal `Err(...)` returns. True panics inside an
-            // async fn unwind to the caller's task; in production they
-            // would be caught at the agent loop's top-level
-            // spawn. Keeping the AssertUnwindSafe wrapping for future-
-            // proofing.
-            match result.0.await {
-                Ok(()) => {}
-                Err(e) => {
+            match tokio::spawn(async move { handler.handle(&evt_for_call).await }).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
                     tracing::warn!(
                         hook = %name,
                         event = %event.event_type,
@@ -325,8 +317,69 @@ impl HookRegistry {
                         "Hook handler returned error"
                     );
                 }
+                Err(join_error) => {
+                    tracing::warn!(
+                        hook = %name,
+                        event = %event.event_type,
+                        error = %join_error,
+                        "Hook handler panicked"
+                    );
+                }
             }
         }
+    }
+
+    /// Fire matching handlers and collect non-empty decision payloads.
+    ///
+    /// Exact handlers run before `scope:*` wildcard handlers, matching
+    /// [`HookRegistry::emit`]. Handler errors are logged and skipped so one
+    /// failing hook cannot prevent later hooks from contributing decisions.
+    pub async fn emit_collect(&self, event: &HookEvent) -> Vec<Value> {
+        let mut collected = Vec::new();
+        for handler in self.matching_handlers(&event.event_type) {
+            let name = handler.name().to_string();
+            let evt_for_call = event.clone();
+            match tokio::spawn(async move { handler.handle_collect(&evt_for_call).await }).await {
+                Ok(Ok(Some(value))) => collected.push(value),
+                Ok(Ok(None)) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        hook = %name,
+                        event = %event.event_type,
+                        error = %e,
+                        "Hook handler returned error while collecting"
+                    );
+                }
+                Err(join_error) => {
+                    tracing::warn!(
+                        hook = %name,
+                        event = %event.event_type,
+                        error = %join_error,
+                        "Hook handler panicked while collecting"
+                    );
+                }
+            }
+        }
+        collected
+    }
+
+    fn matching_handlers(&self, event_type: &str) -> Vec<Arc<dyn HookHandler>> {
+        let mut to_call: Vec<Arc<dyn HookHandler>> = Vec::new();
+
+        if let Some(list) = self.handlers.get(event_type) {
+            to_call.extend(list.iter().cloned());
+        }
+
+        if let Some((scope, _)) = event_type.split_once(':') {
+            let wildcard = format!("{scope}:*");
+            if wildcard != event_type {
+                if let Some(list) = self.handlers.get(&wildcard) {
+                    to_call.extend(list.iter().cloned());
+                }
+            }
+        }
+
+        to_call
     }
 }
 
@@ -564,6 +617,52 @@ mod tests {
         }
     }
 
+    /// In-process handler that panics. Used to prove hook isolation is real.
+    struct PanicHook;
+
+    #[async_trait]
+    impl HookHandler for PanicHook {
+        async fn handle(&self, _event: &HookEvent) -> Result<(), String> {
+            panic!("panic-hook");
+        }
+
+        async fn handle_collect(&self, _event: &HookEvent) -> Result<Option<Value>, String> {
+            panic!("panic-hook-collect");
+        }
+
+        fn name(&self) -> &str {
+            "panic"
+        }
+    }
+
+    /// In-process decision hook for `emit_collect` tests.
+    struct DecisionHook {
+        name: String,
+        value: Option<Value>,
+        error: Option<String>,
+    }
+
+    #[async_trait]
+    impl HookHandler for DecisionHook {
+        async fn handle(&self, _event: &HookEvent) -> Result<(), String> {
+            if let Some(error) = &self.error {
+                return Err(error.clone());
+            }
+            Ok(())
+        }
+
+        async fn handle_collect(&self, _event: &HookEvent) -> Result<Option<Value>, String> {
+            if let Some(error) = &self.error {
+                return Err(error.clone());
+            }
+            Ok(self.value.clone())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
     fn write_manifest(dir: &Path, name: &str, events: &[&str], command: &[&str]) {
         std::fs::create_dir_all(dir).unwrap();
         let yaml = format!(
@@ -729,6 +828,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handler_panic_is_contained_and_later_handlers_run() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mut reg = HookRegistry::new();
+        reg.register_in_process("agent:start", Arc::new(PanicHook));
+        reg.register_in_process(
+            "agent:start",
+            Arc::new(RecordingHook {
+                name: "rec".into(),
+                seen: seen.clone(),
+            }),
+        );
+        reg.emit(&HookEvent::new("agent:start", json!({}))).await;
+        assert_eq!(*seen.lock().unwrap(), vec!["agent:start".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn emit_empty_event_uses_default_object_context() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mut reg = HookRegistry::new();
+        reg.register_in_process(
+            "agent:start",
+            Arc::new(RecordingHook {
+                name: "rec".into(),
+                seen: seen.clone(),
+            }),
+        );
+        let event = HookEvent::empty("agent:start");
+        assert_eq!(event.context, json!({}));
+        reg.emit(&event).await;
+        assert_eq!(*seen.lock().unwrap(), vec!["agent:start".to_string()]);
+    }
+
+    #[tokio::test]
     async fn wildcard_matches_any_subevent() {
         let seen = Arc::new(Mutex::new(Vec::new()));
         let mut reg = HookRegistry::new();
@@ -781,6 +913,145 @@ mod tests {
         reg.emit(&HookEvent::new("command:reset", json!({}))).await;
         // Both fire (order: exact first, then wildcard).
         assert_eq!(seen.lock().unwrap().len(), 2);
+    }
+
+    // ---------- emit_collect decision hooks ----------
+
+    #[tokio::test]
+    async fn emit_collect_collects_decision_payloads() {
+        let mut reg = HookRegistry::new();
+        reg.register_in_process(
+            "command:status",
+            Arc::new(DecisionHook {
+                name: "allow".into(),
+                value: Some(json!({"decision": "allow"})),
+                error: None,
+            }),
+        );
+        reg.register_in_process(
+            "command:status",
+            Arc::new(DecisionHook {
+                name: "deny".into(),
+                value: Some(json!({"decision": "deny", "message": "nope"})),
+                error: None,
+            }),
+        );
+
+        let values = reg.emit_collect(&HookEvent::empty("command:status")).await;
+        assert_eq!(
+            values,
+            vec![
+                json!({"decision": "allow"}),
+                json!({"decision": "deny", "message": "nope"}),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_collect_drops_none_return_values() {
+        let mut reg = HookRegistry::new();
+        reg.register_in_process(
+            "command:x",
+            Arc::new(DecisionHook {
+                name: "none-a".into(),
+                value: None,
+                error: None,
+            }),
+        );
+        reg.register_in_process(
+            "command:x",
+            Arc::new(DecisionHook {
+                name: "deny".into(),
+                value: Some(json!({"decision": "deny"})),
+                error: None,
+            }),
+        );
+        reg.register_in_process(
+            "command:x",
+            Arc::new(DecisionHook {
+                name: "none-b".into(),
+                value: None,
+                error: None,
+            }),
+        );
+
+        let values = reg.emit_collect(&HookEvent::empty("command:x")).await;
+        assert_eq!(values, vec![json!({"decision": "deny"})]);
+    }
+
+    #[tokio::test]
+    async fn emit_collect_handler_error_does_not_abort_chain() {
+        let mut reg = HookRegistry::new();
+        reg.register_in_process(
+            "command:x",
+            Arc::new(DecisionHook {
+                name: "boom".into(),
+                value: None,
+                error: Some("boom".into()),
+            }),
+        );
+        reg.register_in_process(
+            "command:x",
+            Arc::new(DecisionHook {
+                name: "allow".into(),
+                value: Some(json!({"decision": "allow"})),
+                error: None,
+            }),
+        );
+
+        let values = reg.emit_collect(&HookEvent::empty("command:x")).await;
+        assert_eq!(values, vec![json!({"decision": "allow"})]);
+    }
+
+    #[tokio::test]
+    async fn emit_collect_handler_panic_does_not_abort_chain() {
+        let mut reg = HookRegistry::new();
+        reg.register_in_process("command:x", Arc::new(PanicHook));
+        reg.register_in_process(
+            "command:x",
+            Arc::new(DecisionHook {
+                name: "allow".into(),
+                value: Some(json!({"decision": "allow"})),
+                error: None,
+            }),
+        );
+
+        let values = reg.emit_collect(&HookEvent::empty("command:x")).await;
+        assert_eq!(values, vec![json!({"decision": "allow"})]);
+    }
+
+    #[tokio::test]
+    async fn emit_collect_exact_handlers_precede_wildcards() {
+        let mut reg = HookRegistry::new();
+        reg.register_in_process(
+            "command:*",
+            Arc::new(DecisionHook {
+                name: "wildcard".into(),
+                value: Some(json!({"decision": "allow"})),
+                error: None,
+            }),
+        );
+        reg.register_in_process(
+            "command:reset",
+            Arc::new(DecisionHook {
+                name: "exact".into(),
+                value: Some(json!({"decision": "deny"})),
+                error: None,
+            }),
+        );
+
+        let values = reg.emit_collect(&HookEvent::empty("command:reset")).await;
+        assert_eq!(
+            values,
+            vec![json!({"decision": "deny"}), json!({"decision": "allow"})]
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_collect_no_handlers_returns_empty_list() {
+        let reg = HookRegistry::new();
+        let values = reg.emit_collect(&HookEvent::empty("unknown:event")).await;
+        assert!(values.is_empty());
     }
 
     // ---------- builtins ----------

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -22,7 +22,9 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 use hermes_tools::approval::{self, ApprovalChoice, GatewayApprovalRequest};
 
-use crate::adapter::{describe_secret, AdapterProxyConfig, BasePlatformAdapter};
+use crate::adapter::{
+    describe_secret, platform_http_client_builder, AdapterProxyConfig, BasePlatformAdapter,
+};
 use crate::format::to_telegram_markdown_v2;
 
 /// Maximum message length for Telegram (4096 characters).
@@ -785,7 +787,8 @@ impl TelegramAdapter {
             return base.build_client();
         }
 
-        let mut builder = Client::builder().resolve_to_addrs(TELEGRAM_API_HOST, &valid_fallbacks);
+        let mut builder =
+            platform_http_client_builder().resolve_to_addrs(TELEGRAM_API_HOST, &valid_fallbacks);
 
         if let Some(ref http_proxy) = base.proxy.http_proxy {
             let proxy = reqwest::Proxy::all(http_proxy).map_err(|e| {

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T09:38:06.283824+00:00",
+  "generated_at_utc": "2026-05-31T10:26:22.668305+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T09:38:06.283824+00:00`
+Generated: `2026-05-31T10:26:22.668305+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -725,7 +725,7 @@
       "classification": "intentional_divergence",
       "classification_path": "plugins/memory/honcho/README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "dbe3eebc9a56d1910a111800666634dbb1810273",
+      "local_blob": "2ff75a272a17cabd9925f8d479a0d055aaf29da0",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/honcho/README.md",
@@ -4306,17 +4306,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_hooks.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ac9e51919c4e46e23777ed09e69144df0dc0351e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_hooks.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "a614f9cbe0e64d6be4ff71c5e5d81af20c32cca9",
       "workstream": "WS6"
     },
@@ -4576,17 +4576,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_platform_http_client_limits.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "fe613fb1f08433f4359f227e774367eace07cfbf",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_platform_http_client_limits.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "074a6d52ec3b6ea172807db7d674e8a089c34226",
       "workstream": "WS6"
     },
@@ -15466,29 +15466,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T09:38:06.180340+00:00",
+  "generated_at_utc": "2026-05-31T10:26:22.729802+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "fe145f8a2b574f66af38e0e0db3797839d3b49f0",
+    "local_sha": "05dcc204cc0613dadbff360b0ededffc2fcf5417",
     "upstream_ref": "upstream/main",
     "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 603,
-      "intentional_divergence": 258,
+      "functional": 601,
+      "intentional_divergence": 260,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 428,
-      "rust_equivalent_or_contract_test_required": 522,
+      "not_required_for_runtime": 430,
+      "rust_equivalent_or_contract_test_required": 520,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 258,
+      "cleared_intentional_divergence": 260,
       "cleared_non_runtime": 170,
-      "pending_review": 603
+      "pending_review": 601
     },
     "by_workstream": {
       "WS3": 56,
@@ -15497,10 +15497,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 258,
+    "cleared_intentional_divergence": 260,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 603,
+    "pending_review": 601,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T09:38:06.180340+00:00`
+Generated: `2026-05-31T10:26:22.729802+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `603`
+- Pending functional review: `601`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `258`
+- Cleared intentional divergence: `260`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 258 |
+| `cleared_intentional_divergence` | 260 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 603 |
+| `pending_review` | 601 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-31T09:38:06.180340+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 131 |
+| `tests/gateway` | 129 |
 | `tests/hermes_cli` | 120 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -171,6 +171,20 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_hooks.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream gateway hook discovery, wildcard emit ordering, error containment, default empty context, and emit_collect decision hooks are covered by Rust HookRegistry tests; user hook loading intentionally uses zero-Python HOOK.yaml command handlers instead of dynamic handler.py imports.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_platform_http_client_limits.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream persistent-platform HTTP pool limits are covered by Rust BasePlatformAdapter reqwest pool-limit tests for default keepalive tightening, env overrides, malformed env fallback, and shared builder use by long-lived adapters; Python httpx import failure and aiohttp response-leak checks are not part of the Rust runtime.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/gateway/test_api_server_toolset.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream's API-server toolset contract is covered by Rust toolset and platform-toolset tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Scope
- Add Rust `HookEvent::empty` for contextless gateway events.
- Add Rust `HookRegistry::emit_collect` for decision-style hooks with exact-before-wildcard ordering, none filtering, error containment, and panic containment.
- Make `HookRegistry::emit` perform real in-process panic containment with Tokio task `JoinError` handling.
- Add shared reqwest platform HTTP pool limits with upstream-compatible env knobs: `HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY` and `HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE`.
- Route Telegram fallback-DNS client construction through the shared platform HTTP builder.
- Clear parity ledger entries for `tests/gateway/test_hooks.py` and `tests/gateway/test_platform_http_client_limits.py` as Rust-native/intentional divergence coverage.

## Backlog Delta
- Pending functional review: `603 -> 601`
- Cleared intentional divergence: `258 -> 260`

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-gateway hooks`
- `cargo test -p hermes-gateway platform_http_client_limits`
- `cargo test -p hermes-parity-tests --test global_parity_governance`
- `scripts/clippy-warning-gate.sh --check` (`new=0`; stale=2 pre-existing allowlist entries)
- `cargo build --workspace`
- `cargo test --workspace`
