### PR TITLE
parity(gateway): cover unauthorized DM behavior

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4265,32 +4265,310 @@ fn discord_allow_bots_bypasses_gateway_allowlist(
         .unwrap_or(false)
 }
 
+#[derive(Clone, Copy)]
+struct PlatformGatewayAuthEnv {
+    platform: &'static str,
+    allowed_users: &'static str,
+    allow_all_users: &'static str,
+    group_allowed_users: Option<&'static str>,
+    group_allowed_chats: Option<&'static str>,
+}
+
+const PLATFORM_GATEWAY_AUTH_ENVS: &[PlatformGatewayAuthEnv] = &[
+    PlatformGatewayAuthEnv {
+        platform: "telegram",
+        allowed_users: "TELEGRAM_ALLOWED_USERS",
+        allow_all_users: "TELEGRAM_ALLOW_ALL_USERS",
+        group_allowed_users: Some("TELEGRAM_GROUP_ALLOWED_USERS"),
+        group_allowed_chats: Some("TELEGRAM_GROUP_ALLOWED_CHATS"),
+    },
+    PlatformGatewayAuthEnv {
+        platform: "discord",
+        allowed_users: "DISCORD_ALLOWED_USERS",
+        allow_all_users: "DISCORD_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "whatsapp",
+        allowed_users: "WHATSAPP_ALLOWED_USERS",
+        allow_all_users: "WHATSAPP_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "slack",
+        allowed_users: "SLACK_ALLOWED_USERS",
+        allow_all_users: "SLACK_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "signal",
+        allowed_users: "SIGNAL_ALLOWED_USERS",
+        allow_all_users: "SIGNAL_ALLOW_ALL_USERS",
+        group_allowed_users: Some("SIGNAL_GROUP_ALLOWED_USERS"),
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "email",
+        allowed_users: "EMAIL_ALLOWED_USERS",
+        allow_all_users: "EMAIL_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "sms",
+        allowed_users: "SMS_ALLOWED_USERS",
+        allow_all_users: "SMS_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "mattermost",
+        allowed_users: "MATTERMOST_ALLOWED_USERS",
+        allow_all_users: "MATTERMOST_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "matrix",
+        allowed_users: "MATRIX_ALLOWED_USERS",
+        allow_all_users: "MATRIX_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "dingtalk",
+        allowed_users: "DINGTALK_ALLOWED_USERS",
+        allow_all_users: "DINGTALK_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "feishu",
+        allowed_users: "FEISHU_ALLOWED_USERS",
+        allow_all_users: "FEISHU_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "wecom",
+        allowed_users: "WECOM_ALLOWED_USERS",
+        allow_all_users: "WECOM_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: None,
+    },
+    PlatformGatewayAuthEnv {
+        platform: "qqbot",
+        allowed_users: "QQ_ALLOWED_USERS",
+        allow_all_users: "QQ_ALLOW_ALL_USERS",
+        group_allowed_users: None,
+        group_allowed_chats: Some("QQ_GROUP_ALLOWED_USERS"),
+    },
+];
+
+fn canonical_gateway_platform(platform: &str) -> String {
+    let platform = platform.trim().to_ascii_lowercase();
+    match platform.as_str() {
+        "qq" | "qq_bot" => "qqbot".to_string(),
+        _ => platform,
+    }
+}
+
+fn platform_gateway_auth_env(platform: &str) -> Option<PlatformGatewayAuthEnv> {
+    let platform = canonical_gateway_platform(platform);
+    PLATFORM_GATEWAY_AUTH_ENVS
+        .iter()
+        .copied()
+        .find(|entry| entry.platform == platform)
+}
+
+fn env_list_from_lookup<F>(lookup: &mut F, key: &str) -> HashSet<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    lookup(key)
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn env_truthy_from_lookup<F>(lookup: &mut F, key: &str) -> bool
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    lookup(key).is_some_and(|value| env_value_truthy(&value))
+}
+
+fn explicit_platform_unauthorized_dm_behavior(
+    platform_cfg: &PlatformConfig,
+) -> Option<UnauthorizedDmBehavior> {
+    if let Some(raw) = extra_string(platform_cfg, "unauthorized_dm_behavior") {
+        return match raw.trim().to_ascii_lowercase().as_str() {
+            "pair" => Some(UnauthorizedDmBehavior::Pair),
+            "ignore" | "deny" | "drop" => Some(UnauthorizedDmBehavior::Ignore),
+            _ => None,
+        };
+    }
+    (platform_cfg.unauthorized_dm_behavior == UnauthorizedDmBehavior::Pair)
+        .then_some(UnauthorizedDmBehavior::Pair)
+}
+
+fn split_group_authorization_values(
+    platform: &str,
+    values: impl IntoIterator<Item = String>,
+) -> (HashSet<String>, HashSet<String>) {
+    let platform = canonical_gateway_platform(platform);
+    let mut users = HashSet::new();
+    let mut chats = HashSet::new();
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if platform == "qqbot" || (platform == "telegram" && value.starts_with('-')) {
+            chats.insert(value.to_string());
+        } else {
+            users.insert(value.to_string());
+        }
+    }
+    (users, chats)
+}
+
+const GATEWAY_CONFIG_DIRECT_USER_ALLOWLIST_EXTRA_KEYS: &[&str] = &[
+    "allow_from",
+    "allowed_user_ids",
+    "allowed_senders",
+    "allowed_accounts",
+];
+const GATEWAY_CONFIG_GROUP_USER_ALLOWLIST_EXTRA_KEYS: &[&str] =
+    &["group_allow_from", "group_allowed_users"];
+const GATEWAY_CONFIG_GROUP_CHAT_ALLOWLIST_EXTRA_KEYS: &[&str] = &[
+    "group_allowed_chats",
+    "allowed_group_chats",
+    "allowed_groups",
+];
+
 fn build_gateway_dm_manager(config: &hermes_config::GatewayConfig) -> DmManager {
-    let mut dm_manager = DmManager::with_pair_behavior();
+    build_gateway_dm_manager_with_lookup(config, |key| std::env::var(key).ok())
+}
+
+fn build_gateway_dm_manager_with_lookup<F>(
+    config: &hermes_config::GatewayConfig,
+    mut lookup: F,
+) -> DmManager
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut global_users = env_list_from_lookup(&mut lookup, "GATEWAY_ALLOWED_USERS");
+    if env_truthy_from_lookup(&mut lookup, "GATEWAY_ALLOW_ALL_USERS") {
+        global_users.insert("*".to_string());
+    }
+    let has_global_allowlist = !global_users.is_empty();
+    let mut dm_manager = DmManager::new(
+        global_users,
+        HashSet::new(),
+        if has_global_allowlist {
+            UnauthorizedDmBehavior::Ignore
+        } else {
+            UnauthorizedDmBehavior::Pair
+        },
+    );
+    let hermes_home_dir = config
+        .home_dir
+        .as_deref()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(hermes_home);
     for (platform, platform_cfg) in config.platforms.iter().filter(|(_, p)| p.enabled) {
+        let platform = canonical_gateway_platform(platform);
         let mut has_platform_allowlist = false;
         for user in &platform_cfg.allowed_users {
             let trimmed = user.trim();
             if !trimmed.is_empty() {
                 has_platform_allowlist = true;
-                dm_manager.authorize_user_for_platform(platform, trimmed.to_string());
+                dm_manager.authorize_user_for_platform(&platform, trimmed.to_string());
             }
         }
         for admin in &platform_cfg.admin_users {
             let trimmed = admin.trim();
             if !trimmed.is_empty() {
                 has_platform_allowlist = true;
-                dm_manager.add_admin_for_platform(platform, trimmed.to_string());
+                dm_manager.add_admin_for_platform(&platform, trimmed.to_string());
             }
         }
-        let behavior = if platform_cfg.unauthorized_dm_behavior == UnauthorizedDmBehavior::Pair {
-            UnauthorizedDmBehavior::Pair
+        for key in GATEWAY_CONFIG_DIRECT_USER_ALLOWLIST_EXTRA_KEYS {
+            for user in extra_string_set(platform_cfg, key) {
+                has_platform_allowlist = true;
+                dm_manager.authorize_user_for_platform(&platform, user);
+            }
+        }
+        if gateway_platform_config_allows_all_users(platform_cfg) {
+            has_platform_allowlist = true;
+            dm_manager.authorize_user_for_platform(&platform, "*");
+        }
+        if let Some(env) = platform_gateway_auth_env(&platform) {
+            for user in env_list_from_lookup(&mut lookup, env.allowed_users) {
+                has_platform_allowlist = true;
+                dm_manager.authorize_user_for_platform(&platform, user);
+            }
+            if env_truthy_from_lookup(&mut lookup, env.allow_all_users) {
+                has_platform_allowlist = true;
+                dm_manager.authorize_user_for_platform(&platform, "*");
+            }
+            if let Some(group_users_env) = env.group_allowed_users {
+                let (users, chats) = split_group_authorization_values(
+                    &platform,
+                    env_list_from_lookup(&mut lookup, group_users_env),
+                );
+                for user in users {
+                    has_platform_allowlist = true;
+                    dm_manager.authorize_group_user_for_platform(&platform, user);
+                }
+                for chat in chats {
+                    has_platform_allowlist = true;
+                    dm_manager.authorize_group_chat_for_platform(&platform, chat);
+                }
+            }
+            if let Some(group_chats_env) = env.group_allowed_chats {
+                for chat in env_list_from_lookup(&mut lookup, group_chats_env) {
+                    has_platform_allowlist = true;
+                    dm_manager.authorize_group_chat_for_platform(&platform, chat);
+                }
+            }
+        }
+        let mut config_group_values = Vec::new();
+        for key in GATEWAY_CONFIG_GROUP_USER_ALLOWLIST_EXTRA_KEYS {
+            config_group_values.extend(extra_string_set(platform_cfg, key));
+        }
+        let (group_users, legacy_group_chats) =
+            split_group_authorization_values(&platform, config_group_values);
+        for user in group_users {
+            has_platform_allowlist = true;
+            dm_manager.authorize_group_user_for_platform(&platform, user);
+        }
+        for chat in legacy_group_chats {
+            has_platform_allowlist = true;
+            dm_manager.authorize_group_chat_for_platform(&platform, chat);
+        }
+        for key in GATEWAY_CONFIG_GROUP_CHAT_ALLOWLIST_EXTRA_KEYS {
+            for chat in extra_string_set(platform_cfg, key) {
+                has_platform_allowlist = true;
+                dm_manager.authorize_group_chat_for_platform(&platform, chat);
+            }
+        }
+        if platform == "whatsapp" {
+            dm_manager.load_whatsapp_lid_mappings_from_home(&hermes_home_dir);
+        }
+        if let Some(behavior) = explicit_platform_unauthorized_dm_behavior(platform_cfg) {
+            dm_manager.set_platform_unauthorized_behavior(&platform, behavior);
         } else if has_platform_allowlist {
-            UnauthorizedDmBehavior::Ignore
-        } else {
-            UnauthorizedDmBehavior::Pair
-        };
-        dm_manager.set_platform_unauthorized_behavior(platform, behavior);
+            dm_manager
+                .set_platform_unauthorized_behavior(&platform, UnauthorizedDmBehavior::Ignore);
+        }
     }
     dm_manager
 }
