### PR TITLE
parity(gateway): add API server discovery store surfaces

### DIFF
--- a/crates/hermes-gateway/src/platforms/api_server.rs
+++ b/crates/hermes-gateway/src/platforms/api_server.rs
@@ -4,18 +4,21 @@
 //! `/v1/responses` endpoints, allowing any OpenAI-compatible client to
 //! interact with the Hermes Agent gateway.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Notify, RwLock};
 use tracing::{debug, error, info, warn};
 
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
+use hermes_tools::{ToolRegistry, ToolsetManager};
 
 use crate::adapter::BasePlatformAdapter;
 
@@ -113,7 +116,7 @@ impl Default for ApiServerConfig {
 pub struct ChatCompletionRequest {
     pub model: Option<String>,
     pub messages: Vec<ChatMessage>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_boolish")]
     pub stream: bool,
     #[serde(default)]
     pub user: Option<String>,
@@ -125,6 +128,68 @@ pub struct ChatCompletionRequest {
     pub personality: Option<String>,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResponsesRequest {
+    pub model: Option<String>,
+    pub input: ResponseInput,
+    #[serde(default, deserialize_with = "deserialize_boolish")]
+    pub stream: bool,
+    #[serde(
+        default = "default_store_response",
+        deserialize_with = "deserialize_boolish"
+    )]
+    pub store: bool,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub personality: Option<String>,
+    #[serde(default)]
+    pub conversation: Option<String>,
+    #[serde(default)]
+    pub previous_response_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseInput {
+    Text(String),
+    Messages(Vec<ChatMessage>),
+}
+
+fn default_store_response() -> bool {
+    true
+}
+
+fn deserialize_boolish<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Boolish {
+        Bool(bool),
+        String(String),
+        Number(u64),
+    }
+
+    match Option::<Boolish>::deserialize(deserializer)? {
+        None => Ok(false),
+        Some(Boolish::Bool(value)) => Ok(value),
+        Some(Boolish::String(value)) => match value.trim().to_ascii_lowercase().as_str() {
+            "" | "0" | "false" | "off" | "no" | "none" | "null" => Ok(false),
+            "1" | "true" | "on" | "yes" => Ok(true),
+            other => Err(de::Error::custom(format!(
+                "invalid bool-like value {other:?}"
+            ))),
+        },
+        Some(Boolish::Number(value)) => Ok(value != 0),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -214,6 +279,97 @@ struct ResponseMailbox {
     pending: HashMap<String, mpsc::Sender<String>>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredApiResponse {
+    response: serde_json::Value,
+    conversation_history: Vec<ChatMessage>,
+}
+
+#[derive(Debug)]
+struct ResponseStore {
+    max_size: usize,
+    entries: HashMap<String, StoredApiResponse>,
+    lru: VecDeque<String>,
+    conversation_to_response: HashMap<String, String>,
+}
+
+impl ResponseStore {
+    fn new(max_size: usize) -> Self {
+        Self {
+            max_size,
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            conversation_to_response: HashMap::new(),
+        }
+    }
+
+    fn put(&mut self, id: impl Into<String>, response: StoredApiResponse) {
+        let id = id.into();
+        self.entries.insert(id.clone(), response);
+        self.touch(&id);
+        self.evict_if_needed();
+    }
+
+    fn get(&mut self, id: &str) -> Option<StoredApiResponse> {
+        if self.entries.contains_key(id) {
+            self.touch(id);
+        }
+        self.entries.get(id).cloned()
+    }
+
+    fn delete(&mut self, id: &str) -> bool {
+        let existed = self.entries.remove(id).is_some();
+        if existed {
+            self.lru.retain(|entry| entry != id);
+            self.conversation_to_response
+                .retain(|_, response_id| response_id != id);
+        }
+        existed
+    }
+
+    fn set_conversation(
+        &mut self,
+        conversation: impl Into<String>,
+        response_id: impl Into<String>,
+    ) {
+        self.conversation_to_response
+            .insert(conversation.into(), response_id.into());
+    }
+
+    fn get_conversation(&mut self, conversation: &str) -> Option<String> {
+        let response_id = self.conversation_to_response.get(conversation)?.clone();
+        if self.entries.contains_key(&response_id) {
+            self.touch(&response_id);
+            Some(response_id)
+        } else {
+            self.conversation_to_response.remove(conversation);
+            None
+        }
+    }
+
+    fn touch(&mut self, id: &str) {
+        self.lru.retain(|entry| entry != id);
+        self.lru.push_back(id.to_string());
+    }
+
+    fn evict_if_needed(&mut self) {
+        while self.entries.len() > self.max_size {
+            let Some(oldest) = self.lru.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+            self.conversation_to_response
+                .retain(|_, response_id| response_id != &oldest);
+        }
+    }
+}
+
+impl Default for ResponseStore {
+    fn default() -> Self {
+        Self::new(1024)
+    }
+}
+
 #[derive(Default)]
 struct RunCancelRegistry {
     pending: HashMap<String, Arc<Notify>>,
@@ -229,6 +385,7 @@ pub struct ApiServerAdapter {
     stop_signal: Arc<Notify>,
     shutdown_tx: RwLock<Option<tokio::sync::oneshot::Sender<()>>>,
     mailbox: Arc<RwLock<ResponseMailbox>>,
+    response_store: Arc<RwLock<ResponseStore>>,
     run_cancels: Arc<RwLock<RunCancelRegistry>>,
     inbound_tx: Arc<RwLock<Option<mpsc::Sender<ApiInboundRequest>>>>,
 }
@@ -247,6 +404,7 @@ impl ApiServerAdapter {
             stop_signal: Arc::new(Notify::new()),
             shutdown_tx: RwLock::new(None),
             mailbox: Arc::new(RwLock::new(ResponseMailbox::default())),
+            response_store: Arc::new(RwLock::new(ResponseStore::default())),
             run_cancels: Arc::new(RwLock::new(RunCancelRegistry::default())),
             inbound_tx: Arc::new(RwLock::new(None)),
         }
@@ -346,6 +504,7 @@ impl PlatformAdapter for ApiServerAdapter {
             .map_err(|e| GatewayError::ConnectionFailed(format!("Invalid address: {e}")))?;
 
         let mailbox = self.mailbox.clone();
+        let response_store = self.response_store.clone();
         let run_cancels = self.run_cancels.clone();
         let inbound_tx = self.inbound_tx.clone();
         let auth_token = self.config.auth_token.clone();
@@ -375,6 +534,7 @@ impl PlatformAdapter for ApiServerAdapter {
                         match accept {
                             Ok((stream, peer)) => {
                                 let mailbox = mailbox.clone();
+                                let response_store = response_store.clone();
                                 let run_cancels = run_cancels.clone();
                                 let inbound_tx = inbound_tx.clone();
                                 let auth_token = auth_token.clone();
@@ -384,6 +544,7 @@ impl PlatformAdapter for ApiServerAdapter {
                                             stream,
                                             peer,
                                             mailbox,
+                                            response_store,
                                             run_cancels,
                                             inbound_tx,
                                             auth_token,
@@ -490,10 +651,418 @@ fn image_marker_message(image_url: &str, caption: Option<&str>) -> String {
 // Connection handler (minimal HTTP/1.1 without axum dep for compilation)
 // ---------------------------------------------------------------------------
 
+const SECURITY_HEADERS: &[(&str, &str)] = &[
+    ("X-Content-Type-Options", "nosniff"),
+    ("Referrer-Policy", "no-referrer"),
+    (
+        "Content-Security-Policy",
+        "default-src 'none'; frame-ancestors 'none'",
+    ),
+    (
+        "Permissions-Policy",
+        "camera=(), microphone=(), geolocation=()",
+    ),
+    (
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains",
+    ),
+    ("X-Frame-Options", "DENY"),
+    ("X-XSS-Protection", "0"),
+];
+
+#[derive(Clone, Copy)]
+struct HttpStatus {
+    code: u16,
+    reason: &'static str,
+}
+
+const HTTP_OK: HttpStatus = HttpStatus {
+    code: 200,
+    reason: "OK",
+};
+const HTTP_BAD_REQUEST: HttpStatus = HttpStatus {
+    code: 400,
+    reason: "Bad Request",
+};
+const HTTP_UNAUTHORIZED: HttpStatus = HttpStatus {
+    code: 401,
+    reason: "Unauthorized",
+};
+const HTTP_NOT_FOUND: HttpStatus = HttpStatus {
+    code: 404,
+    reason: "Not Found",
+};
+const HTTP_CONFLICT: HttpStatus = HttpStatus {
+    code: 409,
+    reason: "Conflict",
+};
+const HTTP_BAD_GATEWAY: HttpStatus = HttpStatus {
+    code: 502,
+    reason: "Bad Gateway",
+};
+const HTTP_SERVICE_UNAVAILABLE: HttpStatus = HttpStatus {
+    code: 503,
+    reason: "Service Unavailable",
+};
+const HTTP_GATEWAY_TIMEOUT: HttpStatus = HttpStatus {
+    code: 504,
+    reason: "Gateway Timeout",
+};
+
+fn append_security_headers(response: &mut String) {
+    for (name, value) in SECURITY_HEADERS {
+        response.push_str(name);
+        response.push_str(": ");
+        response.push_str(value);
+        response.push_str("\r\n");
+    }
+}
+
+fn http_response(status: HttpStatus, content_type: &str, body: &str) -> String {
+    let mut response = format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\n",
+        status.code, status.reason, content_type
+    );
+    append_security_headers(&mut response);
+    response.push_str(&format!("Content-Length: {}\r\n\r\n{}", body.len(), body));
+    response
+}
+
+fn json_http_response(status: HttpStatus, body: &serde_json::Value) -> serde_json::Result<String> {
+    let payload = serde_json::to_string(body)?;
+    Ok(http_response(status, "application/json", &payload))
+}
+
+fn api_error(message: impl Into<String>, error_type: &str, code: u16) -> serde_json::Value {
+    serde_json::json!({
+        "error": {
+            "message": message.into(),
+            "type": error_type,
+            "code": code.to_string(),
+        }
+    })
+}
+
+fn sse_http_header() -> String {
+    let mut response = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n".to_string();
+    append_security_headers(&mut response);
+    response.push_str("\r\n");
+    response
+}
+
+fn split_path_query(raw_path: &str) -> (&str, Option<&str>) {
+    raw_path
+        .split_once('?')
+        .map(|(path, query)| (path, Some(query)))
+        .unwrap_or((raw_path, None))
+}
+
+fn query_param(query: Option<&str>, key: &str) -> Option<String> {
+    query?.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        (name == key).then(|| urlencoding::decode(value).unwrap_or_default().to_string())
+    })
+}
+
+fn models_response_body() -> serde_json::Value {
+    serde_json::json!({
+        "object": "list",
+        "data": [
+            {
+                "id": "hermes-agent",
+                "object": "model",
+                "owned_by": "hermes",
+            },
+            {
+                "id": "hermes",
+                "object": "model",
+                "owned_by": "hermes",
+            }
+        ]
+    })
+}
+
+fn capabilities_response_body() -> serde_json::Value {
+    serde_json::json!({
+        "object": "hermes.api_server.capabilities",
+        "features": {
+            "chat_completions": true,
+            "responses": true,
+            "response_store": true,
+            "conversation_mapping": true,
+            "session_continuity_header": "X-Hermes-Session-Id",
+            "toolsets": true,
+            "skills": true,
+        },
+        "endpoints": {
+            "health": {"method": "GET", "path": "/health"},
+            "models": {"method": "GET", "path": "/v1/models"},
+            "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
+            "responses": {"method": "POST", "path": "/v1/responses"},
+            "response_get": {"method": "GET", "path": "/v1/responses/{response_id}"},
+            "response_delete": {"method": "DELETE", "path": "/v1/responses/{response_id}"},
+            "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
+            "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+            "skills": {"method": "GET", "path": "/v1/skills"},
+            "toolsets": {"method": "GET", "path": "/v1/toolsets"},
+        }
+    })
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct SkillListEntry {
+    name: String,
+    description: String,
+    category: String,
+}
+
+fn discover_skill_entries() -> Vec<SkillListEntry> {
+    let mut roots = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        roots.push(cwd.join("skills"));
+        roots.push(cwd.join("optional-skills"));
+    }
+    roots.push(hermes_config::paths::skills_dir());
+
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for root in roots {
+        collect_skill_entries(&root, &root, &mut seen, &mut out);
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn collect_skill_entries(
+    root: &Path,
+    dir: &Path,
+    seen: &mut HashSet<String>,
+    out: &mut Vec<SkillListEntry>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_md = path.join("SKILL.md");
+        if skill_md.is_file() {
+            let name = path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            if seen.insert(name.clone()) {
+                let category = path
+                    .parent()
+                    .and_then(|parent| parent.strip_prefix(root).ok())
+                    .and_then(|relative| relative.components().next())
+                    .and_then(|component| component.as_os_str().to_str())
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("general")
+                    .to_string();
+                out.push(SkillListEntry {
+                    name,
+                    description: skill_description(&skill_md),
+                    category,
+                });
+            }
+        } else {
+            collect_skill_entries(root, &path, seen, out);
+        }
+    }
+}
+
+fn skill_description(path: &Path) -> String {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return String::new();
+    };
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+        .unwrap_or("")
+        .chars()
+        .take(240)
+        .collect()
+}
+
+fn skills_response_body() -> serde_json::Value {
+    serde_json::json!({
+        "object": "list",
+        "data": discover_skill_entries(),
+    })
+}
+
+fn toolsets_response_body() -> serde_json::Value {
+    let registry = Arc::new(ToolRegistry::new());
+    let manager = ToolsetManager::new(registry);
+    let default_api_toolset = "hermes-api-server";
+    let data: Vec<serde_json::Value> = manager
+        .list_toolsets()
+        .into_iter()
+        .map(|name| {
+            let tools = manager
+                .resolve_toolset_unfiltered(&name)
+                .unwrap_or_else(|_| Vec::new());
+            serde_json::json!({
+                "name": name,
+                "title": name.replace('-', " "),
+                "description": "Built-in Hermes toolset",
+                "enabled": name == default_api_toolset,
+                "configured": name == default_api_toolset,
+                "tools": tools,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "object": "list",
+        "platform": "api_server",
+        "data": data,
+    })
+}
+
+fn response_input_messages(input: ResponseInput) -> Vec<ChatMessage> {
+    match input {
+        ResponseInput::Text(text) => vec![ChatMessage {
+            role: "user".to_string(),
+            content: text,
+        }],
+        ResponseInput::Messages(messages) => messages,
+    }
+}
+
+fn make_responses_api_body(
+    response_id: &str,
+    model: &str,
+    content: &str,
+    previous_response_id: Option<&str>,
+) -> serde_json::Value {
+    let prompt_tokens = 0_u32;
+    let completion_tokens = content.len() as u32 / 4;
+    serde_json::json!({
+        "id": response_id,
+        "object": "response",
+        "created_at": chrono::Utc::now().timestamp(),
+        "model": model,
+        "previous_response_id": previous_response_id,
+        "output": [
+            {
+                "id": format!("msg_{response_id}"),
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": content,
+                    }
+                ]
+            }
+        ],
+        "usage": {
+            "input_tokens": prompt_tokens,
+            "output_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+    })
+}
+
+async fn cleanup_api_request(
+    mailbox: &Arc<RwLock<ResponseMailbox>>,
+    run_cancels: &Arc<RwLock<RunCancelRegistry>>,
+    request_id: &str,
+    mailbox_key: &str,
+) {
+    mailbox.write().await.pending.remove(mailbox_key);
+    let mut cancels = run_cancels.write().await;
+    cancels.pending.remove(request_id);
+    cancels.pending.remove(mailbox_key);
+}
+
+async fn run_api_request(
+    mailbox: Arc<RwLock<ResponseMailbox>>,
+    run_cancels: Arc<RwLock<RunCancelRegistry>>,
+    inbound_tx: Arc<RwLock<Option<mpsc::Sender<ApiInboundRequest>>>>,
+    inbound: ApiInboundRequest,
+    mailbox_key: String,
+) -> Result<String, (HttpStatus, serde_json::Value)> {
+    let request_id = inbound.request_id.clone();
+    let (reply_tx, mut reply_rx) = mpsc::channel::<String>(1);
+    let cancel_waiter = Arc::new(Notify::new());
+
+    mailbox
+        .write()
+        .await
+        .pending
+        .insert(mailbox_key.clone(), reply_tx);
+    {
+        let mut guard = run_cancels.write().await;
+        guard
+            .pending
+            .insert(request_id.clone(), cancel_waiter.clone());
+        guard
+            .pending
+            .insert(mailbox_key.clone(), cancel_waiter.clone());
+    }
+
+    let maybe_inbound = inbound_tx.read().await.clone();
+    let Some(tx) = maybe_inbound else {
+        cleanup_api_request(&mailbox, &run_cancels, &request_id, &mailbox_key).await;
+        return Err((
+            HTTP_SERVICE_UNAVAILABLE,
+            api_error(
+                "Gateway inbound pipeline is not configured",
+                "service_unavailable",
+                503,
+            ),
+        ));
+    };
+
+    if tx.send(inbound).await.is_err() {
+        cleanup_api_request(&mailbox, &run_cancels, &request_id, &mailbox_key).await;
+        return Err((
+            HTTP_SERVICE_UNAVAILABLE,
+            api_error(
+                "Gateway inbound queue is unavailable",
+                "service_unavailable",
+                503,
+            ),
+        ));
+    }
+
+    let reply = tokio::select! {
+        _ = cancel_waiter.notified() => {
+            Err((
+                HTTP_CONFLICT,
+                api_error("Run stopped", "cancelled_error", 409),
+            ))
+        }
+        timeout_result = tokio::time::timeout(Duration::from_secs(120), reply_rx.recv()) => {
+            match timeout_result {
+                Ok(Some(msg)) => Ok(msg),
+                Ok(None) => Err((
+                    HTTP_BAD_GATEWAY,
+                    api_error("Gateway closed response channel", "internal_error", 502),
+                )),
+                Err(_) => Err((
+                    HTTP_GATEWAY_TIMEOUT,
+                    api_error("Gateway response timeout", "timeout_error", 504),
+                )),
+            }
+        }
+    };
+
+    cleanup_api_request(&mailbox, &run_cancels, &request_id, &mailbox_key).await;
+    reply
+}
+
 async fn handle_connection(
     stream: tokio::net::TcpStream,
     _peer: SocketAddr,
     mailbox: Arc<RwLock<ResponseMailbox>>,
+    response_store: Arc<RwLock<ResponseStore>>,
     run_cancels: Arc<RwLock<RunCancelRegistry>>,
     inbound_tx: Arc<RwLock<Option<mpsc::Sender<ApiInboundRequest>>>>,
     auth_token: Option<String>,
@@ -507,12 +1076,10 @@ async fn handle_connection(
     }
 
     let Some(header_end) = find_bytes(&raw, b"\r\n\r\n") else {
-        let body = r#"{"error":{"message":"Invalid HTTP request","type":"invalid_request_error","code":"400"}}"#;
-        let resp = format!(
-            "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-            body.len(),
-            body
-        );
+        let resp = json_http_response(
+            HTTP_BAD_REQUEST,
+            &api_error("Invalid HTTP request", "invalid_request_error", 400),
+        )?;
         writer.write_all(resp.as_bytes()).await?;
         return Ok(());
     };
@@ -522,7 +1089,8 @@ async fn handle_connection(
     let first_line = header_text.lines().next().unwrap_or("");
     let parts: Vec<&str> = first_line.split_whitespace().collect();
     let method = parts.first().copied().unwrap_or("GET");
-    let path = parts.get(1).copied().unwrap_or("/");
+    let raw_path = parts.get(1).copied().unwrap_or("/");
+    let (path, query) = split_path_query(raw_path);
 
     // Extract Authorization header
     let auth_header = header_text
@@ -537,12 +1105,10 @@ async fn handle_connection(
             .map(|t| t == expected)
             .unwrap_or(false);
         if !valid {
-            let err = serde_json::json!({"error":{"message":"Unauthorized","type":"auth_error","code":"401"}});
-            let body = serde_json::to_string(&err)?;
-            let resp = format!(
-                "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(), body
-            );
+            let resp = json_http_response(
+                HTTP_UNAUTHORIZED,
+                &api_error("Unauthorized", "auth_error", 401),
+            )?;
             writer.write_all(resp.as_bytes()).await?;
             return Ok(());
         }
@@ -562,27 +1128,13 @@ async fn handle_connection(
                     "object": "run",
                     "status": "stopped"
                 });
-                let payload = serde_json::to_string(&body)?;
-                let resp = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                    payload.len(),
-                    payload
-                );
+                let resp = json_http_response(HTTP_OK, &body)?;
                 writer.write_all(resp.as_bytes()).await?;
             } else {
-                let err = serde_json::json!({
-                    "error": {
-                        "message":"Run not found",
-                        "type":"not_found",
-                        "code":"404"
-                    }
-                });
-                let payload = serde_json::to_string(&err)?;
-                let resp = format!(
-                    "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                    payload.len(),
-                    payload
-                );
+                let resp = json_http_response(
+                    HTTP_NOT_FOUND,
+                    &api_error("Run not found", "not_found", 404),
+                )?;
                 writer.write_all(resp.as_bytes()).await?;
             }
             return Ok(());
@@ -590,7 +1142,72 @@ async fn handle_connection(
     }
 
     match (method, path) {
-        ("POST", "/v1/chat/completions") | ("POST", "/v1/responses") => {
+        ("GET", "/health") | ("GET", "/") => {
+            let body = serde_json::json!({"status":"ok","adapter":"api-server"});
+            let resp = json_http_response(HTTP_OK, &body)?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("GET", "/health/detailed") | ("GET", "/v1/health") => {
+            let body = serde_json::json!({
+                "status": "ok",
+                "adapter": "api-server",
+                "features": capabilities_response_body()["features"].clone(),
+            });
+            let resp = json_http_response(HTTP_OK, &body)?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("GET", "/v1/models") => {
+            let resp = json_http_response(HTTP_OK, &models_response_body())?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("GET", "/v1/capabilities") => {
+            let resp = json_http_response(HTTP_OK, &capabilities_response_body())?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("GET", "/v1/skills") => {
+            let _category_filter = query_param(query, "category");
+            let resp = json_http_response(HTTP_OK, &skills_response_body())?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("GET", "/v1/toolsets") => {
+            let _enabled_filter = query_param(query, "enabled");
+            let resp = json_http_response(HTTP_OK, &toolsets_response_body())?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("GET", _) if path.starts_with("/v1/responses/") => {
+            let response_id = path.trim_start_matches("/v1/responses/");
+            let stored = response_store.write().await.get(response_id);
+            if let Some(stored) = stored {
+                let resp = json_http_response(HTTP_OK, &stored.response)?;
+                writer.write_all(resp.as_bytes()).await?;
+            } else {
+                let resp = json_http_response(
+                    HTTP_NOT_FOUND,
+                    &api_error("Response not found", "not_found", 404),
+                )?;
+                writer.write_all(resp.as_bytes()).await?;
+            }
+        }
+        ("DELETE", _) if path.starts_with("/v1/responses/") => {
+            let response_id = path.trim_start_matches("/v1/responses/");
+            let deleted = response_store.write().await.delete(response_id);
+            if deleted {
+                let body = serde_json::json!({
+                    "id": response_id,
+                    "object": "response.deleted",
+                    "deleted": true,
+                });
+                let resp = json_http_response(HTTP_OK, &body)?;
+                writer.write_all(resp.as_bytes()).await?;
+            } else {
+                let resp = json_http_response(
+                    HTTP_NOT_FOUND,
+                    &api_error("Response not found", "not_found", 404),
+                )?;
+                writer.write_all(resp.as_bytes()).await?;
+            }
+        }
+        ("POST", "/v1/chat/completions") => {
             let body_str = String::from_utf8_lossy(body_bytes);
 
             let parsed: Result<ChatCompletionRequest, _> = serde_json::from_str(&body_str);
@@ -600,19 +1217,14 @@ async fn handle_connection(
                     let model = req.model.as_deref().unwrap_or("hermes").to_string();
                     let prompt = build_prompt_from_messages(&req.messages).unwrap_or_default();
                     if prompt.trim().is_empty() {
-                        let err = serde_json::json!({
-                            "error": {
-                                "message": "Request must include at least one user message",
-                                "type":"invalid_request_error",
-                                "code":"400"
-                            }
-                        });
-                        let body = serde_json::to_string(&err)?;
-                        let resp = format!(
-                            "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(),
-                            body
-                        );
+                        let resp = json_http_response(
+                            HTTP_BAD_REQUEST,
+                            &api_error(
+                                "Request must include at least one user message",
+                                "invalid_request_error",
+                                400,
+                            ),
+                        )?;
                         writer.write_all(resp.as_bytes()).await?;
                         return Ok(());
                     }
@@ -633,149 +1245,25 @@ async fn handle_connection(
                         prompt,
                     };
 
-                    let (reply_tx, mut reply_rx) = mpsc::channel::<String>(1);
-                    let cancel_waiter = Arc::new(Notify::new());
+                    let reply = match run_api_request(
+                        mailbox.clone(),
+                        run_cancels.clone(),
+                        inbound_tx.clone(),
+                        inbound,
+                        mailbox_key,
+                    )
+                    .await
                     {
-                        let mut guard = mailbox.write().await;
-                        guard.pending.insert(mailbox_key.clone(), reply_tx);
-                    }
-                    {
-                        let mut guard = run_cancels.write().await;
-                        guard
-                            .pending
-                            .insert(request_id.clone(), cancel_waiter.clone());
-                        guard
-                            .pending
-                            .insert(mailbox_key.clone(), cancel_waiter.clone());
-                    }
-
-                    let maybe_inbound = inbound_tx.read().await.clone();
-                    let Some(tx) = maybe_inbound else {
-                        let mut guard = mailbox.write().await;
-                        guard.pending.remove(&mailbox_key);
-                        let err = serde_json::json!({
-                            "error": {
-                                "message":"Gateway inbound pipeline is not configured",
-                                "type":"service_unavailable",
-                                "code":"503"
-                            }
-                        });
-                        let body = serde_json::to_string(&err)?;
-                        let resp = format!(
-                            "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(),
-                            body
-                        );
-                        writer.write_all(resp.as_bytes()).await?;
-                        return Ok(());
-                    };
-
-                    if tx.send(inbound).await.is_err() {
-                        let mut guard = mailbox.write().await;
-                        guard.pending.remove(&mailbox_key);
-                        let err = serde_json::json!({
-                            "error": {
-                                "message":"Gateway inbound queue is unavailable",
-                                "type":"service_unavailable",
-                                "code":"503"
-                            }
-                        });
-                        let body = serde_json::to_string(&err)?;
-                        let resp = format!(
-                            "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(),
-                            body
-                        );
-                        writer.write_all(resp.as_bytes()).await?;
-                        return Ok(());
-                    }
-
-                    let reply = tokio::select! {
-                        _ = cancel_waiter.notified() => {
-                            let err = serde_json::json!({
-                                "error": {
-                                    "message":"Run stopped",
-                                    "type":"cancelled_error",
-                                    "code":"409"
-                                }
-                            });
-                            let body = serde_json::to_string(&err)?;
-                            let resp = format!(
-                                "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                                body.len(),
-                                body
-                            );
+                        Ok(reply) => reply,
+                        Err((status, body)) => {
+                            let resp = json_http_response(status, &body)?;
                             writer.write_all(resp.as_bytes()).await?;
-                            let mut guard = mailbox.write().await;
-                            guard.pending.remove(&mailbox_key);
-                            let mut cancels = run_cancels.write().await;
-                            cancels.pending.remove(&request_id);
-                            cancels.pending.remove(&mailbox_key);
                             return Ok(());
                         }
-                        timeout_result = tokio::time::timeout(Duration::from_secs(120), reply_rx.recv()) => {
-                            match timeout_result {
-                                Ok(Some(msg)) => msg,
-                                Ok(None) => {
-                                    let err = serde_json::json!({
-                                        "error": {
-                                            "message":"Gateway closed response channel",
-                                            "type":"internal_error",
-                                            "code":"502"
-                                        }
-                                    });
-                                    let body = serde_json::to_string(&err)?;
-                                    let resp = format!(
-                                        "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                                        body.len(),
-                                        body
-                                    );
-                                    writer.write_all(resp.as_bytes()).await?;
-                                    let mut guard = mailbox.write().await;
-                                    guard.pending.remove(&mailbox_key);
-                                    let mut cancels = run_cancels.write().await;
-                                    cancels.pending.remove(&request_id);
-                                    cancels.pending.remove(&mailbox_key);
-                                    return Ok(());
-                                }
-                                Err(_) => {
-                                    let err = serde_json::json!({
-                                        "error": {
-                                            "message":"Gateway response timeout",
-                                            "type":"timeout_error",
-                                            "code":"504"
-                                        }
-                                    });
-                                    let body = serde_json::to_string(&err)?;
-                                    let resp = format!(
-                                        "HTTP/1.1 504 Gateway Timeout\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                                        body.len(),
-                                        body
-                                    );
-                                    writer.write_all(resp.as_bytes()).await?;
-                                    let mut guard = mailbox.write().await;
-                                    guard.pending.remove(&mailbox_key);
-                                    let mut cancels = run_cancels.write().await;
-                                    cancels.pending.remove(&request_id);
-                                    cancels.pending.remove(&mailbox_key);
-                                    return Ok(());
-                                }
-                            }
-                        }
                     };
 
-                    {
-                        let mut guard = mailbox.write().await;
-                        guard.pending.remove(&mailbox_key);
-                    }
-                    {
-                        let mut guard = run_cancels.write().await;
-                        guard.pending.remove(&request_id);
-                        guard.pending.remove(&mailbox_key);
-                    }
-
                     if req.stream {
-                        let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n";
+                        let header = sse_http_header();
                         writer.write_all(header.as_bytes()).await?;
 
                         // Role chunk
@@ -811,40 +1299,166 @@ async fn handle_connection(
                             &model,
                             &reply,
                         );
-                        let body = serde_json::to_string(&response)?;
-                        let resp = format!(
-                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(), body
+                        let resp = http_response(
+                            HTTP_OK,
+                            "application/json",
+                            &serde_json::to_string(&response)?,
                         );
                         writer.write_all(resp.as_bytes()).await?;
                     }
                 }
                 Err(e) => {
-                    let err = serde_json::json!({"error":{"message":format!("Invalid request: {e}"),"type":"invalid_request_error","code":"400"}});
-                    let body = serde_json::to_string(&err)?;
-                    let resp = format!(
-                        "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                        body.len(), body
-                    );
+                    let resp = json_http_response(
+                        HTTP_BAD_REQUEST,
+                        &api_error(
+                            format!("Invalid request: {e}"),
+                            "invalid_request_error",
+                            400,
+                        ),
+                    )?;
                     writer.write_all(resp.as_bytes()).await?;
                 }
             }
         }
-        ("GET", "/health") | ("GET", "/") => {
-            let body = r#"{"status":"ok","adapter":"api-server"}"#;
-            let resp = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            writer.write_all(resp.as_bytes()).await?;
+        ("POST", "/v1/responses") => {
+            let body_str = String::from_utf8_lossy(body_bytes);
+            let parsed: Result<ResponsesRequest, _> = serde_json::from_str(&body_str);
+            match parsed {
+                Ok(req) => {
+                    let request_id = format!(
+                        "resp_{}",
+                        uuid::Uuid::new_v4().to_string().replace('-', "")[..24].to_string()
+                    );
+                    let model = req.model.as_deref().unwrap_or("hermes").to_string();
+                    let mut messages = response_input_messages(req.input);
+                    let previous_response_id = if let Some(id) = req.previous_response_id.clone() {
+                        let exists = response_store.write().await.get(&id).is_some();
+                        if !exists {
+                            let resp = json_http_response(
+                                HTTP_NOT_FOUND,
+                                &api_error("Previous response not found", "not_found", 404),
+                            )?;
+                            writer.write_all(resp.as_bytes()).await?;
+                            return Ok(());
+                        }
+                        Some(id)
+                    } else if let Some(conversation) = req.conversation.as_deref() {
+                        response_store.write().await.get_conversation(conversation)
+                    } else {
+                        None
+                    };
+
+                    if let Some(previous_id) = previous_response_id.as_deref() {
+                        if let Some(previous) = response_store.write().await.get(previous_id) {
+                            let mut history = previous.conversation_history;
+                            history.append(&mut messages);
+                            messages = history;
+                        }
+                    }
+
+                    let prompt = build_prompt_from_messages(&messages).unwrap_or_default();
+                    if prompt.trim().is_empty() {
+                        let resp = json_http_response(
+                            HTTP_BAD_REQUEST,
+                            &api_error(
+                                "Request must include non-empty input",
+                                "invalid_request_error",
+                                400,
+                            ),
+                        )?;
+                        writer.write_all(resp.as_bytes()).await?;
+                        return Ok(());
+                    }
+
+                    let session_id = req
+                        .session_id
+                        .clone()
+                        .or_else(|| req.conversation.clone())
+                        .unwrap_or_else(|| request_id.clone());
+                    let user_id = req
+                        .user
+                        .clone()
+                        .filter(|u| !u.trim().is_empty())
+                        .unwrap_or_else(|| "api-client".to_string());
+                    let inbound = ApiInboundRequest {
+                        request_id: request_id.clone(),
+                        session_id: session_id.clone(),
+                        user_id,
+                        model: req.model.clone(),
+                        provider: req.provider.clone(),
+                        personality: req.personality.clone(),
+                        prompt,
+                    };
+
+                    let reply = match run_api_request(
+                        mailbox.clone(),
+                        run_cancels.clone(),
+                        inbound_tx.clone(),
+                        inbound,
+                        session_id,
+                    )
+                    .await
+                    {
+                        Ok(reply) => reply,
+                        Err((status, body)) => {
+                            let resp = json_http_response(status, &body)?;
+                            writer.write_all(resp.as_bytes()).await?;
+                            return Ok(());
+                        }
+                    };
+
+                    let response = make_responses_api_body(
+                        &request_id,
+                        &model,
+                        &reply,
+                        previous_response_id.as_deref(),
+                    );
+
+                    if req.store {
+                        let mut conversation_history = messages;
+                        conversation_history.push(ChatMessage {
+                            role: "assistant".to_string(),
+                            content: reply.clone(),
+                        });
+                        let mut guard = response_store.write().await;
+                        guard.put(
+                            request_id.clone(),
+                            StoredApiResponse {
+                                response: response.clone(),
+                                conversation_history,
+                            },
+                        );
+                        if let Some(conversation) = req.conversation {
+                            guard.set_conversation(conversation, request_id.clone());
+                        }
+                    }
+
+                    if req.stream {
+                        let header = sse_http_header();
+                        writer.write_all(header.as_bytes()).await?;
+                        let data = format!("data: {}\n\ndata: [DONE]\n\n", response);
+                        writer.write_all(data.as_bytes()).await?;
+                    } else {
+                        let resp = json_http_response(HTTP_OK, &response)?;
+                        writer.write_all(resp.as_bytes()).await?;
+                    }
+                }
+                Err(e) => {
+                    let resp = json_http_response(
+                        HTTP_BAD_REQUEST,
+                        &api_error(
+                            format!("Invalid request: {e}"),
+                            "invalid_request_error",
+                            400,
+                        ),
+                    )?;
+                    writer.write_all(resp.as_bytes()).await?;
+                }
+            }
         }
         _ => {
-            let body = r#"{"error":{"message":"Not found","type":"not_found","code":"404"}}"#;
-            let resp = format!(
-                "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(), body
-            );
+            let resp =
+                json_http_response(HTTP_NOT_FOUND, &api_error("Not found", "not_found", 404))?;
             writer.write_all(resp.as_bytes()).await?;
         }
     }
@@ -964,6 +1578,41 @@ async fn read_http_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn spawn_one_request_server(
+        mailbox: Arc<RwLock<ResponseMailbox>>,
+        response_store: Arc<RwLock<ResponseStore>>,
+        run_cancels: Arc<RwLock<RunCancelRegistry>>,
+        inbound_tx: Arc<RwLock<Option<mpsc::Sender<ApiInboundRequest>>>>,
+        auth_token: Option<String>,
+    ) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.expect("accept");
+            handle_connection(
+                stream,
+                peer,
+                mailbox,
+                response_store,
+                run_cancels,
+                inbound_tx,
+                auth_token,
+            )
+            .await
+            .expect("handle connection");
+        });
+        (addr, handle)
+    }
+
+    async fn read_http_response(mut stream: tokio::net::TcpStream) -> String {
+        let mut bytes = Vec::new();
+        stream.read_to_end(&mut bytes).await.expect("read response");
+        String::from_utf8(bytes).expect("utf8 response")
+    }
 
     #[test]
     fn parse_content_length_is_case_insensitive() {
@@ -1097,5 +1746,207 @@ mod tests {
         assert_eq!(parse_stop_run_path("/v1/runs//stop"), None);
         assert_eq!(parse_stop_run_path("/v1/runs/run_abc123"), None);
         assert_eq!(parse_stop_run_path("/v1/chat/completions"), None);
+    }
+
+    #[test]
+    fn api_boolish_fields_accept_quoted_false() {
+        let chat: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": "false",
+        }))
+        .expect("quoted false stream should deserialize");
+        assert!(!chat.stream);
+
+        let responses: ResponsesRequest = serde_json::from_value(serde_json::json!({
+            "model": "hermes-agent",
+            "input": "hello",
+            "stream": "false",
+            "store": "false",
+        }))
+        .expect("quoted false stream/store should deserialize");
+        assert!(!responses.stream);
+        assert!(!responses.store);
+    }
+
+    #[test]
+    fn response_store_deletes_and_evicts_conversation_mappings() {
+        let mut store = ResponseStore::new(2);
+        let stored = |text: &str| StoredApiResponse {
+            response: serde_json::json!({"id": text}),
+            conversation_history: vec![ChatMessage {
+                role: "assistant".into(),
+                content: text.into(),
+            }],
+        };
+
+        store.put("resp_1", stored("one"));
+        store.set_conversation("chat-a", "resp_1");
+        assert_eq!(store.get_conversation("chat-a").as_deref(), Some("resp_1"));
+        assert!(store.delete("resp_1"));
+        assert_eq!(store.get_conversation("chat-a"), None);
+
+        store.put("resp_2", stored("two"));
+        store.set_conversation("chat-b", "resp_2");
+        store.put("resp_3", stored("three"));
+        store.set_conversation("chat-c", "resp_3");
+        store.put("resp_4", stored("four"));
+
+        assert!(store.get("resp_2").is_none());
+        assert_eq!(store.get_conversation("chat-b"), None);
+        assert_eq!(store.get_conversation("chat-c").as_deref(), Some("resp_3"));
+    }
+
+    #[test]
+    fn api_discovery_bodies_expose_capabilities_toolsets_and_headers() {
+        let capabilities = capabilities_response_body();
+        assert_eq!(
+            capabilities["endpoints"]["skills"],
+            serde_json::json!({"method": "GET", "path": "/v1/skills"})
+        );
+        assert_eq!(
+            capabilities["endpoints"]["toolsets"],
+            serde_json::json!({"method": "GET", "path": "/v1/toolsets"})
+        );
+
+        let toolsets = toolsets_response_body();
+        let data = toolsets["data"].as_array().expect("toolset list");
+        let api_server = data
+            .iter()
+            .find(|entry| entry["name"] == "hermes-api-server")
+            .expect("hermes-api-server toolset");
+        assert_eq!(api_server["enabled"], true);
+        assert!(api_server["tools"]
+            .as_array()
+            .expect("tools")
+            .iter()
+            .any(|tool| tool == "terminal"));
+
+        let response = json_http_response(HTTP_OK, &serde_json::json!({"status": "ok"}))
+            .expect("json response");
+        assert!(response.contains("X-Content-Type-Options: nosniff\r\n"));
+        assert!(response.contains("Referrer-Policy: no-referrer\r\n"));
+        assert!(response.contains("X-Frame-Options: DENY\r\n"));
+        assert!(response
+            .contains("Content-Security-Policy: default-src 'none'; frame-ancestors 'none'\r\n"));
+    }
+
+    #[test]
+    fn skill_discovery_reads_nested_skill_dirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skill_dir = tmp.path().join("creative").join("ascii-art");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# ASCII Art\n\nGenerate terminal-friendly drawings.\n",
+        )
+        .expect("write skill");
+
+        let mut seen = HashSet::new();
+        let mut entries = Vec::new();
+        collect_skill_entries(tmp.path(), tmp.path(), &mut seen, &mut entries);
+
+        assert_eq!(
+            entries,
+            vec![SkillListEntry {
+                name: "ascii-art".into(),
+                description: "Generate terminal-friendly drawings.".into(),
+                category: "creative".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn responses_body_shape_matches_openai_responses_contract() {
+        let body = make_responses_api_body("resp_abc", "hermes-agent", "done", Some("resp_prev"));
+        assert_eq!(body["id"], "resp_abc");
+        assert_eq!(body["object"], "response");
+        assert_eq!(body["previous_response_id"], "resp_prev");
+        assert_eq!(body["output"][0]["type"], "message");
+        assert_eq!(body["output"][0]["content"][0]["type"], "output_text");
+        assert_eq!(body["output"][0]["content"][0]["text"], "done");
+    }
+
+    #[tokio::test]
+    async fn api_discovery_endpoint_serves_capabilities_with_security_headers() {
+        let (tx, _rx) = mpsc::channel(1);
+        let (addr, handle) = spawn_one_request_server(
+            Arc::new(RwLock::new(ResponseMailbox::default())),
+            Arc::new(RwLock::new(ResponseStore::default())),
+            Arc::new(RwLock::new(RunCancelRegistry::default())),
+            Arc::new(RwLock::new(Some(tx))),
+            None,
+        )
+        .await;
+
+        let mut client = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        client
+            .write_all(b"GET /v1/capabilities HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .expect("write request");
+        client.shutdown().await.expect("shutdown write side");
+        let response = read_http_response(client).await;
+        handle.await.expect("server task");
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("X-Content-Type-Options: nosniff\r\n"));
+        assert!(response.contains("\"skills\":{\"method\":\"GET\",\"path\":\"/v1/skills\"}"));
+        assert!(response.contains("\"toolsets\":{\"method\":\"GET\",\"path\":\"/v1/toolsets\"}"));
+    }
+
+    #[tokio::test]
+    async fn responses_endpoint_accepts_input_and_quoted_false_without_storing() {
+        let mailbox = Arc::new(RwLock::new(ResponseMailbox::default()));
+        let response_store = Arc::new(RwLock::new(ResponseStore::default()));
+        let run_cancels = Arc::new(RwLock::new(RunCancelRegistry::default()));
+        let (tx, mut rx) = mpsc::channel(1);
+        let (addr, handle) = spawn_one_request_server(
+            Arc::clone(&mailbox),
+            Arc::clone(&response_store),
+            Arc::clone(&run_cancels),
+            Arc::new(RwLock::new(Some(tx))),
+            None,
+        )
+        .await;
+
+        let body = serde_json::json!({
+            "model": "hermes-agent",
+            "input": "hello",
+            "store": "false",
+            "stream": "false",
+        })
+        .to_string();
+        let request = format!(
+            "POST /v1/responses HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let mut client = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        client
+            .write_all(request.as_bytes())
+            .await
+            .expect("write request");
+
+        let inbound = rx.recv().await.expect("inbound request");
+        assert_eq!(inbound.model.as_deref(), Some("hermes-agent"));
+        assert_eq!(inbound.prompt, "hello");
+        let sender = mailbox
+            .read()
+            .await
+            .pending
+            .get(&inbound.session_id)
+            .cloned()
+            .expect("pending response sender");
+        sender.send("done".to_string()).await.expect("send reply");
+
+        let response = read_http_response(client).await;
+        handle.await.expect("server task");
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(!response.contains("text/event-stream"));
+        assert!(response.contains("\"object\":\"response\""));
+        assert!(response.contains("\"text\":\"done\""));
+        assert!(response_store.read().await.entries.is_empty());
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T04:31:38.755907+00:00",
+  "generated_at_utc": "2026-06-01T05:23:39.410846+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T04:31:38.755907+00:00`
+Generated: `2026-06-01T05:23:39.410846+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -3376,17 +3376,17 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_api_server_bind_guard.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "13a09c9ec499debce7a5125789aa65f10b573bfb",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_api_server_bind_guard.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
-      "ticket": 25,
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 303,
       "upstream_blob": "edab34eb38255d252c6b6745c8d13f87a47b017e",
       "workstream": "WS6"
     },
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T04:31:38.656700+00:00",
+  "generated_at_utc": "2026-06-01T05:23:39.316744+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "7d4de521aa2fe21f28d11ced80c400c3558ab653",
+    "local_sha": "2ff1d2dc1fb156692a296a0f64fd4029057da915",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 590,
-      "intentional_divergence": 277,
+      "functional": 589,
+      "intentional_divergence": 278,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 449,
-      "rust_equivalent_or_contract_test_required": 505,
+      "not_required_for_runtime": 450,
+      "rust_equivalent_or_contract_test_required": 504,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 277,
+      "cleared_intentional_divergence": 278,
       "cleared_non_runtime": 172,
-      "pending_review": 590
+      "pending_review": 589
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 277,
+    "cleared_intentional_divergence": 278,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 590,
+    "pending_review": 589,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T04:31:38.656700+00:00`
+Generated: `2026-06-01T05:23:39.316744+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `590`
+- Pending functional review: `589`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `277`
+- Cleared intentional divergence: `278`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 277 |
+| `cleared_intentional_divergence` | 278 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 590 |
+| `pending_review` | 589 |
 
 ## Workstream Counts
 
@@ -38,7 +38,7 @@ Generated: `2026-06-01T04:31:38.656700+00:00`
 | Classification Path | Count |
 | --- | ---: |
 | `tests/hermes_cli` | 117 |
-| `tests/gateway` | 116 |
+| `tests/gateway` | 115 |
 | `tests/tools` | 86 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -2173,6 +2173,13 @@
       "ticket": 302
     },
     {
+      "path": "tests/gateway/test_api_server_bind_guard.py",
+      "classification": "intentional_divergence",
+      "rationale": "API-server bind-address guard behavior is covered by Rust ApiServerAdapter contracts: network-accessible IPv4/IPv6 and mapped addresses require auth tokens, loopback binds remain allowed without auth, hostname resolution fails closed, and start() rejects unsafe non-loopback binds without an auth token.",
+      "owner": "sheawinkler",
+      "ticket": 303
+    },
+    {
       "path": "tests/gateway/test_gateway_command_help.py",
       "classification": "intentional_divergence",
       "rationale": "Gateway help/start command behavior is covered by Rust gateway command contracts: /start is a no-op platform start event, /commands aliases /help, registered command bypass recognizes aliases, and generated help exposes normalized lowercase command names.",


### PR DESCRIPTION
## Summary
- add Rust API-server discovery endpoints for models, capabilities, skills, and toolsets
- add bool-like stream/store parsing, Responses API input handling, response get/delete, and LRU conversation cleanup
- mark API-server bind-guard Python parity as superseded by Rust contracts; pending review 590 -> 589

## Verification
- python3 scripts/generate-shared-diff-backlog.py --repo-root . --no-fetch
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release
- cargo fmt --all --check
- cargo test -p hermes-gateway --lib
- cargo test -p hermes-gateway --all-features platforms::api_server::tests
- cargo test -p hermes-gateway --all-features
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- git diff --check
- scripts/clippy-warning-gate.sh --check
- cargo build --workspace
- cargo test --workspace --quiet