### PR TITLE
parity(terminal): bridge config requirements

### DIFF
--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -675,6 +675,56 @@ where
     deserializer.deserialize_any(BoolishVisitor)
 }
 
+fn deserialize_string_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringListVisitor;
+
+    impl<'de> Visitor<'de> for StringListVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a string, comma-separated string, or list of strings")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            Ok(value
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToString::to_string)
+                .collect())
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            self.visit_str(&value)
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut values = Vec::new();
+            while let Some(value) = seq.next_element::<String>()? {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    values.push(trimmed.to_string());
+                }
+            }
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_any(StringListVisitor)
+}
+
 fn default_tools() -> Vec<String> {
     vec![
         "bash".into(),
@@ -851,11 +901,25 @@ impl Default for TerminalBackendType {
     }
 }
 
+impl TerminalBackendType {
+    pub fn from_env_name(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "local" => Some(Self::Local),
+            "docker" => Some(Self::Docker),
+            "ssh" => Some(Self::Ssh),
+            "daytona" => Some(Self::Daytona),
+            "modal" => Some(Self::Modal),
+            "singularity" | "apptainer" => Some(Self::Singularity),
+            _ => None,
+        }
+    }
+}
+
 /// Configuration for terminal/command-execution backends.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TerminalConfig {
     /// Which backend type to use.
-    #[serde(default)]
+    #[serde(default, alias = "env_type")]
     pub backend: TerminalBackendType,
 
     /// Timeout in seconds for a single command.
@@ -867,7 +931,7 @@ pub struct TerminalConfig {
     pub max_output_size: usize,
 
     /// Working directory override for command execution.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "cwd")]
     pub workdir: Option<String>,
 
     /// Docker container id/name to reuse instead of creating a new one.
@@ -882,9 +946,68 @@ pub struct TerminalConfig {
     #[serde(default, skip_serializing_if = "is_false")]
     pub docker_mount_cwd_to_workspace: bool,
 
+    /// Run Docker containers as the host uid/gid where supported.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub docker_run_as_host_user: bool,
+
+    /// Docker container CPU limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_cpu: Option<u32>,
+
+    /// Docker/container memory limit in MiB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_memory: Option<u64>,
+
+    /// Docker/container disk limit in MiB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_disk: Option<u64>,
+
+    /// Whether container-backed terminal sessions should persist.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub container_persistent: bool,
+
+    /// Extra env-vars for Docker/container execution, kept as a portable string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_env: Option<String>,
+
+    /// Host env-var names to forward into Docker/container execution.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub docker_forward_env: Vec<String>,
+
+    /// Extra Docker volume specs.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub docker_volumes: Vec<String>,
+
     /// Runtime name for Vercel-backed terminal execution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vercel_runtime: Option<String>,
+
+    /// Modal backend selection mode: auto, direct, or managed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modal_mode: Option<String>,
+
+    /// Explicit shell init files to source before local commands.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub shell_init_files: Vec<String>,
+
+    /// Auto-source common shell startup files when no explicit list is set.
+    #[serde(
+        default = "default_auto_source_bashrc",
+        skip_serializing_if = "is_true"
+    )]
+    pub auto_source_bashrc: bool,
 
     /// SSH backend host.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -913,7 +1036,18 @@ impl Default for TerminalConfig {
             docker_container_id: None,
             docker_image: None,
             docker_mount_cwd_to_workspace: false,
+            docker_run_as_host_user: false,
+            container_cpu: None,
+            container_memory: None,
+            container_disk: None,
+            container_persistent: false,
+            docker_env: None,
+            docker_forward_env: Vec::new(),
+            docker_volumes: Vec::new(),
             vercel_runtime: None,
+            modal_mode: None,
+            shell_init_files: Vec::new(),
+            auto_source_bashrc: default_auto_source_bashrc(),
             ssh_host: None,
             ssh_port: None,
             ssh_user: None,
@@ -926,8 +1060,16 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+fn is_true(value: &bool) -> bool {
+    *value
+}
+
 fn default_terminal_timeout() -> u64 {
     120
+}
+
+fn default_auto_source_bashrc() -> bool {
+    true
 }
 
 fn default_max_output_size() -> usize {

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -7,7 +7,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 // Re-export ConfigError for convenience
 pub use hermes_core::ConfigError;
 
-use crate::config::{GatewayConfig, LlmProviderConfig, ProxyConfig};
+use crate::config::{
+    GatewayConfig, LlmProviderConfig, ProxyConfig, TerminalBackendType, TerminalConfig,
+};
 use crate::merge::merge_configs;
 use crate::paths;
 use crate::platform::PlatformConfig;
@@ -305,6 +307,8 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
             }
         }
     }
+
+    bridge_terminal_config_to_env(&config.terminal);
 
     // Layer 3: environment variables (highest priority)
     apply_env_overrides(&mut config);
@@ -1061,14 +1065,56 @@ fn config_key_routes_to_env(key: &str) -> Option<String> {
     }
 }
 
