### PR TITLE
parity(tools): harden null content guards

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -2911,6 +2911,34 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_openai_response_null_content_is_safe() {
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_null_content",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"Cargo.toml\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "model": "reasoning-tool-only"
+        });
+
+        let resp = parse_openai_response(&json).expect("null content response should parse");
+
+        assert_eq!(resp.message.content.as_deref(), Some(""));
+        let calls = resp.message.tool_calls.as_ref().expect("tool calls");
+        assert_eq!(calls[0].id, "call_null_content");
+        assert_eq!(calls[0].function.name, "read_file");
+    }
+
+    #[test]
     fn test_parse_openai_response_no_choices_includes_provider_context() {
         let json = serde_json::json!({
             "status": 400,
@@ -3434,6 +3462,30 @@ mod tests {
         let reasoning = resp.message.reasoning_content.as_deref().unwrap();
         assert!(reasoning.contains("Step 1"));
         assert!(reasoning.contains("Step 2"));
+    }
+
+    #[test]
+    fn test_openrouter_parse_response_null_content_preserves_reasoning() {
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "reasoning_content": "Tool-only reasoning path"
+                },
+                "finish_reason": "stop"
+            }],
+            "model": "deepseek/deepseek-r1"
+        });
+
+        let resp = OpenRouterProvider::parse_openrouter_response(&json)
+            .expect("reasoning-only OpenRouter response should parse");
+
+        assert_eq!(resp.message.content.as_deref(), Some(""));
+        assert_eq!(
+            resp.message.reasoning_content.as_deref(),
+            Some("Tool-only reasoning path")
+        );
     }
 
     #[test]

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -349,16 +349,19 @@ fn is_json_null(value: &serde_json::Value) -> bool {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AuxiliaryTaskConfig {
     /// `auto` means resolve through the standard auxiliary chain.
-    #[serde(default = "default_auxiliary_provider")]
+    #[serde(
+        default = "default_auxiliary_provider",
+        deserialize_with = "deserialize_provider_or_default"
+    )]
     pub provider: String,
     /// Empty means use the selected provider's default auxiliary model.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_empty")]
     pub model: String,
     /// Direct OpenAI-compatible endpoint. When set, it takes precedence over provider.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_empty")]
     pub base_url: String,
     /// API key for a direct endpoint or explicit task provider.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_or_empty")]
     pub api_key: String,
     /// Per-attempt timeout in seconds. Accepts both `timeout` and legacy `timeout_secs`.
     #[serde(
@@ -407,6 +410,32 @@ impl AuxiliaryTaskConfig {
 
 fn default_auxiliary_provider() -> String {
     "auto".to_string()
+}
+
+fn deserialize_string_or_empty<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Option::<serde_json::Value>::deserialize(deserializer)? {
+        None | Some(serde_json::Value::Null) => Ok(String::new()),
+        Some(serde_json::Value::String(value)) => Ok(value),
+        Some(value) => Err(D::Error::custom(format!(
+            "expected string or null, got {value}"
+        ))),
+    }
+}
+
+fn deserialize_provider_or_default<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Option::<serde_json::Value>::deserialize(deserializer)? {
+        None | Some(serde_json::Value::Null) => Ok(default_auxiliary_provider()),
+        Some(serde_json::Value::String(value)) => Ok(value),
+        Some(value) => Err(D::Error::custom(format!(
+            "expected provider string or null, got {value}"
+        ))),
+    }
 }
 
 /// Upstream-shaped default auxiliary task table used by setup/config UIs.
