### PR TITLE
parity(gateway): add delivery and channel directory contracts

### DIFF
--- a/crates/hermes-gateway/src/channel_directory.rs
+++ b/crates/hermes-gateway/src/channel_directory.rs
@@ -1,13 +1,82 @@
-//! In-memory channel directory for discovery and lookup.
+//! Channel directory cache for discovery, display, and human-friendly lookup.
+//!
+//! The cache lives at `$HERMES_HOME/channel_directory.json` and mirrors the
+//! Python gateway contract: platform entries are persisted by platform name,
+//! missing/corrupt caches load as empty, writes are atomic, and session history
+//! can seed platforms that cannot enumerate channels directly.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-#[derive(Debug, Clone)]
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use hermes_config::hermes_home;
+use hermes_core::errors::GatewayError;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChannelEntry {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing)]
     pub platform: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guild: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+}
+
+impl ChannelEntry {
+    pub fn new(
+        platform: impl Into<String>,
+        id: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            platform: normalize_platform(platform.into().as_str()),
+            guild: None,
+            kind: None,
+            thread_id: None,
+        }
+    }
+
+    pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
+        self
+    }
+
+    pub fn with_guild(mut self, guild: impl Into<String>) -> Self {
+        self.guild = Some(guild.into());
+        self
+    }
+
+    pub fn with_thread(mut self, thread_id: impl Into<String>) -> Self {
+        self.thread_id = Some(thread_id.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelDirectorySnapshot {
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    #[serde(default)]
+    pub platforms: BTreeMap<String, Vec<ChannelEntry>>,
+}
+
+#[async_trait]
+pub trait ChannelDirectoryProvider: Send + Sync {
+    fn platform_name(&self) -> &str;
+    async fn list_channel_entries(&self) -> Result<Vec<ChannelEntry>, GatewayError>;
 }
 
 #[derive(Clone, Default)]
@@ -35,5 +104,737 @@ impl ChannelDirectory {
             .read()
             .map(|c| c.values().cloned().collect())
             .unwrap_or_default()
+    }
+}
+
+pub fn directory_path() -> PathBuf {
+    hermes_home().join("channel_directory.json")
+}
+
+pub fn load_directory() -> ChannelDirectorySnapshot {
+    load_directory_from(directory_path())
+}
+
+pub fn load_directory_from(path: impl AsRef<Path>) -> ChannelDirectorySnapshot {
+    let path = path.as_ref();
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return ChannelDirectorySnapshot::default();
+    };
+    let Ok(mut snapshot) = serde_json::from_str::<ChannelDirectorySnapshot>(&text) else {
+        return ChannelDirectorySnapshot::default();
+    };
+    normalize_snapshot(&mut snapshot);
+    snapshot
+}
+
+pub fn write_directory_atomic(
+    path: impl AsRef<Path>,
+    snapshot: &ChannelDirectorySnapshot,
+) -> io::Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let bytes = serde_json::to_vec_pretty(snapshot).map_err(io::Error::other)?;
+    let tmp_path = path.with_extension(format!(
+        "json.tmp.{}.{}",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+
+    match std::fs::write(&tmp_path, bytes).and_then(|_| std::fs::rename(&tmp_path, path)) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(err)
+        }
+    }
+}
+
+pub fn build_channel_directory(
+    platforms: BTreeMap<String, Vec<ChannelEntry>>,
+) -> ChannelDirectorySnapshot {
+    build_channel_directory_at(directory_path(), platforms)
+}
+
+pub fn build_channel_directory_at(
+    path: impl AsRef<Path>,
+    platforms: BTreeMap<String, Vec<ChannelEntry>>,
+) -> ChannelDirectorySnapshot {
+    let mut snapshot = ChannelDirectorySnapshot {
+        updated_at: Some(Utc::now().to_rfc3339()),
+        platforms,
+    };
+    normalize_snapshot(&mut snapshot);
+    if let Err(err) = write_directory_atomic(path, &snapshot) {
+        warn!(error = %err, "Channel directory: failed to write cache");
+    }
+    snapshot
+}
+
+pub async fn build_channel_directory_from_providers(
+    providers: &[Arc<dyn ChannelDirectoryProvider>],
+) -> ChannelDirectorySnapshot {
+    build_channel_directory_from_providers_at(directory_path(), hermes_home(), providers).await
+}
+
+pub async fn build_channel_directory_from_providers_at(
+    path: impl AsRef<Path>,
+    hermes_home_path: impl AsRef<Path>,
+    providers: &[Arc<dyn ChannelDirectoryProvider>],
+) -> ChannelDirectorySnapshot {
+    let mut platforms: BTreeMap<String, Vec<ChannelEntry>> = BTreeMap::new();
+    let mut discovered = BTreeSet::new();
+
+    for provider in providers {
+        let platform = normalize_platform(provider.platform_name());
+        match provider.list_channel_entries().await {
+            Ok(entries) => {
+                platforms.insert(
+                    platform.clone(),
+                    merge_entries(
+                        entries,
+                        build_from_sessions_in(&hermes_home_path, &platform),
+                    ),
+                );
+                discovered.insert(platform);
+            }
+            Err(err) => {
+                warn!(platform = %platform, error = %err, "Channel directory: provider failed");
+            }
+        }
+    }
+
+    for platform in SESSION_DISCOVERY_PLATFORMS {
+        if discovered.contains(*platform) {
+            continue;
+        }
+        platforms.insert(
+            (*platform).to_string(),
+            build_from_sessions_in(&hermes_home_path, platform),
+        );
+    }
+
+    build_channel_directory_at(path, platforms)
+}
+
+pub fn build_from_sessions(platform_name: &str) -> Vec<ChannelEntry> {
+    build_from_sessions_in(hermes_home(), platform_name)
+}
+
+pub fn build_from_sessions_in(
+    hermes_home_path: impl AsRef<Path>,
+    platform_name: &str,
+) -> Vec<ChannelEntry> {
+    let platform_name = normalize_platform(platform_name);
+    let sessions_path = hermes_home_path
+        .as_ref()
+        .join("sessions")
+        .join("sessions.json");
+    let Ok(text) = std::fs::read_to_string(&sessions_path) else {
+        return Vec::new();
+    };
+    let Ok(Value::Object(sessions)) = serde_json::from_str::<Value>(&text) else {
+        debug!(path = %sessions_path.display(), "Channel directory: sessions cache is not an object");
+        return Vec::new();
+    };
+
+    let mut seen = BTreeSet::new();
+    let mut entries = Vec::new();
+    for session in sessions.values() {
+        let Some(origin) = session.get("origin").and_then(Value::as_object) else {
+            continue;
+        };
+        if value_to_string(origin.get("platform")).as_deref() != Some(platform_name.as_str()) {
+            continue;
+        }
+        let Some(id) = session_entry_id(origin) else {
+            continue;
+        };
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        let mut entry = ChannelEntry::new(&platform_name, id, session_entry_name(origin))
+            .with_kind(
+                value_to_string(session.get("chat_type")).unwrap_or_else(|| "dm".to_string()),
+            );
+        if let Some(thread_id) = value_to_string(origin.get("thread_id")) {
+            entry = entry.with_thread(thread_id);
+        }
+        entries.push(entry);
+    }
+    entries
+}
+
+pub fn resolve_channel_name(platform_name: &str, name: &str) -> Option<String> {
+    resolve_channel_name_from(directory_path(), platform_name, name)
+}
+
+pub fn resolve_channel_name_from(
+    path: impl AsRef<Path>,
+    platform_name: &str,
+    name: &str,
+) -> Option<String> {
+    let directory = load_directory_from(path);
+    let platform_name = normalize_platform(platform_name);
+    let channels = directory.platforms.get(&platform_name)?;
+    if channels.is_empty() {
+        return None;
+    }
+
+    let raw = name.trim();
+    for channel in channels {
+        if channel.id == raw {
+            return Some(channel.id.clone());
+        }
+    }
+
+    let query = normalize_channel_query(raw);
+    for channel in channels {
+        if normalize_channel_query(&channel.name) == query
+            || normalize_channel_query(&channel_target_name(&platform_name, channel)) == query
+        {
+            return Some(channel.id.clone());
+        }
+    }
+
+    if let Some((guild_part, channel_part)) = query.rsplit_once('/') {
+        for channel in channels {
+            if channel
+                .guild
+                .as_deref()
+                .map(|guild| guild.trim().eq_ignore_ascii_case(guild_part))
+                .unwrap_or(false)
+                && normalize_channel_query(&channel.name) == channel_part
+            {
+                return Some(channel.id.clone());
+            }
+        }
+    }
+
+    let matches: Vec<&ChannelEntry> = channels
+        .iter()
+        .filter(|channel| normalize_channel_query(&channel.name).starts_with(&query))
+        .collect();
+    if matches.len() == 1 {
+        Some(matches[0].id.clone())
+    } else {
+        None
+    }
+}
+
+pub fn lookup_channel_type(platform_name: &str, chat_id: &str) -> Option<String> {
+    lookup_channel_type_from(directory_path(), platform_name, chat_id)
+}
+
+pub fn lookup_channel_type_from(
+    path: impl AsRef<Path>,
+    platform_name: &str,
+    chat_id: &str,
+) -> Option<String> {
+    let directory = load_directory_from(path);
+    directory
+        .platforms
+        .get(&normalize_platform(platform_name))?
+        .iter()
+        .find(|entry| entry.id == chat_id)
+        .and_then(|entry| entry.kind.clone())
+}
+
+pub fn format_directory_for_display() -> String {
+    format_directory_for_display_from(directory_path())
+}
+
+pub fn format_directory_for_display_from(path: impl AsRef<Path>) -> String {
+    let directory = load_directory_from(path);
+    let platforms = directory.platforms;
+    if !platforms.values().any(|entries| !entries.is_empty()) {
+        return "No messaging platforms connected or no channels discovered yet.".to_string();
+    }
+
+    let mut lines = vec!["Available messaging targets:\n".to_string()];
+    for (platform, channels) in platforms {
+        if channels.is_empty() {
+            continue;
+        }
+        if platform == "discord" {
+            let mut guilds: BTreeMap<String, Vec<&ChannelEntry>> = BTreeMap::new();
+            let mut dms = Vec::new();
+            for channel in &channels {
+                if let Some(guild) = channel.guild.as_deref().filter(|guild| !guild.is_empty()) {
+                    guilds.entry(guild.to_string()).or_default().push(channel);
+                } else {
+                    dms.push(channel);
+                }
+            }
+            for (guild, mut guild_channels) in guilds {
+                guild_channels.sort_by(|a, b| a.name.cmp(&b.name));
+                lines.push(format!("Discord ({guild}):"));
+                for channel in guild_channels {
+                    lines.push(format!(
+                        "  discord:{}",
+                        channel_target_name(&platform, channel)
+                    ));
+                }
+            }
+            if !dms.is_empty() {
+                lines.push("Discord (DMs):".to_string());
+                for channel in dms {
+                    lines.push(format!(
+                        "  discord:{}",
+                        channel_target_name(&platform, channel)
+                    ));
+                }
+            }
+            lines.push(String::new());
+        } else {
+            lines.push(format!("{}:", title_case_platform(&platform)));
+            for channel in channels {
+                lines.push(format!(
+                    "  {}:{}",
+                    platform,
+                    channel_target_name(&platform, &channel)
+                ));
+            }
+            lines.push(String::new());
+        }
+    }
+
+    lines.push("Use these as the \"target\" parameter when sending.".to_string());
+    lines.push("Bare platform name (e.g. \"telegram\") sends to home channel.".to_string());
+    lines.join("\n")
+}
+
+fn normalize_snapshot(snapshot: &mut ChannelDirectorySnapshot) {
+    let platforms = std::mem::take(&mut snapshot.platforms);
+    snapshot.platforms = platforms
+        .into_iter()
+        .map(|(platform, mut entries)| {
+            let platform = normalize_platform(&platform);
+            for entry in &mut entries {
+                entry.platform = platform.clone();
+            }
+            (platform, entries)
+        })
+        .collect();
+}
+
+fn normalize_platform(name: &str) -> String {
+    name.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+fn normalize_channel_query(value: &str) -> String {
+    value
+        .trim()
+        .trim_start_matches('#')
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn channel_target_name(platform_name: &str, channel: &ChannelEntry) -> String {
+    if platform_name == "discord"
+        && channel
+            .guild
+            .as_deref()
+            .is_some_and(|guild| !guild.is_empty())
+    {
+        return format!("#{}", channel.name);
+    }
+    if platform_name != "discord" {
+        if let Some(kind) = channel.kind.as_deref().filter(|kind| !kind.is_empty()) {
+            return format!("{} ({kind})", channel.name);
+        }
+    }
+    channel.name.clone()
+}
+
+fn session_entry_id(origin: &serde_json::Map<String, Value>) -> Option<String> {
+    let chat_id = value_to_string(origin.get("chat_id"))?;
+    value_to_string(origin.get("thread_id"))
+        .filter(|thread_id| !thread_id.is_empty())
+        .map(|thread_id| format!("{chat_id}:{thread_id}"))
+        .or(Some(chat_id))
+}
+
+fn session_entry_name(origin: &serde_json::Map<String, Value>) -> String {
+    let base_name = value_to_string(origin.get("chat_name"))
+        .or_else(|| value_to_string(origin.get("user_name")))
+        .or_else(|| value_to_string(origin.get("chat_id")))
+        .unwrap_or_else(|| "unknown".to_string());
+    let Some(thread_id) = value_to_string(origin.get("thread_id")).filter(|s| !s.is_empty()) else {
+        return base_name;
+    };
+    let topic =
+        value_to_string(origin.get("chat_topic")).unwrap_or_else(|| format!("topic {thread_id}"));
+    format!("{base_name} / {topic}")
+}
+
+fn value_to_string(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn merge_entries(primary: Vec<ChannelEntry>, secondary: Vec<ChannelEntry>) -> Vec<ChannelEntry> {
+    let mut seen = BTreeSet::new();
+    let mut merged = Vec::new();
+    for entry in primary.into_iter().chain(secondary) {
+        if seen.insert(entry.id.clone()) {
+            merged.push(entry);
+        }
+    }
+    merged
+}
+
+fn title_case_platform(platform: &str) -> String {
+    let mut chars = platform.chars();
+    match chars.next() {
+        Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+        None => String::new(),
+    }
+}
+
+const SESSION_DISCOVERY_PLATFORMS: &[&str] = &[
+    "telegram",
+    "discord",
+    "slack",
+    "whatsapp",
+    "signal",
+    "matrix",
+    "mattermost",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "wecom_callback",
+    "weixin",
+    "qqbot",
+    "qq",
+    "bluebubbles",
+    "email",
+    "sms",
+    "homeassistant",
+    "ntfy",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    struct StaticProvider {
+        platform: &'static str,
+        entries: Vec<ChannelEntry>,
+    }
+
+    #[async_trait]
+    impl ChannelDirectoryProvider for StaticProvider {
+        fn platform_name(&self) -> &str {
+            self.platform
+        }
+
+        async fn list_channel_entries(&self) -> Result<Vec<ChannelEntry>, GatewayError> {
+            Ok(self.entries.clone())
+        }
+    }
+
+    struct FailingProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ChannelDirectoryProvider for FailingProvider {
+        fn platform_name(&self) -> &str {
+            "slack"
+        }
+
+        async fn list_channel_entries(&self) -> Result<Vec<ChannelEntry>, GatewayError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(GatewayError::ConnectionFailed("boom".into()))
+        }
+    }
+
+    fn write_directory(dir: &Path, platforms: BTreeMap<String, Vec<ChannelEntry>>) -> PathBuf {
+        let path = dir.join("channel_directory.json");
+        let snapshot = ChannelDirectorySnapshot {
+            updated_at: Some("2026-01-01T00:00:00".into()),
+            platforms,
+        };
+        write_directory_atomic(&path, &snapshot).expect("write directory");
+        path
+    }
+
+    #[test]
+    fn load_directory_missing_and_corrupt_are_empty() {
+        let tmp = tempdir().expect("tmp");
+        assert_eq!(
+            load_directory_from(tmp.path().join("missing.json")),
+            ChannelDirectorySnapshot::default()
+        );
+
+        let corrupt = tmp.path().join("bad.json");
+        std::fs::write(&corrupt, "{bad json").expect("write corrupt");
+        assert_eq!(
+            load_directory_from(&corrupt),
+            ChannelDirectorySnapshot::default()
+        );
+    }
+
+    #[test]
+    fn load_directory_valid_file_fills_platform_field() {
+        let tmp = tempdir().expect("tmp");
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            "telegram".into(),
+            vec![ChannelEntry::new("", "123", "John").with_kind("dm")],
+        );
+        let path = write_directory(tmp.path(), platforms);
+        let loaded = load_directory_from(path);
+        assert_eq!(loaded.platforms["telegram"][0].name, "John");
+        assert_eq!(loaded.platforms["telegram"][0].platform, "telegram");
+    }
+
+    #[test]
+    fn failed_write_preserves_previous_cache() {
+        let tmp = tempdir().expect("tmp");
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            "telegram".into(),
+            vec![ChannelEntry::new("telegram", "123", "Alice").with_kind("dm")],
+        );
+        let path = write_directory(tmp.path(), platforms);
+        let previous = std::fs::read_to_string(&path).expect("previous");
+
+        let bad_path = tmp.path().join("blocked").join("channel_directory.json");
+        std::fs::write(tmp.path().join("blocked"), "not a dir").expect("block parent");
+        let mut replacement = BTreeMap::new();
+        replacement.insert(
+            "telegram".into(),
+            vec![ChannelEntry::new("telegram", "999", "Bob").with_kind("dm")],
+        );
+        let _ = build_channel_directory_at(&bad_path, replacement);
+
+        assert_eq!(std::fs::read_to_string(&path).expect("current"), previous);
+    }
+
+    #[test]
+    fn resolve_channel_name_matches_exact_case_prefix_guild_and_ids() {
+        let tmp = tempdir().expect("tmp");
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            "discord".into(),
+            vec![
+                ChannelEntry::new("discord", "111", "general")
+                    .with_guild("ServerA")
+                    .with_kind("channel"),
+                ChannelEntry::new("discord", "222", "general")
+                    .with_guild("ServerB")
+                    .with_kind("channel"),
+                ChannelEntry::new("discord", "333", "bot-home")
+                    .with_guild("ServerA")
+                    .with_kind("channel"),
+            ],
+        );
+        platforms.insert(
+            "slack".into(),
+            vec![
+                ChannelEntry::new("slack", "C0B0QV5434G", "engineering").with_kind("channel"),
+                ChannelEntry::new("slack", "C99", "c0b0qv5434g").with_kind("channel"),
+                ChannelEntry::new("slack", "C01", "engineering-backend").with_kind("channel"),
+                ChannelEntry::new("slack", "C02", "design-team").with_kind("channel"),
+            ],
+        );
+        let path = write_directory(tmp.path(), platforms);
+
+        assert_eq!(
+            resolve_channel_name_from(&path, "discord", "#bot-home"),
+            Some("333".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "discord", "ServerA/general"),
+            Some("111".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "discord", "ServerB/general"),
+            Some("222".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "slack", "C0B0QV5434G"),
+            Some("C0B0QV5434G".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "slack", "c0b0qv5434g"),
+            Some("C99".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "slack", "design"),
+            Some("C02".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "slack", "engineering"),
+            Some("C0B0QV5434G".into())
+        );
+    }
+
+    #[test]
+    fn resolve_channel_name_ambiguous_prefix_returns_none_and_display_suffixes_work() {
+        let tmp = tempdir().expect("tmp");
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            "slack".into(),
+            vec![
+                ChannelEntry::new("slack", "C01", "eng-backend").with_kind("channel"),
+                ChannelEntry::new("slack", "C02", "eng-frontend").with_kind("channel"),
+            ],
+        );
+        platforms.insert(
+            "telegram".into(),
+            vec![
+                ChannelEntry::new("telegram", "123", "Alice").with_kind("dm"),
+                ChannelEntry::new("telegram", "456", "Dev Group").with_kind("group"),
+                ChannelEntry::new("telegram", "-1001:17585", "Coaching Chat / topic 17585")
+                    .with_kind("group"),
+            ],
+        );
+        let path = write_directory(tmp.path(), platforms);
+
+        assert_eq!(resolve_channel_name_from(&path, "slack", "eng"), None);
+        assert_eq!(
+            resolve_channel_name_from(&path, "telegram", "Alice (dm)"),
+            Some("123".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "telegram", "Dev Group (group)"),
+            Some("456".into())
+        );
+        assert_eq!(
+            resolve_channel_name_from(&path, "telegram", "Coaching Chat / topic 17585 (group)"),
+            Some("-1001:17585".into())
+        );
+    }
+
+    #[test]
+    fn build_from_sessions_dedupes_and_preserves_distinct_topics() {
+        let tmp = tempdir().expect("tmp");
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+        std::fs::write(
+            sessions_dir.join("sessions.json"),
+            serde_json::json!({
+                "group_root": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat"}, "chat_type": "group"},
+                "topic_a": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat", "thread_id": "17585"}, "chat_type": "group"},
+                "topic_b": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat", "thread_id": "17587"}, "chat_type": "group"},
+                "dup": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat"}, "chat_type": "group"},
+                "discord": {"origin": {"platform": "discord", "chat_id": "999"}}
+            })
+            .to_string(),
+        )
+        .expect("write sessions");
+
+        let entries = build_from_sessions_in(tmp.path(), "telegram");
+        let ids: BTreeSet<String> = entries.iter().map(|entry| entry.id.clone()).collect();
+        let names: BTreeSet<String> = entries.iter().map(|entry| entry.name.clone()).collect();
+        assert_eq!(
+            ids,
+            BTreeSet::from(["-1001".into(), "-1001:17585".into(), "-1001:17587".into()])
+        );
+        assert!(names.contains("Coaching Chat"));
+        assert!(names.contains("Coaching Chat / topic 17585"));
+        assert!(names.contains("Coaching Chat / topic 17587"));
+    }
+
+    #[test]
+    fn lookup_channel_type_and_format_display() {
+        let tmp = tempdir().expect("tmp");
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            "discord".into(),
+            vec![
+                ChannelEntry::new("discord", "1", "general")
+                    .with_guild("Server1")
+                    .with_kind("channel"),
+                ChannelEntry::new("discord", "2", "ideas")
+                    .with_guild("Server1")
+                    .with_kind("forum"),
+                ChannelEntry::new("discord", "3", "chat")
+                    .with_guild("Server2")
+                    .with_kind("channel"),
+            ],
+        );
+        platforms.insert(
+            "telegram".into(),
+            vec![ChannelEntry::new("telegram", "123", "Alice").with_kind("dm")],
+        );
+        let path = write_directory(tmp.path(), platforms);
+
+        assert_eq!(
+            lookup_channel_type_from(&path, "discord", "2"),
+            Some("forum".into())
+        );
+        assert_eq!(lookup_channel_type_from(&path, "discord", "999"), None);
+        let display = format_directory_for_display_from(&path);
+        assert!(display.contains("Discord (Server1):"));
+        assert!(display.contains("Discord (Server2):"));
+        assert!(display.contains("discord:#general"));
+        assert!(display.contains("Telegram:"));
+        assert!(display.contains("telegram:Alice (dm)"));
+    }
+
+    #[tokio::test]
+    async fn provider_errors_do_not_block_session_discovery_and_success_merges_sessions() {
+        let tmp = tempdir().expect("tmp");
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+        std::fs::write(
+            sessions_dir.join("sessions.json"),
+            serde_json::json!({
+                "slack_dm": {"origin": {"platform": "slack", "chat_id": "D456", "chat_name": "Bob"}},
+                "slack_dup": {"origin": {"platform": "slack", "chat_id": "C001", "chat_name": "first"}}
+            })
+            .to_string(),
+        )
+        .expect("write sessions");
+
+        let path = tmp.path().join("channel_directory.json");
+        let provider: Arc<dyn ChannelDirectoryProvider> = Arc::new(StaticProvider {
+            platform: "slack",
+            entries: vec![ChannelEntry::new("slack", "C001", "first").with_kind("channel")],
+        });
+        let snapshot =
+            build_channel_directory_from_providers_at(&path, tmp.path(), &[provider]).await;
+        let ids: BTreeSet<String> = snapshot.platforms["slack"]
+            .iter()
+            .map(|entry| entry.id.clone())
+            .collect();
+        assert_eq!(ids, BTreeSet::from(["C001".into(), "D456".into()]));
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let failing: Arc<dyn ChannelDirectoryProvider> = Arc::new(FailingProvider {
+            calls: calls.clone(),
+        });
+        let snapshot =
+            build_channel_directory_from_providers_at(&path, tmp.path(), &[failing]).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            snapshot.platforms["slack"]
+                .iter()
+                .map(|entry| entry.id.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["D456".into(), "C001".into()])
+        );
+    }
+
+    #[test]
+    fn empty_directory_display_mentions_no_platforms() {
+        let tmp = tempdir().expect("tmp");
+        assert!(
+            format_directory_for_display_from(tmp.path().join("missing.json"))
+                .contains("No messaging platforms")
+        );
     }
 }

