### PR TITLE
parity(gateway): add command surface runtime controls

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -29,7 +29,9 @@ use hermes_agent::sub_agent_orchestrator::SubAgentOrchestrator;
 use hermes_agent::{
     AgentCallbacks, AgentConfig, AgentLoop, InterruptController, SessionPersistence,
 };
-use hermes_config::{hermes_home as hermes_home_dir, load_config, state_dir, GatewayConfig};
+use hermes_config::{
+    hermes_home as hermes_home_dir, load_config, normalize_service_tier, state_dir, GatewayConfig,
+};
 use hermes_core::ToolSchema;
 use hermes_core::{AgentError, LlmProvider};
 use hermes_cron::cron_scheduler_for_data_dir;
@@ -4352,6 +4354,26 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_merges_fast_service_tier_into_extra_body() {
+        let mut cfg = GatewayConfig::default();
+        cfg.agent.service_tier = Some("fast".to_string());
+        cfg.llm_providers.insert(
+            "nous".to_string(),
+            LlmProviderConfig {
+                extra_body: Some(serde_json::json!({
+                    "reasoning_effort": "medium"
+                })),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let agent_cfg = build_agent_config(&cfg, "nous:moonshotai/kimi-k2.6");
+        let body = agent_cfg.extra_body.expect("extra body");
+        assert_eq!(body["reasoning_effort"], "medium");
+        assert_eq!(body["service_tier"], "priority");
+    }
+
+    #[test]
     fn test_build_agent_config_infers_provider_for_bare_model() {
         let mut cfg = GatewayConfig::default();
         cfg.model = Some("claude-opus-4-6".to_string());
@@ -5594,6 +5616,8 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
             })
         })
         .and_then(|cfg| cfg.extra_body.clone());
+    let extra_body =
+        merge_service_tier_extra_body(provider_extra_body, config.agent.normalized_service_tier());
     let skip_memory_env = std::env::var("HERMES_SKIP_MEMORY")
         .ok()
         .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
@@ -5618,7 +5642,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         model: model.to_string(),
         system_prompt: config.system_prompt.clone(),
         personality: config.personality.clone(),
-        extra_body: provider_extra_body,
+        extra_body,
         hermes_home: config.home_dir.clone(),
         provider: Some(resolved_provider),
         stream: config.streaming.enabled,
@@ -5670,6 +5694,27 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         lsp_context_max_chars: config.agent.lsp_context_max_chars,
         ..AgentConfig::default()
     }
