### PR TITLE
parity(cli): add config writer env parity

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4495,6 +4495,7 @@ mod tests {
 
     #[test]
     fn test_sync_runtime_model_env_sets_model_and_provider_values() {
+        let _guard = env_test_lock();
         let mut cfg = GatewayConfig::default();
         cfg.llm_providers
             .insert("anthropic".to_string(), LlmProviderConfig::default());
@@ -4505,6 +4506,10 @@ mod tests {
             "HERMES_INFERENCE_PROVIDER",
             "HERMES_TUI_PROVIDER",
         ];
+        let previous: Vec<(&str, Option<String>)> = keys
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
         for key in keys {
             std::env::remove_var(key);
         }
@@ -4529,8 +4534,11 @@ mod tests {
             Some("anthropic")
         );
 
-        for key in keys {
-            std::env::remove_var(key);
+        for (key, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
         }
     }
 

--- a/crates/hermes-cli/src/config_env.rs
+++ b/crates/hermes-cli/src/config_env.rs
@@ -185,11 +185,9 @@ fn platform_extra_json_to_env_string(key: &str, value: &Value) -> Option<String>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock;
     use hermes_config::{GatewayConfig, PlatformConfig};
     use std::collections::HashMap;
-    use std::sync::Mutex;
-
-    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvGuard {
         pairs: Vec<(String, Option<std::ffi::OsString>)>,
@@ -218,7 +216,7 @@ mod tests {
 
     #[test]
     fn hydrate_env_sets_platform_and_top_level_vars() {
-        let _lock = ENV_TEST_LOCK.lock().expect("env test lock");
+        let _lock = test_env_lock::lock();
         let _guard = EnvGuard::capture(&[
             "HERMES_MODEL",
             "HERMES_MAX_TURNS",
@@ -312,7 +310,7 @@ mod tests {
 
     #[test]
     fn hydrate_env_never_overwrites_existing_values() {
-        let _lock = ENV_TEST_LOCK.lock().expect("env test lock");
+        let _lock = test_env_lock::lock();
         let _guard = EnvGuard::capture(&[
             "HERMES_MODEL",
             "DISCORD_ALLOWED_USERS",

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -49,8 +49,8 @@ use hermes_cli::terminal_backend::build_terminal_backend;
 use hermes_cli::tool_preview::{build_tool_preview_from_value, tool_emoji};
 use hermes_cli::App;
 use hermes_config::{
-    apply_user_config_patch, gateway_pid_path_in, hermes_home, load_config, load_user_config_file,
-    save_config_yaml, state_dir, user_config_field_display, validate_config, ConfigError,
+    gateway_pid_path_in, hermes_home, load_config, load_user_config_file, save_config_yaml,
+    set_user_config_value, state_dir, user_config_field_display, validate_config, ConfigError,
     GatewayConfig, PlatformConfig, UnauthorizedDmBehavior,
 };
 use hermes_core::AgentError;
@@ -2051,14 +2051,27 @@ async fn run_config(
                 .as_ref()
                 .map(PathBuf::from)
                 .unwrap_or_else(hermes_home);
-            let cfg_path = base.join("config.yaml");
-            let mut disk =
-                load_user_config_file(&cfg_path).map_err(|e| AgentError::Config(e.to_string()))?;
-            apply_user_config_patch(&mut disk, &key, &value)
+            let outcome = set_user_config_value(&base, &key, &value)
                 .map_err(|e| AgentError::Config(e.to_string()))?;
-            validate_config(&disk).map_err(|e| AgentError::Config(e.to_string()))?;
-            save_config_yaml(&cfg_path, &disk).map_err(|e| AgentError::Config(e.to_string()))?;
-            println!("Saved {} = {} -> {}", key, value, cfg_path.display());
+            match (outcome.config_path, outcome.env_path, outcome.env_key) {
+                (Some(cfg_path), Some(env_path), Some(env_key)) => {
+                    println!(
+                        "Saved {} = {} -> {} and {} -> {}",
+                        key,
+                        value,
+                        cfg_path.display(),
+                        env_key,
+                        env_path.display()
+                    );
+                }
+                (Some(cfg_path), _, _) => {
+                    println!("Saved {} = {} -> {}", key, value, cfg_path.display());
+                }
+                (_, Some(env_path), Some(env_key)) => {
+                    println!("Saved {} -> {}", env_key, env_path.display());
+                }
+                _ => {}
+            }
         }
         Some("show") => {
             let json = serde_json::to_string_pretty(&config)

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -700,6 +700,38 @@ pub struct TerminalConfig {
     /// Working directory override for command execution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workdir: Option<String>,
+
+    /// Docker container id/name to reuse instead of creating a new one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_container_id: Option<String>,
+
+    /// Docker image used when the Docker backend creates a container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_image: Option<String>,
+
+    /// Mount the current host directory into Docker at `/workspace`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub docker_mount_cwd_to_workspace: bool,
+
+    /// Runtime name for Vercel-backed terminal execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vercel_runtime: Option<String>,
+
+    /// SSH backend host.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_host: Option<String>,
+
+    /// SSH backend port.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_port: Option<u16>,
+
+    /// SSH backend username.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_user: Option<String>,
+
+    /// SSH backend private-key path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssh_key_path: Option<String>,
 }
 
 impl Default for TerminalConfig {
@@ -709,8 +741,20 @@ impl Default for TerminalConfig {
             timeout: default_terminal_timeout(),
             max_output_size: default_max_output_size(),
             workdir: None,
+            docker_container_id: None,
+            docker_image: None,
+            docker_mount_cwd_to_workspace: false,
+            vercel_runtime: None,
+            ssh_host: None,
+            ssh_port: None,
+            ssh_user: None,
+            ssh_key_path: None,
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn default_terminal_timeout() -> u64 {

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -26,8 +26,9 @@ pub use config::{
     SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings,
 };
 pub use loader::{
-    apply_user_config_patch, load_config, load_user_config_file, save_config_yaml,
-    user_config_field_display, validate_config, ConfigError,
+    apply_user_config_patch, atomic_json_write, atomic_json_write_pretty, atomic_write_bytes,
+    atomic_yaml_write, load_config, load_user_config_file, save_config_yaml, set_user_config_value,
+    user_config_field_display, validate_config, ConfigError, ConfigSetResult,
 };
 pub use managed_gateway::{
     build_vendor_gateway_url, coerce_modal_mode, env_var_enabled, get_tool_gateway_scheme,

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -1,6 +1,8 @@
 //! Configuration loading from YAML, JSON, and environment variables.
 
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // Re-export ConfigError for convenience
 pub use hermes_core::ConfigError;
@@ -27,6 +29,74 @@ fn json_to_config_error(e: serde_json::Error) -> ConfigError {
 /// Helper function to convert std::io::Error to ConfigError (avoids orphan rule).
 fn io_to_config_error(e: std::io::Error) -> ConfigError {
     ConfigError::ParseError(e.to_string())
+}
+
+static ATOMIC_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn target_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn atomic_temp_path(path: &Path) -> Result<PathBuf, ConfigError> {
+    let parent = target_parent(path);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            ConfigError::ParseError(format!("invalid config path: {}", path.display()))
+        })?;
+    let nonce = ATOMIC_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    Ok(parent.join(format!(".{file_name}.tmp.{}.{}", std::process::id(), nonce)))
+}
+
+/// Atomically write bytes to a path by writing a sibling temp file then renaming.
+pub fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), ConfigError> {
+    let parent = target_parent(path);
+    std::fs::create_dir_all(parent).map_err(io_to_config_error)?;
+    let tmp_path = atomic_temp_path(path)?;
+
+    let result = (|| -> Result<(), ConfigError> {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut file = options.open(&tmp_path).map_err(io_to_config_error)?;
+        file.write_all(bytes).map_err(io_to_config_error)?;
+        file.sync_all().map_err(io_to_config_error)?;
+        drop(file);
+        std::fs::rename(&tmp_path, path).map_err(io_to_config_error)?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+/// Crash-safe JSON write compatible with upstream `utils.atomic_json_write`.
+pub fn atomic_json_write(path: &Path, value: &serde_json::Value) -> Result<(), ConfigError> {
+    let bytes = serde_json::to_vec(value).map_err(json_to_config_error)?;
+    atomic_write_bytes(path, &bytes)
+}
+
+/// Crash-safe pretty JSON write for user-facing state files.
+pub fn atomic_json_write_pretty(path: &Path, value: &serde_json::Value) -> Result<(), ConfigError> {
+    let bytes = serde_json::to_vec_pretty(value).map_err(json_to_config_error)?;
+    atomic_write_bytes(path, &bytes)
+}
+
+/// Crash-safe YAML write with optional trailing content, matching Python setup helpers.
+pub fn atomic_yaml_write(
+    path: &Path,
+    value: &serde_yaml::Value,
+    extra_content: Option<&str>,
+) -> Result<(), ConfigError> {
+    let mut yaml = serde_yaml::to_string(value).map_err(yaml_to_config_error)?;
+    if let Some(extra) = extra_content {
+        yaml.push_str(extra);
+    }
+    atomic_write_bytes(path, yaml.as_bytes())
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +157,7 @@ fn sanitize_env_file_if_needed(path: &Path) {
     };
     let sanitized = sanitize_env_lines(&original);
     if sanitized != original {
-        let _ = std::fs::write(path, sanitized);
+        let _ = atomic_write_bytes(path, sanitized.as_bytes());
     }
 }
 
@@ -255,9 +325,20 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
 
 /// Load a GatewayConfig from a YAML file.
 pub fn load_from_yaml(path: &Path) -> Result<GatewayConfig, ConfigError> {
+    load_from_yaml_inner(path, true)
+}
+
+fn load_from_yaml_preserving_env_refs(path: &Path) -> Result<GatewayConfig, ConfigError> {
+    load_from_yaml_inner(path, false)
+}
+
+fn load_from_yaml_inner(path: &Path, expand_env_refs: bool) -> Result<GatewayConfig, ConfigError> {
     let contents = std::fs::read_to_string(path).map_err(io_to_config_error)?;
     let mut root: serde_yaml::Value =
         serde_yaml::from_str(&contents).map_err(yaml_to_config_error)?;
+    if expand_env_refs {
+        expand_env_vars_in_yaml(&mut root);
+    }
     if let serde_yaml::Value::Mapping(ref mut m) = root {
         crate::python_yaml_compat::normalize_config_yaml_root(m);
     }
@@ -265,6 +346,60 @@ pub fn load_from_yaml(path: &Path) -> Result<GatewayConfig, ConfigError> {
     mark_platform_enabled_explicit(&mut root, "ntfy");
     let config: GatewayConfig = serde_yaml::from_value(root).map_err(yaml_to_config_error)?;
     Ok(config)
+}
+
+fn expand_env_vars_in_yaml(value: &mut serde_yaml::Value) {
+    match value {
+        serde_yaml::Value::String(s) => {
+            *s = expand_env_refs_in_str(s);
+        }
+        serde_yaml::Value::Sequence(items) => {
+            for item in items {
+                expand_env_vars_in_yaml(item);
+            }
+        }
+        serde_yaml::Value::Mapping(map) => {
+            for value in map.values_mut() {
+                expand_env_vars_in_yaml(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn expand_env_refs_in_str(input: &str) -> String {
+    let mut output = String::new();
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        output.push_str(&rest[..start]);
+        let after_open = &rest[start + 2..];
+        let Some(end) = after_open.find('}') else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+        let name = &after_open[..end];
+        if !name.is_empty()
+            && name
+                .bytes()
+                .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
+        {
+            match std::env::var(name) {
+                Ok(value) => output.push_str(&value),
+                Err(_) => {
+                    output.push_str("${");
+                    output.push_str(name);
+                    output.push('}');
+                }
+            }
+        } else {
+            output.push_str("${");
+            output.push_str(name);
+            output.push('}');
+        }
+        rest = &after_open[end + 1..];
+    }
+    output.push_str(rest);
+    output
 }
 
 fn mark_platform_enabled_explicit(root: &mut serde_yaml::Value, platform: &str) {
@@ -298,7 +433,7 @@ fn mark_platform_enabled_explicit(root: &mut serde_yaml::Value, platform: &str) 
 /// Load `config.yaml` from disk if it exists; otherwise return defaults (no env merge).
 pub fn load_user_config_file(path: &Path) -> Result<GatewayConfig, ConfigError> {
     if path.exists() {
-        let mut cfg = load_from_yaml(path)?;
+        let mut cfg = load_from_yaml_preserving_env_refs(path)?;
         normalize_provider_secrets(&mut cfg);
         Ok(cfg)
     } else {
@@ -815,8 +950,276 @@ pub fn save_config_yaml(path: &Path, config: &GatewayConfig) -> Result<(), Confi
     let mut to_save = config.clone();
     to_save.home_dir = None;
     let yaml = serde_yaml::to_string(&to_save).map_err(yaml_to_config_error)?;
-    std::fs::write(path, yaml).map_err(io_to_config_error)?;
+    atomic_write_bytes(path, yaml.as_bytes())?;
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigSetResult {
+    pub config_path: Option<PathBuf>,
+    pub env_path: Option<PathBuf>,
+    pub env_key: Option<String>,
+    pub config_key: Option<String>,
+}
+
+impl ConfigSetResult {
+    pub fn wrote_config(&self) -> bool {
+        self.config_path.is_some()
+    }
+
+    pub fn wrote_env(&self) -> bool {
+        self.env_path.is_some()
+    }
+}
+
+const EXPLICIT_ENV_CONFIG_KEYS: &[&str] = &[
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "WANDB_API_KEY",
+    "TINKER_API_KEY",
+    "HONCHO_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "BROWSERBASE_API_KEY",
+    "FAL_KEY",
+    "SUDO_PASSWORD",
+    "GITHUB_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+];
+
+/// Python-compatible `hermes config set` persistence.
+///
+/// Secret-like all-caps keys are written to `$HERMES_HOME/.env`; normal dotted
+/// keys are patched into `config.yaml` as raw YAML so list indices and future
+/// upstream keys survive round-trips instead of being dropped by the typed
+/// `GatewayConfig` serializer.
+pub fn set_user_config_value(
+    home_dir: &Path,
+    key: &str,
+    value: &str,
+) -> Result<ConfigSetResult, ConfigError> {
+    let key = key.trim();
+    if key.is_empty() {
+        return Err(ConfigError::ValidationError(
+            "config key must not be empty".to_string(),
+        ));
+    }
+
+    let config_path = home_dir.join("config.yaml");
+    let env_path = home_dir.join(".env");
+    let bridge_env_key = config_env_bridge_key(key);
+    let env_key = config_key_routes_to_env(key).or_else(|| bridge_env_key.clone());
+    let writes_config = bridge_env_key.is_some() || env_key.is_none();
+
+    let mut result = ConfigSetResult {
+        config_path: None,
+        env_path: None,
+        env_key: None,
+        config_key: None,
+    };
+
+    if writes_config {
+        let mut root = load_user_config_yaml_value(&config_path)?;
+        set_yaml_path(&mut root, &split_config_key(key), scalar_yaml_value(value))?;
+        validate_user_config_value(&root)?;
+        atomic_yaml_write(&config_path, &root, None)?;
+        result.config_path = Some(config_path);
+        result.config_key = Some(key.to_string());
+    }
+
+    if let Some(env_key) = env_key {
+        save_env_key_value(&env_path, &env_key, value)?;
+        // SAFETY: config writes run on the foreground CLI path.
+        unsafe { std::env::set_var(&env_key, value) };
+        result.env_path = Some(env_path);
+        result.env_key = Some(env_key);
+    }
+
+    Ok(result)
+}
+
+fn canonical_env_key(key: &str) -> String {
+    key.trim().replace(['.', '-'], "_").to_ascii_uppercase()
+}
+
+fn config_key_routes_to_env(key: &str) -> Option<String> {
+    if key.contains('.') {
+        return None;
+    }
+    let canonical = canonical_env_key(key);
+    if EXPLICIT_ENV_CONFIG_KEYS.contains(&canonical.as_str())
+        || canonical.ends_with("_API_KEY")
+        || canonical.ends_with("_TOKEN")
+        || canonical.starts_with("TERMINAL_SSH_")
+    {
+        Some(canonical)
+    } else {
+        None
+    }
+}
+
+fn config_env_bridge_key(key: &str) -> Option<String> {
+    match key.trim().replace('-', "_").to_ascii_lowercase().as_str() {
+        "terminal.docker_mount_cwd_to_workspace" => {
+            Some("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE".to_string())
+        }
+        "terminal.vercel_runtime" => Some("TERMINAL_VERCEL_RUNTIME".to_string()),
+        _ => None,
+    }
+}
+
+fn split_config_key(key: &str) -> Vec<String> {
+    key.split('.')
+        .filter(|part| !part.is_empty())
+        .enumerate()
+        .map(|(index, part)| {
+            if index == 0 && part == "llm" {
+                "llm_providers".to_string()
+            } else {
+                part.to_string()
+            }
+        })
+        .collect()
+}
+
+fn scalar_yaml_value(value: &str) -> serde_yaml::Value {
+    if value.is_empty() {
+        return serde_yaml::Value::String(String::new());
+    }
+    let trimmed = value.trim();
+    match trimmed.to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" => return serde_yaml::Value::Bool(true),
+        "false" | "no" | "off" => return serde_yaml::Value::Bool(false),
+        _ => {}
+    }
+    if let Ok(n) = trimmed.parse::<i64>() {
+        return serde_yaml::Value::Number(n.into());
+    }
+    serde_yaml::Value::String(value.to_string())
+}
+
+fn load_user_config_yaml_value(path: &Path) -> Result<serde_yaml::Value, ConfigError> {
+    if !path.exists() {
+        return Ok(serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    }
+    let contents = std::fs::read_to_string(path).map_err(io_to_config_error)?;
+    if contents.trim().is_empty() {
+        return Ok(serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    }
+    serde_yaml::from_str(&contents).map_err(yaml_to_config_error)
+}
+
+fn validate_user_config_value(root: &serde_yaml::Value) -> Result<(), ConfigError> {
+    let mut normalized = root.clone();
+    if let serde_yaml::Value::Mapping(ref mut m) = normalized {
+        crate::python_yaml_compat::normalize_config_yaml_root(m);
+    }
+    mark_platform_enabled_explicit(&mut normalized, "slack");
+    mark_platform_enabled_explicit(&mut normalized, "ntfy");
+    let mut cfg: GatewayConfig =
+        serde_yaml::from_value(normalized).map_err(yaml_to_config_error)?;
+    normalize_provider_secrets(&mut cfg);
+    validate_config(&cfg)
+}
+
+fn set_yaml_path(
+    current: &mut serde_yaml::Value,
+    parts: &[String],
+    new_value: serde_yaml::Value,
+) -> Result<(), ConfigError> {
+    if parts.is_empty() {
+        *current = new_value;
+        return Ok(());
+    }
+
+    let head = parts[0].as_str();
+    let tail = &parts[1..];
+    if let Ok(index) = head.parse::<usize>() {
+        ensure_sequence(current);
+        let serde_yaml::Value::Sequence(seq) = current else {
+            unreachable!("ensure_sequence always leaves a sequence")
+        };
+        while seq.len() <= index {
+            seq.push(default_container_for(tail));
+        }
+        if tail.is_empty() {
+            seq[index] = new_value;
+        } else {
+            set_yaml_path(&mut seq[index], tail, new_value)?;
+        }
+        return Ok(());
+    }
+
+    ensure_mapping(current);
+    let serde_yaml::Value::Mapping(map) = current else {
+        unreachable!("ensure_mapping always leaves a mapping")
+    };
+    let key = serde_yaml::Value::String(head.to_string());
+    if tail.is_empty() {
+        map.insert(key, new_value);
+    } else {
+        let entry = map
+            .entry(key)
+            .or_insert_with(|| default_container_for(tail));
+        set_yaml_path(entry, tail, new_value)?;
+    }
+    Ok(())
+}
+
+fn ensure_mapping(value: &mut serde_yaml::Value) {
+    if !matches!(value, serde_yaml::Value::Mapping(_)) {
+        *value = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+    }
+}
+
+fn ensure_sequence(value: &mut serde_yaml::Value) {
+    if !matches!(value, serde_yaml::Value::Sequence(_)) {
+        *value = serde_yaml::Value::Sequence(Vec::new());
+    }
+}
+
+fn default_container_for(tail: &[String]) -> serde_yaml::Value {
+    if tail
+        .first()
+        .is_some_and(|part| part.parse::<usize>().is_ok())
+    {
+        serde_yaml::Value::Sequence(Vec::new())
+    } else {
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+    }
+}
+
+fn save_env_key_value(path: &Path, key: &str, value: &str) -> Result<(), ConfigError> {
+    let original = std::fs::read_to_string(path).unwrap_or_default();
+    let sanitized_value = value.replace('\n', "\\n");
+    let mut lines = Vec::new();
+    let mut replaced = false;
+
+    for line in original.lines() {
+        let line_key = line
+            .split_once('=')
+            .map(|(k, _)| k.trim())
+            .filter(|k| !k.is_empty());
+        if line_key == Some(key) {
+            if !replaced {
+                lines.push(format!("{key}={sanitized_value}"));
+                replaced = true;
+            }
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !replaced {
+        lines.push(format!("{key}={sanitized_value}"));
+    }
+
+    let mut out = lines.join("\n");
+    out.push('\n');
+    atomic_write_bytes(path, out.as_bytes())
 }
 
 // ---------------------------------------------------------------------------
@@ -1162,6 +1565,202 @@ mod tests {
         // Simulate env var (we can't easily set env vars in tests, so test the logic directly)
         config.model = Some("env-model".into());
         assert_eq!(config.model.as_deref(), Some("env-model"));
+    }
+
+    #[test]
+    fn atomic_json_write_roundtrips_and_cleans_temp() {
+        use serde_json::json;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data.json");
+        atomic_json_write(&path, &json!({"key": "value", "nested": {"a": 1}})).unwrap();
+
+        let loaded: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded, json!({"key": "value", "nested": {"a": 1}}));
+        assert!(!std::fs::read_dir(dir.path()).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".tmp.")));
+    }
+
+    #[test]
+    fn atomic_yaml_write_appends_extra_content() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data.yaml");
+        let value: serde_yaml::Value = serde_yaml::from_str("key: value\n").unwrap();
+        atomic_yaml_write(&path, &value, Some("\n# comment\n")).unwrap();
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("key: value"));
+        assert!(text.contains("# comment"));
+    }
+
+    #[test]
+    fn load_from_yaml_expands_env_refs_but_user_config_load_preserves_templates() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+llm_providers:
+  openai:
+    api_key: ${TEST_OPENAI_KEY}
+    base_url: https://${TEST_OPENAI_HOST}/v1
+"#,
+        )
+        .unwrap();
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::set_var("TEST_OPENAI_KEY", "sk-test");
+            std::env::set_var("TEST_OPENAI_HOST", "api.example.test");
+        }
+
+        let runtime = load_from_yaml(&path).unwrap();
+        let openai = runtime.llm_providers.get("openai").unwrap();
+        assert_eq!(openai.api_key.as_deref(), Some("sk-test"));
+        assert_eq!(
+            openai.base_url.as_deref(),
+            Some("https://api.example.test/v1")
+        );
+
+        let editable = load_user_config_file(&path).unwrap();
+        let editable_openai = editable.llm_providers.get("openai").unwrap();
+        assert_eq!(
+            editable_openai.api_key.as_deref(),
+            Some("${TEST_OPENAI_KEY}")
+        );
+        assert_eq!(
+            editable_openai.base_url.as_deref(),
+            Some("https://${TEST_OPENAI_HOST}/v1")
+        );
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("TEST_OPENAI_KEY");
+            std::env::remove_var("TEST_OPENAI_HOST");
+        }
+    }
+
+    #[test]
+    fn load_from_yaml_keeps_unresolved_env_refs_verbatim() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+llm_providers:
+  openai:
+    api_key: ${MISSING_OPENAI_KEY_FOR_TEST}
+"#,
+        )
+        .unwrap();
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("MISSING_OPENAI_KEY_FOR_TEST") };
+        let runtime = load_from_yaml(&path).unwrap();
+        assert_eq!(
+            runtime
+                .llm_providers
+                .get("openai")
+                .and_then(|provider| provider.api_key.as_deref()),
+            Some("${MISSING_OPENAI_KEY_FOR_TEST}")
+        );
+    }
+
+    #[test]
+    fn set_user_config_value_routes_secret_keys_to_env() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let result = set_user_config_value(dir.path(), "openai_api_key", "sk-test").unwrap();
+
+        assert!(result.wrote_env());
+        assert!(!result.wrote_config());
+        assert_eq!(result.env_key.as_deref(), Some("OPENAI_API_KEY"));
+        assert!(std::fs::read_to_string(dir.path().join(".env"))
+            .unwrap()
+            .contains("OPENAI_API_KEY=sk-test"));
+        assert!(!dir.path().join("config.yaml").exists());
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+    }
+
+    #[test]
+    fn set_user_config_value_bridges_terminal_env_keys_and_config() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let result =
+            set_user_config_value(dir.path(), "terminal.vercel_runtime", "python3.13").unwrap();
+
+        assert!(result.wrote_config());
+        assert!(result.wrote_env());
+        assert_eq!(result.env_key.as_deref(), Some("TERMINAL_VERCEL_RUNTIME"));
+        let config_text = std::fs::read_to_string(dir.path().join("config.yaml")).unwrap();
+        let env_text = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(config_text.contains("vercel_runtime: python3.13"));
+        assert!(env_text.contains("TERMINAL_VERCEL_RUNTIME=python3.13"));
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("TERMINAL_VERCEL_RUNTIME") };
+    }
+
+    #[test]
+    fn set_user_config_value_preserves_list_siblings_for_indexed_paths() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+custom_providers:
+- name: provider-a
+  api_key: old-a
+  base_url: https://a.example.com
+- name: provider-b
+  api_key: old-b
+  base_url: https://b.example.com
+"#,
+        )
+        .unwrap();
+
+        set_user_config_value(dir.path(), "custom_providers.0.api_key", "new-a").unwrap();
+
+        let reloaded: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let providers = reloaded
+            .get("custom_providers")
+            .and_then(|v| v.as_sequence())
+            .unwrap();
+        assert_eq!(providers.len(), 2);
+        assert_eq!(
+            providers[0].get("api_key").and_then(|v| v.as_str()),
+            Some("new-a")
+        );
+        assert_eq!(
+            providers[0].get("base_url").and_then(|v| v.as_str()),
+            Some("https://a.example.com")
+        );
+        assert_eq!(
+            providers[1].get("api_key").and_then(|v| v.as_str()),
+            Some("old-b")
+        );
     }
 
     #[test]

--- a/crates/hermes-environments/src/docker.rs
+++ b/crates/hermes-environments/src/docker.rs
@@ -1,5 +1,7 @@
 //! Docker terminal backend – executes commands inside Docker containers.
 
+use std::sync::Mutex;
+
 use async_trait::async_trait;
 use tokio::process::Command as TokioCommand;
 
@@ -8,9 +10,11 @@ use hermes_core::{AgentError, CommandOutput, TerminalBackend};
 /// A [`TerminalBackend`] that runs commands inside a Docker container.
 pub struct DockerBackend {
     /// Active container ID (or name).
-    container_id: Option<String>,
+    container_id: Mutex<Option<String>>,
     /// Docker image to use if creating a new container.
     image: Option<String>,
+    /// Mount the host cwd at /workspace when creating a container.
+    mount_cwd_to_workspace: bool,
     /// Default timeout in seconds.
     default_timeout: u64,
     /// Maximum output size in bytes.
@@ -27,12 +31,14 @@ impl DockerBackend {
     pub fn new(
         container_id: Option<String>,
         image: Option<String>,
+        mount_cwd_to_workspace: bool,
         default_timeout: u64,
         max_output_size: usize,
     ) -> Self {
         Self {
-            container_id,
+            container_id: Mutex::new(container_id),
             image: image.or_else(|| Some("ubuntu:22.04".to_string())),
+            mount_cwd_to_workspace,
             default_timeout,
             max_output_size,
         }
@@ -40,9 +46,14 @@ impl DockerBackend {
 
     /// Ensure we have a running container. If `container_id` is None,
     /// create one from the configured image.
-    async fn ensure_container(&mut self) -> Result<String, AgentError> {
-        if let Some(ref id) = self.container_id {
-            return Ok(id.clone());
+    async fn ensure_container(&self) -> Result<String, AgentError> {
+        if let Some(id) = self
+            .container_id
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+        {
+            return Ok(id);
         }
 
         let image = self
@@ -52,8 +63,22 @@ impl DockerBackend {
 
         tracing::info!("Creating Docker container from image: {}", image);
 
+        let mut args = vec!["run".to_string(), "-d".to_string(), "--tty".to_string()];
+        if self.mount_cwd_to_workspace {
+            if let Ok(cwd) = std::env::current_dir() {
+                args.push("-v".to_string());
+                args.push(format!("{}:/workspace", cwd.display()));
+                args.push("-w".to_string());
+                args.push("/workspace".to_string());
+            }
+        }
+        args.push(image.clone());
+        args.push("tail".to_string());
+        args.push("-f".to_string());
+        args.push("/dev/null".to_string());
+
         let output = TokioCommand::new("docker")
-            .args(["run", "-d", "--tty", image, "tail", "-f", "/dev/null"])
+            .args(&args)
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to create Docker container: {}", e)))?;
@@ -68,15 +93,8 @@ impl DockerBackend {
 
         let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
         tracing::info!("Created container: {}", id);
-        self.container_id = Some(id.clone());
+        *self.container_id.lock().unwrap_or_else(|e| e.into_inner()) = Some(id.clone());
         Ok(id)
-    }
-
-    /// Get the container ID, returning an error if not available.
-    fn container_id(&self) -> Result<&str, AgentError> {
-        self.container_id
-            .as_deref()
-            .ok_or_else(|| AgentError::Config("No Docker container ID available".into()))
     }
 
     fn truncate_output(&self, s: String) -> String {
@@ -98,7 +116,7 @@ impl TerminalBackend for DockerBackend {
         background: bool,
         pty: bool,
     ) -> Result<CommandOutput, AgentError> {
-        let container_id = self.container_id()?;
+        let container_id = self.ensure_container().await?;
         let timeout_secs = timeout.unwrap_or(self.default_timeout);
 
         let mut args = vec!["exec".to_string()];
@@ -157,7 +175,7 @@ impl TerminalBackend for DockerBackend {
         offset: Option<u64>,
         limit: Option<u64>,
     ) -> Result<String, AgentError> {
-        let container_id = self.container_id()?;
+        let container_id = self.ensure_container().await?;
 
         // Use docker exec cat to read the file
         let mut cat_cmd = format!("cat {}", shlex_quote(path));
@@ -177,7 +195,7 @@ impl TerminalBackend for DockerBackend {
         }
 
         let output = TokioCommand::new("docker")
-            .args(["exec", container_id, "sh", "-c", &cat_cmd])
+            .args(["exec", container_id.as_str(), "sh", "-c", &cat_cmd])
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to read file via docker: {}", e)))?;
@@ -194,7 +212,7 @@ impl TerminalBackend for DockerBackend {
     }
 
     async fn write_file(&self, path: &str, content: &str) -> Result<(), AgentError> {
-        let container_id = self.container_id()?;
+        let container_id = self.ensure_container().await?;
 
         // Use docker exec to write the file. We pipe the content through stdin.
         // First ensure the parent directory exists.
@@ -206,7 +224,7 @@ impl TerminalBackend for DockerBackend {
         if !parent_dir.is_empty() {
             let mkdir_cmd = format!("mkdir -p {}", shlex_quote(&parent_dir));
             let mkdir_output = TokioCommand::new("docker")
-                .args(["exec", container_id, "sh", "-c", &mkdir_cmd])
+                .args(["exec", container_id.as_str(), "sh", "-c", &mkdir_cmd])
                 .output()
                 .await
                 .map_err(|e| {
@@ -232,7 +250,7 @@ impl TerminalBackend for DockerBackend {
         );
 
         let output = TokioCommand::new("docker")
-            .args(["exec", container_id, "sh", "-c", &write_cmd])
+            .args(["exec", container_id.as_str(), "sh", "-c", &write_cmd])
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to write file via docker: {}", e)))?;
@@ -249,10 +267,10 @@ impl TerminalBackend for DockerBackend {
     }
 
     async fn file_exists(&self, path: &str) -> Result<bool, AgentError> {
-        let container_id = self.container_id()?;
+        let container_id = self.ensure_container().await?;
 
         let output = TokioCommand::new("docker")
-            .args(["exec", container_id, "test", "-e", path])
+            .args(["exec", container_id.as_str(), "test", "-e", path])
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to check file via docker: {}", e)))?;

--- a/crates/hermes-environments/src/manager.rs
+++ b/crates/hermes-environments/src/manager.rs
@@ -55,8 +55,9 @@ impl BackendManager {
             #[cfg(feature = "docker")]
             TerminalBackendType::Docker => (
                 Arc::new(DockerBackend::new(
-                    None,
-                    None,
+                    config.docker_container_id.clone(),
+                    config.docker_image.clone(),
+                    config.docker_mount_cwd_to_workspace,
                     config.timeout,
                     config.max_output_size,
                 )),
@@ -65,10 +66,13 @@ impl BackendManager {
             #[cfg(feature = "ssh")]
             TerminalBackendType::Ssh => (
                 Arc::new(SshBackend::new(
-                    "localhost".to_string(),
-                    22,
-                    None,
-                    None,
+                    config
+                        .ssh_host
+                        .clone()
+                        .unwrap_or_else(|| "localhost".to_string()),
+                    config.ssh_port.unwrap_or(22),
+                    config.ssh_user.clone(),
+                    config.ssh_key_path.clone(),
                     config.timeout,
                     config.max_output_size,
                 )),

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T00:09:12.348989+00:00",
+  "generated_at_utc": "2026-06-01T01:49:08.572376+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T00:09:12.348989+00:00`
+Generated: `2026-06-01T01:49:08.572376+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -5971,32 +5971,32 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_atomic_json_write.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "08bed89ff36fa877a42b75c0ba9a30a756691d2b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_atomic_json_write.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "6c3e94f6bb89cc13b59507656c8fb9042b700519",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_atomic_yaml_write.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "6a9e4f00d5e3898ecde840a13d9b5f0e63ab7b35",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_atomic_yaml_write.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "c76649fce66d4b6f8bdbaee9d44b32032ba8c957",
       "workstream": "WS6"
     },
@@ -6301,17 +6301,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_config_env_expansion.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "4de3480f7343f72e95f4360f00ff9db8400e6b17",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_config_env_expansion.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "435a47668780d10bb2007c22c0a4f736dd0260a5",
       "workstream": "WS6"
     },
@@ -6496,17 +6496,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_env_loader.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f309dfd4c6a8a09de26b82a6e269c600f47120e9",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_env_loader.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "f719fae01ce75dc48375a655f5208fa331297af1",
       "workstream": "WS6"
     },
@@ -7231,17 +7231,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_set_config_value.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "617a915e32252c165a1f687e1ac89888746b4d4d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_set_config_value.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "d404549cf524ba5061c83eb8e2c02cbb8b1b2080",
       "workstream": "WS6"
     },
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T00:08:29.451035+00:00",
+  "generated_at_utc": "2026-06-01T01:49:08.355065+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "fb3dab608222661db8f4bb5d5449ea571331cd80",
+    "local_sha": "4e51a21546e7fc4c3e633e5168ce6ba528bc74ab",
     "upstream_ref": "upstream/main",
     "upstream_sha": "fa4ebaa8b58be1e37ea623269ebf2c5d87437e7f"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 599,
-      "intentional_divergence": 268,
+      "functional": 594,
+      "intentional_divergence": 273,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 440,
-      "rust_equivalent_or_contract_test_required": 514,
+      "not_required_for_runtime": 445,
+      "rust_equivalent_or_contract_test_required": 509,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 268,
+      "cleared_intentional_divergence": 273,
       "cleared_non_runtime": 172,
-      "pending_review": 599
+      "pending_review": 594
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 268,
+    "cleared_intentional_divergence": 273,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 599,
+    "pending_review": 594,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T00:08:29.451035+00:00`
+Generated: `2026-06-01T01:49:08.355065+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `599`
+- Pending functional review: `594`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `268`
+- Cleared intentional divergence: `273`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 268 |
+| `cleared_intentional_divergence` | 273 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 599 |
+| `pending_review` | 594 |
 
 ## Workstream Counts
 
@@ -37,8 +37,8 @@ Generated: `2026-06-01T00:08:29.451035+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/hermes_cli` | 122 |
 | `tests/gateway` | 119 |
+| `tests/hermes_cli` | 117 |
 | `tests/tools` | 86 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -752,6 +752,41 @@
       "ticket": 25
     },
     {
+      "path": "tests/hermes_cli/test_atomic_json_write.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream crash-safe JSON write intent is covered by Rust hermes-config atomic_json_write/atomic_json_write_pretty helpers using sibling temp files, fsync-before-rename, cleanup on failure, parent directory creation, and roundtrip/no-temp-file tests.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/hermes_cli/test_atomic_yaml_write.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream crash-safe YAML write intent is covered by Rust hermes-config atomic_yaml_write and save_config_yaml using sibling temp files, fsync-before-rename, cleanup on failure, parent directory creation, optional trailing content, and focused YAML write tests.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/hermes_cli/test_config_env_expansion.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream config ${ENV_VAR} expansion is covered by Rust load_from_yaml/load_config recursive value-only expansion for strings, nested mappings, lists, multiple placeholders, and unresolved placeholders while load_user_config_file preserves templates for edit paths.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/hermes_cli/test_env_loader.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream dotenv loader precedence and sanitization intent is covered by Rust load_dotenv/load_dotenv_file tests for user-env precedence, project fallback, sanitized concatenated assignments before loading, and atomic sanitized-file rewrite.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/hermes_cli/test_set_config_value.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream set_config_value routing intent is covered by Rust set_user_config_value and CLI e2e tests for secret-like keys to .env, uppercase normalization, env-bridged terminal keys, raw YAML config writes, falsy scalar handling, llm.* canonicalization to llm_providers, and list-index updates that preserve sibling entries.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/hermes_cli/test_bedrock_model_picker.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream Bedrock model-picker intent is covered by Rust provider canonicalization, region-aware curated fallback, best-effort signed live Bedrock catalog discovery, AWS credential-signal gating, and setup/model catalog tests; the Python test file remains reference-only.",


### PR DESCRIPTION
## Summary
- add Rust-native atomic JSON/YAML/bytes config writes and use atomic saves for sanitized `.env` and config YAML paths
- add runtime-only `${ENV_VAR}` expansion for YAML values while preserving env refs on user config edit paths
- add `set_user_config_value` for CLI config writes with secret `.env` routing, terminal env bridge keys, raw YAML dotted/list-index writes, and `llm.*` canonicalization
- wire Docker/SSH/Vercel terminal config into environment backends, including lazy Docker container creation and optional cwd mount
- clear five `tests/hermes_cli` parity backlog items and regenerate parity proof/backlog docs

## Cleared parity paths
- `tests/hermes_cli/test_atomic_json_write.py`
- `tests/hermes_cli/test_atomic_yaml_write.py`
- `tests/hermes_cli/test_config_env_expansion.py`
- `tests/hermes_cli/test_env_loader.py`
- `tests/hermes_cli/test_set_config_value.py`

## Verification
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `python3 scripts/generate-shared-diff-backlog.py --repo-root . --no-fetch`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release`
- `cargo test -p hermes-config`
- `cargo test -p hermes-config set_user_config_value`
- `cargo test -p hermes-environments --all-features`
- `cargo test -p hermes-cli --all-features e2e_cli_config_set_dotted_llm_and_get_masks_key`
- `cargo test -p hermes-cli --all-features config`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, stale=3 pre-existing)
- `cargo build --workspace`
- `cargo test --workspace --quiet`
