### PR TITLE
test(tools): avoid dotenv side effects in read limits

### DIFF
--- a/crates/hermes-tools/src/tools/file.rs
+++ b/crates/hermes-tools/src/tools/file.rs
@@ -13,7 +13,6 @@ use crate::credential_guard::CredentialGuard;
 
 const DEFAULT_READ_OFFSET: i64 = 1;
 const DEFAULT_READ_LIMIT: i64 = 500;
-const MAX_READ_LIMIT: i64 = 2000;
 const DEFAULT_SEARCH_OFFSET: i64 = 0;
 const DEFAULT_SEARCH_LIMIT: i64 = 50;
 pub const DEFAULT_MAX_READ_CHARS: usize = 200_000;
@@ -44,12 +43,34 @@ fn normalize_read_pagination(
 }
 
 fn configured_max_read_limit(home_dir: Option<&str>) -> i64 {
-    hermes_config::load_config(home_dir)
-        .ok()
-        .map(|config| config.tool_output.max_lines)
-        .map(|max_lines| i64::try_from(max_lines).unwrap_or(i64::MAX))
-        .filter(|max_lines| *max_lines > 0)
-        .unwrap_or(MAX_READ_LIMIT)
+    let home = home_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(hermes_config::paths::hermes_home);
+    let config = load_tool_output_config_without_env_side_effects(&home);
+    i64::try_from(config.tool_output.max_lines)
+        .unwrap_or(i64::MAX)
+        .max(1)
+}
+
+fn load_tool_output_config_without_env_side_effects(home: &Path) -> hermes_config::GatewayConfig {
+    let mut config = hermes_config::GatewayConfig::default();
+    let gateway_json_path = home.join("gateway.json");
+    if gateway_json_path.exists() {
+        if let Ok(json_config) = hermes_config::loader::load_from_json(&gateway_json_path) {
+            config = json_config;
+        }
+    }
+
+    for config_path in [home.join("config.yaml"), home.join("cli-config.yaml")] {
+        if !config_path.exists() {
+            continue;
+        }
+        if let Ok(yaml_config) = hermes_config::load_user_config_file(&config_path) {
+            config = hermes_config::merge_configs(&yaml_config, &config);
+        }
+    }
+
+    config
 }
 
 fn normalize_read_pagination_with_max_lines(


### PR DESCRIPTION
## Summary
- Avoid process-env mutation while resolving `read_file` pagination `tool_output.max_lines`.
- Read `gateway.json`, `config.yaml`, and `cli-config.yaml` directly without `load_dotenv()` side effects.
- Fix the post-merge test race where `~/.hermes-agent-ultra/.env` could reintroduce `HERMES_TOOL_POLICY_MODE=enforce` during `tool_policy` tests.

## Verification
- `cargo test -p hermes-tools read_pagination -- --nocapture`
- `cargo test -p hermes-tools tool_policy::tests -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, `stale=3` pre-existing)
- `cargo build --workspace`
- `cargo test --workspace --quiet` (`HARDENING_WORKSPACE_TEST_RC=0`)
