### PR TITLE
parity(web): add free providers and policy

### DIFF
--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -70,6 +70,10 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub terminal: TerminalConfig,
 
+    /// Web search/extract/crawl backend selection.
+    #[serde(default)]
+    pub web: WebConfig,
+
     /// Named LLM provider configurations.
     #[serde(default)]
     pub llm_providers: HashMap<String, LlmProviderConfig>,
@@ -160,6 +164,7 @@ impl Default for GatewayConfig {
             streaming: StreamingConfig::default(),
             display: DisplayConfig::default(),
             terminal: TerminalConfig::default(),
+            web: WebConfig::default(),
             llm_providers: HashMap::new(),
             fallback_model: None,
             fallback_models: Vec::new(),
@@ -1077,6 +1082,30 @@ fn default_max_output_size() -> usize {
 }
 
 // ---------------------------------------------------------------------------
+// WebConfig
+// ---------------------------------------------------------------------------
+
+/// Web backend selection knobs aligned with Python config shape.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct WebConfig {
+    /// Shared legacy backend selector.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub backend: String,
+
+    /// Search-specific backend selector.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub search_backend: String,
+
+    /// Extract-specific backend selector.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub extract_backend: String,
+
+    /// Crawl-specific backend selector.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub crawl_backend: String,
+}
+
+// ---------------------------------------------------------------------------
 // ApprovalConfig
 // ---------------------------------------------------------------------------
 
@@ -1121,14 +1150,35 @@ pub struct SecurityConfig {
     /// RFC1918/CGNAT/benchmark ranges.
     #[serde(default)]
     pub allow_private_urls: bool,
+
+    /// Website/domain blocklist used by web-facing tools.
+    #[serde(default)]
+    pub website_blocklist: WebsiteBlocklistConfig,
 }
 
 impl Default for SecurityConfig {
     fn default() -> Self {
         Self {
             allow_private_urls: false,
+            website_blocklist: WebsiteBlocklistConfig::default(),
         }
     }
+}
+
+/// Website/domain blocklist configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct WebsiteBlocklistConfig {
+    /// Enable domain blocklist enforcement.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Inline blocked domains or wildcard domain patterns.
+    #[serde(default)]
+    pub domains: Vec<String>,
+
+    /// Additional newline-delimited blocklist files.
+    #[serde(default)]
+    pub shared_files: Vec<String>,
 }
 
 /// Skills configuration.
@@ -1434,6 +1484,18 @@ display:
     fn security_config_default() {
         let s = SecurityConfig::default();
         assert!(!s.allow_private_urls);
+        assert!(!s.website_blocklist.enabled);
+        assert!(s.website_blocklist.domains.is_empty());
+        assert!(s.website_blocklist.shared_files.is_empty());
+    }
+
+    #[test]
+    fn web_config_default_matches_upstream_empty_selectors() {
+        let web = WebConfig::default();
+        assert_eq!(web.backend, "");
+        assert_eq!(web.search_backend, "");
+        assert_eq!(web.extract_backend, "");
+        assert_eq!(web.crawl_backend, "");
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -24,7 +24,8 @@ pub use config::{
     ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DisplayConfig, GatewayConfig,
     LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig, ProxyConfig,
     QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
-    SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings,
+    SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings, WebConfig,
+    WebsiteBlocklistConfig,
 };
 pub use loader::{
     apply_user_config_patch, atomic_json_write, atomic_json_write_pretty, atomic_write_bytes,

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub use hermes_core::ConfigError;
 
 use crate::config::{
-    GatewayConfig, LlmProviderConfig, ProxyConfig, TerminalBackendType, TerminalConfig,
+    GatewayConfig, LlmProviderConfig, ProxyConfig, TerminalBackendType, TerminalConfig, WebConfig,
 };
 use crate::merge::merge_configs;
 use crate::paths;
@@ -309,6 +309,7 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
     }
 
     bridge_terminal_config_to_env(&config.terminal);
+    bridge_web_config_to_env(&config.web);
 
     // Layer 3: environment variables (highest priority)
     apply_env_overrides(&mut config);
@@ -501,7 +502,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, llm.<provider>.api_key|api_key_env|base_url|model|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, llm.<provider>.api_key|api_key_env|base_url|model|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -609,6 +610,18 @@ fn apply_user_config_patch_dotted(
                 }
             };
             config.security.allow_private_urls = parsed;
+        }
+        ["web", "backend"] => {
+            config.web.backend = value.trim().to_string();
+        }
+        ["web", "search_backend"] => {
+            config.web.search_backend = value.trim().to_string();
+        }
+        ["web", "extract_backend"] => {
+            config.web.extract_backend = value.trim().to_string();
+        }
+        ["web", "crawl_backend"] => {
+            config.web.crawl_backend = value.trim().to_string();
         }
         ["sessions", "auto_prune"] => {
             let normalized = value.trim().to_ascii_lowercase();
@@ -820,6 +833,26 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
+        ["web", "backend"] => Ok(if config.web.backend.trim().is_empty() {
+            "(not set)".to_string()
+        } else {
+            config.web.backend.clone()
+        }),
+        ["web", "search_backend"] => Ok(if config.web.search_backend.trim().is_empty() {
+            "(not set)".to_string()
+        } else {
+            config.web.search_backend.clone()
+        }),
+        ["web", "extract_backend"] => Ok(if config.web.extract_backend.trim().is_empty() {
+            "(not set)".to_string()
+        } else {
+            config.web.extract_backend.clone()
+        }),
+        ["web", "crawl_backend"] => Ok(if config.web.crawl_backend.trim().is_empty() {
+            "(not set)".to_string()
+        } else {
+            config.web.crawl_backend.clone()
+        }),
         ["sessions", "auto_prune"] => Ok(config.sessions.auto_prune.to_string()),
         ["sessions", "retention_days"] => Ok(config.sessions.retention_days.to_string()),
         ["sessions", "vacuum_after_prune"] => Ok(config.sessions.vacuum_after_prune.to_string()),
@@ -1113,8 +1146,31 @@ pub fn terminal_config_env_bridge_key(key: &str) -> Option<&'static str> {
         .find_map(|(config_key, env_key)| (*config_key == normalized).then_some(*env_key))
 }
 
+pub fn web_config_env_bridge_pairs() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("backend", "HERMES_WEB_BACKEND"),
+        ("search_backend", "HERMES_WEB_SEARCH_BACKEND"),
+        ("extract_backend", "HERMES_WEB_EXTRACT_BACKEND"),
+        ("crawl_backend", "HERMES_WEB_CRAWL_BACKEND"),
+    ]
+}
+
+pub fn web_config_env_bridge_key(key: &str) -> Option<&'static str> {
+    let normalized = key
+        .trim()
+        .strip_prefix("web.")
+        .unwrap_or_else(|| key.trim())
+        .replace('-', "_")
+        .to_ascii_lowercase();
+    web_config_env_bridge_pairs()
+        .iter()
+        .find_map(|(config_key, env_key)| (*config_key == normalized).then_some(*env_key))
+}
+
 fn config_env_bridge_key(key: &str) -> Option<String> {
-    terminal_config_env_bridge_key(key).map(ToString::to_string)
+    terminal_config_env_bridge_key(key)
+        .or_else(|| web_config_env_bridge_key(key))
+        .map(ToString::to_string)
 }
 
 fn split_config_key(key: &str) -> Vec<String> {
@@ -1437,6 +1493,36 @@ fn bridge_terminal_config_to_env(terminal: &TerminalConfig) {
     }
 }
 
