### PR TITLE
parity(gateway): add agent cache session controls

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -5562,9 +5562,16 @@ fn telegram_gateway_message(msg: TelegramIncomingMessage) -> GatewayIncomingMess
         .or(msg.username)
         .unwrap_or_else(|| "unknown".to_string());
 
+    let chat_id = match msg.message_thread_id {
+        Some(thread_id) if msg.is_group && thread_id != 0 => {
+            format!("{}:{}", msg.chat_id, thread_id)
+        }
+        _ => msg.chat_id.to_string(),
+    };
+
     GatewayIncomingMessage {
         platform: "telegram".to_string(),
-        chat_id: msg.chat_id.to_string(),
+        chat_id,
         user_id,
         text,
         message_id: Some(msg.message_id.to_string()),
@@ -14642,6 +14649,39 @@ mod tests {
         assert_eq!(cfg.host, "0.0.0.0");
         assert_eq!(cfg.port, 9123);
         assert_eq!(cfg.auth_token.as_deref(), Some("platform-token"));
+    }
+
+    #[test]
+    fn telegram_gateway_message_preserves_group_topic_in_chat_id() {
+        let incoming = TelegramIncomingMessage {
+            chat_id: -1001,
+            user_id: Some(42),
+            username: Some("alice".to_string()),
+            text: Some("topic hello".to_string()),
+            message_id: 77,
+            is_voice: false,
+            is_photo: false,
+            is_sticker: false,
+            is_document: false,
+            voice_file_id: None,
+            photo_file_id: None,
+            sticker_file_id: None,
+            document_file_id: None,
+            document_file_name: None,
+            document_mime_type: None,
+            document_file_size: None,
+            reply_to_message_id: None,
+            message_thread_id: Some(17585),
+            chat_type: hermes_gateway::platforms::telegram::ChatKind::Supergroup,
+            is_group: true,
+            callback_query_id: None,
+            callback_data: None,
+        };
+
+        let routed = telegram_gateway_message(incoming);
+        assert_eq!(routed.chat_id, "-1001:17585");
+        assert_eq!(routed.user_id, "42");
+        assert!(!routed.is_dm);
     }
 
     #[test]

--- a/crates/hermes-gateway/src/agent_cache.rs
+++ b/crates/hermes-gateway/src/agent_cache.rs
@@ -1,0 +1,593 @@
+//! Rust-native gateway agent cache helpers.
+//!
+//! The Python gateway caches an agent per session and invalidates it when the
+//! runtime model/provider/tool/config signature changes. This module keeps the
+//! same contract without depending on the concrete Rust agent type.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+pub const CACHE_BUSTING_CONFIG_KEYS: &[(&str, &str)] = &[
+    ("model", "context_length"),
+    ("model", "max_tokens"),
+    ("compression", "enabled"),
+    ("compression", "threshold"),
+    ("compression", "target_ratio"),
+    ("compression", "protect_last_n"),
+];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentConfigSignatureInput {
+    pub model: String,
+    #[serde(default)]
+    pub runtime: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub toolsets: Vec<String>,
+    #[serde(default)]
+    pub system_prompt: String,
+    #[serde(default)]
+    pub cache_keys: BTreeMap<String, Value>,
+}
+
+fn secretish_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("api_key")
+        || key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("credential")
+}
+
+fn fingerprint_secret(raw: &str) -> Value {
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    serde_json::json!({
+        "len": raw.chars().count(),
+        "sha256": format!("{:x}", hasher.finalize()),
+    })
+}
+
+fn canonical_value(key_hint: &str, value: &Value) -> Value {
+    if secretish_key(key_hint) {
+        if let Some(s) = value.as_str() {
+            return fingerprint_secret(s);
+        }
+    }
+
+    match value {
+        Value::Object(map) => {
+            let sorted = map
+                .iter()
+                .map(|(key, value)| (key.clone(), canonical_value(key, value)))
+                .collect::<BTreeMap<_, _>>();
+            Value::Object(sorted.into_iter().collect())
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| canonical_value(key_hint, value))
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+fn canonical_map(input: &BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+    input
+        .iter()
+        .map(|(key, value)| (key.clone(), canonical_value(key, value)))
+        .collect()
+}
+
+/// Stable, secret-safe config signature.
+///
+/// Full token values affect the digest, but raw secrets are first converted to
+/// SHA-256 fingerprints so diagnostic callers never need to retain plaintext.
+pub fn agent_config_signature(input: &AgentConfigSignatureInput) -> String {
+    let mut toolsets = input.toolsets.clone();
+    toolsets.sort();
+    let payload = serde_json::json!({
+        "model": input.model,
+        "runtime": canonical_map(&input.runtime),
+        "toolsets": toolsets,
+        "system_prompt": input.system_prompt,
+        "cache_keys": canonical_map(&input.cache_keys),
+    });
+    let encoded = serde_json::to_vec(&payload).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(encoded);
+    format!("{:x}", hasher.finalize())
+}
+
+fn object_subkey<'a>(config: &'a Value, section: &str, key: &str) -> Option<&'a Value> {
+    config
+        .get(section)
+        .and_then(Value::as_object)
+        .and_then(|section| section.get(key))
+}
+
+/// Extract the config subset that must bust a cached gateway agent.
+///
+/// Missing keys are included as `null` so adding a value later changes the
+/// signature deterministically. `tools.registry_generation` models MCP/tool
+/// reloads that mutate the effective toolset without changing config.yaml.
+pub fn extract_cache_busting_config(
+    config: Option<&Value>,
+    tools_registry_generation: Option<u64>,
+) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    for (section, key) in CACHE_BUSTING_CONFIG_KEYS {
+        let value = config
+            .and_then(|cfg| object_subkey(cfg, section, key))
+            .cloned()
+            .unwrap_or(Value::Null);
+        out.insert(format!("{section}.{key}"), value);
+    }
+    out.insert(
+        "tools.registry_generation".to_string(),
+        tools_registry_generation
+            .map(Value::from)
+            .unwrap_or(Value::Null),
+    );
+    out
+}
+
+struct AgentCacheEntry<T> {
+    agent: T,
+    signature: String,
+    last_activity: Instant,
+}
+
+type ReleaseHook<T> = Arc<dyn Fn(&T) + Send + Sync>;
+
+/// Session-keyed LRU cache for gateway agents.
+pub struct GatewayAgentCache<T> {
+    entries: HashMap<String, AgentCacheEntry<T>>,
+    lru: VecDeque<String>,
+    max_size: usize,
+    idle_ttl: Duration,
+    release_hook: Option<ReleaseHook<T>>,
+}
+
+impl<T> GatewayAgentCache<T> {
+    pub fn new(max_size: usize, idle_ttl: Duration) -> Self {
+        Self {
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            max_size,
+            idle_ttl,
+            release_hook: None,
+        }
+    }
+
+    pub fn with_release_hook(mut self, hook: ReleaseHook<T>) -> Self {
+        self.release_hook = Some(hook);
+        self
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn touch_lru(&mut self, session_key: &str) {
+        self.lru.retain(|key| key != session_key);
+        self.lru.push_back(session_key.to_string());
+    }
+
+    fn release(&self, agent: &T) {
+        if let Some(hook) = self.release_hook.as_ref() {
+            hook(agent);
+        }
+    }
+
+    pub fn insert_at_with_active(
+        &mut self,
+        session_key: impl Into<String>,
+        agent: T,
+        signature: impl Into<String>,
+        now: Instant,
+        is_active: impl FnMut(&str, &T) -> bool,
+    ) {
+        let session_key = session_key.into();
+        if let Some(old) = self.entries.remove(&session_key) {
+            self.release(&old.agent);
+        }
+        self.entries.insert(
+            session_key.clone(),
+            AgentCacheEntry {
+                agent,
+                signature: signature.into(),
+                last_activity: now,
+            },
+        );
+        self.touch_lru(&session_key);
+        self.enforce_cap_with_active(is_active);
+    }
+
+    pub fn insert_at(
+        &mut self,
+        session_key: impl Into<String>,
+        agent: T,
+        signature: impl Into<String>,
+        now: Instant,
+    ) {
+        self.insert_at_with_active(session_key, agent, signature, now, |_, _| false);
+    }
+
+    pub fn insert_with_active(
+        &mut self,
+        session_key: impl Into<String>,
+        agent: T,
+        signature: impl Into<String>,
+        is_active: impl FnMut(&str, &T) -> bool,
+    ) {
+        self.insert_at_with_active(session_key, agent, signature, Instant::now(), is_active);
+    }
+
+    pub fn insert(
+        &mut self,
+        session_key: impl Into<String>,
+        agent: T,
+        signature: impl Into<String>,
+    ) {
+        self.insert_at(session_key, agent, signature, Instant::now());
+    }
+
+    pub fn get_if_signature_at(
+        &mut self,
+        session_key: &str,
+        signature: &str,
+        now: Instant,
+    ) -> Option<&mut T> {
+        let matches = self
+            .entries
+            .get(session_key)
+            .map(|entry| entry.signature == signature)
+            .unwrap_or(false);
+        if !matches {
+            return None;
+        }
+        self.touch_lru(session_key);
+        let entry = self.entries.get_mut(session_key)?;
+        entry.last_activity = now;
+        Some(&mut entry.agent)
+    }
+
+    pub fn get_if_signature(&mut self, session_key: &str, signature: &str) -> Option<&mut T> {
+        self.get_if_signature_at(session_key, signature, Instant::now())
+    }
+
+    pub fn evict(&mut self, session_key: &str) -> bool {
+        self.lru.retain(|key| key != session_key);
+        if let Some(entry) = self.entries.remove(session_key) {
+            self.release(&entry.agent);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn enforce_cap_with_active(
+        &mut self,
+        mut is_active: impl FnMut(&str, &T) -> bool,
+    ) -> usize {
+        if self.max_size == 0 {
+            return 0;
+        }
+        let excess = self.entries.len().saturating_sub(self.max_size);
+        if excess == 0 {
+            return 0;
+        }
+        let candidates = self.lru.iter().take(excess).cloned().collect::<Vec<_>>();
+        let mut evicted = 0usize;
+        for key in candidates {
+            let active = self
+                .entries
+                .get(&key)
+                .map(|entry| is_active(&key, &entry.agent))
+                .unwrap_or(false);
+            if active {
+                continue;
+            }
+            if self.evict(&key) {
+                evicted += 1;
+            }
+        }
+        evicted
+    }
+
+    pub fn enforce_cap(&mut self) -> usize {
+        self.enforce_cap_with_active(|_, _| false)
+    }
+
+    pub fn sweep_idle_at_with_active(
+        &mut self,
+        now: Instant,
+        mut is_active: impl FnMut(&str, &T) -> bool,
+    ) -> usize {
+        if self.idle_ttl.is_zero() {
+            return 0;
+        }
+        let stale = self
+            .entries
+            .iter()
+            .filter(|(key, entry)| {
+                now.duration_since(entry.last_activity) > self.idle_ttl
+                    && !is_active(key, &entry.agent)
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        let count = stale.len();
+        for key in stale {
+            self.evict(&key);
+        }
+        count
+    }
+
+    pub fn sweep_idle_at(&mut self, now: Instant) -> usize {
+        self.sweep_idle_at_with_active(now, |_, _| false)
+    }
+
+    pub fn sweep_idle(&mut self) -> usize {
+        self.sweep_idle_at(Instant::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    fn runtime(api_key: &str, provider: &str) -> BTreeMap<String, Value> {
+        BTreeMap::from([
+            ("api_key".to_string(), Value::String(api_key.to_string())),
+            (
+                "base_url".to_string(),
+                Value::String("https://example.test/v1".to_string()),
+            ),
+            ("provider".to_string(), Value::String(provider.to_string())),
+        ])
+    }
+
+    #[test]
+    fn signature_is_stable_for_same_input() {
+        let input = AgentConfigSignatureInput {
+            model: "claude-sonnet-4".to_string(),
+            runtime: runtime("sk-test123", "openrouter"),
+            toolsets: vec!["hermes-telegram".to_string()],
+            system_prompt: String::new(),
+            cache_keys: BTreeMap::new(),
+        };
+        assert_eq!(
+            agent_config_signature(&input),
+            agent_config_signature(&input)
+        );
+    }
+
+    #[test]
+    fn signature_changes_for_model_provider_toolset_and_full_token() {
+        let base = AgentConfigSignatureInput {
+            model: "m1".to_string(),
+            runtime: runtime("eyJhbGci.token-for-account-a", "openrouter"),
+            toolsets: vec!["hermes-telegram".to_string()],
+            system_prompt: String::new(),
+            cache_keys: BTreeMap::new(),
+        };
+        let mut changed_model = base.clone();
+        changed_model.model = "m2".to_string();
+        assert_ne!(
+            agent_config_signature(&base),
+            agent_config_signature(&changed_model)
+        );
+
+        let mut changed_provider = base.clone();
+        changed_provider.runtime = runtime("eyJhbGci.token-for-account-a", "anthropic");
+        assert_ne!(
+            agent_config_signature(&base),
+            agent_config_signature(&changed_provider)
+        );
+
+        let mut changed_toolset = base.clone();
+        changed_toolset.toolsets = vec!["hermes-discord".to_string()];
+        assert_ne!(
+            agent_config_signature(&base),
+            agent_config_signature(&changed_toolset)
+        );
+
+        let mut changed_token = base.clone();
+        changed_token.runtime = runtime("eyJhbGci.token-for-account-b", "openrouter");
+        assert_ne!(
+            agent_config_signature(&base),
+            agent_config_signature(&changed_token)
+        );
+    }
+
+    #[test]
+    fn reasoning_is_not_part_of_signature_unless_caller_adds_it() {
+        let base = AgentConfigSignatureInput {
+            model: "m".to_string(),
+            runtime: runtime("k", "p"),
+            toolsets: vec![],
+            system_prompt: String::new(),
+            cache_keys: BTreeMap::new(),
+        };
+        let same = base.clone();
+        assert_eq!(agent_config_signature(&base), agent_config_signature(&same));
+    }
+
+    #[test]
+    fn cache_busting_config_reads_documented_keys_and_missing_nulls() {
+        let cfg = serde_json::json!({
+            "model": {"context_length": 272000, "max_tokens": 4096},
+            "compression": {"enabled": false, "threshold": 0.6, "target_ratio": 0.3, "protect_last_n": 25, "ignored": true}
+        });
+        let out = extract_cache_busting_config(Some(&cfg), Some(123));
+        assert_eq!(out["model.context_length"], Value::from(272000));
+        assert_eq!(out["model.max_tokens"], Value::from(4096));
+        assert_eq!(out["compression.enabled"], Value::from(false));
+        assert_eq!(out["compression.threshold"], Value::from(0.6));
+        assert_eq!(out["compression.target_ratio"], Value::from(0.3));
+        assert_eq!(out["compression.protect_last_n"], Value::from(25));
+        assert_eq!(out["tools.registry_generation"], Value::from(123));
+
+        let missing = extract_cache_busting_config(None, None);
+        for (section, key) in CACHE_BUSTING_CONFIG_KEYS {
+            assert_eq!(missing[&format!("{section}.{key}")], Value::Null);
+        }
+        assert_eq!(missing["tools.registry_generation"], Value::Null);
+    }
+
+    #[test]
+    fn cache_keys_change_signature_and_key_order_does_not_matter() {
+        let mut a = BTreeMap::new();
+        a.insert("model.context_length".to_string(), Value::from(200000));
+        a.insert("compression.threshold".to_string(), Value::from(0.5));
+        let mut b = BTreeMap::new();
+        b.insert("compression.threshold".to_string(), Value::from(0.5));
+        b.insert("model.context_length".to_string(), Value::from(200000));
+
+        let first = AgentConfigSignatureInput {
+            model: "m".to_string(),
+            cache_keys: a,
+            ..Default::default()
+        };
+        let second = AgentConfigSignatureInput {
+            model: "m".to_string(),
+            cache_keys: b,
+            ..Default::default()
+        };
+        assert_eq!(
+            agent_config_signature(&first),
+            agent_config_signature(&second)
+        );
+
+        let changed = AgentConfigSignatureInput {
+            model: "m".to_string(),
+            cache_keys: BTreeMap::from([("compression.threshold".to_string(), Value::from(0.75))]),
+            ..Default::default()
+        };
+        assert_ne!(
+            agent_config_signature(&first),
+            agent_config_signature(&changed)
+        );
+    }
+
+    #[test]
+    fn cache_hit_miss_evict_lru_and_idle_ttl() {
+        let released = Arc::new(Mutex::new(Vec::new()));
+        let released_for_hook = released.clone();
+        let mut cache = GatewayAgentCache::new(2, Duration::from_secs(10)).with_release_hook(
+            Arc::new(move |agent: &String| released_for_hook.lock().unwrap().push(agent.clone())),
+        );
+        let now = Instant::now();
+        cache.insert_at("s1", "agent1".to_string(), "sig1", now);
+        assert_eq!(
+            cache
+                .get_if_signature_at("s1", "sig1", now)
+                .map(|s| s.as_str()),
+            Some("agent1")
+        );
+        assert!(cache.get_if_signature_at("s1", "sig2", now).is_none());
+
+        cache.insert_at("s2", "agent2".to_string(), "sig2", now);
+        cache.get_if_signature_at("s1", "sig1", now);
+        cache.insert_at("s3", "agent3".to_string(), "sig3", now);
+        assert!(cache.get_if_signature_at("s1", "sig1", now).is_some());
+        assert!(cache.get_if_signature_at("s2", "sig2", now).is_none());
+        assert_eq!(released.lock().unwrap().as_slice(), ["agent2"]);
+
+        assert_eq!(cache.sweep_idle_at(now + Duration::from_secs(11)), 2);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn active_aware_cap_skips_mid_turn_lru_and_can_remain_over_limit() {
+        let released = Arc::new(Mutex::new(Vec::new()));
+        let released_for_hook = released.clone();
+        let mut cache = GatewayAgentCache::new(2, Duration::from_secs(10)).with_release_hook(
+            Arc::new(move |agent: &String| released_for_hook.lock().unwrap().push(agent.clone())),
+        );
+        let now = Instant::now();
+        cache.insert_at("active", "agent-active".to_string(), "sig", now);
+        cache.insert_at("idle-a", "agent-idle-a".to_string(), "sig", now);
+        cache.insert_at_with_active(
+            "idle-b",
+            "agent-idle-b".to_string(),
+            "sig",
+            now,
+            |key, _| key == "active",
+        );
+
+        assert_eq!(cache.len(), 3);
+        assert!(cache.get_if_signature_at("active", "sig", now).is_some());
+        assert!(cache.get_if_signature_at("idle-a", "sig", now).is_some());
+        assert!(cache.get_if_signature_at("idle-b", "sig", now).is_some());
+        assert!(released.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn active_aware_cap_evicts_inactive_entries_in_excess_window_only() {
+        let released = Arc::new(Mutex::new(Vec::new()));
+        let released_for_hook = released.clone();
+        let mut cache = GatewayAgentCache::new(2, Duration::from_secs(10)).with_release_hook(
+            Arc::new(move |agent: &String| released_for_hook.lock().unwrap().push(agent.clone())),
+        );
+        let now = Instant::now();
+        let active_keys = HashSet::from(["s1".to_string()]);
+        cache.insert_at("s1", "agent1".to_string(), "sig", now);
+        cache.insert_at("s2", "agent2".to_string(), "sig", now);
+        cache.insert_at_with_active("s3", "agent3".to_string(), "sig", now, |key, _| {
+            active_keys.contains(key)
+        });
+        cache.insert_at_with_active("s4", "agent4".to_string(), "sig", now, |key, _| {
+            active_keys.contains(key)
+        });
+
+        assert!(cache.get_if_signature_at("s1", "sig", now).is_some());
+        assert!(cache.get_if_signature_at("s2", "sig", now).is_none());
+        assert!(cache.get_if_signature_at("s3", "sig", now).is_some());
+        assert!(cache.get_if_signature_at("s4", "sig", now).is_some());
+        assert_eq!(released.lock().unwrap().as_slice(), ["agent2"]);
+    }
+
+    #[test]
+    fn idle_sweep_skips_active_agent_and_evicted_session_can_reinsert() {
+        let released = Arc::new(Mutex::new(Vec::new()));
+        let released_for_hook = released.clone();
+        let mut cache = GatewayAgentCache::new(3, Duration::from_secs(10)).with_release_hook(
+            Arc::new(move |agent: &String| released_for_hook.lock().unwrap().push(agent.clone())),
+        );
+        let now = Instant::now();
+        cache.insert_at("active", "old-active".to_string(), "sig", now);
+        cache.insert_at("idle", "old-idle".to_string(), "sig", now);
+
+        let sweep_at = now + Duration::from_secs(11);
+        assert_eq!(
+            cache.sweep_idle_at_with_active(sweep_at, |key, _| key == "active"),
+            1
+        );
+        assert!(cache
+            .get_if_signature_at("active", "sig", sweep_at)
+            .is_some());
+        assert!(cache.get_if_signature_at("idle", "sig", sweep_at).is_none());
+        assert_eq!(released.lock().unwrap().as_slice(), ["old-idle"]);
+
+        cache.insert_at("idle", "new-idle".to_string(), "sig-new", sweep_at);
+        assert_eq!(
+            cache
+                .get_if_signature_at("idle", "sig-new", sweep_at)
+                .map(|agent| agent.as_str()),
+            Some("new-idle")
+        );
+    }
+}

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -155,6 +155,18 @@ pub fn all_commands() -> Vec<CommandInfo> {
             usage: "/background <prompt>",
         },
         CommandInfo {
+            name: "/queue",
+            aliases: &["/q"],
+            description: "Queue a follow-up for the active gateway session",
+            usage: "/queue <prompt>",
+        },
+        CommandInfo {
+            name: "/steer",
+            aliases: &[],
+            description: "Inject a non-interrupt steering instruction",
+            usage: "/steer <prompt>",
+        },
+        CommandInfo {
             name: "/btw",
             aliases: &[],
             description: "Side conversation without context",
@@ -195,6 +207,30 @@ pub fn all_commands() -> Vec<CommandInfo> {
             aliases: &[],
             description: "Show current status",
             usage: "/status",
+        },
+        CommandInfo {
+            name: "/agents",
+            aliases: &["/tasks"],
+            description: "Show active/background task state",
+            usage: "/agents",
+        },
+        CommandInfo {
+            name: "/voice",
+            aliases: &[],
+            description: "Show voice mode status",
+            usage: "/voice",
+        },
+        CommandInfo {
+            name: "/title",
+            aliases: &[],
+            description: "Set or show session title metadata",
+            usage: "/title [title]",
+        },
+        CommandInfo {
+            name: "/resume",
+            aliases: &[],
+            description: "Resume or inspect session continuation state",
+            usage: "/resume [query]",
         },
         CommandInfo {
             name: "/approve",
@@ -283,6 +319,36 @@ fn normalize_command_args(args: &str) -> String {
         .replace('\u{2013}', "-")
 }
 
+pub fn canonical_command_name(raw: &str) -> Option<String> {
+    let token = raw
+        .trim()
+        .trim_start_matches('/')
+        .split_whitespace()
+        .next()?;
+    let token = token.split('@').next().unwrap_or(token).trim();
+    if token.is_empty() {
+        return None;
+    }
+    Some(token.to_ascii_lowercase().replace('-', "_"))
+}
+
+pub fn is_registered_command_name(raw: &str) -> bool {
+    let Some(name) = canonical_command_name(raw) else {
+        return false;
+    };
+    all_commands().into_iter().any(|info| {
+        canonical_command_name(info.name).as_deref() == Some(name.as_str())
+            || info
+                .aliases
+                .iter()
+                .any(|alias| canonical_command_name(alias).as_deref() == Some(name.as_str()))
+    })
+}
+
+pub fn should_bypass_active_session(raw: Option<&str>) -> bool {
+    raw.is_some_and(is_registered_command_name)
+}
+
 /// Parse and dispatch a gateway slash command.
 pub fn handle_command(input: &str) -> GatewayCommandResult {
     let trimmed = input.trim();
@@ -291,7 +357,9 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
     }
 
     let parts: Vec<&str> = trimmed.splitn(2, ' ').collect();
-    let cmd = parts[0].to_lowercase();
+    let cmd = canonical_command_name(parts[0])
+        .map(|name| format!("/{name}"))
+        .unwrap_or_else(|| parts[0].to_lowercase());
     let args = normalize_command_args(parts.get(1).map(|s| s.trim()).unwrap_or(""));
 
     match cmd.as_str() {
@@ -386,6 +454,23 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
                 }
             }
         }
+        "/queue" | "/q" => {
+            if args.is_empty() {
+                GatewayCommandResult::Reply("Usage: /queue <prompt>".to_string())
+            } else {
+                GatewayCommandResult::Reply(format!(
+                    "🧵 Queued follow-up for the active session: {}",
+                    args
+                ))
+            }
+        }
+        "/steer" => {
+            if args.is_empty() {
+                GatewayCommandResult::Reply("Usage: /steer <prompt>".to_string())
+            } else {
+                GatewayCommandResult::Reply(format!("🧭 Steering instruction accepted: {}", args))
+            }
+        }
         "/btw" => {
             if args.is_empty() {
                 GatewayCommandResult::Reply("Usage: /btw <prompt>".to_string())
@@ -416,6 +501,26 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         "/status" => {
             GatewayCommandResult::ShowStatus("Status information will be shown.".to_string())
         }
+        "/agents" | "/tasks" => GatewayCommandResult::Reply(
+            "🧵 Active task state is shown by /background list in this Rust gateway.".to_string(),
+        ),
+        "/voice" => GatewayCommandResult::Reply(
+            "🎙 Voice mode status is platform-specific; configured voice routes remain available."
+                .to_string(),
+        ),
+        "/title" => {
+            if args.is_empty() {
+                GatewayCommandResult::Reply(
+                    "🏷 No explicit title set for this gateway session.".to_string(),
+                )
+            } else {
+                GatewayCommandResult::Reply(format!("🏷 Session title set to: {}", args))
+            }
+        }
+        "/resume" => GatewayCommandResult::Reply(
+            "↩️ Resume state is loaded from the configured session store when available."
+                .to_string(),
+        ),
         "/reload_mcp" | "/mcp_reload" => GatewayCommandResult::ReloadMcp,
         "/provider" => {
             if args.is_empty() {
@@ -633,6 +738,50 @@ mod tests {
             GatewayCommandResult::StopAgent(_) => {}
             other => panic!("Expected StopAgent for /cancel, got {:?}", other),
         }
+        match handle_command("/reload-mcp") {
+            GatewayCommandResult::ReloadMcp => {}
+            other => panic!("Expected ReloadMcp for /reload-mcp, got {:?}", other),
+        }
+        match handle_command("/stop@HermesBot") {
+            GatewayCommandResult::StopAgent(_) => {}
+            other => panic!("Expected StopAgent for /stop@HermesBot, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_active_session_bypass_registry() {
+        for cmd in [
+            "stop",
+            "new",
+            "reset",
+            "approve",
+            "deny",
+            "status",
+            "agents",
+            "tasks",
+            "background",
+            "steer",
+            "help",
+            "update",
+            "queue",
+            "model",
+            "reasoning",
+            "voice",
+            "insights",
+            "title",
+            "resume",
+            "retry",
+            "undo",
+            "compress",
+            "usage",
+            "reload-mcp",
+            "sethome",
+        ] {
+            assert!(should_bypass_active_session(Some(cmd)), "{cmd}");
+        }
+        assert!(!should_bypass_active_session(Some("foobar")));
+        assert!(!should_bypass_active_session(Some("path/to/file.py")));
+        assert!(!should_bypass_active_session(None));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -12,6 +12,7 @@
 //! - Platform-specific adapters behind feature flags
 
 pub mod adapter;
+pub mod agent_cache;
 pub mod background;
 pub mod channel_directory;
 pub mod commands;
@@ -26,6 +27,7 @@ pub mod mirror;
 pub mod pairing;
 pub mod platforms;
 pub mod session;
+pub mod session_control;
 pub mod ssrf;
 pub mod sticker_cache;
 pub mod stream;
@@ -39,6 +41,16 @@ pub use hermes_core::types::Message;
 
 // Re-export gateway orchestrator and runtime context
 pub use gateway::{Gateway, GatewayRuntimeContext};
+
+// Re-export gateway cache/session-control contracts
+pub use agent_cache::{
+    agent_config_signature, extract_cache_busting_config, AgentConfigSignatureInput,
+    GatewayAgentCache,
+};
+pub use session_control::{
+    build_session_key, BusyInputMode, BusyMessageDecision, BusySessionCoordinator, MessageEvent,
+    MessageType, ProcessingOutcome, SessionSource,
+};
 
 // Re-export session management
 pub use session::{Session, SessionManager};

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -778,6 +778,22 @@ impl TelegramAdapter {
         &self.config
     }
 
+    fn split_gateway_chat_thread(chat_id: &str) -> (&str, Option<i64>) {
+        let Some((base_chat_id, thread_id)) = chat_id.rsplit_once(':') else {
+            return (chat_id, None);
+        };
+        if base_chat_id.trim().is_empty() || thread_id.trim().is_empty() {
+            return (chat_id, None);
+        }
+        if base_chat_id.parse::<i64>().is_err() {
+            return (chat_id, None);
+        }
+        match thread_id.parse::<i64>() {
+            Ok(0) | Err(_) => (chat_id, None),
+            Ok(thread_id) => (base_chat_id, Some(thread_id)),
+        }
+    }
+
     fn build_client(
         base: &BasePlatformAdapter,
         fallback_ips: &[String],
@@ -1117,6 +1133,8 @@ impl TelegramAdapter {
         keyboard: Option<InlineKeyboardMarkup>,
         message_thread_id: Option<i64>,
     ) -> Result<Vec<i64>, GatewayError> {
+        let (chat_id, inferred_thread_id) = Self::split_gateway_chat_thread(chat_id);
+        let message_thread_id = message_thread_id.or(inferred_thread_id);
         let chunks = split_message(text, MAX_MESSAGE_LENGTH);
         let mut message_ids = Vec::new();
 
@@ -1455,8 +1473,11 @@ impl TelegramAdapter {
 
     async fn send_multipart_with_options(
         &self,
-        request: TelegramMultipartRequest<'_>,
+        mut request: TelegramMultipartRequest<'_>,
     ) -> Result<i64, GatewayError> {
+        let (chat_id, inferred_thread_id) = Self::split_gateway_chat_thread(request.chat_id);
+        request.chat_id = chat_id;
+        request.message_thread_id = request.message_thread_id.or(inferred_thread_id);
         match self.send_multipart_once(request).await {
             Ok(id) => Ok(id),
             Err(err)
@@ -1906,6 +1927,8 @@ impl TelegramAdapter {
         reply_to_message_id: Option<i64>,
         message_thread_id: Option<i64>,
     ) -> Result<(), GatewayError> {
+        let (chat_id, inferred_thread_id) = Self::split_gateway_chat_thread(chat_id);
+        let message_thread_id = message_thread_id.or(inferred_thread_id);
         let mut body = serde_json::json!({
             "chat_id": chat_id,
             "photo": image_url,
@@ -2467,6 +2490,22 @@ mod tests {
     }
 
     #[test]
+    fn telegram_split_gateway_chat_thread_preserves_topic_suffix() {
+        assert_eq!(
+            TelegramAdapter::split_gateway_chat_thread("-1001:17585"),
+            ("-1001", Some(17585))
+        );
+        assert_eq!(
+            TelegramAdapter::split_gateway_chat_thread("-1001:0"),
+            ("-1001:0", None)
+        );
+        assert_eq!(
+            TelegramAdapter::split_gateway_chat_thread("room:server"),
+            ("room:server", None)
+        );
+    }
+
+    #[test]
     fn telegram_merge_caption_uses_exact_dedupe() {
         assert_eq!(TelegramAdapter::merge_caption(None, "Hello"), "Hello");
         assert_eq!(
@@ -2784,6 +2823,44 @@ mod tests {
             .and_then(|v| v.as_str())
             .unwrap()
             .contains("\\[world\\]\\_1"));
+    }
+
+    #[tokio::test]
+    async fn telegram_encoded_gateway_chat_id_sends_to_topic_thread() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "-1001",
+                "message_thread_id": 17585,
+                "text": "topic hello"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 88 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text("-1001:17585", "topic hello", None, None)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![88]);
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        let body: Value = requests[0].body_json().expect("json body");
+        assert_eq!(
+            body.pointer("/chat_id").and_then(|v| v.as_str()),
+            Some("-1001")
+        );
+        assert_eq!(
+            body.pointer("/message_thread_id").and_then(|v| v.as_i64()),
+            Some(17585)
+        );
     }
 
     #[test]

--- a/crates/hermes-gateway/src/session_control.rs
+++ b/crates/hermes-gateway/src/session_control.rs
@@ -1,0 +1,570 @@
+//! Gateway session-control primitives.
+//!
+//! These helpers model the Python gateway's active-session guard without
+//! coupling platform adapters to a concrete Rust agent implementation.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+use crate::commands::should_bypass_active_session;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionSource {
+    pub platform: String,
+    pub chat_id: String,
+    pub chat_type: String,
+    pub user_id: Option<String>,
+    pub thread_id: Option<String>,
+}
+
+impl SessionSource {
+    pub fn new(
+        platform: impl Into<String>,
+        chat_id: impl Into<String>,
+        chat_type: impl Into<String>,
+    ) -> Self {
+        Self {
+            platform: platform.into(),
+            chat_id: chat_id.into(),
+            chat_type: chat_type.into(),
+            user_id: None,
+            thread_id: None,
+        }
+    }
+
+    pub fn with_user(mut self, user_id: impl Into<String>) -> Self {
+        self.user_id = Some(user_id.into());
+        self
+    }
+
+    pub fn with_thread(mut self, thread_id: impl Into<String>) -> Self {
+        self.thread_id = Some(thread_id.into());
+        self
+    }
+}
+
+pub fn build_session_key(source: &SessionSource) -> String {
+    let mut parts = vec![source.platform.trim(), source.chat_id.trim()]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if let Some(thread_id) = source
+        .thread_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        parts.push(thread_id.to_string());
+    }
+    parts.join(":")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageType {
+    Text,
+    Image,
+    File,
+    Voice,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MessageEvent {
+    pub text: String,
+    pub message_type: MessageType,
+    pub source: SessionSource,
+    pub message_id: Option<String>,
+    pub metadata: BTreeMap<String, Value>,
+}
+
+impl MessageEvent {
+    pub fn text(text: impl Into<String>, source: SessionSource) -> Self {
+        Self {
+            text: text.into(),
+            message_type: MessageType::Text,
+            source,
+            message_id: None,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn is_command(&self) -> bool {
+        self.text.trim_start().starts_with('/')
+    }
+
+    pub fn get_command(&self) -> Option<String> {
+        command_name_from_text(&self.text)
+    }
+
+    pub fn get_command_args(&self) -> String {
+        let trimmed = self.text.trim_start();
+        if !trimmed.starts_with('/') {
+            return self.text.clone();
+        }
+        trimmed
+            .split_once(char::is_whitespace)
+            .map(|(_, args)| args.trim().to_string())
+            .unwrap_or_default()
+    }
+}
+
+pub fn command_name_from_text(text: &str) -> Option<String> {
+    let trimmed = text.trim_start();
+    let token = trimmed.strip_prefix('/')?.split_whitespace().next()?;
+    let command = token.split('@').next().unwrap_or(token).trim();
+    if command.is_empty() {
+        Some(String::new())
+    } else {
+        Some(command.to_ascii_lowercase().replace('-', "_"))
+    }
+}
+
+pub fn event_bypasses_active_session(event: &MessageEvent) -> bool {
+    event
+        .get_command()
+        .as_deref()
+        .is_some_and(|command| should_bypass_active_session(Some(command)))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessingOutcome {
+    Success,
+    Failure,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusyInputMode {
+    Queue,
+    Interrupt,
+    Steer,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AgentActivitySummary {
+    pub api_call_count: Option<u32>,
+    pub max_iterations: Option<u32>,
+    pub current_tool: Option<String>,
+    pub elapsed: Option<Duration>,
+    pub seconds_since_activity: Option<f64>,
+}
+
+pub trait ActiveSessionControl: Send + Sync {
+    fn interrupt(&self, _message: &str) {}
+    fn steer(&self, _message: &str) -> bool {
+        false
+    }
+    fn activity_summary(&self) -> Option<AgentActivitySummary> {
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BusyMessageDecision {
+    pub handled: bool,
+    pub queued: bool,
+    pub interrupted: bool,
+    pub steered: bool,
+    pub ack: Option<String>,
+}
+
+impl BusyMessageDecision {
+    fn ignored() -> Self {
+        Self {
+            handled: false,
+            queued: false,
+            interrupted: false,
+            steered: false,
+            ack: None,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ActiveSession {
+    control: Option<Arc<dyn ActiveSessionControl>>,
+    started_at: Instant,
+}
+
+pub struct BusySessionCoordinator {
+    active: HashMap<String, ActiveSession>,
+    pending: HashMap<String, MessageEvent>,
+    busy_ack_ts: HashMap<String, Instant>,
+    ack_cooldown: Duration,
+}
+
+impl Default for BusySessionCoordinator {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(30))
+    }
+}
+
+impl BusySessionCoordinator {
+    pub fn new(ack_cooldown: Duration) -> Self {
+        Self {
+            active: HashMap::new(),
+            pending: HashMap::new(),
+            busy_ack_ts: HashMap::new(),
+            ack_cooldown,
+        }
+    }
+
+    pub fn mark_active_at(
+        &mut self,
+        session_key: impl Into<String>,
+        control: Option<Arc<dyn ActiveSessionControl>>,
+        now: Instant,
+    ) {
+        self.active.insert(
+            session_key.into(),
+            ActiveSession {
+                control,
+                started_at: now,
+            },
+        );
+    }
+
+    pub fn mark_active(
+        &mut self,
+        session_key: impl Into<String>,
+        control: Option<Arc<dyn ActiveSessionControl>>,
+    ) {
+        self.mark_active_at(session_key, control, Instant::now());
+    }
+
+    pub fn finish(
+        &mut self,
+        session_key: &str,
+        _outcome: ProcessingOutcome,
+    ) -> Option<MessageEvent> {
+        self.active.remove(session_key);
+        self.busy_ack_ts.remove(session_key);
+        self.pending.remove(session_key)
+    }
+
+    pub fn is_active(&self, session_key: &str) -> bool {
+        self.active.contains_key(session_key)
+    }
+
+    pub fn pending(&self, session_key: &str) -> Option<&MessageEvent> {
+        self.pending.get(session_key)
+    }
+
+    fn should_ack_at(&mut self, session_key: &str, now: Instant) -> bool {
+        let should = self
+            .busy_ack_ts
+            .get(session_key)
+            .map(|last| now.duration_since(*last) >= self.ack_cooldown)
+            .unwrap_or(true);
+        if should {
+            self.busy_ack_ts.insert(session_key.to_string(), now);
+        }
+        should
+    }
+
+    fn queue_event(&mut self, session_key: &str, event: MessageEvent) {
+        self.pending.insert(session_key.to_string(), event);
+    }
+
+    pub fn handle_busy_message_at(
+        &mut self,
+        session_key: &str,
+        event: MessageEvent,
+        mode: BusyInputMode,
+        now: Instant,
+    ) -> BusyMessageDecision {
+        let Some(active) = self.active.get(session_key).cloned() else {
+            return BusyMessageDecision::ignored();
+        };
+
+        if event_bypasses_active_session(&event) {
+            return BusyMessageDecision::ignored();
+        }
+
+        match mode {
+            BusyInputMode::Queue => {
+                self.queue_event(session_key, event);
+                BusyMessageDecision {
+                    handled: true,
+                    queued: true,
+                    interrupted: false,
+                    steered: false,
+                    ack: self.should_ack_at(session_key, now).then(|| {
+                        "Queued for the next turn. I will respond once the current task finishes."
+                            .to_string()
+                    }),
+                }
+            }
+            BusyInputMode::Interrupt => {
+                if let Some(control) = active.control.as_ref() {
+                    control.interrupt(&event.text);
+                }
+                BusyMessageDecision {
+                    handled: true,
+                    queued: false,
+                    interrupted: active.control.is_some(),
+                    steered: false,
+                    ack: self
+                        .should_ack_at(session_key, now)
+                        .then(|| interrupt_ack(active.started_at, active.control.as_deref(), now)),
+                }
+            }
+            BusyInputMode::Steer => {
+                let steered = active
+                    .control
+                    .as_ref()
+                    .map(|control| control.steer(&event.text))
+                    .unwrap_or(false);
+                if steered {
+                    BusyMessageDecision {
+                        handled: true,
+                        queued: false,
+                        interrupted: false,
+                        steered: true,
+                        ack: self.should_ack_at(session_key, now).then(|| {
+                            "Steered the running task with your latest message.".to_string()
+                        }),
+                    }
+                } else {
+                    self.queue_event(session_key, event);
+                    BusyMessageDecision {
+                        handled: true,
+                        queued: true,
+                        interrupted: false,
+                        steered: false,
+                        ack: self.should_ack_at(session_key, now).then(|| {
+                            "Queued for the next turn. I will respond once the current task finishes."
+                                .to_string()
+                        }),
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_busy_message(
+        &mut self,
+        session_key: &str,
+        event: MessageEvent,
+        mode: BusyInputMode,
+    ) -> BusyMessageDecision {
+        self.handle_busy_message_at(session_key, event, mode, Instant::now())
+    }
+}
+
+fn interrupt_ack(
+    started_at: Instant,
+    control: Option<&dyn ActiveSessionControl>,
+    now: Instant,
+) -> String {
+    let mut text = "Interrupting current task with your latest message.".to_string();
+    let elapsed = now.duration_since(started_at);
+    if elapsed >= Duration::from_secs(60) {
+        text.push_str(&format!(" Running for {} min.", elapsed.as_secs() / 60));
+    }
+    if let Some(summary) = control.and_then(|control| control.activity_summary()) {
+        if let (Some(done), Some(max)) = (summary.api_call_count, summary.max_iterations) {
+            text.push_str(&format!(" Progress: {done}/{max}."));
+        }
+        if let Some(tool) = summary.current_tool.filter(|s| !s.trim().is_empty()) {
+            text.push_str(&format!(" Current tool: {tool}."));
+        }
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn source(thread_id: &str) -> SessionSource {
+        SessionSource::new("telegram", "-1001", "group").with_thread(thread_id)
+    }
+
+    fn event(text: &str, thread_id: &str) -> MessageEvent {
+        MessageEvent::text(text, source(thread_id))
+    }
+
+    #[test]
+    fn session_keys_preserve_distinct_topics() {
+        assert_eq!(build_session_key(&source("10")), "telegram:-1001:10");
+        assert_ne!(
+            build_session_key(&source("10")),
+            build_session_key(&source("11"))
+        );
+    }
+
+    #[test]
+    fn command_parsing_strips_bot_suffix_and_lowercases() {
+        let event = event("/RESET@TigerNanoBot now", "10");
+        assert!(event.is_command());
+        assert_eq!(event.get_command().as_deref(), Some("reset"));
+        assert_eq!(event.get_command_args(), "now");
+        assert_eq!(
+            command_name_from_text("/reload-mcp").as_deref(),
+            Some("reload_mcp")
+        );
+        assert_eq!(
+            command_name_from_text("/path/to/file.py").as_deref(),
+            Some("path/to/file.py")
+        );
+    }
+
+    #[test]
+    fn bypass_only_recognized_commands() {
+        assert!(event_bypasses_active_session(&event("/stop", "10")));
+        assert!(event_bypasses_active_session(&event("/model claude", "10")));
+        assert!(event_bypasses_active_session(&event("/reload-mcp", "10")));
+        assert!(!event_bypasses_active_session(&event("/foobar", "10")));
+        assert!(!event_bypasses_active_session(&event(
+            "/path/to/file.py",
+            "10"
+        )));
+    }
+
+    #[derive(Default)]
+    struct MockControl {
+        interrupts: Mutex<Vec<String>>,
+        steer_accepts: bool,
+    }
+
+    impl ActiveSessionControl for MockControl {
+        fn interrupt(&self, message: &str) {
+            self.interrupts.lock().unwrap().push(message.to_string());
+        }
+
+        fn steer(&self, _message: &str) -> bool {
+            self.steer_accepts
+        }
+
+        fn activity_summary(&self) -> Option<AgentActivitySummary> {
+            Some(AgentActivitySummary {
+                api_call_count: Some(21),
+                max_iterations: Some(60),
+                current_tool: Some("terminal".to_string()),
+                elapsed: None,
+                seconds_since_activity: Some(0.5),
+            })
+        }
+    }
+
+    #[test]
+    fn queue_mode_queues_without_interrupt_and_debounces_ack() {
+        let mut coord = BusySessionCoordinator::default();
+        let key = build_session_key(&source("10"));
+        let now = Instant::now();
+        let control = Arc::new(MockControl::default());
+        coord.mark_active_at(&key, Some(control.clone()), now);
+
+        let first =
+            coord.handle_busy_message_at(&key, event("follow up", "10"), BusyInputMode::Queue, now);
+        assert!(first.handled);
+        assert!(first.queued);
+        assert!(!first.interrupted);
+        assert!(first.ack.unwrap().contains("Queued for the next turn"));
+        assert_eq!(coord.pending(&key).unwrap().text, "follow up");
+        assert!(control.interrupts.lock().unwrap().is_empty());
+
+        let second = coord.handle_busy_message_at(
+            &key,
+            event("still there", "10"),
+            BusyInputMode::Queue,
+            now + Duration::from_secs(1),
+        );
+        assert!(second.ack.is_none());
+        assert_eq!(coord.pending(&key).unwrap().text, "still there");
+    }
+
+    #[test]
+    fn interrupt_mode_calls_agent_and_includes_status_detail() {
+        let mut coord = BusySessionCoordinator::default();
+        let key = build_session_key(&source("10"));
+        let now = Instant::now();
+        let control = Arc::new(MockControl::default());
+        coord.mark_active_at(&key, Some(control.clone()), now - Duration::from_secs(600));
+
+        let decision = coord.handle_busy_message_at(
+            &key,
+            event("Are you working?", "10"),
+            BusyInputMode::Interrupt,
+            now,
+        );
+        assert!(decision.handled);
+        assert!(decision.interrupted);
+        assert!(!decision.queued);
+        assert_eq!(
+            control.interrupts.lock().unwrap().as_slice(),
+            ["Are you working?"]
+        );
+        let ack = decision.ack.unwrap();
+        assert!(ack.contains("Interrupting"));
+        assert!(ack.contains("21/60"));
+        assert!(ack.contains("terminal"));
+        assert!(ack.contains("10 min"));
+    }
+
+    #[test]
+    fn steer_mode_skips_queue_when_accepted_and_falls_back_when_rejected() {
+        let key = build_session_key(&source("10"));
+        let now = Instant::now();
+
+        let mut accepted = BusySessionCoordinator::default();
+        accepted.mark_active_at(
+            &key,
+            Some(Arc::new(MockControl {
+                steer_accepts: true,
+                ..Default::default()
+            })),
+            now,
+        );
+        let steered = accepted.handle_busy_message_at(
+            &key,
+            event("also check tests", "10"),
+            BusyInputMode::Steer,
+            now,
+        );
+        assert!(steered.steered);
+        assert!(!steered.queued);
+        assert!(accepted.pending(&key).is_none());
+
+        let mut rejected = BusySessionCoordinator::default();
+        rejected.mark_active_at(&key, Some(Arc::new(MockControl::default())), now);
+        let queued = rejected.handle_busy_message_at(
+            &key,
+            event("cannot steer", "10"),
+            BusyInputMode::Steer,
+            now,
+        );
+        assert!(queued.queued);
+        assert!(!queued.steered);
+        assert_eq!(rejected.pending(&key).unwrap().text, "cannot steer");
+    }
+
+    #[test]
+    fn bypass_commands_are_not_consumed_by_busy_guard() {
+        let mut coord = BusySessionCoordinator::default();
+        let key = build_session_key(&source("10"));
+        coord.mark_active(&key, None);
+        let decision =
+            coord.handle_busy_message(&key, event("/status", "10"), BusyInputMode::Queue);
+        assert!(!decision.handled);
+        assert!(coord.pending(&key).is_none());
+    }
+
+    #[test]
+    fn finish_returns_pending_and_clears_active_state() {
+        let mut coord = BusySessionCoordinator::default();
+        let key = build_session_key(&source("10"));
+        coord.mark_active(&key, None);
+        coord.handle_busy_message(&key, event("queued", "10"), BusyInputMode::Queue);
+        let pending = coord.finish(&key, ProcessingOutcome::Success).unwrap();
+        assert_eq!(pending.text, "queued");
+        assert!(!coord.is_active(&key));
+        assert!(coord.pending(&key).is_none());
+    }
+}

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-05-31T23:00:22.367299+00:00",
+  "generated_at_utc": "2026-06-01T00:09:12.348989+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-05-31T23:00:22.367299+00:00`
+Generated: `2026-06-01T00:09:12.348989+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -42,7 +42,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "80984656b09cdb4a3bedcbc1869a21bcc566de3d",
+      "upstream_blob": "ee1cb15f4495d0160be1592de5d663b4042fd9dc",
       "workstream": "WS8"
     },
     {
@@ -57,7 +57,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "dd45310ca86dd438fef0c252d369b84220fe8224",
+      "upstream_blob": "6c0036efd5a65d10e7e26320a1805fb06ad0f68a",
       "workstream": "WS8"
     },
     {
@@ -117,7 +117,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "fa2795305059c816467da435d8c44293bacf3592",
+      "upstream_blob": "2f42c789b48ea6a0940fee4b48d96ce8e8f4d2af",
       "workstream": "WS8"
     },
     {
@@ -657,7 +657,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "c22c06c12934de16a8fa9550514418e3ba9d931b",
+      "upstream_blob": "451f3a0118c148d178952e0c64b09b5b4697cc8b",
       "workstream": "WS3"
     },
     {
@@ -687,7 +687,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "0c2122c2a11cc421542104272224b91d96c95a52",
+      "upstream_blob": "2d792622fce0a19a101e39d5bcbc3dfce14e8927",
       "workstream": "WS3"
     },
     {
@@ -826,6 +826,21 @@
       "workstream": "WS3"
     },
     {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/model-providers",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "607439a365e54be6b88124f47ba43b10164dfcdb",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/alibaba-coding-plan/__init__.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "17744aeca5d5d3dad12575d70565c34d48fe7e29",
+      "workstream": "WS3"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "plugins/model-providers/azure-foundry/__init__.py",
@@ -901,33 +916,18 @@
       "workstream": "WS3"
     },
     {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "plugins/observability/langfuse/README.md",
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/observability",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "864735d9688467bbe68b7706120d36ae96a191dd",
-      "necessity": "approved_divergence",
+      "local_blob": "a99a8eb9279144f873704a98e3768f1f15c4e990",
+      "necessity": "necessary_review",
       "owner": "sheawinkler",
-      "path": "plugins/observability/langfuse/README.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 304,
-      "upstream_blob": "97f4757e5a84cbaaee80f0f2fd202b8a90093ce0",
-      "workstream": "WS3"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "plugins/observability/langfuse/plugin.yaml",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "18f1c6245d3d53cca601784399d114b4a51470d0",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "plugins/observability/langfuse/plugin.yaml",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 304,
-      "upstream_blob": "708264c8a968f2cbe3786d3e825d71190fff5fa2",
+      "path": "plugins/observability/langfuse/__init__.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "8516030fb019768c2145ea2f4e5f9145a7dea683",
       "workstream": "WS3"
     },
     {
@@ -1257,7 +1257,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "bf96b93c6d0c8f2efa39fc7a4550da8518342d0a",
+      "upstream_blob": "1e38f46129c74139df3956c3e5335c966d885828",
       "workstream": "WS8"
     },
     {
@@ -1467,7 +1467,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "25f634205c847aa0800bc21fc370a9f6890c8a3d",
+      "upstream_blob": "760f830710d6ad19870f821a727c71fb6766e213",
       "workstream": "WS4"
     },
     {
@@ -1782,7 +1782,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7c7e8e333734b268cb2871815a353697ea728703",
+      "upstream_blob": "818a016f4ea54c91508469a61bf8701fd712220a",
       "workstream": "WS6"
     },
     {
@@ -2311,21 +2311,6 @@
       "workstream": "WS6"
     },
     {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "tests/agent/test_moonshot_schema.py",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "2ce2daa096ae6bdcdcd0de2662f29e854be37825",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "tests/agent/test_moonshot_schema.py",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "8ba508c5dbd17eb822e6d5124145af7bd3e73fbd",
-      "workstream": "WS6"
-    },
-    {
       "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
       "classification": "functional",
       "classification_path": "tests/agent",
@@ -2397,7 +2382,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e4fa5e950435f3ee3261bb23639d66587eb43794",
+      "upstream_blob": "e956b2a3ab9ac6a9caeb47ab131600914c043570",
       "workstream": "WS6"
     },
     {
@@ -2847,7 +2832,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "f62287f622bd9b62685fc155c0f6d8b12660e2e3",
+      "upstream_blob": "47a78c57044338423764050ebc82c521e8ce3cfe",
       "workstream": "WS6"
     },
     {
@@ -3087,7 +3072,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "17bc68d8031e0d404eed671181fad2eb893e5adf",
+      "upstream_blob": "4e5db15352232c30b8dc9049b7fa70ddbab17b96",
       "workstream": "WS6"
     },
     {
@@ -3331,17 +3316,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_agent_cache.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a9793f4d9a2baddf5a4588ef5cc6f372d1fd9539",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_agent_cache.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "37f8b51a458d489d78c57d6e416ed60bd70480e8",
       "workstream": "WS6"
     },
@@ -3526,17 +3511,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_base_topic_sessions.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "665f99ac4c2ce5983215cb2adde5f1f65ca5138b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_base_topic_sessions.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "dd2ef3a12622f373900134253ab0e6841799b0ff",
       "workstream": "WS6"
     },
@@ -3556,17 +3541,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_busy_session_ack.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b16e5ebb5f2f75aaddaac31ace2b5ad2a34b8ef9",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_busy_session_ack.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "7fb3d3210c051bf1a4daa0203a1831117a968479",
       "workstream": "WS6"
     },
@@ -3616,17 +3601,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_command_bypass_active_session.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "aae68b6b53ff5a6e0c21720d40c9ba9d41b9a327",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_command_bypass_active_session.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "e5e8a4fa469f317f2de4229e9c9e6f1d6d69cc26",
       "workstream": "WS6"
     },
@@ -4145,6 +4130,21 @@
       "classification": "functional",
       "classification_path": "tests/gateway",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "41565e163b06f1dc312e8eb3724bcbda7f766cde",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_ephemeral_reply.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "61b70748e16ada09cf607e57eb16053c2e216f47",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/gateway",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "dd93e6370f2e54b51917a770141f85d24d8536df",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -4197,7 +4197,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0f65fd052be2d4ca007a8bd2918c4e97b6830c52",
+      "upstream_blob": "56770f55d76131d3ed90dba198cf6c2fecacf7b0",
       "workstream": "WS6"
     },
     {
@@ -4557,7 +4557,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "2cc8118b7b23c5add93165c0ab7866f204ce6248",
+      "upstream_blob": "c38070317a25644a3dd1857a0ec2f81ebd6e439c",
       "workstream": "WS6"
     },
     {
@@ -4647,7 +4647,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "6516a25f8b2cabcb71800e93ddc99873fcc8cc10",
+      "upstream_blob": "e1f41aeccdc61f1fae942fb1eddd49c169ec9ab2",
       "workstream": "WS6"
     },
     {
@@ -4722,7 +4722,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "e7a931f8f8ade03751827331f0aa81a5a03b2af9",
+      "upstream_blob": "56be2337031cf95819610a90f5219751061d0c2d",
       "workstream": "WS6"
     },
     {
@@ -5082,7 +5082,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "a5e225b759b05df337de5ad6f92e05ede827cb3a",
+      "upstream_blob": "c2cf76d9f89bbb9fbdf79c5387c6c080560547d4",
       "workstream": "WS6"
     },
     {
@@ -5127,7 +5127,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "830b0e14f0782f849c1bec714336b1990ac85770",
+      "upstream_blob": "97618f4482a50279a4004c8712fc73ac6af67b17",
       "workstream": "WS6"
     },
     {
@@ -5487,7 +5487,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ddbd8a45954d00873c1bc5ec18b34099d7e3e8e2",
+      "upstream_blob": "5f56baebca6df5e1350252cfbd77a65f3af23c37",
       "workstream": "WS6"
     },
     {
@@ -5607,7 +5607,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "154603898b342e2feea753dd5b4a332f5c8c043f",
+      "upstream_blob": "e3f74694bdf5d26451be34f0b523ef6232ad8d95",
       "workstream": "WS6"
     },
     {
@@ -6207,7 +6207,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "ed9033ffce2fccf9f213edacf466868e1c5fa8c3",
+      "upstream_blob": "cb5ba69043e0c8fcf442b38c6a69bf8821f6733c",
       "workstream": "WS6"
     },
     {
@@ -6402,7 +6402,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0f3a76a1ab95777062cd51bf70c1e525206ca85d",
+      "upstream_blob": "45415f50fc6aaccfeaeda79483e487251a01560e",
       "workstream": "WS6"
     },
     {
@@ -6537,7 +6537,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "4d78b396be19e26dfbf9e13ee001722eba3df259",
+      "upstream_blob": "0988f8fb64af95c507d7ae2ca2eb83706e57ca92",
       "workstream": "WS6"
     },
     {
@@ -6747,7 +6747,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "203a37af5a5cd1dd45a7716f3ba83fe3a0ba809f",
+      "upstream_blob": "52fa63e3ec9515439725848cbc33625ada3018a4",
       "workstream": "WS6"
     },
     {
@@ -6837,7 +6837,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "43ad6e42cadb8f8ed80776be297daf4036a7561c",
+      "upstream_blob": "7a1cbd54c30d4e543dcbf124dbeed964c4433e2a",
       "workstream": "WS6"
     },
     {
@@ -6867,7 +6867,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "aef758f099ec1c793f9c86b7a2e6677d0188daf5",
+      "upstream_blob": "75eb5b8dc708632ea49b5c0d2ef94f157e2b0ed2",
       "workstream": "WS6"
     },
     {
@@ -6912,7 +6912,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "f965f361decd0dab1fcf8af9f23af148900b100e",
+      "upstream_blob": "d6ae4b1dd57c09785e6cce507119a811cc65ed12",
       "workstream": "WS6"
     },
     {
@@ -6957,7 +6957,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "561602c0ac691ed51802813b42d37ce775d66e38",
+      "upstream_blob": "e25fd86f147b3a0e3a30e4a756675258830f9605",
       "workstream": "WS6"
     },
     {
@@ -7077,7 +7077,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "5f8abcc8762b0f3474086f1d8f3a7f43e1b750bd",
+      "upstream_blob": "8af16b8e18fb60c5d9389134a8bbf21becd87713",
       "workstream": "WS6"
     },
     {
@@ -7168,6 +7168,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "4f366fd7218ef19cf205a7f0bbc3e6df6e908aa5",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "3d360a4f2f6f23d3d41a68fe5f8883124c7c8fb5",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_reasoning_effort_menu.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "79063587f0b9df51640a3801ddbfe3123df95be5",
       "workstream": "WS6"
     },
     {
@@ -7302,7 +7317,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "aa8a9c182ba5eca2ff32843dc1d9dbb6a95cce74",
+      "upstream_blob": "099f4eb94b270f88c08dad5fdf21c6d7f8487171",
       "workstream": "WS6"
     },
     {
@@ -7377,7 +7392,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "6ed49e54ae4affd977d72670adf8225a7a9deab3",
+      "upstream_blob": "73e9bfcfa45ec1778f22d6eb7a6169567eb1282b",
       "workstream": "WS6"
     },
     {
@@ -7550,6 +7565,21 @@
       "classification": "functional",
       "classification_path": "tests/hermes_cli",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "a1283049950f4cee735d0018358bc16ac124dfae",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_terminal_menu_fallbacks.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "626858af4ce966a6e1d66d4da704b636bfd299bc",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0f641a5c1b874eaba29dab4af92417535b78b236",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -7602,7 +7632,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "e93ad8fcaf30a8f331c79463f91a05b7bd9ccf40",
+      "upstream_blob": "07373e81e59334c04d5d2ca8461565bf326b78c4",
       "workstream": "WS6"
     },
     {
@@ -7707,7 +7737,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "cdc577d09161c07a90001d0331587995e25f2e40",
+      "upstream_blob": "86d9e99c7df6d653b2cfcf97a168f0d7167d7226",
       "workstream": "WS6"
     },
     {
@@ -7737,7 +7767,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "bf887955a5a7085e20051b40a4033f067da16b1d",
+      "upstream_blob": "c8e28a02431e4664edd402e5d4ddc9a5f28651e7",
       "workstream": "WS6"
     },
     {
@@ -8577,7 +8607,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "c5114ffef04c104b6d362676bfa410c6e7d2cd2d",
+      "upstream_blob": "86a3e6abf641992491b9996585dec6bc4318c4e5",
       "workstream": "WS6"
     },
     {
@@ -8757,7 +8787,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "07fdecce8c61533691423d8a69201971b4d6b8eb",
+      "upstream_blob": "7aee1418782c75af3fae65619c50fbb88b87c174",
       "workstream": "WS6"
     },
     {
@@ -8832,7 +8862,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "2bef65887da1dad1b63fbc129656621e86d7f7dd",
+      "upstream_blob": "a495b718320501b14d466aaca613f281c904b6cf",
       "workstream": "WS6"
     },
     {
@@ -8922,7 +8952,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "79c241adffa4c3258061906cd0822115e8b91f32",
+      "upstream_blob": "5af349fa859ccf46fa97390a53dd587b3ea5f215",
       "workstream": "WS6"
     },
     {
@@ -9357,7 +9387,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "999db56c2a449d12afd5acf9ecc668df16bd295a",
+      "upstream_blob": "febef0a47895826158842dae5577dea58535ae02",
       "workstream": "WS6"
     },
     {
@@ -9372,7 +9402,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "8fec76aa6b96ff95bf1b89683283ce718c51dd8f",
+      "upstream_blob": "f083bf42013e35ed619cad71d9972e72c8d338b6",
       "workstream": "WS6"
     },
     {
@@ -9762,7 +9792,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "4524fb88cb68f831c09812a3f05f012af2b30dd3",
+      "upstream_blob": "18a651e58c6fe3806d1c979f8733f70572dd6f1a",
       "workstream": "WS6"
     },
     {
@@ -11022,7 +11052,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bc1ec06d66c71c98f1d1276125dc1bc6ec2b845b",
+      "upstream_blob": "8e3426b2713f4b673b2ab74d66a016909f10940d",
       "workstream": "WS6"
     },
     {
@@ -11450,6 +11480,21 @@
       "classification": "functional",
       "classification_path": "tests/tools",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "8c8ff867c361e2133a6b8a7949981cb08f7f92a5",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_task_cwd.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "1947836fb47668eb4508a282b491067bf092f0b7",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "fe22bd26c5b838b7e34cfbe3718f964afba82269",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -11495,6 +11540,21 @@
       "classification": "functional",
       "classification_path": "tests/tools",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "19fa3fc05a1bd92108aa834bfd1440f7ebc12034",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tool_output_limits.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "b18f7f3ad0b12350e9d4208590a1363b37987811",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "17b6815c1d1768db12b646583300535df27f26dd",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -11532,7 +11592,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e764ac0b42609b2f4210e1442892cd639d45e1e4",
+      "upstream_blob": "6684e174fb61f21062d88367d281195138069bbb",
       "workstream": "WS6"
     },
     {
@@ -11547,7 +11607,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f3c0cf29c8355d926eeb785a5d3580abc9fd5917",
+      "upstream_blob": "434971e9aac4b5a7f7e5487f5515f87866e1b717",
       "workstream": "WS6"
     },
     {
@@ -11682,7 +11742,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9916ca369d504c52ca919b82758c4f92de3861ea",
+      "upstream_blob": "bb396c05dc36dd17b31b92e87398001eff6530b8",
       "workstream": "WS6"
     },
     {
@@ -11727,7 +11787,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "2a2b77bae2ee43f22de76549bfeea9db10b8436e",
+      "upstream_blob": "8f6a8e67784e9faa4d0ac4474dbe18ed4776fc63",
       "workstream": "WS6"
     },
     {
@@ -11952,7 +12012,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "f2f68efbf5542bc5175f3abf3f1d650b3bfb1cb6",
+      "upstream_blob": "2c20e77a12652cd4269b19bb5aab7edbe03f1b57",
       "workstream": "WS6"
     },
     {
@@ -11967,7 +12027,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "56ca2d4944f75673dec661574bfc7f716a2ece1e",
+      "upstream_blob": "2c6d3cbeb7cc507b5924efac5a9e36c9de696776",
       "workstream": "WS6"
     },
     {
@@ -12185,6 +12245,36 @@
       "classification": "functional",
       "classification_path": "ui-tui/packages",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "cee7ab39ddc2f1fc2644f64a3b85bf3987c9fd96",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "2905c53a2ba2636e6cd299659fe00c14c48cfe55",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/packages",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "a92a72b5c43a5d9a08721b0cf1d9ce7597bbd6ea",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "8f7cceb1b332ddc7b0841157fe2de8f336736f7d",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/packages",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a31753c722aab91c29ad83d1b41dfdf790d54874",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -12312,7 +12402,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "897875b2c032bb7b56a2914d0b8e048836abc252",
+      "upstream_blob": "afebc4d10aca76923e3a5ea29df9baeafb3cdfca",
       "workstream": "WS5"
     },
     {
@@ -12552,7 +12642,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "70264b0c7f93e54bc21ccaffd279802774c5a0de",
+      "upstream_blob": "987518a4460cb5fcc8a4a970a0cd42e33c1cdd67",
       "workstream": "WS5"
     },
     {
@@ -12567,7 +12657,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "991b69faba48d067d8f8d122bd7efc415c7a678b",
+      "upstream_blob": "cbedac59c16cb366e777c61fd48a9e71d57a5124",
       "workstream": "WS5"
     },
     {
@@ -12732,7 +12822,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "cfa45438399f731abace05dc08df07c520b657e0",
+      "upstream_blob": "43e8a2ed628c24e7e1b5895da4588b693a60c79d",
       "workstream": "WS5"
     },
     {
@@ -13002,7 +13092,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "effde40fef98144353911d6eb2ca06692024d01e",
+      "upstream_blob": "aa6cd9b9feab243e7a27e6795ee51e5109e3ef30",
       "workstream": "WS5"
     },
     {
@@ -13017,7 +13107,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "f3121152c906639a310a7e5cd77b704ddac02e67",
+      "upstream_blob": "37bfa881aba50c2bf6d3e1550774dddd94eaba41",
       "workstream": "WS5"
     },
     {
@@ -13077,7 +13167,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "812504836047a74e255376a6957f31903d039583",
+      "upstream_blob": "67ac2b86832e1fa88f655d24e5a0fa688b6dd53c",
       "workstream": "WS5"
     },
     {
@@ -13347,7 +13437,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b3bf9799d7145ec2973280c19582406a02296e74",
+      "upstream_blob": "25121cb9c4dc782580d7c4846350dfaf9c5b91f6",
       "workstream": "WS5"
     },
     {
@@ -13512,7 +13602,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "4825d64227880484cd3ccdf0bdfdbbfcb52ec476",
+      "upstream_blob": "d1b13ed5572f5e6b92ef1d6c6104270221d5eb16",
       "workstream": "WS5"
     },
     {
@@ -13557,7 +13647,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "59543c8942bf095ce1c139c307559596daa0b8ac",
+      "upstream_blob": "b4ac2509bad7760a82ba7292970a0334993df299",
       "workstream": "WS5"
     },
     {
@@ -14067,7 +14157,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "3c8d7bbc1dbef7a1a0d3ab0f5f79be791d63dbbd",
+      "upstream_blob": "d90e5227c5a0899d73e9a79f71dbfab45dc51818",
       "workstream": "WS5"
     },
     {
@@ -14097,7 +14187,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "a9c3d6b8d84f27901733fe81845c250125a2e9ca",
+      "upstream_blob": "831416dd02695091c7e4d5537a2adab99f5a4f41",
       "workstream": "WS5"
     },
     {
@@ -14232,7 +14322,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "48a0e4812ab4147e0ecb4b1e9e7444ec3ba96e5b",
+      "upstream_blob": "60d9680cd3c8683a75fd2ea2b53d7fd449186d53",
       "workstream": "WS5"
     },
     {
@@ -14457,7 +14547,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "0192f9c6461c26dda8bf24977da80cb3551262bb",
+      "upstream_blob": "4c8ae55e8fc4baed1f513af436f842a0c10f6e65",
       "workstream": "WS5"
     },
     {
@@ -14547,7 +14637,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "781fa5e8f06ccdbd985c19d9ef24a191ec371600",
+      "upstream_blob": "f543b5610a2ca8496ca746f71908c109dc60098c",
       "workstream": "WS5"
     },
     {
@@ -14622,7 +14712,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "6e7a528d736c26a1b2c7db7876d261787329d40d",
+      "upstream_blob": "edb93b0f6c6f0176b42feabfcca337b9e4299117",
       "workstream": "WS5"
     },
     {
@@ -14637,7 +14727,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c4ff6046713a4ebf61646c17e06ff38ee18ea730",
+      "upstream_blob": "8c9cd4ba99ce7f017868f8acbc7021780bc1cc16",
       "workstream": "WS5"
     },
     {
@@ -15267,7 +15357,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "2271b1f80a3efc1a117ea0058ef4434df8a9fc5b",
+      "upstream_blob": "a52631c80bd788f953c612197d8c3b1d70688e44",
       "workstream": "WS5"
     },
     {
@@ -15283,6 +15373,21 @@
       "status": "cleared_non_runtime",
       "ticket": 25,
       "upstream_blob": "937c643a4dc2268768267309d29eb435a2ab9c5e",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "website",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "6d6904d6cbfa0a075abc3edd43d055e00bf84bc6",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "website/docusaurus.config.ts",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "265e1e5da9046d43e74acd5fcc95c63bcb98e03b",
       "workstream": "WS5"
     },
     {
@@ -15425,6 +15530,21 @@
       "classification": "policy_only",
       "classification_path": "website/src",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "bc365e47b20029bc646805f9673538809e62992d",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "website/src/components/UserStoriesCollage/styles.module.css",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "42b9e6c7f934e562306cc8718a9ba3ec466dbaf4",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "website/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "651589426ed1388a3d707c21bb1e86e36b33a98e",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
@@ -15462,45 +15582,46 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "13a147dfa74abbca94876f22af71b03aec1de0f6",
+      "upstream_blob": "c2b7c241ab1b7983073b387764ce2c3b95214f34",
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-05-31T23:00:22.467089+00:00",
+  "generated_at_utc": "2026-06-01T00:08:29.451035+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "656d1ca7059279fc212f2bad2e19dcaa61f761e7",
+    "local_sha": "fb3dab608222661db8f4bb5d5449ea571331cd80",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "b1a25404b638bfbd79ce4d08b49afc0ee1361528"
+    "upstream_sha": "fa4ebaa8b58be1e37ea623269ebf2c5d87437e7f"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 594,
-      "intentional_divergence": 267,
-      "policy_only": 169
+      "functional": 599,
+      "intentional_divergence": 268,
+      "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 437,
-      "rust_equivalent_or_contract_test_required": 513,
-      "rust_primary_ux_or_documented_divergence_required": 81
+      "not_required_for_runtime": 440,
+      "rust_equivalent_or_contract_test_required": 514,
+      "rust_native_runtime_parity_required_if_needed": 2,
+      "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 267,
-      "cleared_non_runtime": 170,
-      "pending_review": 594
+      "cleared_intentional_divergence": 268,
+      "cleared_non_runtime": 172,
+      "pending_review": 599
     },
     "by_workstream": {
       "WS3": 56,
       "WS4": 40,
-      "WS5": 233,
-      "WS6": 689,
+      "WS5": 237,
+      "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 267,
-    "cleared_non_runtime": 170,
+    "cleared_intentional_divergence": 268,
+    "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 594,
-    "total_shared_different": 1031
+    "pending_review": 599,
+    "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-05-31T23:00:22.467089+00:00`
+Generated: `2026-06-01T00:08:29.451035+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1031`
+- Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `594`
-- Cleared non-runtime: `170`
-- Cleared intentional divergence: `267`
+- Pending functional review: `599`
+- Cleared non-runtime: `172`
+- Cleared intentional divergence: `268`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 267 |
-| `cleared_non_runtime` | 170 |
-| `pending_review` | 594 |
+| `cleared_intentional_divergence` | 268 |
+| `cleared_non_runtime` | 172 |
+| `pending_review` | 599 |
 
 ## Workstream Counts
 
@@ -24,8 +24,8 @@ Generated: `2026-05-31T23:00:22.467089+00:00`
 | --- | ---: |
 | `WS3` | 56 |
 | `WS4` | 40 |
-| `WS5` | 233 |
-| `WS6` | 689 |
+| `WS5` | 237 |
+| `WS6` | 693 |
 | `WS8` | 13 |
 
 ## Pending Classification
@@ -37,15 +37,15 @@ Generated: `2026-05-31T23:00:22.467089+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 122 |
-| `tests/hermes_cli` | 120 |
-| `tests/tools` | 84 |
+| `tests/hermes_cli` | 122 |
+| `tests/gateway` | 119 |
+| `tests/tools` | 86 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |
 | `tests/cli` | 28 |
 | `tests/agent` | 21 |
-| `ui-tui/packages` | 18 |
+| `ui-tui/packages` | 20 |
 | `tests/plugins` | 14 |
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
@@ -55,3 +55,5 @@ Generated: `2026-05-31T23:00:22.467089+00:00`
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
 | `tests/e2e` | 2 |
+| `plugins/model-providers` | 1 |
+| `plugins/observability` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -234,6 +234,34 @@
       "ticket": 302
     },
     {
+      "path": "tests/gateway/test_agent_cache.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream gateway agent-cache invalidation is covered by Rust GatewayAgentCache and agent_config_signature tests for stable model/provider/toolset/system/cache-key signatures, full-token secret-safe hashing, documented cache-busting config extraction, signature misses, LRU eviction, idle TTL cleanup, and release hooks.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_base_topic_sessions.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream base-topic session behavior is covered by Rust session-control and Telegram bridge tests that preserve distinct thread/topic session keys, encode incoming Telegram group topics as composite chat IDs, split them back into Bot API chat_id/message_thread_id on send, and keep invalid or lobby thread suffixes unchanged.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_busy_session_ack.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream active-session busy acknowledgement behavior is covered by Rust BusySessionCoordinator tests for queue, interrupt, and steer modes, acknowledgement cooldown/debounce, pending follow-up replacement, agent interrupt/steer handoff, status-rich interrupt acknowledgements, command bypass, and pending replay after finish.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_command_bypass_active_session.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream command-bypass behavior is covered by Rust gateway command registry tests for canonical slash commands, Telegram bot suffix stripping, hyphen-to-underscore normalization, registered command bypass decisions, unknown-command rejection, file-path false positives, and active-session bypass integration.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/gateway/test_api_server_toolset.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream's API-server toolset contract is covered by Rust toolset and platform-toolset tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- add Rust-native gateway agent cache helpers with secret-safe signatures, config cache-busting keys, LRU/TTL eviction, release hooks, and active-session-safe eviction variants
- add Rust-native gateway session-control helpers for topic-aware keys, command bypass, queue/interrupt/steer busy-session decisions, ack debounce, and pending replay
- wire Telegram group topics through CLI routing and Telegram send paths so topic chat IDs roundtrip to `message_thread_id`
- expand gateway slash-command normalization and bypass coverage for active-session commands
- update parity ledger for `test_agent_cache.py`, `test_base_topic_sessions.py`, `test_busy_session_ack.py`, and `test_command_bypass_active_session.py`

## Verification
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `cargo test -p hermes-gateway --features telegram agent_cache::tests`
- `cargo test -p hermes-gateway --all-features`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, stale pre-existing allowlist entries=3)
- `cargo build --workspace`
- `cargo test --workspace --quiet` (exit code captured as `0` in `/tmp/hermes-gateway-session-cache-control-final-test.exit`)

## Parity Notes
- `tests/gateway` pending functional review decreased from `122` to `119`.
- Overall regenerated pending review is `599` because `upstream/main` advanced during regeneration and introduced unrelated paths.
