### PR TITLE
parity(terminal): harden local foreground execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "async-trait",
  "hermes-config",
  "hermes-core",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/hermes-environments/Cargo.toml
+++ b/crates/hermes-environments/Cargo.toml
@@ -24,6 +24,9 @@ tracing = { workspace = true }
 async-trait = { workspace = true }
 reqwest = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 hermes-config = { workspace = true, features = ["test-helpers"] }

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -13,6 +13,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::ChildStdin;
 use tokio::process::Command as TokioCommand;
 use tokio::sync::Mutex as AsyncMutex;
+use tokio::task::JoinHandle;
 
 use hermes_core::{AgentError, CommandOutput, TerminalBackend};
 
@@ -20,6 +21,7 @@ const PROCESS_OUTPUT_WINDOW_CHARS: usize = 200_000;
 const PROCESS_PREVIEW_CHARS: usize = 1_000;
 const PROCESS_WAIT_OUTPUT_CHARS: usize = 2_000;
 const PROCESS_LOG_DEFAULT_LINES: usize = 200;
+const FOREGROUND_DRAIN_GRACE_MS: u64 = 120;
 
 static NEXT_PROCESS_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -165,6 +167,132 @@ impl LocalBackend {
         }
     }
 
+    fn append_bytes(output: &Arc<Mutex<Vec<u8>>>, bytes: &[u8], max_bytes: usize) {
+        let mut guard = output.lock().unwrap_or_else(|e| e.into_inner());
+        let remaining = max_bytes.saturating_sub(guard.len());
+        if remaining > 0 {
+            guard.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+        }
+    }
+
+    async fn read_stream_to_bytes<R>(
+        mut stream: R,
+        output: Arc<Mutex<Vec<u8>>>,
+        max_output_bytes: usize,
+    ) where
+        R: AsyncRead + Unpin,
+    {
+        let mut chunk = [0_u8; 4096];
+        loop {
+            match stream.read(&mut chunk).await {
+                Ok(0) => break,
+                Ok(read) => Self::append_bytes(&output, &chunk[..read], max_output_bytes),
+                Err(err) => {
+                    let note = format!("\n[stream read error: {err}]");
+                    Self::append_bytes(&output, note.as_bytes(), max_output_bytes);
+                    break;
+                }
+            }
+        }
+    }
+
+    fn decode_output(bytes: &Arc<Mutex<Vec<u8>>>) -> String {
+        let guard = bytes.lock().unwrap_or_else(|e| e.into_inner());
+        String::from_utf8_lossy(&guard).to_string()
+    }
+
+    async fn finish_or_abort_reader(mut handle: JoinHandle<()>) {
+        if tokio::time::timeout(std::time::Duration::from_millis(50), &mut handle)
+            .await
+            .is_err()
+        {
+            // A shell-backgrounded grandchild may still hold the pipe open
+            // after the parent shell exits. Abort the reader instead of
+            // waiting for EOF from an unmanaged descendant.
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
+    async fn collect_foreground_child(
+        &self,
+        mut cmd: TokioCommand,
+        timeout_secs: u64,
+        stdin_payload: Option<Vec<u8>>,
+        spawn_label: &str,
+        timeout_label: &str,
+    ) -> Result<CommandOutput, AgentError> {
+        configure_foreground_process_group(&mut cmd);
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| AgentError::Io(format!("Failed to spawn {spawn_label}: {e}")))?;
+        if let Some(payload) = stdin_payload {
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin
+                    .write_all(&payload)
+                    .await
+                    .map_err(|e| AgentError::Io(format!("Failed to write stdin: {e}")))?;
+                stdin
+                    .flush()
+                    .await
+                    .map_err(|e| AgentError::Io(format!("Failed to flush stdin: {e}")))?;
+            }
+        }
+
+        let stdout = Arc::new(Mutex::new(Vec::new()));
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        let mut stdout_task = child.stdout.take().map(|stream| {
+            let stdout = stdout.clone();
+            let max = self.max_output_size;
+            tokio::spawn(async move {
+                Self::read_stream_to_bytes(stream, stdout, max).await;
+            })
+        });
+        let mut stderr_task = child.stderr.take().map(|stream| {
+            let stderr = stderr.clone();
+            let max = self.max_output_size;
+            tokio::spawn(async move {
+                Self::read_stream_to_bytes(stream, stderr, max).await;
+            })
+        });
+
+        let wait_result =
+            tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), child.wait()).await;
+
+        match wait_result {
+            Ok(Ok(status)) => {
+                tokio::time::sleep(std::time::Duration::from_millis(FOREGROUND_DRAIN_GRACE_MS))
+                    .await;
+                if let Some(handle) = stdout_task.take() {
+                    Self::finish_or_abort_reader(handle).await;
+                }
+                if let Some(handle) = stderr_task.take() {
+                    Self::finish_or_abort_reader(handle).await;
+                }
+                Ok(CommandOutput {
+                    exit_code: status.code().unwrap_or(-1),
+                    stdout: Self::decode_output(&stdout),
+                    stderr: Self::decode_output(&stderr),
+                })
+            }
+            Ok(Err(e)) => Err(AgentError::Io(format!(
+                "Failed to wait for {spawn_label}: {e}"
+            ))),
+            Err(_) => {
+                terminate_child_process(&mut child).await;
+                if let Some(handle) = stdout_task.take() {
+                    Self::finish_or_abort_reader(handle).await;
+                }
+                if let Some(handle) = stderr_task.take() {
+                    Self::finish_or_abort_reader(handle).await;
+                }
+                Err(AgentError::Timeout(format!(
+                    "{timeout_label} timed out after {timeout_secs} seconds"
+                )))
+            }
+        }
+    }
+
     fn terminate_pid(pid: u32) -> Result<(), AgentError> {
         #[cfg(unix)]
         {
@@ -198,6 +326,46 @@ impl LocalBackend {
             }
         }
     }