@@ -1156,19 +1185,35 @@ fn default_max_output_size() -> usize {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct WebConfig {
     /// Shared legacy backend selector.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_or_empty",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub backend: String,
 
     /// Search-specific backend selector.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_or_empty",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub search_backend: String,
 
     /// Extract-specific backend selector.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_or_empty",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub extract_backend: String,
 
     /// Crawl-specific backend selector.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_or_empty",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub crawl_backend: String,
 }
 
@@ -1469,6 +1514,72 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn config_null_string_guards_match_python_tool_defaults() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+web:
+  backend: null
+  search_backend: null
+  extract_backend: null
+  crawl_backend: null
+auxiliary:
+  compression:
+    provider: null
+    model: null
+    base_url: null
+    api_key: null
+tts:
+  provider: null
+mcp_servers:
+  - name: local
+    command: hermes-mcp
+    auth: null
+"#,
+        )
+        .expect("null-valued config fields should deserialize");
+
+        assert_eq!(cfg.web, WebConfig::default());
+        let compression = cfg.auxiliary.get("compression").expect("compression task");
+        assert_eq!(compression.provider, "auto");
+        assert_eq!(compression.model, "");
+        assert_eq!(compression.base_url, "");
+        assert_eq!(compression.api_key, "");
+        assert_eq!(cfg.tts["provider"], serde_json::Value::Null);
+        assert_eq!(cfg.mcp_servers.len(), 1);
+        assert_eq!(cfg.mcp_servers[0].name, "local");
+    }
+
+    #[test]
+    fn config_null_guards_preserve_valid_strings() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+web:
+  backend: tavily
+  search_backend: brave-free
+  extract_backend: firecrawl
+  crawl_backend: tavily
+auxiliary:
+  vision:
+    provider: OPENROUTER
+    model: google/gemini-2.5-flash
+    base_url: https://router.example/v1
+    api_key: local-key
+"#,
+        )
+        .expect("valid string-valued config fields should deserialize");
+
+        assert_eq!(cfg.web.backend, "tavily");
+        assert_eq!(cfg.web.search_backend, "brave-free");
+        assert_eq!(cfg.web.extract_backend, "firecrawl");
+        assert_eq!(cfg.web.crawl_backend, "tavily");
+        let vision = cfg.auxiliary.get("vision").expect("vision task");
+        assert_eq!(vision.provider, "OPENROUTER");
+        assert_eq!(vision.model, "google/gemini-2.5-flash");
+        assert_eq!(vision.base_url, "https://router.example/v1");
+        assert_eq!(vision.api_key, "local-key");
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/browser.rs
+++ b/crates/hermes-tools/src/backends/browser.rs
@@ -230,6 +230,16 @@ fn yaml_gateway_route(value: &serde_yaml::Value) -> bool {
     }
 }
 