--- a/crates/hermes-gateway/src/delivery.rs
+++ b/crates/hermes-gateway/src/delivery.rs
@@ -1,10 +1,11 @@
 //! Delivery queue and router for deferred platform sends.
 //!
-//! Provides a `DeliveryQueue` for queuing messages, a `DeliveryTarget` enum
+//! Provides a `DeliveryQueue` for queuing messages, a `DeliveryTarget`
 //! for specifying where messages should be routed, and a `DeliveryRouter`
 //! that holds registered adapters and dispatches messages accordingly.
 
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -61,40 +62,227 @@ impl DeliveryQueue {
 // DeliveryTarget
 // ---------------------------------------------------------------------------
 
+/// Source information used when resolving an `origin` delivery target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliveryOrigin {
+    pub platform: String,
+    pub chat_id: String,
+    pub thread_id: Option<String>,
+}
+
+impl DeliveryOrigin {
+    pub fn new(platform: impl Into<String>, chat_id: impl Into<String>) -> Self {
+        Self {
+            platform: platform.into(),
+            chat_id: chat_id.into(),
+            thread_id: None,
+        }
+    }
+
+    pub fn with_thread(
+        platform: impl Into<String>,
+        chat_id: impl Into<String>,
+        thread_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform: platform.into(),
+            chat_id: chat_id.into(),
+            thread_id: Some(thread_id.into()),
+        }
+    }
+}
+
 /// Specifies where a message should be delivered.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DeliveryTarget {