@@ -4298,6 +4576,7 @@ fn build_gateway_dm_manager(config: &hermes_config::GatewayConfig) -> DmManager 
 const GATEWAY_USER_ALLOWLIST_ENV_VARS: &[&str] = &[
     "TELEGRAM_ALLOWED_USERS",
     "TELEGRAM_GROUP_ALLOWED_USERS",
+    "TELEGRAM_GROUP_ALLOWED_CHATS",
     "DISCORD_ALLOWED_USERS",
     "WHATSAPP_ALLOWED_USERS",
     "SLACK_ALLOWED_USERS",
@@ -4333,11 +4612,15 @@ const GATEWAY_ALLOW_ALL_ENV_VARS: &[&str] = &[
 ];
 
 const GATEWAY_CONFIG_USER_ALLOWLIST_EXTRA_KEYS: &[&str] = &[
+    "allow_from",
     "group_allow_from",
     "group_allowed_users",
+    "group_allowed_chats",
     "allowed_user_ids",
     "allowed_senders",
     "allowed_accounts",
+    "allowed_group_chats",
+    "allowed_groups",
 ];
 
 fn env_value_truthy(raw: &str) -> bool {
@@ -4401,18 +4684,31 @@ fn gateway_allowlist_startup_would_warn(config: &GatewayConfig) -> bool {
     gateway_allowlist_startup_would_warn_with_lookup(config, |key| std::env::var(key).ok())
 }
 
-fn parse_group_access_mode(platform_cfg: &PlatformConfig) -> GroupAccessMode {
+fn explicit_group_access_mode(platform_cfg: &PlatformConfig) -> Option<GroupAccessMode> {
     let explicit = extra_string(platform_cfg, "group_policy")
         .or_else(|| extra_string(platform_cfg, "group_access"));
     if let Some(policy) = explicit {
         match policy.trim().to_ascii_lowercase().as_str() {
-            "disabled" | "deny" | "off" | "none" => return GroupAccessMode::Disabled,
-            "allowlist" | "restricted" | "whitelist" => return GroupAccessMode::Allowlist,
-            "open" | "all" | "enabled" => return GroupAccessMode::Open,
+            "disabled" | "deny" | "off" | "none" => return Some(GroupAccessMode::Disabled),
+            "allowlist" | "restricted" | "whitelist" => return Some(GroupAccessMode::Allowlist),
+            "open" | "all" | "enabled" => return Some(GroupAccessMode::Open),
             _ => {}
         }
     }
-    if !platform_cfg.allowed_users.is_empty() || !platform_cfg.admin_users.is_empty() {
+    None
+}
+
+fn parse_group_access_mode(
+    platform_cfg: &PlatformConfig,
+    has_group_authorization: bool,
+) -> GroupAccessMode {
+    if let Some(mode) = explicit_group_access_mode(platform_cfg) {
+        return mode;
+    }
+    if has_group_authorization
+        || !platform_cfg.allowed_users.is_empty()
+        || !platform_cfg.admin_users.is_empty()
+    {
         GroupAccessMode::Allowlist
     } else {
         GroupAccessMode::Open
@@ -4422,10 +4718,24 @@ fn parse_group_access_mode(platform_cfg: &PlatformConfig) -> GroupAccessMode {
 fn build_gateway_platform_access_policies(
     config: &hermes_config::GatewayConfig,
 ) -> std::collections::HashMap<String, PlatformAccessPolicy> {
+    build_gateway_platform_access_policies_with_lookup(config, |key| std::env::var(key).ok())
+}
+
+fn build_gateway_platform_access_policies_with_lookup<F>(
+    config: &hermes_config::GatewayConfig,
+    mut lookup: F,
+) -> std::collections::HashMap<String, PlatformAccessPolicy>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let global_allowed_users = env_list_from_lookup(&mut lookup, "GATEWAY_ALLOWED_USERS");
+    let global_allow_all = env_truthy_from_lookup(&mut lookup, "GATEWAY_ALLOW_ALL_USERS");
     let mut policies = std::collections::HashMap::new();
     for (platform, platform_cfg) in config.platforms.iter().filter(|(_, cfg)| cfg.enabled) {
+        let platform = canonical_gateway_platform(platform);
         let mut allowed_users = HashSet::new();
         let mut admin_users = HashSet::new();
+        let mut authorized_group_chats = HashSet::new();
         for user in &platform_cfg.allowed_users {
             let trimmed = user.trim();
             if !trimmed.is_empty() {
@@ -4438,40 +4748,80 @@ fn build_gateway_platform_access_policies(
                 admin_users.insert(trimmed.to_string());
             }
         }
+        for key in GATEWAY_CONFIG_DIRECT_USER_ALLOWLIST_EXTRA_KEYS {
+            allowed_users.extend(extra_string_set(platform_cfg, key));
+        }
+        allowed_users.extend(global_allowed_users.iter().cloned());
+        if global_allow_all || gateway_platform_config_allows_all_users(platform_cfg) {
+            allowed_users.insert("*".to_string());
+        }
+        if let Some(env) = platform_gateway_auth_env(&platform) {
+            allowed_users.extend(env_list_from_lookup(&mut lookup, env.allowed_users));
+            if env_truthy_from_lookup(&mut lookup, env.allow_all_users) {
+                allowed_users.insert("*".to_string());
+            }
+            if let Some(group_users_env) = env.group_allowed_users {
+                let (users, chats) = split_group_authorization_values(
+                    &platform,
+                    env_list_from_lookup(&mut lookup, group_users_env),
+                );
+                allowed_users.extend(users);
+                authorized_group_chats.extend(chats);
+            }
+            if let Some(group_chats_env) = env.group_allowed_chats {
+                authorized_group_chats.extend(env_list_from_lookup(&mut lookup, group_chats_env));
+            }
+        }
+        let mut config_group_values = Vec::new();
+        for key in GATEWAY_CONFIG_GROUP_USER_ALLOWLIST_EXTRA_KEYS {
+            config_group_values.extend(extra_string_set(platform_cfg, key));
+        }
+        let (group_users, legacy_group_chats) =
+            split_group_authorization_values(&platform, config_group_values);
+        allowed_users.extend(group_users);
+        authorized_group_chats.extend(legacy_group_chats);
+        for key in GATEWAY_CONFIG_GROUP_CHAT_ALLOWLIST_EXTRA_KEYS {
+            authorized_group_chats.extend(extra_string_set(platform_cfg, key));
+        }
 
-        let group_mode = parse_group_access_mode(platform_cfg);
+        let group_mode = parse_group_access_mode(
+            platform_cfg,
+            !authorized_group_chats.is_empty()
+                || !allowed_users.is_empty()
+                || !admin_users.is_empty(),
+        );
         let has_allowlist = !allowed_users.is_empty() || !admin_users.is_empty();
         let slash_requires_allowlist = extra_bool_loose(platform_cfg, "slash_requires_allowlist")
             .or_else(|| extra_bool_loose(platform_cfg, "require_allowlist_for_slash"))
-            .unwrap_or_else(|| platform.eq_ignore_ascii_case("discord") && has_allowlist);
+            .unwrap_or_else(|| platform == "discord" && has_allowlist);
 
         let mut allowed_channels = extra_string_set(platform_cfg, "allowed_channels");
-        if platform.eq_ignore_ascii_case("telegram") {
-            allowed_channels.extend(extra_string_set(platform_cfg, "allowed_chats"));
-            allowed_channels.extend(extra_string_set(platform_cfg, "group_allowed_chats"));
-        }
-        if platform.eq_ignore_ascii_case("dingtalk") {
+        if platform == "telegram" {
             allowed_channels.extend(extra_string_set(platform_cfg, "allowed_chats"));
         }
-        if platform.eq_ignore_ascii_case("matrix") {
+        if platform == "dingtalk" {
+            allowed_channels.extend(extra_string_set(platform_cfg, "allowed_chats"));
+        }
+        if platform == "matrix" {
             allowed_channels.extend(extra_string_set(platform_cfg, "allowed_rooms"));
         }
         let mut ignored_channels = extra_string_set(platform_cfg, "ignored_channels");
-        if platform.eq_ignore_ascii_case("telegram") {
+        if platform == "telegram" {
             ignored_channels.extend(extra_string_set(platform_cfg, "ignored_threads"));
         }
 
         policies.insert(
-            platform.to_ascii_lowercase(),
+            platform.clone(),
             PlatformAccessPolicy {
                 allowed_users,
                 admin_users,
                 allowed_channels,
+                authorized_group_chats,
                 ignored_channels,
                 group_mode,
                 slash_requires_allowlist,
                 bot_sender_bypasses_allowlist: discord_allow_bots_bypasses_gateway_allowlist(
-                    platform,
+                    &platform,
                     platform_cfg,
                 ),
                 reactions_enabled: extra_bool_loose(platform_cfg, "reactions"),
@@ -14755,8 +15105,8 @@ mod tests {
         let policy = policies.get("telegram").expect("telegram policy");
         assert!(policy.allowed_channels.contains("-100"));
         assert!(policy.allowed_channels.contains("*"));
-        assert!(policy.allowed_channels.contains("-200"));
-        assert!(policy.allowed_channels.contains("-300"));
+        assert!(policy.authorized_group_chats.contains("-200"));
+        assert!(policy.authorized_group_chats.contains("-300"));
         assert!(policy.ignored_channels.contains("31"));
         assert!(policy.ignored_channels.contains("32"));
     }
@@ -14834,6 +15184,153 @@ mod tests {
             dm.handle_dm("+15559999999", "signal").await,
             hermes_gateway::DmDecision::Pair { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn gateway_dm_manager_global_allowlist_ignores_unauthorized_dm() {
+        let mut config = hermes_config::GatewayConfig::default();
+        let signal = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        config.platforms.insert("signal".to_string(), signal);
+        let env = std::collections::HashMap::from([(
+            "GATEWAY_ALLOWED_USERS".to_string(),
+            "111111111".to_string(),
+        )]);
+
+        let dm = build_gateway_dm_manager_with_lookup(&config, |key| env.get(key).cloned());
+        assert_eq!(
+            dm.handle_dm("111111111", "signal").await,
+            hermes_gateway::DmDecision::Allow
+        );
+        assert_eq!(
+            dm.handle_dm("+15559999999", "signal").await,
+            hermes_gateway::DmDecision::Deny
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_dm_manager_group_authorization_matches_upstream_contract() {
+        let mut config = hermes_config::GatewayConfig::default();
+        let mut telegram = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        telegram.extra.insert(
+            "group_allow_from".to_string(),
+            serde_json::json!(["999", "-1001878443972"]),
+        );
+        telegram.extra.insert(
+            "group_allowed_chats".to_string(),
+            serde_json::json!(["-200"]),
+        );
+        config.platforms.insert("telegram".to_string(), telegram);
+        let mut qq = PlatformConfig {
+            enabled: true,
+            ..PlatformConfig::default()
+        };
+        qq.extra.insert(
+            "group_allowed_chats".to_string(),
+            serde_json::json!(["group-openid-1"]),
+        );
+        config.platforms.insert("qq".to_string(), qq);
+
+        let dm = build_gateway_dm_manager_with_lookup(&config, |_key| None);
+        assert!(dm.is_authorized_source("telegram", "999", "-1009999999999", false));
+        assert!(dm.is_authorized_source("telegram", "123", "-1001878443972", false));
+        assert!(dm.is_authorized_source("telegram", "123", "-200", false));
+        assert!(!dm.is_authorized_source("telegram", "999", "999", true));
+        assert_eq!(
+            dm.handle_dm("999", "telegram").await,
+            hermes_gateway::DmDecision::Deny
+        );
+        assert!(dm.is_authorized_source("qqbot", "member-openid-999", "group-openid-1", false));
+        assert!(!dm.is_authorized_source("qqbot", "member-openid-999", "group-openid-2", false));
+    }
+
+    #[tokio::test]
+    async fn gateway_dm_manager_whatsapp_lid_mapping_authorizes_phone_allowlist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session_dir = tmp.path().join("whatsapp").join("session");
+        std::fs::create_dir_all(&session_dir).expect("session dir");
+        std::fs::write(
+            session_dir.join("lid-mapping-15550000001.json"),
+            "\"900000000000001\"",
+        )
+        .expect("forward mapping");
+        std::fs::write(
+            session_dir.join("lid-mapping-900000000000001_reverse.json"),
+            "\"15550000001\"",
+        )
+        .expect("reverse mapping");
+
+        let mut config = hermes_config::GatewayConfig {
+            home_dir: Some(tmp.path().to_string_lossy().to_string()),
+            ..hermes_config::GatewayConfig::default()
+        };
+        config.platforms.insert(
+            "whatsapp".to_string(),
+            PlatformConfig {
+                enabled: true,
+                ..PlatformConfig::default()
+            },
+        );
+        let env = std::collections::HashMap::from([(
+            "WHATSAPP_ALLOWED_USERS".to_string(),
+            "15550000001".to_string(),
+        )]);
+
+        let dm = build_gateway_dm_manager_with_lookup(&config, |key| env.get(key).cloned());
+        assert_eq!(
+            dm.handle_dm("900000000000001@lid", "whatsapp").await,
+            hermes_gateway::DmDecision::Allow
+        );
+    }
+
+    #[test]
+    fn gateway_platform_access_policy_group_authorization_matches_env_contract() {
+        let mut config = hermes_config::GatewayConfig::default();
+        config.platforms.insert(
+            "telegram".to_string(),
+            PlatformConfig {
+                enabled: true,
+                ..PlatformConfig::default()
+            },
+        );
+        config.platforms.insert(
+            "qqbot".to_string(),
+            PlatformConfig {
+                enabled: true,
+                ..PlatformConfig::default()
+            },
+        );
+        let env = std::collections::HashMap::from([
+            (
+                "TELEGRAM_GROUP_ALLOWED_USERS".to_string(),
+                "999,-1001878443972".to_string(),
+            ),
+            (
+                "TELEGRAM_GROUP_ALLOWED_CHATS".to_string(),
+                "-200".to_string(),
+            ),
+            (
+                "QQ_GROUP_ALLOWED_USERS".to_string(),
+                "group-openid-1".to_string(),
+            ),
+        ]);
+
+        let policies = build_gateway_platform_access_policies_with_lookup(&config, |key| {
+            env.get(key).cloned()
+        });
+        let telegram = policies.get("telegram").expect("telegram policy");
+        assert_eq!(telegram.group_mode, GroupAccessMode::Allowlist);
+        assert!(telegram.allowed_users.contains("999"));
+        assert!(telegram.authorized_group_chats.contains("-1001878443972"));
+        assert!(telegram.authorized_group_chats.contains("-200"));
+        let qq = policies.get("qqbot").expect("qqbot policy");
+        assert_eq!(qq.group_mode, GroupAccessMode::Allowlist);
+        assert!(qq.authorized_group_chats.contains("group-openid-1"));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/dm.rs
+++ b/crates/hermes-gateway/src/dm.rs
@@ -7,6 +7,8 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Mutex;
 
 use hermes_config::UnauthorizedDmBehavior;
 
@@ -48,12 +50,33 @@ pub struct DmManager {
     /// Per-platform admin user IDs from config/env allowlists.
     platform_admin_users: HashMap<String, HashSet<String>>,
 
+    /// Per-platform group sender allowlists. These never authorize DMs.
+    platform_group_authorized_users: HashMap<String, HashSet<String>>,
+
+    /// Per-platform group chat allowlists. These never authorize DMs.
+    platform_group_authorized_chats: HashMap<String, HashSet<String>>,
+
+    /// Per-platform aliases such as WhatsApp LID <-> phone mappings.
+    platform_user_aliases: HashMap<String, HashMap<String, HashSet<String>>>,
+
     /// How to handle DMs from unauthorized users.
     unauthorized_dm_behavior: UnauthorizedDmBehavior,
 
     /// Per-platform unauthorized-DM policy. This preserves Python behavior
     /// where strict allowlists default to ignoring strangers instead of pairing.
     platform_unauthorized_dm_behavior: HashMap<String, UnauthorizedDmBehavior>,
+
+    /// Pending pairing codes keyed by platform and user.
+    pairing_codes: Mutex<HashMap<DmPairingKey, String>>,
+
+    /// Users whose pairing requests are currently rate-limited.
+    pairing_rate_limited: Mutex<HashSet<DmPairingKey>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DmPairingKey {
+    platform: String,
+    user_id: String,
 }
 
 impl DmManager {
@@ -68,8 +91,13 @@ impl DmManager {
             admin_users,
             platform_authorized_users: HashMap::new(),
             platform_admin_users: HashMap::new(),
+            platform_group_authorized_users: HashMap::new(),
+            platform_group_authorized_chats: HashMap::new(),
+            platform_user_aliases: HashMap::new(),
             unauthorized_dm_behavior,
             platform_unauthorized_dm_behavior: HashMap::new(),
+            pairing_codes: Mutex::new(HashMap::new()),
+            pairing_rate_limited: Mutex::new(HashSet::new()),
         }
     }
 
@@ -80,8 +108,13 @@ impl DmManager {
             admin_users: HashSet::new(),
             platform_authorized_users: HashMap::new(),
             platform_admin_users: HashMap::new(),
+            platform_group_authorized_users: HashMap::new(),
+            platform_group_authorized_chats: HashMap::new(),
+            platform_user_aliases: HashMap::new(),
             unauthorized_dm_behavior: UnauthorizedDmBehavior::Pair,
             platform_unauthorized_dm_behavior: HashMap::new(),
+            pairing_codes: Mutex::new(HashMap::new()),
+            pairing_rate_limited: Mutex::new(HashSet::new()),
         }
     }
 
@@ -92,13 +125,22 @@ impl DmManager {
             admin_users: HashSet::new(),
             platform_authorized_users: HashMap::new(),
             platform_admin_users: HashMap::new(),
+            platform_group_authorized_users: HashMap::new(),
+            platform_group_authorized_chats: HashMap::new(),
+            platform_user_aliases: HashMap::new(),
             unauthorized_dm_behavior: UnauthorizedDmBehavior::Ignore,
             platform_unauthorized_dm_behavior: HashMap::new(),
+            pairing_codes: Mutex::new(HashMap::new()),
+            pairing_rate_limited: Mutex::new(HashSet::new()),
         }
     }
 
     fn platform_key(platform: &str) -> String {
-        platform.trim().to_ascii_lowercase()
+        let key = platform.trim().to_ascii_lowercase();
+        match key.as_str() {
+            "qq" | "qq_bot" => "qqbot".to_string(),
+            _ => key,
+        }
     }
 
     fn user_matches_any(user_id: &str, set: &HashSet<String>) -> bool {
@@ -123,6 +165,155 @@ impl DmManager {
         })
     }
 
+    fn user_variants_for_platform(platform: &str, user_id: &str) -> HashSet<String> {
+        let mut variants = HashSet::new();
+        let candidate = user_id.trim();
+        if candidate.is_empty() {
+            return variants;
+        }
+
+        variants.insert(candidate.to_string());
+        variants.insert(candidate.strip_prefix('@').unwrap_or(candidate).to_string());
+
+        if Self::platform_key(platform) == "whatsapp" {
+            let base = candidate
+                .strip_suffix("@lid")
+                .or_else(|| candidate.strip_suffix("@s.whatsapp.net"))
+                .unwrap_or(candidate)
+                .trim();
+            if !base.is_empty() {
+                variants.insert(base.to_string());
+                if let Some(no_plus) = base.strip_prefix('+') {
+                    if !no_plus.is_empty() {
+                        variants.insert(no_plus.to_string());
+                    }
+                } else if base.chars().all(|c| c.is_ascii_digit()) {
+                    variants.insert(format!("+{base}"));
+                }
+            }
+        }
+
+        variants
+    }
+
+    fn alias_key(value: &str) -> String {
+        value.trim().to_ascii_lowercase()
+    }
+
+    fn insert_alias(
+        aliases: &mut HashMap<String, HashSet<String>>,
+        platform: &str,
+        key: &str,
+        alias: &str,
+    ) {
+        for key_variant in Self::user_variants_for_platform(platform, key) {
+            let key_variant = Self::alias_key(&key_variant);
+            if key_variant.is_empty() {
+                continue;
+            }
+            let entry = aliases.entry(key_variant).or_default();
+            for alias_variant in Self::user_variants_for_platform(platform, alias) {
+                let alias_variant = alias_variant.trim();
+                if !alias_variant.is_empty() {
+                    entry.insert(alias_variant.to_string());
+                }
+            }
+        }
+    }
+
+    fn user_matches_platform_set(
+        &self,
+        platform: &str,
+        user_id: &str,
+        set: &HashSet<String>,
+    ) -> bool {
+        if Self::user_matches_any(user_id, set) {
+            return true;
+        }
+
+        let platform = Self::platform_key(platform);
+        let variants = Self::user_variants_for_platform(&platform, user_id);
+        if variants
+            .iter()
+            .any(|variant| Self::user_matches_any(variant, set))
+        {
+            return true;
+        }
+
+        let Some(aliases) = self.platform_user_aliases.get(&platform) else {
+            return false;
+        };
+        variants.iter().any(|variant| {
+            aliases
+                .get(&Self::alias_key(variant))
+                .is_some_and(|mapped| {
+                    mapped
+                        .iter()
+                        .any(|alias| Self::user_matches_any(alias, set))
+                })
+        })
+    }
+
+    fn chat_matches_any(chat_id: &str, set: &HashSet<String>) -> bool {
+        let candidate = chat_id.trim();
+        if candidate.is_empty() {
+            return false;
+        }
+        set.iter().any(|entry| {
+            let allowed = entry.trim();
+            allowed == "*" || allowed.eq_ignore_ascii_case(candidate)
+        })
+    }
+
+    fn pairing_key(platform: &str, user_id: &str) -> Option<DmPairingKey> {
+        let platform = Self::platform_key(platform);
+        let user_id = user_id.trim();
+        if platform.is_empty() || user_id.is_empty() {
+            return None;
+        }
+        Some(DmPairingKey {
+            platform,
+            user_id: user_id.to_string(),
+        })
+    }
+
+    fn new_pairing_code() -> String {
+        uuid::Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(8)
+            .collect::<String>()
+            .to_ascii_uppercase()
+    }
+
+    fn pairing_message(code: &str) -> String {
+        format!(
+            "Your pairing code is {code}. Send this code to an admin to approve this gateway session."
+        )
+    }
+
+    fn pending_pairing_message(&self, platform: &str, user_id: &str) -> Option<String> {
+        let key = Self::pairing_key(platform, user_id)?;
+        if self
+            .pairing_rate_limited
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .contains(&key)
+        {
+            return None;
+        }
+        let mut codes = self
+            .pairing_codes
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let code = codes
+            .entry(key)
+            .or_insert_with(Self::new_pairing_code)
+            .clone();
+        Some(Self::pairing_message(&code))
+    }
+
     /// Handle an incoming DM from a user on a platform.
     ///
     /// Returns a `DmDecision` indicating how to proceed:
@@ -131,24 +322,7 @@ impl DmManager {
     /// - `Deny` if unauthorized and behavior is Ignore
     pub async fn handle_dm(&self, user_id: &str, _platform: &str) -> DmDecision {
         let platform = Self::platform_key(_platform);
-        if let Some(admins) = self.platform_admin_users.get(&platform) {
-            if Self::user_matches_any(user_id, admins) {
-                return DmDecision::Allow;
-            }
-        }
-        if let Some(users) = self.platform_authorized_users.get(&platform) {
-            if Self::user_matches_any(user_id, users) {
-                return DmDecision::Allow;
-            }
-        }
-
-        // Admins are always allowed
-        if Self::user_matches_any(user_id, &self.admin_users) {
-            return DmDecision::Allow;
-        }
-
-        // Authorized users are always allowed
-        if Self::user_matches_any(user_id, &self.authorized_users) {
+        if self.is_authorized_for_platform(&platform, user_id) {
             return DmDecision::Allow;
         }
 
@@ -159,11 +333,14 @@ impl DmManager {
             .copied()
             .unwrap_or(self.unauthorized_dm_behavior);
         match behavior {
-            UnauthorizedDmBehavior::Pair => DmDecision::Pair {
-                message: Some(
-                    "Your request has been submitted for approval. You will be notified once an admin reviews it.".to_string(),
-                ),
-            },
+            UnauthorizedDmBehavior::Pair => {
+                match self.pending_pairing_message(&platform, user_id) {
+                    Some(message) => DmDecision::Pair {
+                        message: Some(message),
+                    },
+                    None => DmDecision::Deny,
+                }
+            }
             UnauthorizedDmBehavior::Ignore => DmDecision::Deny,
         }
     }
@@ -183,6 +360,85 @@ impl DmManager {
             .entry(Self::platform_key(platform.as_ref()))
             .or_default()
             .insert(user_id.into());
+    }
+
+    /// Add a platform-scoped group sender allowlist entry.
+    pub fn authorize_group_user_for_platform(
+        &mut self,
+        platform: impl AsRef<str>,
+        user_id: impl Into<String>,
+    ) {
+        self.platform_group_authorized_users
+            .entry(Self::platform_key(platform.as_ref()))
+            .or_default()
+            .insert(user_id.into());
+    }
+
+    /// Add a platform-scoped group chat allowlist entry.
+    pub fn authorize_group_chat_for_platform(
+        &mut self,
+        platform: impl AsRef<str>,
+        chat_id: impl Into<String>,
+    ) {
+        self.platform_group_authorized_chats
+            .entry(Self::platform_key(platform.as_ref()))
+            .or_default()
+            .insert(chat_id.into());
+    }
+
+    /// Add a platform-scoped user alias, for example WhatsApp LID <-> phone ID.
+    pub fn add_user_alias_for_platform(
+        &mut self,
+        platform: impl AsRef<str>,
+        user_id: impl AsRef<str>,
+        alias: impl AsRef<str>,
+    ) {
+        let platform = Self::platform_key(platform.as_ref());
+        let user_id = user_id.as_ref().trim();
+        let alias = alias.as_ref().trim();
+        if user_id.is_empty() || alias.is_empty() {
+            return;
+        }
+        let aliases = self
+            .platform_user_aliases
+            .entry(platform.clone())
+            .or_default();
+        Self::insert_alias(aliases, &platform, user_id, alias);
+        Self::insert_alias(aliases, &platform, alias, user_id);
+    }
+
+    /// Load WhatsApp LID mapping files from `$HERMES_HOME/whatsapp/session`.
+    pub fn load_whatsapp_lid_mappings_from_home(&mut self, home: impl AsRef<Path>) -> usize {
+        let session_dir = home.as_ref().join("whatsapp").join("session");
+        let Ok(entries) = std::fs::read_dir(session_dir) else {
+            return 0;
+        };
+        let mut loaded = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(raw_key) = file_name
+                .strip_prefix("lid-mapping-")
+                .and_then(|s| s.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            let key = raw_key.strip_suffix("_reverse").unwrap_or(raw_key);
+            let Ok(raw) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<String>(&raw) else {
+                continue;
+            };
+            self.add_user_alias_for_platform("whatsapp", key, value);
+            loaded += 1;
+        }
+        loaded
     }
 
     /// Remove a user from the authorized users set.
@@ -223,12 +479,36 @@ impl DmManager {
         let platform = Self::platform_key(platform);
         self.platform_authorized_users
             .get(&platform)
-            .is_some_and(|users| Self::user_matches_any(user_id, users))
+            .is_some_and(|users| self.user_matches_platform_set(&platform, user_id, users))
             || self
                 .platform_admin_users
                 .get(&platform)
-                .is_some_and(|admins| Self::user_matches_any(user_id, admins))
-            || self.is_authorized(user_id)
+                .is_some_and(|admins| self.user_matches_platform_set(&platform, user_id, admins))
+            || self.user_matches_platform_set(&platform, user_id, &self.authorized_users)
+            || self.user_matches_platform_set(&platform, user_id, &self.admin_users)
+    }
+
+    /// Check if a DM or group source is authorized for the given platform.
+    pub fn is_authorized_source(
+        &self,
+        platform: &str,
+        user_id: &str,
+        chat_id: &str,
+        is_dm: bool,
+    ) -> bool {
+        if is_dm {
+            return self.is_authorized_for_platform(platform, user_id);
+        }
+
+        let platform = Self::platform_key(platform);
+        self.platform_group_authorized_users
+            .get(&platform)
+            .is_some_and(|users| self.user_matches_platform_set(&platform, user_id, users))
+            || self
+                .platform_group_authorized_chats
+                .get(&platform)
+                .is_some_and(|chats| Self::chat_matches_any(chat_id, chats))
+            || self.is_authorized_for_platform(&platform, user_id)
     }
 
     /// Check if a user is an admin.
@@ -254,6 +534,16 @@ impl DmManager {
     ) {
         self.platform_unauthorized_dm_behavior
             .insert(Self::platform_key(platform.as_ref()), behavior);
+    }
+
+    /// Mark a user's pairing flow as rate-limited.
+    pub fn record_pairing_rate_limit(&self, platform: &str, user_id: &str) {
+        if let Some(key) = Self::pairing_key(platform, user_id) {
+            self.pairing_rate_limited
+                .lock()
+                .unwrap_or_else(|err| err.into_inner())
+                .insert(key);
+        }
     }
 }
 
@@ -283,7 +573,11 @@ mod tests {
     async fn dm_manager_pair_behavior() {
         let dm = DmManager::with_pair_behavior();
         let decision = dm.handle_dm("unknown_user", "telegram").await;
-        assert!(matches!(decision, DmDecision::Pair { .. }));
+        let DmDecision::Pair { message } = decision else {
+            panic!("expected pairing decision");
+        };
+        let message = message.expect("pairing message");
+        assert!(message.contains("pairing code"));
     }
 
     #[tokio::test]
@@ -320,10 +614,50 @@ mod tests {
         dm.set_platform_unauthorized_behavior("telegram", UnauthorizedDmBehavior::Ignore);
 
         assert_eq!(dm.handle_dm("123", "telegram").await, DmDecision::Allow);
-        assert_eq!(dm.handle_dm("123", "discord").await, DmDecision::Pair {
-            message: Some("Your request has been submitted for approval. You will be notified once an admin reviews it.".to_string())
-        });
+        assert!(matches!(
+            dm.handle_dm("123", "discord").await,
+            DmDecision::Pair { .. }
+        ));
         assert_eq!(dm.handle_dm("999", "telegram").await, DmDecision::Deny);
+    }
+
+    #[tokio::test]
+    async fn dm_manager_group_allowlists_do_not_authorize_dms() {
+        let mut dm = DmManager::with_ignore_behavior();
+        dm.authorize_group_user_for_platform("telegram", "999");
+        dm.authorize_group_chat_for_platform("telegram", "-1001878443972");
+
+        assert!(dm.is_authorized_source("telegram", "999", "-1001878443972", false));
+        assert!(dm.is_authorized_source("telegram", "123", "-1001878443972", false));
+        assert!(!dm.is_authorized_source("telegram", "999", "999", true));
+    }
+
+    #[tokio::test]
+    async fn dm_manager_whatsapp_lid_alias_authorizes_phone_allowlist() {
+        let mut dm = DmManager::with_ignore_behavior();
+        dm.authorize_user_for_platform("whatsapp", "15550000001");
+        dm.add_user_alias_for_platform("whatsapp", "900000000000001", "15550000001");
+
+        assert_eq!(
+            dm.handle_dm("900000000000001@lid", "whatsapp").await,
+            DmDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn dm_manager_rate_limited_pairing_gets_no_response() {
+        let dm = DmManager::with_pair_behavior();
+        let first = dm.handle_dm("15551234567@s.whatsapp.net", "whatsapp").await;
+        let DmDecision::Pair { message } = first else {
+            panic!("expected pairing decision");
+        };
+        assert!(message.expect("pairing message").contains("pairing code"));
+
+        dm.record_pairing_rate_limit("whatsapp", "15551234567@s.whatsapp.net");
+        assert_eq!(
+            dm.handle_dm("15551234567@s.whatsapp.net", "whatsapp").await,
+            DmDecision::Deny
+        );
     }
 
     #[test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -294,6 +294,7 @@ pub struct PlatformAccessPolicy {
     pub allowed_users: HashSet<String>,
     pub admin_users: HashSet<String>,
     pub allowed_channels: HashSet<String>,
+    pub authorized_group_chats: HashSet<String>,
     pub ignored_channels: HashSet<String>,
     pub group_mode: GroupAccessMode,
     pub slash_requires_allowlist: bool,
@@ -351,6 +352,10 @@ impl PlatformAccessPolicy {
 
     fn is_channel_ignored(&self, channel_id: &str) -> bool {
         Self::channel_matches_any(channel_id, &self.ignored_channels)
+    }
+
+    pub fn is_group_chat_authorized(&self, channel_id: &str) -> bool {
+        Self::channel_matches_any(channel_id, &self.authorized_group_chats)
     }
 
     fn allows_sender_without_user_allowlist(
@@ -710,7 +715,10 @@ impl Gateway {
                         return Ok(());
                     }
                     GroupAccessMode::Allowlist => {
-                        if !bypasses_user_allowlist && !policy.is_user_allowed(&incoming.user_id) {
+                        if !bypasses_user_allowlist
+                            && !policy.is_user_allowed(&incoming.user_id)
+                            && !policy.is_group_chat_authorized(&incoming.chat_id)
+                        {
                             debug!(
                                 platform = incoming.platform,
                                 user_id = incoming.user_id,
@@ -2848,6 +2856,123 @@ mod tests {
             gw.session_transcript_len("telegram", "-100123", "any_user")
                 .await,
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_group_chat_authorization_allows_listed_chat_sender() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let mut policies = HashMap::new();
+        let mut policy = PlatformAccessPolicy {
+            group_mode: GroupAccessMode::Allowlist,
+            ..PlatformAccessPolicy::default()
+        };
+        policy.allowed_users.insert("999".to_string());
+        policy
+            .authorized_group_chats
+            .insert("-1001878443972".to_string());
+        policies.insert("telegram".to_string(), policy);
+        gw.set_platform_access_policies(policies).await;
+
+        let legacy_chat_source = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "-1001878443972".into(),
+            user_id: "123".into(),
+            text: "hello group".into(),
+            message_id: None,
+            is_dm: false,
+        };
+        assert!(gw.route_message(&legacy_chat_source).await.is_err());
+        assert_eq!(
+            gw.session_transcript_len("telegram", "-1001878443972", "123")
+                .await,
+            1
+        );
+
+        let sender_source = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "-1009999999999".into(),
+            user_id: "999".into(),
+            text: "hello group".into(),
+            message_id: None,
+            is_dm: false,
+        };
+        assert!(gw.route_message(&sender_source).await.is_err());
+        assert_eq!(
+            gw.session_transcript_len("telegram", "-1009999999999", "999")
+                .await,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_route_unauthorized_dm_pairs_with_code_message() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_pair_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("whatsapp", adapter).await;
+
+        let incoming = IncomingMessage {
+            platform: "whatsapp".into(),
+            chat_id: "15551234567@s.whatsapp.net".into(),
+            user_id: "15551234567@s.whatsapp.net".into(),
+            text: "hello".into(),
+            message_id: None,
+            is_dm: true,
+        };
+
+        assert!(gw.route_message(&incoming).await.is_ok());
+        let messages = sent.lock().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].1.contains("pairing code"));
+        assert_eq!(
+            gw.session_transcript_len(
+                "whatsapp",
+                "15551234567@s.whatsapp.net",
+                "15551234567@s.whatsapp.net"
+            )
+            .await,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_route_rate_limited_dm_sends_no_response() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_pair_behavior();
+        dm_manager.record_pairing_rate_limit("whatsapp", "15551234567@s.whatsapp.net");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("whatsapp", adapter).await;
+
+        let incoming = IncomingMessage {
+            platform: "whatsapp".into(),
+            chat_id: "15551234567@s.whatsapp.net".into(),
+            user_id: "15551234567@s.whatsapp.net".into(),
+            text: "hello".into(),
+            message_id: None,
+            is_dm: true,
+        };
+
+        assert!(gw.route_message(&incoming).await.is_ok());
+        assert!(sent.lock().unwrap().is_empty());
+        assert_eq!(
+            gw.session_transcript_len(
+                "whatsapp",
+                "15551234567@s.whatsapp.net",
+                "15551234567@s.whatsapp.net"
+            )
+            .await,
+            0
         );
     }
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T19:56:44.400545+00:00",
+  "generated_at_utc": "2026-05-31T22:15:34.592590+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T19:56:44.400545+00:00`
+Generated: `2026-05-31T22:15:34.592590+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -5581,17 +5581,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_unauthorized_dm_behavior.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "bedd3a1f6978d6a3db59e87a056d936dee1dcf59",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_unauthorized_dm_behavior.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "0aaad477c338d5629e15da061ff27050eee8a79f",
       "workstream": "WS6"
     },
@@ -15466,29 +15466,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T19:56:37.494325+00:00",
+  "generated_at_utc": "2026-05-31T22:15:34.499033+00:00",
   "refs": {
-    "local_ref": "HEAD",
-    "local_sha": "2375790b531094d144267ea971ac247ce2606d1d",
+    "local_ref": "main",
+    "local_sha": "374a305049eb857c09c58a70cabe2d27f57c3aa6",
     "upstream_ref": "upstream/main",
     "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 597,
-      "intentional_divergence": 264,
+      "functional": 596,
+      "intentional_divergence": 265,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 434,
-      "rust_equivalent_or_contract_test_required": 516,
+      "not_required_for_runtime": 435,
+      "rust_equivalent_or_contract_test_required": 515,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 264,
+      "cleared_intentional_divergence": 265,
       "cleared_non_runtime": 170,
-      "pending_review": 597
+      "pending_review": 596
     },
     "by_workstream": {
       "WS3": 56,
@@ -15497,10 +15497,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 264,
+    "cleared_intentional_divergence": 265,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 597,
+    "pending_review": 596,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T19:56:37.494325+00:00`
+Generated: `2026-05-31T22:15:34.499033+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `597`
+- Pending functional review: `596`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `264`
+- Cleared intentional divergence: `265`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 264 |
+| `cleared_intentional_divergence` | 265 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 597 |
+| `pending_review` | 596 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-31T19:56:37.494325+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 125 |
+| `tests/gateway` | 124 |
 | `tests/hermes_cli` | 120 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -185,6 +185,13 @@
       "ticket": 302
     },
     {
+      "path": "tests/gateway/test_unauthorized_dm_behavior.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream unauthorized-DM behavior is covered by Rust DmManager, Gateway route, and CLI builder tests for platform/global allowlists, wildcard allowlists, WhatsApp LID-to-phone mapping, Telegram group sender allowlists, Telegram legacy group-chat IDs, QQ group chat allowlists, allowlist-derived ignore defaults, explicit pair overrides, pairing-code replies, and pairing rate-limit suppression.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/gateway/test_hooks.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream gateway hook discovery, wildcard emit ordering, error containment, default empty context, and emit_collect decision hooks are covered by Rust HookRegistry tests; user hook loading intentionally uses zero-Python HOOK.yaml command handlers instead of dynamic handler.py imports.",


### PR DESCRIPTION
## Summary
- Implement Rust-native unauthorized-DM parity for platform/global allowlists, wildcard allowlists, explicit pair overrides, allowlist-derived ignore defaults, pairing-code replies, and rate-limit suppression.
- Add WhatsApp LID-to-phone mapping support from `$HERMES_HOME/whatsapp/session` and group authorization coverage for Telegram sender IDs, Telegram legacy negative chat IDs, Telegram group chat allowlists, and QQ group chat allowlists.
- Separate group chat authorization from hard channel gates with `authorized_group_chats`, then update parity docs for `tests/gateway/test_unauthorized_dm_behavior.py`.

## Parity Ledger
- Pending functional review: 597 -> 596
- Cleared intentional divergence: 264 -> 265
- `tests/gateway` pending prefix: 125 -> 124

## Verification
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` (`new=0`; two pre-existing stale allowlist entries)
- `cargo test -p hermes-gateway dm_manager -- --nocapture`
- `cargo test -p hermes-gateway gateway_route_unauthorized_dm_pairs_with_code_message -- --nocapture`
- `cargo test -p hermes-gateway gateway_route_rate_limited_dm_sends_no_response -- --nocapture`
- `cargo test -p hermes-gateway gateway_group_chat_authorization_allows_listed_chat_sender -- --nocapture`
- `cargo test -p hermes-cli gateway_dm_manager_ -- --nocapture`
- `cargo test -p hermes-cli gateway_platform_access_policy -- --nocapture`
- `cargo build --workspace`
- `cargo test --workspace`
