### PR TITLE
parity(gateway): cover Signal format and pacing

### DIFF
--- a/crates/hermes-gateway/src/platforms/mod.rs
+++ b/crates/hermes-gateway/src/platforms/mod.rs
@@ -17,6 +17,8 @@ pub mod whatsapp;
 
 #[cfg(feature = "signal")]
 pub mod signal;
+#[cfg(feature = "signal")]
+pub mod signal_rate_limit;
 
 #[cfg(feature = "matrix")]
 pub mod matrix;

--- a/crates/hermes-gateway/src/platforms/signal.rs
+++ b/crates/hermes-gateway/src/platforms/signal.rs
@@ -1,6 +1,7 @@
 //! Signal messaging adapter via signal-cli REST API.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use reqwest::Client;
@@ -12,6 +13,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::platforms::signal_rate_limit;
 
 // ---------------------------------------------------------------------------
 // Incoming message types
@@ -77,11 +79,13 @@ impl SignalAdapter {
     /// Send a message via signal-cli REST API.
     pub async fn send_text(&self, recipient: &str, text: &str) -> Result<(), GatewayError> {
         let url = format!("{}/v2/send", self.config.api_url);
-        let body = serde_json::json!({
-            "message": text,
+        let (plain_text, styles) = markdown_to_signal(text);
+        let mut body = serde_json::json!({
+            "message": plain_text,
             "number": self.config.phone_number,
             "recipients": [recipient]
         });
+        apply_signal_styles_to_body(&mut body, &styles);
 
         let resp = self
             .client
@@ -161,6 +165,247 @@ impl SignalAdapter {
             .map_err(|e| GatewayError::ConnectionFailed(format!("Signal parse failed: {}", e)))?;
         Ok(messages)
     }
+}
+
+fn apply_signal_styles_to_body(body: &mut serde_json::Value, styles: &[String]) {
+    if styles.is_empty() {
+        return;
+    }
+    if styles.len() == 1 {
+        body["textStyle"] = serde_json::Value::String(styles[0].clone());
+    } else {
+        body["textStyles"] = serde_json::Value::Array(
+            styles
+                .iter()
+                .cloned()
+                .map(serde_json::Value::String)
+                .collect(),
+        );
+    }
+}
+
+fn collapse_excess_newlines(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut newline_count = 0usize;
+    for ch in input.chars() {
+        if ch == '\n' {
+            newline_count += 1;
+            if newline_count <= 2 {
+                out.push(ch);
+            }
+        } else {
+            newline_count = 0;
+            out.push(ch);
+        }
+    }
+    out.trim().to_string()
+}
+
+fn utf16_len(value: &str) -> usize {
+    value.encode_utf16().count()
+}
+
+fn append_styled(out: &mut String, styles: &mut Vec<String>, text: &str, style: &str) {
+    if text.is_empty() {
+        return;
+    }
+    let start = utf16_len(out);
+    let len = utf16_len(text);
+    out.push_str(text);
+    styles.push(format!("{start}:{len}:{style}"));
+}
+
+fn is_line_start(input: &str, byte_idx: usize) -> bool {
+    byte_idx == 0 || input[..byte_idx].ends_with('\n')
+}
+
+fn find_same_line_marker(haystack: &str, marker: &str) -> Option<usize> {
+    let marker_pos = haystack.find(marker)?;
+    let newline_pos = haystack.find('\n');
+    if newline_pos.is_some_and(|pos| pos < marker_pos) {
+        None
+    } else {
+        Some(marker_pos)
+    }
+}
+
+fn prev_char(input: &str, byte_idx: usize) -> Option<char> {
+    input[..byte_idx].chars().next_back()
+}
+
+fn next_char(input: &str, byte_idx: usize) -> Option<char> {
+    input[byte_idx..].chars().next()
+}
+
+fn is_ascii_word(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn single_asterisk_close_offset(rest: &str) -> Option<usize> {
+    let mut search_from = 1usize;
+    while search_from < rest.len() {
+        let found = find_same_line_marker(&rest[search_from..], "*")?;
+        let close = search_from + found;
+        let before = prev_char(rest, close);
+        let after = next_char(rest, close + 1);
+        if before != Some('*') && after != Some('*') {
+            return Some(close);
+        }
+        search_from = close + 1;
+    }
+    None
+}
+
+fn single_underscore_close_offset(rest: &str) -> Option<usize> {
+    let mut search_from = 1usize;
+    while search_from < rest.len() {
+        let found = find_same_line_marker(&rest[search_from..], "_")?;
+        let close = search_from + found;
+        let before = prev_char(rest, close);
+        let after = next_char(rest, close + 1);
+        if before != Some('_') && after.is_none_or(|ch| !is_ascii_word(ch)) {
+            return Some(close);
+        }
+        search_from = close + 1;
+    }
+    None
+}
+
+fn append_next_char(input: &str, byte_idx: &mut usize, out: &mut String) {
+    let ch = input[*byte_idx..]
+        .chars()
+        .next()
+        .expect("byte index must point at a char boundary");
+    out.push(ch);
+    *byte_idx += ch.len_utf8();
+}
+
+/// Convert Markdown-like Signal output into signal-cli plain text plus
+/// UTF-16 body range descriptors (`start:length:STYLE`).
+pub fn markdown_to_signal(text: &str) -> (String, Vec<String>) {
+    let input = collapse_excess_newlines(text);
+    if input.is_empty() {
+        return (String::new(), Vec::new());
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut styles = Vec::new();
+    let mut i = 0usize;
+    while i < input.len() {
+        let rest = &input[i..];
+
+        if let Some(after_fence) = rest.strip_prefix("```") {
+            if let Some(close_rel) = after_fence.find("```") {
+                let block = &after_fence[..close_rel];
+                let code = if let Some(newline) = block.find('\n') {
+                    &block[newline + 1..]
+                } else {
+                    block
+                };
+                append_styled(
+                    &mut out,
+                    &mut styles,
+                    code.trim_end_matches('\n'),
+                    "MONOSPACE",
+                );
+                i += 3 + close_rel + 3;
+                continue;
+            }
+        }
+
+        if is_line_start(&input, i) && rest.starts_with('#') {
+            let hashes = rest.chars().take_while(|ch| *ch == '#').count();
+            if (1..=6).contains(&hashes) {
+                let marker_len = hashes;
+                if next_char(rest, marker_len).is_some_and(char::is_whitespace) {
+                    let after_marker = rest[marker_len..].trim_start_matches([' ', '\t']);
+                    let consumed_ws = rest[marker_len..].len() - after_marker.len();
+                    let content_start = marker_len + consumed_ws;
+                    let line_len = rest[content_start..]
+                        .find('\n')
+                        .unwrap_or(rest.len() - content_start);
+                    let line = &rest[content_start..content_start + line_len];
+                    append_styled(&mut out, &mut styles, line, "BOLD");
+                    i += content_start + line_len;
+                    continue;
+                }
+            }
+        }
+
+        if let Some(close) = rest
+            .strip_prefix("**")
+            .and_then(|tail| find_same_line_marker(tail, "**"))
+            .map(|pos| pos + 2)
+        {
+            let inner = &rest[2..close];
+            append_styled(&mut out, &mut styles, inner, "BOLD");
+            i += close + 2;
+            continue;
+        }
+
+        if let Some(close) = rest
+            .strip_prefix("__")
+            .and_then(|tail| find_same_line_marker(tail, "__"))
+            .map(|pos| pos + 2)
+        {
+            let inner = &rest[2..close];
+            append_styled(&mut out, &mut styles, inner, "BOLD");
+            i += close + 2;
+            continue;
+        }
+
+        if let Some(close) = rest
+            .strip_prefix("~~")
+            .and_then(|tail| find_same_line_marker(tail, "~~"))
+            .map(|pos| pos + 2)
+        {
+            let inner = &rest[2..close];
+            append_styled(&mut out, &mut styles, inner, "STRIKETHROUGH");
+            i += close + 2;
+            continue;
+        }
+
+        if let Some(close) = rest
+            .strip_prefix('`')
+            .and_then(|tail| find_same_line_marker(tail, "`"))
+            .map(|pos| pos + 1)
+        {
+            let inner = &rest[1..close];
+            append_styled(&mut out, &mut styles, inner, "MONOSPACE");
+            i += close + 1;
+            continue;
+        }
+
+        if rest.starts_with('*')
+            && !rest.starts_with("**")
+            && !rest.starts_with("* ")
+            && !next_char(rest, 1).is_some_and(char::is_whitespace)
+        {
+            if let Some(close) = single_asterisk_close_offset(rest) {
+                let inner = &rest[1..close];
+                append_styled(&mut out, &mut styles, inner, "ITALIC");
+                i += close + 1;
+                continue;
+            }
+        }
+
+        if rest.starts_with('_')
+            && !rest.starts_with("__")
+            && !next_char(rest, 1).is_some_and(char::is_whitespace)
+            && prev_char(&input, i).is_none_or(|ch| !is_ascii_word(ch))
+        {
+            if let Some(close) = single_underscore_close_offset(rest) {
+                let inner = &rest[1..close];
+                append_styled(&mut out, &mut styles, inner, "ITALIC");
+                i += close + 1;
+                continue;
+            }
+        }
+
+        append_next_char(&input, &mut i, &mut out);
+    }
+
+    (out, styles)
 }
 
 fn normalized_image_content_type(content_type: Option<&str>) -> Option<String> {
@@ -278,6 +523,21 @@ impl PlatformAdapter for SignalAdapter {
 
         let b64 = base64_encode(&file_bytes);
 
+        let scheduler = signal_rate_limit::get_scheduler();
+        let started = Instant::now();
+        let waited = {
+            let mut scheduler = scheduler.lock().await;
+            scheduler.acquire(1).await.map_err(|err| {
+                GatewayError::SendFailed(format!("Signal attachment scheduler error: {err}"))
+            })?
+        };
+        if waited >= signal_rate_limit::SIGNAL_BATCH_PACING_NOTICE_THRESHOLD {
+            debug!(
+                waited = %signal_rate_limit::format_wait(waited),
+                "Signal attachment send paced by scheduler"
+            );
+        }
+
         let url = format!("{}/v2/send", self.config.api_url);
         let body = serde_json::json!({
             "message": caption.unwrap_or(""),
@@ -296,10 +556,18 @@ impl PlatformAdapter for SignalAdapter {
 
         if !resp.status().is_success() {
             let text = resp.text().await.unwrap_or_default();
+            if signal_rate_limit::is_signal_rate_limit_error(&text) {
+                let retry_after = signal_rate_limit::extract_retry_after_seconds(&text);
+                scheduler.lock().await.feedback(retry_after, 1);
+            }
             return Err(GatewayError::SendFailed(format!(
                 "Signal attachment error: {text}"
             )));
         }
+        scheduler
+            .lock()
+            .await
+            .report_rpc_duration(started.elapsed(), 1);
         Ok(())
     }
 
@@ -410,7 +678,7 @@ impl PlatformAdapter for SignalAdapter {
 /// Simple base64 encoding using the `base64` crate convention (standard alphabet).
 fn base64_encode(data: &[u8]) -> String {
     const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut result = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
@@ -435,6 +703,31 @@ fn base64_encode(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn style_types(styles: &[String]) -> Vec<&str> {
+        styles
+            .iter()
+            .filter_map(|style| style.rsplit(':').next())
+            .collect()
+    }
+
+    fn styles_with_type<'a>(styles: &'a [String], style_type: &str) -> Vec<&'a String> {
+        styles
+            .iter()
+            .filter(|style| style.ends_with(&format!(":{style_type}")))
+            .collect()
+    }
+
+    fn extract_utf16(text: &str, style: &str) -> String {
+        let parts: Vec<_> = style.split(':').collect();
+        let start = parts[0].parse::<usize>().expect("style start");
+        let len = parts[1].parse::<usize>().expect("style len");
+        let encoded: Vec<u16> = text.encode_utf16().collect();
+        String::from_utf16(&encoded[start..start + len]).expect("valid utf16 slice")
+    }
 
     #[test]
     fn remote_image_file_name_keeps_extension() {
@@ -456,5 +749,129 @@ mod tests {
     fn image_fallback_text_with_caption() {
         let text = image_fallback_text("https://cdn.example.com/path/diagram", Some("Figure 1"));
         assert_eq!(text, "Figure 1\nhttps://cdn.example.com/path/diagram");
+    }
+
+    #[test]
+    fn signal_markdown_basic_styles_strip_markers() {
+        let (text, styles) = markdown_to_signal("**bold** and *italic* and ~~strike~~");
+        assert_eq!(text, "bold and italic and strike");
+        let mut types = style_types(&styles);
+        types.sort_unstable();
+        assert_eq!(types, vec!["BOLD", "ITALIC", "STRIKETHROUGH"]);
+    }
+
+    #[test]
+    fn signal_markdown_handles_inline_and_fenced_code() {
+        let (text, styles) = markdown_to_signal("run `ls -la`\n```python\nprint('hello')\n```");
+        assert!(text.contains("ls -la"));
+        assert!(text.contains("print('hello')"));
+        assert!(!text.contains("```"));
+        assert!(!text.contains("python"));
+        assert_eq!(styles_with_type(&styles, "MONOSPACE").len(), 2);
+    }
+
+    #[test]
+    fn signal_markdown_headings_become_bold_ranges() {
+        let (text, styles) = markdown_to_signal("## First\n\nSome text\n\n### Second");
+        assert_eq!(text, "First\n\nSome text\n\nSecond");
+        assert_eq!(styles_with_type(&styles, "BOLD").len(), 2);
+        assert!(!text.contains("##"));
+    }
+
+    #[test]
+    fn signal_markdown_avoids_italic_false_positives() {
+        for input in [
+            "the config_file is ready",
+            "set OPENAI_API_KEY and ANTHROPIC_API_KEY",
+            "/tools/delegate_tool.py",
+            "* item one\n* item two\n* item three",
+            "*foo\nbar*",
+            "_foo\nbar_",
+        ] {
+            let (_text, styles) = markdown_to_signal(input);
+            assert!(
+                styles_with_type(&styles, "ITALIC").is_empty(),
+                "unexpected italic style for {input:?}: {styles:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn signal_markdown_keeps_italic_inside_bullet() {
+        let (text, styles) = markdown_to_signal("* this has *emphasis* inside\n* plain item");
+        assert!(text.contains("emphasis"));
+        assert_eq!(styles_with_type(&styles, "ITALIC").len(), 1);
+    }
+
+    #[test]
+    fn signal_markdown_positions_are_utf16_body_ranges() {
+        let (text, styles) = markdown_to_signal("🎉🎉 **test**");
+        assert_eq!(text, "🎉🎉 test");
+        assert_eq!(styles.len(), 1);
+        assert_eq!(styles[0], "5:4:BOLD");
+        assert_eq!(extract_utf16(&text, &styles[0]), "test");
+    }
+
+    #[test]
+    fn signal_markdown_collapses_excess_newlines_and_preserves_links() {
+        let (text, styles) =
+            markdown_to_signal("first\n\n\n\nsecond\nCheck [link](https://example.com)");
+        assert!(!text.contains("\n\n\n"));
+        assert!(text.contains("https://example.com"));
+        assert!(styles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_text_posts_signal_style_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v2/send"))
+            .and(body_partial_json(json!({
+                "message": "hello world",
+                "number": "+15551234567",
+                "recipients": ["+15559876543"],
+                "textStyle": "6:5:BOLD"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"timestamp": 1})))
+            .mount(&server)
+            .await;
+
+        let adapter = SignalAdapter::new(SignalConfig {
+            phone_number: "+15551234567".to_string(),
+            api_url: server.uri(),
+            proxy: AdapterProxyConfig::default(),
+        })
+        .expect("adapter");
+
+        adapter
+            .send_text("+15559876543", "hello **world**")
+            .await
+            .expect("send text");
+    }
+
+    #[tokio::test]
+    async fn send_text_posts_multiple_signal_styles() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v2/send"))
+            .and(body_partial_json(json!({
+                "message": "bold and italic",
+                "textStyles": ["0:4:BOLD", "9:6:ITALIC"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"timestamp": 1})))
+            .mount(&server)
+            .await;
+
+        let adapter = SignalAdapter::new(SignalConfig {
+            phone_number: "+15551234567".to_string(),
+            api_url: server.uri(),
+            proxy: AdapterProxyConfig::default(),
+        })
+        .expect("adapter");
+
+        adapter
+            .send_text("+15559876543", "**bold** and *italic*")
+            .await
+            .expect("send text");
     }
 }

--- a/crates/hermes-gateway/src/platforms/signal_rate_limit.rs
+++ b/crates/hermes-gateway/src/platforms/signal_rate_limit.rs
@@ -1,0 +1,314 @@
+//! Signal attachment rate-limit scheduler.
+//!
+//! Signal's server-side attachment bucket is per account.  This module keeps a
+//! process-wide token-bucket model so concurrent gateway sessions pace uploads
+//! before the server starts returning 429s.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex as AsyncMutex;
+
+pub const SIGNAL_MAX_ATTACHMENTS_PER_MSG: usize = 32;
+pub const SIGNAL_RATE_LIMIT_BUCKET_CAPACITY: f64 = 50.0;
+pub const SIGNAL_RATE_LIMIT_DEFAULT_RETRY_AFTER: f64 = 4.0;
+pub const SIGNAL_RATE_LIMIT_MAX_ATTEMPTS: usize = 2;
+pub const SIGNAL_BATCH_PACING_NOTICE_THRESHOLD: f64 = 10.0;
+
+static SCHEDULER: Mutex<Option<Arc<AsyncMutex<SignalAttachmentScheduler>>>> = Mutex::new(None);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SignalSchedulerState {
+    pub tokens: f64,
+    pub capacity: usize,
+    pub refill_rate: f64,
+    pub refill_seconds_per_token: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignalSchedulerError {
+    message: String,
+}
+
+impl std::fmt::Display for SignalSchedulerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SignalSchedulerError {}
+
+/// Token-bucket simulator for Signal attachment sends.
+#[derive(Debug, Clone)]
+pub struct SignalAttachmentScheduler {
+    pub capacity: f64,
+    pub tokens: f64,
+    pub refill_rate: f64,
+    pub last_refill: Instant,
+}
+
+impl Default for SignalAttachmentScheduler {
+    fn default() -> Self {
+        Self::new(
+            SIGNAL_RATE_LIMIT_BUCKET_CAPACITY,
+            SIGNAL_RATE_LIMIT_DEFAULT_RETRY_AFTER,
+        )
+    }
+}
+
+impl SignalAttachmentScheduler {
+    pub fn new(capacity: f64, default_retry_after: f64) -> Self {
+        let capacity = capacity.max(1.0);
+        let retry_after = default_retry_after.max(0.001);
+        Self {
+            capacity,
+            tokens: capacity,
+            refill_rate: 1.0 / retry_after,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.saturating_duration_since(self.last_refill);
+        if elapsed > Duration::ZERO && self.tokens < self.capacity {
+            self.tokens =
+                (self.tokens + elapsed.as_secs_f64() * self.refill_rate).min(self.capacity);
+        }
+        self.last_refill = now;
+    }
+
+    pub fn estimate_wait(&self, n: usize) -> f64 {
+        if n == 0 {
+            return 0.0;
+        }
+        let elapsed = Instant::now()
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64();
+        let projected = if elapsed > 0.0 && self.tokens < self.capacity {
+            (self.tokens + elapsed * self.refill_rate).min(self.capacity)
+        } else {
+            self.tokens
+        };
+        let deficit = n as f64 - projected;
+        if deficit <= 0.0 {
+            0.0
+        } else {
+            deficit / self.refill_rate
+        }
+    }
+
+    /// Wait until `n` attachment tokens should be available.
+    ///
+    /// This mirrors upstream behavior: acquire waits but does not deduct.  The
+    /// caller records the completed RPC with `report_rpc_duration`, because the
+    /// server checks capacity at RPC start and upload time should not be
+    /// credited as refill.
+    pub async fn acquire(&mut self, n: usize) -> Result<f64, SignalSchedulerError> {
+        if n == 0 {
+            return Ok(0.0);
+        }
+        if n as f64 > self.capacity {
+            return Err(SignalSchedulerError {
+                message: format!(
+                    "Signal scheduler requested {n} tokens but capacity is {}",
+                    self.capacity as usize
+                ),
+            });
+        }
+
+        let mut slept = 0.0;
+        loop {
+            self.refill();
+            if self.tokens >= n as f64 {
+                return Ok(slept);
+            }
+
+            let wait = (n as f64 - self.tokens) / self.refill_rate;
+            tokio::time::sleep(Duration::from_secs_f64(wait)).await;
+            slept += wait;
+        }
+    }
+
+    pub fn report_rpc_duration(&mut self, _rpc_duration: Duration, n_attachments: usize) {
+        if n_attachments == 0 {
+            return;
+        }
+        self.tokens = (self.tokens - n_attachments as f64).max(0.0);
+        self.last_refill = Instant::now();
+    }
+
+    pub fn feedback(&mut self, retry_after: Option<f64>, _n_attempted: usize) {
+        if let Some(retry_after) = retry_after.filter(|v| *v > 0.0) {
+            self.refill_rate = 1.0 / retry_after;
+        }
+        self.tokens = 0.0;
+        self.last_refill = Instant::now();
+    }
+
+    pub fn state(&self) -> SignalSchedulerState {
+        let projected = (self.tokens
+            + Instant::now()
+                .saturating_duration_since(self.last_refill)
+                .as_secs_f64()
+                * self.refill_rate)
+            .min(self.capacity);
+        SignalSchedulerState {
+            tokens: (projected * 10.0).round() / 10.0,
+            capacity: self.capacity as usize,
+            refill_rate: self.refill_rate,
+            refill_seconds_per_token: if self.refill_rate > 0.0 {
+                1.0 / self.refill_rate
+            } else {
+                f64::INFINITY
+            },
+        }
+    }
+}
+
+pub fn get_scheduler() -> Arc<AsyncMutex<SignalAttachmentScheduler>> {
+    let mut guard = SCHEDULER.lock().expect("signal scheduler lock poisoned");
+    guard
+        .get_or_insert_with(|| Arc::new(AsyncMutex::new(SignalAttachmentScheduler::default())))
+        .clone()
+}
+
+#[cfg(test)]
+pub fn reset_scheduler() {
+    *SCHEDULER.lock().expect("signal scheduler lock poisoned") = None;
+}
+
+pub fn extract_retry_after_seconds(message: &str) -> Option<f64> {
+    let lower = message.to_ascii_lowercase();
+    let marker = "retry after ";
+    let idx = lower.find(marker)?;
+    let rest = &message[idx + marker.len()..];
+    let number: String = rest
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit() || *ch == '.')
+        .collect();
+    number.parse::<f64>().ok()
+}
+
+pub fn is_signal_rate_limit_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    message.contains("[429]")
+        || lower.contains("ratelimit")
+        || lower.contains("retrylaterexception")
+        || lower.contains("retry after")
+}
+
+pub fn format_wait(seconds: f64) -> String {
+    let seconds = seconds.max(0.0);
+    if seconds < 90.0 {
+        format!("{}s", seconds.round() as u64)
+    } else {
+        format!("{} min", ((seconds / 60.0).round() as u64).max(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheduler_defaults_match_signal_bucket_contract() {
+        let scheduler = SignalAttachmentScheduler::default();
+        assert_eq!(scheduler.capacity, SIGNAL_RATE_LIMIT_BUCKET_CAPACITY);
+        assert_eq!(scheduler.tokens, scheduler.capacity);
+        assert_eq!(
+            scheduler.refill_rate,
+            1.0 / SIGNAL_RATE_LIMIT_DEFAULT_RETRY_AFTER
+        );
+    }
+
+    #[test]
+    fn estimate_wait_is_zero_when_bucket_has_enough_tokens() {
+        let scheduler = SignalAttachmentScheduler::default();
+        assert_eq!(scheduler.estimate_wait(10), 0.0);
+        assert_eq!(
+            scheduler.estimate_wait(SIGNAL_RATE_LIMIT_BUCKET_CAPACITY as usize),
+            0.0
+        );
+    }
+
+    #[test]
+    fn estimate_wait_is_proportional_to_deficit() {
+        let scheduler = SignalAttachmentScheduler {
+            tokens: 0.0,
+            last_refill: Instant::now(),
+            ..Default::default()
+        };
+        let wait = scheduler.estimate_wait(32);
+        let expected = 32.0 / scheduler.refill_rate;
+        assert!((wait - expected).abs() < 0.001, "{wait} != {expected}");
+    }
+
+    #[tokio::test]
+    async fn acquire_zero_is_noop() {
+        let mut scheduler = SignalAttachmentScheduler::default();
+        let original = scheduler.tokens;
+        let waited = scheduler.acquire(0).await.expect("zero acquire");
+        assert_eq!(waited, 0.0);
+        assert_eq!(scheduler.tokens, original);
+    }
+
+    #[tokio::test]
+    async fn acquire_within_capacity_does_not_deduct_until_reported() {
+        let mut scheduler = SignalAttachmentScheduler::default();
+        let waited = scheduler.acquire(10).await.expect("acquire");
+        assert_eq!(waited, 0.0);
+        assert_eq!(scheduler.tokens, scheduler.capacity);
+        scheduler.report_rpc_duration(Duration::from_millis(1), 10);
+        assert_eq!(scheduler.tokens, scheduler.capacity - 10.0);
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_more_than_capacity() {
+        let mut scheduler = SignalAttachmentScheduler::default();
+        let err = scheduler
+            .acquire(SIGNAL_RATE_LIMIT_BUCKET_CAPACITY as usize + 1)
+            .await
+            .expect_err("over capacity should fail");
+        assert!(err.to_string().contains("capacity"));
+    }
+
+    #[test]
+    fn feedback_calibrates_refill_rate_and_zeros_tokens() {
+        let mut scheduler = SignalAttachmentScheduler::default();
+        scheduler.feedback(Some(42.0), 1);
+        assert_eq!(scheduler.refill_rate, 1.0 / 42.0);
+        assert_eq!(scheduler.tokens, 0.0);
+    }
+
+    #[test]
+    fn refill_clamps_at_capacity() {
+        let mut scheduler = SignalAttachmentScheduler {
+            tokens: 0.0,
+            last_refill: Instant::now() - Duration::from_secs(365 * 24 * 3600),
+            ..Default::default()
+        };
+        scheduler.refill();
+        assert_eq!(scheduler.tokens, scheduler.capacity);
+    }
+
+    #[test]
+    fn retry_after_and_rate_limit_detection_cover_signal_cli_shapes() {
+        assert_eq!(
+            extract_retry_after_seconds("AttachmentInvalidException: Retry after 42 seconds"),
+            Some(42.0)
+        );
+        assert!(is_signal_rate_limit_error("[429] RateLimitException"));
+        assert!(is_signal_rate_limit_error("RetryLaterException"));
+        assert!(!is_signal_rate_limit_error("network unavailable"));
+    }
+
+    #[test]
+    fn singleton_can_be_reset_for_tests() {
+        reset_scheduler();
+        let first = get_scheduler();
+        reset_scheduler();
+        let second = get_scheduler();
+        assert!(!Arc::ptr_eq(&first, &second));
+    }
+}

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T22:15:34.592590+00:00",
+  "generated_at_utc": "2026-05-31T23:00:22.367299+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T22:15:34.592590+00:00`
+Generated: `2026-05-31T23:00:22.367299+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -5086,32 +5086,32 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_signal_format.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "ef50f62fd0a4fe739e4bb9e6d316211a27d0cc01",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_signal_format.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "0050a980f59a84bcd37b34a15ecd0c7a94a34c5f",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_signal_rate_limit.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "963f8b9303bfde3ac68d60e9ffee79117dce569d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_signal_rate_limit.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "d2111cb3d28e9dcfc8053f070b720bfbd2a224df",
       "workstream": "WS6"
     },
@@ -15466,29 +15466,29 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T22:15:34.499033+00:00",
+  "generated_at_utc": "2026-05-31T23:00:22.467089+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "374a305049eb857c09c58a70cabe2d27f57c3aa6",
+    "local_sha": "656d1ca7059279fc212f2bad2e19dcaa61f761e7",
     "upstream_ref": "upstream/main",
     "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 596,
-      "intentional_divergence": 265,
+      "functional": 594,
+      "intentional_divergence": 267,
       "policy_only": 169
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 435,
-      "rust_equivalent_or_contract_test_required": 515,
+      "not_required_for_runtime": 437,
+      "rust_equivalent_or_contract_test_required": 513,
       "rust_primary_ux_or_documented_divergence_required": 81
     },
     "by_status": {
-      "cleared_intentional_divergence": 265,
+      "cleared_intentional_divergence": 267,
       "cleared_non_runtime": 170,
-      "pending_review": 596
+      "pending_review": 594
     },
     "by_workstream": {
       "WS3": 56,
@@ -15497,10 +15497,10 @@
       "WS6": 689,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 265,
+    "cleared_intentional_divergence": 267,
     "cleared_non_runtime": 170,
     "pending_classification": 0,
-    "pending_review": 596,
+    "pending_review": 594,
     "total_shared_different": 1031
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T22:15:34.499033+00:00`
+Generated: `2026-05-31T23:00:22.467089+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1031`
 - Pending classification: `0`
-- Pending functional review: `596`
+- Pending functional review: `594`
 - Cleared non-runtime: `170`
-- Cleared intentional divergence: `265`
+- Cleared intentional divergence: `267`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 265 |
+| `cleared_intentional_divergence` | 267 |
 | `cleared_non_runtime` | 170 |
-| `pending_review` | 596 |
+| `pending_review` | 594 |
 
 ## Workstream Counts
 
@@ -37,7 +37,7 @@ Generated: `2026-05-31T22:15:34.499033+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 124 |
+| `tests/gateway` | 122 |
 | `tests/hermes_cli` | 120 |
 | `tests/tools` | 84 |
 | `ui-tui/src` | 60 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -192,6 +192,20 @@
       "ticket": 302
     },
     {
+      "path": "tests/gateway/test_signal_format.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Signal markdown formatting is covered by Rust Signal gateway tests for bold, italic, strikethrough, monospace, fenced code blocks with language tags, heading-to-bold conversion, UTF-16 body ranges, newline collapse, link preservation, and italic false-positive regressions for snake_case, bullet lists, and cross-line spans.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_signal_rate_limit.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Signal attachment rate-limit behavior is covered by Rust token-bucket scheduler tests for default capacity/refill, wait estimation, zero/in-capacity/over-capacity acquire, post-RPC deduction, retry-after feedback calibration, refill clamping, rate-limit detection, wait formatting, and process-wide scheduler reset.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/gateway/test_hooks.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream gateway hook discovery, wildcard emit ordering, error containment, default empty context, and emit_collect decision hooks are covered by Rust HookRegistry tests; user hook loading intentionally uses zero-Python HOOK.yaml command handlers instead of dynamic handler.py imports.",


### PR DESCRIPTION
## Summary
- Add Rust-native Signal markdown-to-body-range formatting and include `textStyle` / `textStyles` in Signal send payloads.
- Add a process-wide Signal attachment token-bucket scheduler with retry-after feedback and wire it into attachment sends.
- Clear parity backlog entries for `tests/gateway/test_signal_format.py` and `tests/gateway/test_signal_rate_limit.py`.

## Verification
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `cargo test -p hermes-gateway --features signal`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, `stale=3`)
- `cargo build --workspace`
- `cargo test --workspace --quiet`

## Risk
- No live Signal API call was made; REST coverage is via wiremock payload tests plus Rust scheduler/unit/workspace tests.
