### PR TITLE
parity(cli): add quick command dispatch

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -10,7 +10,7 @@ use std::{
     fmt::Write as _,
     io::Write as _,
     path::{Path, PathBuf},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 use bytes::Bytes;
@@ -3396,11 +3396,144 @@ fn canonical_command(cmd: &str) -> &str {
 // Command dispatcher
 // ---------------------------------------------------------------------------
 
+enum QuickCommandDispatch {
+    Handled,
+    Alias { cmd: String, args: Vec<String> },
+}
+
+fn quick_command_key(cmd: &str) -> String {
+    cmd.trim()
+        .trim_start_matches('/')
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .replace('-', "_")
+}
+
+fn quick_command_args(args: &[&str]) -> String {
+    args.join(" ")
+}
+
+fn split_slash_command(input: &str) -> (String, Vec<String>) {
+    let trimmed = input.trim();
+    let mut parts = trimmed.split_whitespace();
+    let cmd = parts.next().unwrap_or(trimmed).to_string();
+    let args = parts.map(ToString::to_string).collect();
+    (cmd, args)
+}
+
+async fn run_quick_exec(
+    name: &str,
+    command: &str,
+    timeout_secs: u64,
+) -> Result<String, AgentError> {
+    let child = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output();
+    let output = match tokio::time::timeout(Duration::from_secs(timeout_secs), child).await {
+        Ok(result) => result.map_err(|e| {
+            AgentError::ToolExecution(format!("quick command `{name}` failed: {e}"))
+        })?,
+        Err(_) => {
+            return Ok(format!(
+                "Quick command `{name}` timed out after {timeout_secs}s."
+            ));
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string();
+    if !stdout.trim().is_empty() {
+        return Ok(stdout);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr)
+        .trim_end()
+        .to_string();
+    if !stderr.trim().is_empty() {
+        return Ok(stderr);
+    }
+    Ok("Quick command completed with no output.".to_string())
+}
+
+async fn handle_quick_command(
+    app: &mut App,
+    cmd: &str,
+    args: &[&str],
+) -> Result<Option<QuickCommandDispatch>, AgentError> {
+    let key = quick_command_key(cmd);
+    let Some(quick) = app.config.quick_commands.get(&key).cloned() else {
+        return Ok(None);
+    };
+
+    match quick.kind.trim().to_ascii_lowercase().as_str() {
+        "exec" => {
+            let Some(command) = quick.command.as_deref().filter(|v| !v.trim().is_empty()) else {
+                emit_command_output(
+                    app,
+                    format!("Quick command `{key}` has no command defined."),
+                );
+                return Ok(Some(QuickCommandDispatch::Handled));
+            };
+            let output = run_quick_exec(&key, command, quick.timeout_secs()).await?;
+            emit_command_output(app, output);
+            Ok(Some(QuickCommandDispatch::Handled))
+        }
+        "alias" => {
+            let Some(target) = quick.target.as_deref().filter(|v| !v.trim().is_empty()) else {
+                emit_command_output(app, format!("Quick command `{key}` has no target defined."));
+                return Ok(Some(QuickCommandDispatch::Handled));
+            };
+            let mut rewritten = target.trim().to_string();
+            let extra = quick_command_args(args);
+            if !extra.is_empty() {
+                rewritten.push(' ');
+                rewritten.push_str(&extra);
+            }
+            let (alias_cmd, alias_args) = split_slash_command(&rewritten);
+            Ok(Some(QuickCommandDispatch::Alias {
+                cmd: alias_cmd,
+                args: alias_args,
+            }))
+        }
+        other => {
+            emit_command_output(
+                app,
+                format!("Quick command `{key}` has unsupported type `{other}`."),
+            );
+            Ok(Some(QuickCommandDispatch::Handled))
+        }
+    }
+}
+
 /// Handle a slash command.
 ///
 /// `cmd` is the full command token including the `/` prefix
 /// (e.g. `/model`, `/new`). `args` are the remaining tokens.
 pub async fn handle_slash_command(
+    app: &mut App,
+    cmd: &str,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    if let Some(dispatch) = handle_quick_command(app, cmd, args).await? {
+        match dispatch {
+            QuickCommandDispatch::Handled => return Ok(CommandResult::Handled),
+            QuickCommandDispatch::Alias { cmd, args } => {
+                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                return dispatch_slash_command(app, &cmd, &arg_refs).await;
+            }
+        }
+    }
+
+    dispatch_slash_command(app, cmd, args).await
+}
+
+async fn dispatch_slash_command(
     app: &mut App,
     cmd: &str,
     args: &[&str],
@@ -24896,6 +25029,12 @@ mod tests {
             .unwrap_or_default()
     }
 
+    fn insert_quick_command(app: &mut App, name: &str, command: hermes_config::QuickCommandConfig) {
+        let mut config = (*app.config).clone();
+        config.quick_commands.insert(name.to_string(), command);
+        app.config = Arc::new(config);
+    }
+
     #[tokio::test]
     async fn external_plugin_command_rejects_python_dispatch() {
         let err = handle_cli_external_plugin_subcommand(vec!["honcho".to_string()])
@@ -24992,6 +25131,113 @@ mod tests {
         let results = autocomplete_contextual("/objective behavior ");
         assert!(results.contains(&"/objective behavior strict ".to_string()));
         assert!(results.contains(&"/objective behavior sigma ".to_string()));
+    }
+
+    #[tokio::test]
+    async fn quick_exec_command_prints_stdout_before_agent_loop() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        insert_quick_command(
+            &mut app,
+            "dn",
+            hermes_config::QuickCommandConfig {
+                kind: "exec".to_string(),
+                command: Some("printf daily-note".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let result = handle_slash_command(&mut app, "/dn", &[])
+            .await
+            .expect("quick command");
+
+        assert_eq!(result, CommandResult::Handled);
+        assert_eq!(latest_ui_assistant_text(&app), "daily-note");
+    }
+
+    #[tokio::test]
+    async fn quick_exec_no_output_and_timeout_have_user_visible_replies() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        insert_quick_command(
+            &mut app,
+            "empty",
+            hermes_config::QuickCommandConfig {
+                kind: "exec".to_string(),
+                command: Some("true".to_string()),
+                ..Default::default()
+            },
+        );
+        insert_quick_command(
+            &mut app,
+            "slow",
+            hermes_config::QuickCommandConfig {
+                kind: "exec".to_string(),
+                command: Some("sleep 1".to_string()),
+                timeout_secs: Some(0),
+                ..Default::default()
+            },
+        );
+
+        handle_slash_command(&mut app, "/empty", &[])
+            .await
+            .expect("empty command");
+        assert!(latest_ui_assistant_text(&app).contains("no output"));
+
+        handle_slash_command(&mut app, "/slow", &[])
+            .await
+            .expect("timeout command");
+        assert!(latest_ui_assistant_text(&app).contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn quick_alias_rewrites_to_builtin_and_passes_args() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        insert_quick_command(
+            &mut app,
+            "sc",
+            hermes_config::QuickCommandConfig {
+                kind: "alias".to_string(),
+                target: Some("/queue".to_string()),
+                ..Default::default()
+            },
+        );
+
+        handle_slash_command(&mut app, "/sc", &["some", "args"])
+            .await
+            .expect("alias command");
+
+        assert!(latest_ui_assistant_text(&app).contains("some args"));
+    }
+
+    #[tokio::test]
+    async fn quick_command_takes_priority_over_builtin_slash_command() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        insert_quick_command(
+            &mut app,
+            "help",
+            hermes_config::QuickCommandConfig {
+                kind: "exec".to_string(),
+                command: Some("printf overridden".to_string()),
+                ..Default::default()
+            },
+        );
+
+        handle_slash_command(&mut app, "/help", &[])
+            .await
+            .expect("overridden help");
+
+        assert_eq!(latest_ui_assistant_text(&app), "overridden");
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -2760,6 +2760,7 @@ async fn run_gateway(
             // Build gateway runtime and context-aware message handler.
             let runtime_gateway_config = RuntimeGatewayConfig {
                 streaming_enabled: config.streaming.enabled,
+                quick_commands: config.quick_commands.clone(),
                 ..RuntimeGatewayConfig::default()
             };
             let session_manager = Arc::new(SessionManager::new(config.session.clone()));

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -88,6 +88,10 @@ pub struct GatewayConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub auxiliary: BTreeMap<String, AuxiliaryTaskConfig>,
 
+    /// User-defined slash commands that bypass the agent loop.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub quick_commands: BTreeMap<String, QuickCommandConfig>,
+
     /// Upstream-compatible TTS configuration block.
     ///
     /// Kept as structured JSON because upstream accepts provider-specific
@@ -155,6 +159,7 @@ impl Default for GatewayConfig {
             fallback_models: Vec::new(),
             smart_model_routing: SmartModelRoutingConfig::default(),
             auxiliary: BTreeMap::new(),
+            quick_commands: BTreeMap::new(),
             tts: serde_json::Value::Null,
             proxy: None,
             approval: ApprovalConfig::default(),
@@ -167,6 +172,55 @@ impl Default for GatewayConfig {
             home_dir: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuickCommandConfig {
+    /// Command kind. Supported runtime kinds: `exec` and `alias`.
+    #[serde(
+        default = "default_quick_command_type",
+        rename = "type",
+        alias = "kind"
+    )]
+    pub kind: String,
+
+    /// Shell command to run for `exec`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+
+    /// Slash command target for `alias`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+
+    /// Optional execution timeout in seconds. Defaults to 30.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+
+    /// Back-compat alias for `timeout_secs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u64>,
+}
+
+impl Default for QuickCommandConfig {
+    fn default() -> Self {
+        Self {
+            kind: default_quick_command_type(),
+            command: None,
+            target: None,
+            timeout_secs: None,
+            timeout: None,
+        }
+    }
+}
+
+impl QuickCommandConfig {
+    pub fn timeout_secs(&self) -> u64 {
+        self.timeout_secs.or(self.timeout).unwrap_or(30)
+    }
+}
+
+fn default_quick_command_type() -> String {
+    "exec".to_string()
 }
 
 fn is_json_null(value: &serde_json::Value) -> bool {
@@ -1040,6 +1094,32 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn quick_commands_deserialize_exec_and_alias_configs() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+quick_commands:
+  dn:
+    type: exec
+    command: echo daily-note
+    timeout_secs: 5
+  sc:
+    type: alias
+    target: /context
+"#,
+        )
+        .expect("quick command config");
+
+        let exec = cfg.quick_commands.get("dn").expect("exec command");
+        assert_eq!(exec.kind, "exec");
+        assert_eq!(exec.command.as_deref(), Some("echo daily-note"));
+        assert_eq!(exec.timeout_secs(), 5);
+
+        let alias = cfg.quick_commands.get("sc").expect("alias command");
+        assert_eq!(alias.kind, "alias");
+        assert_eq!(alias.target.as_deref(), Some("/context"));
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -22,7 +22,7 @@ pub mod streaming;
 pub use config::{
     default_auxiliary_task_configs, AgentLoopBehaviorConfig, ApprovalConfig, AuxiliaryTaskConfig,
     CheapModelRouteConfig, GatewayConfig, LlmProviderConfig, McpServerEntry, ProfileConfig,
-    ProxyConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
+    ProxyConfig, QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
     SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings,
 };
 pub use loader::{

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -126,6 +126,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 fallback_models: Vec::new(),
                 smart_model_routing: SmartModelRoutingConfig::default(),
                 auxiliary: Default::default(),
+                quick_commands: Default::default(),
                 tts: serde_json::Value::Null,
                 proxy: None,
                 approval: ApprovalConfig::default(),

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -10,12 +10,15 @@
 //! Also integrates `StreamManager` for progressive message editing.
 
 use chrono::{DateTime, Utc};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
+use hermes_config::QuickCommandConfig;
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 use hermes_core::types::{Message, MessageRole};
@@ -54,6 +57,10 @@ pub struct GatewayConfig {
     /// Streaming configuration.
     #[serde(default)]
     pub streaming: StreamConfig,
+
+    /// User-defined slash commands that bypass the agent loop.
+    #[serde(default)]
+    pub quick_commands: BTreeMap<String, QuickCommandConfig>,
 }
 
 impl Default for GatewayConfig {
@@ -64,6 +71,7 @@ impl Default for GatewayConfig {
             media_cache_max_bytes: 0,
             streaming_enabled: false,
             streaming: StreamConfig::default(),
+            quick_commands: BTreeMap::new(),
         }
     }
 }
@@ -901,11 +909,128 @@ impl Gateway {
         Ok(())
     }
 
+    fn quick_command_key(raw: &str) -> String {
+        raw.trim()
+            .trim_start_matches('/')
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .replace('-', "_")
+    }
+
+    fn split_slash_command(input: &str) -> (String, String) {
+        let trimmed = input.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let cmd = parts.next().unwrap_or(trimmed).to_string();
+        let args = parts.next().unwrap_or_default().trim().to_string();
+        (cmd, args)
+    }
+
+    async fn run_quick_exec(
+        name: &str,
+        command: &str,
+        timeout_secs: u64,
+    ) -> Result<String, GatewayError> {
+        let child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .kill_on_drop(true)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        let output = match tokio::time::timeout(Duration::from_secs(timeout_secs), child).await {
+            Ok(result) => result.map_err(|e| {
+                GatewayError::Platform(format!("quick command `{name}` failed: {e}"))
+            })?,
+            Err(_) => {
+                return Ok(format!(
+                    "Quick command `{name}` timed out after {timeout_secs}s."
+                ));
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout)
+            .trim_end()
+            .to_string();
+        if !stdout.trim().is_empty() {
+            return Ok(stdout);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr)
+            .trim_end()
+            .to_string();
+        if !stderr.trim().is_empty() {
+            return Ok(stderr);
+        }
+        Ok("Quick command completed with no output.".to_string())
+    }
+
+    async fn resolve_quick_command(&self, input: &str) -> Result<Option<String>, GatewayError> {
+        let (cmd, args) = Self::split_slash_command(input);
+        let key = Self::quick_command_key(&cmd);
+        let Some(quick) = self.config.quick_commands.get(&key).cloned() else {
+            return Ok(None);
+        };
+
+        match quick.kind.trim().to_ascii_lowercase().as_str() {
+            "exec" => {
+                let Some(command) = quick.command.as_deref().filter(|v| !v.trim().is_empty())
+                else {
+                    return Ok(Some(format!(
+                        "Quick command `{key}` has no command defined."
+                    )));
+                };
+                Ok(Some(
+                    Self::run_quick_exec(&key, command, quick.timeout_secs()).await?,
+                ))
+            }
+            "alias" => {
+                let Some(target) = quick.target.as_deref().filter(|v| !v.trim().is_empty()) else {
+                    return Ok(Some(format!(
+                        "Quick command `{key}` has no target defined."
+                    )));
+                };
+                let mut rewritten = target.trim().to_string();
+                if !args.is_empty() {
+                    rewritten.push(' ');
+                    rewritten.push_str(&args);
+                }
+                Ok(match handle_command(&rewritten) {
+                    GatewayCommandResult::Reply(text)
+                    | GatewayCommandResult::ShowHelp(text)
+                    | GatewayCommandResult::Unknown(text)
+                    | GatewayCommandResult::ResetSession(text)
+                    | GatewayCommandResult::SwitchFast(text)
+                    | GatewayCommandResult::ToggleVerbose(text)
+                    | GatewayCommandResult::ToggleYolo(text)
+                    | GatewayCommandResult::ToggleReasoning(text)
+                    | GatewayCommandResult::ShowUsage(text)
+                    | GatewayCommandResult::ShowStatus(text)
+                    | GatewayCommandResult::CompressContext(text)
+                    | GatewayCommandResult::StopAgent(text) => Some(text),
+                    GatewayCommandResult::SwitchModel { reply, .. }
+                    | GatewayCommandResult::SwitchPersonality { reply, .. }
+                    | GatewayCommandResult::SetHome { reply, .. } => Some(reply),
+                    _ => Some(format!("Quick command `{key}` routed to `{rewritten}`.")),
+                })
+            }
+            other => Ok(Some(format!(
+                "Quick command `{key}` has unsupported type `{other}`."
+            ))),
+        }
+    }
+
     async fn execute_slash_command(
         &self,
         incoming: &IncomingMessage,
         session_key: &str,
     ) -> Result<bool, GatewayError> {
+        if let Some(reply) = self.resolve_quick_command(&incoming.text).await? {
+            self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
+                .await?;
+            return Ok(true);
+        }
+
         let result = handle_command(&incoming.text);
         if !matches!(result, GatewayCommandResult::Unknown(_)) {
             if let Some(command_name) = Self::extract_command_name(&incoming.text) {
@@ -2502,6 +2627,92 @@ mod tests {
         fn platform_name(&self) -> &str {
             "test"
         }
+    }
+
+    #[tokio::test]
+    async fn gateway_quick_exec_returns_stdout_from_config() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_pair_behavior();
+        let mut cfg = GatewayConfig::default();
+        cfg.quick_commands.insert(
+            "limits".to_string(),
+            QuickCommandConfig {
+                kind: "exec".to_string(),
+                command: Some("printf ok".to_string()),
+                ..Default::default()
+            },
+        );
+        let gw = Gateway::new(session_mgr, dm_manager, cfg);
+
+        let reply = gw
+            .resolve_quick_command("/limits")
+            .await
+            .expect("quick command")
+            .expect("reply");
+
+        assert_eq!(reply, "ok");
+    }
+
+    #[tokio::test]
+    async fn gateway_quick_exec_reports_timeout_and_missing_command() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_pair_behavior();
+        let mut cfg = GatewayConfig::default();
+        cfg.quick_commands.insert(
+            "slow".to_string(),
+            QuickCommandConfig {
+                kind: "exec".to_string(),
+                command: Some("sleep 1".to_string()),
+                timeout_secs: Some(0),
+                ..Default::default()
+            },
+        );
+        cfg.quick_commands.insert(
+            "oops".to_string(),
+            QuickCommandConfig {
+                kind: "exec".to_string(),
+                ..Default::default()
+            },
+        );
+        let gw = Gateway::new(session_mgr, dm_manager, cfg);
+
+        let timeout = gw
+            .resolve_quick_command("/slow")
+            .await
+            .expect("timeout command")
+            .expect("timeout reply");
+        assert!(timeout.contains("timed out"));
+
+        let missing = gw
+            .resolve_quick_command("/oops")
+            .await
+            .expect("missing command")
+            .expect("missing reply");
+        assert!(missing.contains("no command defined"));
+    }
+
+    #[tokio::test]
+    async fn gateway_quick_alias_routes_to_builtin_command() {
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_pair_behavior();
+        let mut cfg = GatewayConfig::default();
+        cfg.quick_commands.insert(
+            "stat".to_string(),
+            QuickCommandConfig {
+                kind: "alias".to_string(),
+                target: Some("/status".to_string()),
+                ..Default::default()
+            },
+        );
+        let gw = Gateway::new(session_mgr, dm_manager, cfg);
+
+        let reply = gw
+            .resolve_quick_command("/stat")
+            .await
+            .expect("alias command")
+            .expect("alias reply");
+
+        assert!(reply.contains("Status information"));
     }
 
     #[async_trait]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T01:49:08.572376+00:00",
+  "generated_at_utc": "2026-06-01T02:41:13.450612+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T01:49:08.572376+00:00`
+Generated: `2026-06-01T02:41:13.450612+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -2926,17 +2926,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/cli/test_quick_commands.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c89d639d13e4de01e2e3ac59ccfc8a5cb36336bb",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/cli/test_quick_commands.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "5f4ce2d32ac407dfdd128f2ad0d3c6d67620762b",
       "workstream": "WS6"
     },
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T01:49:08.355065+00:00",
+  "generated_at_utc": "2026-06-01T02:41:04.663481+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "4e51a21546e7fc4c3e633e5168ce6ba528bc74ab",
+    "local_sha": "fa9b7fceac357ea7f2bc2a11ff9b2499e5ec34e5",
     "upstream_ref": "upstream/main",
     "upstream_sha": "fa4ebaa8b58be1e37ea623269ebf2c5d87437e7f"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 594,
-      "intentional_divergence": 273,
+      "functional": 593,
+      "intentional_divergence": 274,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 445,
-      "rust_equivalent_or_contract_test_required": 509,
+      "not_required_for_runtime": 446,
+      "rust_equivalent_or_contract_test_required": 508,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 273,
+      "cleared_intentional_divergence": 274,
       "cleared_non_runtime": 172,
-      "pending_review": 594
+      "pending_review": 593
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 273,
+    "cleared_intentional_divergence": 274,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 594,
+    "pending_review": 593,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T01:49:08.355065+00:00`
+Generated: `2026-06-01T02:41:04.663481+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `594`
+- Pending functional review: `593`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `273`
+- Cleared intentional divergence: `274`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 273 |
+| `cleared_intentional_divergence` | 274 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 594 |
+| `pending_review` | 593 |
 
 ## Workstream Counts
 
@@ -43,7 +43,7 @@ Generated: `2026-06-01T01:49:08.355065+00:00`
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |
-| `tests/cli` | 28 |
+| `tests/cli` | 27 |
 | `tests/agent` | 21 |
 | `ui-tui/packages` | 20 |
 | `tests/plugins` | 14 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1151,6 +1151,13 @@
       "ticket": 25
     },
     {
+      "path": "tests/cli/test_quick_commands.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream quick-command behavior is covered by Rust shared quick_commands config, CLI slash dispatch that runs exec commands before built-ins, alias forwarding, no-output and timeout replies, plus gateway quick-command exec/alias handling from runtime config.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
       "path": "tests/tui_gateway",
       "classification": "functional",
       "rationale": "TUI gateway tests cover interactive gateway behavior and must stay parity-reviewed against Rust-native UX/runtime contracts.",


### PR DESCRIPTION
## Summary
- add shared `quick_commands` config with `exec`/`alias` support and timeout compatibility fields
- route CLI slash commands through configured quick commands before built-ins, including stdout/stderr/no-output/timeout replies and alias forwarding
- carry quick commands into gateway runtime config and handle gateway exec/alias dispatch before built-in slash commands
- clear `tests/cli/test_quick_commands.py` from the shared-different parity backlog

## Verification
- `python3 scripts/generate-shared-diff-backlog.py --repo-root . --no-fetch`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release`
- `cargo test -p hermes-config quick_commands`
- `cargo test -p hermes-gateway quick_`
- `cargo test -p hermes-cli quick_`
- `cargo test -p hermes-cli --all-features quick_`
- `cargo test -p hermes-gateway --all-features quick_`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, stale=3 pre-existing)
- `cargo build --workspace`
- `cargo test --workspace --quiet`
