### PR TITLE
parity(model): normalize provider runtime ids

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -3261,6 +3261,9 @@ impl AgentLoop {
             })?;
         let base_url = self.resolve_runtime_base_url(provider, route_base_url);
         let mode = api_mode.unwrap_or(&self.config.api_mode);
+        let normalized_model_name =
+            crate::model_normalize::normalize_model_for_provider(model_name, provider);
+        let model_name = normalized_model_name.as_str();
 
         let provider_obj: Arc<dyn LlmProvider> = match provider {
             "openai" | "codex" | "openai-codex" => {

--- a/crates/hermes-agent/src/auxiliary_builder.rs
+++ b/crates/hermes-agent/src/auxiliary_builder.rs
@@ -337,6 +337,8 @@ fn build_main_runtime_candidate(
     let api_key = resolve_main_api_key(main, label).or_else(|| {
         provider_allows_no_api_key(label, base_url.as_deref()).then(|| "local-no-key".to_string())
     })?;
+    let normalized_model = crate::model_normalize::normalize_model_for_provider(model, label);
+    let model = normalized_model.as_str();
 
     let provider: Arc<dyn LlmProvider> = match label {
         "openrouter" => Arc::new(

--- a/crates/hermes-agent/src/lib.rs
+++ b/crates/hermes-agent/src/lib.rs
@@ -21,6 +21,7 @@ pub mod interrupt;
 pub mod lsp_context;
 pub mod memory_manager;
 pub mod memory_plugins;
+pub mod model_normalize;
 pub mod oauth;
 pub mod plugins;
 pub mod provider;

--- a/crates/hermes-agent/src/model_normalize.rs
+++ b/crates/hermes-agent/src/model_normalize.rs
@@ -1,0 +1,344 @@
+//! Provider-aware model identifier normalization.
+//!
+//! The CLI accepts user-facing model names, catalog slugs, and provider-prefixed
+//! IDs. Runtime providers need the exact shape each upstream API expects.
+
+use hermes_intelligence::anthropic_adapter::normalize_model_name as normalize_anthropic_model_name;
+
+const DOT_TO_HYPHEN_PROVIDERS: &[&str] = &["anthropic"];
+
+fn canonical_provider(provider: &str) -> String {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "codex" => "openai-codex".to_string(),
+        "github-copilot" | "github-models" => "copilot".to_string(),
+        "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
+        "opencode" | "zen" => "opencode-zen".to_string(),
+        "go" => "opencode-go".to_string(),
+        "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
+        "glm" | "z-ai" | "z_ai" | "zhipu" => "zai".to_string(),
+        "claude" | "claude-code" => "anthropic".to_string(),
+        "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn split_vendor_prefix(model: &str) -> Option<(&str, &str)> {
+    let (vendor, rest) = model.split_once('/')?;
+    let vendor = vendor.trim();
+    let rest = rest.trim();
+    if vendor.is_empty() || rest.is_empty() {
+        return None;
+    }
+    Some((vendor, rest))
+}
+
+fn strip_if_vendor_matches<'a>(model: &'a str, vendors: &[&str]) -> &'a str {
+    let Some((vendor, rest)) = split_vendor_prefix(model) else {
+        return model.trim();
+    };
+    if vendors
+        .iter()
+        .any(|candidate| vendor.eq_ignore_ascii_case(candidate))
+    {
+        rest
+    } else {
+        model.trim()
+    }
+}
+
+fn strip_known_vendor_prefix(model: &str) -> &str {
+    let Some((vendor, rest)) = split_vendor_prefix(model) else {
+        return model.trim();
+    };
+    let known = [
+        "anthropic",
+        "openai",
+        "google",
+        "moonshot",
+        "moonshotai",
+        "kimi",
+        "zai",
+        "z-ai",
+        "zai-org",
+        "qwen",
+        "deepseek",
+        "minimax",
+    ];
+    if known
+        .iter()
+        .any(|candidate| vendor.eq_ignore_ascii_case(candidate))
+    {
+        rest
+    } else {
+        model.trim()
+    }
+}
+
+pub fn detect_vendor(model: &str) -> Option<&'static str> {
+    let bare = split_vendor_prefix(model)
+        .map(|(_, rest)| rest)
+        .unwrap_or_else(|| model.trim());
+    let lower = bare.to_ascii_lowercase();
+    if lower.starts_with("claude-") || lower.contains("/claude-") {
+        Some("anthropic")
+    } else if lower.starts_with("gpt-") || lower.starts_with("o1") || lower.starts_with("o3") {
+        Some("openai")
+    } else if lower.starts_with("minimax") {
+        Some("minimax")
+    } else if lower.starts_with("glm-") {
+        Some("z-ai")
+    } else if lower.starts_with("kimi-") {
+        Some("moonshotai")
+    } else if lower.starts_with("qwen") {
+        Some("qwen")
+    } else if lower.starts_with("gemini-") {
+        Some("google")
+    } else if lower.starts_with("deepseek-") {
+        Some("deepseek")
+    } else {
+        None
+    }
+}
+
+fn normalize_for_aggregator(model: &str) -> String {
+    let trimmed = model.trim();
+    if trimmed.contains('/') {
+        return trimmed.to_string();
+    }
+    match detect_vendor(trimmed) {
+        Some(vendor) => format!("{vendor}/{trimmed}"),
+        None => trimmed.to_string(),
+    }
+}
+
+fn normalize_for_copilot(model: &str) -> String {
+    claude_dash_version_to_dot(strip_known_vendor_prefix(model))
+}
+
+fn claude_dash_version_to_dot(model: &str) -> String {
+    let lower = model.trim().to_ascii_lowercase();
+    if !lower.starts_with("claude-") {
+        return model.trim().to_string();
+    }
+    let parts: Vec<&str> = lower.split('-').collect();
+    if parts.len() < 4 {
+        return lower;
+    }
+    let last = parts[parts.len() - 1];
+    let prev = parts[parts.len() - 2];
+    if last.len() <= 2
+        && prev.len() <= 2
+        && last.chars().all(|c| c.is_ascii_digit())
+        && prev.chars().all(|c| c.is_ascii_digit())
+    {
+        let mut normalized: Vec<String> = parts[..parts.len() - 2]
+            .iter()
+            .map(|part| (*part).to_string())
+            .collect();
+        normalized.push(format!("{prev}.{last}"));
+        normalized.join("-")
+    } else {
+        lower
+    }
+}
+
+pub fn normalize_for_deepseek(model: &str) -> String {
+    let bare = strip_if_vendor_matches(model, &["deepseek"])
+        .trim()
+        .to_ascii_lowercase();
+    if matches!(bare.as_str(), "deepseek-chat" | "deepseek-reasoner") {
+        return bare;
+    }
+    if let Some(rest) = bare.strip_prefix("deepseek-v") {
+        if rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            return bare;
+        }
+    }
+    if bare.contains("r1")
+        || bare.contains("reason")
+        || bare.contains("think")
+        || bare.contains("cot")
+    {
+        "deepseek-reasoner".to_string()
+    } else {
+        "deepseek-chat".to_string()
+    }
+}
+
+fn normalize_for_opencode_zen(model: &str) -> String {
+    let bare = strip_if_vendor_matches(model, &["opencode-zen", "zen"]);
+    let lower = bare.to_ascii_lowercase();
+    if lower.starts_with("claude-") || lower.starts_with("anthropic/claude-") {
+        normalize_anthropic_model_name(bare, false)
+    } else {
+        bare.to_string()
+    }
+}
+
+/// Normalize a model ID for the target provider API.
+pub fn normalize_model_for_provider(model: &str, provider: &str) -> String {
+    let provider = canonical_provider(provider);
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    match provider.as_str() {
+        "anthropic" => normalize_anthropic_model_name(trimmed, false),
+        "openrouter" | "nous" => normalize_for_aggregator(trimmed),
+        "opencode-go" => strip_if_vendor_matches(trimmed, &["opencode-go", "go"]).to_string(),
+        "opencode-zen" => normalize_for_opencode_zen(trimmed),
+        "copilot" | "copilot-acp" => normalize_for_copilot(trimmed),
+        "openai" | "openai-codex" | "codex" => {
+            strip_if_vendor_matches(trimmed, &["openai"]).to_string()
+        }
+        "deepseek" => normalize_for_deepseek(trimmed),
+        "zai" => strip_if_vendor_matches(trimmed, &["zai", "z-ai", "z_ai", "zhipu"]).to_string(),
+        "kimi" => strip_if_vendor_matches(trimmed, &["moonshot", "moonshotai", "kimi"]).to_string(),
+        "qwen" => strip_if_vendor_matches(trimmed, &["qwen", "alibaba"]).to_string(),
+        _ if DOT_TO_HYPHEN_PROVIDERS.contains(&provider.as_str()) => trimmed.replace('.', "-"),
+        _ => trimmed.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_vendor, normalize_for_deepseek, normalize_model_for_provider};
+
+    #[test]
+    fn opencode_go_preserves_dot_versions() {
+        for model in [
+            "minimax-m2.7",
+            "minimax-m2.5",
+            "glm-4.5",
+            "kimi-k2.5",
+            "some-model-1.0.3",
+        ] {
+            assert_eq!(normalize_model_for_provider(model, "opencode-go"), model);
+        }
+    }
+
+    #[test]
+    fn anthropic_strips_vendor_and_converts_dots() {
+        assert_eq!(
+            normalize_model_for_provider("anthropic/claude-sonnet-4.6", "anthropic"),
+            "claude-sonnet-4-6"
+        );
+        assert_eq!(
+            normalize_model_for_provider("claude-opus-4.5", "anthropic"),
+            "claude-opus-4-5"
+        );
+    }
+
+    #[test]
+    fn opencode_zen_preserves_non_claude_dots_but_hyphenates_claude() {
+        assert_eq!(
+            normalize_model_for_provider("opencode-zen/claude-opus-4.5", "opencode-zen"),
+            "claude-opus-4-5"
+        );
+        assert_eq!(
+            normalize_model_for_provider("opencode-zen/glm-5.1", "opencode-zen"),
+            "glm-5.1"
+        );
+        assert_eq!(
+            normalize_model_for_provider("minimax-m2.5-free", "opencode-zen"),
+            "minimax-m2.5-free"
+        );
+    }
+
+    #[test]
+    fn copilot_uses_bare_dot_notation() {
+        let cases = [
+            ("anthropic/claude-opus-4.6", "claude-opus-4.6"),
+            ("anthropic/claude-sonnet-4-6", "claude-sonnet-4.6"),
+            ("claude-opus-4-6", "claude-opus-4.6"),
+            ("openai/gpt-5.4", "gpt-5.4"),
+            ("gpt-5-mini", "gpt-5-mini"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(normalize_model_for_provider(input, "copilot"), expected);
+            assert_eq!(normalize_model_for_provider(input, "copilot-acp"), expected);
+        }
+    }
+
+    #[test]
+    fn aggregators_prepend_detected_vendor_for_bare_models() {
+        assert_eq!(
+            normalize_model_for_provider("claude-sonnet-4.6", "openrouter"),
+            "anthropic/claude-sonnet-4.6"
+        );
+        assert_eq!(
+            normalize_model_for_provider("gpt-5.4", "nous"),
+            "openai/gpt-5.4"
+        );
+        assert_eq!(
+            normalize_model_for_provider("anthropic/claude-sonnet-4.6", "openrouter"),
+            "anthropic/claude-sonnet-4.6"
+        );
+    }
+
+    #[test]
+    fn native_provider_prefixes_strip_only_on_matching_provider() {
+        assert_eq!(
+            normalize_model_for_provider("zai/glm-5.1", "zai"),
+            "glm-5.1"
+        );
+        assert_eq!(
+            normalize_model_for_provider("google/gemini-2.5-pro", "gemini"),
+            "google/gemini-2.5-pro"
+        );
+        assert_eq!(
+            normalize_model_for_provider("moonshot/kimi-k2.5", "kimi-coding"),
+            "kimi-k2.5"
+        );
+        assert_eq!(
+            normalize_model_for_provider("Qwen/Qwen3.5-397B-A17B", "huggingface"),
+            "Qwen/Qwen3.5-397B-A17B"
+        );
+        assert_eq!(
+            normalize_model_for_provider("modal/zai-org/GLM-5-FP8", "custom"),
+            "modal/zai-org/GLM-5-FP8"
+        );
+    }
+
+    #[test]
+    fn detect_vendor_covers_catalog_bare_names() {
+        assert_eq!(detect_vendor("claude-sonnet-4.6"), Some("anthropic"));
+        assert_eq!(detect_vendor("gpt-5.4-mini"), Some("openai"));
+        assert_eq!(detect_vendor("minimax-m2.7"), Some("minimax"));
+        assert_eq!(detect_vendor("glm-4.5"), Some("z-ai"));
+        assert_eq!(detect_vendor("kimi-k2.5"), Some("moonshotai"));
+    }
+
+    #[test]
+    fn deepseek_v_series_passes_through_and_reasoners_fold() {
+        for model in [
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+            "deepseek/deepseek-v4-pro",
+            "DeepSeek-V4-Pro",
+            "deepseek-v10-ultra",
+        ] {
+            assert_eq!(
+                normalize_for_deepseek(model),
+                model.split('/').next_back().unwrap().to_ascii_lowercase()
+            );
+        }
+        assert_eq!(normalize_for_deepseek("deepseek-chat"), "deepseek-chat");
+        assert_eq!(normalize_for_deepseek("DEEPSEEK-CHAT"), "deepseek-chat");
+        for model in [
+            "deepseek-r1",
+            "deepseek-r1-0528",
+            "deepseek-think-v3",
+            "deepseek-reasoning-preview",
+            "deepseek-cot-experimental",
+        ] {
+            assert_eq!(normalize_for_deepseek(model), "deepseek-reasoner");
+        }
+        assert_eq!(normalize_for_deepseek("unknown-model"), "deepseek-chat");
+        assert_eq!(
+            normalize_model_for_provider("deepseek-v4-pro", "deepseek"),
+            "deepseek-v4-pro"
+        );
+    }
+}

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -6285,6 +6285,10 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
 pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvider> {
     let (provider_name, model_name) = resolve_provider_and_model(config, model);
     let runtime_provider = normalize_runtime_provider_name(provider_name.as_str());
+    let model_name = hermes_agent::model_normalize::normalize_model_for_provider(
+        model_name.as_str(),
+        runtime_provider.as_str(),
+    );
 
     let provider_config = config
         .llm_providers

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-01T17:32:44.622691+00:00",
+  "generated_at_utc": "2026-06-01T18:34:03.930420+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-01T17:32:44.622691+00:00`
+Generated: `2026-06-01T18:34:03.930420+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -6826,31 +6826,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_model_catalog.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2b757ac79b28834d98cc4547d6521e2ad3962c24",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_model_catalog.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7a1cbd54c30d4e543dcbf124dbeed964c4433e2a",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_model_normalize.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f2a4bf3d68481f3bd5a803585bc7807db1b15e4f",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_model_normalize.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7e4a6d22e872f45c87533855be8ae0868520e7bd",
       "workstream": "WS6"
@@ -6886,31 +6886,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_model_validation.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "03c0fcca3d47aa4b3c1ac64d3e04f2a2bd3c0bad",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_model_validation.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "89465b6c6c7538e5f27ddf878aab10b0bd0589d7",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_models.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d0201a3e8028dd7c656a5d50c1b9ba631d7e32de",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_models.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "d6ae4b1dd57c09785e6cce507119a811cc65ed12",
       "workstream": "WS6"
@@ -7201,16 +7201,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/hermes_cli",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli/test_runtime_provider_resolution.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "d17b1a41e3a875443643a4c0f2cb535df5b160bc",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/hermes_cli/test_runtime_provider_resolution.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "2f89be933688c28adcece574be52817116957aa0",
       "workstream": "WS6"
@@ -15586,30 +15586,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-01T17:32:44.515932+00:00",
+  "generated_at_utc": "2026-06-01T18:34:03.807704+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "042eb2012d601fb661e6c9e754715281c4440332",
+    "local_sha": "1436bbe048c92e930dab6f7ccf77518fdb47cb5f",
     "upstream_ref": "upstream/main",
     "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 560,
-      "intentional_divergence": 307,
+      "functional": 555,
+      "intentional_divergence": 312,
       "policy_only": 171
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 479,
-      "rust_equivalent_or_contract_test_required": 475,
+      "not_required_for_runtime": 484,
+      "rust_equivalent_or_contract_test_required": 470,
       "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 83
     },
     "by_status": {
-      "cleared_intentional_divergence": 307,
+      "cleared_intentional_divergence": 312,
       "cleared_non_runtime": 172,
-      "pending_review": 560
+      "pending_review": 555
     },
     "by_workstream": {
       "WS3": 56,
@@ -15618,10 +15618,10 @@
       "WS6": 693,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 307,
+    "cleared_intentional_divergence": 312,
     "cleared_non_runtime": 172,
     "pending_classification": 0,
-    "pending_review": 560,
+    "pending_review": 555,
     "total_shared_different": 1039
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-01T17:32:44.515932+00:00`
+Generated: `2026-06-01T18:34:03.807704+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1039`
 - Pending classification: `0`
-- Pending functional review: `560`
+- Pending functional review: `555`
 - Cleared non-runtime: `172`
-- Cleared intentional divergence: `307`
+- Cleared intentional divergence: `312`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 307 |
+| `cleared_intentional_divergence` | 312 |
 | `cleared_non_runtime` | 172 |
-| `pending_review` | 560 |
+| `pending_review` | 555 |
 
 ## Workstream Counts
 
@@ -37,8 +37,8 @@ Generated: `2026-06-01T17:32:44.515932+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/hermes_cli` | 117 |
 | `tests/gateway` | 113 |
+| `tests/hermes_cli` | 112 |
 | `tests/tools` | 60 |
 | `ui-tui/src` | 60 |
 | `tests/run_agent` | 56 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -2395,6 +2395,41 @@
       "rationale": "Upstream managed Browserbase/Browser Use/Modal intent is covered by Rust provider contracts: Browserbase remains direct-credential only, Browser Use supports direct and Nous-managed gateway modes with timeout/proxy payloads, idempotency-key preservation across timeout/in-progress conflicts, external-call-id persistence, and Modal backend selection is covered by hermes-config managed gateway and hermes-tools terminal/register_builtins contracts.",
       "owner": "sheawinkler",
       "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_model_normalize.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream provider-aware model normalization intent is now implemented in Rust hermes-agent::model_normalize and wired into CLI build_provider, AgentLoop runtime provider construction, and auxiliary main-runtime providers. Rust tests cover dot preservation for opencode-go, Anthropic dot-to-hyphen conversion, Copilot bare dot notation, aggregator vendor-prefix insertion, matching-only native prefix stripping, vendor detection, and DeepSeek V-series/reasoner folding.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_model_validation.py",
+      "classification": "intentional_divergence",
+      "rationale": "Python /model validation behavior is superseded by Rust CLI model-switch contracts: provider aliases/capabilities are covered by crates/hermes-cli providers/model_switch/commands tests, provider catalogs are resolved through curated/models.dev/live OpenAI-compatible helpers, unlisted Codex models are soft-accepted, and runtime-facing model IDs now pass through shared Rust provider-aware normalization before provider construction.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_runtime_provider_resolution.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream runtime-provider resolution intent is covered by Rust AgentLoop and CLI runtime provider contracts: provider aliases, api_key/api_key_env/base_url precedence, OAuth token-store refresh for openai-codex and qwen-oauth, credential-pool fallback, local no-key providers, and StepFun/Copilot/direct provider defaults are tested; this tranche adds shared model normalization to runtime-routed provider construction.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_models.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream hermes_cli.models catalog/model-id intent is covered by Rust provider registry and model_switch contracts: known provider and OAuth snapshots, curated provider model lists, models.dev merge ordering and deduplication, OpenRouter curated-only safety, Nous/OpenRouter agentic merge, local provider fallbacks, signed provider catalog cache verification, and provider-aware model normalization for runtime IDs.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/hermes_cli/test_model_catalog.py",
+      "classification": "intentional_divergence",
+      "rationale": "Python remote manifest/cache behavior is intentionally replaced by Rust provider catalog resolution: curated models plus models.dev/live provider discovery are cached in a signed provider-model cache, stale or tampered cache payloads are rejected, and provider_catalog_entries exposes bounded previews with total model counts for CLI/TUI listing.",
+      "owner": "sheawinkler",
+      "ticket": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add shared Rust `hermes-agent::model_normalize` for provider-aware model IDs
- wire normalization into CLI provider construction, AgentLoop runtime-routed providers, and auxiliary main-runtime providers
- cover opencode-go/opencode-zen, Anthropic, Copilot/Copilot ACP, aggregators, native provider prefixes, vendor detection, and DeepSeek V-series/reasoner normalization
- clear five model/provider parity backlog items and regenerate parity ledgers

## Verification
- `cargo test -p hermes-agent model_normalize -- --nocapture` (`8 passed`)
- `cargo test -p hermes-agent runtime_provider -- --nocapture` (`7 passed`)
- `cargo test -p hermes-cli normalize_runtime_provider_name -- --nocapture` (`1 passed`)
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, `stale=3`)
- `cargo build --workspace`
- `cargo test --workspace --quiet`

## Parity Delta
- `pending_review`: `560 -> 555`
- `cleared_intentional_divergence`: `307 -> 312`