-    /// Send back to the originating platform/chat.
-    Origin,
-    /// Deliver to the local agent (e.g., for internal processing).
-    Local,
-    /// Deliver to a specific platform and chat.
-    Platform { name: String, chat_id: String },
+pub struct DeliveryTarget {
+    /// Normalized platform name (`local`, `telegram`, `discord`, ...).
+    pub platform: String,
+    /// Platform channel/chat identifier. `None` means the platform home target.
+    pub chat_id: Option<String>,
+    /// Optional thread/topic identifier for platforms that support threaded sends.
+    pub thread_id: Option<String>,
+    /// True when this target was parsed from `origin`.
+    pub is_origin: bool,
+    /// True when a chat/channel id was explicitly supplied in the target string.
+    pub is_explicit: bool,
+}
+
+impl DeliveryTarget {
+    pub fn local() -> Self {
+        Self {
+            platform: "local".to_string(),
+            chat_id: None,
+            thread_id: None,
+            is_origin: false,
+            is_explicit: false,
+        }
+    }
+
+    pub fn origin_fallback() -> Self {
+        Self {
+            is_origin: true,
+            ..Self::local()
+        }
+    }
+
+    pub fn platform_home(name: impl AsRef<str>) -> Self {
+        Self {
+            platform: normalize_platform(name.as_ref()),
+            chat_id: None,
+            thread_id: None,
+            is_origin: false,
+            is_explicit: false,
+        }
+    }
+
+    pub fn platform_chat(name: impl AsRef<str>, chat_id: impl Into<String>) -> Self {
+        Self {
+            platform: normalize_platform(name.as_ref()),
+            chat_id: Some(chat_id.into()),
+            thread_id: None,
+            is_origin: false,
+            is_explicit: true,
+        }
+    }
+
+    pub fn platform_thread(
+        name: impl AsRef<str>,
+        chat_id: impl Into<String>,
+        thread_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform: normalize_platform(name.as_ref()),
+            chat_id: Some(chat_id.into()),
+            thread_id: Some(thread_id.into()),
+            is_origin: false,
+            is_explicit: true,
+        }
+    }
+
+    pub fn parse(target_str: &str) -> Self {
+        Self::parse_with_origin(target_str, None)
+    }
+
+    pub fn parse_with_origin(target_str: &str, origin: Option<&DeliveryOrigin>) -> Self {
+        let trimmed = target_str.trim();
+        if trimmed.eq_ignore_ascii_case("origin") {
+            return origin.map_or_else(Self::origin_fallback, |origin| Self {
+                platform: normalize_platform(&origin.platform),
+                chat_id: Some(origin.chat_id.clone()),
+                thread_id: origin.thread_id.clone(),
+                is_origin: true,
+                is_explicit: false,
+            });
+        }
+
+        if trimmed.eq_ignore_ascii_case("local") || trimmed.is_empty() {
+            return Self::local();
+        }
+
+        if let Some((platform_raw, rest)) = trimmed.split_once(':') {
+            let platform = normalize_platform(platform_raw);
+            if !is_known_platform(&platform) {
+                return Self::local();
+            }
+
+            let mut parts = rest.splitn(2, ':');
+            let chat_id = parts.next().map(str::trim).filter(|s| !s.is_empty());
+            let thread_id = parts.next().map(str::trim).filter(|s| !s.is_empty());
+
+            return match (chat_id, thread_id) {
+                (Some(chat_id), Some(thread_id)) => {
+                    Self::platform_thread(platform, chat_id.to_string(), thread_id.to_string())
+                }
+                (Some(chat_id), None) => Self::platform_chat(platform, chat_id.to_string()),
+                (None, _) => Self::platform_home(platform),
+            };
+        }
+
+        let platform = normalize_platform(trimmed);
+        if is_known_platform(&platform) {
+            Self::platform_home(platform)
+        } else {
+            Self::local()
+        }
+    }
+
+    pub fn is_local(&self) -> bool {
+        self.platform == "local"
+    }
+
+    pub fn target_label(&self) -> String {
+        if self.is_origin {
+            return "origin".to_string();
+        }
+        if self.is_local() {
+            return "local".to_string();
+        }
+        match (&self.chat_id, &self.thread_id) {
+            (Some(chat_id), Some(thread_id)) => {
+                format!("{}:{}:{}", self.platform, chat_id, thread_id)
+            }
+            (Some(chat_id), None) => format!("{}:{}", self.platform, chat_id),
+            (None, _) => self.platform.clone(),
+        }
+    }
+}
+
+impl fmt::Display for DeliveryTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.target_label())
+    }
+}
+
+fn normalize_platform(name: &str) -> String {
+    name.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+fn is_known_platform(name: &str) -> bool {
+    matches!(
+        name,
+        "local"
+            | "telegram"
+            | "discord"
+            | "slack"
+            | "whatsapp"
+            | "signal"
+            | "matrix"
+            | "mattermost"
+            | "dingtalk"
+            | "feishu"
+            | "wecom"
+            | "wecom_callback"
+            | "weixin"
+            | "qqbot"
+            | "qq"
+            | "bluebubbles"
+            | "email"
+            | "sms"
+            | "homeassistant"
+            | "ntfy"
+            | "api_server"
+            | "webhook"
+    )
 }
 
 /// Parse a target string into a `DeliveryTarget`.
 ///
 /// Supported formats:
-/// - `"origin"` -> `DeliveryTarget::Origin`
-/// - `"local"` -> `DeliveryTarget::Local`
-/// - `"telegram:12345"` -> `DeliveryTarget::Platform { name: "telegram", chat_id: "12345" }`
-/// - `"discord:channel_id"` -> `DeliveryTarget::Platform { name: "discord", chat_id: "channel_id" }`
+/// - `"origin"` -> local fallback unless origin metadata is supplied
+/// - `"local"` -> local queue
+/// - `"telegram:12345"` -> explicit Telegram chat
+/// - `"discord"` -> Discord home target
+/// - `"slack:C123ABC:thread123"` -> explicit Slack channel/thread
 pub fn parse_target(target_str: &str) -> DeliveryTarget {
-    let trimmed = target_str.trim();
-    if trimmed.eq_ignore_ascii_case("origin") {
-        return DeliveryTarget::Origin;
-    }
-    if trimmed.eq_ignore_ascii_case("local") {
-        return DeliveryTarget::Local;
-    }
-    if let Some((name_raw, chat_id_raw)) = trimmed.split_once(':') {
-        DeliveryTarget::Platform {
-            name: name_raw.trim().to_ascii_lowercase(),
-            chat_id: chat_id_raw.trim().to_string(),
-        }
-    } else {
-        DeliveryTarget::Origin
-    }
+    DeliveryTarget::parse(target_str)
+}
+
+/// Parse a target string and resolve `origin` using explicit source metadata.
+pub fn parse_target_with_origin(
+    target_str: &str,
+    origin: Option<&DeliveryOrigin>,
+) -> DeliveryTarget {
+    DeliveryTarget::parse_with_origin(target_str, origin)
 }
 
 // ---------------------------------------------------------------------------
@@ -136,9 +324,9 @@ impl DeliveryRouter {
 
     /// Route a delivery to the appropriate target.
     ///
-    /// - `Origin` target requires `origin_platform` and `origin_chat_id` to be provided.
-    /// - `Local` target enqueues to the fallback queue for internal processing.
-    /// - `Platform` target sends directly to the named adapter.
+    /// - `origin` targets use explicit origin args when supplied, otherwise their parsed source.
+    /// - `local` targets enqueue to the fallback queue for internal processing.
+    /// - Platform targets with explicit chat IDs send directly to the named adapter.
     pub async fn route_delivery(
         &self,
         target: &DeliveryTarget,
@@ -146,31 +334,35 @@ impl DeliveryRouter {
         origin_platform: Option<&str>,
         origin_chat_id: Option<&str>,
     ) -> Result<(), GatewayError> {
-        match target {
-            DeliveryTarget::Origin => {
-                let platform_name = origin_platform.ok_or_else(|| {
-                    GatewayError::SendFailed(
-                        "Origin target but no origin platform specified".into(),
-                    )
-                })?;
-                let chat_id = origin_chat_id.ok_or_else(|| {
-                    GatewayError::SendFailed("Origin target but no origin chat_id specified".into())
-                })?;
-                self.send_to_platform(platform_name, chat_id, message).await
-            }
-            DeliveryTarget::Local => {
-                self.fallback_queue.enqueue(DeliveryItem {
-                    platform: "local".to_string(),
-                    chat_id: "local".to_string(),
-                    text: message.to_string(),
-                });
-                debug!("Message enqueued to local delivery queue");
-                Ok(())
-            }
-            DeliveryTarget::Platform { name, chat_id } => {
-                self.send_to_platform(name, chat_id, message).await
-            }
+        let platform_name = origin_platform
+            .filter(|_| target.is_origin)
+            .unwrap_or(target.platform.as_str());
+        let chat_id = origin_chat_id
+            .filter(|_| target.is_origin)
+            .or(target.chat_id.as_deref());
+
+        if platform_name == "local" {
+            self.enqueue_local(message);
+            return Ok(());
         }
+
+        if let Some(chat_id) = chat_id {
+            self.send_to_platform(platform_name, chat_id, message).await
+        } else {
+            Err(GatewayError::SendFailed(format!(
+                "Delivery target '{}' has no chat_id/home channel configured",
+                target
+            )))
+        }
+    }
+
+    fn enqueue_local(&self, message: &str) {
+        self.fallback_queue.enqueue(DeliveryItem {
+            platform: "local".to_string(),
+            chat_id: "local".to_string(),
+            text: message.to_string(),
+        });
+        debug!("Message enqueued to local delivery queue");
     }
 
     /// Send a message to a specific platform adapter.
@@ -218,32 +410,30 @@ impl DeliveryRouter {
         origin_platform: Option<&str>,
         origin_chat_id: Option<&str>,
     ) -> Result<(), GatewayError> {
-        let (platform_name, chat_id) = match target {
-            DeliveryTarget::Origin => {
-                let p = origin_platform.ok_or_else(|| {
-                    GatewayError::SendFailed("Origin target but no origin platform".into())
-                })?;
-                let c = origin_chat_id.ok_or_else(|| {
-                    GatewayError::SendFailed("Origin target but no origin chat_id".into())
-                })?;
-                (p, c)
-            }
-            DeliveryTarget::Local => {
-                debug!("File delivery to local is not supported, queueing as text");
-                let msg = format!(
-                    "[file:{}]{}",
-                    file_path,
-                    caption.map(|c| format!(" {c}")).unwrap_or_default()
-                );
-                self.fallback_queue.enqueue(DeliveryItem {
-                    platform: "local".to_string(),
-                    chat_id: "local".to_string(),
-                    text: msg,
-                });
-                return Ok(());
-            }
-            DeliveryTarget::Platform { name, chat_id } => (name.as_str(), chat_id.as_str()),
-        };
+        let platform_name = origin_platform
+            .filter(|_| target.is_origin)
+            .unwrap_or(target.platform.as_str());
+        let chat_id = origin_chat_id
+            .filter(|_| target.is_origin)
+            .or(target.chat_id.as_deref());
+
+        if platform_name == "local" {
+            debug!("File delivery to local is not supported, queueing as text");
+            let msg = format!(
+                "[file:{}]{}",
+                file_path,
+                caption.map(|c| format!(" {c}")).unwrap_or_default()
+            );
+            self.enqueue_local(&msg);
+            return Ok(());
+        }
+
+        let chat_id = chat_id.ok_or_else(|| {
+            GatewayError::SendFailed(format!(
+                "File delivery target '{}' has no chat_id/home channel configured",
+                target
+            ))
+        })?;
 
         let adapters = self.adapters.read().await;
         match adapters.get(platform_name) {
@@ -273,47 +463,66 @@ mod tests {
 
     #[test]
     fn test_parse_target_origin() {
-        assert_eq!(parse_target("origin"), DeliveryTarget::Origin);
-        assert_eq!(parse_target("ORIGIN"), DeliveryTarget::Origin);
+        let target = parse_target("origin");
+        assert_eq!(target.platform, "local");
+        assert!(target.is_origin);
+        assert_eq!(target.to_string(), "origin");
+
+        let origin = DeliveryOrigin::with_thread("TELEGRAM", "789", "42");
+        let resolved = parse_target_with_origin("ORIGIN", Some(&origin));
+        assert_eq!(resolved.platform, "telegram");
+        assert_eq!(resolved.chat_id.as_deref(), Some("789"));
+        assert_eq!(resolved.thread_id.as_deref(), Some("42"));
+        assert!(resolved.is_origin);
     }
 
     #[test]
     fn test_parse_target_local() {
-        assert_eq!(parse_target("local"), DeliveryTarget::Local);
+        let target = parse_target("local");
+        assert_eq!(target.platform, "local");
+        assert_eq!(target.chat_id, None);
+        assert!(!target.is_origin);
     }
 
     #[test]
     fn test_parse_target_platform() {
-        assert_eq!(
-            parse_target("telegram:12345"),
-            DeliveryTarget::Platform {
-                name: "telegram".into(),
-                chat_id: "12345".into()
-            }
-        );
-        assert_eq!(
-            parse_target("discord:channel_abc"),
-            DeliveryTarget::Platform {
-                name: "discord".into(),
-                chat_id: "channel_abc".into()
-            }
-        );
+        let telegram = parse_target("telegram:12345");
+        assert_eq!(telegram.platform, "telegram");
+        assert_eq!(telegram.chat_id.as_deref(), Some("12345"));
+        assert!(telegram.is_explicit);
+
+        let discord = parse_target("discord");
+        assert_eq!(discord.platform, "discord");
+        assert_eq!(discord.chat_id, None);
+        assert!(!discord.is_explicit);
     }
 
     #[test]
     fn test_parse_target_platform_preserves_chat_id_case() {
-        assert_eq!(
-            parse_target("SLACK:ChanID-AbC123"),
-            DeliveryTarget::Platform {
-                name: "slack".into(),
-                chat_id: "ChanID-AbC123".into()
-            }
-        );
+        let target = parse_target("SLACK:ChanID-AbC123");
+        assert_eq!(target.platform, "slack");
+        assert_eq!(target.chat_id.as_deref(), Some("ChanID-AbC123"));
+        assert_eq!(target.to_string(), "slack:ChanID-AbC123");
+    }
+
+    #[test]
+    fn test_parse_target_thread_preserves_case_and_limits_split() {
+        let target = parse_target("slack:C123ABC:thread123");
+        assert_eq!(target.platform, "slack");
+        assert_eq!(target.chat_id.as_deref(), Some("C123ABC"));
+        assert_eq!(target.thread_id.as_deref(), Some("thread123"));
+        assert_eq!(target.to_string(), "slack:C123ABC:thread123");
+
+        let matrix = parse_target("matrix:!RoomABC:example.org");
+        assert_eq!(matrix.platform, "matrix");
+        assert_eq!(matrix.chat_id.as_deref(), Some("!RoomABC"));
+        assert_eq!(matrix.thread_id.as_deref(), Some("example.org"));
     }
 
     #[test]
     fn test_parse_target_fallback() {
-        assert_eq!(parse_target("unknown"), DeliveryTarget::Origin);
+        assert_eq!(parse_target("unknown").platform, "local");
+        assert_eq!(parse_target("unknown:123").platform, "local");
     }
 
     #[test]

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -54,7 +54,10 @@ pub use ssrf::{is_safe_url, validate_url};
 
 // Re-export DM management
 pub use channel_directory::{ChannelDirectory, ChannelEntry};
-pub use delivery::{parse_target, DeliveryItem, DeliveryQueue, DeliveryRouter, DeliveryTarget};
+pub use delivery::{
+    parse_target, parse_target_with_origin, DeliveryItem, DeliveryOrigin, DeliveryQueue,
+    DeliveryRouter, DeliveryTarget,
+};
 pub use dm::{DmDecision, DmManager};
 pub use mirror::MirrorManager;
 pub use pairing::{PairingManager, PairingState};

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -21,6 +21,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{describe_secret, AdapterProxyConfig, BasePlatformAdapter};
+use crate::channel_directory::{ChannelDirectoryProvider, ChannelEntry};
 
 /// Slack Web API base URL.
 const SLACK_API_BASE: &str = "https://slack.com/api";
@@ -73,6 +74,33 @@ pub struct SlackResponse {
     pub ts: Option<String>,
     #[serde(default)]
     pub channel: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub channels: Vec<SlackConversation>,
+    #[serde(default)]
+    pub response_metadata: SlackResponseMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SlackResponseMetadata {
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversation {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub is_private: bool,
 }
 
 /// Response for `users.info`.
@@ -1040,6 +1068,83 @@ impl SlackAdapter {
         Ok(())
     }
 
+    /// List channels visible to the bot user for channel-directory discovery.
+    pub async fn list_user_conversations(&self) -> Result<Vec<ChannelEntry>, GatewayError> {
+        self.list_user_conversations_from_base(SLACK_API_BASE).await
+    }
+
+    async fn list_user_conversations_from_base(
+        &self,
+        base_url: &str,
+    ) -> Result<Vec<ChannelEntry>, GatewayError> {
+        let endpoint = format!("{}/users.conversations", base_url.trim_end_matches('/'));
+        let mut cursor: Option<String> = None;
+        let mut entries = Vec::new();
+
+        loop {
+            let mut query = vec![
+                ("types", "public_channel,private_channel".to_string()),
+                ("limit", "200".to_string()),
+            ];
+            if let Some(cursor) = cursor.as_deref().filter(|cursor| !cursor.is_empty()) {
+                query.push(("cursor", cursor.to_string()));
+            }
+
+            let resp = self
+                .client
+                .get(&endpoint)
+                .header("Authorization", format!("Bearer {}", self.config.token))
+                .query(&query)
+                .send()
+                .await
+                .map_err(|e| {
+                    GatewayError::ConnectionFailed(format!(
+                        "Slack users.conversations failed: {}",
+                        e
+                    ))
+                })?;
+
+            let page: SlackConversationsResponse = resp.json().await.map_err(|e| {
+                GatewayError::ConnectionFailed(format!(
+                    "Failed to parse Slack users.conversations response: {}",
+                    e
+                ))
+            })?;
+
+            if !page.ok {
+                return Err(GatewayError::ConnectionFailed(format!(
+                    "Slack users.conversations error: {}",
+                    page.error.unwrap_or_else(|| "unknown".into())
+                )));
+            }
+
+            for channel in page.channels {
+                let Some(id) = channel.id.filter(|id| !id.is_empty()) else {
+                    continue;
+                };
+                let Some(name) = channel.name.filter(|name| !name.is_empty()) else {
+                    continue;
+                };
+                let kind = if channel.is_private {
+                    "private"
+                } else {
+                    "channel"
+                };
+                entries.push(ChannelEntry::new("slack", id, name).with_kind(kind));
+            }
+
+            cursor = page
+                .response_metadata
+                .next_cursor
+                .filter(|cursor| !cursor.is_empty());
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        Ok(entries)
+    }
+
     // -----------------------------------------------------------------------
     // Web API: Permalinks
     // -----------------------------------------------------------------------
@@ -1116,6 +1221,17 @@ impl SlackAdapter {
         }
 
         Ok(result)
+    }
+}
+
+#[async_trait]
+impl ChannelDirectoryProvider for SlackAdapter {
+    fn platform_name(&self) -> &str {
+        "slack"
+    }
+
+    async fn list_channel_entries(&self) -> Result<Vec<ChannelEntry>, GatewayError> {
+        self.list_user_conversations().await
     }
 }
 
@@ -1278,6 +1394,8 @@ fn slack_image_url_blocks(image_url: &str, caption: Option<&str>) -> (serde_json
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // --- Original tests (preserved) ---
 
@@ -1700,6 +1818,90 @@ mod tests {
             serde_json::from_value(serde_json::json!({ "ok": false, "error": "user_not_found" }))
                 .unwrap();
         assert_eq!(err.error.as_deref(), Some("user_not_found"));
+    }
+
+    #[tokio::test]
+    async fn list_user_conversations_paginates_and_skips_invalid_channels() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users.conversations"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "channels": [
+                    {"id": "C001", "name": "first", "is_private": false},
+                    {"id": "", "name": "no-id"},
+                    {"id": "C002"}
+                ],
+                "response_metadata": {"next_cursor": "cur1"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/users.conversations"))
+            .and(query_param("cursor", "cur1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "channels": [
+                    {"id": "G123", "name": "secret-chat", "is_private": true}
+                ],
+                "response_metadata": {"next_cursor": ""}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = SlackAdapter::new(SlackConfig {
+            token: "xoxb-test-token".into(),
+            app_token: None,
+            socket_mode: false,
+            reactions: true,
+            proxy: AdapterProxyConfig::default(),
+        })
+        .expect("adapter");
+
+        let entries = adapter
+            .list_user_conversations_from_base(&server.uri())
+            .await
+            .expect("conversations");
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["C001", "G123"]
+        );
+        assert_eq!(entries[0].kind.as_deref(), Some("channel"));
+        assert_eq!(entries[1].kind.as_deref(), Some("private"));
+    }
+
+    #[tokio::test]
+    async fn list_user_conversations_not_ok_returns_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users.conversations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": false,
+                "error": "missing_scope"
+            })))
+            .mount(&server)
+            .await;
+
+        let adapter = SlackAdapter::new(SlackConfig {
+            token: "xoxb-test-token".into(),
+            app_token: None,
+            socket_mode: false,
+            reactions: true,
+            proxy: AdapterProxyConfig::default(),
+        })
+        .expect("adapter");
+
+        let err = adapter
+            .list_user_conversations_from_base(&server.uri())
+            .await
+            .expect_err("missing scope");
+        assert!(err.to_string().contains("missing_scope"));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T10:26:22.668305+00:00",
+  "generated_at_utc": "2026-05-31T19:07:36.702544+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T10:26:22.668305+00:00`
+Generated: `2026-05-31T19:07:36.702544+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3586,17 +3586,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_channel_directory.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "cdaf2c540c356c91fd97791e80a23f753963cf18",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_channel_directory.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "18e8ae2fb09e11260dd5fe958258a4484d712360",
       "workstream": "WS6"
     },
@@ -3691,17 +3691,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_delivery.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "36422312dd94017b652111b18284f107c2bec4c5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_delivery.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "f94836e315911572fc826768eccf4b9e3d7f0f0f",
       "workstream": "WS6"
     },
@@ -15466,29 +15466,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T10:26:22.729802+00:00",
+  "generated_at_utc": "2026-05-31T19:07:30.909099+00:00",
   "refs": {
-    "local_ref": "HEAD",
-    "local_sha": "05dcc204cc0613dadbff360b0ededffc2fcf5417",
+    "local_ref": "main",
+    "local_sha": "01fc2facc93c38cef273bb46fb47a35a1184a21d",
     "upstream_ref": "upstream/main",
     "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 601,
-      "intentional_divergence": 260,
+      "functional": 599,
+      "intentional_divergence": 262,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 430,
-      "rust_equivalent_or_contract_test_required": 520,
+      "not_required_for_runtime": 432,
+      "rust_equivalent_or_contract_test_required": 518,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 260,
+      "cleared_intentional_divergence": 262,
       "cleared_non_runtime": 170,
-      "pending_review": 601
+      "pending_review": 599
     },
     "by_workstream": {
       "WS3": 56,
@@ -15497,10 +15497,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 260,
+    "cleared_intentional_divergence": 262,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 601,
+    "pending_review": 599,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T10:26:22.729802+00:00`
+Generated: `2026-05-31T19:07:30.909099+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `601`
+- Pending functional review: `599`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `260`
+- Cleared intentional divergence: `262`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 260 |
+| `cleared_intentional_divergence` | 262 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 601 |
+| `pending_review` | 599 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-31T10:26:22.729802+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 129 |
+| `tests/gateway` | 127 |
 | `tests/hermes_cli` | 120 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -178,6 +178,20 @@
       "ticket": 302
     },
     {
+      "path": "tests/gateway/test_delivery.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream delivery target parsing is covered by Rust DeliveryTarget tests for origin resolution, local fallback, platform-home targets, explicit chat IDs, thread IDs, case-insensitive platform names, case-preserving chat IDs, Matrix-style colon splitting, target string roundtrips, and unknown-platform local fallback.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_channel_directory.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream channel-directory cache behavior is covered by Rust tests for missing/corrupt load fallback, atomic writes, session-derived channel discovery with topic composite IDs, exact/display/guild/prefix/id resolution, channel-type lookup, display formatting, provider error isolation, provider/session merge dedupe, and Slack users.conversations pagination.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/gateway/test_platform_http_client_limits.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream persistent-platform HTTP pool limits are covered by Rust BasePlatformAdapter reqwest pool-limit tests for default keepalive tightening, env overrides, malformed env fallback, and shared builder use by long-lived adapters; Python httpx import failure and aiohttp response-leak checks are not part of the Rust runtime.",


### PR DESCRIPTION
## Summary
- add Rust-native `DeliveryTarget` semantics for origin/local/platform-home/explicit chat/thread targets, including case-preserving chat IDs and case-insensitive platform parsing
- replace the gateway channel directory stub with a disk-backed `$HERMES_HOME/channel_directory.json` cache, atomic writes, session-derived discovery, display/lookup helpers, and a provider trait
- add Slack `users.conversations` pagination for channel-directory discovery and update the parity ledger for `test_delivery.py` and `test_channel_directory.py`

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, stale allowlist entries unchanged)
- `cargo test -p hermes-gateway --no-default-features delivery`
- `cargo test -p hermes-gateway --no-default-features channel_directory`
- `cargo test -p hermes-gateway --features slack list_user_conversations`
- `cargo build --workspace`
- `cargo test --workspace`

## Parity Ledger
- `pending_review`: `601` -> `599`
- `cleared_intentional_divergence`: `260` -> `262`
