### PR TITLE
parity(tools): add output limit config

### DIFF
--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -42,6 +42,10 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub budget: BudgetConfig,
 
+    /// Configurable raw tool-output truncation limits.
+    #[serde(default)]
+    pub tool_output: ToolOutputConfig,
+
     /// Per-platform configuration (keyed by platform name, e.g. "discord").
     #[serde(default)]
     pub platforms: HashMap<String, PlatformConfig>,
@@ -157,6 +161,7 @@ impl Default for GatewayConfig {
             system_prompt: None,
             tools: default_tools(),
             budget: BudgetConfig::default(),
+            tool_output: ToolOutputConfig::default(),
             platforms: HashMap::new(),
             platform_toolsets: default_platform_toolsets(),
             session: SessionConfig::default(),
@@ -182,6 +187,68 @@ impl Default for GatewayConfig {
             agent: AgentLoopBehaviorConfig::default(),
             home_dir: None,
         }
+    }
+}
+
+pub const DEFAULT_TOOL_OUTPUT_MAX_BYTES: usize = 50_000;
+pub const DEFAULT_TOOL_OUTPUT_MAX_LINES: usize = 2_000;
+pub const DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH: usize = 2_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolOutputConfig {
+    pub max_bytes: usize,
+    pub max_lines: usize,
+    pub max_line_length: usize,
+}
+
+impl Default for ToolOutputConfig {
+    fn default() -> Self {
+        Self {
+            max_bytes: DEFAULT_TOOL_OUTPUT_MAX_BYTES,
+            max_lines: DEFAULT_TOOL_OUTPUT_MAX_LINES,
+            max_line_length: DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ToolOutputConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Ok(Self::from_value(&value))
+    }
+}
+
+impl ToolOutputConfig {
+    pub fn from_value(value: &serde_json::Value) -> Self {
+        let mut config = Self::default();
+        let Some(map) = value.as_object() else {
+            return config;
+        };
+
+        if let Some(max_bytes) = map.get("max_bytes").and_then(Self::positive_usize) {
+            config.max_bytes = max_bytes;
+        }
+        if let Some(max_lines) = map.get("max_lines").and_then(Self::positive_usize) {
+            config.max_lines = max_lines;
+        }
+        if let Some(max_line_length) = map.get("max_line_length").and_then(Self::positive_usize) {
+            config.max_line_length = max_line_length;
+        }
+
+        config
+    }
+
+    fn positive_usize(value: &serde_json::Value) -> Option<usize> {
+        if let Some(raw) = value.as_u64() {
+            return usize::try_from(raw).ok().filter(|v| *v > 0);
+        }
+        value
+            .as_str()
+            .and_then(|raw| raw.trim().parse::<usize>().ok())
+            .filter(|v| *v > 0)
     }
 }
 
@@ -1262,6 +1329,7 @@ mod tests {
         assert_eq!(cfg.max_turns, 250);
         assert!(!cfg.tools.is_empty());
         assert!(cfg.model.is_none());
+        assert_eq!(cfg.tool_output, ToolOutputConfig::default());
         assert!(cfg.auxiliary.is_empty());
         assert!(cfg.tts.is_null());
         assert!(cfg.proxy.is_none());
@@ -1461,6 +1529,63 @@ display:
         )
         .expect("quoted false");
         assert!(!disabled.display.tool_progress_command_enabled());
+    }
+
+    #[test]
+    fn tool_output_config_default_matches_upstream_limits() {
+        let tool_output = ToolOutputConfig::default();
+        assert_eq!(tool_output.max_bytes, DEFAULT_TOOL_OUTPUT_MAX_BYTES);
+        assert_eq!(tool_output.max_lines, DEFAULT_TOOL_OUTPUT_MAX_LINES);
+        assert_eq!(
+            tool_output.max_line_length,
+            DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH
+        );
+    }
+
+    #[test]
+    fn tool_output_config_accepts_partial_positive_overrides() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+tool_output:
+  max_bytes: "75000"
+  max_lines: 50
+"#,
+        )
+        .expect("tool_output config");
+
+        assert_eq!(cfg.tool_output.max_bytes, 75_000);
+        assert_eq!(cfg.tool_output.max_lines, 50);
+        assert_eq!(
+            cfg.tool_output.max_line_length,
+            DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH
+        );
+    }
+
+    #[test]
+    fn tool_output_config_rejects_invalid_values_to_field_defaults() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+tool_output:
+  max_bytes: null
+  max_lines: -1
+  max_line_length: 0
+"#,
+        )
+        .expect("tool_output fallback config");
+
+        assert_eq!(cfg.tool_output, ToolOutputConfig::default());
+    }
+
+    #[test]
+    fn tool_output_config_non_object_falls_back_to_defaults() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+tool_output: nonsense
+"#,
+        )
+        .expect("non-object tool_output fallback");
+
+        assert_eq!(cfg.tool_output, ToolOutputConfig::default());
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -24,8 +24,9 @@ pub use config::{
     ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DisplayConfig, GatewayConfig,
     LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig, ProxyConfig,
     QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
-    SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolsSettings, WebConfig,
-    WebsiteBlocklistConfig,
+    SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolOutputConfig, ToolsSettings,
+    WebConfig, WebsiteBlocklistConfig, DEFAULT_TOOL_OUTPUT_MAX_BYTES,
+    DEFAULT_TOOL_OUTPUT_MAX_LINES, DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH,
 };
 pub use loader::{
     apply_user_config_patch, atomic_json_write, atomic_json_write_pretty, atomic_write_bytes,

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 use hermes_config::{
     AgentLoopBehaviorConfig, ApprovalConfig, DailyReset, GatewayConfig, IdleReset, PlatformConfig,
     ProfileConfig, SecurityConfig, SessionConfig, SessionResetPolicy, SessionsMaintenanceConfig,
-    SkillsSettings, SmartModelRoutingConfig, StreamingConfig, TerminalConfig, ToolsSettings,
-    UnauthorizedDmBehavior,
+    SkillsSettings, SmartModelRoutingConfig, StreamingConfig, TerminalConfig, ToolOutputConfig,
+    ToolsSettings, UnauthorizedDmBehavior,
 };
 use hermes_core::BudgetConfig;
 
@@ -115,6 +115,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 system_prompt: None,
                 tools: vec!["bash".into(), "read".into()],
                 budget: BudgetConfig::default(),
+                tool_output: ToolOutputConfig::default(),
                 platforms: HashMap::new(),
                 platform_toolsets: hermes_config::config::default_platform_toolsets(),
                 session,

--- a/crates/hermes-tools/src/tools/file.rs
+++ b/crates/hermes-tools/src/tools/file.rs
@@ -40,13 +40,31 @@ fn normalize_read_pagination(
     offset_raw: Option<&Value>,
     limit_raw: Option<&Value>,
 ) -> (Option<u64>, Option<u64>) {
+    normalize_read_pagination_with_max_lines(offset_raw, limit_raw, configured_max_read_limit(None))
+}
+
+fn configured_max_read_limit(home_dir: Option<&str>) -> i64 {
+    hermes_config::load_config(home_dir)
+        .ok()
+        .map(|config| config.tool_output.max_lines)
+        .map(|max_lines| i64::try_from(max_lines).unwrap_or(i64::MAX))
+        .filter(|max_lines| *max_lines > 0)
+        .unwrap_or(MAX_READ_LIMIT)
+}
+
+fn normalize_read_pagination_with_max_lines(
+    offset_raw: Option<&Value>,
+    limit_raw: Option<&Value>,
+    max_lines: i64,
+) -> (Option<u64>, Option<u64>) {
     let offset = offset_raw.map(|_| {
         let normalized = parse_int_param(offset_raw, DEFAULT_READ_OFFSET).max(1);
         // Tool schema is 1-indexed while backend slicing is 0-indexed.
         normalized.saturating_sub(1) as u64
     });
+    let max_lines = max_lines.max(1);
     let limit = limit_raw
-        .map(|_| parse_int_param(limit_raw, DEFAULT_READ_LIMIT).clamp(1, MAX_READ_LIMIT) as u64);
+        .map(|_| parse_int_param(limit_raw, DEFAULT_READ_LIMIT).clamp(1, max_lines) as u64);
     (offset, limit)
 }
 
@@ -636,21 +654,60 @@ mod tests {
 
     #[test]
     fn read_pagination_normalizes_invalid_values() {
-        let (offset, limit) = normalize_read_pagination(Some(&json!(0)), Some(&json!(0)));
+        let default_max_lines = hermes_config::DEFAULT_TOOL_OUTPUT_MAX_LINES as i64;
+        let (offset, limit) = normalize_read_pagination_with_max_lines(
+            Some(&json!(0)),
+            Some(&json!(0)),
+            default_max_lines,
+        );
         assert_eq!(offset, Some(0));
         assert_eq!(limit, Some(1));
 
-        let (offset, limit) = normalize_read_pagination(Some(&json!(-10)), Some(&json!(-5)));
+        let (offset, limit) = normalize_read_pagination_with_max_lines(
+            Some(&json!(-10)),
+            Some(&json!(-5)),
+            default_max_lines,
+        );
         assert_eq!(offset, Some(0));
         assert_eq!(limit, Some(1));
 
-        let (offset, limit) = normalize_read_pagination(Some(&json!("bad")), Some(&json!("bad")));
+        let (offset, limit) = normalize_read_pagination_with_max_lines(
+            Some(&json!("bad")),
+            Some(&json!("bad")),
+            default_max_lines,
+        );
         assert_eq!(offset, Some(0));
         assert_eq!(limit, Some(500));
 
-        let (offset, limit) = normalize_read_pagination(Some(&json!(2)), Some(&json!(999_999)));
+        let (offset, limit) = normalize_read_pagination_with_max_lines(
+            Some(&json!(2)),
+            Some(&json!(999_999)),
+            default_max_lines,
+        );
         assert_eq!(offset, Some(1));
         assert_eq!(limit, Some(2000));
+    }
+
+    #[test]
+    fn read_pagination_clamps_to_configured_tool_output_lines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            "tool_output:\n  max_lines: 50\n",
+        )
+        .expect("config.yaml");
+
+        let home = tmp.path().to_str().expect("utf-8 tempdir");
+        let max_lines = configured_max_read_limit(Some(home));
+        let (offset, limit) = normalize_read_pagination_with_max_lines(
+            Some(&json!(1)),
+            Some(&json!(1000)),
+            max_lines,
+        );
+
+        assert_eq!(max_lines, 50);
+        assert_eq!(offset, Some(0));
+        assert_eq!(limit, Some(50));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T13:04:36.113826+00:00",
+  "generated_at_utc": "2026-06-01T14:11:56.836591+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T13:04:36.113826+00:00`
+Generated: `2026-06-01T14:11:56.836591+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -11536,16 +11536,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tool_output_limits.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "19fa3fc05a1bd92108aa834bfd1440f7ebc12034",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tool_output_limits.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "b18f7f3ad0b12350e9d4208590a1363b37987811",
       "workstream": "WS6"
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T13:04:35.959793+00:00",
+  "generated_at_utc": "2026-06-01T14:11:57.000783+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "3d1d0ccb5be085617926637278d0e2e2be26619a",
+    "local_sha": "cb63c1c94453be9e8161691a0fdd7e4225ec07f6",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 570,
-      "intentional_divergence": 297,
+      "functional": 569,
+      "intentional_divergence": 298,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 469,
-      "rust_equivalent_or_contract_test_required": 485,
+      "not_required_for_runtime": 470,
+      "rust_equivalent_or_contract_test_required": 484,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 297,
+      "cleared_intentional_divergence": 298,
       "cleared_non_runtime": 172,
-      "pending_review": 570
+      "pending_review": 569
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 297,
+    "cleared_intentional_divergence": 298,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 570,
+    "pending_review": 569,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T13:04:35.959793+00:00`
+Generated: `2026-06-01T14:11:57.000783+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `570`
+- Pending functional review: `569`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `297`
+- Cleared intentional divergence: `298`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 297 |
+| `cleared_intentional_divergence` | 298 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 570 |
+| `pending_review` | 569 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-06-01T13:04:35.959793+00:00`
 | --- | ---: |
 | `tests/hermes_cli` | 117 |
 | `tests/gateway` | 113 |
-| `tests/tools` | 69 |
+| `tests/tools` | 68 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -2325,6 +2325,13 @@
       "rationale": "Upstream website blocklist policy intent is covered by Rust website_policy contracts for security.website_blocklist defaults, inline and shared-file domain loading, malformed config errors, invalid shape errors, parent-domain matching, wildcard-subdomain semantics, and unreadable shared-file warning behavior.",
       "owner": "sheawinkler",
       "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_tool_output_limits.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream configurable tool-output limit intent is covered by Rust ToolOutputConfig defaults and tolerant parsing plus read_file pagination clamping through tool_output.max_lines; Rust keeps agent budget truncation separate from tool display limits.",
+      "owner": "sheawinkler",
+      "ticket": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Rust `ToolOutputConfig` defaults and tolerant parsing for configurable tool-output limits.
- Clamp `read_file` pagination limits through configured `tool_output.max_lines`.
- Clear `tests/tools/test_tool_output_limits.py` from the shared-diff backlog with Rust-native tests and regenerated parity docs.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `python3 scripts/generate-shared-diff-backlog.py --repo-root . --local-ref HEAD --no-fetch`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci`
- `cargo test -p hermes-config tool_output -- --nocapture`
- `cargo test -p hermes-tools read_pagination -- --nocapture`
- `cargo test -p hermes-config prop_gateway_config_json_roundtrip --test prop_config_roundtrip -- --nocapture`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, `stale=3` pre-existing)
- `cargo build --workspace`
- `cargo test --workspace --quiet` (`WORKSPACE_TEST_RC=0`)

## Parity Delta
- `pending_review`: 570 -> 569
- `cleared_intentional_divergence`: 297 -> 298