+fn browser_vision_payload(instruction: &str, screenshot: Value) -> String {
+    json!({
+        "status": "vision_analysis",
+        "instruction": instruction,
+        "screenshot": screenshot,
+        "note": "Screenshot captured; vision analysis requires LLM integration"
+    })
+    .to_string()
+}
+
 /// Browser backend using Chrome DevTools Protocol.
 /// Connects to Chrome via WebSocket for automation.
 pub struct CdpBrowserBackend {
@@ -994,13 +1004,7 @@ impl BrowserBackend for BrowserbaseBrowserBackend {
         let result = self
             .browserbase_command("Page.captureScreenshot", json!({"format": "png"}))
             .await?;
-        Ok(json!({
-            "status": "vision_analysis",
-            "instruction": instruction,
-            "screenshot": result,
-            "note": "Screenshot captured; vision analysis requires LLM integration"
-        })
-        .to_string())
+        Ok(browser_vision_payload(instruction, result))
     }
 
     async fn console(&self, action: &str) -> Result<String, ToolError> {
@@ -1133,13 +1137,7 @@ impl BrowserBackend for BrowserUseBrowserBackend {
         let result = self
             .browser_use_command("Page.captureScreenshot", json!({"format": "png"}))
             .await?;
-        Ok(json!({
-            "status": "vision_analysis",
-            "instruction": instruction,
-            "screenshot": result,
-            "note": "Screenshot captured; vision analysis requires LLM integration"
-        })
-        .to_string())
+        Ok(browser_vision_payload(instruction, result))
     }
 
     async fn console(&self, action: &str) -> Result<String, ToolError> {
@@ -1342,13 +1340,7 @@ impl BrowserBackend for CdpBrowserBackend {
         let result = self
             .cdp_command("Page.captureScreenshot", json!({"format": "png"}))
             .await?;
-        Ok(json!({
-            "status": "vision_analysis",
-            "instruction": instruction,
-            "screenshot": result,
-            "note": "Screenshot captured; vision analysis requires LLM integration"
-        })
-        .to_string())
+        Ok(browser_vision_payload(instruction, result))
     }
 
     async fn console(&self, action: &str) -> Result<String, ToolError> {
@@ -1719,6 +1711,20 @@ mod tests {
                 "timeout": 120,
                 "browserSettings": {"advancedStealth": true},
             })
+        );
+    }
+
+    #[test]
+    fn browser_vision_payload_is_llm_content_independent() {
+        let raw = browser_vision_payload("inspect", json!({"data": "png-bytes"}));
+        let value: Value = serde_json::from_str(&raw).expect("vision payload json");
+
+        assert_eq!(value["status"], "vision_analysis");
+        assert_eq!(value["instruction"], "inspect");
+        assert_eq!(value["screenshot"]["data"], "png-bytes");
+        assert_eq!(
+            value["note"],
+            "Screenshot captured; vision analysis requires LLM integration"
         );
     }
 

--- a/crates/hermes-tools/src/backends/tts.rs
+++ b/crates/hermes-tools/src/backends/tts.rs
@@ -268,6 +268,29 @@ pub(crate) fn tts_speed_for_provider(
     raw.map(|speed| speed.clamp(0.25, 4.0))
 }
 
+fn resolve_tts_provider_name(
+    explicit_provider: Option<&str>,
+    tts_config: &Value,
+    elevenlabs_available: bool,
+) -> String {
+    let configured_provider = tts_config
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    explicit_provider
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or(configured_provider)
+        .unwrap_or(if elevenlabs_available {
+            "elevenlabs"
+        } else {
+            "openai"
+        })
+        .to_ascii_lowercase()
+}
+
 fn command_tts_timeout(config: &Value) -> Duration {
     let seconds = number_from_config(config.get("timeout_seconds"))
         .or_else(|| number_from_config(config.get("timeout")))
@@ -887,24 +910,8 @@ impl TtsBackend for MultiTtsBackend {
         // 2. Otherwise OpenAI (cheapest HTTP-only path)
         // Zero-Python: edge_tts removed entirely — callers asking for
         // "edge_tts" receive a clear migration error.
-        let configured_provider = self
-            .tts_config
-            .get("provider")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty());
-        let resolved_provider_raw = provider
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .or(configured_provider)
-            .unwrap_or_else(|| {
-                if self.elevenlabs_key.is_some() {
-                    "elevenlabs"
-                } else {
-                    "openai"
-                }
-            });
-        let resolved_provider_key = resolved_provider_raw.to_ascii_lowercase();
+        let resolved_provider_key =
+            resolve_tts_provider_name(provider, &self.tts_config, self.elevenlabs_key.is_some());
         let resolved_provider = resolved_provider_key.as_str();
 
         let max_len = resolve_max_text_length(Some(resolved_provider), &self.tts_config);
@@ -1115,6 +1122,26 @@ mod tests {
         assert_eq!(
             tts_speed_for_provider("openai", &cfg, Some(0.1)),
             Some(0.25)
+        );
+    }
+
+    #[test]
+    fn tts_provider_resolution_treats_null_and_missing_as_default() {
+        assert_eq!(
+            resolve_tts_provider_name(None, &json!({"provider": null}), false),
+            "openai"
+        );
+        assert_eq!(
+            resolve_tts_provider_name(None, &json!({}), true),
+            "elevenlabs"
+        );
+        assert_eq!(
+            resolve_tts_provider_name(Some(" OPENAI "), &json!({"provider": "piper"}), true),
+            "openai"
+        );
+        assert_eq!(
+            resolve_tts_provider_name(None, &json!({"provider": " PIPER "}), false),
+            "piper"
         );
     }
 

--- a/crates/hermes-tools/src/backends/vision.rs
+++ b/crates/hermes-tools/src/backends/vision.rs
@@ -141,6 +141,15 @@ pub(crate) fn validate_image_url_for_vision(image_url: &str) -> bool {
     !is_blocked_image_host(host)
 }
 
+pub(crate) fn vision_response_content(data: &Value) -> String {
+    data["choices"][0]["message"]["content"]
+        .as_str()
+        .map(str::trim)
+        .filter(|content| !content.is_empty())
+        .unwrap_or("No analysis available")
+        .to_string()
+}
+
 #[async_trait]
 impl VisionBackend for OpenAiVisionBackend {
     async fn analyze(&self, image_url: &str, question: &str) -> Result<String, ToolError> {
@@ -183,11 +192,7 @@ impl VisionBackend for OpenAiVisionBackend {
             ToolError::ExecutionFailed(format!("Failed to parse vision response: {}", e))
         })?;
 
-        let content = data["choices"][0]["message"]["content"]
-            .as_str()
-            .unwrap_or("No analysis available");
-
-        Ok(content.to_string())
+        Ok(vision_response_content(&data))
     }
 }
 
@@ -241,5 +246,27 @@ mod tests {
             "http://169.254.169.254/latest"
         ));
         assert!(!validate_image_url_for_vision("http://[::1]/"));