+fn bridge_web_config_to_env(web: &WebConfig) {
+    if !web.backend.trim().is_empty() {
+        set_env_if_missing("HERMES_WEB_BACKEND", web.backend.clone());
+    }
+    if !web.search_backend.trim().is_empty() {
+        set_env_if_missing("HERMES_WEB_SEARCH_BACKEND", web.search_backend.clone());
+    }
+    if !web.extract_backend.trim().is_empty() {
+        set_env_if_missing("HERMES_WEB_EXTRACT_BACKEND", web.extract_backend.clone());
+    }
+    if !web.crawl_backend.trim().is_empty() {
+        set_env_if_missing("HERMES_WEB_CRAWL_BACKEND", web.crawl_backend.clone());
+    }
+}
+
+fn apply_web_env_overrides(config: &mut WebConfig) {
+    if let Some(v) = env_var_nonempty("HERMES_WEB_BACKEND") {
+        config.backend = v;
+    }
+    if let Some(v) = env_var_nonempty("HERMES_WEB_SEARCH_BACKEND") {
+        config.search_backend = v;
+    }
+    if let Some(v) = env_var_nonempty("HERMES_WEB_EXTRACT_BACKEND") {
+        config.extract_backend = v;
+    }
+    if let Some(v) = env_var_nonempty("HERMES_WEB_CRAWL_BACKEND") {
+        config.crawl_backend = v;
+    }
+}
+
 fn apply_terminal_env_overrides(config: &mut TerminalConfig) {
     if let Some(v) =
         env_var_nonempty("TERMINAL_ENV").or_else(|| env_var_nonempty("TERMINAL_BACKEND"))
@@ -1579,6 +1665,7 @@ fn apply_terminal_env_overrides(config: &mut TerminalConfig) {
 /// `WEIXIN_*`、`DINGTALK_*` 等与 Python `gateway/platforms/*.py` 一致的键写入 `platforms`。
 pub fn apply_env_overrides(config: &mut GatewayConfig) {
     apply_terminal_env_overrides(&mut config.terminal);
+    apply_web_env_overrides(&mut config.web);
 
     if let Ok(v) = std::env::var("HERMES_MODEL") {
         config.model = Some(v);
@@ -1795,6 +1882,13 @@ mod tests {
         }
         // SAFETY: tests serialize env mutation with ENV_LOCK.
         unsafe { std::env::remove_var("TERMINAL_BACKEND") };
+    }
+
+    fn clear_web_env_bridge_vars() {
+        for (_, env_key) in web_config_env_bridge_pairs() {
+            // SAFETY: tests serialize env mutation with ENV_LOCK.
+            unsafe { std::env::remove_var(env_key) };
+        }
     }
 
     #[test]
@@ -2114,6 +2208,94 @@ llm_providers:
         assert!(env_text.contains("TERMINAL_DOCKER_ENV=FOO=bar"));
         assert!(env_text.contains("TERMINAL_AUTO_SOURCE_BASHRC=false"));
         clear_terminal_env_bridge_vars();
+    }
+
+    #[test]
+    fn web_config_bridge_map_covers_runtime_backend_keys() {
+        let keys = web_config_env_bridge_pairs()
+            .iter()
+            .map(|(key, _)| *key)
+            .collect::<std::collections::HashSet<_>>();
+        for key in [
+            "backend",
+            "search_backend",
+            "extract_backend",
+            "crawl_backend",
+        ] {
+            assert!(keys.contains(key), "missing web bridge key: {key}");
+            assert!(
+                web_config_env_bridge_key(&format!("web.{key}")).is_some(),
+                "web.{key} should map to an env var"
+            );
+        }
+    }
+
+    #[test]
+    fn set_user_config_value_bridges_web_backend_keys() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_web_env_bridge_vars();
+        let dir = tempdir().unwrap();
+        for (key, value, env_key) in [
+            ("web.backend", "firecrawl", "HERMES_WEB_BACKEND"),
+            (
+                "web.search_backend",
+                "brave-free",
+                "HERMES_WEB_SEARCH_BACKEND",
+            ),
+            (
+                "web.extract_backend",
+                "tavily",
+                "HERMES_WEB_EXTRACT_BACKEND",
+            ),
+            ("web.crawl_backend", "tavily", "HERMES_WEB_CRAWL_BACKEND"),
+        ] {
+            let result = set_user_config_value(dir.path(), key, value).unwrap();
+            assert!(result.wrote_config(), "{key} should write config");
+            assert!(result.wrote_env(), "{key} should write env");
+            assert_eq!(result.env_key.as_deref(), Some(env_key));
+        }
+        let env_text = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(env_text.contains("HERMES_WEB_SEARCH_BACKEND=brave-free"));
+        clear_web_env_bridge_vars();
+    }
+
+    #[test]
+    fn load_config_bridges_web_yaml_to_env_without_overriding_existing_env() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_web_env_bridge_vars();
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+web:
+  backend: firecrawl
+  search_backend: searxng
+  extract_backend: tavily
+  crawl_backend: tavily
+"#,
+        )
+        .unwrap();
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::set_var("HERMES_WEB_SEARCH_BACKEND", "brave-free") };
+
+        let cfg = load_config(Some(dir.path().to_string_lossy().as_ref())).unwrap();
+        assert_eq!(cfg.web.backend, "firecrawl");
+        assert_eq!(cfg.web.search_backend, "brave-free");
+        assert_eq!(cfg.web.extract_backend, "tavily");
+        assert_eq!(std::env::var("HERMES_WEB_BACKEND").unwrap(), "firecrawl");
+        assert_eq!(
+            std::env::var("HERMES_WEB_SEARCH_BACKEND").unwrap(),
+            "brave-free"
+        );
+        assert_eq!(
+            std::env::var("HERMES_WEB_EXTRACT_BACKEND").unwrap(),
+            "tavily"
+        );
+        clear_web_env_bridge_vars();
     }
 
     #[test]

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -122,6 +122,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 streaming,
                 display: Default::default(),
                 terminal: TerminalConfig::default(),
+                web: Default::default(),
                 llm_providers: HashMap::new(),
                 fallback_model: None,
                 fallback_models: Vec::new(),

--- a/crates/hermes-tools/src/backends/web.rs
+++ b/crates/hermes-tools/src/backends/web.rs
@@ -1,4 +1,4 @@
-//! Real web tool backends: Exa/Tavily/Firecrawl/xAI/SearXNG search,
+//! Real web tool backends: Exa/Tavily/Firecrawl/xAI/SearXNG/Brave/DDG search,
 //! Firecrawl/Tavily extract, Tavily crawl, and local fallbacks.
 
 use async_trait::async_trait;