+}
+
+#[cfg(unix)]
+fn configure_foreground_process_group(cmd: &mut TokioCommand) {
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_foreground_process_group(_cmd: &mut TokioCommand) {}
+
+#[cfg(unix)]
+async fn terminate_child_process(child: &mut tokio::process::Child) {
+    if let Some(pid) = child.id() {
+        let pgid = -(pid as i32);
+        unsafe {
+            libc::kill(pgid, libc::SIGTERM);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) | Err(_) => unsafe {
+                libc::kill(pgid, libc::SIGKILL);
+            },
+        }
+    }
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+#[cfg(not(unix))]
+async fn terminate_child_process(child: &mut tokio::process::Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -533,6 +701,155 @@ else printf '%s\n' \"Hermes could not find bash or zsh in PATH. Run 'exec zsh -l
     }
 }
 
+fn rewrite_compound_background(command: &str) -> String {
+    let mut out = String::with_capacity(command.len());
+    for line in command.split_inclusive('\n') {
+        let (body, newline) = line
+            .strip_suffix('\n')
+            .map(|body| (body, "\n"))
+            .unwrap_or((line, ""));
+        out.push_str(&rewrite_compound_background_line(body));
+        out.push_str(newline);
+    }
+    out
+}
+
+fn rewrite_compound_background_line(line: &str) -> String {
+    if line.trim_start().starts_with('#') {
+        return line.to_string();
+    }
+    let Some(amp_idx) = trailing_background_ampersand(line) else {
+        return line.to_string();
+    };
+    let Some(op) = last_top_level_chain_operator(line, amp_idx) else {
+        return line.to_string();
+    };
+
+    let mut tail_start = op.end;
+    while tail_start < amp_idx {
+        let Some(ch) = line[tail_start..amp_idx].chars().next() else {
+            break;
+        };
+        if !ch.is_whitespace() {
+            break;
+        }
+        tail_start += ch.len_utf8();
+    }
+    if line[tail_start..amp_idx].trim().is_empty() {
+        return line.to_string();
+    }
+
+    let mut rewritten = String::with_capacity(line.len() + 4);
+    rewritten.push_str(&line[..tail_start]);
+    rewritten.push_str("{ ");
+    rewritten.push_str(&line[tail_start..=amp_idx]);
+    rewritten.push_str(" }");
+    rewritten.push_str(&line[amp_idx + 1..]);
+    rewritten
+}
+
+#[derive(Clone, Copy)]
+struct ChainOperator {
+    end: usize,
+}
+
+fn trailing_background_ampersand(line: &str) -> Option<usize> {
+    let mut idx = line.len();
+    while idx > 0 {
+        let (prev, ch) = line[..idx].char_indices().next_back()?;
+        if !ch.is_whitespace() {
+            idx = prev;
+            break;
+        }
+        idx = prev;
+    }
+    if line[idx..].chars().next()? != '&' || is_escaped(line, idx) {
+        return None;
+    }
+    if idx > 0 && line[..idx].ends_with('&') {
+        return None;
+    }
+    Some(idx)
+}
+
+fn is_escaped(input: &str, idx: usize) -> bool {
+    let mut count = 0usize;
+    let mut pos = idx;
+    while pos > 0 {
+        let Some((prev, ch)) = input[..pos].char_indices().next_back() else {
+            break;
+        };
+        if ch != '\\' {
+            break;
+        }
+        count += 1;
+        pos = prev;
+    }
+    count % 2 == 1
+}
+
+fn last_top_level_chain_operator(line: &str, stop: usize) -> Option<ChainOperator> {
+    let mut last = None;
+    let mut single = false;
+    let mut double = false;
+    let mut paren_depth = 0usize;
+    let mut command_sub_depth = 0usize;
+    let mut iter = line[..stop].char_indices().peekable();
+
+    while let Some((idx, ch)) = iter.next() {
+        if is_escaped(line, idx) {
+            continue;
+        }
+        if single {
+            if ch == '\'' {
+                single = false;
+            }
+            continue;
+        }
+        if double {
+            if ch == '"' {
+                double = false;
+                continue;
+            }
+            if ch == '$' && iter.peek().is_some_and(|(_, next)| *next == '(') {
+                command_sub_depth += 1;
+                iter.next();
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' => single = true,
+            '"' => double = true,
+            '$' if iter.peek().is_some_and(|(_, next)| *next == '(') => {
+                command_sub_depth += 1;
+                iter.next();
+            }
+            '(' if command_sub_depth == 0 => paren_depth += 1,
+            ')' if command_sub_depth > 0 => command_sub_depth -= 1,
+            ')' if paren_depth > 0 => paren_depth -= 1,
+            ';' if paren_depth == 0 && command_sub_depth == 0 => last = None,
+            '|' if paren_depth == 0 && command_sub_depth == 0 => {
+                if iter.peek().is_some_and(|(_, next)| *next == '|') {
+                    iter.next();
+                    last = Some(ChainOperator { end: idx + 2 });
+                } else {
+                    last = None;
+                }
+            }
+            '&' if paren_depth == 0
+                && command_sub_depth == 0
+                && iter.peek().is_some_and(|(_, next)| *next == '&') =>
+            {
+                iter.next();
+                last = Some(ChainOperator { end: idx + 2 });
+            }
+            _ => {}
+        }
+    }
+    last
+}
+
 impl Default for LocalBackend {
     fn default() -> Self {
         Self::new(120, 1_048_576)
@@ -550,7 +867,8 @@ impl TerminalBackend for LocalBackend {
         pty: bool,
     ) -> Result<CommandOutput, AgentError> {
         let timeout_secs = timeout.unwrap_or(self.default_timeout);
-        let command_with_profiles = with_login_profile_sources(command);
+        let rewritten_command = rewrite_compound_background(command);
+        let command_with_profiles = with_login_profile_sources(&rewritten_command);
 
         if pty && !background {
             // PTY mode: allocate a pseudo-terminal for interactive commands.
@@ -574,37 +892,15 @@ impl TerminalBackend for LocalBackend {
                     pty_cmd.current_dir(resolve_path(dir)?);
                 }
 
-                let result =
-                    tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
-                        let output = pty_cmd.output().await.map_err(|e| {
-                            AgentError::Io(format!("Failed to spawn PTY command: {}", e))
-                        })?;
-                        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                        Ok(CommandOutput {
-                            exit_code: output.status.code().unwrap_or(-1),
-                            stdout: if stdout.len() > self.max_output_size {
-                                stdout[..self.max_output_size].to_string()
-                            } else {
-                                stdout
-                            },
-                            stderr: if stderr.len() > self.max_output_size {
-                                stderr[..self.max_output_size].to_string()
-                            } else {
-                                stderr
-                            },
-                        })
-                    })
+                return self
+                    .collect_foreground_child(
+                        pty_cmd,
+                        timeout_secs,
+                        None,
+                        "PTY command",
+                        "PTY command",
+                    )
                     .await;
-
-                return match result {
-                    Ok(Ok(output)) => Ok(output),
-                    Ok(Err(e)) => Err(e),
-                    Err(_) => Err(AgentError::Timeout(format!(
-                        "PTY command timed out after {} seconds",
-                        timeout_secs
-                    ))),
-                };
             }
 
             #[cfg(not(unix))]
@@ -652,110 +948,78 @@ impl TerminalBackend for LocalBackend {
             cmd.stdin(Stdio::null());
         }
 
+        if !background {
+            return self
+                .collect_foreground_child(cmd, timeout_secs, None, "command", "Command")
+                .await;
+        }
+
         let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
             let mut child = cmd
                 .spawn()
                 .map_err(|e| AgentError::Io(format!("Failed to spawn command: {}", e)))?;
 
-            // In background mode, track the process session and return immediately.
-            if background {
-                let session_id = Self::next_process_session_id();
-                let pid = child.id();
-                let output = Arc::new(Mutex::new(String::new()));
-                let status = Arc::new(Mutex::new(ProcessStatus::default()));
-                let stdin = Arc::new(AsyncMutex::new(child.stdin.take()));
-                let max_output_chars = self.max_process_output_chars();
-                let session = ProcessSession {
-                    id: session_id.clone(),
-                    command: command.to_string(),
-                    pid,
-                    started_at: Self::now_unix_ts(),
-                    status: status.clone(),
-                    output: output.clone(),
-                    stdin,
-                };
-                self.background_processes
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .insert(session_id.clone(), session);
+            let session_id = Self::next_process_session_id();
+            let pid = child.id();
+            let output = Arc::new(Mutex::new(String::new()));
+            let status = Arc::new(Mutex::new(ProcessStatus::default()));
+            let stdin = Arc::new(AsyncMutex::new(child.stdin.take()));
+            let max_output_chars = self.max_process_output_chars();
+            let session = ProcessSession {
+                id: session_id.clone(),
+                command: rewritten_command.clone(),
+                pid,
+                started_at: Self::now_unix_ts(),
+                status: status.clone(),
+                output: output.clone(),
+                stdin,
+            };
+            self.background_processes
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(session_id.clone(), session);
 
-                if let Some(stdout) = child.stdout.take() {
-                    let output = output.clone();
-                    tokio::spawn(async move {
-                        Self::read_stream_to_buffer(stdout, output, max_output_chars).await;
-                    });
-                }
-                if let Some(stderr) = child.stderr.take() {
-                    let output = output.clone();
-                    tokio::spawn(async move {
-                        Self::read_stream_to_buffer(stderr, output, max_output_chars).await;
-                    });
-                }
-
+            if let Some(stdout) = child.stdout.take() {
+                let output = output.clone();
                 tokio::spawn(async move {
-                    match child.wait().await {
-                        Ok(exit) => {
-                            let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
-                            guard.exited = true;
-                            guard.exit_code = exit.code();
-                        }
-                        Err(err) => {
-                            let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
-                            guard.exited = true;
-                            guard.exit_code = Some(-1);
-                            let note = format!("\n[wait error: {err}]");
-                            Self::append_output(&output, &note, max_output_chars);
-                        }
-                    }
+                    Self::read_stream_to_buffer(stdout, output, max_output_chars).await;
                 });
-
-                let started = json!({
-                    "output": "Background process started",
-                    "session_id": session_id,
-                    "pid": pid,
-                    "exit_code": 0,
-                    "error": Value::Null
-                });
-                return Ok(CommandOutput {
-                    exit_code: 0,
-                    stdout: started.to_string(),
-                    stderr: String::new(),
+            }
+            if let Some(stderr) = child.stderr.take() {
+                let output = output.clone();
+                tokio::spawn(async move {
+                    Self::read_stream_to_buffer(stderr, output, max_output_chars).await;
                 });
             }
 
-            let output = child
-                .wait_with_output()
-                .await
-                .map_err(|e| AgentError::Io(format!("Failed to wait for command: {}", e)))?;
+            tokio::spawn(async move {
+                match child.wait().await {
+                    Ok(exit) => {
+                        let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
+                        guard.exited = true;
+                        guard.exit_code = exit.code();
+                    }
+                    Err(err) => {
+                        let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
+                        guard.exited = true;
+                        guard.exit_code = Some(-1);
+                        let note = format!("\n[wait error: {err}]");
+                        Self::append_output(&output, &note, max_output_chars);
+                    }
+                }
+            });
 
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-            // Truncate output if it exceeds max_output_size
-            let stdout = if stdout.len() > self.max_output_size {
-                tracing::warn!(
-                    "Command output exceeded max size ({} bytes), truncating",
-                    stdout.len()
-                );
-                stdout[..self.max_output_size].to_string()
-            } else {
-                stdout
-            };
-
-            let stderr = if stderr.len() > self.max_output_size {
-                tracing::warn!(
-                    "Command stderr exceeded max size ({} bytes), truncating",
-                    stderr.len()
-                );
-                stderr[..self.max_output_size].to_string()
-            } else {
-                stderr
-            };
-
+            let started = json!({
+                "output": "Background process started",
+                "session_id": session_id,
+                "pid": pid,
+                "exit_code": 0,
+                "error": Value::Null
+            });
             Ok(CommandOutput {
-                exit_code: output.status.code().unwrap_or(-1),
-                stdout,
-                stderr,
+                exit_code: 0,
+                stdout: started.to_string(),
+                stderr: String::new(),
             })
         })
         .await;
@@ -784,7 +1048,8 @@ impl TerminalBackend for LocalBackend {
                 .execute_command(command, timeout, workdir, background, pty)
                 .await;
         };
-        let command_with_profiles = with_login_profile_sources(command);
+        let rewritten_command = rewrite_compound_background(command);
+        let command_with_profiles = with_login_profile_sources(&rewritten_command);
 
         if background {
             let started = self
@@ -824,49 +1089,15 @@ impl TerminalBackend for LocalBackend {
                     pty_cmd.current_dir(resolve_path(dir)?);
                 }
 
-                let result =
-                    tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
-                        let mut child = pty_cmd.spawn().map_err(|e| {
-                            AgentError::Io(format!("Failed to spawn PTY command: {}", e))
-                        })?;
-                        if let Some(mut stdin) = child.stdin.take() {
-                            stdin.write_all(stdin_owned.as_bytes()).await.map_err(|e| {
-                                AgentError::Io(format!("Failed to write PTY stdin: {e}"))
-                            })?;
-                            stdin.flush().await.map_err(|e| {
-                                AgentError::Io(format!("Failed to flush PTY stdin: {e}"))
-                            })?;
-                        }
-
-                        let output = child.wait_with_output().await.map_err(|e| {
-                            AgentError::Io(format!("Failed to wait for PTY command: {}", e))
-                        })?;
-                        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                        Ok(CommandOutput {
-                            exit_code: output.status.code().unwrap_or(-1),
-                            stdout: if stdout.len() > self.max_output_size {
-                                stdout[..self.max_output_size].to_string()
-                            } else {
-                                stdout
-                            },
-                            stderr: if stderr.len() > self.max_output_size {
-                                stderr[..self.max_output_size].to_string()
-                            } else {
-                                stderr
-                            },
-                        })
-                    })
+                return self
+                    .collect_foreground_child(
+                        pty_cmd,
+                        timeout_secs,
+                        Some(stdin_owned.as_bytes().to_vec()),
+                        "PTY command",
+                        "PTY command",
+                    )
                     .await;
-
-                return match result {
-                    Ok(Ok(output)) => Ok(output),
-                    Ok(Err(e)) => Err(e),
-                    Err(_) => Err(AgentError::Timeout(format!(
-                        "PTY command timed out after {} seconds",
-                        timeout_secs
-                    ))),
-                };
             }
 
             #[cfg(not(unix))]
@@ -888,51 +1119,14 @@ impl TerminalBackend for LocalBackend {
             cmd.current_dir(resolve_path(dir)?);
         }
 
-        let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
-            let mut child = cmd
-                .spawn()
-                .map_err(|e| AgentError::Io(format!("Failed to spawn command: {}", e)))?;
-            if let Some(mut stdin) = child.stdin.take() {
-                stdin
-                    .write_all(stdin_owned.as_bytes())
-                    .await
-                    .map_err(|e| AgentError::Io(format!("Failed to write stdin: {e}")))?;
-                stdin
-                    .flush()
-                    .await
-                    .map_err(|e| AgentError::Io(format!("Failed to flush stdin: {e}")))?;
-            }
-
-            let output = child
-                .wait_with_output()
-                .await
-                .map_err(|e| AgentError::Io(format!("Failed to wait for command: {}", e)))?;
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            Ok(CommandOutput {
-                exit_code: output.status.code().unwrap_or(-1),
-                stdout: if stdout.len() > self.max_output_size {
-                    stdout[..self.max_output_size].to_string()
-                } else {
-                    stdout
-                },
-                stderr: if stderr.len() > self.max_output_size {
-                    stderr[..self.max_output_size].to_string()
-                } else {
-                    stderr
-                },
-            })
-        })
-        .await;
-
-        match result {
-            Ok(Ok(output)) => Ok(output),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(AgentError::Timeout(format!(
-                "Command timed out after {} seconds",
-                timeout_secs
-            ))),
-        }
+        self.collect_foreground_child(
+            cmd,
+            timeout_secs,
+            Some(stdin_owned.into_bytes()),
+            "command",
+            "Command",
+        )
+        .await
     }
 
     async fn read_file(
@@ -1293,6 +1487,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_rewrite_compound_background_contract() {
+        assert_eq!(rewrite_compound_background("A && B &"), "A && { B & }");
+        assert_eq!(rewrite_compound_background("A || B &"), "A || { B & }");
+        assert_eq!(
+            rewrite_compound_background("A && B && C &"),
+            "A && B && { C & }"
+        );
+        assert_eq!(
+            rewrite_compound_background("cd /tmp && server &\nsleep 1"),
+            "cd /tmp && { server & }\nsleep 1"
+        );
+        assert_eq!(rewrite_compound_background("sleep 5 &"), "sleep 5 &");
+        assert_eq!(rewrite_compound_background("A && B | C &"), "A && B | C &");
+        assert_eq!(
+            rewrite_compound_background("A && B &>/dev/null &"),
+            "A && { B &>/dev/null & }"
+        );
+        assert_eq!(
+            rewrite_compound_background("echo 'A && B &'"),
+            "echo 'A && B &'"
+        );
+        assert_eq!(
+            rewrite_compound_background("   A && B &"),
+            "   A && { B & }"
+        );
+        let once = rewrite_compound_background("A && B &");
+        assert_eq!(rewrite_compound_background(&once), once);
+    }
+
     #[cfg(not(unix))]
     #[test]
     fn test_with_login_profile_sources_is_passthrough_off_unix() {
@@ -1344,6 +1568,73 @@ mod tests {
             Err(AgentError::Timeout(_)) => {}
             _ => panic!("Expected timeout error"),
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_plain_shell_background_child_does_not_hang_foreground_collection() {
+        let backend = LocalBackend::new(10, 1_048_576);
+        let marker = "hermes_bg_nohang_marker";
+        let probe = "hermes_bg_nohang_probe";
+        let command = format!("python3 -c 'import time; time.sleep(60)' {probe} & echo {marker}");
+        let started = std::time::Instant::now();
+        let output = backend
+            .execute_command(&command, Some(5), None, false, false)
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", probe])
+            .status();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "foreground collection hung for {elapsed:?}"
+        );
+        assert_eq!(output.exit_code, 0);
+        assert!(output.stdout.contains(marker), "stdout={:?}", output.stdout);
+    }
+
+    #[tokio::test]
+    async fn test_foreground_collection_preserves_multibyte_utf8_boundaries() {
+        let backend = LocalBackend::new(10, 100_000);
+        let command = "python3 -c 'import sys; sys.stdout.buffer.write(chr(0x65e5).encode(\"utf-8\") * 10000); sys.stdout.buffer.write(b\"\\n\")'";
+        let output = backend
+            .execute_command(command, Some(10), None, false, false)
+            .await
+            .unwrap();
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout.matches('\u{65e5}').count(), 10_000);
+        assert!(!output.stdout.contains("binary output detected"));
+    }
+
+    #[tokio::test]
+    async fn test_foreground_collection_preserves_high_volume_line_output() {
+        let backend = LocalBackend::new(10, 1_048_576);
+        let output = backend
+            .execute_command("seq 1 3000", Some(10), None, false, false)
+            .await
+            .unwrap();
+        let lines = output.stdout.trim().split('\n').collect::<Vec<_>>();
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(lines.len(), 3000);
+        assert_eq!(lines.first().copied(), Some("1"));
+        assert_eq!(lines.last().copied(), Some("3000"));
+    }
+
+    #[tokio::test]
+    async fn test_foreground_collection_replaces_invalid_utf8() {
+        let backend = LocalBackend::new(10, 1_048_576);
+        let command = "python3 -c 'import sys; sys.stdout.buffer.write(b\"before \"); sys.stdout.buffer.write(b\"\\xff\\xfe\"); sys.stdout.buffer.write(b\" after\\n\")'";
+        let output = backend
+            .execute_command(command, Some(5), None, false, false)
+            .await
+            .unwrap();
+        assert_eq!(output.exit_code, 0);
+        assert!(output.stdout.contains("before"));
+        assert!(output.stdout.contains("after"));
+        assert!(output.stdout.contains('\u{fffd}'));
+        assert!(!output.stdout.contains("binary output detected"));
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -12,6 +12,101 @@ use hermes_core::{
 
 use crate::approval::{ApprovalDecision, ApprovalManager};
 
+const DEFAULT_FOREGROUND_MAX_TIMEOUT_SECS: u64 = 600;
+
+fn foreground_max_timeout_secs() -> u64 {
+    std::env::var("TERMINAL_MAX_FOREGROUND_TIMEOUT")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_FOREGROUND_MAX_TIMEOUT_SECS)
+}
+
+fn has_unquoted_trailing_background_operator(command: &str) -> bool {
+    let mut idx = command.len();
+    while idx > 0 {
+        let Some((prev, ch)) = command[..idx].char_indices().next_back() else {
+            return false;
+        };
+        if !ch.is_whitespace() {
+            idx = prev;
+            break;
+        }
+        idx = prev;
+    }
+    if !command[idx..].starts_with('&') {
+        return false;
+    }
+    let mut slash_count = 0usize;
+    let mut pos = idx;
+    while pos > 0 {
+        let Some((prev, ch)) = command[..pos].char_indices().next_back() else {
+            break;
+        };
+        if ch != '\\' {
+            break;
+        }
+        slash_count += 1;
+        pos = prev;
+    }
+    slash_count.is_multiple_of(2)
+}
+
+fn foreground_background_wrapper_error(command: &str) -> Option<String> {
+    let lower = command.trim().to_ascii_lowercase();
+    let padded = format!(" {lower} ");
+    if has_unquoted_trailing_background_operator(command) {
+        return Some(
+            "Foreground command uses '&' shell backgrounding. Use terminal(background=true) so Hermes can track lifecycle and output.".to_string(),
+        );
+    }
+    if lower.starts_with("nohup ") || padded.contains(" nohup ") {
+        return Some(
+            "Foreground command uses nohup. Use terminal(background=true) instead of shell-level background wrappers.".to_string(),
+        );
+    }
+    if lower.starts_with("setsid ") || padded.contains(" setsid ") || padded.contains(" disown ") {
+        return Some(
+            "Foreground command uses setsid/disown. Use terminal(background=true) so Hermes can manage the process.".to_string(),
+        );
+    }
+    None
+}
+
+fn is_help_variant(command: &str) -> bool {
+    command
+        .split_ascii_whitespace()
+        .any(|part| matches!(part, "--help" | "-h" | "help"))
+}
+
+fn long_lived_foreground_error(command: &str) -> Option<String> {
+    if is_help_variant(command) {
+        return None;
+    }
+    let lower = command.trim().to_ascii_lowercase();
+    let padded = format!(" {lower} ");
+    let long_lived = [
+        " pnpm dev ",
+        " npm run dev ",
+        " yarn dev ",
+        " bun dev ",
+        " next dev ",
+        " vite ",
+        " webpack serve ",
+        " cargo watch ",
+        " python -m http.server ",
+        " python3 -m http.server ",
+        " uvicorn ",
+        " gunicorn ",
+    ]
+    .iter()
+    .any(|needle| padded.contains(needle));
+
+    long_lived.then(|| {
+        "This foreground command appears to start a long-lived server/watch process. Run it with background=true, then verify readiness with logs or a health check.".to_string()
+    })
+}
+
 // ---------------------------------------------------------------------------
 // TerminalHandler
 // ---------------------------------------------------------------------------
@@ -39,6 +134,28 @@ impl ToolHandler for TerminalHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'command' parameter".into()))?;
 
+        let timeout = params.get("timeout").and_then(|v| v.as_u64());
+        let background = params
+            .get("background")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !background {
+            if let Some(timeout) = timeout {
+                let max_timeout = foreground_max_timeout_secs();
+                if timeout > max_timeout {
+                    return Err(ToolError::ExecutionFailed(format!(
+                        "Foreground timeout {timeout}s exceeds max {max_timeout}s. Use background=true with process polling for longer commands."
+                    )));
+                }
+            }
+            if let Some(error) = foreground_background_wrapper_error(command) {
+                return Err(ToolError::ExecutionFailed(error));
+            }
+            if let Some(error) = long_lived_foreground_error(command) {
+                return Err(ToolError::ExecutionFailed(error));
+            }
+        }
+
         match self.approval.check_approval_from_env(command, "local") {
             ApprovalDecision::Denied => {
                 return Err(ToolError::ExecutionFailed(format!(
@@ -58,14 +175,7 @@ impl ToolHandler for TerminalHandler {
             ApprovalDecision::Approved => {}
         }
 
-        let timeout = params.get("timeout").and_then(|v| v.as_u64());
-
         let workdir = params.get("workdir").and_then(|v| v.as_str());
-
-        let background = params
-            .get("background")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
 
         let pty = params.get("pty").and_then(|v| v.as_bool()).unwrap_or(false);
         let stdin_data = params.get("stdin_data").and_then(|v| v.as_str());
@@ -102,7 +212,10 @@ impl ToolHandler for TerminalHandler {
             "timeout".into(),
             json!({
                 "type": "integer",
-                "description": "Timeout in milliseconds (default: 30000)"
+                "description": format!(
+                    "Timeout in seconds. Foreground commands above {}s are rejected; use background=true for longer jobs.",
+                    foreground_max_timeout_secs()
+                )
             }),
         );
         props.insert(
@@ -624,6 +737,18 @@ mod tests {
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let schema = handler.schema();
         assert_eq!(schema.name, "terminal");
+        let timeout_desc = schema
+            .parameters
+            .properties
+            .as_ref()
+            .expect("properties")
+            .get("timeout")
+            .and_then(Value::as_object)
+            .and_then(|obj| obj.get("description"))
+            .and_then(Value::as_str)
+            .expect("timeout description");
+        assert!(timeout_desc.contains("600s"));
+        assert!(timeout_desc.contains("background=true"));
     }
 
     #[test]
@@ -635,6 +760,84 @@ mod tests {
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let result = block_on(handler.execute(json!({"command": "echo hello"}))).unwrap();
         assert!(result.contains("echo hello"));
+    }
+
+    #[test]
+    fn test_terminal_handler_rejects_foreground_timeout_above_cap() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _max = EnvGuard::remove("TERMINAL_MAX_FOREGROUND_TIMEOUT");
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let err = block_on(handler.execute(json!({"command": "echo hello", "timeout": 9999})))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("9999s"));
+        assert!(msg.contains("600s"));
+        assert!(msg.contains("background=true"));
+    }
+
+    #[test]
+    fn test_terminal_handler_allows_background_timeout_above_cap() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _max = EnvGuard::remove("TERMINAL_MAX_FOREGROUND_TIMEOUT");
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let result = block_on(handler.execute(json!({
+            "command": "python server.py",
+            "background": true,
+            "timeout": 9999
+        })))
+        .unwrap();
+        assert!(result.contains("python server.py"));
+    }
+
+    #[test]
+    fn test_terminal_handler_rejects_shell_background_wrappers_in_foreground() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let err = block_on(handler.execute(json!({
+            "command": "nohup pnpm dev > /tmp/hermes-server.log 2>&1 &"
+        })))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("background=true"));
+        assert!(msg.to_ascii_lowercase().contains("background"));
+    }
+
+    #[test]
+    fn test_terminal_handler_rejects_long_lived_server_foreground() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let err = block_on(handler.execute(json!({"command": "pnpm dev"}))).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.to_ascii_lowercase().contains("long-lived"));
+        assert!(msg.contains("background=true"));
+    }
+
+    #[test]
+    fn test_terminal_handler_allows_help_variant_for_server_command() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let result = block_on(handler.execute(json!({"command": "pnpm dev --help"}))).unwrap();
+        assert!(result.contains("pnpm dev --help"));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T08:35:59.713404+00:00",
+  "generated_at_utc": "2026-06-01T09:57:47.763225+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T08:35:59.713404+00:00`
+Generated: `2026-06-01T09:57:47.763225+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -10681,16 +10681,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_local_background_child_hang.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a8cc0ba10244af946728a8f9035c548ab5be8b46",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_local_background_child_hang.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "2ed8c575c6959081994cfcec543e66f13e4b81a1",
       "workstream": "WS6"
@@ -11416,16 +11416,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_terminal_compound_background.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d8922bcf556ef6a36577f24bd4d3cf65ca35bf9c",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_terminal_compound_background.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "eeef435772e89d11595f046ae672d11e63561ad6",
       "workstream": "WS6"
@@ -11446,16 +11446,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_terminal_foreground_timeout_cap.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "54848f62924f233064bbc865b099edc68d2abd5b",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_terminal_foreground_timeout_cap.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0e9893cbad1e17cd57085573bfccfcb66a2ddfac",
       "workstream": "WS6"
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T08:35:59.575987+00:00",
+  "generated_at_utc": "2026-06-01T09:57:47.646784+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "b2132f6a0205f9631057500bd7e84a9cacd7ec9c",
+    "local_sha": "3426dedeb5201b6f68a87efa22db5f2b1801f8d1",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 584,
-      "intentional_divergence": 283,
+      "functional": 581,
+      "intentional_divergence": 286,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 455,
-      "rust_equivalent_or_contract_test_required": 499,
+      "not_required_for_runtime": 458,
+      "rust_equivalent_or_contract_test_required": 496,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 283,
+      "cleared_intentional_divergence": 286,
       "cleared_non_runtime": 172,
-      "pending_review": 584
+      "pending_review": 581
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 283,
+    "cleared_intentional_divergence": 286,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 584,
+    "pending_review": 581,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T08:35:59.575987+00:00`
+Generated: `2026-06-01T09:57:47.646784+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `584`
+- Pending functional review: `581`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `283`
+- Cleared intentional divergence: `286`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 283 |
+| `cleared_intentional_divergence` | 286 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 584 |
+| `pending_review` | 581 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-06-01T08:35:59.575987+00:00`
 | --- | ---: |
 | `tests/hermes_cli` | 117 |
 | `tests/gateway` | 113 |
-| `tests/tools` | 83 |
+| `tests/tools` | 80 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1739,6 +1739,27 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_local_background_child_hang.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream local background-child pipe-hang intent is covered by Rust LocalBackend foreground collector contracts for shell-background child prompt return, high-volume output, timeout behavior, multibyte and invalid UTF-8 preservation, and process-group timeout cleanup.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_terminal_compound_background.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream compound-background rewrite intent is covered by Rust LocalBackend rewrite_compound_background contracts for &&/|| chains, redirects, quoting, idempotence, newlines, pipes, and simple-background passthrough.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_terminal_foreground_timeout_cap.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream foreground timeout cap and background-wrapper/server guard intent is covered by Rust TerminalHandler contracts for explicit >600s foreground rejection, background exemption, schema hint, nohup/& wrapper rejection, long-lived server detection, and help passthrough.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/tools/test_url_safety.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream URL safety/SSRF intent is covered by Rust hermes-tools url_safety contracts for http/https-only parsing, DNS fail-closed behavior, private/reserved IPv4 and IPv6 blocking including CGNAT, benchmark, multicast, and IPv4-mapped IPv6 ranges, metadata hostname/IP always-blocking, allow_private_urls toggle semantics, and the exact QQ multimedia benchmark-IP exception.",


### PR DESCRIPTION
## Summary
- harden Rust terminal foreground execution against shell-background pipe hangs
- add foreground timeout/background-wrapper/server guardrails to the terminal tool surface
- add compound-background rewrite coverage and byte-based foreground output collection that preserves UTF-8 boundaries
- update parity ledgers for three cleared WS6 terminal/local upstream test intents

## Cleared parity paths
- `tests/tools/test_terminal_foreground_timeout_cap.py`
- `tests/tools/test_terminal_compound_background.py`
- `tests/tools/test_local_background_child_hang.py`

## Verification
- `cargo fmt --all --check`
- `cargo test -p hermes-environments --all-features -- --nocapture`
- `cargo test -p hermes-tools --all-features terminal_handler -- --nocapture`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, existing stale=3)
- `cargo build --workspace`
- `cargo test --workspace --quiet` (`workspace_test_exit=0`)

## Ledger
- `pending_review`: 584 -> 581