+    }
+
+    #[test]
+    fn vision_response_content_handles_null_and_empty_analysis() {
+        assert_eq!(
+            vision_response_content(&serde_json::json!({
+                "choices": [{"message": {"content": null}}]
+            })),
+            "No analysis available"
+        );
+        assert_eq!(
+            vision_response_content(&serde_json::json!({
+                "choices": [{"message": {"content": "   "}}]
+            })),
+            "No analysis available"
+        );
+        assert_eq!(
+            vision_response_content(&serde_json::json!({
+                "choices": [{"message": {"content": "  The page shows a login form.  "}}]
+            })),
+            "The page shows a login form."
+        );
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T14:11:56.836591+00:00",
+  "generated_at_utc": "2026-06-01T16:08:26.893246+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T14:11:56.836591+00:00`
+Generated: `2026-06-01T16:08:26.893246+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -10006,16 +10006,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_browser_content_none_guard.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "6952bb938cc08c203ef9b108ec1aff08c474a5e9",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_browser_content_none_guard.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c1e8984822ebf7546eb8e5f32cfd1736061b488f",
       "workstream": "WS6"
@@ -10216,16 +10216,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_config_null_guard.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a6ab64009ce66dc8f534963c6e38b3a84c1342e3",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_config_null_guard.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "cb80ab8ecf570303f42b1b1c782bc0fa8ce6091d",
       "workstream": "WS6"
@@ -10666,16 +10666,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_llm_content_none_guard.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b0adea8c7adac4325a70d05a2fc0af8a45183745",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_llm_content_none_guard.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f18101e82739d6c8b8c4c0f677da1f43a9f4ac78",
       "workstream": "WS6"
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T14:11:57.000783+00:00",
+  "generated_at_utc": "2026-06-01T16:08:26.771537+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "cb63c1c94453be9e8161691a0fdd7e4225ec07f6",
+    "local_sha": "bcc98f3a21c0061a4d101745ab650466bd1bb307",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 569,
-      "intentional_divergence": 298,
+      "functional": 566,
+      "intentional_divergence": 301,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 470,
-      "rust_equivalent_or_contract_test_required": 484,
+      "not_required_for_runtime": 473,
+      "rust_equivalent_or_contract_test_required": 481,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 298,
+      "cleared_intentional_divergence": 301,
       "cleared_non_runtime": 172,
-      "pending_review": 569
+      "pending_review": 566
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 298,
+    "cleared_intentional_divergence": 301,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 569,
+    "pending_review": 566,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T14:11:57.000783+00:00`
+Generated: `2026-06-01T16:08:26.771537+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `569`
+- Pending functional review: `566`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `298`
+- Cleared intentional divergence: `301`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 298 |
+| `cleared_intentional_divergence` | 301 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 569 |
+| `pending_review` | 566 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-06-01T14:11:57.000783+00:00`
 | --- | ---: |
 | `tests/hermes_cli` | 117 |
 | `tests/gateway` | 113 |
-| `tests/tools` | 68 |
+| `tests/tools` | 65 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |
 | `tests` | 39 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -2332,6 +2332,27 @@
       "rationale": "Upstream configurable tool-output limit intent is covered by Rust ToolOutputConfig defaults and tolerant parsing plus read_file pagination clamping through tool_output.max_lines; Rust keeps agent budget truncation separate from tool display limits.",
       "owner": "sheawinkler",
       "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_browser_content_none_guard.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream browser_tool LLM-content None guard intent is superseded by Rust browser vision design: browser backends return a deterministic screenshot payload without dereferencing LLM message.content, and the shared vision response parser converts null or blank multimodal analysis content to a non-empty fallback string.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_config_null_guard.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream config null-coalescing intent is covered by Rust typed config null guards: web backend selectors deserialize null as defaults, auxiliary provider/model/base_url/api_key deserialize null as safe defaults, tts.provider null falls through provider resolution, and unknown MCP auth:null does not crash parsing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_llm_content_none_guard.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream OpenAI-compatible message.content None guard intent is covered centrally by Rust OpenAI/OpenRouter response parsing: null assistant content becomes an empty string without panicking, tool-call-only responses keep tool calls, and reasoning-only OpenRouter responses preserve reasoning_content for downstream use.",
+      "owner": "sheawinkler",
+      "ticket": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- treat explicit YAML nulls for web backend selectors and auxiliary task strings as safe defaults
- add null-safe TTS provider resolution and focused config/TTS tests
- add OpenAI/OpenRouter null-content and reasoning-only response regression coverage
- centralize browser vision payloads and add null/blank vision-content fallback coverage
- clear 3 upstream parity backlog items and regenerate parity proof/backlog docs

## Verification
- cargo test -p hermes-config config_null -- --nocapture
- cargo test -p hermes-agent test_parse_openai_response_null_content_is_safe -- --nocapture
- cargo test -p hermes-agent test_openrouter_parse_response_null_content_preserves_reasoning -- --nocapture
- cargo test -p hermes-tools tts_provider_resolution -- --nocapture
- cargo test -p hermes-tools vision_response_content -- --nocapture
- cargo test -p hermes-tools browser_vision_payload -- --nocapture
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- python3 scripts/generate-shared-diff-backlog.py --repo-root . --local-ref HEAD --no-fetch
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci
- scripts/clippy-warning-gate.sh --check
- cargo build --workspace
- cargo test --workspace --quiet