@@ -47,7 +47,9 @@ impl WebSearchBackend for FallbackSearchBackend {
                  - FIRECRAWL_API_KEY or FIRECRAWL_API_URL (https://firecrawl.dev)\n\
                  - XAI_API_KEY with HERMES_WEB_SEARCH_BACKEND=xai (https://x.ai)\n\
                  - SERPER_API_KEY (https://serper.dev)\n\
-                 - SEARXNG_BASE_URL (https://docs.searxng.org/dev/search_api.html)\n\n\
+                 - SEARXNG_BASE_URL or SEARXNG_URL (https://docs.searxng.org/dev/search_api.html)\n\
+                 - BRAVE_SEARCH_API_KEY with HERMES_WEB_SEARCH_BACKEND=brave-free\n\
+                 - HERMES_WEB_SEARCH_BACKEND=ddgs for keyless DuckDuckGo Instant Answer search\n\n\
                  Query was: {}", query
             ),
             "query": query,
@@ -101,6 +103,8 @@ impl WebCrawlBackend for FallbackCrawlBackend {
 const MAX_EXTRACT_BYTES: usize = 512_000; // 500 KB
 const TAVILY_BASE_URL_DEFAULT: &str = "https://api.tavily.com";
 const SEARXNG_SEARCH_PATH: &str = "/search";
+const BRAVE_SEARCH_URL_DEFAULT: &str = "https://api.search.brave.com/res/v1/web/search";
+const DDG_INSTANT_ANSWER_URL_DEFAULT: &str = "https://api.duckduckgo.com/";
 const FIRECRAWL_BASE_URL_DEFAULT: &str = "https://api.firecrawl.dev";
 const XAI_BASE_URL_DEFAULT: &str = "https://api.x.ai/v1";
 const XAI_WEB_MODEL_DEFAULT: &str = "grok-4.3";
@@ -109,6 +113,30 @@ const XAI_WEB_TIMEOUT_SECS_DEFAULT: u64 = 90;
 /// A web extraction backend that fetches HTML via reqwest with no external API dependency.
 pub struct SimpleExtractBackend {
     client: Client,
+}
+
+/// Extract backend for search-only providers selected via legacy `web.backend`.
+pub struct SearchOnlyExtractBackend {
+    provider: &'static str,
+}
+
+impl SearchOnlyExtractBackend {
+    pub fn new(provider: &'static str) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl WebExtractBackend for SearchOnlyExtractBackend {
+    async fn extract(&self, url: &str, _include_links: bool) -> Result<String, ToolError> {
+        Ok(json!({
+            "success": false,
+            "error": format!("{} is a search-only web backend and cannot extract URLs", self.provider),
+            "url": url,
+            "provider": self.provider,
+        })
+        .to_string())
+    }
 }
 
 impl SimpleExtractBackend {
@@ -677,6 +705,26 @@ fn tavily_crawl_payload(
     payload
 }
 
+fn search_result(
+    title: impl Into<String>,
+    url: impl Into<String>,
+    description: impl Into<String>,
+    score: Option<f64>,
+    position: usize,
+) -> Value {
+    let title = title.into();
+    let url = url.into();
+    let description = description.into();
+    json!({
+        "title": title,
+        "url": url,
+        "description": description,
+        "text": description,
+        "score": score.unwrap_or(0.0),
+        "position": position,
+    })
+}
+
 fn normalize_tavily_documents(response: &Value, fallback_url: &str) -> Vec<Value> {
     let mut documents = Vec::new();
     if let Some(results) = response.get("results").and_then(|v| v.as_array()) {
@@ -757,15 +805,19 @@ impl SearxngSearchBackend {
         }
     }
 
-    /// Create from `SEARXNG_BASE_URL`.
+    /// Create from `SEARXNG_BASE_URL` or upstream-compatible `SEARXNG_URL`.
     pub fn from_env() -> Result<Self, ToolError> {
-        let base_url = std::env::var("SEARXNG_BASE_URL").map_err(|_| {
-            ToolError::ExecutionFailed("SEARXNG_BASE_URL environment variable not set".into())
-        })?;
+        let base_url = std::env::var("SEARXNG_BASE_URL")
+            .or_else(|_| std::env::var("SEARXNG_URL"))
+            .map_err(|_| {
+                ToolError::ExecutionFailed(
+                    "SEARXNG_BASE_URL or SEARXNG_URL environment variable not set".into(),
+                )
+            })?;
         let base_url = base_url.trim();
         if base_url.is_empty() {
             return Err(ToolError::ExecutionFailed(
-                "SEARXNG_BASE_URL environment variable is empty".into(),
+                "SEARXNG_BASE_URL/SEARXNG_URL environment variable is empty".into(),
             ));
         }
         Ok(Self::new(base_url.to_string()))
@@ -815,43 +867,275 @@ impl WebSearchBackend for SearxngSearchBackend {
         let data: Value = serde_json::from_str(&text).map_err(|e| {
             ToolError::ExecutionFailed(format!("Failed to parse SearXNG response: {}", e))
         })?;
-        let formatted: Vec<Value> = data
+        let mut rows: Vec<Value> = data
             .get("results")
             .and_then(|r| r.as_array())
             .map(|arr| {
                 arr.iter()
-                    .take(num_results)
                     .map(|r| {
-                        json!({
-                            "title": r.get("title").and_then(|v| v.as_str()).unwrap_or(""),
-                            "url": r.get("url").and_then(|v| v.as_str()).unwrap_or(""),
-                            "text": r
-                                .get("content")
-                                .or_else(|| r.get("snippet"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(""),
-                            "score": r.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0),
-                        })
+                        let description = r
+                            .get("content")
+                            .or_else(|| r.get("snippet"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        search_result(
+                            r.get("title").and_then(|v| v.as_str()).unwrap_or(""),
+                            r.get("url").and_then(|v| v.as_str()).unwrap_or(""),
+                            description,
+                            r.get("score").and_then(|v| v.as_f64()),
+                            0,
+                        )
                     })
                     .collect()
             })
             .unwrap_or_default();
+        rows.sort_by(|a, b| {
+            let left = a.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let right = b.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            right
+                .partial_cmp(&left)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for (idx, row) in rows.iter_mut().take(num_results).enumerate() {
+            row["position"] = json!(idx + 1);
+        }
+        let formatted: Vec<Value> = rows.into_iter().take(num_results).collect();
 
         serde_json::to_string_pretty(&json!({ "results": formatted }))
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
     }
 }
 
+// ---------------------------------------------------------------------------
+// BraveFreeSearchBackend
+// ---------------------------------------------------------------------------
+
+/// Brave Search API backend using the free web endpoint.
+pub struct BraveFreeSearchBackend {
+    client: Client,
+    api_key: String,
+    endpoint: String,
+}
+
+impl BraveFreeSearchBackend {
+    pub fn new(api_key: String, endpoint: String) -> Self {
+        Self {
+            client: Client::new(),
+            api_key,
+            endpoint,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, ToolError> {
+        let api_key = std::env::var("BRAVE_SEARCH_API_KEY").map_err(|_| {
+            ToolError::ExecutionFailed("BRAVE_SEARCH_API_KEY environment variable not set".into())
+        })?;
+        let api_key = api_key.trim();
+        if api_key.is_empty() {
+            return Err(ToolError::ExecutionFailed(
+                "BRAVE_SEARCH_API_KEY environment variable is empty".into(),
+            ));
+        }
+        let endpoint = std::env::var("BRAVE_SEARCH_URL")
+            .unwrap_or_else(|_| BRAVE_SEARCH_URL_DEFAULT.to_string());
+        Ok(Self::new(api_key.to_string(), endpoint))
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[async_trait]
+impl WebSearchBackend for BraveFreeSearchBackend {
+    async fn search(
+        &self,
+        query: &str,
+        num_results: usize,
+        _category: Option<&str>,
+    ) -> Result<String, ToolError> {
+        let count = num_results.clamp(1, 20).to_string();
+        let resp = self
+            .client
+            .get(&self.endpoint)
+            .header("X-Subscription-Token", &self.api_key)
+            .query(&[("q", query), ("count", count.as_str())])
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Brave Search request failed: {e}")))?;
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to read Brave Search response: {e}"))
+        })?;
+        if !status.is_success() {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Brave Search API error ({status}): {text}"
+            )));
+        }
+        let data: Value = serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to parse Brave Search response: {e}"))
+        })?;
+        let formatted = normalize_brave_results(&data, num_results);
+        serde_json::to_string_pretty(&json!({ "results": formatted, "provider": "brave-free" }))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
+    }
+}
+
+fn normalize_brave_results(response: &Value, limit: usize) -> Vec<Value> {
+    response
+        .get("web")
+        .and_then(|web| web.get("results"))
+        .and_then(|results| results.as_array())
+        .map(|rows| {
+            rows.iter()
+                .take(limit)
+                .enumerate()
+                .map(|(idx, row)| {
+                    search_result(
+                        row.get("title").and_then(|v| v.as_str()).unwrap_or(""),
+                        row.get("url").and_then(|v| v.as_str()).unwrap_or(""),
+                        row.get("description")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        None,
+                        idx + 1,
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// DuckDuckGoSearchBackend
+// ---------------------------------------------------------------------------
+
+/// Keyless DuckDuckGo Instant Answer backend.
+pub struct DuckDuckGoSearchBackend {
+    client: Client,
+    endpoint: String,
+}
+
+impl DuckDuckGoSearchBackend {
+    pub fn new(endpoint: String) -> Self {
+        Self {
+            client: Client::new(),
+            endpoint,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, ToolError> {
+        Ok(Self::new(std::env::var("DDG_SEARCH_URL").unwrap_or_else(
+            |_| DDG_INSTANT_ANSWER_URL_DEFAULT.to_string(),
+        )))
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[async_trait]
+impl WebSearchBackend for DuckDuckGoSearchBackend {
+    async fn search(
+        &self,
+        query: &str,
+        num_results: usize,
+        _category: Option<&str>,
+    ) -> Result<String, ToolError> {
+        let resp = self
+            .client
+            .get(&self.endpoint)
+            .query(&[
+                ("q", query),
+                ("format", "json"),
+                ("no_html", "1"),
+                ("skip_disambig", "1"),
+            ])
+            .send()
+            .await
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!("DuckDuckGo search request failed: {e}"))
+            })?;
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to read DuckDuckGo response: {e}"))
+        })?;
+        if !status.is_success() {
+            return Err(ToolError::ExecutionFailed(format!(
+                "DuckDuckGo API error ({status}): {text}"
+            )));
+        }
+        let data: Value = serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to parse DuckDuckGo response: {e}"))
+        })?;
+        let formatted = normalize_duckduckgo_results(&data, num_results);
+        serde_json::to_string_pretty(&json!({ "results": formatted, "provider": "ddgs" }))
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
+    }
+}
+
+fn normalize_duckduckgo_results(response: &Value, limit: usize) -> Vec<Value> {
+    let mut rows = Vec::new();
+    if let Some(url) = response
+        .get("AbstractURL")
+        .and_then(|v| v.as_str())
+        .filter(|v| !v.trim().is_empty())
+    {
+        rows.push(search_result(
+            response
+                .get("Heading")
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            url,
+            response
+                .get("AbstractText")
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            None,
+            0,
+        ));
+    }
+    collect_duckduckgo_related(response.get("RelatedTopics"), &mut rows);
+    for (idx, row) in rows.iter_mut().take(limit).enumerate() {
+        row["position"] = json!(idx + 1);
+    }
+    rows.into_iter().take(limit).collect()
+}
+
+fn collect_duckduckgo_related(value: Option<&Value>, rows: &mut Vec<Value>) {
+    let Some(Value::Array(items)) = value else {
+        return;
+    };
+    for item in items {
+        if let Some(topics) = item.get("Topics") {
+            collect_duckduckgo_related(Some(topics), rows);
+            continue;
+        }
+        let Some(url) = item
+            .get("FirstURL")
+            .and_then(|v| v.as_str())
+            .filter(|v| !v.trim().is_empty())
+        else {
+            continue;
+        };
+        let text = item.get("Text").and_then(|v| v.as_str()).unwrap_or("");
+        let title = text.split(" - ").next().unwrap_or(text);
+        rows.push(search_result(title, url, text, None, 0));
+    }
+}
+
 /// Resolve preferred web-search backend from environment.
 ///
 /// Priority:
-/// 1. Explicit `HERMES_WEB_SEARCH_BACKEND` override
-///    - `exa`, `tavily`, `firecrawl`, `xai`, `searxng`, `fallback`
+/// 1. Explicit `HERMES_WEB_SEARCH_BACKEND` override, then legacy `HERMES_WEB_BACKEND`
+///    - `exa`, `tavily`, `firecrawl`, `xai`, `searxng`, `brave-free`, `ddgs`, `fallback`
 /// 2. Exa (`EXA_API_KEY`)
 /// 3. Tavily (`TAVILY_API_KEY`, optional `TAVILY_BASE_URL`)
 /// 4. Firecrawl (`FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL`, or managed gateway)
-/// 5. SearXNG (`SEARXNG_BASE_URL`)
-/// 6. Fallback helpful message backend
+/// 5. SearXNG (`SEARXNG_BASE_URL` or `SEARXNG_URL`)
+/// 6. Brave (`BRAVE_SEARCH_API_KEY`)
+/// 7. Keyless DDG fallback
 pub fn search_backend_from_env_or_fallback() -> Box<dyn WebSearchBackend> {
     match search_backend_choice_from_env() {
         "exa" => ExaSearchBackend::from_env()
@@ -869,20 +1153,22 @@ pub fn search_backend_from_env_or_fallback() -> Box<dyn WebSearchBackend> {
         "searxng" => SearxngSearchBackend::from_env()
             .map(|b| Box::new(b) as Box<dyn WebSearchBackend>)
             .unwrap_or_else(|_| Box::new(FallbackSearchBackend::new())),
+        "brave-free" => BraveFreeSearchBackend::from_env()
+            .map(|b| Box::new(b) as Box<dyn WebSearchBackend>)
+            .unwrap_or_else(|_| Box::new(FallbackSearchBackend::new())),
+        "ddgs" => DuckDuckGoSearchBackend::from_env()
+            .map(|b| Box::new(b) as Box<dyn WebSearchBackend>)
+            .unwrap_or_else(|_| Box::new(FallbackSearchBackend::new())),
         _ => Box::new(FallbackSearchBackend::new()),
     }
 }
 
 fn search_backend_choice_from_env() -> &'static str {
-    if let Ok(choice) = std::env::var("HERMES_WEB_SEARCH_BACKEND") {
-        match choice.trim().to_ascii_lowercase().as_str() {
-            "exa" => return "exa",
-            "tavily" => return "tavily",
-            "firecrawl" => return "firecrawl",
-            "xai" | "grok" => return "xai",
-            "searxng" | "searx" => return "searxng",
-            "fallback" | "none" | "off" | "disabled" => return "fallback",
-            _ => {}
+    if let Some(choice) = env_optional_nonempty("HERMES_WEB_SEARCH_BACKEND")
+        .or_else(|| env_optional_nonempty("HERMES_WEB_BACKEND"))
+    {
+        if let Some(normalized) = normalize_search_backend_choice(&choice) {
+            return normalized;
         }
     }
 
@@ -892,17 +1178,34 @@ fn search_backend_choice_from_env() -> &'static str {
         "tavily"
     } else if firecrawl_direct_config_present() || firecrawl_managed_config_present() {
         "firecrawl"
-    } else if env_present_nonempty("SEARXNG_BASE_URL") {
+    } else if searxng_config_present() {
         "searxng"
+    } else if env_present_nonempty("BRAVE_SEARCH_API_KEY") {
+        "brave-free"
     } else {
-        "fallback"
+        "ddgs"
+    }
+}
+
+fn normalize_search_backend_choice(choice: &str) -> Option<&'static str> {
+    match choice.trim().to_ascii_lowercase().as_str() {
+        "exa" => Some("exa"),
+        "tavily" => Some("tavily"),
+        "firecrawl" => Some("firecrawl"),
+        "xai" | "grok" => Some("xai"),
+        "searxng" | "searx" => Some("searxng"),
+        "brave" | "brave-free" | "brave_free" => Some("brave-free"),
+        "ddg" | "ddgs" | "duckduckgo" => Some("ddgs"),
+        "fallback" | "none" | "off" | "disabled" => Some("fallback"),
+        _ => None,
     }
 }
 
 /// Resolve preferred web-extract backend from environment.
 ///
 /// Priority:
-/// 1. Explicit `HERMES_WEB_EXTRACT_BACKEND` override: `firecrawl`, `tavily`, `simple`
+/// 1. Explicit `HERMES_WEB_EXTRACT_BACKEND` override, then legacy `HERMES_WEB_BACKEND`
+///    (`firecrawl`, `tavily`, `simple`; search-only backends return a clear error)
 /// 2. Firecrawl direct/self-hosted/managed when configured
 /// 3. Tavily when configured
 /// 4. Simple local HTML fetch fallback
@@ -914,6 +1217,11 @@ pub fn extract_backend_from_env_or_fallback() -> Box<dyn WebExtractBackend> {
         "tavily" => TavilyExtractBackend::from_env()
             .map(|b| Box::new(b) as Box<dyn WebExtractBackend>)
             .unwrap_or_else(|_| Box::new(SimpleExtractBackend::new())),
+        "search-only:brave-free" => Box::new(SearchOnlyExtractBackend::new("brave-free")),
+        "search-only:ddgs" => Box::new(SearchOnlyExtractBackend::new("ddgs")),
+        "search-only:searxng" => Box::new(SearchOnlyExtractBackend::new("searxng")),
+        "search-only:exa" => Box::new(SearchOnlyExtractBackend::new("exa")),
+        "search-only:xai" => Box::new(SearchOnlyExtractBackend::new("xai")),
         _ => Box::new(SimpleExtractBackend::new()),
     }
 }
@@ -924,6 +1232,20 @@ fn extract_backend_choice_from_env() -> &'static str {
             "firecrawl" => return "firecrawl",
             "tavily" => return "tavily",
             "simple" | "fallback" | "local" | "none" | "off" | "disabled" => return "simple",
+            _ => {}
+        }
+    }
+    if let Some(choice) = env_optional_nonempty("HERMES_WEB_BACKEND")
+        .and_then(|choice| normalize_search_backend_choice(&choice).map(str::to_string))
+    {
+        match choice.as_str() {
+            "firecrawl" => return "firecrawl",
+            "tavily" => return "tavily",
+            "brave-free" => return "search-only:brave-free",
+            "ddgs" => return "search-only:ddgs",
+            "searxng" => return "search-only:searxng",
+            "exa" => return "search-only:exa",
+            "xai" => return "search-only:xai",
             _ => {}
         }
     }
@@ -960,6 +1282,13 @@ fn crawl_backend_choice_from_env() -> &'static str {
             _ => {}
         }
     }
+    if let Some(choice) = env_optional_nonempty("HERMES_WEB_BACKEND")
+        .and_then(|choice| normalize_search_backend_choice(&choice).map(str::to_string))
+    {
+        if choice == "tavily" {
+            return "tavily";
+        }
+    }
 
     if env_present_nonempty("TAVILY_API_KEY") {
         "tavily"
@@ -973,6 +1302,10 @@ fn env_present_nonempty(name: &str) -> bool {
         .ok()
         .map(|v| !v.trim().is_empty())
         .unwrap_or(false)
+}
+
+fn searxng_config_present() -> bool {
+    env_present_nonempty("SEARXNG_BASE_URL") || env_present_nonempty("SEARXNG_URL")
 }
 
 fn env_optional_nonempty(name: &str) -> Option<String> {
@@ -1688,8 +2021,13 @@ mod web_search_env_tests {
                 "TOOL_GATEWAY_DOMAIN",
                 "TOOL_GATEWAY_SCHEME",
                 "SEARXNG_BASE_URL",
+                "SEARXNG_URL",
+                "BRAVE_SEARCH_API_KEY",
+                "BRAVE_SEARCH_URL",
+                "DDG_SEARCH_URL",
                 "XAI_API_KEY",
                 "XAI_BASE_URL",
+                "HERMES_WEB_BACKEND",
                 "HERMES_WEB_SEARCH_BACKEND",
                 "HERMES_WEB_EXTRACT_BACKEND",
                 "HERMES_WEB_CRAWL_BACKEND",
@@ -1775,6 +2113,14 @@ mod web_search_env_tests {
     }
 
     #[test]
+    fn searxng_from_env_accepts_upstream_url_alias() {
+        let _scope = EnvScope::new();
+        std::env::set_var("SEARXNG_URL", "https://search.example.com/");
+        let backend = SearxngSearchBackend::from_env().expect("searxng backend from alias");
+        assert_eq!(backend.base_url(), "https://search.example.com");
+    }
+
+    #[test]
     fn search_backend_choice_uses_searxng_when_only_base_url_available() {
         let _scope = EnvScope::new();
         std::env::set_var("SEARXNG_BASE_URL", "https://search.example.com");
@@ -1792,7 +2138,7 @@ mod web_search_env_tests {
     fn search_backend_choice_uses_xai_only_when_explicit() {
         let _scope = EnvScope::new();
         std::env::set_var("XAI_API_KEY", "xai-key");
-        assert_eq!(search_backend_choice_from_env(), "fallback");
+        assert_eq!(search_backend_choice_from_env(), "ddgs");
         std::env::set_var("HERMES_WEB_SEARCH_BACKEND", "xai");
         assert_eq!(search_backend_choice_from_env(), "xai");
     }
@@ -1805,9 +2151,31 @@ mod web_search_env_tests {
         assert_eq!(search_backend_choice_from_env(), "searxng");
     }
 
-    #[tokio::test]
-    async fn search_backend_falls_back_when_keys_missing() {
+    #[test]
+    fn search_backend_choice_honors_legacy_generic_web_backend() {
         let _scope = EnvScope::new();
+        std::env::set_var("HERMES_WEB_BACKEND", "brave");
+        std::env::set_var("EXA_API_KEY", "exa-key");
+        assert_eq!(search_backend_choice_from_env(), "brave-free");
+    }
+
+    #[test]
+    fn search_backend_choice_uses_brave_when_key_is_available() {
+        let _scope = EnvScope::new();
+        std::env::set_var("BRAVE_SEARCH_API_KEY", "brave-key");
+        assert_eq!(search_backend_choice_from_env(), "brave-free");
+    }
+
+    #[test]
+    fn search_backend_choice_uses_keyless_ddg_as_last_resort() {
+        let _scope = EnvScope::new();
+        assert_eq!(search_backend_choice_from_env(), "ddgs");
+    }
+
+    #[tokio::test]
+    async fn search_backend_falls_back_when_explicitly_disabled() {
+        let _scope = EnvScope::new();
+        std::env::set_var("HERMES_WEB_SEARCH_BACKEND", "fallback");
         let backend = search_backend_from_env_or_fallback();
         let out = backend
             .search("hello", 3, None)
@@ -1824,6 +2192,13 @@ mod web_search_env_tests {
         assert_eq!(extract_backend_choice_from_env(), "tavily");
         std::env::set_var("FIRECRAWL_API_KEY", "fire-key");
         assert_eq!(extract_backend_choice_from_env(), "firecrawl");
+    }
+
+    #[test]
+    fn extract_backend_choice_reports_search_only_generic_backend() {
+        let _scope = EnvScope::new();
+        std::env::set_var("HERMES_WEB_BACKEND", "ddgs");
+        assert_eq!(extract_backend_choice_from_env(), "search-only:ddgs");
     }
 
     #[test]
@@ -1883,6 +2258,44 @@ mod web_search_env_tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["title"], "Rust");
         assert_eq!(rows[0]["text"], "lang");
+    }
+
+    #[test]
+    fn normalize_brave_results_maps_positions_and_limit() {
+        let rows = normalize_brave_results(
+            &json!({
+                "web": {
+                    "results": [
+                        {"title": "A", "url": "https://a.example", "description": "desc a"},
+                        {"title": "B", "url": "https://b.example", "description": "desc b"}
+                    ]
+                }
+            }),
+            1,
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["title"], "A");
+        assert_eq!(rows[0]["description"], "desc a");
+        assert_eq!(rows[0]["position"], 1);
+    }
+
+    #[test]
+    fn normalize_duckduckgo_results_flattens_related_topics() {
+        let rows = normalize_duckduckgo_results(
+            &json!({
+                "RelatedTopics": [
+                    {"Text": "A - desc a", "FirstURL": "https://a.example"},
+                    {"Topics": [
+                        {"Text": "B - desc b", "FirstURL": "https://b.example"}
+                    ]}
+                ]
+            }),
+            5,
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["title"], "A");
+        assert_eq!(rows[1]["url"], "https://b.example");
+        assert_eq!(rows[1]["position"], 2);
     }
 
     #[test]

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -23,6 +23,7 @@ pub mod toolset;
 pub mod toolset_distributions;
 pub mod tts_streaming;
 pub mod v4a_patch;
+pub mod website_policy;
 
 // Re-export registry types
 pub use registry::{ToolEntry, ToolEntryInfo, ToolRegistry};

--- a/crates/hermes-tools/src/website_policy.rs
+++ b/crates/hermes-tools/src/website_policy.rs
@@ -1,0 +1,365 @@
+//! Website/domain blocklist policy for web-facing tools.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebsitePolicyError {
+    message: String,
+}
+
+impl WebsitePolicyError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for WebsitePolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for WebsitePolicyError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebsiteBlockRule {
+    pub pattern: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebsiteBlocklistPolicy {
+    pub enabled: bool,
+    pub rules: Vec<WebsiteBlockRule>,
+}
+
+impl WebsiteBlocklistPolicy {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "enabled": self.enabled,
+            "rules": self.rules.iter().map(|rule| json!({"pattern": rule.pattern})).collect::<Vec<_>>(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebsiteAccessBlock {
+    pub url: String,
+    pub host: String,
+    pub rule: String,
+}
+
+impl WebsiteAccessBlock {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "url": self.url,
+            "host": self.host,
+            "rule": self.rule,
+        })
+    }
+}
+
+pub fn load_website_blocklist(
+    config_path: Option<&Path>,
+) -> Result<WebsiteBlocklistPolicy, WebsitePolicyError> {
+    let path = config_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(hermes_config::config_path);
+    if !path.exists() {
+        return Ok(WebsiteBlocklistPolicy {
+            enabled: false,
+            rules: Vec::new(),
+        });
+    }
+
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| WebsitePolicyError::new(format!("Failed to read config YAML: {e}")))?;
+    let root: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .map_err(|e| WebsitePolicyError::new(format!("Invalid config YAML: {e}")))?;
+    let serde_yaml::Value::Mapping(root) = root else {
+        return Err(WebsitePolicyError::new("config root must be a mapping"));
+    };
+
+    let Some(security) = mapping_get(&root, "security") else {
+        return Ok(WebsiteBlocklistPolicy {
+            enabled: false,
+            rules: Vec::new(),
+        });
+    };
+    let serde_yaml::Value::Mapping(security) = security else {
+        return Err(WebsitePolicyError::new("security must be a mapping"));
+    };
+    let Some(blocklist) = mapping_get(security, "website_blocklist") else {
+        return Ok(WebsiteBlocklistPolicy {
+            enabled: false,
+            rules: Vec::new(),
+        });
+    };
+    let serde_yaml::Value::Mapping(blocklist) = blocklist else {
+        return Err(WebsitePolicyError::new(
+            "security.website_blocklist must be a mapping",
+        ));
+    };
+
+    let enabled = match mapping_get(blocklist, "enabled") {
+        Some(serde_yaml::Value::Bool(value)) => *value,
+        Some(_) => {
+            return Err(WebsitePolicyError::new(
+                "security.website_blocklist.enabled must be a boolean",
+            ))
+        }
+        None => false,
+    };
+
+    let mut rules = Vec::new();
+    if let Some(domains) = mapping_get(blocklist, "domains") {
+        let serde_yaml::Value::Sequence(domains) = domains else {
+            return Err(WebsitePolicyError::new(
+                "security.website_blocklist.domains must be a list",
+            ));
+        };
+        for domain in domains {
+            if let Some(rule) = domain.as_str().and_then(normalize_domain_rule) {
+                rules.push(WebsiteBlockRule { pattern: rule });
+            }
+        }
+    }
+
+    if let Some(shared_files) = mapping_get(blocklist, "shared_files") {
+        let serde_yaml::Value::Sequence(shared_files) = shared_files else {
+            return Err(WebsitePolicyError::new(
+                "security.website_blocklist.shared_files must be a list",
+            ));
+        };
+        for shared in shared_files {
+            let Some(path) = shared.as_str().map(PathBuf::from) else {
+                continue;
+            };
+            match std::fs::read_to_string(&path) {
+                Ok(raw) => {
+                    for line in raw.lines() {
+                        let line = line.split('#').next().unwrap_or("").trim();
+                        if let Some(rule) = normalize_domain_rule(line) {
+                            rules.push(WebsiteBlockRule { pattern: rule });
+                        }
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Skipping unreadable website blocklist {}: {err}",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    dedupe_rules(&mut rules);
+    Ok(WebsiteBlocklistPolicy { enabled, rules })
+}
+
+pub fn check_website_access(
+    url: &str,
+    config_path: Option<&Path>,
+) -> Result<Option<WebsiteAccessBlock>, WebsitePolicyError> {
+    let policy = load_website_blocklist(config_path)?;
+    Ok(check_website_access_with_policy(url, &policy))
+}
+
+pub fn check_website_access_with_policy(
+    url: &str,
+    policy: &WebsiteBlocklistPolicy,
+) -> Option<WebsiteAccessBlock> {
+    if !policy.enabled {
+        return None;
+    }
+    let host = url_host(url)?;
+    for rule in &policy.rules {
+        if domain_rule_matches(&host, &rule.pattern) {
+            return Some(WebsiteAccessBlock {
+                url: url.to_string(),
+                host,
+                rule: rule.pattern.clone(),
+            });
+        }
+    }
+    None
+}
+
+fn mapping_get<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a serde_yaml::Value> {
+    map.get(serde_yaml::Value::String(key.to_string()))
+}
+
+fn normalize_domain_rule(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let host = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        Url::parse(trimmed)
+            .ok()
+            .and_then(|url| url.host_str().map(ToString::to_string))?
+    } else {
+        trimmed
+            .trim_start_matches("//")
+            .split('/')
+            .next()
+            .unwrap_or(trimmed)
+            .to_string()
+    };
+    let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+    let host = host.strip_prefix("www.").unwrap_or(&host).to_string();
+    if host.is_empty() {
+        None
+    } else {
+        Some(host)
+    }
+}
+
+fn url_host(input: &str) -> Option<String> {
+    Url::parse(input)
+        .ok()
+        .and_then(|url| url.host_str().map(ToString::to_string))
+        .map(|host| host.trim().trim_end_matches('.').to_ascii_lowercase())
+        .filter(|host| !host.is_empty())
+}
+
+fn domain_rule_matches(host: &str, rule: &str) -> bool {
+    if let Some(suffix) = rule.strip_prefix("*.") {
+        return host.ends_with(&format!(".{suffix}")) && host != suffix;
+    }
+    host == rule || host.ends_with(&format!(".{rule}"))
+}
+
+fn dedupe_rules(rules: &mut Vec<WebsiteBlockRule>) {
+    let mut seen = std::collections::BTreeSet::new();
+    rules.retain(|rule| seen.insert(rule.pattern.clone()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_website_blocklist_merges_config_and_shared_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = tmp.path().join("community-blocklist.txt");
+        std::fs::write(&shared, "# comment\nexample.org\nsub.bad.net\n").unwrap();
+        let config = tmp.path().join("config.yaml");
+        std::fs::write(
+            &config,
+            format!(
+                r#"
+security:
+  website_blocklist:
+    enabled: true
+    domains:
+      - example.com
+      - https://www.evil.test/path
+    shared_files:
+      - {}
+"#,
+                shared.display()
+            ),
+        )
+        .unwrap();
+
+        let policy = load_website_blocklist(Some(&config)).unwrap();
+        assert!(policy.enabled);
+        let rules = policy
+            .rules
+            .iter()
+            .map(|rule| rule.pattern.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            rules,
+            ["evil.test", "example.com", "example.org", "sub.bad.net"]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn check_website_access_matches_parent_domain_subdomains() {
+        let policy = WebsiteBlocklistPolicy {
+            enabled: true,
+            rules: vec![WebsiteBlockRule {
+                pattern: "example.com".to_string(),
+            }],
+        };
+        let blocked =
+            check_website_access_with_policy("https://docs.example.com/page", &policy).unwrap();
+        assert_eq!(blocked.host, "docs.example.com");
+        assert_eq!(blocked.rule, "example.com");
+    }
+
+    #[test]
+    fn check_website_access_supports_wildcard_subdomains_only() {
+        let policy = WebsiteBlocklistPolicy {
+            enabled: true,
+            rules: vec![WebsiteBlockRule {
+                pattern: "*.tracking.example".to_string(),
+            }],
+        };
+        assert!(check_website_access_with_policy("https://a.tracking.example", &policy).is_some());
+        assert!(
+            check_website_access_with_policy("https://www.tracking.example", &policy).is_some()
+        );
+        assert!(check_website_access_with_policy("https://tracking.example", &policy).is_none());
+    }
+
+    #[test]
+    fn load_website_blocklist_uses_disabled_default_when_section_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("config.yaml");
+        std::fs::write(&config, "display:\n  tool_progress: all\n").unwrap();
+        let policy = load_website_blocklist(Some(&config)).unwrap();
+        assert!(!policy.enabled);
+        assert!(policy.rules.is_empty());
+    }
+
+    #[test]
+    fn load_website_blocklist_rejects_invalid_shapes_cleanly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cases = [
+            ("[]", "config root must be a mapping"),
+            ("security: []\n", "security must be a mapping"),
+            (
+                "security:\n  website_blocklist: block everything\n",
+                "security.website_blocklist must be a mapping",
+            ),
+            (
+                "security:\n  website_blocklist:\n    enabled: \"false\"\n",
+                "security.website_blocklist.enabled must be a boolean",
+            ),
+            (
+                "security:\n  website_blocklist:\n    domains: example.com\n",
+                "security.website_blocklist.domains must be a list",
+            ),
+            (
+                "security:\n  website_blocklist:\n    shared_files: community.txt\n",
+                "security.website_blocklist.shared_files must be a list",
+            ),
+        ];
+        for (idx, (yaml, message)) in cases.iter().enumerate() {
+            let config = tmp.path().join(format!("case-{idx}.yaml"));
+            std::fs::write(&config, yaml).unwrap();
+            let err = load_website_blocklist(Some(&config)).unwrap_err();
+            assert!(err.to_string().contains(message), "{yaml:?} produced {err}");
+        }
+    }
+
+    #[test]
+    fn load_website_blocklist_rejects_malformed_yaml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("config.yaml");
+        std::fs::write(&config, "security: [oops\n").unwrap();
+        let err = load_website_blocklist(Some(&config)).unwrap_err();
+        assert!(err.to_string().contains("Invalid config YAML"));
+    }
+}

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T12:14:44.222759+00:00",
+  "generated_at_utc": "2026-06-01T13:04:36.113826+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T12:14:44.222759+00:00`
+Generated: `2026-06-01T13:04:36.113826+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -11821,46 +11821,46 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_web_providers_brave_free.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "36fe41640e8cf7879d320d66f22f1fe9f78e262e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_web_providers_brave_free.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "a75b9d38e4f33c27f2a62b3e713d1c59c34fddca",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_web_providers_ddgs.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "9a3ceec737221de40c026496bea56a4d945bdfca",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_web_providers_ddgs.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7919931614f553891482cf0f497b7441473b1733",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_web_providers_searxng.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "4779ed6ce6ea887aa6d163611f30612bfea011e2",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_web_providers_searxng.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "31bbaeb47ca8c583394afab65292944effd490b9",
       "workstream": "WS6"
@@ -11881,31 +11881,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_web_tools_tavily.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "aef39e8e16f09d174eccb63acd415a952a47a220",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_web_tools_tavily.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "de820794965951744c3eb1d0ea33bda50c9f0ca1",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_website_policy.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "4573e0276508cda4c0a7d2a03d20e8dd3de0d57c",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_website_policy.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "bfe222ef892c1cd8fe982baed546281022465519",
       "workstream": "WS6"
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T11:39:06.826828+00:00",
+  "generated_at_utc": "2026-06-01T13:04:35.959793+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "430b352583e2e38ebb82b7b953fceaf2212ba4f3",
+    "local_ref": "HEAD",
+    "local_sha": "3d1d0ccb5be085617926637278d0e2e2be26619a",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 575,
-      "intentional_divergence": 292,
+      "functional": 570,
+      "intentional_divergence": 297,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 464,
-      "rust_equivalent_or_contract_test_required": 490,
+      "not_required_for_runtime": 469,
+      "rust_equivalent_or_contract_test_required": 485,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 292,
+      "cleared_intentional_divergence": 297,
       "cleared_non_runtime": 172,
-      "pending_review": 575
+      "pending_review": 570
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 292,
+    "cleared_intentional_divergence": 297,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 575,
+    "pending_review": 570,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T11:39:06.826828+00:00`
+Generated: `2026-06-01T13:04:35.959793+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `575`
+- Pending functional review: `570`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `292`
+- Cleared intentional divergence: `297`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 292 |
+| `cleared_intentional_divergence` | 297 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 575 |
+| `pending_review` | 570 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-06-01T11:39:06.826828+00:00`
 | --- | ---: |
 | `tests/hermes_cli` | 117 |
 | `tests/gateway` | 113 |
-| `tests/tools` | 74 |
+| `tests/tools` | 69 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -2290,6 +2290,41 @@
       "rationale": "API-server cron jobs behavior is covered by Rust-native gateway contracts backed by hermes_cron: list/create/get/update/delete, include_disabled filtering, pause/resume/manual run, default local delivery, whitelisted updates including skill aliases, required-field and length validation, repeat validation, invalid-ID rejection with source-context logging, and bearer-auth gating. Python-only cron-unavailable and mock self-binding branches are not applicable because the Rust gateway links the scheduler directly and exercises real scheduler calls.",
       "owner": "sheawinkler",
       "ticket": 303
+    },
+    {
+      "path": "tests/tools/test_web_providers_brave_free.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Brave free provider intent is covered by Rust BraveFreeSearchBackend contracts for BRAVE_SEARCH_API_KEY gating, X-Subscription-Token requests, count clamping, result normalization, explicit/generic backend selection, auto-detect priority, and search-only extract/crawl error routing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_web_providers_ddgs.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream ddgs provider intent is covered by Rust DuckDuckGoSearchBackend contracts for keyless DuckDuckGo search, abstract/related-topic normalization, one-indexed positions, explicit/generic ddgs and duckduckgo backend aliases, last-resort auto-detect, and search-only extract/crawl error routing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_web_providers_searxng.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream SearXNG provider intent is covered by Rust SearxngSearchBackend contracts for SEARXNG_BASE_URL and SEARXNG_URL aliases, trailing-slash normalization, score-descending sorting, limit truncation, result normalization, availability checks, and search-only extract/crawl errors.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_web_tools_tavily.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Tavily web-tool intent is covered by Rust Tavily search/extract/crawl backend contracts for API-key body payloads, base URL handling, search result normalization, extracted document and failed-result normalization, and handler dispatch through the Rust web tool backend registry.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_website_policy.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream website blocklist policy intent is covered by Rust website_policy contracts for security.website_blocklist defaults, inline and shared-file domain loading, malformed config errors, invalid shape errors, parent-domain matching, wildcard-subdomain semantics, and unreadable shared-file warning behavior.",
+      "owner": "sheawinkler",
+      "ticket": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Rust WebConfig backend selectors with env/config bridging for web search/extract/crawl backends
- add Rust Brave free, keyless DuckDuckGo, and SearXNG provider parity paths plus search-only extract/crawl routing
- add Rust website blocklist policy loader/matcher and clear five now-superseded upstream Python test files from the shared-diff backlog

## Parity Delta
- pending_review: 575 -> 570
- cleared_intentional_divergence: 292 -> 297

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- python3 scripts/generate-shared-diff-backlog.py --repo-root . --local-ref HEAD --no-fetch
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci
- scripts/clippy-warning-gate.sh --check (new=0; stale=3 pre-existing)
- cargo test -p hermes-config web_config -- --nocapture
- cargo test -p hermes-config web_backend -- --nocapture
- cargo test -p hermes-config load_config_bridges_web -- --nocapture
- cargo test -p hermes-config prop_gateway_config_json_roundtrip --test prop_config_roundtrip -- --nocapture
- cargo test -p hermes-tools web_search_env_tests -- --nocapture
- cargo test -p hermes-tools website_policy -- --nocapture
- cargo build --workspace
- cargo test --workspace --quiet