### PR TITLE
parity(gateway): harden access-control contracts

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -51,7 +51,7 @@ use hermes_cli::App;
 use hermes_config::{
     apply_user_config_patch, gateway_pid_path_in, hermes_home, load_config, load_user_config_file,
     save_config_yaml, state_dir, user_config_field_display, validate_config, ConfigError,
-    GatewayConfig, PlatformConfig,
+    GatewayConfig, PlatformConfig, UnauthorizedDmBehavior,
 };
 use hermes_core::AgentError;
 use hermes_core::PlatformAdapter;
@@ -2700,6 +2700,13 @@ async fn run_gateway(
                 println!(
                     "Note: no chat platforms enabled in config.yaml — gateway still runs cron + HTTP webhooks."
                 );
+            } else if gateway_allowlist_startup_would_warn(&config) {
+                tracing::warn!(
+                    "No gateway user allowlist or allow-all override configured; set platform *_ALLOWED_USERS or explicit *_ALLOW_ALL_USERS to silence this warning"
+                );
+                println!(
+                    "Warning: no gateway user allowlist configured. Set platform *_ALLOWED_USERS or explicit *_ALLOW_ALL_USERS=true if this is intentional."
+                );
             }
             let requirement_issues = gateway_requirement_issues(&config);
             if !requirement_issues.is_empty() {
@@ -4260,21 +4267,138 @@ fn discord_allow_bots_bypasses_gateway_allowlist(
 
 fn build_gateway_dm_manager(config: &hermes_config::GatewayConfig) -> DmManager {
     let mut dm_manager = DmManager::with_pair_behavior();
-    for platform_cfg in config.platforms.values().filter(|p| p.enabled) {
+    for (platform, platform_cfg) in config.platforms.iter().filter(|(_, p)| p.enabled) {
+        let mut has_platform_allowlist = false;
         for user in &platform_cfg.allowed_users {
             let trimmed = user.trim();
             if !trimmed.is_empty() {
-                dm_manager.authorize_user(trimmed.to_string());
+                has_platform_allowlist = true;
+                dm_manager.authorize_user_for_platform(platform, trimmed.to_string());
             }
         }
         for admin in &platform_cfg.admin_users {
             let trimmed = admin.trim();
             if !trimmed.is_empty() {
-                dm_manager.add_admin(trimmed.to_string());
+                has_platform_allowlist = true;
+                dm_manager.add_admin_for_platform(platform, trimmed.to_string());
             }
         }
+        let behavior = if platform_cfg.unauthorized_dm_behavior == UnauthorizedDmBehavior::Pair {
+            UnauthorizedDmBehavior::Pair
+        } else if has_platform_allowlist {
+            UnauthorizedDmBehavior::Ignore
+        } else {
+            UnauthorizedDmBehavior::Pair
+        };
+        dm_manager.set_platform_unauthorized_behavior(platform, behavior);
     }
     dm_manager
+}
+
+const GATEWAY_USER_ALLOWLIST_ENV_VARS: &[&str] = &[
+    "TELEGRAM_ALLOWED_USERS",
+    "TELEGRAM_GROUP_ALLOWED_USERS",
+    "DISCORD_ALLOWED_USERS",
+    "WHATSAPP_ALLOWED_USERS",
+    "SLACK_ALLOWED_USERS",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "EMAIL_ALLOWED_USERS",
+    "SMS_ALLOWED_USERS",
+    "MATTERMOST_ALLOWED_USERS",
+    "MATRIX_ALLOWED_USERS",
+    "DINGTALK_ALLOWED_USERS",
+    "FEISHU_ALLOWED_USERS",
+    "WECOM_ALLOWED_USERS",
+    "QQ_ALLOWED_USERS",
+    "QQ_GROUP_ALLOWED_USERS",
+    "GATEWAY_ALLOWED_USERS",
+];
+
+const GATEWAY_ALLOW_ALL_ENV_VARS: &[&str] = &[
+    "GATEWAY_ALLOW_ALL_USERS",
+    "TELEGRAM_ALLOW_ALL_USERS",
+    "DISCORD_ALLOW_ALL_USERS",
+    "WHATSAPP_ALLOW_ALL_USERS",
+    "SLACK_ALLOW_ALL_USERS",
+    "SIGNAL_ALLOW_ALL_USERS",
+    "EMAIL_ALLOW_ALL_USERS",
+    "SMS_ALLOW_ALL_USERS",
+    "MATTERMOST_ALLOW_ALL_USERS",
+    "MATRIX_ALLOW_ALL_USERS",
+    "DINGTALK_ALLOW_ALL_USERS",
+    "FEISHU_ALLOW_ALL_USERS",
+    "WECOM_ALLOW_ALL_USERS",
+    "QQ_ALLOW_ALL_USERS",
+];
+
+const GATEWAY_CONFIG_USER_ALLOWLIST_EXTRA_KEYS: &[&str] = &[
+    "group_allow_from",
+    "group_allowed_users",
+    "allowed_user_ids",
+    "allowed_senders",
+    "allowed_accounts",
+];
+
+fn env_value_truthy(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn string_list_has_non_empty(values: &[String]) -> bool {
+    values.iter().any(|value| !value.trim().is_empty())
+}
+
+fn gateway_platform_config_has_allowlist(platform_cfg: &PlatformConfig) -> bool {
+    string_list_has_non_empty(&platform_cfg.allowed_users)
+        || string_list_has_non_empty(&platform_cfg.admin_users)
+        || GATEWAY_CONFIG_USER_ALLOWLIST_EXTRA_KEYS
+            .iter()
+            .any(|key| !extra_string_set(platform_cfg, key).is_empty())
+}
+
+fn gateway_platform_config_allows_all_users(platform_cfg: &PlatformConfig) -> bool {
+    extra_bool_loose(platform_cfg, "allow_all_users").unwrap_or(false)
+}
+
+fn gateway_config_has_allowlist_or_allow_all(config: &GatewayConfig) -> bool {
+    config
+        .platforms
+        .values()
+        .filter(|platform_cfg| platform_cfg.enabled)
+        .any(|platform_cfg| {
+            gateway_platform_config_has_allowlist(platform_cfg)
+                || gateway_platform_config_allows_all_users(platform_cfg)
+        })
+}
+
+fn gateway_allowlist_startup_would_warn_from_lookup<F>(mut lookup: F) -> bool
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let any_allowlist = GATEWAY_USER_ALLOWLIST_ENV_VARS.iter().any(|key| {
+        lookup(key)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+    });
+    let allow_all = GATEWAY_ALLOW_ALL_ENV_VARS
+        .iter()
+        .any(|key| lookup(key).is_some_and(|value| env_value_truthy(&value)));
+    !any_allowlist && !allow_all
+}
+
+fn gateway_allowlist_startup_would_warn_with_lookup<F>(config: &GatewayConfig, lookup: F) -> bool
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    !gateway_config_has_allowlist_or_allow_all(config)
+        && gateway_allowlist_startup_would_warn_from_lookup(lookup)
+}
+
+fn gateway_allowlist_startup_would_warn(config: &GatewayConfig) -> bool {
+    gateway_allowlist_startup_would_warn_with_lookup(config, |key| std::env::var(key).ok())
 }
 
 fn parse_group_access_mode(platform_cfg: &PlatformConfig) -> GroupAccessMode {
@@ -4325,6 +4449,12 @@ fn build_gateway_platform_access_policies(
         if platform.eq_ignore_ascii_case("telegram") {
             allowed_channels.extend(extra_string_set(platform_cfg, "allowed_chats"));
             allowed_channels.extend(extra_string_set(platform_cfg, "group_allowed_chats"));
+        }
+        if platform.eq_ignore_ascii_case("dingtalk") {
+            allowed_channels.extend(extra_string_set(platform_cfg, "allowed_chats"));
+        }
+        if platform.eq_ignore_ascii_case("matrix") {
+            allowed_channels.extend(extra_string_set(platform_cfg, "allowed_rooms"));
         }
         let mut ignored_channels = extra_string_set(platform_cfg, "ignored_channels");
         if platform.eq_ignore_ascii_case("telegram") {
@@ -14629,6 +14759,145 @@ mod tests {
         assert!(policy.allowed_channels.contains("-300"));
         assert!(policy.ignored_channels.contains("31"));
         assert!(policy.ignored_channels.contains("32"));
+    }
+
+    #[test]
+    fn gateway_platform_access_policy_reads_dingtalk_and_matrix_aliases() {
+        let mut config = hermes_config::GatewayConfig::default();
+        let mut dingtalk = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        dingtalk.extra.insert(
+            "allowed_chats".to_string(),
+            serde_json::json!("cidABC,cidDEF"),
+        );
+        config.platforms.insert("dingtalk".to_string(), dingtalk);
+
+        let mut matrix = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        matrix.extra.insert(
+            "allowed_rooms".to_string(),
+            serde_json::json!(["!room1:srv", "!room2:srv"]),
+        );
+        config.platforms.insert("matrix".to_string(), matrix);
+
+        let policies = build_gateway_platform_access_policies(&config);
+        let dingtalk = policies.get("dingtalk").expect("dingtalk policy");
+        assert!(dingtalk.allowed_channels.contains("cidABC"));
+        assert!(dingtalk.allowed_channels.contains("cidDEF"));
+        let matrix = policies.get("matrix").expect("matrix policy");
+        assert!(matrix.allowed_channels.contains("!room1:srv"));
+        assert!(matrix.allowed_channels.contains("!room2:srv"));
+    }
+
+    #[tokio::test]
+    async fn gateway_dm_manager_scopes_configured_allowlists_by_platform() {
+        let mut config = hermes_config::GatewayConfig::default();
+        let mut telegram = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        telegram.allowed_users = vec!["123".to_string()];
+        config.platforms.insert("telegram".to_string(), telegram);
+
+        let dm = build_gateway_dm_manager(&config);
+        assert_eq!(
+            dm.handle_dm("123", "telegram").await,
+            hermes_gateway::DmDecision::Allow
+        );
+        assert!(matches!(
+            dm.handle_dm("123", "discord").await,
+            hermes_gateway::DmDecision::Pair { .. }
+        ));
+        assert_eq!(
+            dm.handle_dm("999", "telegram").await,
+            hermes_gateway::DmDecision::Deny
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_dm_manager_allows_explicit_pair_with_allowlist() {
+        let mut config = hermes_config::GatewayConfig::default();
+        let mut signal = PlatformConfig {
+            enabled: true,
+            unauthorized_dm_behavior: UnauthorizedDmBehavior::Pair,
+            ..PlatformConfig::default()
+        };
+        signal.allowed_users = vec!["+15550000001".to_string()];
+        config.platforms.insert("signal".to_string(), signal);
+
+        let dm = build_gateway_dm_manager(&config);
+        assert!(matches!(
+            dm.handle_dm("+15559999999", "signal").await,
+            hermes_gateway::DmDecision::Pair { .. }
+        ));
+    }
+
+    #[test]
+    fn gateway_allowlist_startup_warning_matches_env_contract() {
+        let env_lookup = |pairs: &[(&str, &str)]| {
+            let env = pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<std::collections::HashMap<_, _>>();
+            gateway_allowlist_startup_would_warn_from_lookup(|key| env.get(key).cloned())
+        };
+
+        assert!(env_lookup(&[]));
+        assert!(!env_lookup(&[("SIGNAL_GROUP_ALLOWED_USERS", "user1")]));
+        assert!(!env_lookup(&[("TELEGRAM_ALLOW_ALL_USERS", "true")]));
+        assert!(!env_lookup(&[("GATEWAY_ALLOW_ALL_USERS", "yes")]));
+        assert!(env_lookup(&[("GATEWAY_ALLOW_ALL_USERS", "no")]));
+
+        let empty_env = |_key: &str| -> Option<String> { None };
+        let mut config = hermes_config::GatewayConfig::default();
+        let mut telegram = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        assert!(gateway_allowlist_startup_would_warn_with_lookup(
+            &config, empty_env
+        ));
+
+        telegram.allowed_users = vec!["123".to_string()];
+        config.platforms.insert("telegram".to_string(), telegram);
+        assert!(!gateway_allowlist_startup_would_warn_with_lookup(
+            &config, empty_env
+        ));
+
+        let mut group_config = hermes_config::GatewayConfig::default();
+        let mut signal = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        signal.extra.insert(
+            "group_allow_from".to_string(),
+            serde_json::json!(["+15550000001"]),
+        );
+        group_config.platforms.insert("signal".to_string(), signal);
+        assert!(!gateway_allowlist_startup_would_warn_with_lookup(
+            &group_config,
+            empty_env
+        ));
+
+        let mut allow_all_config = hermes_config::GatewayConfig::default();
+        let mut discord = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        discord
+            .extra
+            .insert("allow_all_users".to_string(), serde_json::json!(true));
+        allow_all_config
+            .platforms
+            .insert("discord".to_string(), discord);
+        assert!(!gateway_allowlist_startup_would_warn_with_lookup(
+            &allow_all_config,
+            empty_env
+        ));
     }
 
     #[test]

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -242,6 +242,95 @@ fn apply_dingtalk_env(config: &mut GatewayConfig) {
     if let Some(v) = env_nonempty("DINGTALK_OPENAPI_ENDPOINT") {
         set_extra(dt, "openapi_endpoint", json!(v));
     }
+    if let Some(v) = env_nonempty("DINGTALK_ALLOWED_CHATS") {
+        set_extra(dt, "allowed_chats", json!(comma_list_to_strings(&v)));
+    }
+}
+
+fn apply_mattermost_env(config: &mut GatewayConfig) {
+    let server_url = env_nonempty("MATTERMOST_SERVER_URL");
+    let token = env_nonempty("MATTERMOST_TOKEN");
+    let team_id = env_nonempty("MATTERMOST_TEAM_ID");
+    let allowed_channels = env_nonempty("MATTERMOST_ALLOWED_CHANNELS");
+
+    if server_url.is_none() && token.is_none() && team_id.is_none() && allowed_channels.is_none() {
+        return;
+    }
+
+    let mattermost = config
+        .platforms
+        .entry("mattermost".into())
+        .or_insert_with(PlatformConfig::default);
+    if let Some(v) = server_url {
+        set_extra(mattermost, "server_url", json!(v));
+    }
+    if let Some(v) = token {
+        mattermost.token = Some(v);
+        let enabled_was_explicit = mattermost
+            .extra
+            .remove("_enabled_explicit")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !mattermost.enabled && !enabled_was_explicit {
+            mattermost.enabled = true;
+        }
+    }
+    if let Some(v) = team_id {
+        set_extra(mattermost, "team_id", json!(v));
+    }
+    if let Some(v) = allowed_channels {
+        set_extra(
+            mattermost,
+            "allowed_channels",
+            json!(comma_list_to_strings(&v)),
+        );
+    }
+}
+
+fn apply_matrix_env(config: &mut GatewayConfig) {
+    let homeserver_url = env_nonempty("MATRIX_HOMESERVER_URL");
+    let user_id = env_nonempty("MATRIX_USER_ID");
+    let access_token = env_nonempty("MATRIX_ACCESS_TOKEN");
+    let room_id = env_nonempty("MATRIX_ROOM_ID").or_else(|| env_nonempty("MATRIX_HOME_ROOM"));
+    let allowed_rooms = env_nonempty("MATRIX_ALLOWED_ROOMS");
+
+    if homeserver_url.is_none()
+        && user_id.is_none()
+        && access_token.is_none()
+        && room_id.is_none()
+        && allowed_rooms.is_none()
+    {
+        return;
+    }
+
+    let matrix = config
+        .platforms
+        .entry("matrix".into())
+        .or_insert_with(PlatformConfig::default);
+    if let Some(v) = homeserver_url {
+        set_extra(matrix, "homeserver_url", json!(v));
+    }
+    if let Some(v) = user_id {
+        set_extra(matrix, "user_id", json!(v));
+    }
+    if let Some(v) = access_token {
+        matrix.token = Some(v.clone());
+        set_extra(matrix, "access_token", json!(v));
+        let enabled_was_explicit = matrix
+            .extra
+            .remove("_enabled_explicit")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !matrix.enabled && !enabled_was_explicit {
+            matrix.enabled = true;
+        }
+    }
+    if let Some(v) = room_id {
+        set_extra(matrix, "room_id", json!(v));
+    }
+    if let Some(v) = allowed_rooms {
+        set_extra(matrix, "allowed_rooms", json!(comma_list_to_strings(&v)));
+    }
 }
 
 fn apply_ntfy_env(config: &mut GatewayConfig) {
@@ -370,6 +459,8 @@ pub fn apply_python_named_platform_env(config: &mut GatewayConfig) {
     apply_discord_env(config);
     apply_weixin_env(config);
     apply_dingtalk_env(config);
+    apply_mattermost_env(config);
+    apply_matrix_env(config);
     apply_ntfy_env(config);
 }
 
@@ -776,6 +867,7 @@ mod tests {
             std::env::set_var("DINGTALK_CLIENT_ID", "cid");
             std::env::set_var("DINGTALK_CLIENT_SECRET", "sec");
             std::env::set_var("DINGTALK_OPENAPI_ENDPOINT", "https://api.example.com");
+            std::env::set_var("DINGTALK_ALLOWED_CHATS", "cidABC,cidDEF");
         }
         let mut cfg = GatewayConfig::default();
         apply_python_named_platform_env(&mut cfg);
@@ -792,10 +884,51 @@ mod tests {
             dt.extra.get("openapi_endpoint").and_then(|v| v.as_str()),
             Some("https://api.example.com")
         );
+        assert_eq!(
+            dt.extra
+                .get("allowed_chats")
+                .and_then(|v| v.as_array())
+                .map(|items| items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>()),
+            Some(vec!["cidABC", "cidDEF"])
+        );
         unsafe {
             std::env::remove_var("DINGTALK_CLIENT_ID");
             std::env::remove_var("DINGTALK_CLIENT_SECRET");
             std::env::remove_var("DINGTALK_OPENAPI_ENDPOINT");
+            std::env::remove_var("DINGTALK_ALLOWED_CHATS");
+        }
+    }
+
+    #[test]
+    fn mattermost_and_matrix_allowed_channel_envs_are_imported() {
+        let _env = env_lock();
+        unsafe {
+            std::env::set_var("MATTERMOST_ALLOWED_CHANNELS", "chanABC,chanDEF");
+            std::env::set_var("MATRIX_ALLOWED_ROOMS", "!room1:srv,!room2:srv");
+        }
+        let mut cfg = GatewayConfig::default();
+        apply_python_named_platform_env(&mut cfg);
+        let mattermost = cfg.platforms.get("mattermost").expect("mattermost block");
+        assert_eq!(
+            mattermost
+                .extra
+                .get("allowed_channels")
+                .and_then(|v| v.as_array())
+                .map(|items| items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>()),
+            Some(vec!["chanABC", "chanDEF"])
+        );
+        let matrix = cfg.platforms.get("matrix").expect("matrix block");
+        assert_eq!(
+            matrix
+                .extra
+                .get("allowed_rooms")
+                .and_then(|v| v.as_array())
+                .map(|items| items.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>()),
+            Some(vec!["!room1:srv", "!room2:srv"])
+        );
+        unsafe {
+            std::env::remove_var("MATTERMOST_ALLOWED_CHANNELS");
+            std::env::remove_var("MATRIX_ALLOWED_ROOMS");
         }
     }
 

--- a/crates/hermes-gateway/src/dm.rs
+++ b/crates/hermes-gateway/src/dm.rs
@@ -6,7 +6,7 @@
 //! - Ignore: Silently discard the message
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use hermes_config::UnauthorizedDmBehavior;
 
@@ -42,8 +42,18 @@ pub struct DmManager {
     /// Set of user IDs that have admin privileges.
     admin_users: HashSet<String>,
 
+    /// Per-platform user IDs from config/env allowlists.
+    platform_authorized_users: HashMap<String, HashSet<String>>,
+
+    /// Per-platform admin user IDs from config/env allowlists.
+    platform_admin_users: HashMap<String, HashSet<String>>,
+
     /// How to handle DMs from unauthorized users.
     unauthorized_dm_behavior: UnauthorizedDmBehavior,
+
+    /// Per-platform unauthorized-DM policy. This preserves Python behavior
+    /// where strict allowlists default to ignoring strangers instead of pairing.
+    platform_unauthorized_dm_behavior: HashMap<String, UnauthorizedDmBehavior>,
 }
 
 impl DmManager {
@@ -56,7 +66,10 @@ impl DmManager {
         Self {
             authorized_users,
             admin_users,
+            platform_authorized_users: HashMap::new(),
+            platform_admin_users: HashMap::new(),
             unauthorized_dm_behavior,
+            platform_unauthorized_dm_behavior: HashMap::new(),
         }
     }
 
@@ -65,7 +78,10 @@ impl DmManager {
         Self {
             authorized_users: HashSet::new(),
             admin_users: HashSet::new(),
+            platform_authorized_users: HashMap::new(),
+            platform_admin_users: HashMap::new(),
             unauthorized_dm_behavior: UnauthorizedDmBehavior::Pair,
+            platform_unauthorized_dm_behavior: HashMap::new(),
         }
     }
 
@@ -74,8 +90,37 @@ impl DmManager {
         Self {
             authorized_users: HashSet::new(),
             admin_users: HashSet::new(),
+            platform_authorized_users: HashMap::new(),
+            platform_admin_users: HashMap::new(),
             unauthorized_dm_behavior: UnauthorizedDmBehavior::Ignore,
+            platform_unauthorized_dm_behavior: HashMap::new(),
         }
+    }
+
+    fn platform_key(platform: &str) -> String {
+        platform.trim().to_ascii_lowercase()
+    }
+
+    fn user_matches_any(user_id: &str, set: &HashSet<String>) -> bool {
+        let candidate = user_id.trim();
+        if candidate.is_empty() {
+            return false;
+        }
+        let candidate_no_at = candidate.strip_prefix('@').unwrap_or(candidate);
+        set.iter().any(|entry| {
+            let allowed = entry.trim();
+            if allowed.is_empty() {
+                return false;
+            }
+            if allowed == "*" {
+                return true;
+            }
+            let allowed_no_at = allowed.strip_prefix('@').unwrap_or(allowed);
+            allowed.eq_ignore_ascii_case(candidate)
+                || allowed.eq_ignore_ascii_case(candidate_no_at)
+                || allowed_no_at.eq_ignore_ascii_case(candidate)
+                || allowed_no_at.eq_ignore_ascii_case(candidate_no_at)
+        })
     }
 
     /// Handle an incoming DM from a user on a platform.
@@ -85,18 +130,35 @@ impl DmManager {
     /// - `Pair` if unauthorized and behavior is Pair
     /// - `Deny` if unauthorized and behavior is Ignore
     pub async fn handle_dm(&self, user_id: &str, _platform: &str) -> DmDecision {
+        let platform = Self::platform_key(_platform);
+        if let Some(admins) = self.platform_admin_users.get(&platform) {
+            if Self::user_matches_any(user_id, admins) {
+                return DmDecision::Allow;
+            }
+        }
+        if let Some(users) = self.platform_authorized_users.get(&platform) {
+            if Self::user_matches_any(user_id, users) {
+                return DmDecision::Allow;
+            }
+        }
+
         // Admins are always allowed
-        if self.admin_users.contains(user_id) {
+        if Self::user_matches_any(user_id, &self.admin_users) {
             return DmDecision::Allow;
         }
 
         // Authorized users are always allowed
-        if self.authorized_users.contains(user_id) {
+        if Self::user_matches_any(user_id, &self.authorized_users) {
             return DmDecision::Allow;
         }
 
         // Unauthorized user: apply the configured behavior
-        match self.unauthorized_dm_behavior {
+        let behavior = self
+            .platform_unauthorized_dm_behavior
+            .get(&platform)
+            .copied()
+            .unwrap_or(self.unauthorized_dm_behavior);
+        match behavior {
             UnauthorizedDmBehavior::Pair => DmDecision::Pair {
                 message: Some(
                     "Your request has been submitted for approval. You will be notified once an admin reviews it.".to_string(),
@@ -111,6 +173,18 @@ impl DmManager {
         self.authorized_users.insert(user_id.into());
     }
 
+    /// Add a platform-scoped user to the authorized users set.
+    pub fn authorize_user_for_platform(
+        &mut self,
+        platform: impl AsRef<str>,
+        user_id: impl Into<String>,
+    ) {
+        self.platform_authorized_users
+            .entry(Self::platform_key(platform.as_ref()))
+            .or_default()
+            .insert(user_id.into());
+    }
+
     /// Remove a user from the authorized users set.
     pub fn deauthorize_user(&mut self, user_id: &str) {
         self.authorized_users.remove(user_id);
@@ -121,6 +195,18 @@ impl DmManager {
         self.admin_users.insert(user_id.into());
     }
 
+    /// Add a platform-scoped admin user.
+    pub fn add_admin_for_platform(
+        &mut self,
+        platform: impl AsRef<str>,
+        user_id: impl Into<String>,
+    ) {
+        self.platform_admin_users
+            .entry(Self::platform_key(platform.as_ref()))
+            .or_default()
+            .insert(user_id.into());
+    }
+
     /// Remove a user from the admin users set.
     pub fn remove_admin(&mut self, user_id: &str) {
         self.admin_users.remove(user_id);
@@ -128,12 +214,26 @@ impl DmManager {
 
     /// Check if a user is authorized.
     pub fn is_authorized(&self, user_id: &str) -> bool {
-        self.authorized_users.contains(user_id) || self.admin_users.contains(user_id)
+        Self::user_matches_any(user_id, &self.authorized_users)
+            || Self::user_matches_any(user_id, &self.admin_users)
+    }
+
+    /// Check if a user is authorized globally or for the given platform.
+    pub fn is_authorized_for_platform(&self, platform: &str, user_id: &str) -> bool {
+        let platform = Self::platform_key(platform);
+        self.platform_authorized_users
+            .get(&platform)
+            .is_some_and(|users| Self::user_matches_any(user_id, users))
+            || self
+                .platform_admin_users
+                .get(&platform)
+                .is_some_and(|admins| Self::user_matches_any(user_id, admins))
+            || self.is_authorized(user_id)
     }
 
     /// Check if a user is an admin.
     pub fn is_admin(&self, user_id: &str) -> bool {
-        self.admin_users.contains(user_id)
+        Self::user_matches_any(user_id, &self.admin_users)
     }
 
     /// Get the number of authorized users.
@@ -144,6 +244,16 @@ impl DmManager {
     /// Get the number of admin users.
     pub fn admin_user_count(&self) -> usize {
         self.admin_users.len()
+    }
+
+    /// Override unauthorized-DM behavior for a platform.
+    pub fn set_platform_unauthorized_behavior(
+        &mut self,
+        platform: impl AsRef<str>,
+        behavior: UnauthorizedDmBehavior,
+    ) {
+        self.platform_unauthorized_dm_behavior
+            .insert(Self::platform_key(platform.as_ref()), behavior);
     }
 }
 
@@ -191,6 +301,29 @@ mod tests {
 
         dm.deauthorize_user("user1");
         assert!(!dm.is_authorized("user1"));
+    }
+
+    #[tokio::test]
+    async fn dm_manager_wildcard_authorizes_any_non_empty_user() {
+        let mut dm = DmManager::with_ignore_behavior();
+        dm.authorize_user("*");
+
+        assert_eq!(dm.handle_dm("user1", "telegram").await, DmDecision::Allow);
+        assert_eq!(dm.handle_dm("999", "discord").await, DmDecision::Allow);
+        assert_eq!(dm.handle_dm("", "discord").await, DmDecision::Deny);
+    }
+
+    #[tokio::test]
+    async fn dm_manager_platform_scoped_allowlist_does_not_cross_authorize() {
+        let mut dm = DmManager::with_pair_behavior();
+        dm.authorize_user_for_platform("telegram", "123");
+        dm.set_platform_unauthorized_behavior("telegram", UnauthorizedDmBehavior::Ignore);
+
+        assert_eq!(dm.handle_dm("123", "telegram").await, DmDecision::Allow);
+        assert_eq!(dm.handle_dm("123", "discord").await, DmDecision::Pair {
+            message: Some("Your request has been submitted for approval. You will be notified once an admin reviews it.".to_string())
+        });
+        assert_eq!(dm.handle_dm("999", "telegram").await, DmDecision::Deny);
     }
 
     #[test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -317,6 +317,9 @@ impl PlatformAccessPolicy {
             if allowed.is_empty() {
                 return false;
             }
+            if allowed == "*" {
+                return true;
+            }
             let allowed_no_at = allowed.strip_prefix('@').unwrap_or(allowed);
             allowed.eq_ignore_ascii_case(candidate)
                 || allowed.eq_ignore_ascii_case(candidate_no_at)
@@ -2817,6 +2820,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_group_allowlist_star_authorizes_any_sender() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let mut policies = HashMap::new();
+        let mut policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Allowlist,
+            ..PlatformAccessPolicy::default()
+        };
+        policy.allowed_users.insert("*".to_string());
+        policies.insert("telegram".to_string(), policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let incoming = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "-100123".into(),
+            user_id: "any_user".into(),
+            text: "hello group".into(),
+            message_id: None,
+            is_dm: false,
+        };
+
+        let result = gw.route_message(&incoming).await;
+        assert!(result.is_err());
+        assert_eq!(
+            gw.session_transcript_len("telegram", "-100123", "any_user")
+                .await,
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn gateway_channel_allow_and_ignore_policy_matches_discord_contract() {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let adapter = Arc::new(TestAdapter {
@@ -2885,6 +2920,62 @@ mod tests {
             2
         );
         assert_eq!(sent.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn gateway_allowed_channel_policy_blocks_mentions_but_not_dms() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_ignore_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("telegram", adapter).await;
+        gw.set_message_handler(Arc::new(|_messages| {
+            Box::pin(async { Ok("handled".to_string()) })
+        }))
+        .await;
+
+        let mut policies = HashMap::new();
+        let mut policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Open,
+            ..PlatformAccessPolicy::default()
+        };
+        policy.allowed_channels.insert("-100allowed".to_string());
+        policies.insert("telegram".to_string(), policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let mentioned_blocked_group = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "-100blocked".into(),
+            user_id: "user1".into(),
+            text: "@hermes_bot hello".into(),
+            message_id: Some("m1".into()),
+            is_dm: false,
+        };
+        assert!(gw.route_message(&mentioned_blocked_group).await.is_ok());
+        assert_eq!(
+            gw.session_transcript_len("telegram", "-100blocked", "user1")
+                .await,
+            0
+        );
+
+        let dm = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "-100blocked".into(),
+            user_id: "user1".into(),
+            text: "dm hello".into(),
+            message_id: Some("m2".into()),
+            is_dm: true,
+        };
+        assert!(gw.route_message(&dm).await.is_ok());
+        assert_eq!(
+            gw.session_transcript_len("telegram", "-100blocked", "user1")
+                .await,
+            2
+        );
     }
 
     #[tokio::test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T19:07:36.702544+00:00",
+  "generated_at_utc": "2026-05-31T19:56:44.400545+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T19:07:36.702544+00:00`
+Generated: `2026-05-31T19:56:44.400545+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3346,32 +3346,32 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_allowed_channels_widening.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "73c69f248eec7d6dc5997093f5553d5bbf8f6b05",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_allowed_channels_widening.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "0d214713a1cc1082314cd75deb3cba1a043760ec",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_allowlist_startup_check.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "96441c05213553d3ea69ce7eca988147f2fa9456",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_allowlist_startup_check.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "abb2db7db123d9df633430a85b1259c72f3cdb76",
       "workstream": "WS6"
     },
@@ -15466,29 +15466,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T19:07:30.909099+00:00",
+  "generated_at_utc": "2026-05-31T19:56:37.494325+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "01fc2facc93c38cef273bb46fb47a35a1184a21d",
+    "local_ref": "HEAD",
+    "local_sha": "2375790b531094d144267ea971ac247ce2606d1d",
     "upstream_ref": "upstream/main",
     "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 599,
-      "intentional_divergence": 262,
+      "functional": 597,
+      "intentional_divergence": 264,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 432,
-      "rust_equivalent_or_contract_test_required": 518,
+      "not_required_for_runtime": 434,
+      "rust_equivalent_or_contract_test_required": 516,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 262,
+      "cleared_intentional_divergence": 264,
       "cleared_non_runtime": 170,
-      "pending_review": 599
+      "pending_review": 597
     },
     "by_workstream": {
       "WS3": 56,
@@ -15497,10 +15497,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 262,
+    "cleared_intentional_divergence": 264,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 599,
+    "pending_review": 597,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T19:07:30.909099+00:00`
+Generated: `2026-05-31T19:56:37.494325+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `599`
+- Pending functional review: `597`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `262`
+- Cleared intentional divergence: `264`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 262 |
+| `cleared_intentional_divergence` | 264 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 599 |
+| `pending_review` | 597 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-31T19:07:30.909099+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 127 |
+| `tests/gateway` | 125 |
 | `tests/hermes_cli` | 120 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -171,6 +171,20 @@
       "ticket": 25
     },
     {
+      "path": "tests/gateway/test_allowed_channels_widening.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Telegram, DingTalk, Mattermost, and Matrix allowed-chat/channel/room gating is covered by Rust config-env import tests and gateway platform access policy tests for aliases, no-restriction defaults, blocked non-allowlisted group traffic, mention non-bypass, and DM bypass of channel restrictions.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_allowlist_startup_check.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream startup allowlist warning semantics are covered by Rust gateway startup warning helper tests for no-config warning, SIGNAL_GROUP_ALLOWED_USERS suppression, platform allow-all suppression, global allow-all suppression, and false-like allow-all rejection; runtime gateway startup emits the warning when chat platforms are enabled without a user allowlist or explicit allow-all override.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/gateway/test_hooks.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream gateway hook discovery, wildcard emit ordering, error containment, default empty context, and emit_collect decision hooks are covered by Rust HookRegistry tests; user hook loading intentionally uses zero-Python HOOK.yaml command handlers instead of dynamic handler.py imports.",


### PR DESCRIPTION
## Summary
- scope gateway DM allowlists by platform and support wildcard user allowlists
- import and enforce DingTalk/Mattermost/Matrix allowed channel/room env parity in Rust
- add config/env-aware startup warning contract for missing gateway user allowlists
- update parity ledger: pending functional review 599 -> 597

## Verification
- cargo fmt --all --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- git diff --check
- scripts/clippy-warning-gate.sh --check (new=0; stale=2 pre-existing allowlist entries)
- cargo test -p hermes-cli gateway_allowlist_startup_warning_matches_env_contract -- --nocapture
- cargo build --workspace
- cargo test --workspace