+pub fn terminal_config_env_bridge_pairs() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("backend", "TERMINAL_ENV"),
+        ("env_type", "TERMINAL_ENV"),
+        ("workdir", "TERMINAL_CWD"),
+        ("cwd", "TERMINAL_CWD"),
+        ("timeout", "TERMINAL_TIMEOUT"),
+        ("max_output_size", "TERMINAL_MAX_OUTPUT_SIZE"),
+        ("docker_container_id", "TERMINAL_DOCKER_CONTAINER_ID"),
+        ("docker_image", "TERMINAL_DOCKER_IMAGE"),
+        (
+            "docker_mount_cwd_to_workspace",
+            "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+        ),
+        (
+            "docker_run_as_host_user",
+            "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+        ),
+        ("container_cpu", "TERMINAL_CONTAINER_CPU"),
+        ("container_memory", "TERMINAL_CONTAINER_MEMORY"),
+        ("container_disk", "TERMINAL_CONTAINER_DISK"),
+        ("container_persistent", "TERMINAL_CONTAINER_PERSISTENT"),
+        ("docker_env", "TERMINAL_DOCKER_ENV"),
+        ("docker_forward_env", "TERMINAL_DOCKER_FORWARD_ENV"),
+        ("docker_volumes", "TERMINAL_DOCKER_VOLUMES"),
+        ("vercel_runtime", "TERMINAL_VERCEL_RUNTIME"),
+        ("modal_mode", "TERMINAL_MODAL_MODE"),
+        ("shell_init_files", "TERMINAL_SHELL_INIT_FILES"),
+        ("auto_source_bashrc", "TERMINAL_AUTO_SOURCE_BASHRC"),
+        ("ssh_host", "TERMINAL_SSH_HOST"),
+        ("ssh_port", "TERMINAL_SSH_PORT"),
+        ("ssh_user", "TERMINAL_SSH_USER"),
+        ("ssh_key_path", "TERMINAL_SSH_KEY_PATH"),
+    ]
+}
+
+pub fn terminal_config_env_bridge_key(key: &str) -> Option<&'static str> {
+    let normalized = key
+        .trim()
+        .strip_prefix("terminal.")
+        .unwrap_or_else(|| key.trim())
+        .replace('-', "_")
+        .to_ascii_lowercase();
+    terminal_config_env_bridge_pairs()
+        .iter()
+        .find_map(|(config_key, env_key)| (*config_key == normalized).then_some(*env_key))
+}
+
 fn config_env_bridge_key(key: &str) -> Option<String> {
-    match key.trim().replace('-', "_").to_ascii_lowercase().as_str() {
-        "terminal.docker_mount_cwd_to_workspace" => {
-            Some("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE".to_string())
-        }
-        "terminal.vercel_runtime" => Some("TERMINAL_VERCEL_RUNTIME".to_string()),
-        _ => None,
-    }
+    terminal_config_env_bridge_key(key).map(ToString::to_string)
 }
 
 fn split_config_key(key: &str) -> Vec<String> {
@@ -1233,6 +1279,273 @@ pub fn load_from_json(path: &Path) -> Result<GatewayConfig, ConfigError> {
     Ok(config)
 }
 
+fn env_var_nonempty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn parse_bool_env(name: &str, value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => {
+            tracing::warn!("{name} is not a valid bool-like value: {value}");
+            None
+        }
+    }
+}
+
+fn parse_list_env(value: &str, split_colon: bool) -> Vec<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    if trimmed.starts_with('[') {
+        if let Ok(values) = serde_json::from_str::<Vec<String>>(trimmed) {
+            return values
+                .into_iter()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect();
+        }
+    }
+    let delimiter = if trimmed.contains(',') || !split_colon {
+        ','
+    } else {
+        ':'
+    };
+    trimmed
+        .split(delimiter)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn set_env_if_missing(name: &str, value: String) {
+    if value.trim().is_empty() || env_var_nonempty(name).is_some() {
+        return;
+    }
+    // SAFETY: configuration loading runs during CLI/gateway startup.
+    unsafe { std::env::set_var(name, value) };
+}
+
+fn bridge_terminal_config_to_env(terminal: &TerminalConfig) {
+    let default = TerminalConfig::default();
+    if terminal.backend != default.backend {
+        set_env_if_missing(
+            "TERMINAL_ENV",
+            match terminal.backend {
+                TerminalBackendType::Local => "local",
+                TerminalBackendType::Docker => "docker",
+                TerminalBackendType::Ssh => "ssh",
+                TerminalBackendType::Daytona => "daytona",
+                TerminalBackendType::Modal => "modal",
+                TerminalBackendType::Singularity => "singularity",
+            }
+            .to_string(),
+        );
+    }
+    if terminal.timeout != default.timeout {
+        set_env_if_missing("TERMINAL_TIMEOUT", terminal.timeout.to_string());
+    }
+    if terminal.max_output_size != default.max_output_size {
+        set_env_if_missing(
+            "TERMINAL_MAX_OUTPUT_SIZE",
+            terminal.max_output_size.to_string(),
+        );
+    }
+    if let Some(value) = &terminal.workdir {
+        set_env_if_missing("TERMINAL_CWD", value.clone());
+    }
+    if let Some(value) = &terminal.docker_container_id {
+        set_env_if_missing("TERMINAL_DOCKER_CONTAINER_ID", value.clone());
+    }
+    if let Some(value) = &terminal.docker_image {
+        set_env_if_missing("TERMINAL_DOCKER_IMAGE", value.clone());
+    }
+    if terminal.docker_mount_cwd_to_workspace != default.docker_mount_cwd_to_workspace {
+        set_env_if_missing(
+            "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+            terminal.docker_mount_cwd_to_workspace.to_string(),
+        );
+    }
+    if terminal.docker_run_as_host_user != default.docker_run_as_host_user {
+        set_env_if_missing(
+            "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+            terminal.docker_run_as_host_user.to_string(),
+        );
+    }
+    if let Some(value) = terminal.container_cpu {
+        set_env_if_missing("TERMINAL_CONTAINER_CPU", value.to_string());
+    }
+    if let Some(value) = terminal.container_memory {
+        set_env_if_missing("TERMINAL_CONTAINER_MEMORY", value.to_string());
+    }
+    if let Some(value) = terminal.container_disk {
+        set_env_if_missing("TERMINAL_CONTAINER_DISK", value.to_string());
+    }
+    if terminal.container_persistent != default.container_persistent {
+        set_env_if_missing(
+            "TERMINAL_CONTAINER_PERSISTENT",
+            terminal.container_persistent.to_string(),
+        );
+    }
+    if let Some(value) = &terminal.docker_env {
+        set_env_if_missing("TERMINAL_DOCKER_ENV", value.clone());
+    }
+    if !terminal.docker_forward_env.is_empty() {
+        set_env_if_missing(
+            "TERMINAL_DOCKER_FORWARD_ENV",
+            terminal.docker_forward_env.join(","),
+        );
+    }
+    if !terminal.docker_volumes.is_empty() {
+        set_env_if_missing("TERMINAL_DOCKER_VOLUMES", terminal.docker_volumes.join(","));
+    }
+    if let Some(value) = &terminal.vercel_runtime {
+        set_env_if_missing("TERMINAL_VERCEL_RUNTIME", value.clone());
+    }
+    if let Some(value) = &terminal.modal_mode {
+        set_env_if_missing("TERMINAL_MODAL_MODE", value.clone());
+    }
+    if !terminal.shell_init_files.is_empty() {
+        set_env_if_missing(
+            "TERMINAL_SHELL_INIT_FILES",
+            terminal.shell_init_files.join(","),
+        );
+    }
+    if terminal.auto_source_bashrc != default.auto_source_bashrc {
+        set_env_if_missing(
+            "TERMINAL_AUTO_SOURCE_BASHRC",
+            terminal.auto_source_bashrc.to_string(),
+        );
+    }
+    if let Some(value) = &terminal.ssh_host {
+        set_env_if_missing("TERMINAL_SSH_HOST", value.clone());
+    }
+    if let Some(value) = terminal.ssh_port {
+        set_env_if_missing("TERMINAL_SSH_PORT", value.to_string());
+    }
+    if let Some(value) = &terminal.ssh_user {
+        set_env_if_missing("TERMINAL_SSH_USER", value.clone());
+    }
+    if let Some(value) = &terminal.ssh_key_path {
+        set_env_if_missing("TERMINAL_SSH_KEY_PATH", value.clone());
+    }
+}
+
+fn apply_terminal_env_overrides(config: &mut TerminalConfig) {
+    if let Some(v) =
+        env_var_nonempty("TERMINAL_ENV").or_else(|| env_var_nonempty("TERMINAL_BACKEND"))
+    {
+        match TerminalBackendType::from_env_name(&v) {
+            Some(backend) => config.backend = backend,
+            None => tracing::warn!("Unknown TERMINAL_ENV '{v}'"),
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_TIMEOUT") {
+        if let Ok(n) = v.parse::<u64>() {
+            config.timeout = n;
+        } else {
+            tracing::warn!("TERMINAL_TIMEOUT is not a valid u64: {v}");
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_MAX_OUTPUT_SIZE") {
+        if let Ok(n) = v.parse::<usize>() {
+            config.max_output_size = n;
+        } else {
+            tracing::warn!("TERMINAL_MAX_OUTPUT_SIZE is not a valid usize: {v}");
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_CWD") {
+        config.workdir = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_CONTAINER_ID") {
+        config.docker_container_id = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_IMAGE") {
+        config.docker_image = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE")
+        .and_then(|v| parse_bool_env("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", &v))
+    {
+        config.docker_mount_cwd_to_workspace = v;
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_RUN_AS_HOST_USER")
+        .and_then(|v| parse_bool_env("TERMINAL_DOCKER_RUN_AS_HOST_USER", &v))
+    {
+        config.docker_run_as_host_user = v;
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_CONTAINER_CPU") {
+        if let Ok(n) = v.parse::<u32>() {
+            config.container_cpu = Some(n);
+        } else {
+            tracing::warn!("TERMINAL_CONTAINER_CPU is not a valid u32: {v}");
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_CONTAINER_MEMORY") {
+        if let Ok(n) = v.parse::<u64>() {
+            config.container_memory = Some(n);
+        } else {
+            tracing::warn!("TERMINAL_CONTAINER_MEMORY is not a valid u64: {v}");
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_CONTAINER_DISK") {
+        if let Ok(n) = v.parse::<u64>() {
+            config.container_disk = Some(n);
+        } else {
+            tracing::warn!("TERMINAL_CONTAINER_DISK is not a valid u64: {v}");
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_CONTAINER_PERSISTENT")
+        .and_then(|v| parse_bool_env("TERMINAL_CONTAINER_PERSISTENT", &v))
+    {
+        config.container_persistent = v;
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_ENV") {
+        config.docker_env = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_FORWARD_ENV") {
+        config.docker_forward_env = parse_list_env(&v, false);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_DOCKER_VOLUMES") {
+        config.docker_volumes = parse_list_env(&v, false);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_VERCEL_RUNTIME") {
+        config.vercel_runtime = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_MODAL_MODE") {
+        config.modal_mode = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_SHELL_INIT_FILES") {
+        config.shell_init_files = parse_list_env(&v, true);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_AUTO_SOURCE_BASHRC")
+        .and_then(|v| parse_bool_env("TERMINAL_AUTO_SOURCE_BASHRC", &v))
+    {
+        config.auto_source_bashrc = v;
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_SSH_HOST") {
+        config.ssh_host = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_SSH_PORT") {
+        if let Ok(n) = v.parse::<u16>() {
+            config.ssh_port = Some(n);
+        } else {
+            tracing::warn!("TERMINAL_SSH_PORT is not a valid u16: {v}");
+        }
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_SSH_USER") {
+        config.ssh_user = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("TERMINAL_SSH_KEY_PATH") {
+        config.ssh_key_path = Some(v);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // apply_env_overrides
 // ---------------------------------------------------------------------------
@@ -1265,6 +1578,8 @@ pub fn load_from_json(path: &Path) -> Result<GatewayConfig, ConfigError> {
 /// 另见 [`crate::python_platform_env::apply_python_named_platform_env`]：
 /// `WEIXIN_*`、`DINGTALK_*` 等与 Python `gateway/platforms/*.py` 一致的键写入 `platforms`。
 pub fn apply_env_overrides(config: &mut GatewayConfig) {
+    apply_terminal_env_overrides(&mut config.terminal);
+
     if let Ok(v) = std::env::var("HERMES_MODEL") {
         config.model = Some(v);
     }
@@ -1472,6 +1787,15 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_terminal_env_bridge_vars() {
+        for (_, env_key) in terminal_config_env_bridge_pairs() {
+            // SAFETY: tests serialize env mutation with ENV_LOCK.
+            unsafe { std::env::remove_var(env_key) };
+        }
+        // SAFETY: tests serialize env mutation with ENV_LOCK.
+        unsafe { std::env::remove_var("TERMINAL_BACKEND") };
+    }
 
     #[test]
     fn validate_valid_config() {
@@ -1704,6 +2028,7 @@ llm_providers:
         use tempfile::tempdir;
 
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_terminal_env_bridge_vars();
         let dir = tempdir().unwrap();
         let result =
             set_user_config_value(dir.path(), "terminal.vercel_runtime", "python3.13").unwrap();
@@ -1718,6 +2043,120 @@ llm_providers:
 
         // SAFETY: test process serializes env mutation via ENV_LOCK.
         unsafe { std::env::remove_var("TERMINAL_VERCEL_RUNTIME") };
+    }
+
+    #[test]
+    fn terminal_config_bridge_map_covers_critical_writable_keys() {
+        let keys = terminal_config_env_bridge_pairs()
+            .iter()
+            .map(|(key, _)| *key)
+            .collect::<std::collections::HashSet<_>>();
+        for key in [
+            "backend",
+            "docker_run_as_host_user",
+            "docker_mount_cwd_to_workspace",
+            "docker_env",
+            "docker_image",
+            "container_cpu",
+            "container_memory",
+            "container_disk",
+            "container_persistent",
+            "shell_init_files",
+            "auto_source_bashrc",
+            "vercel_runtime",
+            "modal_mode",
+        ] {
+            assert!(keys.contains(key), "missing terminal bridge key: {key}");
+            assert!(
+                terminal_config_env_bridge_key(&format!("terminal.{key}")).is_some(),
+                "terminal.{key} should map to an env var"
+            );
+        }
+    }
+
+    #[test]
+    fn set_user_config_value_bridges_all_terminal_runtime_keys() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_terminal_env_bridge_vars();
+        let dir = tempdir().unwrap();
+        for (key, value, env_key) in [
+            (
+                "terminal.docker_run_as_host_user",
+                "true",
+                "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+            ),
+            (
+                "terminal.docker_mount_cwd_to_workspace",
+                "true",
+                "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+            ),
+            ("terminal.docker_env", "FOO=bar", "TERMINAL_DOCKER_ENV"),
+            (
+                "terminal.shell_init_files",
+                "~/custom.sh",
+                "TERMINAL_SHELL_INIT_FILES",
+            ),
+            (
+                "terminal.auto_source_bashrc",
+                "false",
+                "TERMINAL_AUTO_SOURCE_BASHRC",
+            ),
+        ] {
+            let result = set_user_config_value(dir.path(), key, value).unwrap();
+            assert!(result.wrote_config(), "{key} should write config");
+            assert!(result.wrote_env(), "{key} should write env");
+            assert_eq!(result.env_key.as_deref(), Some(env_key));
+        }
+        let env_text = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(env_text.contains("TERMINAL_DOCKER_RUN_AS_HOST_USER=true"));
+        assert!(env_text.contains("TERMINAL_DOCKER_ENV=FOO=bar"));
+        assert!(env_text.contains("TERMINAL_AUTO_SOURCE_BASHRC=false"));
+        clear_terminal_env_bridge_vars();
+    }
+
+    #[test]
+    fn load_config_bridges_terminal_yaml_to_env_without_overriding_existing_env() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_terminal_env_bridge_vars();
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+terminal:
+  backend: docker
+  docker_image: rust:1.90
+  docker_env: FOO=bar
+  docker_mount_cwd_to_workspace: true
+  shell_init_files: "~/custom.sh"
+  auto_source_bashrc: false
+"#,
+        )
+        .unwrap();
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::set_var("TERMINAL_DOCKER_IMAGE", "already-set") };
+
+        let cfg = load_config(Some(dir.path().to_string_lossy().as_ref())).unwrap();
+        assert_eq!(cfg.terminal.backend, TerminalBackendType::Docker);
+        assert_eq!(cfg.terminal.docker_image.as_deref(), Some("already-set"));
+        assert_eq!(std::env::var("TERMINAL_ENV").unwrap(), "docker");
+        assert_eq!(
+            std::env::var("TERMINAL_DOCKER_IMAGE").unwrap(),
+            "already-set"
+        );
+        assert_eq!(std::env::var("TERMINAL_DOCKER_ENV").unwrap(), "FOO=bar");
+        assert_eq!(
+            std::env::var("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE").unwrap(),
+            "true"
+        );
+        assert_eq!(
+            std::env::var("TERMINAL_AUTO_SOURCE_BASHRC").unwrap(),
+            "false"
+        );
+        clear_terminal_env_bridge_vars();
     }
 
     #[test]

--- a/crates/hermes-environments/src/docker.rs
+++ b/crates/hermes-environments/src/docker.rs
@@ -15,6 +15,22 @@ pub struct DockerBackend {
     image: Option<String>,
     /// Mount the host cwd at /workspace when creating a container.
     mount_cwd_to_workspace: bool,
+    /// Run the container as the host uid/gid when supported.
+    run_as_host_user: bool,
+    /// CPU limit for newly-created containers.
+    container_cpu: Option<u32>,
+    /// Memory limit in MiB for newly-created containers.
+    container_memory: Option<u64>,
+    /// Disk limit in MiB for newly-created containers.
+    container_disk: Option<u64>,
+    /// Keep container after it stops.
+    container_persistent: bool,
+    /// Extra env vars to pass to Docker as KEY=VALUE entries.
+    docker_env: Option<String>,
+    /// Host env-var names to forward.
+    docker_forward_env: Vec<String>,
+    /// Extra Docker volume specs.
+    docker_volumes: Vec<String>,
     /// Default timeout in seconds.
     default_timeout: u64,
     /// Maximum output size in bytes.
@@ -32,6 +48,14 @@ impl DockerBackend {
         container_id: Option<String>,
         image: Option<String>,
         mount_cwd_to_workspace: bool,
+        run_as_host_user: bool,
+        container_cpu: Option<u32>,
+        container_memory: Option<u64>,
+        container_disk: Option<u64>,
+        container_persistent: bool,
+        docker_env: Option<String>,
+        docker_forward_env: Vec<String>,
+        docker_volumes: Vec<String>,
         default_timeout: u64,
         max_output_size: usize,
     ) -> Self {
@@ -39,9 +63,83 @@ impl DockerBackend {
             container_id: Mutex::new(container_id),
             image: image.or_else(|| Some("ubuntu:22.04".to_string())),
             mount_cwd_to_workspace,
+            run_as_host_user,
+            container_cpu,
+            container_memory,
+            container_disk,
+            container_persistent,
+            docker_env,
+            docker_forward_env,
+            docker_volumes,
             default_timeout,
             max_output_size,
         }
+    }
+
+    fn docker_env_pairs(&self) -> Vec<String> {
+        self.docker_env
+            .as_deref()
+            .unwrap_or("")
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty() && entry.contains('='))
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    fn build_run_args(&self, image: &str) -> Vec<String> {
+        let mut args = vec!["run".to_string(), "-d".to_string(), "--tty".to_string()];
+        if !self.container_persistent {
+            args.push("--rm".to_string());
+        }
+        if self.run_as_host_user {
+            #[cfg(unix)]
+            {
+                let uid = unsafe { libc::getuid() };
+                let gid = unsafe { libc::getgid() };
+                args.push("--user".to_string());
+                args.push(format!("{uid}:{gid}"));
+            }
+        }
+        if let Some(cpu) = self.container_cpu {
+            args.push("--cpus".to_string());
+            args.push(cpu.to_string());
+        }
+        if let Some(memory) = self.container_memory {
+            args.push("--memory".to_string());
+            args.push(format!("{memory}m"));
+        }
+        if let Some(disk) = self.container_disk {
+            args.push("--storage-opt".to_string());
+            args.push(format!("size={disk}m"));
+        }
+        for env_pair in self.docker_env_pairs() {
+            args.push("-e".to_string());
+            args.push(env_pair);
+        }
+        for env_name in &self.docker_forward_env {
+            if let Ok(value) = std::env::var(env_name) {
+                args.push("-e".to_string());
+                args.push(format!("{env_name}={value}"));
+            }
+        }
+        for volume in &self.docker_volumes {
+            args.push("-v".to_string());
+            args.push(volume.clone());
+        }
+        if self.mount_cwd_to_workspace {
+            if let Ok(cwd) = std::env::current_dir() {
+                args.push("-v".to_string());
+                args.push(format!("{}:/workspace", cwd.display()));
+                args.push("-w".to_string());
+                args.push("/workspace".to_string());
+            }
+        }
+        args.push(image.to_string());
+        args.push("tail".to_string());
+        args.push("-f".to_string());
+        args.push("/dev/null".to_string());
+        args
     }
 
     /// Ensure we have a running container. If `container_id` is None,
@@ -63,19 +161,7 @@ impl DockerBackend {
 
         tracing::info!("Creating Docker container from image: {}", image);
 
-        let mut args = vec!["run".to_string(), "-d".to_string(), "--tty".to_string()];
-        if self.mount_cwd_to_workspace {
-            if let Ok(cwd) = std::env::current_dir() {
-                args.push("-v".to_string());
-                args.push(format!("{}:/workspace", cwd.display()));
-                args.push("-w".to_string());
-                args.push("/workspace".to_string());
-            }
-        }
-        args.push(image.clone());
-        args.push("tail".to_string());
-        args.push("-f".to_string());
-        args.push("/dev/null".to_string());
+        let args = self.build_run_args(image);
 
         let output = TokioCommand::new("docker")
             .args(&args)
@@ -277,6 +363,70 @@ impl TerminalBackend for DockerBackend {
 
         // test -e returns 0 if file exists, 1 otherwise
         Ok(output.status.success())
+    }
+}
+
+#[cfg(test)]
+mod quote_tests {
+    use super::*;
+
+    struct EnvGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(old) = &self.old {
+                std::env::set_var(self.key, old);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    fn build_run_args_include_terminal_config_env_and_resource_flags() {
+        let _forward = EnvGuard::set("HERMES_DOCKER_FORWARD_TEST", "forwarded");
+        let backend = DockerBackend::new(
+            None,
+            Some("rust:1.90".to_string()),
+            false,
+            true,
+            Some(2),
+            Some(4096),
+            Some(51200),
+            true,
+            Some("FOO=bar,BAZ=qux".to_string()),
+            vec!["HERMES_DOCKER_FORWARD_TEST".to_string()],
+            vec!["/host/cache:/cache".to_string()],
+            120,
+            1_048_576,
+        );
+
+        let args = backend.build_run_args("rust:1.90");
+        assert!(args.windows(2).any(|w| w == ["--cpus", "2"]));
+        assert!(args.windows(2).any(|w| w == ["--memory", "4096m"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["--storage-opt", "size=51200m"]));
+        assert!(args.windows(2).any(|w| w == ["-e", "FOO=bar"]));
+        assert!(args.windows(2).any(|w| w == ["-e", "BAZ=qux"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-e", "HERMES_DOCKER_FORWARD_TEST=forwarded"]));
+        assert!(args.windows(2).any(|w| w == ["-v", "/host/cache:/cache"]));
+        assert!(!args.iter().any(|arg| arg == "--rm"));
+        #[cfg(unix)]
+        assert!(args.iter().any(|arg| arg == "--user"));
     }
 }
 

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -15,6 +15,7 @@ use tokio::process::Command as TokioCommand;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
 
+use hermes_config::TerminalConfig;
 use hermes_core::{AgentError, CommandOutput, TerminalBackend};
 
 const PROCESS_OUTPUT_WINDOW_CHARS: usize = 200_000;
@@ -48,6 +49,10 @@ pub struct LocalBackend {
     default_timeout: u64,
     /// Maximum output size in bytes before truncation.
     max_output_size: usize,
+    /// Explicit shell init files for local command prelude.
+    shell_init_files: Vec<String>,
+    /// Auto-source common shell startup files when no explicit list is set.
+    auto_source_bashrc: bool,
     /// Background processes tracked by session id for lifecycle operations.
     background_processes: Arc<Mutex<HashMap<String, ProcessSession>>>,
 }
@@ -55,9 +60,36 @@ pub struct LocalBackend {
 impl LocalBackend {
     /// Create a new local backend with the given defaults.
     pub fn new(default_timeout: u64, max_output_size: usize) -> Self {
+        let (shell_init_files, auto_source_bashrc) = terminal_shell_init_config_from_env();
+        Self::new_with_shell_init(
+            default_timeout,
+            max_output_size,
+            shell_init_files,
+            auto_source_bashrc,
+        )
+    }
+
+    /// Create a local backend directly from terminal configuration.
+    pub fn from_terminal_config(config: &TerminalConfig) -> Self {
+        Self::new_with_shell_init(
+            config.timeout,
+            config.max_output_size,
+            config.shell_init_files.clone(),
+            config.auto_source_bashrc,
+        )
+    }
+
+    pub fn new_with_shell_init(
+        default_timeout: u64,
+        max_output_size: usize,
+        shell_init_files: Vec<String>,
+        auto_source_bashrc: bool,
+    ) -> Self {
         Self {
             default_timeout,
             max_output_size,
+            shell_init_files,
+            auto_source_bashrc,
             background_processes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -223,11 +255,12 @@ impl LocalBackend {
         timeout_label: &str,
     ) -> Result<CommandOutput, AgentError> {
         configure_foreground_process_group(&mut cmd);
-        let mut child = cmd
+        let child = cmd
             .spawn()
             .map_err(|e| AgentError::Io(format!("Failed to spawn {spawn_label}: {e}")))?;
+        let mut child_guard = ForegroundChildGuard::new(child);
         if let Some(payload) = stdin_payload {
-            if let Some(mut stdin) = child.stdin.take() {
+            if let Some(mut stdin) = child_guard.child_mut().stdin.take() {
                 stdin
                     .write_all(&payload)
                     .await
@@ -241,14 +274,14 @@ impl LocalBackend {
 
         let stdout = Arc::new(Mutex::new(Vec::new()));
         let stderr = Arc::new(Mutex::new(Vec::new()));
-        let mut stdout_task = child.stdout.take().map(|stream| {
+        let mut stdout_task = child_guard.child_mut().stdout.take().map(|stream| {
             let stdout = stdout.clone();
             let max = self.max_output_size;
             tokio::spawn(async move {
                 Self::read_stream_to_bytes(stream, stdout, max).await;
             })
         });
-        let mut stderr_task = child.stderr.take().map(|stream| {
+        let mut stderr_task = child_guard.child_mut().stderr.take().map(|stream| {
             let stderr = stderr.clone();
             let max = self.max_output_size;
             tokio::spawn(async move {
@@ -256,8 +289,11 @@ impl LocalBackend {
             })
         });
 
-        let wait_result =
-            tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), child.wait()).await;
+        let wait_result = tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            child_guard.child_mut().wait(),
+        )
+        .await;
 
         match wait_result {
             Ok(Ok(status)) => {
@@ -269,6 +305,7 @@ impl LocalBackend {
                 if let Some(handle) = stderr_task.take() {
                     Self::finish_or_abort_reader(handle).await;
                 }
+                child_guard.disarm();
                 Ok(CommandOutput {
                     exit_code: status.code().unwrap_or(-1),
                     stdout: Self::decode_output(&stdout),
@@ -279,7 +316,8 @@ impl LocalBackend {
                 "Failed to wait for {spawn_label}: {e}"
             ))),
             Err(_) => {
-                terminate_child_process(&mut child).await;
+                terminate_child_process(child_guard.child_mut()).await;
+                child_guard.disarm();
                 if let Some(handle) = stdout_task.take() {
                     Self::finish_or_abort_reader(handle).await;
                 }
@@ -342,6 +380,56 @@ fn configure_foreground_process_group(cmd: &mut TokioCommand) {
 
 #[cfg(not(unix))]
 fn configure_foreground_process_group(_cmd: &mut TokioCommand) {}
+
+struct ForegroundChildGuard {
+    child: Option<tokio::process::Child>,
+    pid: Option<u32>,
+}
+
+impl ForegroundChildGuard {
+    fn new(child: tokio::process::Child) -> Self {
+        let pid = child.id();
+        Self {
+            child: Some(child),
+            pid,
+        }
+    }
+
+    fn child_mut(&mut self) -> &mut tokio::process::Child {
+        self.child.as_mut().expect("foreground child present")
+    }
+
+    fn disarm(&mut self) {
+        self.child.take();
+    }
+}
+
+impl Drop for ForegroundChildGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        terminate_child_process_sync(self.pid);
+        let _ = child.start_kill();
+    }
+}
+
+#[cfg(unix)]
+fn terminate_child_process_sync(pid: Option<u32>) {
+    if let Some(pid) = pid {
+        let pgid = -(pid as i32);
+        unsafe {
+            libc::kill(pgid, libc::SIGTERM);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        unsafe {
+            libc::kill(pgid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_child_process_sync(_pid: Option<u32>) {}
 
 #[cfg(unix)]
 async fn terminate_child_process(child: &mut tokio::process::Child) {
@@ -623,6 +711,151 @@ fn shell_env_cleanup_snippet() -> String {
     snippet
 }
 
+fn parse_shell_init_list(value: &str) -> Vec<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    if trimmed.starts_with('[') {
+        if let Ok(values) = serde_json::from_str::<Vec<String>>(trimmed) {
+            return values
+                .into_iter()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect();
+        }
+    }
+    let delimiter = if trimmed.contains(',') { ',' } else { ':' };
+    trimmed
+        .split(delimiter)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn bool_env_or_default(name: &str, default: bool) -> bool {
+    let Some(value) = std::env::var(name).ok() else {
+        return default;
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        _ => default,
+    }
+}
+
+fn terminal_shell_init_config_from_env() -> (Vec<String>, bool) {
+    let explicit = std::env::var("TERMINAL_SHELL_INIT_FILES")
+        .ok()
+        .map(|v| parse_shell_init_list(&v))
+        .unwrap_or_default();
+    let auto_source_bashrc = bool_env_or_default("TERMINAL_AUTO_SOURCE_BASHRC", true);
+    (explicit, auto_source_bashrc)
+}
+
+fn expand_env_refs(input: &str) -> String {
+    let mut output = String::new();
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        output.push_str(&rest[..start]);
+        let after_open = &rest[start + 2..];
+        let Some(end) = after_open.find('}') else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+        let name = &after_open[..end];
+        if !name.is_empty()
+            && name
+                .bytes()
+                .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
+        {
+            if let Ok(value) = std::env::var(name) {
+                output.push_str(&value);
+            }
+        } else {
+            output.push_str("${");
+            output.push_str(name);
+            output.push('}');
+        }
+        rest = &after_open[end + 1..];
+    }
+    output.push_str(rest);
+    output
+}
+
+fn expand_shell_init_path(input: &str) -> PathBuf {
+    let expanded = expand_env_refs(input.trim());
+    if expanded == "~" {
+        return home_dir().unwrap_or_else(|| PathBuf::from(expanded));
+    }
+    if let Some(rest) = expanded.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(expanded)
+}
+
+fn resolve_existing_shell_init_files(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    paths.into_iter().filter(|p| p.is_file()).collect()
+}
+
+fn auto_shell_init_candidates(shell: &str) -> Vec<PathBuf> {
+    let Some(home) = home_dir() else {
+        return Vec::new();
+    };
+    match shell {
+        "zsh" => [".zshenv", ".zprofile", ".zshrc", ".profile"]
+            .into_iter()
+            .map(|file| home.join(file))
+            .collect(),
+        _ => [".profile", ".bash_profile", ".bashrc"]
+            .into_iter()
+            .map(|file| home.join(file))
+            .collect(),
+    }
+}
+
+fn resolve_shell_init_files_for_shell(
+    shell: &str,
+    explicit_files: &[String],
+    auto_source_bashrc: bool,
+) -> Vec<PathBuf> {
+    if !explicit_files.is_empty() {
+        return resolve_existing_shell_init_files(
+            explicit_files
+                .iter()
+                .map(|path| expand_shell_init_path(path.as_str())),
+        );
+    }
+    if !auto_source_bashrc {
+        return Vec::new();
+    }
+    resolve_existing_shell_init_files(auto_shell_init_candidates(shell))
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn shell_source_prelude(files: &[PathBuf]) -> String {
+    let mut prelude = String::new();
+    if files.is_empty() {
+        return prelude;
+    }
+    prelude.push_str("set +e; ");
+    for file in files {
+        let quoted = shell_single_quote(&file.to_string_lossy());
+        prelude.push_str("[ -r ");
+        prelude.push_str(&quoted);
+        prelude.push_str(" ] && . ");
+        prelude.push_str(&quoted);
+        prelude.push_str(" || true; ");
+    }
+    prelude
+}
+
 fn scrub_subprocess_env(cmd: &mut TokioCommand) {
     let mut forced = Vec::new();
     for (key, _) in std::env::vars() {
@@ -657,20 +890,26 @@ fn scrub_subprocess_env(cmd: &mut TokioCommand) {
     cmd.env("PATH", normalized_path);
 }
 
-fn with_login_profile_sources(command: &str) -> String {
+fn with_login_profile_sources(
+    command: &str,
+    explicit_files: &[String],
+    auto_source_bashrc: bool,
+) -> String {
     #[cfg(unix)]
     {
         let cleanup = shell_env_cleanup_snippet();
-        fn shell_single_quote(value: &str) -> String {
-            format!("'{}'", value.replace('\'', "'\\''"))
-        }
-
-        let bash_command = shell_single_quote(&format!(
-            "[ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; [ -f \"$HOME/.bash_profile\" ] && . \"$HOME/.bash_profile\"; {cleanup}{command}"
+        let bash_prelude = shell_source_prelude(&resolve_shell_init_files_for_shell(
+            "bash",
+            explicit_files,
+            auto_source_bashrc,
         ));
-        let zsh_command = shell_single_quote(&format!(
-            "[ -f \"$HOME/.zshenv\" ] && . \"$HOME/.zshenv\"; [ -f \"$HOME/.zprofile\" ] && . \"$HOME/.zprofile\"; [ -f \"$HOME/.zshrc\" ] && . \"$HOME/.zshrc\"; [ -f \"$HOME/.profile\" ] && . \"$HOME/.profile\"; {cleanup}{command}"
+        let zsh_prelude = shell_source_prelude(&resolve_shell_init_files_for_shell(
+            "zsh",
+            explicit_files,
+            auto_source_bashrc,
         ));
+        let bash_command = shell_single_quote(&format!("{bash_prelude}{cleanup}{command}"));
+        let zsh_command = shell_single_quote(&format!("{zsh_prelude}{cleanup}{command}"));
         let preferred_shell = std::env::var("SHELL")
             .ok()
             .and_then(|raw| {
@@ -697,6 +936,8 @@ else printf '%s\n' \"Hermes could not find bash or zsh in PATH. Run 'exec zsh -l
     }
     #[cfg(not(unix))]
     {
+        let _ = explicit_files;
+        let _ = auto_source_bashrc;
         command.to_string()
     }
 }
@@ -868,7 +1109,11 @@ impl TerminalBackend for LocalBackend {
     ) -> Result<CommandOutput, AgentError> {
         let timeout_secs = timeout.unwrap_or(self.default_timeout);
         let rewritten_command = rewrite_compound_background(command);
-        let command_with_profiles = with_login_profile_sources(&rewritten_command);
+        let command_with_profiles = with_login_profile_sources(
+            &rewritten_command,
+            &self.shell_init_files,
+            self.auto_source_bashrc,
+        );
 
         if pty && !background {
             // PTY mode: allocate a pseudo-terminal for interactive commands.
@@ -1049,7 +1294,11 @@ impl TerminalBackend for LocalBackend {
                 .await;
         };
         let rewritten_command = rewrite_compound_background(command);
-        let command_with_profiles = with_login_profile_sources(&rewritten_command);
+        let command_with_profiles = with_login_profile_sources(
+            &rewritten_command,
+            &self.shell_init_files,
+            self.auto_source_bashrc,
+        );
 
         if background {
             let started = self
@@ -1437,6 +1686,33 @@ mod tests {
             .block_on(future)
     }
 
+    #[cfg(unix)]
+    fn pids_for_marker(marker: &str) -> Vec<u32> {
+        let output = std::process::Command::new("ps")
+            .args(["-axo", "pid=,command="])
+            .output()
+            .expect("ps output");
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| line.contains(marker))
+            .filter_map(|line| line.split_whitespace().next()?.parse::<u32>().ok())
+            .collect()
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_marker(marker: &str, present: bool, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            let found = !pids_for_marker(marker).is_empty();
+            if found == present {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        let found = !pids_for_marker(marker).is_empty();
+        found == present
+    }
+
     struct EnvGuard {
         key: &'static str,
         original: Option<OsString>,
@@ -1462,21 +1738,29 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_with_login_profile_sources_prepends_profile_loads() {
-        let wrapped = with_login_profile_sources("echo hi");
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let td = tempdir().unwrap();
+        for file in [".profile", ".bash_profile", ".bashrc", ".zshrc"] {
+            std::fs::write(td.path().join(file), "export HERMES_TEST=1\n").unwrap();
+        }
+        let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
+        let wrapped = with_login_profile_sources("echo hi", &[], true);
         assert!(wrapped.contains("command -v bash"));
         assert!(wrapped.contains("exec bash -lc"));
-        assert!(wrapped.contains(". \"$HOME/.bash_profile\""));
+        assert!(wrapped.contains(".bash_profile"));
+        assert!(wrapped.contains(".bashrc"));
         assert!(wrapped.contains("command -v zsh"));
         assert!(wrapped.contains("exec zsh -lc"));
-        assert!(wrapped.contains(". \"$HOME/.zshrc\""));
+        assert!(wrapped.contains(".zshrc"));
         assert!(wrapped.contains("echo hi"));
     }
 
     #[cfg(unix)]
     #[test]
     fn test_with_login_profile_sources_prefers_user_shell_when_supported() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _shell = EnvGuard::set("SHELL", "/bin/zsh");
-        let wrapped = with_login_profile_sources("echo hi");
+        let wrapped = with_login_profile_sources("echo hi", &[], true);
         let preferred = "if command -v zsh >/dev/null 2>&1; then exec zsh -lc";
         let fallback = "if command -v bash >/dev/null 2>&1; then exec bash -lc";
         let preferred_idx = wrapped.find(preferred).expect("preferred zsh branch");
@@ -1485,6 +1769,73 @@ mod tests {
             preferred_idx < fallback_idx,
             "preferred shell branch should come before fallback"
         );
+    }
+
+    #[test]
+    fn test_resolve_shell_init_files_auto_profile_before_bashrc() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let td = tempdir().unwrap();
+        for file in [".profile", ".bash_profile", ".bashrc"] {
+            std::fs::write(td.path().join(file), "export HERMES_TEST=1\n").unwrap();
+        }
+        let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
+
+        let resolved = resolve_shell_init_files_for_shell("bash", &[], true);
+        let names = resolved
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|name| name.to_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(names, [".profile", ".bash_profile", ".bashrc"]);
+    }
+
+    #[test]
+    fn test_resolve_shell_init_files_explicit_list_wins_over_auto() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let td = tempdir().unwrap();
+        std::fs::write(td.path().join(".bashrc"), "export FROM_BASHRC=1\n").unwrap();
+        let custom = td.path().join("custom.sh");
+        std::fs::write(&custom, "export FROM_CUSTOM=1\n").unwrap();
+        let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
+
+        let resolved = resolve_shell_init_files_for_shell(
+            "bash",
+            &[custom.to_string_lossy().to_string()],
+            true,
+        );
+        assert_eq!(resolved, [custom]);
+    }
+
+    #[test]
+    fn test_resolve_shell_init_files_auto_source_off_suppresses_defaults() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let td = tempdir().unwrap();
+        std::fs::write(td.path().join(".bashrc"), "export FROM_BASHRC=1\n").unwrap();
+        let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
+
+        let resolved = resolve_shell_init_files_for_shell("bash", &[], false);
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_shell_init_files_expands_home_and_env_vars() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let td = tempdir().unwrap();
+        let rc_dir = td.path().join("rc");
+        std::fs::create_dir_all(&rc_dir).unwrap();
+        let custom = rc_dir.join("custom.sh");
+        std::fs::write(&custom, "export FROM_CUSTOM=1\n").unwrap();
+        let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
+        let _custom_dir = EnvGuard::set("CUSTOM_RC_DIR", rc_dir.to_string_lossy().as_ref());
+
+        let home_resolved =
+            resolve_shell_init_files_for_shell("bash", &["~/rc/custom.sh".to_string()], false);
+        let env_resolved = resolve_shell_init_files_for_shell(
+            "bash",
+            &["${CUSTOM_RC_DIR}/custom.sh".to_string()],
+            false,
+        );
+        assert_eq!(home_resolved.as_slice(), std::slice::from_ref(&custom));
+        assert_eq!(env_resolved, [custom]);
     }
 
     #[test]
@@ -1520,7 +1871,7 @@ mod tests {
     #[cfg(not(unix))]
     #[test]
     fn test_with_login_profile_sources_is_passthrough_off_unix() {
-        let wrapped = with_login_profile_sources("echo hi");
+        let wrapped = with_login_profile_sources("echo hi", &[], true);
         assert_eq!(wrapped, "echo hi");
     }
 
@@ -1558,6 +1909,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_execute_command_sources_explicit_shell_init_file() {
+        let td = tempdir().unwrap();
+        let init = td.path().join("custom-init.sh");
+        std::fs::write(
+            &init,
+            "export HERMES_SHELL_INIT_PROBE=probe-ok\nexport PATH=\"/opt/shell-init-probe/bin:$PATH\"\n",
+        )
+        .unwrap();
+        let backend = LocalBackend::new_with_shell_init(
+            10,
+            1_048_576,
+            vec![init.to_string_lossy().to_string()],
+            false,
+        );
+
+        let output = backend
+            .execute_command(
+                "printf '%s|%s' \"$HERMES_SHELL_INIT_PROBE\" \"$PATH\"",
+                Some(10),
+                Some(td.path().to_string_lossy().as_ref()),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert!(output.stdout.contains("probe-ok"));
+        assert!(output.stdout.contains("/opt/shell-init-probe/bin"));
+    }
+
+    #[tokio::test]
     async fn test_execute_command_timeout() {
         let backend = LocalBackend::new(1, 1_048_576);
         let result = backend
@@ -1568,6 +1951,34 @@ mod tests {
             Err(AgentError::Timeout(_)) => {}
             _ => panic!("Expected timeout error"),
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_foreground_child_group_is_killed_when_future_is_aborted() {
+        let backend = Arc::new(LocalBackend::new(60, 1_048_576));
+        let marker = format!("hermes_abort_guard_{}", std::process::id());
+        let command = format!("python3 -c 'import time; time.sleep(60)' {marker}");
+        let task = {
+            let backend = backend.clone();
+            tokio::spawn(async move {
+                backend
+                    .execute_command(&command, Some(60), None, false, false)
+                    .await
+            })
+        };
+
+        assert!(
+            wait_for_marker(&marker, true, std::time::Duration::from_secs(5)).await,
+            "test setup failed to observe marker process"
+        );
+        task.abort();
+        let _ = task.await;
+        assert!(
+            wait_for_marker(&marker, false, std::time::Duration::from_secs(5)).await,
+            "foreground process marker survived future cancellation: {:?}",
+            pids_for_marker(&marker)
+        );
     }
 
     #[cfg(unix)]

--- a/crates/hermes-environments/src/manager.rs
+++ b/crates/hermes-environments/src/manager.rs
@@ -49,7 +49,7 @@ impl BackendManager {
     fn create_backend(config: &TerminalConfig) -> (Arc<dyn TerminalBackend>, TerminalBackendType) {
         match config.backend {
             TerminalBackendType::Local => (
-                Arc::new(LocalBackend::new(config.timeout, config.max_output_size)),
+                Arc::new(LocalBackend::from_terminal_config(config)),
                 TerminalBackendType::Local,
             ),
             #[cfg(feature = "docker")]
@@ -58,6 +58,14 @@ impl BackendManager {
                     config.docker_container_id.clone(),
                     config.docker_image.clone(),
                     config.docker_mount_cwd_to_workspace,
+                    config.docker_run_as_host_user,
+                    config.container_cpu,
+                    config.container_memory,
+                    config.container_disk,
+                    config.container_persistent,
+                    config.docker_env.clone(),
+                    config.docker_forward_env.clone(),
+                    config.docker_volumes.clone(),
                     config.timeout,
                     config.max_output_size,
                 )),
@@ -116,7 +124,7 @@ impl BackendManager {
                     config.backend
                 );
                 (
-                    Arc::new(LocalBackend::new(config.timeout, config.max_output_size)),
+                    Arc::new(LocalBackend::from_terminal_config(config)),
                     TerminalBackendType::Local,
                 )
             }

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -16,6 +16,7 @@ pub mod register_builtins;
 pub mod registry;
 pub mod rtk_filter;
 pub mod teams_pipeline;
+pub mod terminal_requirements;
 pub mod tool_policy;
 pub mod tools;
 pub mod toolset;

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -47,6 +47,24 @@ pub fn register_builtin_tools(
             None,
         );
     }
+    fn reg_with_check(
+        registry: &ToolRegistry,
+        toolset: &str,
+        handler: Arc<dyn ToolHandler>,
+        emoji: &str,
+        env_deps: Vec<String>,
+        check_fn: Arc<dyn Fn() -> bool + Send + Sync>,
+    ) {
+        let schema = handler.schema();
+        let name = schema.name.clone();
+        let desc = schema.description.clone();
+        registry.register(
+            name, toolset, schema, handler, check_fn, env_deps, true, desc, emoji, None,
+        );
+    }
+
+    let terminal_requirements_check: Arc<dyn Fn() -> bool + Send + Sync> =
+        Arc::new(crate::terminal_requirements::check_terminal_requirements);
 
     // -- Web tools -----------------------------------------------------------
     reg(
@@ -78,7 +96,7 @@ pub fn register_builtin_tools(
     );
 
     // -- Terminal ------------------------------------------------------------
-    reg(
+    reg_with_check(
         registry,
         "terminal",
         Arc::new(crate::tools::terminal::TerminalHandler::new(
@@ -86,8 +104,9 @@ pub fn register_builtin_tools(
         )),
         "💻",
         vec![],
+        terminal_requirements_check.clone(),
     );
-    reg(
+    reg_with_check(
         registry,
         "terminal",
         Arc::new(crate::tools::terminal::ProcessHandler::new(Arc::new(
@@ -95,10 +114,11 @@ pub fn register_builtin_tools(
         ))),
         "🧵",
         vec![],
+        terminal_requirements_check.clone(),
     );
 
     // -- File tools ----------------------------------------------------------
-    reg(
+    reg_with_check(
         registry,
         "file",
         Arc::new(crate::tools::file::ReadFileHandler::new(
@@ -106,8 +126,9 @@ pub fn register_builtin_tools(
         )),
         "📖",
         vec![],
+        terminal_requirements_check.clone(),
     );
-    reg(
+    reg_with_check(
         registry,
         "file",
         Arc::new(crate::tools::file::WriteFileHandler::new(
@@ -115,6 +136,7 @@ pub fn register_builtin_tools(
         )),
         "✏️",
         vec![],
+        terminal_requirements_check.clone(),
     );
     reg(
         registry,
@@ -534,12 +556,13 @@ pub fn register_builtin_tools(
     );
 
     // -- Process registry ----------------------------------------------------
-    reg(
+    reg_with_check(
         registry,
         "terminal",
         Arc::new(crate::tools::process_registry::ProcessRegistryHandler::default()),
         "📊",
         vec![],
+        terminal_requirements_check,
     );
 
     // -- Transcription -------------------------------------------------------
@@ -638,4 +661,217 @@ fn dirs_home() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use hermes_core::{AgentError, CommandOutput, Skill, SkillMeta};
+    use serde_json::Value;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(value) = &self.original {
+                    std::env::set_var(self.key, value);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    struct MockTerminalBackend;
+
+    #[async_trait]
+    impl TerminalBackend for MockTerminalBackend {
+        async fn execute_command(
+            &self,
+            _command: &str,
+            _timeout: Option<u64>,
+            _workdir: Option<&str>,
+            _background: bool,
+            _pty: bool,
+        ) -> Result<CommandOutput, AgentError> {
+            Ok(CommandOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+
+        async fn read_file(
+            &self,
+            _path: &str,
+            _offset: Option<u64>,
+            _limit: Option<u64>,
+        ) -> Result<String, AgentError> {
+            Ok(String::new())
+        }
+
+        async fn write_file(&self, _path: &str, _content: &str) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn file_exists(&self, _path: &str) -> Result<bool, AgentError> {
+            Ok(false)
+        }
+
+        async fn list_processes(&self) -> Result<Value, AgentError> {
+            Ok(serde_json::json!([]))
+        }
+    }
+
+    struct MockSkillProvider;
+
+    #[async_trait]
+    impl SkillProvider for MockSkillProvider {
+        async fn create_skill(
+            &self,
+            name: &str,
+            content: &str,
+            category: Option<&str>,
+        ) -> Result<Skill, AgentError> {
+            Ok(Skill {
+                name: name.into(),
+                content: content.into(),
+                category: category.map(String::from),
+                description: None,
+            })
+        }
+
+        async fn get_skill(&self, _name: &str) -> Result<Option<Skill>, AgentError> {
+            Ok(None)
+        }
+
+        async fn list_skills(&self) -> Result<Vec<SkillMeta>, AgentError> {
+            Ok(Vec::new())
+        }
+
+        async fn update_skill(&self, name: &str, content: &str) -> Result<Skill, AgentError> {
+            Ok(Skill {
+                name: name.into(),
+                content: content.into(),
+                category: None,
+                description: None,
+            })
+        }
+
+        async fn delete_skill(&self, _name: &str) -> Result<(), AgentError> {
+            Ok(())
+        }
+    }
+
+    fn registered_names() -> Vec<String> {
+        let registry = ToolRegistry::new();
+        register_builtin_tools(
+            &registry,
+            Arc::new(MockTerminalBackend),
+            Arc::new(MockSkillProvider),
+        );
+        let mut names: Vec<String> = registry
+            .get_definitions()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn local_backend_exposes_terminal_and_terminal_backed_file_tools() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", home.path().to_string_lossy().as_ref());
+        let _terminal_env = EnvGuard::set("TERMINAL_ENV", "local");
+        let names = registered_names();
+
+        for expected in [
+            "terminal",
+            "process",
+            "process_registry",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+        ] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "local backend should expose {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_backend_hides_terminal_backed_tools_but_keeps_local_file_tools() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", home.path().to_string_lossy().as_ref());
+        let _terminal_env = EnvGuard::set("TERMINAL_ENV", "unknown-backend");
+        let _ssh_host = EnvGuard::remove("TERMINAL_SSH_HOST");
+        let _ssh_user = EnvGuard::remove("TERMINAL_SSH_USER");
+        let names = registered_names();
+
+        for hidden in [
+            "terminal",
+            "process",
+            "process_registry",
+            "read_file",
+            "write_file",
+        ] {
+            assert!(
+                !names.contains(&hidden.to_string()),
+                "invalid backend should hide {hidden}"
+            );
+        }
+        for independent in ["patch", "search_files", "execute_code"] {
+            assert!(
+                names.contains(&independent.to_string()),
+                "invalid backend should keep independent tool {independent}"
+            );
+        }
+    }
+
+    #[test]
+    fn managed_modal_backend_exposes_terminal_tools_without_direct_modal_credentials() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", home.path().to_string_lossy().as_ref());
+        let _userprofile = EnvGuard::set("USERPROFILE", home.path().to_string_lossy().as_ref());
+        let _terminal_env = EnvGuard::set("TERMINAL_ENV", "modal");
+        let _modal_mode = EnvGuard::set("TERMINAL_MODAL_MODE", "managed");
+        let _modal_id = EnvGuard::remove("MODAL_TOKEN_ID");
+        let _modal_secret = EnvGuard::remove("MODAL_TOKEN_SECRET");
+        let _enabled = EnvGuard::set("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+        let _token = EnvGuard::set("TOOL_GATEWAY_USER_TOKEN", "nous-token");
+        let _domain = EnvGuard::set("TOOL_GATEWAY_DOMAIN", "tools.example.invalid");
+        let names = registered_names();
+
+        assert!(names.contains(&"terminal".to_string()));
+        assert!(names.contains(&"process".to_string()));
+        assert!(names.contains(&"execute_code".to_string()));
+    }
 }

--- a/crates/hermes-tools/src/terminal_requirements.rs
+++ b/crates/hermes-tools/src/terminal_requirements.rs
@@ -1,0 +1,457 @@
+//! Runtime availability checks for terminal-backed tools.
+//!
+//! These checks mirror the upstream terminal requirements gate without making
+//! tool discovery crash or block indefinitely. They are deliberately scoped to
+//! terminal-backed tools; Rust `execute_code` is local and independently gated.
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use hermes_config::managed_gateway::{
+    has_direct_modal_credentials, is_managed_tool_gateway_ready, managed_nous_tools_enabled,
+    resolve_modal_backend_state, ModalMode, ResolveOptions, SelectedBackend,
+};
+
+const REQUIREMENT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUIREMENT_CACHE_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+struct CachedReport {
+    fingerprint: String,
+    checked_at: Instant,
+    report: TerminalRequirementReport,
+}
+
+static REQUIREMENT_CACHE: OnceLock<Mutex<Option<CachedReport>>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalRequirementReport {
+    pub backend: String,
+    pub available: bool,
+    pub reason: Option<String>,
+}
+
+impl TerminalRequirementReport {
+    fn ok(backend: impl Into<String>) -> Self {
+        Self {
+            backend: backend.into(),
+            available: true,
+            reason: None,
+        }
+    }
+
+    fn unavailable(backend: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            backend: backend.into(),
+            available: false,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+pub fn check_terminal_requirements() -> bool {
+    terminal_requirements_report().available
+}
+
+pub fn terminal_requirements_report() -> TerminalRequirementReport {
+    let fingerprint = requirement_fingerprint();
+    let cache = REQUIREMENT_CACHE.get_or_init(|| Mutex::new(None));
+    if let Ok(guard) = cache.lock() {
+        if let Some(cached) = guard.as_ref() {
+            if cached.fingerprint == fingerprint
+                && cached.checked_at.elapsed() < REQUIREMENT_CACHE_TTL
+            {
+                return cached.report.clone();
+            }
+        }
+    }
+
+    let report = terminal_requirements_report_uncached();
+    if let Ok(mut guard) = cache.lock() {
+        *guard = Some(CachedReport {
+            fingerprint,
+            checked_at: Instant::now(),
+            report: report.clone(),
+        });
+    }
+    report
+}
+
+fn terminal_requirements_report_uncached() -> TerminalRequirementReport {
+    let backend = env_nonempty("TERMINAL_ENV")
+        .unwrap_or_else(|| "local".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    match backend.as_str() {
+        "" | "local" => TerminalRequirementReport::ok("local"),
+        "docker" => check_command_backend(
+            "docker",
+            &["docker"],
+            &["version"],
+            "Docker executable not found in PATH or common install locations",
+        ),
+        "singularity" | "apptainer" => check_command_backend(
+            "singularity",
+            &["apptainer", "singularity"],
+            &["--version"],
+            "Apptainer/Singularity executable not found in PATH",
+        ),
+        "ssh" => check_ssh_requirements(),
+        "modal" => check_modal_requirements(),
+        "daytona" => check_daytona_requirements(),
+        "vercel_sandbox" => TerminalRequirementReport::unavailable(
+            "vercel_sandbox",
+            "Vercel Sandbox is not available in the Rust terminal runtime; choose local, docker, ssh, daytona, modal, or singularity.",
+        ),
+        other => TerminalRequirementReport::unavailable(
+            other,
+            format!(
+                "Unknown TERMINAL_ENV '{other}'. Use one of: local, docker, singularity, modal, daytona, ssh."
+            ),
+        ),
+    }
+}
+
+fn requirement_fingerprint() -> String {
+    [
+        "TERMINAL_ENV",
+        "TERMINAL_MODAL_MODE",
+        "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_USER",
+        "DAYTONA_API_KEY",
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
+        "HOME",
+        "USERPROFILE",
+        "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+        "TOOL_GATEWAY_USER_TOKEN",
+        "TOOL_GATEWAY_DOMAIN",
+        "TOOL_GATEWAY_SCHEME",
+        "MODAL_GATEWAY_URL",
+        "PATH",
+        "DOCKER_CONTEXT",
+        "DOCKER_HOST",
+    ]
+    .into_iter()
+    .map(|key| format!("{key}={}", env::var(key).unwrap_or_default()))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn check_command_backend(
+    backend: &str,
+    executable_names: &[&str],
+    probe_args: &[&str],
+    missing_message: &str,
+) -> TerminalRequirementReport {
+    let Some(executable) = find_executable(executable_names) else {
+        return TerminalRequirementReport::unavailable(backend, missing_message);
+    };
+    if command_success_with_timeout(&executable, probe_args, REQUIREMENT_COMMAND_TIMEOUT) {
+        TerminalRequirementReport::ok(backend)
+    } else {
+        TerminalRequirementReport::unavailable(
+            backend,
+            format!(
+                "{} requirement probe failed or timed out: {} {}",
+                backend,
+                executable.display(),
+                probe_args.join(" ")
+            ),
+        )
+    }
+}
+
+fn check_ssh_requirements() -> TerminalRequirementReport {
+    let host = env_nonempty("TERMINAL_SSH_HOST");
+    let user = env_nonempty("TERMINAL_SSH_USER");
+    if host.is_none() || user.is_none() {
+        return TerminalRequirementReport::unavailable(
+            "ssh",
+            "SSH backend selected but TERMINAL_SSH_HOST and TERMINAL_SSH_USER are not both set. Configure both or switch TERMINAL_ENV to 'local'.",
+        );
+    }
+    TerminalRequirementReport::ok("ssh")
+}
+
+fn check_modal_requirements() -> TerminalRequirementReport {
+    let modal_mode = env_nonempty("TERMINAL_MODAL_MODE");
+    let has_direct = has_direct_modal_credentials();
+    let managed_ready = is_managed_tool_gateway_ready("modal", ResolveOptions::default());
+    let state = resolve_modal_backend_state(modal_mode.as_deref(), has_direct, managed_ready);
+
+    match state.selected_backend {
+        Some(SelectedBackend::Managed) => TerminalRequirementReport::ok("modal"),
+        Some(SelectedBackend::Direct) => TerminalRequirementReport::ok("modal"),
+        None if state.managed_mode_blocked => TerminalRequirementReport::unavailable(
+            "modal",
+            "Modal backend selected with TERMINAL_MODAL_MODE=managed, but Nous Tool Gateway access is not currently available and no direct Modal credentials/config were found.",
+        ),
+        None if matches!(state.mode, ModalMode::Managed) => TerminalRequirementReport::unavailable(
+            "modal",
+            "Modal backend selected with TERMINAL_MODAL_MODE=managed, but the managed tool gateway is unavailable.",
+        ),
+        None if matches!(state.mode, ModalMode::Direct) => {
+            let managed_hint = if managed_nous_tools_enabled() {
+                " Configure Modal or choose TERMINAL_MODAL_MODE=managed/auto."
+            } else {
+                " Configure Modal or choose TERMINAL_MODAL_MODE=auto."
+            };
+            TerminalRequirementReport::unavailable(
+                "modal",
+                format!(
+                    "Modal backend selected with TERMINAL_MODAL_MODE=direct, but no direct Modal credentials/config were found.{managed_hint}"
+                ),
+            )
+        }
+        None => {
+            let reason = if managed_nous_tools_enabled() {
+                "Modal backend selected but no direct Modal credentials/config or managed tool gateway was found. Configure Modal, set up the managed gateway, or choose a different TERMINAL_ENV."
+            } else {
+                "Modal backend selected but no direct Modal credentials/config was found. Configure Modal or choose a different TERMINAL_ENV."
+            };
+            TerminalRequirementReport::unavailable("modal", reason)
+        }
+    }
+}
+
+fn check_daytona_requirements() -> TerminalRequirementReport {
+    if env_nonempty("DAYTONA_API_KEY").is_some() {
+        TerminalRequirementReport::ok("daytona")
+    } else {
+        TerminalRequirementReport::unavailable(
+            "daytona",
+            "Daytona backend selected but DAYTONA_API_KEY is not set.",
+        )
+    }
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    env::var(key).ok().filter(|value| !value.trim().is_empty())
+}
+
+fn find_executable(names: &[&str]) -> Option<PathBuf> {
+    for name in names {
+        let candidate = Path::new(name);
+        if candidate.components().count() > 1 && is_executable(candidate) {
+            return Some(candidate.to_path_buf());
+        }
+
+        if let Some(found) = find_on_path(name) {
+            return Some(found);
+        }
+
+        for common in common_executable_locations(name) {
+            if is_executable(&common) {
+                return Some(common);
+            }
+        }
+    }
+    None
+}
+
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    let paths = env::var_os("PATH")?;
+    for dir in env::split_paths(&paths) {
+        let candidate = dir.join(name);
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn common_executable_locations(name: &str) -> Vec<PathBuf> {
+    match name {
+        "docker" => vec![
+            PathBuf::from("/usr/local/bin/docker"),
+            PathBuf::from("/opt/homebrew/bin/docker"),
+            PathBuf::from("/usr/bin/docker"),
+            PathBuf::from("/Applications/Docker.app/Contents/Resources/bin/docker"),
+            PathBuf::from("/Applications/OrbStack.app/Contents/MacOS/docker"),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn command_success_with_timeout(executable: &Path, args: &[&str], timeout: Duration) -> bool {
+    let mut child = match Command::new(executable)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => return false,
+    };
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return false;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return false;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = env::var(key).ok();
+            unsafe { env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = env::var(key).ok();
+            unsafe { env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(value) = &self.original {
+                    env::set_var(self.key, value);
+                } else {
+                    env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    fn clear_terminal_env() -> Vec<EnvGuard> {
+        [
+            "TERMINAL_ENV",
+            "TERMINAL_MODAL_MODE",
+            "TERMINAL_SSH_HOST",
+            "TERMINAL_SSH_USER",
+            "DAYTONA_API_KEY",
+            "MODAL_TOKEN_ID",
+            "MODAL_TOKEN_SECRET",
+            "HOME",
+            "USERPROFILE",
+            "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+            "TOOL_GATEWAY_USER_TOKEN",
+            "TOOL_GATEWAY_DOMAIN",
+            "TOOL_GATEWAY_SCHEME",
+            "MODAL_GATEWAY_URL",
+        ]
+        .into_iter()
+        .map(EnvGuard::remove)
+        .collect()
+    }
+
+    #[test]
+    fn local_terminal_requirements_pass_by_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guards = clear_terminal_env();
+        assert!(check_terminal_requirements());
+    }
+
+    #[test]
+    fn unknown_terminal_env_is_unavailable() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guards = clear_terminal_env();
+        let _env = EnvGuard::set("TERMINAL_ENV", "unknown-backend");
+        let report = terminal_requirements_report();
+        assert!(!report.available);
+        assert!(report
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Unknown TERMINAL_ENV 'unknown-backend'"));
+    }
+
+    #[test]
+    fn ssh_requires_host_and_user() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guards = clear_terminal_env();
+        let _env = EnvGuard::set("TERMINAL_ENV", "ssh");
+        let report = terminal_requirements_report();
+        assert!(!report.available);
+        assert!(report
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("TERMINAL_SSH_HOST and TERMINAL_SSH_USER"));
+
+        let _host = EnvGuard::set("TERMINAL_SSH_HOST", "example.invalid");
+        let _user = EnvGuard::set("TERMINAL_SSH_USER", "hermes");
+        assert!(terminal_requirements_report().available);
+    }
+
+    #[test]
+    fn modal_managed_mode_requires_managed_gateway() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guards = clear_terminal_env();
+        let _env = EnvGuard::set("TERMINAL_ENV", "modal");
+        let _mode = EnvGuard::set("TERMINAL_MODAL_MODE", "managed");
+        let unavailable = terminal_requirements_report();
+        assert!(!unavailable.available);
+
+        let _enabled = EnvGuard::set("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+        let _token = EnvGuard::set("TOOL_GATEWAY_USER_TOKEN", "nous-token");
+        let _domain = EnvGuard::set("TOOL_GATEWAY_DOMAIN", "tools.example.invalid");
+        let available = terminal_requirements_report();
+        assert!(available.available, "{available:?}");
+    }
+
+    #[test]
+    fn modal_direct_mode_requires_direct_credentials() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guards = clear_terminal_env();
+        let _env = EnvGuard::set("TERMINAL_ENV", "modal");
+        let _mode = EnvGuard::set("TERMINAL_MODAL_MODE", "direct");
+        let unavailable = terminal_requirements_report();
+        assert!(!unavailable.available);
+
+        let _id = EnvGuard::set("MODAL_TOKEN_ID", "tok-id");
+        let _secret = EnvGuard::set("MODAL_TOKEN_SECRET", "tok-secret");
+        assert!(terminal_requirements_report().available);
+    }
+
+    #[test]
+    fn vercel_sandbox_is_known_but_not_exposed_without_rust_backend() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guards = clear_terminal_env();
+        let _env = EnvGuard::set("TERMINAL_ENV", "vercel_sandbox");
+        let report = terminal_requirements_report();
+        assert!(!report.available);
+        assert_eq!(report.backend, "vercel_sandbox");
+        assert!(report
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("not available in the Rust terminal runtime"));
+    }
+}

--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::{json, Value};
-use std::sync::OnceLock;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use hermes_core::{
     tool_schema, CommandOutput, JsonSchema, TerminalBackend, ToolError, ToolHandler, ToolSchema,
@@ -113,16 +114,48 @@ fn long_lived_foreground_error(command: &str) -> Option<String> {
 
 /// Tool for executing terminal commands via an injected backend.
 pub struct TerminalHandler {
-    backend: std::sync::Arc<dyn TerminalBackend>,
+    backend: Arc<dyn TerminalBackend>,
     approval: ApprovalManager,
+    task_cwds: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl TerminalHandler {
-    pub fn new(backend: std::sync::Arc<dyn TerminalBackend>) -> Self {
+    pub fn new(backend: Arc<dyn TerminalBackend>) -> Self {
         Self {
             backend,
             approval: ApprovalManager::new(),
+            task_cwds: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    pub fn set_task_cwd(&self, task_id: impl Into<String>, cwd: impl Into<String>) {
+        let task_id = task_id.into();
+        let cwd = cwd.into();
+        if task_id.trim().is_empty() || cwd.trim().is_empty() {
+            return;
+        }
+        self.task_cwds
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(task_id, cwd);
+    }
+
+    pub fn clear_task_cwd(&self, task_id: &str) {
+        self.task_cwds
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(task_id);
+    }
+
+    fn task_cwd(&self, task_id: &str) -> Option<String> {
+        if task_id.trim().is_empty() {
+            return None;
+        }
+        self.task_cwds
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(task_id)
+            .cloned()
     }
 }
 
@@ -175,7 +208,17 @@ impl ToolHandler for TerminalHandler {
             ApprovalDecision::Approved => {}
         }
 
-        let workdir = params.get("workdir").and_then(|v| v.as_str());
+        let explicit_workdir = params.get("workdir").and_then(|v| v.as_str());
+        let task_workdir = explicit_workdir
+            .is_none()
+            .then(|| {
+                params
+                    .get("task_id")
+                    .and_then(|v| v.as_str())
+                    .and_then(|task_id| self.task_cwd(task_id))
+            })
+            .flatten();
+        let workdir = explicit_workdir.or(task_workdir.as_deref());
 
         let pty = params.get("pty").and_then(|v| v.as_bool()).unwrap_or(false);
         let stdin_data = params.get("stdin_data").and_then(|v| v.as_str());
@@ -222,7 +265,14 @@ impl ToolHandler for TerminalHandler {
             "workdir".into(),
             json!({
                 "type": "string",
-                "description": "Working directory for the command"
+                "description": "Working directory for the command. Overrides registered task cwd."
+            }),
+        );
+        props.insert(
+            "task_id".into(),
+            json!({
+                "type": "string",
+                "description": "Optional task/session id used to resolve a registered cwd when workdir is omitted"
             }),
         );
         props.insert(
@@ -680,6 +730,63 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RecordingBackend {
+        calls: Arc<Mutex<Vec<Option<String>>>>,
+    }
+
+    #[async_trait]
+    impl TerminalBackend for RecordingBackend {
+        async fn execute_command(
+            &self,
+            cmd: &str,
+            timeout: Option<u64>,
+            workdir: Option<&str>,
+            background: bool,
+            pty: bool,
+        ) -> Result<CommandOutput, AgentError> {
+            self.execute_command_with_stdin(cmd, timeout, workdir, background, pty, None)
+                .await
+        }
+
+        async fn execute_command_with_stdin(
+            &self,
+            _cmd: &str,
+            _timeout: Option<u64>,
+            workdir: Option<&str>,
+            _background: bool,
+            _pty: bool,
+            _stdin_data: Option<&str>,
+        ) -> Result<CommandOutput, AgentError> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(workdir.map(ToString::to_string));
+            Ok(CommandOutput {
+                exit_code: 0,
+                stdout: "ok".to_string(),
+                stderr: String::new(),
+            })
+        }
+
+        async fn read_file(
+            &self,
+            _path: &str,
+            _offset: Option<u64>,
+            _limit: Option<u64>,
+        ) -> Result<String, AgentError> {
+            Ok(String::new())
+        }
+
+        async fn write_file(&self, _path: &str, _content: &str) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn file_exists(&self, _path: &str) -> Result<bool, AgentError> {
+            Ok(true)
+        }
+    }
+
     struct MockProcessBackend;
 
     #[async_trait]
@@ -760,6 +867,49 @@ mod tests {
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let result = block_on(handler.execute(json!({"command": "echo hello"}))).unwrap();
         assert!(result.contains("echo hello"));
+    }
+
+    #[test]
+    fn test_terminal_handler_uses_registered_task_cwd_when_workdir_omitted() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let backend = Arc::new(RecordingBackend::default());
+        let calls = backend.calls.clone();
+        let handler = TerminalHandler::new(backend);
+        handler.set_task_cwd("acp-session-1", "/workspace/acp");
+
+        block_on(handler.execute(json!({
+            "command": "pwd",
+            "task_id": "acp-session-1"
+        })))
+        .unwrap();
+
+        let calls = calls.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(calls.as_slice(), [Some("/workspace/acp".to_string())]);
+    }
+
+    #[test]
+    fn test_terminal_handler_explicit_workdir_wins_over_task_cwd() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let backend = Arc::new(RecordingBackend::default());
+        let calls = backend.calls.clone();
+        let handler = TerminalHandler::new(backend);
+        handler.set_task_cwd("acp-session-1", "/workspace/acp");
+
+        block_on(handler.execute(json!({
+            "command": "pwd",
+            "task_id": "acp-session-1",
+            "workdir": "/explicit/workdir"
+        })))
+        .unwrap();
+
+        let calls = calls.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(calls.as_slice(), [Some("/explicit/workdir".to_string())]);
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T09:57:47.763225+00:00",
+  "generated_at_utc": "2026-06-01T12:14:44.222759+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T09:57:47.763225+00:00`
+Generated: `2026-06-01T12:14:44.222759+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -10711,31 +10711,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_local_interrupt_cleanup.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a9b74559380283f4c23690f5d10bb248dc779d16",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_local_interrupt_cleanup.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "73b7c76dcb8b27079620fd0ff0f614da61600b05",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_local_shell_init.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "7dabaadf12ae7aeb414feb3a4e60508b4b5edea2",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_local_shell_init.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1bdaeeeb67a3ce6a3489d50ed7fc1fa97c9683d2",
       "workstream": "WS6"
@@ -11431,16 +11431,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_terminal_config_env_sync.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1aecea0cd7c3ae75178d5c3ec5f7aa2822a89f75",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_terminal_config_env_sync.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1613184341711b5c49405d9393ea7ace5e818522",
       "workstream": "WS6"
@@ -11461,46 +11461,46 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_terminal_requirements.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "265fd567fd26a33b23570123d0543b65798224b5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_terminal_requirements.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "a2c1f00e12f26e08d51f66eab4186cf39e59f914",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_terminal_task_cwd.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8c8ff867c361e2133a6b8a7949981cb08f7f92a5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_terminal_task_cwd.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1947836fb47668eb4508a282b491067bf092f0b7",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_terminal_tool_requirements.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "fe22bd26c5b838b7e34cfbe3718f964afba82269",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_terminal_tool_requirements.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8e54a37dd3e06b52e9d0f3d23f05a3f64929115f",
       "workstream": "WS6"
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T09:57:47.646784+00:00",
+  "generated_at_utc": "2026-06-01T11:39:06.826828+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "3426dedeb5201b6f68a87efa22db5f2b1801f8d1",
+    "local_sha": "430b352583e2e38ebb82b7b953fceaf2212ba4f3",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 581,
-      "intentional_divergence": 286,
+      "functional": 575,
+      "intentional_divergence": 292,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 458,
-      "rust_equivalent_or_contract_test_required": 496,
+      "not_required_for_runtime": 464,
+      "rust_equivalent_or_contract_test_required": 490,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 286,
+      "cleared_intentional_divergence": 292,
       "cleared_non_runtime": 172,
-      "pending_review": 581
+      "pending_review": 575
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 286,
+    "cleared_intentional_divergence": 292,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 581,
+    "pending_review": 575,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T09:57:47.646784+00:00`
+Generated: `2026-06-01T11:39:06.826828+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `581`
+- Pending functional review: `575`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `286`
+- Cleared intentional divergence: `292`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 286 |
+| `cleared_intentional_divergence` | 292 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 581 |
+| `pending_review` | 575 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-06-01T09:57:47.646784+00:00`
 | --- | ---: |
 | `tests/hermes_cli` | 117 |
 | `tests/gateway` | 113 |
-| `tests/tools` | 80 |
+| `tests/tools` | 74 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1760,6 +1760,48 @@
       "ticket": 25
     },
     {
+      "path": "tests/tools/test_local_interrupt_cleanup.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream local interrupt-cleanup intent is covered by Rust LocalBackend foreground child ownership: foreground process groups are killed on timeout and when the command future is aborted, with regression coverage proving marker child processes are gone after cancellation.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_local_shell_init.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream local shell init intent is covered by Rust LocalBackend config-driven shell startup sourcing: explicit shell_init_files, auto_source_bashrc disablement, HOME/env expansion, bash/zsh/profile ordering, and an execution test that sources an explicit init file before the command.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_terminal_config_env_sync.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream terminal config/env drift intent is covered by Rust hermes-config central bridge mapping, config-set env sync, YAML-to-env load bridging without overriding existing env, Docker resource/env/volume consumption, and backend manager plumbing for terminal runtime keys.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_terminal_requirements.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream terminal requirements intent is covered by Rust terminal_requirements gates for local, docker, singularity/apptainer, ssh host/user, modal direct/managed selection, daytona API-key presence, and unknown backend rejection; local Vercel Sandbox Python salvage is intentionally not exposed because no Rust terminal backend exists for it.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_terminal_task_cwd.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ACP task cwd intent is covered by Rust TerminalHandler task cwd registration: commands with task_id inherit registered cwd when workdir is omitted, and explicit workdir keeps precedence.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_terminal_tool_requirements.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream tool availability intent is covered by Rust ToolRegistry check_fn gating for terminal-backed tools: local and managed-modal backends expose terminal/process/file tools, invalid terminal backends hide terminal/process/read_file/write_file/process_registry, and Rust execute_code remains independently available as local non-Python execution.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
       "path": "tests/tools/test_url_safety.py",
       "classification": "intentional_divergence",
       "rationale": "Upstream URL safety/SSRF intent is covered by Rust hermes-tools url_safety contracts for http/https-only parsing, DNS fail-closed behavior, private/reserved IPv4 and IPv6 blocking including CGNAT, benchmark, multicast, and IPv4-mapped IPv6 ranges, metadata hostname/IP always-blocking, allow_private_urls toggle semantics, and the exact QQ multimedia benchmark-IP exception.",


### PR DESCRIPTION
## Summary
- bridge terminal config keys to env and env overrides across Rust config loading
- wire local shell init sourcing, abort cleanup, Docker runtime config, task cwd, and terminal requirements gating
- update parity ledger for six tests/tools paths; pending_review is now 575

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci
- scripts/clippy-warning-gate.sh --check (new=0; stale=3 unchanged)
- cargo build --workspace
- cargo test --workspace --quiet