+}
+
+fn merge_service_tier_extra_body(
+    extra_body: Option<Value>,
+    service_tier: Option<String>,
+) -> Option<Value> {
+    let Some(service_tier) = service_tier.and_then(|tier| normalize_service_tier(Some(&tier)))
+    else {
+        return extra_body;
+    };
+    let mut map = match extra_body {
+        Some(Value::Object(map)) => map,
+        Some(other) => {
+            let mut map = serde_json::Map::new();
+            map.insert("extra_body".to_string(), other);
+            map
+        }
+        None => serde_json::Map::new(),
+    };
+    map.insert("service_tier".to_string(), Value::String(service_tier));
+    Some(Value::Object(map))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -2760,6 +2760,8 @@ async fn run_gateway(
             // Build gateway runtime and context-aware message handler.
             let runtime_gateway_config = RuntimeGatewayConfig {
                 streaming_enabled: config.streaming.enabled,
+                display: config.display.clone(),
+                service_tier: config.agent.normalized_service_tier(),
                 quick_commands: config.quick_commands.clone(),
                 ..RuntimeGatewayConfig::default()
             };
@@ -4002,6 +4004,22 @@ fn build_agent_for_gateway_context(
         if !provider.trim().is_empty() {
             agent_config.provider = Some(provider);
         }
+    }
+    if let Some(service_tier) = ctx.service_tier.clone() {
+        let mut extra = match agent_config.extra_body.take() {
+            Some(serde_json::Value::Object(map)) => map,
+            Some(other) => {
+                let mut map = serde_json::Map::new();
+                map.insert("extra_body".to_string(), other);
+                map
+            }
+            None => serde_json::Map::new(),
+        };
+        extra.insert(
+            "service_tier".to_string(),
+            serde_json::Value::String(service_tier),
+        );
+        agent_config.extra_body = Some(serde_json::Value::Object(extra));
     }
     if !ctx.session_key.trim().is_empty() {
         agent_config.session_id = Some(ctx.session_key.clone());

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -2,7 +2,8 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as DeError, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use hermes_core::BudgetConfig;
 
@@ -60,6 +61,10 @@ pub struct GatewayConfig {
     /// Streaming / progressive-output settings.
     #[serde(default)]
     pub streaming: StreamingConfig,
+
+    /// Display controls shared by CLI/gateway surfaces.
+    #[serde(default)]
+    pub display: DisplayConfig,
 
     /// Terminal / command-execution backend settings.
     #[serde(default)]
@@ -153,6 +158,7 @@ impl Default for GatewayConfig {
             session: SessionConfig::default(),
             sessions: SessionsMaintenanceConfig::default(),
             streaming: StreamingConfig::default(),
+            display: DisplayConfig::default(),
             terminal: TerminalConfig::default(),
             llm_providers: HashMap::new(),
             fallback_model: None,
@@ -172,6 +178,46 @@ impl Default for GatewayConfig {
             home_dir: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct DisplayConfig {
+    /// Enable `/verbose` as a runtime tool-progress cycling command.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_boolish",
+        skip_serializing_if = "is_false"
+    )]
+    pub tool_progress_command: bool,
+
+    /// Global tool-progress display mode: `off`, `new`, `all`, or `verbose`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_progress: Option<String>,
+
+    /// Per-platform display overrides keyed by normalized platform name.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub platforms: BTreeMap<String, PlatformDisplayConfig>,
+}
+
+impl DisplayConfig {
+    pub fn tool_progress_command_enabled(&self) -> bool {
+        self.tool_progress_command
+    }
+
+    pub fn platform_tool_progress(&self, platform: &str) -> Option<&str> {
+        let key = platform.trim().to_ascii_lowercase().replace('-', "_");
+        self.platforms
+            .get(&key)
+            .and_then(|cfg| cfg.tool_progress.as_deref())
+            .or(self.tool_progress.as_deref())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PlatformDisplayConfig {
+    /// Platform-specific tool-progress mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_progress: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -502,6 +548,9 @@ pub struct AgentLoopBehaviorConfig {
     /// Character budget for injected LSP context block.
     #[serde(default = "default_agent_lsp_context_max_chars")]
     pub lsp_context_max_chars: usize,
+    /// Optional provider request service tier. `fast` maps to provider `priority`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 fn default_agent_memory_nudge_interval() -> u32 {
@@ -552,12 +601,78 @@ impl Default for AgentLoopBehaviorConfig {
             code_index_max_symbols: default_agent_code_index_max_symbols(),
             lsp_context_enabled: default_agent_lsp_context_enabled(),
             lsp_context_max_chars: default_agent_lsp_context_max_chars(),
+            service_tier: None,
         }
+    }
+}
+
+impl AgentLoopBehaviorConfig {
+    pub fn normalized_service_tier(&self) -> Option<String> {
+        normalize_service_tier(self.service_tier.as_deref())
+    }
+}
+
+pub fn normalize_service_tier(raw: Option<&str>) -> Option<String> {
+    let value = raw?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    match value.to_ascii_lowercase().as_str() {
+        "fast" | "priority" => Some("priority".to_string()),
+        "off" | "normal" | "standard" | "default" | "none" => None,
+        other => Some(other.to_string()),
     }
 }
 
 fn default_max_turns() -> u32 {
     250
+}
+
+fn deserialize_boolish<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct BoolishVisitor;
+
+    impl<'de> Visitor<'de> for BoolishVisitor {
+        type Value = bool;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a bool or a bool-like string")
+        }
+
+        fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+            Ok(value)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+            Ok(value != 0)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(value != 0)
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            match value.trim().to_ascii_lowercase().as_str() {
+                "" | "0" | "false" | "no" | "off" => Ok(false),
+                "1" | "true" | "yes" | "on" => Ok(true),
+                other => Err(E::custom(format!("invalid bool-like value `{other}`"))),
+            }
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            self.visit_str(&value)
+        }
+    }
+
+    deserializer.deserialize_any(BoolishVisitor)
 }
 
 fn default_tools() -> Vec<String> {
@@ -1120,6 +1235,40 @@ quick_commands:
         let alias = cfg.quick_commands.get("sc").expect("alias command");
         assert_eq!(alias.kind, "alias");
         assert_eq!(alias.target.as_deref(), Some("/context"));
+    }
+
+    #[test]
+    fn display_config_accepts_boolish_verbose_gate_and_platform_modes() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+display:
+  tool_progress_command: "true"
+  tool_progress: all
+  platforms:
+    telegram:
+      tool_progress: off
+agent:
+  service_tier: fast
+"#,
+        )
+        .expect("display config");
+
+        assert!(cfg.display.tool_progress_command_enabled());
+        assert_eq!(cfg.display.platform_tool_progress("telegram"), Some("off"));
+        assert_eq!(cfg.display.platform_tool_progress("slack"), Some("all"));
+        assert_eq!(
+            cfg.agent.normalized_service_tier().as_deref(),
+            Some("priority")
+        );
+
+        let disabled: GatewayConfig = serde_yaml::from_str(
+            r#"
+display:
+  tool_progress_command: "false"
+"#,
+        )
+        .expect("quoted false");
+        assert!(!disabled.display.tool_progress_command_enabled());
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -20,9 +20,10 @@ pub mod streaming;
 
 // Re-export key types for convenience
 pub use config::{
-    default_auxiliary_task_configs, AgentLoopBehaviorConfig, ApprovalConfig, AuxiliaryTaskConfig,
-    CheapModelRouteConfig, GatewayConfig, LlmProviderConfig, McpServerEntry, ProfileConfig,
-    ProxyConfig, QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
+    default_auxiliary_task_configs, normalize_service_tier, AgentLoopBehaviorConfig,
+    ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DisplayConfig, GatewayConfig,
+    LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig, ProxyConfig,
+    QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
     SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings,
 };
 pub use loader::{

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -120,6 +120,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 session,
                 sessions: SessionsMaintenanceConfig::default(),
                 streaming,
+                display: Default::default(),
                 terminal: TerminalConfig::default(),
                 llm_providers: HashMap::new(),
                 fallback_model: None,

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -50,8 +50,11 @@ pub enum GatewayCommandResult {
     BtwTask { prompt: String },
     /// Toggle reasoning display.
     ToggleReasoning(String),
-    /// Switch to fast model.
-    SwitchFast(String),
+    /// Switch gateway turns into or out of priority processing.
+    SwitchFast {
+        service_tier: Option<String>,
+        reply: String,
+    },
     /// Retry the last message.
     Retry,
     /// Undo the last exchange.
@@ -94,6 +97,12 @@ pub struct CommandInfo {
 /// All registered gateway slash commands.
 pub fn all_commands() -> Vec<CommandInfo> {
     vec![
+        CommandInfo {
+            name: "/start",
+            aliases: &[],
+            description: "Acknowledge platform start events without entering the agent loop",
+            usage: "/start",
+        },
         CommandInfo {
             name: "/new",
             aliases: &[],
@@ -319,6 +328,18 @@ fn normalize_command_args(args: &str) -> String {
         .replace('\u{2013}', "-")
 }
 
+fn parse_fast_service_tier(args: &str) -> Result<Option<String>, String> {
+    let value = args.trim();
+    if value.is_empty() {
+        return Ok(Some("priority".to_string()));
+    }
+    match value.to_ascii_lowercase().as_str() {
+        "fast" | "priority" => Ok(Some("priority".to_string())),
+        "off" | "normal" | "standard" | "default" | "none" => Ok(None),
+        _ => Err("Usage: /fast [fast|off]".to_string()),
+    }
+}
+
 pub fn canonical_command_name(raw: &str) -> Option<String> {
     let token = raw
         .trim()
@@ -363,6 +384,7 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
     let args = normalize_command_args(parts.get(1).map(|s| s.trim()).unwrap_or(""));
 
     match cmd.as_str() {
+        "/start" => GatewayCommandResult::Noop,
         "/new" => GatewayCommandResult::ResetSession("🆕 New conversation started.".to_string()),
         "/reset" | "/clear" => GatewayCommandResult::ResetSession("🔄 Session reset.".to_string()),
         "/model" => {
@@ -483,7 +505,17 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         "/reasoning" | "/think" => {
             GatewayCommandResult::ToggleReasoning("🧠 Reasoning display toggled.".to_string())
         }
-        "/fast" => GatewayCommandResult::SwitchFast("⚡ Switched to fast model.".to_string()),
+        "/fast" => match parse_fast_service_tier(&args) {
+            Ok(Some(service_tier)) => GatewayCommandResult::SwitchFast {
+                service_tier: Some(service_tier),
+                reply: "⚡ Priority processing enabled for this gateway session.".to_string(),
+            },
+            Ok(None) => GatewayCommandResult::SwitchFast {
+                service_tier: None,
+                reply: "⚡ Priority processing disabled for this gateway session.".to_string(),
+            },
+            Err(msg) => GatewayCommandResult::Reply(msg),
+        },
         "/verbose" => GatewayCommandResult::ToggleVerbose("📝 Verbose mode toggled.".to_string()),
         "/yolo" => GatewayCommandResult::ToggleYolo(
             "🤠 YOLO mode toggled. Auto-approving all actions.".to_string(),
@@ -690,6 +722,41 @@ mod tests {
             }
             other => panic!("Expected ShowHelp, got {:?}", other),
         }
+
+        match handle_command("/commands") {
+            GatewayCommandResult::ShowHelp(text) => {
+                assert!(text.contains("Available Commands"));
+                assert!(text.contains("`/start`"));
+            }
+            other => panic!("Expected ShowHelp for /commands, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_start_noop_and_fast_service_tier() {
+        match handle_command("/start") {
+            GatewayCommandResult::Noop => {}
+            other => panic!("Expected Noop for /start, got {:?}", other),
+        }
+
+        match handle_command("/fast") {
+            GatewayCommandResult::SwitchFast { service_tier, .. } => {
+                assert_eq!(service_tier.as_deref(), Some("priority"));
+            }
+            other => panic!("Expected SwitchFast for /fast, got {:?}", other),
+        }
+
+        match handle_command("/fast off") {
+            GatewayCommandResult::SwitchFast { service_tier, .. } => {
+                assert!(service_tier.is_none());
+            }
+            other => panic!("Expected SwitchFast disable for /fast off, got {:?}", other),
+        }
+
+        match handle_command("/fast turbo") {
+            GatewayCommandResult::Reply(text) => assert!(text.contains("Usage")),
+            other => panic!("Expected usage reply for invalid /fast, got {:?}", other),
+        }
     }
 
     #[test]
@@ -761,7 +828,9 @@ mod tests {
             "tasks",
             "background",
             "steer",
+            "start",
             "help",
+            "commands",
             "update",
             "queue",
             "model",

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
-use hermes_config::QuickCommandConfig;
+use hermes_config::{normalize_service_tier, DisplayConfig, QuickCommandConfig};
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 use hermes_core::types::{Message, MessageRole};
@@ -58,6 +58,14 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub streaming: StreamConfig,
 
+    /// Display command/runtime settings.
+    #[serde(default)]
+    pub display: DisplayConfig,
+
+    /// Default provider service tier for gateway agent turns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+
     /// User-defined slash commands that bypass the agent loop.
     #[serde(default)]
     pub quick_commands: BTreeMap<String, QuickCommandConfig>,
@@ -71,6 +79,8 @@ impl Default for GatewayConfig {
             media_cache_max_bytes: 0,
             streaming_enabled: false,
             streaming: StreamConfig::default(),
+            display: DisplayConfig::default(),
+            service_tier: None,
             quick_commands: BTreeMap::new(),
         }
     }
@@ -155,6 +165,8 @@ pub struct GatewayRuntimeContext {
     pub branch: Option<String>,
     pub personality: Option<String>,
     pub home: Option<String>,
+    pub service_tier: Option<String>,
+    pub tool_progress: Option<String>,
     pub verbose: bool,
     pub yolo: bool,
     pub reasoning: bool,
@@ -223,6 +235,8 @@ struct SessionRuntimeState {
     branch: Option<String>,
     personality: Option<String>,
     home: Option<String>,
+    service_tier: Option<String>,
+    tool_progress: Option<String>,
     /// Optional usage budget (same units as `/budget` input; gateway displays as-is).
     budget: Option<f64>,
     verbose: bool,
@@ -239,6 +253,8 @@ impl Default for SessionRuntimeState {
             branch: None,
             personality: None,
             home: None,
+            service_tier: None,
+            tool_progress: None,
             budget: None,
             verbose: false,
             yolo: false,
@@ -272,6 +288,7 @@ pub struct Gateway {
     streaming_handler_with_context: RwLock<Option<StreamingMessageHandlerWithContext>>,
     /// Runtime command state for each session.
     runtime_state: RwLock<HashMap<String, SessionRuntimeState>>,
+    tool_progress_modes: RwLock<BTreeMap<String, String>>,
     /// Basic usage counters for each session.
     usage_stats: RwLock<HashMap<String, UsageStats>>,
     /// Tracks async `/background` and `/btw` tasks.
@@ -404,6 +421,7 @@ impl Gateway {
             streaming_handler: RwLock::new(None),
             streaming_handler_with_context: RwLock::new(None),
             runtime_state: RwLock::new(HashMap::new()),
+            tool_progress_modes: RwLock::new(BTreeMap::new()),
             usage_stats: RwLock::new(HashMap::new()),
             background_tasks: Arc::new(BackgroundTaskManager::new(8)),
             mcp_reload_generation: RwLock::new(0),
@@ -1000,7 +1018,6 @@ impl Gateway {
                     | GatewayCommandResult::ShowHelp(text)
                     | GatewayCommandResult::Unknown(text)
                     | GatewayCommandResult::ResetSession(text)
-                    | GatewayCommandResult::SwitchFast(text)
                     | GatewayCommandResult::ToggleVerbose(text)
                     | GatewayCommandResult::ToggleYolo(text)
                     | GatewayCommandResult::ToggleReasoning(text)
@@ -1009,6 +1026,7 @@ impl Gateway {
                     | GatewayCommandResult::CompressContext(text)
                     | GatewayCommandResult::StopAgent(text) => Some(text),
                     GatewayCommandResult::SwitchModel { reply, .. }
+                    | GatewayCommandResult::SwitchFast { reply, .. }
                     | GatewayCommandResult::SwitchPersonality { reply, .. }
                     | GatewayCommandResult::SetHome { reply, .. } => Some(reply),
                     _ => Some(format!("Quick command `{key}` routed to `{rewritten}`.")),
@@ -1018,6 +1036,79 @@ impl Gateway {
                 "Quick command `{key}` has unsupported type `{other}`."
             ))),
         }
+    }
+
+    fn normalize_tool_progress_mode(raw: &str) -> Option<String> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "false" | "0" => Some("off".to_string()),
+            "new" => Some("new".to_string()),
+            "all" | "true" | "1" => Some("all".to_string()),
+            "verbose" => Some("verbose".to_string()),
+            _ => None,
+        }
+    }
+
+    fn default_tool_progress_for_platform(&self, platform: &str) -> String {
+        let platform_key = platform.trim().to_ascii_lowercase().replace('-', "_");
+        self.config
+            .display
+            .platform_tool_progress(&platform_key)
+            .and_then(Self::normalize_tool_progress_mode)
+            .unwrap_or_else(|| match platform_key.as_str() {
+                // Inbox-style gateway platforms stay quiet unless explicitly raised.
+                "telegram" | "slack" => "off".to_string(),
+                _ => "all".to_string(),
+            })
+    }
+
+    fn next_tool_progress_mode(current: &str) -> &'static str {
+        match current {
+            "off" => "new",
+            "new" => "all",
+            "all" => "verbose",
+            _ => "off",
+        }
+    }
+
+    async fn apply_verbose_command(
+        &self,
+        incoming: &IncomingMessage,
+        session_key: &str,
+    ) -> Result<String, GatewayError> {
+        if !self.config.display.tool_progress_command_enabled() {
+            return Ok(
+                "Tool progress command is not enabled. Set `display.tool_progress_command: true` to use `/verbose`."
+                    .to_string(),
+            );
+        }
+
+        let platform = incoming
+            .platform
+            .trim()
+            .to_ascii_lowercase()
+            .replace('-', "_");
+        let default_mode = self.default_tool_progress_for_platform(&platform);
+        let next = {
+            let mut modes = self.tool_progress_modes.write().await;
+            let current = modes
+                .get(&platform)
+                .cloned()
+                .unwrap_or_else(|| default_mode.clone());
+            let next = Self::next_tool_progress_mode(&current).to_string();
+            modes.insert(platform.clone(), next.clone());
+            next
+        };
+
+        let mut states = self.runtime_state.write().await;
+        let state = states.entry(session_key.to_string()).or_default();
+        state.tool_progress = Some(next.clone());
+        state.verbose = next == "verbose";
+        drop(states);
+
+        Ok(format!(
+            "📝 Tool progress for {platform}: {}",
+            next.to_ascii_uppercase()
+        ))
     }
 
     async fn execute_slash_command(
@@ -1216,14 +1307,7 @@ impl Gateway {
                 Ok(true)
             }
             GatewayCommandResult::ToggleVerbose(_) => {
-                let mut states = self.runtime_state.write().await;
-                let state = states.entry(session_key.to_string()).or_default();
-                state.verbose = !state.verbose;
-                let reply = format!(
-                    "📝 Verbose mode: {}",
-                    if state.verbose { "ON" } else { "OFF" }
-                );
-                drop(states);
+                let reply = self.apply_verbose_command(incoming, session_key).await?;
                 self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
                     .await?;
                 Ok(true)
@@ -1403,18 +1487,18 @@ impl Gateway {
                     .await?;
                 Ok(true)
             }
-            GatewayCommandResult::SwitchFast(_) => {
+            GatewayCommandResult::SwitchFast {
+                service_tier,
+                reply,
+            } => {
                 let mut states = self.runtime_state.write().await;
-                states.entry(session_key.to_string()).or_default().model =
-                    Some("openai:gpt-4o-mini".to_string());
+                states
+                    .entry(session_key.to_string())
+                    .or_default()
+                    .service_tier = service_tier.clone();
                 drop(states);
-                self.send_message(
-                    &incoming.platform,
-                    &incoming.chat_id,
-                    "⚡ Fast model enabled: openai:gpt-4o-mini",
-                    None,
-                )
-                .await?;
+                self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
+                    .await?;
                 Ok(true)
             }
             GatewayCommandResult::Retry => {
@@ -1844,6 +1928,12 @@ impl Gateway {
         if let Some(branch) = state.branch {
             hints.push(format!("branch={}", branch));
         }
+        if let Some(service_tier) = state
+            .service_tier
+            .or_else(|| normalize_service_tier(self.config.service_tier.as_deref()))
+        {
+            hints.push(format!("service_tier={service_tier}"));
+        }
         if hints.is_empty() {
             return messages;
         }
@@ -1882,6 +1972,10 @@ impl Gateway {
             branch: state.branch,
             personality: state.personality,
             home: state.home,
+            service_tier: state
+                .service_tier
+                .or_else(|| normalize_service_tier(self.config.service_tier.as_deref())),
+            tool_progress: state.tool_progress,
             verbose: state.verbose,
             yolo: state.yolo,
             reasoning: state.reasoning,
@@ -2054,14 +2148,19 @@ impl Gateway {
             .count();
 
         format!(
-            "🧭 Gateway status\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- reasoning: {}\n- verbose: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
+            "🧭 Gateway status\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- service tier: {}\n- reasoning: {}\n- verbose: {}\n- tool progress: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
             state.model.unwrap_or_else(|| "default".to_string()),
             state.provider.unwrap_or_else(|| "default".to_string()),
             state.profile.unwrap_or_else(|| "default".to_string()),
             state.branch.unwrap_or_else(|| "main".to_string()),
             state.personality.unwrap_or_else(|| "default".to_string()),
+            state
+                .service_tier
+                .or_else(|| normalize_service_tier(self.config.service_tier.as_deref()))
+                .unwrap_or_else(|| "default".to_string()),
             if state.reasoning { "ON" } else { "OFF" },
             if state.verbose { "ON" } else { "OFF" },
+            state.tool_progress.unwrap_or_else(|| "default".to_string()),
             if state.yolo { "ON" } else { "OFF" },
             state.home.unwrap_or_else(|| "(not set)".to_string()),
             messages.len(),
@@ -3905,6 +4004,16 @@ mod tests {
         };
         assert!(gw.route_message(&set_branch).await.is_ok());
 
+        let set_fast = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/fast".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&set_fast).await.is_ok());
+
         let normal = IncomingMessage {
             platform: "test".into(),
             chat_id: "chat1".into(),
@@ -3932,6 +4041,71 @@ mod tests {
         assert!(echoed.contains("provider=openai"));
         assert!(echoed.contains("profile=prod"));
         assert!(echoed.contains("branch=feature/parity"));
+        assert!(echoed.contains("service_tier=priority"));
+    }
+
+    #[tokio::test]
+    async fn gateway_verbose_command_is_config_gated_and_cycles_tool_progress() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("telegram", adapter.clone()).await;
+
+        let verbose = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "chat-verbose".into(),
+            user_id: "user1".into(),
+            text: "/verbose".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&verbose).await.is_ok());
+        assert!(sent
+            .lock()
+            .unwrap()
+            .last()
+            .expect("disabled reply")
+            .1
+            .contains("tool_progress_command"));
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let mut cfg = GatewayConfig::default();
+        cfg.display.tool_progress_command = true;
+        cfg.display.tool_progress = Some("all".to_string());
+        let gw = Gateway::new(session_mgr, dm_manager, cfg);
+        gw.register_adapter("telegram", adapter.clone()).await;
+
+        assert!(gw.route_message(&verbose).await.is_ok());
+        let first = sent
+            .lock()
+            .unwrap()
+            .last()
+            .expect("verbose reply")
+            .1
+            .clone();
+        assert!(first.contains("telegram"));
+        assert!(first.contains("VERBOSE"));
+
+        let session_key =
+            gw.session_manager
+                .compose_session_key("telegram", "chat-verbose", "user1");
+        let states = gw.runtime_state.read().await;
+        let state = states.get(&session_key).expect("runtime state");
+        assert_eq!(state.tool_progress.as_deref(), Some("verbose"));
+        assert!(state.verbose);
+        drop(states);
+
+        assert!(gw.route_message(&verbose).await.is_ok());
+        let second = sent.lock().unwrap().last().expect("off reply").1.clone();
+        assert!(second.contains("OFF"));
     }
 
     #[tokio::test]

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -143,6 +143,8 @@ impl HttpServerState {
         run_sessions_db_auto_maintenance(&config);
         let runtime_gateway_config = RuntimeGatewayConfig {
             streaming_enabled: config.streaming.enabled,
+            display: config.display.clone(),
+            service_tier: config.agent.normalized_service_tier(),
             ..RuntimeGatewayConfig::default()
         };
         let session_manager = Arc::new(SessionManager::new(config.session.clone()));

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T02:41:13.450612+00:00",
+  "generated_at_utc": "2026-06-01T04:31:38.755907+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T02:41:13.450612+00:00`
+Generated: `2026-06-01T04:31:38.755907+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -87,7 +87,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "f1e04a3b64150404c9d9af6adb13603476d938b9",
+      "upstream_blob": "660257d7cd365a33724a47dec40a90713c06385f",
       "workstream": "WS8"
     },
     {
@@ -1257,7 +1257,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "1e38f46129c74139df3956c3e5335c966d885828",
+      "upstream_blob": "706ca36d366052ee259825d1e0ecb71fa3e84746",
       "workstream": "WS8"
     },
     {
@@ -2802,7 +2802,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "a25d903f687fa14744909f631cf92d963ebe899c",
+      "upstream_blob": "07d16366d04e24636e749cc71db9d6f214490aa6",
       "workstream": "WS6"
     },
     {
@@ -4171,17 +4171,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_fast_command.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c904b659d1b341b40bf15f2248f72e1aa5a9fce2",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_fast_command.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "58db9faf05e342b2f4593302926a3fec9d75c21b",
       "workstream": "WS6"
     },
@@ -4261,17 +4261,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_gateway_command_help.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "61d5d73de0d5dabaf6ffb564e0ffd25e3c94cb8a",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_gateway_command_help.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "d1dfb71d94dc5868675bb9d690e862759849a351",
       "workstream": "WS6"
     },
@@ -5641,17 +5641,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_verbose_command.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d6debebae599778041ca5e2871141ff95fbe4beb",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_verbose_command.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 302,
       "upstream_blob": "04399b1da50807457443ce0a85b8b3cfeb3aa09c",
       "workstream": "WS6"
     },
@@ -6957,7 +6957,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "e25fd86f147b3a0e3a30e4a756675258830f9605",
+      "upstream_blob": "752f6fabc28e987f1f16e1ccaacf11ea8d0fb345",
       "workstream": "WS6"
     },
     {
@@ -10377,7 +10377,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "688e0f5c85ccb13177511687e1a2dd6e7905f011",
+      "upstream_blob": "099e167e77983d196edb4ef71c282f31eaa80a19",
       "workstream": "WS6"
     },
     {
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T02:41:04.663481+00:00",
+  "generated_at_utc": "2026-06-01T04:31:38.656700+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "fa9b7fceac357ea7f2bc2a11ff9b2499e5ec34e5",
+    "local_sha": "7d4de521aa2fe21f28d11ced80c400c3558ab653",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "fa4ebaa8b58be1e37ea623269ebf2c5d87437e7f"
+    "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 593,
-      "intentional_divergence": 274,
+      "functional": 590,
+      "intentional_divergence": 277,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 446,
-      "rust_equivalent_or_contract_test_required": 508,
+      "not_required_for_runtime": 449,
+      "rust_equivalent_or_contract_test_required": 505,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 274,
+      "cleared_intentional_divergence": 277,
       "cleared_non_runtime": 172,
-      "pending_review": 593
+      "pending_review": 590
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 274,
+    "cleared_intentional_divergence": 277,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 593,
+    "pending_review": 590,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T02:41:04.663481+00:00`
+Generated: `2026-06-01T04:31:38.656700+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `593`
+- Pending functional review: `590`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `274`
+- Cleared intentional divergence: `277`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 274 |
+| `cleared_intentional_divergence` | 277 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 593 |
+| `pending_review` | 590 |
 
 ## Workstream Counts
 
@@ -37,8 +37,8 @@ Generated: `2026-06-01T02:41:04.663481+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/gateway` | 119 |
 | `tests/hermes_cli` | 117 |
+| `tests/gateway` | 116 |
 | `tests/tools` | 86 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -2164,6 +2164,27 @@
       "rationale": "Session search behavior is covered by Rust SessionSearchHandler and SqliteSessionSearchBackend contracts, including schema shape, browse/search modes, role filters, current-session exclusion, result limit capping, timestamp formatting, scrolling, pattern matching, and hidden-source filtering.",
       "owner": "sheawinkler",
       "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_fast_command.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream gateway fast-command priority behavior is covered by Rust gateway /fast handling: command parsing accepts fast/priority and off modes, stores service_tier=priority in gateway runtime state/context, injects the service tier into agent extra_body, and exposes it in runtime hints/status.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_gateway_command_help.py",
+      "classification": "intentional_divergence",
+      "rationale": "Gateway help/start command behavior is covered by Rust gateway command contracts: /start is a no-op platform start event, /commands aliases /help, registered command bypass recognizes aliases, and generated help exposes normalized lowercase command names.",
+      "owner": "sheawinkler",
+      "ticket": 302
+    },
+    {
+      "path": "tests/gateway/test_verbose_command.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream gateway /verbose tool-progress behavior is covered by Rust DisplayConfig and gateway runtime tests: bool-like display.tool_progress_command gating, quoted false disablement, per-platform/default tool_progress resolution, off/new/all/verbose cycling, and runtime verbose/tool_progress state updates.",
+      "owner": "sheawinkler",
+      "ticket": 302
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add shared display config and gateway `/verbose` tool-progress cycling with config gating
- add gateway `/fast [fast|off]` service-tier runtime controls and pass priority into agent extra_body
- add `/start` no-op command parity and command/help registry tests
- clear three gateway command-surface parity backlog paths

## Verification
- `python3 scripts/generate-shared-diff-backlog.py --repo-root . --no-fetch`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release`
- `cargo fmt --all --check`
- `cargo test -p hermes-config display_config`
- `cargo test -p hermes-gateway test_start_noop_and_fast_service_tier`
- `cargo test -p hermes-gateway gateway_verbose_command_is_config_gated_and_cycles_tool_progress`
- `cargo test -p hermes-gateway gateway_runtime_state_is_injected_into_agent_messages`
- `cargo test -p hermes-cli test_build_agent_config_merges_fast_service_tier_into_extra_body`
- `cargo test -p hermes-http --lib`
- `cargo test -p hermes-gateway --all-features gateway_verbose_command_is_config_gated_and_cycles_tool_progress`
- `cargo test -p hermes-gateway --all-features gateway_runtime_state_is_injected_into_agent_messages`
- `cargo test -p hermes-cli --all-features test_build_agent_config_merges_fast_service_tier_into_extra_body`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, stale=3 pre-existing)
- `cargo build --workspace`
- `cargo test --workspace --quiet`
