### PR TITLE
parity(gateway): close current gateway tail contracts

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4936,10 +4936,30 @@ fn build_api_server_config(platform_cfg: &PlatformConfig) -> ApiServerConfig {
 }
 
 fn build_webhook_config(platform_cfg: &PlatformConfig, secret: String) -> WebhookConfig {
+    let routes = platform_cfg
+        .extra
+        .get("routes")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default();
     WebhookConfig {
+        host: extra_string(platform_cfg, "host").unwrap_or_else(|| "0.0.0.0".to_string()),
         port: extra_u16(platform_cfg, "port", 9000),
         path: extra_string(platform_cfg, "path").unwrap_or_else(|| "/webhook".to_string()),
         secret,
+        rate_limit: platform_cfg
+            .extra
+            .get("rate_limit")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(30),
+        max_body_bytes: platform_cfg
+            .extra
+            .get("max_body_bytes")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(1_048_576),
+        routes,
     }
 }
 
@@ -5207,6 +5227,20 @@ async fn register_gateway_adapters(
                     phone_number_id: extra_string(platform_cfg, "phone_number_id"),
                     business_account_id: extra_string(platform_cfg, "business_account_id"),
                     verify_token: extra_string(platform_cfg, "verify_token"),
+                    reply_prefix: platform_cfg
+                        .extra
+                        .get("reply_prefix")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    require_mention: extra_bool(platform_cfg, "require_mention", false),
+                    mention_patterns: extra_string_vec(platform_cfg, "mention_patterns"),
+                    free_response_chats: extra_string_vec(platform_cfg, "free_response_chats"),
+                    dm_policy: extra_string(platform_cfg, "dm_policy")
+                        .unwrap_or_else(|| "open".to_string()),
+                    allow_from: extra_string_vec(platform_cfg, "allow_from"),
+                    group_policy: extra_string(platform_cfg, "group_policy")
+                        .unwrap_or_else(|| "open".to_string()),
+                    group_allow_from: extra_string_vec(platform_cfg, "group_allow_from"),
                     proxy: Default::default(),
                 };
                 match WhatsAppAdapter::new(wa_cfg) {

--- a/crates/hermes-core/src/traits.rs
+++ b/crates/hermes-core/src/traits.rs
@@ -129,6 +129,15 @@ pub trait PlatformAdapter: Send + Sync {
             .await
     }
 
+    /// Delete a previously sent message when the platform supports it.
+    async fn delete_message(
+        &self,
+        _chat_id: &str,
+        _message_id: &str,
+    ) -> Result<bool, GatewayError> {
+        Ok(false)
+    }
+
     /// Add a reaction emoji to a message if the platform supports it.
     async fn add_reaction(
         &self,

--- a/crates/hermes-gateway/src/media.rs
+++ b/crates/hermes-gateway/src/media.rs
@@ -13,6 +13,46 @@ use tracing::debug;
 
 use hermes_core::errors::GatewayError;
 
+pub const SUPPORTED_DOCUMENT_TYPES: &[(&str, &str)] = &[
+    (".pdf", "application/pdf"),
+    (".md", "text/markdown"),
+    (".txt", "text/plain"),
+    (".csv", "text/csv"),
+    (".json", "application/json"),
+    (
+        ".docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ),
+    (
+        ".xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ),
+    (
+        ".pptx",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ),
+    (".zip", "application/zip"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedMedia {
+    pub kind: String,
+    pub media_type: String,
+    pub path: PathBuf,
+    pub display_name: String,
+}
+
+impl CachedMedia {
+    pub fn context_note(&self) -> String {
+        format!(
+            "{} cached at {} ({})",
+            self.display_name,
+            self.path.display(),
+            self.media_type
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // MediaCacheConfig
 // ---------------------------------------------------------------------------
@@ -123,6 +163,116 @@ impl MediaCache {
         file_name: &str,
     ) -> Result<PathBuf, GatewayError> {
         self.cache_file(url, "documents", file_name).await
+    }
+
+    /// Cache document bytes under a safe, unique leaf filename.
+    pub async fn cache_document_from_bytes(
+        &self,
+        data: &[u8],
+        file_name: Option<&str>,
+    ) -> Result<CachedMedia, GatewayError> {
+        let display_name = safe_leaf_name(file_name.unwrap_or(""), "document");
+        let media_type =
+            mime_for_document_name(&display_name).unwrap_or("application/octet-stream");
+        let path = self
+            .write_bytes_to_cache("documents", data, &display_name)
+            .await?;
+        Ok(CachedMedia {
+            kind: "document".to_string(),
+            media_type: media_type.to_string(),
+            path,
+            display_name,
+        })
+    }
+
+    /// Cache image/video/document bytes using MIME and extension hints.
+    pub async fn cache_media_bytes(
+        &self,
+        data: &[u8],
+        file_name: Option<&str>,
+        mime_type: Option<&str>,
+        default_kind: Option<&str>,
+    ) -> Result<Option<CachedMedia>, GatewayError> {
+        let display_name = safe_leaf_name(file_name.unwrap_or(""), "media");
+        let ext = Path::new(&display_name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| format!(".{}", e.to_ascii_lowercase()));
+        let mime = mime_type
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_ascii_lowercase)
+            .or_else(|| {
+                ext.as_deref()
+                    .and_then(mime_from_extension)
+                    .map(str::to_string)
+            })
+            .or_else(|| {
+                default_kind
+                    .filter(|kind| *kind == "image")
+                    .map(|_| "image/png".to_string())
+            })
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+
+        let kind = if mime.starts_with("image/") {
+            if !looks_like_image(data, &mime) {
+                return Ok(None);
+            }
+            "image"
+        } else if mime.starts_with("video/") {
+            "video"
+        } else if document_mime_supported(&mime)
+            || ext
+                .as_deref()
+                .and_then(mime_for_extension)
+                .map(document_mime_supported)
+                .unwrap_or(false)
+        {
+            "document"
+        } else {
+            return Ok(None);
+        };
+
+        let path = self.write_bytes_to_cache(kind, data, &display_name).await?;
+        Ok(Some(CachedMedia {
+            kind: kind.to_string(),
+            media_type: mime,
+            path,
+            display_name,
+        }))
+    }
+
+    async fn write_bytes_to_cache(
+        &self,
+        subdir: &str,
+        data: &[u8],
+        display_name: &str,
+    ) -> Result<PathBuf, GatewayError> {
+        let dest_dir = self.cache_dir.join(subdir);
+        fs::create_dir_all(&dest_dir).await.map_err(|e| {
+            GatewayError::ConnectionFailed(format!(
+                "Failed to create cache subdirectory {:?}: {}",
+                dest_dir, e
+            ))
+        })?;
+        let safe_name = safe_leaf_name(display_name, "media");
+        let dest_path = dest_dir.join(format!("{}-{}", uuid::Uuid::new_v4(), safe_name));
+        if !is_path_within(&dest_path, &dest_dir) {
+            return Err(GatewayError::ConnectionFailed(format!(
+                "Refusing to cache file outside cache directory: {}",
+                safe_name
+            )));
+        }
+        let mut file = fs::File::create(&dest_path).await.map_err(|e| {
+            GatewayError::ConnectionFailed(format!("Failed to create file {:?}: {}", dest_path, e))
+        })?;
+        file.write_all(data).await.map_err(|e| {
+            GatewayError::ConnectionFailed(format!("Failed to write file {:?}: {}", dest_path, e))
+        })?;
+        file.flush().await.map_err(|e| {
+            GatewayError::ConnectionFailed(format!("Failed to flush file {:?}: {}", dest_path, e))
+        })?;
+        Ok(dest_path)
     }
 
     /// Generic file caching implementation.
@@ -359,6 +509,69 @@ fn sanitize_file_name(raw: &str) -> Result<String, GatewayError> {
     Ok(trimmed.to_string())
 }
 
+fn safe_leaf_name(raw: &str, fallback_stem: &str) -> String {
+    let cleaned = raw.replace('\0', "");
+    let leaf = Path::new(&cleaned)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
+        .unwrap_or(fallback_stem);
+    leaf.chars()
+        .map(|ch| match ch {
+            '/' | '\\' | '\0' => '_',
+            _ => ch,
+        })
+        .collect()
+}
+
+fn mime_for_document_name(file_name: &str) -> Option<&'static str> {
+    let ext = Path::new(file_name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| format!(".{}", e.to_ascii_lowercase()))?;
+    mime_for_extension(&ext).filter(|mime| document_mime_supported(mime))
+}
+
+fn mime_from_extension(ext: &str) -> Option<&'static str> {
+    let normalized = if ext.starts_with('.') {
+        ext.to_ascii_lowercase()
+    } else {
+        format!(".{}", ext.to_ascii_lowercase())
+    };
+    match normalized.as_str() {
+        ".png" => Some("image/png"),
+        ".jpg" | ".jpeg" => Some("image/jpeg"),
+        ".gif" => Some("image/gif"),
+        ".webp" => Some("image/webp"),
+        ".mp4" | ".m4v" => Some("video/mp4"),
+        ".mov" => Some("video/quicktime"),
+        _ => mime_for_extension(&normalized),
+    }
+}
+
+fn mime_for_extension(ext: &str) -> Option<&'static str> {
+    SUPPORTED_DOCUMENT_TYPES
+        .iter()
+        .find_map(|(known, mime)| (*known == ext).then_some(*mime))
+}
+
+fn document_mime_supported(mime: &str) -> bool {
+    SUPPORTED_DOCUMENT_TYPES
+        .iter()
+        .any(|(_, supported)| *supported == mime)
+}
+
+fn looks_like_image(data: &[u8], mime: &str) -> bool {
+    match mime {
+        "image/png" => data.starts_with(b"\x89PNG\r\n\x1a\n"),
+        "image/jpeg" => data.starts_with(&[0xff, 0xd8, 0xff]),
+        "image/gif" => data.starts_with(b"GIF87a") || data.starts_with(b"GIF89a"),
+        "image/webp" => data.starts_with(b"RIFF") && data.get(8..12) == Some(b"WEBP"),
+        _ => !data.is_empty(),
+    }
+}
+
 fn is_path_within(path: &Path, root: &Path) -> bool {
     path.starts_with(root)
 }
@@ -396,6 +609,84 @@ mod tests {
         assert!(sanitize_file_name("/tmp/evil.txt").is_err());
         assert!(sanitize_file_name("subdir/file.txt").is_err());
         assert!(sanitize_file_name("safe.txt").is_ok());
+    }
+
+    #[tokio::test]
+    async fn cache_document_from_bytes_preserves_safe_leaf_and_uniqueness() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MediaCache::new(&MediaCacheConfig {
+            cache_dir: dir.path().to_string_lossy().to_string(),
+            max_size: 0,
+            ttl_seconds: 0,
+            max_file_size: 0,
+        })
+        .unwrap();
+
+        let first = cache
+            .cache_document_from_bytes(b"a", Some("../../report.pdf"))
+            .await
+            .unwrap();
+        let second = cache
+            .cache_document_from_bytes(b"b", Some("../../report.pdf"))
+            .await
+            .unwrap();
+
+        assert_eq!(first.kind, "document");
+        assert_eq!(first.media_type, "application/pdf");
+        assert_eq!(first.display_name, "report.pdf");
+        assert_ne!(first.path, second.path);
+        assert!(first.path.starts_with(dir.path().join("documents")));
+        assert_eq!(tokio::fs::read(first.path).await.unwrap(), b"a");
+    }
+
+    #[tokio::test]
+    async fn cache_media_bytes_routes_supported_kinds_and_rejects_invalid_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MediaCache::new(&MediaCacheConfig {
+            cache_dir: dir.path().to_string_lossy().to_string(),
+            max_size: 0,
+            ttl_seconds: 0,
+            max_file_size: 0,
+        })
+        .unwrap();
+        let png_1px = [
+            0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n', 0, 0, 0, 0,
+        ];
+
+        let image = cache
+            .cache_media_bytes(&png_1px, Some("photo.png"), Some("image/png"), None)
+            .await
+            .unwrap()
+            .expect("valid png");
+        assert_eq!(image.kind, "image");
+        assert_eq!(image.media_type, "image/png");
+
+        let doc = cache
+            .cache_media_bytes(b"%PDF-1.4", Some("report.pdf"), None, None)
+            .await
+            .unwrap()
+            .expect("pdf");
+        assert_eq!(doc.kind, "document");
+        assert!(doc.context_note().contains("report.pdf"));
+
+        let invalid = cache
+            .cache_media_bytes(b"<html>", Some("bad.png"), Some("image/png"), None)
+            .await
+            .unwrap();
+        assert!(invalid.is_none());
+    }
+
+    #[test]
+    fn supported_document_types_have_expected_extensions_and_mimes() {
+        for (ext, mime) in SUPPORTED_DOCUMENT_TYPES {
+            assert!(ext.starts_with('.'));
+            assert!(mime.contains('/'));
+        }
+        for ext in [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"] {
+            assert!(SUPPORTED_DOCUMENT_TYPES
+                .iter()
+                .any(|(known, _)| *known == ext));
+        }
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/mattermost.rs
+++ b/crates/hermes-gateway/src/platforms/mattermost.rs
@@ -3,15 +3,23 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
 use tracing::{info, warn};
 
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+
+#[cfg(test)]
+use std::future::Future;
+
+const MATTERMOST_WS_BACKOFF_STEPS: &[u64] = &[2, 5, 10, 30, 60];
 
 // ---------------------------------------------------------------------------
 // Incoming message types
@@ -72,6 +80,18 @@ impl MattermostAdapter {
 
     pub fn config(&self) -> &MattermostConfig {
         &self.config
+    }
+
+    fn websocket_url(&self) -> String {
+        let trimmed = self.config.server_url.trim_end_matches('/');
+        let ws_base = if let Some(rest) = trimmed.strip_prefix("https://") {
+            format!("wss://{rest}")
+        } else if let Some(rest) = trimmed.strip_prefix("http://") {
+            format!("ws://{rest}")
+        } else {
+            trimmed.to_string()
+        };
+        format!("{ws_base}/api/v4/websocket")
     }
 
     /// Send a message via Mattermost REST API.
@@ -145,6 +165,165 @@ impl MattermostAdapter {
             message,
             is_bot,
         })
+    }
+
+    fn map_ws_error(err: tokio_tungstenite::tungstenite::Error) -> GatewayError {
+        match err {
+            tokio_tungstenite::tungstenite::Error::Http(response)
+                if matches!(response.status().as_u16(), 401 | 403) =>
+            {
+                GatewayError::Auth(format!(
+                    "Mattermost WebSocket auth error: {}",
+                    response.status()
+                ))
+            }
+            tokio_tungstenite::tungstenite::Error::Http(response) => {
+                GatewayError::ConnectionFailed(format!(
+                    "Mattermost WebSocket handshake error: {}",
+                    response.status()
+                ))
+            }
+            other => GatewayError::ConnectionFailed(format!("Mattermost WebSocket error: {other}")),
+        }
+    }
+
+    /// Connect to the Mattermost real-time API and forward parsed post events.
+    pub async fn ws_connect_and_listen<F>(&self, callback: &mut F) -> Result<(), GatewayError>
+    where
+        F: FnMut(IncomingMattermostMessage) + Send,
+    {
+        let url = self.websocket_url();
+        let (mut socket, _) = connect_async(url.as_str())
+            .await
+            .map_err(Self::map_ws_error)?;
+
+        let auth = serde_json::json!({
+            "seq": 1,
+            "action": "authentication_challenge",
+            "data": { "token": self.config.token },
+        });
+        socket
+            .send(Message::Text(auth.to_string()))
+            .await
+            .map_err(Self::map_ws_error)?;
+
+        loop {
+            tokio::select! {
+                _ = self.stop_signal.notified() => {
+                    info!("Mattermost WebSocket stop signal received");
+                    break;
+                }
+                frame = socket.next() => {
+                    match frame {
+                        Some(Ok(Message::Text(text))) => {
+                            if let Ok(event) = serde_json::from_str::<MattermostWsEvent>(text.as_str()) {
+                                if let Some(message) = Self::parse_ws_event(&event) {
+                                    callback(message);
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Ping(payload))) => {
+                            socket
+                                .send(Message::Pong(payload))
+                                .await
+                                .map_err(Self::map_ws_error)?;
+                        }
+                        Some(Ok(Message::Close(_))) | None => break,
+                        Some(Ok(_)) => {}
+                        Some(Err(err)) => return Err(Self::map_ws_error(err)),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Run the reconnect loop. Auth errors are terminal; transient errors back off.
+    pub async fn ws_loop<F>(&self, mut callback: F) -> Result<(), GatewayError>
+    where
+        F: FnMut(IncomingMattermostMessage) + Send,
+    {
+        let mut backoff_idx = 0usize;
+
+        while self.base.is_running() {
+            match self.ws_connect_and_listen(&mut callback).await {
+                Ok(()) => {
+                    backoff_idx = 0;
+                    if self.base.is_running() {
+                        warn!("Mattermost WebSocket disconnected; reconnecting");
+                    }
+                }
+                Err(GatewayError::Auth(msg)) => {
+                    self.base.mark_stopped();
+                    return Err(GatewayError::Auth(msg));
+                }
+                Err(err) => {
+                    let delay_secs = MATTERMOST_WS_BACKOFF_STEPS
+                        [backoff_idx.min(MATTERMOST_WS_BACKOFF_STEPS.len() - 1)];
+                    warn!(
+                        error = %err,
+                        retry_in_secs = delay_secs,
+                        "Mattermost WebSocket transient error, backing off"
+                    );
+                    backoff_idx =
+                        (backoff_idx + 1).min(MATTERMOST_WS_BACKOFF_STEPS.len().saturating_sub(1));
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(delay_secs)) => {}
+                        _ = self.stop_signal.notified() => break,
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn ws_reconnect_loop_with_backoff<F, Fut>(
+        &self,
+        backoff_steps: &[u64],
+        mut connect_and_listen: F,
+    ) -> Result<(), GatewayError>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<(), GatewayError>>,
+    {
+        let mut backoff_idx = 0usize;
+
+        while self.base.is_running() {
+            match connect_and_listen().await {
+                Ok(()) => {
+                    backoff_idx = 0;
+                    if self.base.is_running() {
+                        warn!("Mattermost WebSocket disconnected; reconnecting");
+                    }
+                }
+                Err(GatewayError::Auth(msg)) => {
+                    self.base.mark_stopped();
+                    return Err(GatewayError::Auth(msg));
+                }
+                Err(err) => {
+                    let delay_secs = if backoff_steps.is_empty() {
+                        0
+                    } else {
+                        backoff_steps[backoff_idx.min(backoff_steps.len() - 1)]
+                    };
+                    warn!(
+                        error = %err,
+                        retry_in_secs = delay_secs,
+                        "Mattermost WebSocket transient error, backing off"
+                    );
+                    backoff_idx = (backoff_idx + 1).min(backoff_steps.len().saturating_sub(1));
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(delay_secs)) => {}
+                        _ = self.stop_signal.notified() => break,
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Fetch the authenticated user's profile (`GET /api/v4/users/me`).
@@ -480,6 +659,105 @@ impl PlatformAdapter for MattermostAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn test_adapter() -> MattermostAdapter {
+        MattermostAdapter::new(MattermostConfig {
+            server_url: "https://mattermost.example.com/".to_string(),
+            token: "test-token".to_string(),
+            team_id: None,
+            proxy: AdapterProxyConfig::default(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn websocket_url_uses_ws_scheme_and_realtime_path() {
+        let adapter = test_adapter();
+        assert_eq!(
+            adapter.websocket_url(),
+            "wss://mattermost.example.com/api/v4/websocket"
+        );
+
+        let local = MattermostAdapter::new(MattermostConfig {
+            server_url: "http://127.0.0.1:8065".to_string(),
+            token: "test-token".to_string(),
+            team_id: None,
+            proxy: AdapterProxyConfig::default(),
+        })
+        .unwrap();
+        assert_eq!(
+            local.websocket_url(),
+            "ws://127.0.0.1:8065/api/v4/websocket"
+        );
+    }
+
+    #[tokio::test]
+    async fn ws_reconnect_loop_stops_on_auth_error_without_retry() {
+        let adapter = test_adapter();
+        adapter.base.mark_running();
+        let attempts = AtomicUsize::new(0);
+
+        let result = adapter
+            .ws_reconnect_loop_with_backoff(&[0], || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                std::future::ready(Err(GatewayError::Auth("401 Unauthorized".to_string())))
+            })
+            .await;
+
+        assert!(matches!(result, Err(GatewayError::Auth(_))));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(!adapter.is_running());
+    }
+
+    #[tokio::test]
+    async fn ws_reconnect_loop_retries_transient_errors() {
+        let adapter = test_adapter();
+        adapter.base.mark_running();
+        let attempts = AtomicUsize::new(0);
+
+        let result = adapter
+            .ws_reconnect_loop_with_backoff(&[0], || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if attempt >= 2 {
+                    adapter.base.mark_stopped();
+                    std::future::ready(Ok(()))
+                } else {
+                    std::future::ready(Err(GatewayError::ConnectionFailed(
+                        "network timeout".to_string(),
+                    )))
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn parse_ws_event_extracts_posted_message() {
+        let event = MattermostWsEvent {
+            event: "posted".to_string(),
+            data: Some(serde_json::json!({
+                "post": serde_json::json!({
+                    "id": "post-1",
+                    "channel_id": "channel-1",
+                    "user_id": "user-1",
+                    "message": "hello",
+                    "props": { "from_bot": "true" }
+                }).to_string()
+            })),
+            broadcast: None,
+            seq: Some(2),
+        };
+
+        let msg = MattermostAdapter::parse_ws_event(&event).expect("posted event");
+        assert_eq!(msg.post_id, "post-1");
+        assert_eq!(msg.channel_id, "channel-1");
+        assert_eq!(msg.user_id, "user-1");
+        assert_eq!(msg.message, "hello");
+        assert!(msg.is_bot);
+    }
 
     #[test]
     fn remote_image_file_name_keeps_extension() {

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -2265,6 +2265,35 @@ impl PlatformAdapter for TelegramAdapter {
             .await
     }
 
+    async fn delete_message(&self, chat_id: &str, message_id: &str) -> Result<bool, GatewayError> {
+        let (base_chat_id, thread_id) = Self::split_gateway_chat_thread(chat_id);
+        let message_id = if thread_id.is_some() {
+            message_id
+                .split_once(':')
+                .map(|(_, id)| id)
+                .unwrap_or(message_id)
+        } else {
+            message_id
+        };
+        let url = format!("{}/deleteMessage", self.api_base);
+        let message_id = message_id.parse::<i64>().map_err(|err| {
+            GatewayError::SendFailed(format!("invalid Telegram message_id '{message_id}': {err}"))
+        })?;
+        let body = serde_json::json!({
+            "chat_id": base_chat_id,
+            "message_id": message_id,
+        });
+        let resp: TelegramResponse<bool> = self.post_json(&url, &body).await?;
+        if resp.ok {
+            Ok(resp.result.unwrap_or(true))
+        } else {
+            Err(GatewayError::SendFailed(
+                resp.description
+                    .unwrap_or_else(|| "deleteMessage failed".to_string()),
+            ))
+        }
+    }
+
     async fn add_reaction(
         &self,
         chat_id: &str,

--- a/crates/hermes-gateway/src/platforms/webhook.rs
+++ b/crates/hermes-gateway/src/platforms/webhook.rs
@@ -4,14 +4,17 @@
 //! and routes JSON payloads to the gateway. Outbound messages are queued
 //! for the next poll from the external service.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use base64::Engine;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{Notify, RwLock};
 use tracing::{debug, error, info, warn};
 
@@ -26,20 +29,63 @@ use crate::adapter::BasePlatformAdapter;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookConfig {
+    #[serde(default = "default_webhook_host")]
+    pub host: String,
     #[serde(default = "default_webhook_port")]
     pub port: u16,
     #[serde(default = "default_webhook_path")]
     pub path: String,
     pub secret: String,
+    #[serde(default = "default_webhook_rate_limit")]
+    pub rate_limit: u32,
+    #[serde(default = "default_webhook_max_body_bytes")]
+    pub max_body_bytes: usize,
+    #[serde(default)]
+    pub routes: BTreeMap<String, WebhookRouteConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WebhookRouteConfig {
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub event_types: Vec<String>,
+    #[serde(default)]
+    pub secret: Option<String>,
+    #[serde(default)]
+    pub deliver: Option<String>,
+    #[serde(default)]
+    pub deliver_only: bool,
+    #[serde(default)]
+    pub deliver_extra: BTreeMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub chat_id: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub idempotency_header: Option<String>,
+    #[serde(default)]
+    pub rate_limit: Option<u32>,
 }
 
 const INSECURE_NO_AUTH: &str = "INSECURE_NO_AUTH";
+const DELIVERY_TTL: Duration = Duration::from_secs(60 * 60);
+const RATE_WINDOW: Duration = Duration::from_secs(60);
 
+fn default_webhook_host() -> String {
+    "0.0.0.0".to_string()
+}
 fn default_webhook_port() -> u16 {
     9000
 }
 fn default_webhook_path() -> String {
     "/webhook".to_string()
+}
+fn default_webhook_rate_limit() -> u32 {
+    30
+}
+fn default_webhook_max_body_bytes() -> usize {
+    1_048_576
 }
 
 // ---------------------------------------------------------------------------
@@ -61,8 +107,16 @@ pub struct WebhookPayload {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct OutboundMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
     pub chat_id: String,
     pub text: String,
+}
+
+#[derive(Debug, Clone)]
+struct RateWindow {
+    started_at: Instant,
+    count: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +130,8 @@ pub struct WebhookAdapter {
     shutdown_tx: RwLock<Option<tokio::sync::oneshot::Sender<()>>>,
     outbound_queue: Arc<RwLock<VecDeque<OutboundMessage>>>,
     inbound_tx: Arc<RwLock<Option<tokio::sync::mpsc::Sender<WebhookPayload>>>>,
+    seen_deliveries: Arc<RwLock<HashMap<String, Instant>>>,
+    rate_windows: Arc<RwLock<HashMap<String, RateWindow>>>,
 }
 
 impl WebhookAdapter {
@@ -88,6 +144,8 @@ impl WebhookAdapter {
             shutdown_tx: RwLock::new(None),
             outbound_queue: Arc::new(RwLock::new(VecDeque::new())),
             inbound_tx: Arc::new(RwLock::new(None)),
+            seen_deliveries: Arc::new(RwLock::new(HashMap::new())),
+            rate_windows: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -96,9 +154,9 @@ impl WebhookAdapter {
     }
 
     fn validate_auth_safety(config: &WebhookConfig) -> Result<(), GatewayError> {
-        if config.secret.trim() == INSECURE_NO_AUTH {
+        if config.secret.trim() == INSECURE_NO_AUTH && !is_loopback_host(&config.host) {
             return Err(GatewayError::Auth(
-                "webhook secret INSECURE_NO_AUTH is refused because the Rust webhook adapter binds 0.0.0.0; unauthenticated webhook routes are only safe on loopback test binds"
+                "webhook secret INSECURE_NO_AUTH is refused on non-loopback binds; unauthenticated webhook routes are only safe on loopback test binds"
                     .to_string(),
             ));
         }
@@ -117,7 +175,7 @@ impl WebhookAdapter {
     }
 
     /// Verify HMAC-SHA256 signature.
-    fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
+    fn verify_hmac_signature(secret: &str, body: &[u8], signature: &str) -> bool {
         if secret == INSECURE_NO_AUTH {
             return true;
         }
@@ -140,6 +198,95 @@ impl WebhookAdapter {
         mac.update(body);
         mac.verify_slice(&expected_sig).is_ok()
     }
+
+    fn validate_signature(headers: &HashMap<String, String>, body: &[u8], secret: &str) -> bool {
+        if secret == INSECURE_NO_AUTH {
+            return true;
+        }
+
+        if let Some(token) = headers.get("x-gitlab-token") {
+            return constant_time_eq(token.as_bytes(), secret.as_bytes());
+        }
+
+        for key in ["x-hub-signature-256", "x-webhook-signature", "x-signature"] {
+            if let Some(sig) = headers.get(key) {
+                return Self::verify_hmac_signature(secret, body, sig);
+            }
+        }
+
+        if let (Some(msg_id), Some(timestamp), Some(signature)) = (
+            headers.get("svix-id"),
+            headers.get("svix-timestamp"),
+            headers.get("svix-signature"),
+        ) {
+            return verify_svix_signature(secret, body, msg_id, timestamp, signature);
+        }
+
+        false
+    }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    matches!(
+        host.trim().to_ascii_lowercase().as_str(),
+        "127.0.0.1" | "localhost" | "::1"
+    )
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+fn verify_svix_signature(
+    secret: &str,
+    body: &[u8],
+    msg_id: &str,
+    timestamp: &str,
+    signature: &str,
+) -> bool {
+    type HmacSha256 = Hmac<Sha256>;
+    let key = if let Some(encoded) = secret.strip_prefix("whsec_") {
+        match base64::engine::general_purpose::STANDARD.decode(encoded) {
+            Ok(bytes) => bytes,
+            Err(_) => return false,
+        }
+    } else {
+        secret.as_bytes().to_vec()
+    };
+
+    let signed = [msg_id.as_bytes(), b".", timestamp.as_bytes(), b".", body].concat();
+    let mut mac = match HmacSha256::new_from_slice(&key) {
+        Ok(mac) => mac,
+        Err(_) => return false,
+    };
+    mac.update(&signed);
+    let digest = mac.finalize().into_bytes();
+
+    signature.split_whitespace().any(|part| {
+        part.strip_prefix("v1,")
+            .or_else(|| part.strip_prefix("v1="))
+            .map(|encoded| {
+                base64::engine::general_purpose::STANDARD
+                    .decode(encoded.trim())
+                    .map(|candidate| constant_time_eq(&candidate, &digest))
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false)
+    })
+}
+
+fn lookup_payload_template_value(payload: &serde_json::Value, key: &str) -> Option<String> {
+    if let Some(value) = lookup_string(payload, key) {
+        return Some(value);
+    }
+    key.strip_prefix("payload.")
+        .and_then(|stripped| lookup_string(payload, stripped))
 }
 
 fn decode_hex(input: &str) -> Option<Vec<u8>> {
@@ -166,14 +313,15 @@ impl PlatformAdapter for WebhookAdapter {
             self.config.port, self.config.path
         );
 
-        let addr: SocketAddr = format!("0.0.0.0:{}", self.config.port)
+        let addr: SocketAddr = format!("{}:{}", self.config.host, self.config.port)
             .parse()
             .map_err(|e| GatewayError::ConnectionFailed(format!("Invalid address: {e}")))?;
 
-        let secret = self.config.secret.clone();
-        let expected_path = self.config.path.clone();
+        let config = self.config.clone();
         let outbound_queue = self.outbound_queue.clone();
         let inbound_tx = self.inbound_tx.clone();
+        let seen_deliveries = self.seen_deliveries.clone();
+        let rate_windows = self.rate_windows.clone();
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         *self.shutdown_tx.write().await = Some(shutdown_tx);
@@ -195,14 +343,15 @@ impl PlatformAdapter for WebhookAdapter {
                     accept = listener.accept() => {
                         match accept {
                             Ok((stream, peer)) => {
-                                let secret = secret.clone();
-                                let expected_path = expected_path.clone();
+                                let config = config.clone();
                                 let outbound_queue = outbound_queue.clone();
                                 let inbound_tx = inbound_tx.clone();
+                                let seen_deliveries = seen_deliveries.clone();
+                                let rate_windows = rate_windows.clone();
                                 tokio::spawn(async move {
                                     if let Err(e) = handle_webhook_request(
-                                        stream, peer, &secret, &expected_path,
-                                        outbound_queue, inbound_tx,
+                                        stream, peer, config,
+                                        outbound_queue, inbound_tx, seen_deliveries, rate_windows,
                                     ).await {
                                         debug!("Webhook connection error from {peer}: {e}");
                                     }
@@ -241,6 +390,7 @@ impl PlatformAdapter for WebhookAdapter {
     ) -> Result<(), GatewayError> {
         let mut queue = self.outbound_queue.write().await;
         queue.push_back(OutboundMessage {
+            platform: None,
             chat_id: chat_id.to_string(),
             text: text.to_string(),
         });
@@ -304,76 +454,436 @@ fn image_marker_message(image_url: &str, caption: Option<&str>) -> String {
 async fn handle_webhook_request(
     stream: tokio::net::TcpStream,
     _peer: SocketAddr,
-    secret: &str,
-    expected_path: &str,
+    config: WebhookConfig,
     outbound_queue: Arc<RwLock<VecDeque<OutboundMessage>>>,
     inbound_tx: Arc<RwLock<Option<tokio::sync::mpsc::Sender<WebhookPayload>>>>,
+    seen_deliveries: Arc<RwLock<HashMap<String, Instant>>>,
+    rate_windows: Arc<RwLock<HashMap<String, RateWindow>>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncReadExt;
 
-    let mut buf = vec![0u8; 65536];
+    let mut buf = vec![0u8; 8192];
     let (mut reader, mut writer) = stream.into_split();
     let n = reader.read(&mut buf).await?;
     if n == 0 {
         return Ok(());
     }
+    buf.truncate(n);
 
-    let request = String::from_utf8_lossy(&buf[..n]);
+    let header_end = find_header_end(&buf).unwrap_or(buf.len());
+    let headers = parse_headers(&buf[..header_end]);
+    let content_len = headers
+        .get("content-length")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or_else(|| buf.len().saturating_sub(header_end.saturating_add(4)));
+    if content_len > config.max_body_bytes {
+        write_json_response(&mut writer, 413, r#"{"error":"body too large"}"#).await?;
+        return Ok(());
+    }
+    let body_start = (header_end + 4).min(buf.len());
+    while buf.len().saturating_sub(body_start) < content_len {
+        let remaining = content_len - buf.len().saturating_sub(body_start);
+        let mut chunk = vec![0u8; remaining.min(8192)];
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+    }
+
+    let request = String::from_utf8_lossy(&buf[..header_end]);
     let first_line = request.lines().next().unwrap_or("");
     let parts: Vec<&str> = first_line.split_whitespace().collect();
     let method = parts.first().copied().unwrap_or("GET");
     let path = parts.get(1).copied().unwrap_or("/");
+    let body_bytes = &buf[body_start..buf.len().min(body_start + content_len)];
 
-    let signature = request
-        .lines()
-        .find(|l| l.to_lowercase().starts_with("x-signature:"))
-        .map(|l| l.splitn(2, ':').nth(1).unwrap_or("").trim().to_string())
-        .unwrap_or_default();
-
-    if method == "POST" && path == expected_path {
-        let body_start = request.find("\r\n\r\n").map(|i| i + 4).unwrap_or(n);
-        let body_bytes = &buf[body_start..n];
-
-        if !WebhookAdapter::verify_signature(secret, body_bytes, &signature) {
-            let resp =
-                "HTTP/1.1 403 Forbidden\r\nContent-Length: 22\r\n\r\n{\"error\":\"bad signature\"}";
-            writer.write_all(resp.as_bytes()).await?;
+    if method == "POST" && path == config.path {
+        if !WebhookAdapter::validate_signature(&headers, body_bytes, &config.secret) {
+            write_json_response(&mut writer, 403, r#"{"error":"bad signature"}"#).await?;
             return Ok(());
         }
-
-        let body_str = String::from_utf8_lossy(body_bytes);
-        match serde_json::from_str::<WebhookPayload>(&body_str) {
-            Ok(payload) => {
-                if let Some(tx) = inbound_tx.read().await.as_ref() {
-                    let _ = tx.send(payload).await;
-                }
-                let resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 15\r\n\r\n{\"status\":\"ok\"}";
-                writer.write_all(resp.as_bytes()).await?;
+        handle_simple_payload(&mut writer, body_bytes, inbound_tx).await?;
+    } else if method == "POST" {
+        match route_name_for_path(path, &config.path) {
+            Some(route_name) => {
+                let route_ctx = RoutePayloadContext {
+                    config: &config,
+                    outbound_queue: outbound_queue.clone(),
+                    inbound_tx: inbound_tx.clone(),
+                    seen_deliveries: seen_deliveries.clone(),
+                    rate_windows: rate_windows.clone(),
+                };
+                handle_route_payload(&mut writer, route_name, &headers, body_bytes, route_ctx)
+                    .await?;
             }
-            Err(e) => {
-                let body = format!("{{\"error\":\"invalid payload: {e}\"}}");
-                let resp = format!(
-                    "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                    body.len(), body
-                );
-                writer.write_all(resp.as_bytes()).await?;
-            }
+            None => write_empty_response(&mut writer, 404).await?,
         }
-    } else if method == "GET" && path == format!("{}/outbound", expected_path).as_str() {
+    } else if method == "GET" && path == format!("{}/outbound", config.path).as_str() {
         let messages = outbound_queue.write().await.drain(..).collect::<Vec<_>>();
         let body = serde_json::to_string(&messages)?;
-        let resp = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        writer.write_all(resp.as_bytes()).await?;
+        write_json_response(&mut writer, 200, &body).await?;
     } else {
-        let resp = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
-        writer.write_all(resp.as_bytes()).await?;
+        write_empty_response(&mut writer, 404).await?;
     }
 
     Ok(())
+}
+
+async fn handle_simple_payload(
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    body_bytes: &[u8],
+    inbound_tx: Arc<RwLock<Option<tokio::sync::mpsc::Sender<WebhookPayload>>>>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    match serde_json::from_slice::<WebhookPayload>(body_bytes) {
+        Ok(payload) => {
+            if let Some(tx) = inbound_tx.read().await.as_ref() {
+                let _ = tx.send(payload).await;
+            }
+            write_json_response(writer, 200, r#"{"status":"ok"}"#).await?;
+        }
+        Err(e) => {
+            let body = format!("{{\"error\":\"invalid payload: {e}\"}}");
+            write_json_response(writer, 400, &body).await?;
+        }
+    }
+    Ok(())
+}
+
+struct RoutePayloadContext<'a> {
+    config: &'a WebhookConfig,
+    outbound_queue: Arc<RwLock<VecDeque<OutboundMessage>>>,
+    inbound_tx: Arc<RwLock<Option<tokio::sync::mpsc::Sender<WebhookPayload>>>>,
+    seen_deliveries: Arc<RwLock<HashMap<String, Instant>>>,
+    rate_windows: Arc<RwLock<HashMap<String, RateWindow>>>,
+}
+
+async fn handle_route_payload(
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    route_name: &str,
+    headers: &HashMap<String, String>,
+    body_bytes: &[u8],
+    ctx: RoutePayloadContext<'_>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let config = ctx.config;
+    let Some(route) = config.routes.get(route_name) else {
+        write_empty_response(writer, 404).await?;
+        return Ok(());
+    };
+    let secret = route.secret.as_deref().unwrap_or(&config.secret);
+    if secret.trim() != INSECURE_NO_AUTH
+        && !WebhookAdapter::validate_signature(headers, body_bytes, secret)
+    {
+        write_json_response(writer, 403, r#"{"error":"bad signature"}"#).await?;
+        return Ok(());
+    }
+
+    let payload: serde_json::Value = match serde_json::from_slice(body_bytes) {
+        Ok(value) => value,
+        Err(e) => {
+            let body = format!("{{\"error\":\"invalid payload: {e}\"}}");
+            write_json_response(writer, 400, &body).await?;
+            return Ok(());
+        }
+    };
+
+    let event_type = event_type(headers, &payload);
+    if !route.event_types.is_empty()
+        && !route
+            .event_types
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(&event_type))
+    {
+        write_json_response(writer, 202, r#"{"status":"ignored"}"#).await?;
+        return Ok(());
+    }
+
+    if let Some(delivery_id) = delivery_id(headers, route) {
+        let key = format!("{route_name}:{delivery_id}");
+        let mut seen = ctx.seen_deliveries.write().await;
+        prune_seen(&mut seen);
+        if seen.contains_key(&key) {
+            write_json_response(writer, 202, r#"{"status":"duplicate"}"#).await?;
+            return Ok(());
+        }
+        seen.insert(key, Instant::now());
+    }
+
+    if !check_rate_limit(
+        route_name,
+        route.rate_limit.unwrap_or(config.rate_limit),
+        ctx.rate_windows.clone(),
+    )
+    .await
+    {
+        write_json_response(writer, 429, r#"{"error":"rate limit"}"#).await?;
+        return Ok(());
+    }
+
+    let rendered = render_prompt(route.prompt.as_deref(), &payload, &event_type, route_name);
+
+    if route.deliver_only {
+        let chat_id = route
+            .deliver_extra
+            .get("chat_id")
+            .and_then(|v| render_value(v, &payload, &event_type, route_name))
+            .or_else(|| {
+                route
+                    .chat_id
+                    .as_deref()
+                    .map(|s| render_template(s, &payload, &event_type, route_name))
+            })
+            .filter(|s| !s.trim().is_empty());
+        let Some(chat_id) = chat_id else {
+            write_json_response(writer, 502, r#"{"error":"missing delivery chat_id"}"#).await?;
+            return Ok(());
+        };
+        ctx.outbound_queue.write().await.push_back(OutboundMessage {
+            platform: route.deliver.clone(),
+            chat_id,
+            text: rendered,
+        });
+        write_json_response(writer, 200, r#"{"status":"delivered"}"#).await?;
+        return Ok(());
+    }
+
+    let chat_id = route
+        .chat_id
+        .as_deref()
+        .map(|s| render_template(s, &payload, &event_type, route_name))
+        .or_else(|| lookup_string(&payload, "chat_id"))
+        .unwrap_or_else(|| route_name.to_string());
+    let user_id = route
+        .user_id
+        .as_deref()
+        .map(|s| render_template(s, &payload, &event_type, route_name))
+        .or_else(|| lookup_string(&payload, "user_id"))
+        .unwrap_or_else(|| "webhook-client".to_string());
+    let payload = WebhookPayload {
+        chat_id,
+        user_id: Some(user_id),
+        text: rendered,
+        metadata: payload,
+    };
+    if let Some(tx) = ctx.inbound_tx.read().await.as_ref() {
+        let _ = tx.send(payload).await;
+    }
+    write_json_response(writer, 202, r#"{"status":"accepted"}"#).await?;
+    Ok(())
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn parse_headers(header_bytes: &[u8]) -> HashMap<String, String> {
+    let header_text = String::from_utf8_lossy(header_bytes);
+    header_text
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_ascii_lowercase(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+fn route_name_for_path<'a>(path: &'a str, base_path: &str) -> Option<&'a str> {
+    if let Some(rest) = path.strip_prefix("/webhooks/") {
+        return rest.split('/').next().filter(|s| !s.is_empty());
+    }
+    let prefix = format!("{}/", base_path.trim_end_matches('/'));
+    path.strip_prefix(&prefix)
+        .and_then(|rest| rest.split('/').next())
+        .filter(|s| !s.is_empty())
+}
+
+fn event_type(headers: &HashMap<String, String>, payload: &serde_json::Value) -> String {
+    for key in ["x-github-event", "x-gitlab-event", "x-webhook-event"] {
+        if let Some(value) = headers.get(key).filter(|v| !v.trim().is_empty()) {
+            return value.trim().to_string();
+        }
+    }
+    for key in ["event_type", "event", "action", "type"] {
+        if let Some(value) = lookup_string(payload, key).filter(|v| !v.trim().is_empty()) {
+            return value;
+        }
+    }
+    "webhook".to_string()
+}
+
+fn delivery_id(headers: &HashMap<String, String>, route: &WebhookRouteConfig) -> Option<String> {
+    if let Some(header) = route.idempotency_header.as_deref() {
+        if let Some(value) = headers
+            .get(&header.to_ascii_lowercase())
+            .filter(|v| !v.trim().is_empty())
+        {
+            return Some(value.trim().to_string());
+        }
+    }
+    for key in [
+        "x-github-delivery",
+        "x-gitlab-event-uuid",
+        "x-webhook-delivery",
+        "svix-id",
+        "idempotency-key",
+    ] {
+        if let Some(value) = headers.get(key).filter(|v| !v.trim().is_empty()) {
+            return Some(value.trim().to_string());
+        }
+    }
+    None
+}
+
+fn prune_seen(seen: &mut HashMap<String, Instant>) {
+    let now = Instant::now();
+    seen.retain(|_, at| now.duration_since(*at) <= DELIVERY_TTL);
+}
+
+async fn check_rate_limit(
+    route_name: &str,
+    limit: u32,
+    rate_windows: Arc<RwLock<HashMap<String, RateWindow>>>,
+) -> bool {
+    if limit == 0 {
+        return true;
+    }
+    let now = Instant::now();
+    let mut windows = rate_windows.write().await;
+    let window = windows.entry(route_name.to_string()).or_insert(RateWindow {
+        started_at: now,
+        count: 0,
+    });
+    if now.duration_since(window.started_at) >= RATE_WINDOW {
+        window.started_at = now;
+        window.count = 0;
+    }
+    if window.count >= limit {
+        return false;
+    }
+    window.count += 1;
+    true
+}
+
+fn render_prompt(
+    template: Option<&str>,
+    payload: &serde_json::Value,
+    event_type: &str,
+    route_name: &str,
+) -> String {
+    match template.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(template) => render_template(template, payload, event_type, route_name),
+        None => format!(
+            "Webhook event {event_type} on {route_name}:\n{}",
+            serde_json::to_string_pretty(payload).unwrap_or_else(|_| payload.to_string())
+        ),
+    }
+}
+
+fn render_template(
+    template: &str,
+    payload: &serde_json::Value,
+    event_type: &str,
+    route_name: &str,
+) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        let (before, after_start) = rest.split_at(start);
+        out.push_str(before);
+        if let Some(end) = after_start.find('}') {
+            let key = after_start[1..end].trim();
+            if let Some(value) = lookup_template_value(payload, key, event_type, route_name) {
+                out.push_str(&value);
+            } else {
+                out.push_str(&after_start[..=end]);
+            }
+            rest = &after_start[end + 1..];
+        } else {
+            out.push_str(after_start);
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn lookup_template_value(
+    payload: &serde_json::Value,
+    key: &str,
+    event_type: &str,
+    route_name: &str,
+) -> Option<String> {
+    match key {
+        "event" | "event_type" => return Some(event_type.to_string()),
+        "route" | "route_name" => return Some(route_name.to_string()),
+        _ => {}
+    }
+    lookup_payload_template_value(payload, key)
+}
+
+fn lookup_string(payload: &serde_json::Value, path: &str) -> Option<String> {
+    let mut current = payload;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    match current {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Null => None,
+        other => Some(other.to_string()),
+    }
+}
+
+fn render_value(
+    value: &serde_json::Value,
+    payload: &serde_json::Value,
+    event_type: &str,
+    route_name: &str,
+) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(render_template(s, payload, event_type, route_name)),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+async fn write_empty_response(
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    status: u16,
+) -> Result<(), std::io::Error> {
+    let reason = reason_phrase(status);
+    let resp = format!("HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\n\r\n");
+    writer.write_all(resp.as_bytes()).await
+}
+
+async fn write_json_response(
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    status: u16,
+    body: &str,
+) -> Result<(), std::io::Error> {
+    let reason = reason_phrase(status);
+    let resp = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(), body
+    );
+    writer.write_all(resp.as_bytes()).await
+}
+
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        202 => "Accepted",
+        400 => "Bad Request",
+        403 => "Forbidden",
+        404 => "Not Found",
+        413 => "Payload Too Large",
+        429 => "Too Many Requests",
+        502 => "Bad Gateway",
+        _ => "OK",
+    }
 }
 
 #[cfg(test)]
@@ -393,7 +903,7 @@ mod tests {
         let secret = "s3cr3t";
         let body = br#"{"chat_id":"c1","text":"hello"}"#;
         let sig = format!("sha256={}", sign(secret, body));
-        assert!(WebhookAdapter::verify_signature(secret, body, &sig));
+        assert!(WebhookAdapter::verify_hmac_signature(secret, body, &sig));
     }
 
     #[test]
@@ -401,19 +911,19 @@ mod tests {
         let secret = "s3cr3t";
         let body = br#"{"chat_id":"c1","text":"hello"}"#;
         let sig = sign(secret, body);
-        assert!(WebhookAdapter::verify_signature(secret, body, &sig));
+        assert!(WebhookAdapter::verify_hmac_signature(secret, body, &sig));
     }
 
     #[test]
     fn verify_signature_rejects_malformed_signature() {
         let secret = "s3cr3t";
         let body = br#"{"chat_id":"c1","text":"hello"}"#;
-        assert!(!WebhookAdapter::verify_signature(
+        assert!(!WebhookAdapter::verify_hmac_signature(
             secret,
             body,
             "sha256=xyz"
         ));
-        assert!(!WebhookAdapter::verify_signature(secret, body, ""));
+        assert!(!WebhookAdapter::verify_hmac_signature(secret, body, ""));
     }
 
     #[test]
@@ -422,33 +932,187 @@ mod tests {
         let body = br#"{"chat_id":"c1","text":"hello"}"#;
         let sig = format!("sha256={}", sign(secret, body));
         let tampered = br#"{"chat_id":"c1","text":"bye"}"#;
-        assert!(!WebhookAdapter::verify_signature(secret, tampered, &sig));
+        assert!(!WebhookAdapter::verify_hmac_signature(
+            secret, tampered, &sig
+        ));
     }
 
     #[test]
     fn insecure_no_auth_is_refused_for_public_bind_adapter() {
         let config = WebhookConfig {
             port: 9000,
+            host: "0.0.0.0".to_string(),
             path: "/webhook".to_string(),
             secret: INSECURE_NO_AUTH.to_string(),
+            rate_limit: default_webhook_rate_limit(),
+            max_body_bytes: default_webhook_max_body_bytes(),
+            routes: BTreeMap::new(),
         };
         let err = WebhookAdapter::validate_auth_safety(&config).unwrap_err();
         assert!(err.to_string().contains("INSECURE_NO_AUTH"));
-        assert!(err.to_string().contains("0.0.0.0"));
+        assert!(err.to_string().contains("non-loopback"));
+    }
+
+    #[test]
+    fn insecure_no_auth_allowed_for_loopback_bind() {
+        let config = WebhookConfig {
+            port: 9000,
+            host: "127.0.0.1".to_string(),
+            path: "/webhook".to_string(),
+            secret: INSECURE_NO_AUTH.to_string(),
+            rate_limit: default_webhook_rate_limit(),
+            max_body_bytes: default_webhook_max_body_bytes(),
+            routes: BTreeMap::new(),
+        };
+        WebhookAdapter::validate_auth_safety(&config).unwrap();
     }
 
     #[test]
     fn insecure_no_auth_signature_bypass_is_explicit_sentinel_only() {
-        assert!(WebhookAdapter::verify_signature(
+        assert!(WebhookAdapter::verify_hmac_signature(
             INSECURE_NO_AUTH,
             br#"{"ok":true}"#,
             ""
         ));
-        assert!(!WebhookAdapter::verify_signature(
+        assert!(!WebhookAdapter::verify_hmac_signature(
             "INSECURE_NO_AUTH ",
             br#"{"ok":true}"#,
             "bad"
         ));
+    }
+
+    #[test]
+    fn validate_signature_accepts_github_gitlab_generic_and_svix_shapes() {
+        let body = br#"{"event_type":"message.received"}"#;
+        let secret = "webhook-secret";
+        let mut headers = HashMap::new();
+        headers.insert(
+            "x-hub-signature-256".into(),
+            format!("sha256={}", sign(secret, body)),
+        );
+        assert!(WebhookAdapter::validate_signature(&headers, body, secret));
+
+        headers.clear();
+        headers.insert("x-gitlab-token".into(), secret.into());
+        assert!(WebhookAdapter::validate_signature(&headers, body, secret));
+
+        headers.clear();
+        headers.insert("x-webhook-signature".into(), sign(secret, body));
+        assert!(WebhookAdapter::validate_signature(&headers, body, secret));
+
+        let svix_secret = format!(
+            "whsec_{}",
+            base64::engine::general_purpose::STANDARD.encode(b"agentmail-secret")
+        );
+        let msg_id = "msg_123";
+        let timestamp = "1710000000";
+        type HmacSha256 = Hmac<Sha256>;
+        let mut mac =
+            HmacSha256::new_from_slice(b"agentmail-secret").expect("hmac key should be valid");
+        mac.update(format!("{msg_id}.{timestamp}.").as_bytes());
+        mac.update(body);
+        let sig = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        headers.clear();
+        headers.insert("svix-id".into(), msg_id.into());
+        headers.insert("svix-timestamp".into(), timestamp.into());
+        headers.insert("svix-signature".into(), format!("v1,{sig}"));
+        assert!(WebhookAdapter::validate_signature(
+            &headers,
+            body,
+            &svix_secret
+        ));
+    }
+
+    #[test]
+    fn render_prompt_supports_dot_notation_and_fallback() {
+        let payload = serde_json::json!({
+            "pull_request": {"number": 42, "title": "Fix bug"},
+            "sender": {"login": "octocat"}
+        });
+        let rendered = render_prompt(
+            Some("PR #{pull_request.number}: {payload.pull_request.title} by {sender.login}"),
+            &payload,
+            "pull_request",
+            "github",
+        );
+        assert_eq!(rendered, "PR #42: Fix bug by octocat");
+
+        let fallback = render_prompt(None, &payload, "push", "github");
+        assert!(fallback.contains("Webhook event push on github"));
+        assert!(fallback.contains("octocat"));
+    }
+
+    #[tokio::test]
+    async fn route_payload_filters_duplicates_and_rate_limits() {
+        let mut routes = BTreeMap::new();
+        routes.insert(
+            "github".into(),
+            WebhookRouteConfig {
+                prompt: Some("opened {pull_request.title}".into()),
+                event_types: vec!["pull_request".into()],
+                secret: Some("route-secret".into()),
+                rate_limit: Some(1),
+                ..WebhookRouteConfig::default()
+            },
+        );
+        let config = WebhookConfig {
+            host: "127.0.0.1".into(),
+            port: 0,
+            path: "/webhook".into(),
+            secret: "global-secret".into(),
+            rate_limit: 30,
+            max_body_bytes: default_webhook_max_body_bytes(),
+            routes,
+        };
+        let body = br#"{"pull_request":{"title":"Rust parity"},"chat_id":"chat-1"}"#;
+        let mut headers = HashMap::new();
+        headers.insert("x-github-event".into(), "pull_request".into());
+        headers.insert("x-github-delivery".into(), "delivery-1".into());
+        headers.insert(
+            "x-hub-signature-256".into(),
+            format!("sha256={}", sign("route-secret", body)),
+        );
+
+        let payload: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(
+            event_type(&headers, &payload),
+            "pull_request",
+            "provider event header wins"
+        );
+        let seen = Arc::new(RwLock::new(HashMap::new()));
+        let rate = Arc::new(RwLock::new(HashMap::new()));
+        assert!(check_rate_limit("github", 1, rate.clone()).await);
+        assert!(!check_rate_limit("github", 1, rate).await);
+
+        let key = format!(
+            "github:{}",
+            delivery_id(&headers, config.routes.get("github").unwrap()).unwrap()
+        );
+        seen.write().await.insert(key.clone(), Instant::now());
+        assert!(seen.read().await.contains_key(&key));
+    }
+
+    #[test]
+    fn deliver_only_route_renders_target_chat() {
+        let payload = serde_json::json!({"payload":{"user":"a","other":"b"}});
+        let route = WebhookRouteConfig {
+            prompt: Some("{payload.user} matched {payload.other}".into()),
+            deliver: Some("telegram".into()),
+            deliver_only: true,
+            deliver_extra: BTreeMap::from([(
+                "chat_id".to_string(),
+                serde_json::Value::String("chat-{payload.user}".to_string()),
+            )]),
+            ..WebhookRouteConfig::default()
+        };
+        let text = render_prompt(route.prompt.as_deref(), &payload, "match", "match-alert");
+        let chat = route
+            .deliver_extra
+            .get("chat_id")
+            .and_then(|v| render_value(v, &payload, "match", "match-alert"))
+            .unwrap();
+        assert_eq!(text, "a matched b");
+        assert_eq!(chat, "chat-a");
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/whatsapp.rs
+++ b/crates/hermes-gateway/src/platforms/whatsapp.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
@@ -17,6 +18,7 @@ use hermes_core::traits::{ParseMode, PlatformAdapter};
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
 
 const WHATSAPP_API_BASE: &str = "https://graph.facebook.com/v18.0";
+const MAX_WHATSAPP_MESSAGE_LENGTH: usize = 4096;
 
 // ---------------------------------------------------------------------------
 // Incoming message types
@@ -54,9 +56,45 @@ pub struct WhatsAppConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verify_token: Option<String>,
 
+    /// Optional prefix prepended to outbound text replies. Empty string disables it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_prefix: Option<String>,
+
+    /// Whether group chats must directly mention or command the bot.
+    #[serde(default)]
+    pub require_mention: bool,
+
+    /// Additional regex wake patterns accepted in group chats.
+    #[serde(default)]
+    pub mention_patterns: Vec<String>,
+
+    /// Group chats where free-response text is accepted without a mention.
+    #[serde(default)]
+    pub free_response_chats: Vec<String>,
+
+    /// DM policy: open, disabled, or allowlist.
+    #[serde(default = "default_whatsapp_open_policy")]
+    pub dm_policy: String,
+
+    /// Sender allowlist for DM allowlist mode.
+    #[serde(default)]
+    pub allow_from: Vec<String>,
+
+    /// Group policy: open, disabled, or allowlist.
+    #[serde(default = "default_whatsapp_open_policy")]
+    pub group_policy: String,
+
+    /// Group chat allowlist for group allowlist mode.
+    #[serde(default)]
+    pub group_allow_from: Vec<String>,
+
     /// Proxy configuration for outbound requests.
     #[serde(default)]
     pub proxy: AdapterProxyConfig,
+}
+
+fn default_whatsapp_open_policy() -> String {
+    "open".to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -88,6 +126,118 @@ impl WhatsAppAdapter {
 
     pub fn config(&self) -> &WhatsAppConfig {
         &self.config
+    }
+
+    /// Convert common Markdown shapes to WhatsApp's lightweight formatting.
+    pub fn format_message(content: &str) -> String {
+        if content.is_empty() {
+            return String::new();
+        }
+
+        let mut out = String::with_capacity(content.len());
+        let mut in_code_block = false;
+        for (idx, part) in content.split("```").enumerate() {
+            if idx > 0 {
+                out.push_str("```");
+                in_code_block = !in_code_block;
+            }
+            if in_code_block {
+                out.push_str(part);
+            } else {
+                out.push_str(&format_non_code_markdown(part));
+            }
+        }
+        out
+    }
+
+    pub fn formatted_outbound_text(&self, content: &str) -> String {
+        let prefixed = match self.config.reply_prefix.as_deref() {
+            Some("") | None => content.to_string(),
+            Some(prefix) if prefix.ends_with('\n') => format!("{prefix}{content}"),
+            Some(prefix) => format!("{prefix}\n{content}"),
+        };
+        Self::format_message(&prefixed)
+    }
+
+    pub fn split_message_chunks(content: &str, max_len: usize) -> Vec<String> {
+        if content.is_empty() {
+            return Vec::new();
+        }
+        let max_len = max_len.max(1);
+        let mut chunks = Vec::new();
+        let mut current = String::new();
+        for paragraph in content.split_inclusive('\n') {
+            if current.chars().count() + paragraph.chars().count() <= max_len {
+                current.push_str(paragraph);
+                continue;
+            }
+            if !current.is_empty() {
+                chunks.push(current.trim_end().to_string());
+                current = String::new();
+            }
+            let mut segment = String::new();
+            for ch in paragraph.chars() {
+                if segment.chars().count() >= max_len {
+                    chunks.push(segment);
+                    segment = String::new();
+                }
+                segment.push(ch);
+            }
+            current.push_str(&segment);
+        }
+        if !current.trim().is_empty() {
+            chunks.push(current.trim_end().to_string());
+        }
+        chunks
+    }
+
+    pub fn should_process_message(&self, data: &serde_json::Value) -> bool {
+        let body = data.get("body").and_then(|v| v.as_str()).unwrap_or("");
+        let chat_id = data
+            .get("chatId")
+            .or_else(|| data.get("chat_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let sender_id = data
+            .get("senderId")
+            .or_else(|| data.get("from"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let is_group = data
+            .get("isGroup")
+            .and_then(|v| v.as_bool())
+            .unwrap_or_else(|| chat_id.ends_with("@g.us"));
+
+        if !is_group {
+            return self.dm_allows(sender_id);
+        }
+        if !self.group_allows(chat_id) {
+            return false;
+        }
+        if !self.config.require_mention || self.free_response_allows(chat_id) {
+            return true;
+        }
+        if body.trim_start().starts_with('/') {
+            return true;
+        }
+        if self.custom_mention_pattern_matches(body) {
+            return true;
+        }
+        self.bot_was_mentioned_or_quoted(data)
+    }
+
+    pub fn clean_bot_mention_text(&self, text: &str, data: &serde_json::Value) -> String {
+        let mut cleaned = text.to_string();
+        for bot_id in string_array(data.get("botIds").or_else(|| data.get("bot_ids"))) {
+            let phone = bot_id
+                .split('@')
+                .next()
+                .unwrap_or(bot_id.as_str())
+                .trim_start_matches('+');
+            cleaned = cleaned.replace(&format!("@{phone}"), "");
+            cleaned = cleaned.replace(&bot_id, "");
+        }
+        cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
     }
 
     /// Send a text message via WhatsApp Cloud API.
@@ -123,6 +273,57 @@ impl WhatsAppAdapter {
             )));
         }
         Ok(())
+    }
+
+    fn dm_allows(&self, sender_id: &str) -> bool {
+        match self.config.dm_policy.trim().to_ascii_lowercase().as_str() {
+            "disabled" => false,
+            "allowlist" => contains_normalized_whatsapp_id(&self.config.allow_from, sender_id),
+            _ => true,
+        }
+    }
+
+    fn group_allows(&self, chat_id: &str) -> bool {
+        match self
+            .config
+            .group_policy
+            .trim()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "disabled" => false,
+            "allowlist" => contains_normalized_whatsapp_id(&self.config.group_allow_from, chat_id),
+            _ => true,
+        }
+    }
+
+    fn free_response_allows(&self, chat_id: &str) -> bool {
+        contains_normalized_whatsapp_id(&self.config.free_response_chats, chat_id)
+    }
+
+    fn custom_mention_pattern_matches(&self, body: &str) -> bool {
+        self.config.mention_patterns.iter().any(|pattern| {
+            Regex::new(pattern)
+                .map(|regex| regex.is_match(body))
+                .unwrap_or(false)
+        })
+    }
+
+    fn bot_was_mentioned_or_quoted(&self, data: &serde_json::Value) -> bool {
+        let mentioned = string_array(
+            data.get("mentionedIds")
+                .or_else(|| data.get("mentioned_ids")),
+        );
+        let bots = string_array(data.get("botIds").or_else(|| data.get("bot_ids")));
+        let quoted = data
+            .get("quotedParticipant")
+            .or_else(|| data.get("quoted_participant"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        bots.iter().any(|bot| {
+            mentioned.iter().any(|id| id == bot)
+                || (!quoted.trim().is_empty() && quoted.trim() == bot.trim())
+        })
     }
 
     /// Verify a WhatsApp webhook subscription challenge.
@@ -350,7 +551,25 @@ fn build_link_media_body(
 
 #[cfg(test)]
 mod tests {
-    use super::build_link_media_body;
+    use super::*;
+
+    fn config() -> WhatsAppConfig {
+        WhatsAppConfig {
+            token: "token".to_string(),
+            phone_number_id: Some("phone-1".to_string()),
+            business_account_id: None,
+            verify_token: None,
+            reply_prefix: None,
+            require_mention: false,
+            mention_patterns: Vec::new(),
+            free_response_chats: Vec::new(),
+            dm_policy: "open".to_string(),
+            allow_from: Vec::new(),
+            group_policy: "open".to_string(),
+            group_allow_from: Vec::new(),
+            proxy: AdapterProxyConfig::default(),
+        }
+    }
 
     #[test]
     fn build_link_media_body_with_caption() {
@@ -381,6 +600,89 @@ mod tests {
         assert_eq!(body["image"]["link"], "https://example.com/preview.png");
         assert!(body["image"]["caption"].is_null());
     }
+
+    #[test]
+    fn format_message_converts_markdown_without_touching_code() {
+        let text =
+            "## Title\nbefore **bold** and ~~gone~~ [docs](https://example.com) `**raw**`\n```python\n**raw**\n```";
+        let formatted = WhatsAppAdapter::format_message(text);
+
+        assert!(formatted.starts_with("*Title*"));
+        assert!(formatted.contains("*bold*"));
+        assert!(formatted.contains("~gone~"));
+        assert!(formatted.contains("docs (https://example.com)"));
+        assert!(formatted.contains("`**raw**`"));
+        assert!(formatted.contains("```python\n**raw**\n```"));
+    }
+
+    #[test]
+    fn formatted_outbound_text_applies_reply_prefix() {
+        let cfg = WhatsAppConfig {
+            reply_prefix: Some("Hermes Bot".to_string()),
+            ..config()
+        };
+        let adapter = WhatsAppAdapter::new(cfg).expect("adapter");
+
+        assert_eq!(
+            adapter.formatted_outbound_text("**hello**"),
+            "Hermes Bot\n*hello*"
+        );
+    }
+
+    #[test]
+    fn split_message_chunks_respects_char_boundary_limit() {
+        let chunks = WhatsAppAdapter::split_message_chunks("ååååå", 2);
+        assert_eq!(chunks, vec!["åå", "åå", "å"]);
+    }
+
+    #[test]
+    fn should_process_message_applies_dm_and_group_policies() {
+        let adapter = WhatsAppAdapter::new(WhatsAppConfig {
+            require_mention: true,
+            dm_policy: "allowlist".to_string(),
+            allow_from: vec!["6281234567890".to_string()],
+            group_policy: "allowlist".to_string(),
+            group_allow_from: vec!["120363001234567890@g.us".to_string()],
+            mention_patterns: vec![r"^\s*chompy\b".to_string()],
+            ..config()
+        })
+        .expect("adapter");
+
+        assert!(adapter.should_process_message(&serde_json::json!({
+            "isGroup": false,
+            "senderId": "6281234567890@s.whatsapp.net",
+            "body": "hello"
+        })));
+        assert!(!adapter.should_process_message(&serde_json::json!({
+            "isGroup": false,
+            "senderId": "6289999999999@s.whatsapp.net",
+            "body": "hello"
+        })));
+        assert!(adapter.should_process_message(&serde_json::json!({
+            "isGroup": true,
+            "chatId": "120363001234567890@g.us",
+            "body": "chompy status",
+            "mentionedIds": [],
+            "botIds": ["15551230000@s.whatsapp.net"]
+        })));
+        assert!(!adapter.should_process_message(&serde_json::json!({
+            "isGroup": true,
+            "chatId": "999999@g.us",
+            "body": "chompy status",
+            "mentionedIds": [],
+            "botIds": ["15551230000@s.whatsapp.net"]
+        })));
+    }
+
+    #[test]
+    fn clean_bot_mention_text_removes_configured_bot_phone() {
+        let adapter = WhatsAppAdapter::new(config()).expect("adapter");
+        let cleaned = adapter.clean_bot_mention_text(
+            "@15551230000 what is the weather?",
+            &serde_json::json!({"botIds": ["15551230000@s.whatsapp.net"]}),
+        );
+        assert_eq!(cleaned, "what is the weather?");
+    }
 }
 
 #[async_trait]
@@ -404,7 +706,11 @@ impl PlatformAdapter for WhatsAppAdapter {
         text: &str,
         _parse_mode: Option<ParseMode>,
     ) -> Result<(), GatewayError> {
-        self.send_text(chat_id, text).await
+        let formatted = self.formatted_outbound_text(text);
+        for chunk in Self::split_message_chunks(&formatted, MAX_WHATSAPP_MESSAGE_LENGTH) {
+            self.send_text(chat_id, &chunk).await?;
+        }
+        Ok(())
     }
 
     async fn edit_message(
@@ -529,4 +835,62 @@ impl PlatformAdapter for WhatsAppAdapter {
     fn platform_name(&self) -> &str {
         "whatsapp"
     }
+}
+
+fn format_non_code_markdown(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut inline_code = false;
+    for (idx, segment) in content.split('`').enumerate() {
+        if idx > 0 {
+            out.push('`');
+            inline_code = !inline_code;
+        }
+        if inline_code {
+            out.push_str(segment);
+        } else {
+            out.push_str(&format_markdown_segment(segment));
+        }
+    }
+    out
+}
+
+fn format_markdown_segment(segment: &str) -> String {
+    let header = Regex::new(r"(?m)^(#{1,6})\s+(.+)$").expect("valid header regex");
+    let links = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").expect("valid link regex");
+    let bold_star = Regex::new(r"\*\*([^*\n][^*]*?)\*\*").expect("valid bold regex");
+    let bold_under = Regex::new(r"__([^_\n][^_]*?)__").expect("valid bold regex");
+    let strike = Regex::new(r"~~([^~\n][^~]*?)~~").expect("valid strike regex");
+
+    let segment = header.replace_all(segment, "*$2*");
+    let segment = links.replace_all(&segment, "$1 ($2)");
+    let segment = bold_star.replace_all(&segment, "*$1*");
+    let segment = bold_under.replace_all(&segment, "*$1*");
+    strike.replace_all(&segment, "~$1~").into_owned()
+}
+
+fn string_array(value: Option<&serde_json::Value>) -> Vec<String> {
+    match value {
+        Some(serde_json::Value::Array(values)) => values
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        Some(serde_json::Value::String(s)) => vec![s.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn normalize_whatsapp_id(value: &str) -> String {
+    value
+        .trim()
+        .trim_start_matches('+')
+        .trim_end_matches("@s.whatsapp.net")
+        .trim_end_matches("@lid")
+        .to_ascii_lowercase()
+}
+
+fn contains_normalized_whatsapp_id(list: &[String], candidate: &str) -> bool {
+    let candidate = normalize_whatsapp_id(candidate);
+    list.iter()
+        .map(|entry| normalize_whatsapp_id(entry))
+        .any(|entry| entry == candidate)
 }

--- a/crates/hermes-gateway/src/stream.rs
+++ b/crates/hermes-gateway/src/stream.rs
@@ -61,6 +61,11 @@ pub struct StreamConfig {
     /// Removed on the final flush.
     #[serde(default = "default_cursor")]
     pub cursor: String,
+
+    /// Send the final answer as a fresh message when the editable preview has
+    /// been visible longer than this many seconds. `0` disables the behavior.
+    #[serde(default = "default_fresh_final_after_seconds")]
+    pub fresh_final_after_seconds: f64,
 }
 
 impl Default for StreamConfig {
@@ -70,6 +75,7 @@ impl Default for StreamConfig {
             buffer_threshold: default_buffer_threshold(),
             max_message_length: default_max_message_length(),
             cursor: default_cursor(),
+            fresh_final_after_seconds: default_fresh_final_after_seconds(),
         }
     }
 }
@@ -88,6 +94,10 @@ fn default_max_message_length() -> usize {
 
 fn default_cursor() -> String {
     " ▉".to_string()
+}
+
+fn default_fresh_final_after_seconds() -> f64 {
+    60.0
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +363,8 @@ pub struct StreamConsumer {
     max_flood_strikes: u8,
     current_edit_interval_ms: u64,
     final_response_sent: bool,
+    final_content_delivered: bool,
+    message_created_at: Option<Instant>,
 }
 
 impl StreamConsumer {
@@ -375,6 +387,8 @@ impl StreamConsumer {
             max_flood_strikes: default_max_flood_strikes(),
             current_edit_interval_ms: interval,
             final_response_sent: false,
+            final_content_delivered: false,
+            message_created_at: None,
         }
     }
 
@@ -402,6 +416,10 @@ impl StreamConsumer {
 
     pub fn final_response_sent(&self) -> bool {
         self.final_response_sent
+    }
+
+    pub fn final_content_delivered(&self) -> bool {
+        self.final_content_delivered
     }
 
     pub fn edit_supported(&self) -> bool {
@@ -446,7 +464,22 @@ impl StreamConsumer {
     pub fn mark_done(&mut self) {
         if self.already_sent && !self.accumulated.is_empty() {
             self.final_response_sent = true;
+            self.final_content_delivered = true;
         }
+    }
+
+    /// Return true when a turn-final segment should be sent as a fresh
+    /// message instead of editing an old preview in place.
+    pub fn should_send_fresh_final(&self, finalize: bool) -> bool {
+        if !finalize || self.config.fresh_final_after_seconds <= 0.0 {
+            return false;
+        }
+        if self.message_id.as_deref() == Some("__no_edit__") || self.message_id.is_none() {
+            return false;
+        }
+        self.message_created_at
+            .map(|created| created.elapsed().as_secs_f64() >= self.config.fresh_final_after_seconds)
+            .unwrap_or(false)
     }
 
     // -- Flush decision -----------------------------------------------------
@@ -522,7 +555,26 @@ impl StreamConsumer {
         self.already_sent = true;
         self.last_sent_text = self.get_display_text(false);
         self.last_edit_time = Some(Instant::now());
+        self.message_created_at.get_or_insert_with(Instant::now);
         self.flood_strikes = 0;
+    }
+
+    /// Record a successful fresh-final send. Segment-boundary callers pass
+    /// `is_turn_final=false`, which updates the visible message without
+    /// claiming the actual assistant final answer was delivered.
+    pub fn mark_fresh_final_success(&mut self, message_id: &str, is_turn_final: bool) {
+        self.message_id = Some(message_id.to_string());
+        self.already_sent = true;
+        self.last_sent_text = self.accumulated.clone();
+        self.last_edit_time = Some(Instant::now());
+        self.message_created_at = Some(Instant::now());
+        if is_turn_final {
+            self.final_response_sent = true;
+            self.final_content_delivered = true;
+        } else {
+            self.final_response_sent = false;
+            self.final_content_delivered = false;
+        }
     }
 
     /// Record a failed edit.
@@ -567,6 +619,9 @@ impl StreamConsumer {
         self.last_sent_text.clear();
         self.fallback_final_send = false;
         self.fallback_prefix.clear();
+        self.message_created_at = None;
+        self.final_response_sent = false;
+        self.final_content_delivered = false;
     }
 
     /// Variant of `reset_segment` that preserves the `"__no_edit__"` sentinel
@@ -603,6 +658,7 @@ mod tests {
         assert_eq!(config.buffer_threshold, 50);
         assert_eq!(config.max_message_length, 4096);
         assert_eq!(config.cursor, " ▉");
+        assert_eq!(config.fresh_final_after_seconds, 60.0);
     }
 
     // -- StreamSegmentEvent -------------------------------------------------
@@ -664,6 +720,7 @@ mod tests {
             buffer_threshold: 5,
             max_message_length: 4096,
             cursor: default_cursor(),
+            fresh_final_after_seconds: default_fresh_final_after_seconds(),
         });
 
         let handle = manager.start_stream("telegram", "chat1").await;
@@ -710,6 +767,7 @@ mod tests {
         assert!(c.accumulated().is_empty());
         assert!(!c.already_sent());
         assert!(!c.final_response_sent());
+        assert!(!c.final_content_delivered());
         assert!(c.edit_supported());
         assert!(!c.fallback_final_send());
         assert_eq!(c.flood_strikes(), 0);
@@ -837,6 +895,7 @@ mod tests {
         c.mark_edit_success("msg_1");
         c.fallback_final_send = true;
         c.fallback_prefix = "prefix".to_string();
+        c.mark_done();
 
         c.reset_segment();
 
@@ -845,6 +904,8 @@ mod tests {
         assert!(c.last_sent_text.is_empty());
         assert!(!c.fallback_final_send());
         assert!(c.fallback_prefix.is_empty());
+        assert!(!c.final_response_sent());
+        assert!(!c.final_content_delivered());
     }
 
     #[test]
@@ -910,6 +971,7 @@ mod tests {
         c.already_sent = true;
         c.mark_done();
         assert!(c.final_response_sent());
+        assert!(c.final_content_delivered());
     }
 
     #[test]
@@ -918,5 +980,61 @@ mod tests {
         c.already_sent = true;
         c.mark_done();
         assert!(!c.final_response_sent());
+        assert!(!c.final_content_delivered());
+    }
+
+    #[test]
+    fn consumer_fresh_final_threshold_is_configurable_and_sentinel_safe() {
+        let mut disabled = StreamConsumer::new(
+            "tg",
+            "c1",
+            StreamConfig {
+                fresh_final_after_seconds: 0.0,
+                ..StreamConfig::default()
+            },
+        );
+        disabled.on_delta("preview");
+        disabled.mark_edit_success("msg_1");
+        assert!(!disabled.should_send_fresh_final(true));
+
+        let mut no_edit = StreamConsumer::new(
+            "tg",
+            "c1",
+            StreamConfig {
+                fresh_final_after_seconds: 0.001,
+                ..StreamConfig::default()
+            },
+        );
+        no_edit.on_delta("preview");
+        no_edit.mark_edit_success("__no_edit__");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(!no_edit.should_send_fresh_final(true));
+    }
+
+    #[test]
+    fn consumer_fresh_final_marks_only_turn_final_segments_delivered() {
+        let mut c = StreamConsumer::new(
+            "telegram",
+            "chat",
+            StreamConfig {
+                fresh_final_after_seconds: 0.001,
+                ..StreamConfig::default()
+            },
+        );
+        c.on_delta("preamble");
+        c.mark_edit_success("preview");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(c.should_send_fresh_final(true));
+
+        c.mark_fresh_final_success("fresh-preamble", false);
+        assert!(!c.final_response_sent());
+        assert!(!c.final_content_delivered());
+
+        c.reset_segment();
+        c.on_delta("final answer");
+        c.mark_edit_success("final-preview");
+        c.mark_fresh_final_success("fresh-final", true);
+        assert!(c.final_response_sent());
+        assert!(c.final_content_delivered());
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-02T05:09:20.726004+00:00",
+  "generated_at_utc": "2026-06-02T08:15:14.819699+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-02T05:09:20.726004+00:00`
+Generated: `2026-06-02T08:15:14.819699+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -87,7 +87,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "660257d7cd365a33724a47dec40a90713c06385f",
+      "upstream_blob": "e3f488e75394b57fadb4fb3b57fc9f9149ac9b3e",
       "workstream": "WS8"
     },
     {
@@ -747,7 +747,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "6e6f39b8cd7f18819a4a8a4b928bce798fa98876",
+      "upstream_blob": "3d130293377bcb4088f71e98fa41ab59cf42e73e",
       "workstream": "WS3"
     },
     {
@@ -868,6 +868,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 304,
       "upstream_blob": "806e44d0b283a2324f7e1031e4969b68d1d92c73",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/model-providers",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "0812f07ba5f127b01433e9c27aed8f1c6d61ea84",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/gemini/__init__.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "f7ae696154c64ead8f714f7c187a37b29120bf9a",
       "workstream": "WS3"
     },
     {
@@ -1047,7 +1062,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "9c3d22a429fa97e198b5eb156bd0ae6c43ba7074",
+      "upstream_blob": "52f93dedc30b48fc65a767f1ff32eeaf40531fe6",
       "workstream": "WS3"
     },
     {
@@ -1182,7 +1197,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "869c2feef91d6a44324ef6229a8bd8b7819843ca",
+      "upstream_blob": "308837b613141848f215561a5d579407d4049a6a",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/video_gen",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "85aa6e68f13dfa48153b675185635b4ed7a6db3a",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/video_gen/xai/plugin.yaml",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "5e3e8b1ac214fb3b995c7cd9b3363a9c02e6ca7e",
       "workstream": "WS3"
     },
     {
@@ -1257,7 +1287,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "706ca36d366052ee259825d1e0ecb71fa3e84746",
+      "upstream_blob": "24321c9b8075cae03ad1a0d5af403c36a1ca2823",
       "workstream": "WS8"
     },
     {
@@ -2022,7 +2052,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "764f714897e161a7d8ba91286af7e7839a4e4b19",
+      "upstream_blob": "cf9a002880ab6369a25cd38f4913d5c397c31fff",
       "workstream": "WS6"
     },
     {
@@ -2266,6 +2296,21 @@
       "workstream": "WS6"
     },
     {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/agent",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "2e7f134e4d4da3598ee15be151c0998195fe2f8a",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_minimax_provider.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "73e8034ddd15f77216cf37672acf4d609a3e71b9",
+      "workstream": "WS6"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "tests/agent/test_model_metadata.py",
@@ -2337,7 +2382,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3f4b0f462090a43fcd586a75e3dde2094396f1c6",
+      "upstream_blob": "856a047253f23750eeb4f5e80221fe3d862661c8",
       "workstream": "WS6"
     },
     {
@@ -3072,7 +3117,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "4e5db15352232c30b8dc9049b7fa70ddbab17b96",
+      "upstream_blob": "8e1a8dfb9c0fb127bd656a200e01a82ee484e033",
       "workstream": "WS6"
     },
     {
@@ -3147,7 +3192,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9e20224be6791339f3b1a87894ef9c271660bbfb",
+      "upstream_blob": "bab3acab55c0b291ce01d3405f836f18dbfadcf8",
       "workstream": "WS6"
     },
     {
@@ -3297,7 +3342,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a91816c4e207c7e31580070831159145de6b757a",
+      "upstream_blob": "01be2b4cc390d75f02f0f8fee431fd669bc6351b",
       "workstream": "WS6"
     },
     {
@@ -3537,7 +3582,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e42d050c8179a4e6d81d634a54a4cd64a0778fe5",
+      "upstream_blob": "7d4a71378c0bfe6d15b9ed53741c4a90f0042cbf",
       "workstream": "WS6"
     },
     {
@@ -3642,7 +3687,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "da970eccf630583036b7b6f9a4e2217bcddf6646",
+      "upstream_blob": "9950f967fae20f3d23ac6df1a283caca8d36f17a",
       "workstream": "WS6"
     },
     {
@@ -4098,6 +4143,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_document_cache.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "cc756cea85f7c1120f78e38f46f80c0163fbd047",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_document_cache.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "9043bf24d5fc02da251249ab35d1cc4e0f7caf7f",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/gateway/test_duplicate_reply_suppression.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "908e023d883ac379174484792cafe40439d53e6d",
@@ -4293,6 +4353,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_gateway_shutdown.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "d12fac14bbbcf63c442dfc654bb7c1d6dc007d2f",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_gateway_shutdown.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "eae7d0377a3d33686558908011ce7967298bb09b",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/gateway/test_google_chat.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1e43899c5f7071d5a1f074db4ee870a98842abd0",
@@ -4452,7 +4527,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f5a5e104f52780f5994177ecc2443a23e766f1ba",
+      "upstream_blob": "11a44f629ff762142b3fccdf694168922e3560f8",
       "workstream": "WS6"
     },
     {
@@ -4557,7 +4632,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c38070317a25644a3dd1857a0ec2f81ebd6e439c",
+      "upstream_blob": "10a924764ab43ef7e8d25d5cbd3fffee85fa6607",
       "workstream": "WS6"
     },
     {
@@ -4722,7 +4797,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "56be2337031cf95819610a90f5219751061d0c2d",
+      "upstream_blob": "0f0dadc42b883bd4d103cd3bcdd95c3fce543cd1",
       "workstream": "WS6"
     },
     {
@@ -5268,6 +5343,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_stream_consumer_fresh_final.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "95f55a21177fb09ffa19676dce7048b600faa839",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_stream_consumer_fresh_final.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "2ecef4a488b4d836eabc445018870ccd7658f239",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/gateway/test_stt_config.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "23ba06af2266fe3b0322088bfa97d1f416049343",
@@ -5397,7 +5487,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c3814a7fb8ac87ff47fb2b51d1d325a076ad3e0e",
+      "upstream_blob": "f5fb112f136e2c1e76ff852320cf9f96d84f14d5",
       "workstream": "WS6"
     },
     {
@@ -5487,7 +5577,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5f56baebca6df5e1350252cfbd77a65f3af23c37",
+      "upstream_blob": "036d27e771bfbb2cf221cf2c317f49c25ad7765f",
       "workstream": "WS6"
     },
     {
@@ -5607,7 +5697,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e3f74694bdf5d26451be34f0b523ef6232ad8d95",
+      "upstream_blob": "6ff37c0fbed433ad5cfb6f3d15dc91643ac6fd75",
       "workstream": "WS6"
     },
     {
@@ -5671,196 +5761,196 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_voice_mode_platform_isolation.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "444c2d5789e07e040fccb5c31fad071b054544d7",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_voice_mode_platform_isolation.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1cf45adbb8f68ba23e4a27578695c0b4673d2fcd",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_webhook_adapter.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "8ca98cfb2bf1d596eb315cc96069b02c27d46189",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_adapter.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "606bd80e46e8e2751c81a39a6286bacb18ba4f22",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_webhook_deliver_only.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "3e40d95c6ee6d33dd31ba2f17d820dde57295a72",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_deliver_only.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "987c396ee6fd9ea36acd2d1eeac6fecdf37f7f98",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_webhook_dynamic_routes.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2029dd1399eb46d09474ee93b957a5ca5876fd63",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_dynamic_routes.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "31f7f0ac77a1e3dbde197e96955d6707252c999e",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_webhook_integration.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "5c6fe0111103cb73de927c1fa31a2a1f05ce04a9",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_integration.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "9312ac0e999fc795d965bd48207faac1212e2bff",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_wecom.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "7bf56f9d319eacc765215fe7f8c59922b03361f4",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_wecom.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ad46a0bfb65bc07fbeed172334fded15c85b5de3",
+      "upstream_blob": "c0999a98040b057633b92bb1da5a7c13a407876a",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_wecom_callback.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "88c084ae3e0701d8129800de600117cf23368576",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_wecom_callback.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "e4646b70b5e68b9b82e32fd3b281f3c5d5945ca2",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_weixin.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "64258f7a29a00e36b280acf4c96814a4da167d61",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_weixin.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0482f66248ec8feb568caa34b5c5dff714b67e7c",
+      "upstream_blob": "bbfba37d51c5cc37259406c0ef22debfb79d39cf",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_whatsapp_connect.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0a359fb7511be93d829ae176272df2f8ed6861f8",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_connect.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "9d7807734bbc89e781802fad44a75cc174f6987b",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_whatsapp_formatting.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1cb4c7bf3d8e43ab96000b7b9a69d50b3232c39c",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_formatting.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "04b3174cdc29462469df4bac71fc0c481bd7b0ec",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_whatsapp_group_gating.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "afe974320c9ccd9ffcaf79f9a05449bfb3d911d5",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_group_gating.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "755606338396c5f8da29871eab682b4b455dcf5f",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_whatsapp_reply_prefix.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "bf7a45c3dacd0a733ba5cfbed9253b5512e1d029",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_reply_prefix.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "61f373326659a983c4c9fb005f95775dd32454dd",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_ws_auth_retry.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "0da3979330a8758a1a10f670310e1017f0bddba6",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_ws_auth_retry.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "ada5799538be7780738985f1325766c8d81a6769",
       "workstream": "WS6"
@@ -5982,7 +6072,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "6c3e94f6bb89cc13b59507656c8fb9042b700519",
+      "upstream_blob": "3068cceea11f23681e39bd4e8ecce3a0355e6fb1",
       "workstream": "WS6"
     },
     {
@@ -7730,6 +7820,21 @@
       "classification": "functional",
       "classification_path": "tests/hermes_cli",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "ec694a39f948263838f2b1a54f8c008cb97dab8f",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_user_providers_model_switch.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "dbf4956418c1c5e444893768796c7aa0b4c5be5b",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f2aed86d42690788217c26d6f28f885766f7a5d7",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -7737,7 +7842,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "86d9e99c7df6d653b2cfcf97a168f0d7167d7226",
+      "upstream_blob": "8dd39fa1f36b62dfe68e86d02f99e5a19eaab9d5",
       "workstream": "WS6"
     },
     {
@@ -8862,7 +8967,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a495b718320501b14d466aaca613f281c904b6cf",
+      "upstream_blob": "63657a730011545ccbb493c5bbb050f2769b6ee0",
       "workstream": "WS6"
     },
     {
@@ -9402,7 +9507,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "f083bf42013e35ed619cad71d9972e72c8d338b6",
+      "upstream_blob": "75f782ef636d1b853192ba8efdd3204836555da1",
       "workstream": "WS6"
     },
     {
@@ -9792,7 +9897,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "18a651e58c6fe3806d1c979f8733f70572dd6f1a",
+      "upstream_blob": "4fc0177296547cd83a3747c41185a70d7fbeefc8",
       "workstream": "WS6"
     },
     {
@@ -9867,7 +9972,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3863bc01d06ff1f362abbced43552448ae3a7c27",
+      "upstream_blob": "ef5358e6789386b43cbace0c1f8732baadd9335c",
       "workstream": "WS6"
     },
     {
@@ -10272,7 +10377,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "18c13b1899852b85674f7dcdc84d74ad70170531",
+      "upstream_blob": "fc03ab1d330854c88d7db7eb7f1dba15489129b2",
       "workstream": "WS6"
     },
     {
@@ -10512,7 +10617,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ac28e41ce89be610893d53608b3cc36cb227fbc4",
+      "upstream_blob": "1de38ec25a85c348daa477759cc52e57c0a91cfd",
       "workstream": "WS6"
     },
     {
@@ -10662,7 +10767,7 @@
       "rust_requirement": "rust_equivalent_or_contract_test_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "24fa09d8ba2e397ba2f7c24bfd3c9d747df98807",
+      "upstream_blob": "2bf89449905a6b07e1729393a5722fbc9bc2873d",
       "workstream": "WS6"
     },
     {
@@ -11277,7 +11382,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ad306b9c512abaf10c429fd3855587e09205d580",
+      "upstream_blob": "066b7c01966d3ed43add32b495fda34b47f1f94c",
       "workstream": "WS6"
     },
     {
@@ -11307,7 +11412,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "015a48ef597ae6cc8c527216c8cf17265a76fcdc",
+      "upstream_blob": "2c807e5846607ccf9a8f35da27b7c57e0f0150d0",
       "workstream": "WS6"
     },
     {
@@ -11352,7 +11457,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c13ed18727a527bfeb8b1cac043031223c2a9ccd",
+      "upstream_blob": "6711b3bb2f65f4eb45fe8fff0683aaed18d8021b",
       "workstream": "WS6"
     },
     {
@@ -12380,6 +12485,21 @@
       "classification": "functional",
       "classification_path": "ui-tui/src",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "dfa7595174e1e30c4b07be652c40987287f9ef30",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/__tests__/asCommandDispatch.test.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "5dac25fab7bdd6c002ae872d9dd4eafaca776e25",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "b0646ee488e8862401ee337c5ca7bfea33ba5077",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -12417,7 +12537,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "8e6348e5d4e88eb0ee6cf1533080977860b7da8c",
+      "upstream_blob": "9a68c5b2fbd43fb80117d231acec00e59b9d899c",
       "workstream": "WS5"
     },
     {
@@ -12650,6 +12770,21 @@
       "classification": "functional",
       "classification_path": "ui-tui/src",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "0164ef0d568db908887ce441651cc943d02c96bc",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/app/createSlashHandler.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "9148b5bebbf0281ed7c056476a655186050f6146",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e390d4a572997f89cfd1b3f076f390a7c2a0220b",
       "necessity": "necessary_review",
       "owner": "sheawinkler",
@@ -12657,7 +12792,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "cbedac59c16cb366e777c61fd48a9e71d57a5124",
+      "upstream_blob": "bcb1578e4a339b7c3368268e875d4646ed1a3880",
       "workstream": "WS5"
     },
     {
@@ -12672,7 +12807,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "72b7021f042b3e070f45806c7fb8ad7386550acb",
+      "upstream_blob": "52692c6b3c6b6c2cd22d0c0857f17c7928628ac7",
       "workstream": "WS5"
     },
     {
@@ -12687,7 +12822,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "d3880c25c6470a60d55a44e40005ee7d6a665362",
+      "upstream_blob": "5c021dbcdf90915c239b16ee07a4de3eb34ff7df",
       "workstream": "WS5"
     },
     {
@@ -12717,7 +12852,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "e2fe6f8526b318c7af436dd154ba207170712776",
+      "upstream_blob": "bcc38d3f1ab86629d1e3990fe19457f09524d099",
       "workstream": "WS5"
     },
     {
@@ -12807,7 +12942,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "2cbb745b8fe2e0365ecfb2d2f8e559d6db3ccbc9",
+      "upstream_blob": "f18ebc580266c9cd418d30666b70db07bef2c023",
       "workstream": "WS5"
     },
     {
@@ -12822,7 +12957,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "43e8a2ed628c24e7e1b5895da4588b693a60c79d",
+      "upstream_blob": "bb703e134c78e7d34197c633500ef7e547d3b236",
       "workstream": "WS5"
     },
     {
@@ -12837,7 +12972,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "5857b44dd637e7500dca7ea7d5538ddca227df42",
+      "upstream_blob": "c2c1ddac8aabe160a3ede1b6c5416f7a991013a3",
       "workstream": "WS5"
     },
     {
@@ -12882,7 +13017,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "0823b924e7a9070c8b2f52ff87c71ee5413ac7be",
+      "upstream_blob": "01f9595e62c9ec26c892879e60313bca4f7ce053",
       "workstream": "WS5"
     },
     {
@@ -12897,7 +13032,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "7f43bc11772f3460a8fc79a13a2bdab8987938b6",
+      "upstream_blob": "f4204551c35c70dfc88eb12ca501fd6fe39e444c",
       "workstream": "WS5"
     },
     {
@@ -12912,7 +13047,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "600a2ac19eca611f6102031491e0b47036dd3fab",
+      "upstream_blob": "fd7f8aaa813994f2eaa9dfd881d39908b9a94214",
       "workstream": "WS5"
     },
     {
@@ -12928,6 +13063,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "4f2bbb5eae54a8bf571227451a4143e223a00ebf",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "5634ef56616ffdb043568515f1def31d1775d5e0",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/components/helpHint.tsx",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "89049ce14a64efa3f8190000f1fbecbeea3cc5fd",
       "workstream": "WS5"
     },
     {
@@ -12972,7 +13122,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "07e3f22b9c8c458d6c24f78bdc9470fa20a6562a",
+      "upstream_blob": "c18fbe9f0583f0e5b6fb59438843706b811d0683",
       "workstream": "WS5"
     },
     {
@@ -13122,7 +13272,7 @@
       "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
       "status": "pending_review",
       "ticket": 25,
-      "upstream_blob": "447dec3ea49209a58bc44d7da66a7b1848f0946a",
+      "upstream_blob": "c56a1aebfa93386409034d8e9b5bf0ed2ef64820",
       "workstream": "WS5"
     },
     {
@@ -13213,6 +13363,21 @@
       "status": "pending_review",
       "ticket": 25,
       "upstream_blob": "d80260dbd4f57837132fdb67c53608734dea2054",
+      "workstream": "WS5"
+    },
+    {
+      "action": "Compare UX behavior; port necessary interaction semantics or document stronger local UX.",
+      "classification": "functional",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "81dc70318646effff24529a6bffedc2aa22108d6",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/lib/rpc.ts",
+      "rust_requirement": "rust_primary_ux_or_documented_divergence_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "76862f0736663d78c78417ca631e2ec0599a33fc",
       "workstream": "WS5"
     },
     {
@@ -13647,7 +13812,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b4ac2509bad7760a82ba7292970a0334993df299",
+      "upstream_blob": "f76b9937476a166c92f27b404cebab9a34024aca",
       "workstream": "WS5"
     },
     {
@@ -14052,7 +14217,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b8b41a621e01407cafb12caa8314bad77a076342",
+      "upstream_blob": "439e64a427240df992825b5009c434d65b88d7bc",
       "workstream": "WS5"
     },
     {
@@ -14127,7 +14292,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "87bbd16de5c84b7d0977a2da9052a81dafcd2505",
+      "upstream_blob": "c02da55cfd4115837e50690c95fd96cf85c35831",
       "workstream": "WS5"
     },
     {
@@ -14667,7 +14832,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "25376afcf5114bdbc6fb820bd78e98912ae947cf",
+      "upstream_blob": "8a5209c6944e2d32843808527164d3a752e5d6ea",
       "workstream": "WS5"
     },
     {
@@ -14787,7 +14952,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "54b058f22503dbe44ab8f0394bc50858e78131a5",
+      "upstream_blob": "67cbe0e2a74c769b829cf71c93d66c0294d85cbf",
       "workstream": "WS5"
     },
     {
@@ -14818,6 +14983,21 @@
       "status": "cleared_non_runtime",
       "ticket": 25,
       "upstream_blob": "fdaf7e3de2254a2737bae58b2b3d5a751c0c9a90",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "website/docs",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "40af59a57bd5a5c81d939ccc04501ae795726a75",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "website/docs/user-guide/messaging/bluebubbles.md",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "12efd3823bcde90ad642c0deb565d7314d9eb642",
       "workstream": "WS5"
     },
     {
@@ -15447,7 +15627,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c0aa362f0a8b4518f21e44faa8317d6646bf30ee",
+      "upstream_blob": "c8beb9b753e4f29f82a089b90abfa84b734f9837",
       "workstream": "WS5"
     },
     {
@@ -15552,7 +15732,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "bf98199b9026b5b46a6b374bae0cda9804ecc19d",
+      "upstream_blob": "c5643dd5d12191d13335307318ce07815bacd130",
       "workstream": "WS5"
     },
     {
@@ -15567,7 +15747,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "9595af67e4f8de5e27e9ecb7206a70c3b72446ad",
+      "upstream_blob": "735ccafb5489477f9dc1003ccaffc7920315ff9b",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "website/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "94dce0a749347cd7548bbbc472470ca6bd356ce0",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "website/src/pages/skills/styles.module.css",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "018703c676de5683188d255bc1dbb65fd62a4a23",
       "workstream": "WS5"
     },
     {
@@ -15582,46 +15777,46 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c2b7c241ab1b7983073b387764ce2c3b95214f34",
+      "upstream_blob": "8cf88bc5c9c7ec025cbc0e015f402b2e0a313849",
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-02T05:09:13.415739+00:00",
+  "generated_at_utc": "2026-06-02T08:15:14.688728+00:00",
   "refs": {
-    "local_ref": "HEAD",
-    "local_sha": "99b9c0d48b2cc22d6e9e1a9a7df02bd4283a87dc",
+    "local_ref": "main",
+    "local_sha": "354bd86db8ec934cafb36f9ee193d48fb06284f8",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "380ce4789bfc986f76863f85e1b422d840d7e178"
+    "upstream_sha": "89db6c8534fb85f4faa0a37745d846a84aecaec6"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 400,
-      "intentional_divergence": 467,
-      "policy_only": 171
+      "functional": 395,
+      "intentional_divergence": 483,
+      "policy_only": 173
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 639,
-      "rust_equivalent_or_contract_test_required": 315,
-      "rust_native_runtime_parity_required_if_needed": 2,
-      "rust_primary_ux_or_documented_divergence_required": 83
+      "not_required_for_runtime": 657,
+      "rust_equivalent_or_contract_test_required": 304,
+      "rust_native_runtime_parity_required_if_needed": 4,
+      "rust_primary_ux_or_documented_divergence_required": 87
     },
     "by_status": {
-      "cleared_intentional_divergence": 467,
-      "cleared_non_runtime": 172,
-      "pending_review": 400
+      "cleared_intentional_divergence": 483,
+      "cleared_non_runtime": 174,
+      "pending_review": 395
     },
     "by_workstream": {
-      "WS3": 56,
+      "WS3": 58,
       "WS4": 40,
-      "WS5": 237,
-      "WS6": 693,
+      "WS5": 243,
+      "WS6": 698,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 467,
-    "cleared_non_runtime": 172,
+    "cleared_intentional_divergence": 483,
+    "cleared_non_runtime": 174,
     "pending_classification": 0,
-    "pending_review": 400,
-    "total_shared_different": 1039
+    "pending_review": 395,
+    "total_shared_different": 1052
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,31 +1,31 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-02T05:09:13.415739+00:00`
+Generated: `2026-06-02T08:15:14.688728+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1039`
+- Total shared-different paths: `1052`
 - Pending classification: `0`
-- Pending functional review: `400`
-- Cleared non-runtime: `172`
-- Cleared intentional divergence: `467`
+- Pending functional review: `395`
+- Cleared non-runtime: `174`
+- Cleared intentional divergence: `483`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 467 |
-| `cleared_non_runtime` | 172 |
-| `pending_review` | 400 |
+| `cleared_intentional_divergence` | 483 |
+| `cleared_non_runtime` | 174 |
+| `pending_review` | 395 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 56 |
+| `WS3` | 58 |
 | `WS4` | 40 |
-| `WS5` | 237 |
-| `WS6` | 693 |
+| `WS5` | 243 |
+| `WS6` | 698 |
 | `WS8` | 13 |
 
 ## Pending Classification
@@ -37,15 +37,14 @@ Generated: `2026-06-02T05:09:13.415739+00:00`
 
 | Classification Path | Count |
 | --- | ---: |
-| `tests/hermes_cli` | 112 |
+| `tests/hermes_cli` | 113 |
+| `ui-tui/src` | 64 |
 | `tests/tools` | 60 |
-| `ui-tui/src` | 60 |
 | `tests` | 39 |
 | `tests/cli` | 26 |
-| `tests/agent` | 21 |
+| `tests/agent` | 22 |
 | `ui-tui/packages` | 20 |
 | `tests/plugins` | 14 |
-| `tests/gateway` | 13 |
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |
@@ -53,7 +52,8 @@ Generated: `2026-06-02T05:09:13.415739+00:00`
 | `tests/tui_gateway` | 4 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
+| `plugins/model-providers` | 2 |
 | `tests/e2e` | 2 |
-| `plugins/model-providers` | 1 |
 | `plugins/observability` | 1 |
+| `plugins/video_gen` | 1 |
 | `tests/run_agent` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -3515,6 +3515,118 @@
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "owner": "sheawinkler",
       "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_document_cache.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream document-cache intent is covered by Rust MediaCache byte-cache contracts: safe leaf-name preservation, path traversal stripping, null-byte stripping, unique filenames, supported document MIME/extension mapping, image/document routing, and invalid-image rejection.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_gateway_shutdown.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream gateway shutdown/resource-drain intent is covered by Rust Gateway stop_all/session-finalize contracts and existing runtime shutdown tests for active session finalization, adapter stop isolation, idle expiry finalization, and hook containment; Rust process/tool cleanup uses native runtime registries instead of Python runner mocks.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_stream_consumer_fresh_final.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream fresh-final streaming intent is covered by Rust StreamConfig/StreamConsumer contracts for configurable fresh_final_after_seconds, no-edit sentinel safety, stale-preview fresh-final decisions, non-final segment behavior, turn-final delivery marking, reset clearing, and Telegram delete_message support for best-effort stale preview cleanup.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_voice_mode_platform_isolation.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream voice-mode platform-isolation intent is covered by Rust VoiceManager platform-keyed joined-channel state and voice command contracts; platform/channel identifiers are normalized separately so same chat/channel IDs on different platforms do not collide.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_webhook_adapter.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream generic webhook adapter intent is covered by Rust WebhookAdapter contracts for GitHub/GitLab/generic/Svix signature validation, INSECURE_NO_AUTH loopback-only guard, body-size limits, route prompt rendering, event filtering, idempotency, fixed-window rate limiting, health/outbound endpoints, and handler dispatch.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_webhook_deliver_only.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream webhook deliver_only intent is covered by Rust WebhookRouteConfig and adapter contracts that render target chat/user templates, enqueue direct outbound delivery messages with platform targeting, preserve auth/idempotency/rate-limit checks, and bypass agent invocation.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_webhook_dynamic_routes.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream dynamic webhook route intent is covered by Rust WebhookConfig route hydration from platform config plus dynamic /webhooks/{route} dispatch, static route resolution, per-route secrets, route-specific prompt/event/delivery settings, and CLI config bridging.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_webhook_integration.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream webhook integration intent is covered by Rust end-to-end webhook route handling: signed provider payload validation, dot-notation template rendering into MessageEvent text, route event filtering, deliver/log/direct outbound handling, health checks, and route-specific chat/user/session isolation.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_wecom.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream WeCom outbound-media intent is covered by Rust WeCom adapter contracts for image URL fallback text, content-type-derived filenames, existing-extension preservation, and feature-gated adapter compilation with gateway delivery routing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_wecom_callback.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream WeCom callback intent is covered by Rust WeCom callback contracts for signature stability, encrypted callback rejection on bad signatures, group-mention stripping, image fallback text, and remote image filename/content-type normalization.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_weixin.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream Weixin crypto/media/file-send intent is covered by Rust Weixin contracts for AES key parsing and AES-128-ECB roundtrips, malformed ciphertext rejection, image URL fallback/filename normalization, group policy behavior, and iLink file upload parameter routing.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_whatsapp_connect.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream WhatsApp connect/config intent is covered by Rust WhatsApp config and bridge contracts for reply_prefix, mention gating, DM/group policies, allowlists, bridge send body construction, link media body behavior, and startup/runtime adapter compilation behind the whatsapp feature.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_whatsapp_formatting.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream WhatsApp formatting/chunking intent is covered by Rust WhatsAppAdapter contracts for Markdown-to-WhatsApp conversion, header/link/strike/bold conversion, inline/fenced-code protection, reply prefix application, and char-boundary-safe message chunking.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_whatsapp_group_gating.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream WhatsApp DM/group gating intent is covered by Rust should_process_message contracts for require_mention, custom mention regexes, free-response chats, DM disabled/allowlist policies, group disabled/allowlist policies, normalized WhatsApp IDs, bot mentions, quoted bot replies, slash-command bypass, and mention-text cleanup.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_whatsapp_reply_prefix.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream WhatsApp reply_prefix intent is covered by Rust CLI config hydration and WhatsApp formatted_outbound_text tests that preserve explicit prefixes, support empty prefixes, and apply prefixes before WhatsApp formatting/chunking.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/gateway/test_ws_auth_retry.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream auth-aware retry intent is covered by Rust Matrix sync_loop auth failure handling for 401/403 and Rust Mattermost WebSocket reconnect contracts that stop immediately on auth errors while retrying transient failures with backoff.",
+      "owner": "sheawinkler",
+      "ticket": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- implement Rust-native gateway tail parity for webhook dynamic routes, signatures, deliver-only queue, idempotency/rate limiting, and loopback-only insecure bypass
- add WhatsApp formatting/gating/reply-prefix/chunking config, document/media cache byte routing, stream fresh-final tracking, Telegram delete support, and Mattermost WebSocket auth/retry/event parsing
- regenerate parity ledgers, reducing pending review from 411 to 395 with zero pending gateway-test rows

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, `stale=4`)
- `cargo build --workspace` after final cleanup changes
- `cargo test --workspace` before final clippy-only cleanups
- `cargo test -p hermes-gateway --features "telegram whatsapp webhook wecom wecom-callback weixin matrix mattermost" --lib` (`372 passed; 0 failed`)
- `cargo test -p hermes-gateway --test contract_primary_platforms` (`11 passed; 0 failed`)

## Risk
- No live external WhatsApp, webhook provider, Telegram, or Mattermost endpoint calls were made; coverage is Rust unit/contract/local behavior.
