### PR TITLE
parity(tools): close runtime storage env and safety contracts

### DIFF
--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -1110,6 +1110,14 @@ pub struct TerminalConfig {
     )]
     pub auto_source_bashrc: bool,
 
+    /// Host env-var names allowed through provider/tool subprocess sanitizers.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub env_passthrough: Vec<String>,
+
     /// SSH backend host.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ssh_host: Option<String>,
@@ -1149,6 +1157,7 @@ impl Default for TerminalConfig {
             modal_mode: None,
             shell_init_files: Vec::new(),
             auto_source_bashrc: default_auto_source_bashrc(),
+            env_passthrough: Vec::new(),
             ssh_host: None,
             ssh_port: None,
             ssh_user: None,
@@ -1706,6 +1715,24 @@ tool_output: nonsense
         assert_eq!(json, "\"docker\"");
         let back: TerminalBackendType = serde_json::from_str(&json).unwrap();
         assert_eq!(back, TerminalBackendType::Docker);
+    }
+
+    #[test]
+    fn terminal_config_accepts_env_passthrough_list() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+terminal:
+  env_passthrough:
+    - OPENAI_API_KEY
+    - TENOR_API_KEY
+"#,
+        )
+        .expect("terminal env passthrough config");
+
+        assert_eq!(
+            cfg.terminal.env_passthrough,
+            vec!["OPENAI_API_KEY".to_string(), "TENOR_API_KEY".to_string()]
+        );
     }
 
     #[test]

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -1,6 +1,6 @@
 //! Local terminal backend – executes commands on the same host.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -53,6 +53,8 @@ pub struct LocalBackend {
     shell_init_files: Vec<String>,
     /// Auto-source common shell startup files when no explicit list is set.
     auto_source_bashrc: bool,
+    /// Env-var names allowed through subprocess secret sanitizers.
+    env_passthrough: Vec<String>,
     /// Background processes tracked by session id for lifecycle operations.
     background_processes: Arc<Mutex<HashMap<String, ProcessSession>>>,
 }
@@ -60,12 +62,13 @@ pub struct LocalBackend {
 impl LocalBackend {
     /// Create a new local backend with the given defaults.
     pub fn new(default_timeout: u64, max_output_size: usize) -> Self {
-        let (shell_init_files, auto_source_bashrc) = terminal_shell_init_config_from_env();
+        let (shell_init_files, auto_source_bashrc, env_passthrough) = terminal_config_from_env();
         Self::new_with_shell_init(
             default_timeout,
             max_output_size,
             shell_init_files,
             auto_source_bashrc,
+            env_passthrough,
         )
     }
 
@@ -76,6 +79,7 @@ impl LocalBackend {
             config.max_output_size,
             config.shell_init_files.clone(),
             config.auto_source_bashrc,
+            config.env_passthrough.clone(),
         )
     }
 
@@ -84,12 +88,14 @@ impl LocalBackend {
         max_output_size: usize,
         shell_init_files: Vec<String>,
         auto_source_bashrc: bool,
+        env_passthrough: Vec<String>,
     ) -> Self {
         Self {
             default_timeout,
             max_output_size,
             shell_init_files,
             auto_source_bashrc,
+            env_passthrough,
             background_processes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -648,6 +654,7 @@ const SUBPROCESS_ENV_BLOCKLIST_PREFIXES: &[&str] = &[
 ];
 
 const SUBPROCESS_ENV_FORCE_PREFIX: &str = "_HERMES_FORCE_";
+const SUBPROCESS_ENV_PASSTHROUGH_VAR: &str = "HERMES_SUBPROCESS_ENV_PASSTHROUGH";
 
 const SANE_PATH_ENTRIES: &[&str] = &[
     "/usr/local/bin",
@@ -664,6 +671,43 @@ fn should_strip_subprocess_env(key: &str) -> bool {
         || SUBPROCESS_ENV_BLOCKLIST_PREFIXES
             .iter()
             .any(|prefix| key.starts_with(prefix))
+}
+
+fn normalize_env_passthrough_name(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || !trimmed
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn parse_subprocess_env_passthrough(value: &str) -> BTreeSet<String> {
+    value
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | ':' | ';'))
+        .filter_map(normalize_env_passthrough_name)
+        .collect()
+}
+
+fn subprocess_env_passthrough_set(configured: &[String]) -> BTreeSet<String> {
+    let mut values = std::env::var(SUBPROCESS_ENV_PASSTHROUGH_VAR)
+        .ok()
+        .map(|raw| parse_subprocess_env_passthrough(&raw))
+        .unwrap_or_default();
+    values.extend(
+        configured
+            .iter()
+            .filter_map(|name| normalize_env_passthrough_name(name)),
+    );
+    values
+}
+
+fn is_subprocess_env_passthrough(key: &str, passthrough: &BTreeSet<String>) -> bool {
+    passthrough.contains(key)
 }
 
 fn normalize_subprocess_path(path: Option<&str>) -> String {
@@ -686,8 +730,20 @@ fn normalize_subprocess_path(path: Option<&str>) -> String {
     entries.join(":")
 }
 
-fn shell_env_cleanup_snippet() -> String {
+fn shell_env_cleanup_snippet(configured_passthrough: &[String]) -> String {
     let mut snippet = String::new();
+    let configured_passthrough = configured_passthrough
+        .iter()
+        .filter_map(|name| normalize_env_passthrough_name(name))
+        .collect::<Vec<_>>()
+        .join(" ");
+    if !configured_passthrough.is_empty() {
+        snippet.push_str(
+            "HERMES_SUBPROCESS_ENV_PASSTHROUGH=\"${HERMES_SUBPROCESS_ENV_PASSTHROUGH:-} ",
+        );
+        snippet.push_str(&configured_passthrough);
+        snippet.push_str("\"; ");
+    }
     if !SUBPROCESS_ENV_BLOCKLIST_PREFIXES.is_empty() {
         snippet
             .push_str("for __hermes_env in $(env | sed 's/=.*//'); do case \"$__hermes_env\" in ");
@@ -698,10 +754,10 @@ fn shell_env_cleanup_snippet() -> String {
             snippet.push_str(prefix);
             snippet.push('*');
         }
-        snippet.push_str(") unset \"$__hermes_env\" ;; esac; done; unset __hermes_env; ");
+        snippet.push_str(") case \" ${HERMES_SUBPROCESS_FORCE_TARGETS:-} ${HERMES_SUBPROCESS_ENV_PASSTHROUGH:-} \" in *\" $__hermes_env \"*) ;; *) unset \"$__hermes_env\" ;; esac ;; esac; done; unset __hermes_env; ");
     }
     for key in SUBPROCESS_ENV_BLOCKLIST_EXACT {
-        snippet.push_str("case \" ${HERMES_SUBPROCESS_FORCE_TARGETS:-} \" in *\" ");
+        snippet.push_str("case \" ${HERMES_SUBPROCESS_FORCE_TARGETS:-} ${HERMES_SUBPROCESS_ENV_PASSTHROUGH:-} \" in *\" ");
         snippet.push_str(key);
         snippet.push_str(" \"*) ;; *) unset ");
         snippet.push_str(key);
@@ -745,13 +801,17 @@ fn bool_env_or_default(name: &str, default: bool) -> bool {
     }
 }
 
-fn terminal_shell_init_config_from_env() -> (Vec<String>, bool) {
+fn terminal_config_from_env() -> (Vec<String>, bool, Vec<String>) {
     let explicit = std::env::var("TERMINAL_SHELL_INIT_FILES")
         .ok()
         .map(|v| parse_shell_init_list(&v))
         .unwrap_or_default();
     let auto_source_bashrc = bool_env_or_default("TERMINAL_AUTO_SOURCE_BASHRC", true);
-    (explicit, auto_source_bashrc)
+    let env_passthrough = std::env::var(SUBPROCESS_ENV_PASSTHROUGH_VAR)
+        .ok()
+        .map(|v| parse_subprocess_env_passthrough(&v).into_iter().collect())
+        .unwrap_or_default();
+    (explicit, auto_source_bashrc, env_passthrough)
 }
 
 fn expand_env_refs(input: &str) -> String {
@@ -856,10 +916,11 @@ fn shell_source_prelude(files: &[PathBuf]) -> String {
     prelude
 }
 
-fn scrub_subprocess_env(cmd: &mut TokioCommand) {
+fn scrub_subprocess_env(cmd: &mut TokioCommand, configured_passthrough: &[String]) {
+    let passthrough = subprocess_env_passthrough_set(configured_passthrough);
     let mut forced = Vec::new();
     for (key, _) in std::env::vars() {
-        if should_strip_subprocess_env(&key) {
+        if should_strip_subprocess_env(&key) && !is_subprocess_env_passthrough(&key, &passthrough) {
             cmd.env_remove(key);
         } else if let Some(target) = key.strip_prefix(SUBPROCESS_ENV_FORCE_PREFIX) {
             cmd.env_remove(&key);
@@ -885,6 +946,14 @@ fn scrub_subprocess_env(cmd: &mut TokioCommand) {
     } else {
         cmd.env("HERMES_SUBPROCESS_FORCE_TARGETS", forced_targets.join(" "));
     }
+    if passthrough.is_empty() {
+        cmd.env_remove(SUBPROCESS_ENV_PASSTHROUGH_VAR);
+    } else {
+        cmd.env(
+            SUBPROCESS_ENV_PASSTHROUGH_VAR,
+            passthrough.into_iter().collect::<Vec<_>>().join(" "),
+        );
+    }
 
     let normalized_path = normalize_subprocess_path(std::env::var("PATH").ok().as_deref());
     cmd.env("PATH", normalized_path);
@@ -894,10 +963,11 @@ fn with_login_profile_sources(
     command: &str,
     explicit_files: &[String],
     auto_source_bashrc: bool,
+    env_passthrough: &[String],
 ) -> String {
     #[cfg(unix)]
     {
-        let cleanup = shell_env_cleanup_snippet();
+        let cleanup = shell_env_cleanup_snippet(env_passthrough);
         let bash_prelude = shell_source_prelude(&resolve_shell_init_files_for_shell(
             "bash",
             explicit_files,
@@ -938,6 +1008,7 @@ else printf '%s\n' \"Hermes could not find bash or zsh in PATH. Run 'exec zsh -l
     {
         let _ = explicit_files;
         let _ = auto_source_bashrc;
+        let _ = env_passthrough;
         command.to_string()
     }
 }
@@ -1113,6 +1184,7 @@ impl TerminalBackend for LocalBackend {
             &rewritten_command,
             &self.shell_init_files,
             self.auto_source_bashrc,
+            &self.env_passthrough,
         );
 
         if pty && !background {
@@ -1131,7 +1203,7 @@ impl TerminalBackend for LocalBackend {
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())
                     .stdin(Stdio::null());
-                scrub_subprocess_env(&mut pty_cmd);
+                scrub_subprocess_env(&mut pty_cmd, &self.env_passthrough);
 
                 if let Some(dir) = workdir {
                     pty_cmd.current_dir(resolve_path(dir)?);
@@ -1180,7 +1252,7 @@ impl TerminalBackend for LocalBackend {
             shell_cmd
         };
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-        scrub_subprocess_env(&mut cmd);
+        scrub_subprocess_env(&mut cmd, &self.env_passthrough);
 
         if let Some(dir) = workdir {
             cmd.current_dir(resolve_path(dir)?);
@@ -1298,6 +1370,7 @@ impl TerminalBackend for LocalBackend {
             &rewritten_command,
             &self.shell_init_files,
             self.auto_source_bashrc,
+            &self.env_passthrough,
         );
 
         if background {
@@ -1332,7 +1405,7 @@ impl TerminalBackend for LocalBackend {
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())
                     .stdin(Stdio::piped());
-                scrub_subprocess_env(&mut pty_cmd);
+                scrub_subprocess_env(&mut pty_cmd, &self.env_passthrough);
 
                 if let Some(dir) = workdir {
                     pty_cmd.current_dir(resolve_path(dir)?);
@@ -1363,7 +1436,7 @@ impl TerminalBackend for LocalBackend {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::piped());
-        scrub_subprocess_env(&mut cmd);
+        scrub_subprocess_env(&mut cmd, &self.env_passthrough);
         if let Some(dir) = workdir {
             cmd.current_dir(resolve_path(dir)?);
         }
@@ -1724,6 +1797,12 @@ mod tests {
             std::env::set_var(key, value);
             Self { key, original }
         }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
     }
 
     impl Drop for EnvGuard {
@@ -1744,7 +1823,7 @@ mod tests {
             std::fs::write(td.path().join(file), "export HERMES_TEST=1\n").unwrap();
         }
         let _home = EnvGuard::set("HOME", td.path().to_string_lossy().as_ref());
-        let wrapped = with_login_profile_sources("echo hi", &[], true);
+        let wrapped = with_login_profile_sources("echo hi", &[], true, &[]);
         assert!(wrapped.contains("command -v bash"));
         assert!(wrapped.contains("exec bash -lc"));
         assert!(wrapped.contains(".bash_profile"));
@@ -1760,7 +1839,7 @@ mod tests {
     fn test_with_login_profile_sources_prefers_user_shell_when_supported() {
         let _lock = ENV_TEST_LOCK.lock().expect("lock env");
         let _shell = EnvGuard::set("SHELL", "/bin/zsh");
-        let wrapped = with_login_profile_sources("echo hi", &[], true);
+        let wrapped = with_login_profile_sources("echo hi", &[], true, &[]);
         let preferred = "if command -v zsh >/dev/null 2>&1; then exec zsh -lc";
         let fallback = "if command -v bash >/dev/null 2>&1; then exec bash -lc";
         let preferred_idx = wrapped.find(preferred).expect("preferred zsh branch");
@@ -1839,6 +1918,109 @@ mod tests {
     }
 
     #[test]
+    fn test_subprocess_env_passthrough_parses_configured_and_env_values() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _passthrough = EnvGuard::set(
+            SUBPROCESS_ENV_PASSTHROUGH_VAR,
+            "OPENAI_API_KEY,ANTHROPIC_TOKEN:BAD-NAME VALID_NAME",
+        );
+        let parsed = subprocess_env_passthrough_set(&["GOOGLE_API_KEY".to_string()]);
+        assert!(parsed.contains("OPENAI_API_KEY"));
+        assert!(parsed.contains("ANTHROPIC_TOKEN"));
+        assert!(parsed.contains("VALID_NAME"));
+        assert!(parsed.contains("GOOGLE_API_KEY"));
+        assert!(!parsed.contains("BAD-NAME"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_shell_cleanup_keeps_configured_passthrough() {
+        let wrapped = with_login_profile_sources(
+            "echo hi",
+            &[],
+            true,
+            &[
+                "OPENAI_API_KEY".to_string(),
+                "HERMES_GATEWAY_SECRET".to_string(),
+            ],
+        );
+        assert!(wrapped.contains("HERMES_SUBPROCESS_ENV_PASSTHROUGH"));
+        assert!(wrapped.contains("OPENAI_API_KEY"));
+        assert!(wrapped.contains("HERMES_GATEWAY_SECRET"));
+        assert!(wrapped.contains(
+            "${HERMES_SUBPROCESS_FORCE_TARGETS:-} ${HERMES_SUBPROCESS_ENV_PASSTHROUGH:-}"
+        ));
+    }
+
+    #[test]
+    fn test_terminal_sanitizer_blocks_provider_env_by_default() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _api = EnvGuard::set("OPENAI_API_KEY", "secret-value");
+        let _passthrough = EnvGuard::remove(SUBPROCESS_ENV_PASSTHROUGH_VAR);
+        let backend =
+            LocalBackend::new_with_shell_init(10, 1_048_576, Vec::new(), true, Vec::new());
+
+        let output = block_on(backend.execute_command(
+            "printf '%s' \"${OPENAI_API_KEY-unset}\"",
+            Some(10),
+            None,
+            false,
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "unset");
+    }
+
+    #[test]
+    fn test_terminal_config_passthrough_allows_blocklisted_env() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _api = EnvGuard::set("OPENAI_API_KEY", "secret-value");
+        let _passthrough = EnvGuard::remove(SUBPROCESS_ENV_PASSTHROUGH_VAR);
+        let backend = LocalBackend::new_with_shell_init(
+            10,
+            1_048_576,
+            Vec::new(),
+            true,
+            vec!["OPENAI_API_KEY".to_string()],
+        );
+
+        let output = block_on(backend.execute_command(
+            "printf '%s' \"$OPENAI_API_KEY\"",
+            Some(10),
+            None,
+            false,
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "secret-value");
+    }
+
+    #[test]
+    fn test_terminal_registry_env_passthrough_allows_prefix_blocked_env() {
+        let _lock = ENV_TEST_LOCK.lock().expect("lock env");
+        let _gateway = EnvGuard::set("HERMES_GATEWAY_SECRET", "gateway-secret");
+        let _passthrough = EnvGuard::set(SUBPROCESS_ENV_PASSTHROUGH_VAR, "HERMES_GATEWAY_SECRET");
+        let backend =
+            LocalBackend::new_with_shell_init(10, 1_048_576, Vec::new(), true, Vec::new());
+
+        let output = block_on(backend.execute_command(
+            "printf '%s' \"$HERMES_GATEWAY_SECRET\"",
+            Some(10),
+            None,
+            false,
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "gateway-secret");
+    }
+
+    #[test]
     fn test_rewrite_compound_background_contract() {
         assert_eq!(rewrite_compound_background("A && B &"), "A && { B & }");
         assert_eq!(rewrite_compound_background("A || B &"), "A || { B & }");
@@ -1871,7 +2053,7 @@ mod tests {
     #[cfg(not(unix))]
     #[test]
     fn test_with_login_profile_sources_is_passthrough_off_unix() {
-        let wrapped = with_login_profile_sources("echo hi", &[], true);
+        let wrapped = with_login_profile_sources("echo hi", &[], true, &[]);
         assert_eq!(wrapped, "echo hi");
     }
 
@@ -1922,6 +2104,7 @@ mod tests {
             1_048_576,
             vec![init.to_string_lossy().to_string()],
             false,
+            Vec::new(),
         );
 
         let output = backend

--- a/crates/hermes-tools/src/backends/file.rs
+++ b/crates/hermes-tools/src/backends/file.rs
@@ -14,16 +14,24 @@ use hermes_core::ToolError;
 
 /// Real file patch backend using fuzzy string matching.
 ///
-/// Implements an 8-strategy matching chain (ported from Python `fuzzy_match.py`):
+/// Implements a 9-strategy matching chain (ported from Python `fuzzy_match.py`):
 /// 1. Exact match
 /// 2. Line-trimmed (strip leading/trailing whitespace per line)
 /// 3. Whitespace normalized (collapse multiple spaces/tabs)
 /// 4. Indentation flexible (ignore indentation differences)
 /// 5. Escape normalized (convert \\n literals to newlines)
-/// 6. Trimmed boundary (trim first/last line only)
-/// 7. Block anchor (match first+last lines, similarity for middle)
-/// 8. Context-aware (50% line similarity threshold)
+/// 6. Unicode normalized (smart punctuation aliases)
+/// 7. Trimmed boundary (trim first/last line only)
+/// 8. Block anchor (match first+last lines, similarity for middle)
+/// 9. Context-aware (50% line similarity threshold)
 pub struct LocalPatchBackend;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FuzzyMatch {
+    start: usize,
+    end: usize,
+    strategy: &'static str,
+}
 
 impl LocalPatchBackend {
     pub fn new() -> Self {
@@ -32,44 +40,85 @@ impl LocalPatchBackend {
 
     /// Find the best fuzzy match for `needle` in `haystack`.
     /// Returns (start_index, end_index) of the best match, or None.
-    fn fuzzy_find(haystack: &str, needle: &str) -> Option<(usize, usize)> {
+    fn fuzzy_find(haystack: &str, needle: &str) -> Option<FuzzyMatch> {
         // Strategy 1: Exact match
         if let Some(pos) = haystack.find(needle) {
-            return Some((pos, pos + needle.len()));
+            return Some(FuzzyMatch {
+                start: pos,
+                end: pos + needle.len(),
+                strategy: "exact",
+            });
         }
 
         // Strategy 2: Line-trimmed match
-        if let Some(result) = Self::strategy_line_trimmed(haystack, needle) {
-            return Some(result);
+        if let Some((start, end)) = Self::strategy_line_trimmed(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "line_trimmed",
+            });
         }
 
         // Strategy 3: Whitespace normalized
-        if let Some(result) = Self::strategy_whitespace_normalized(haystack, needle) {
-            return Some(result);
+        if let Some((start, end)) = Self::strategy_whitespace_normalized(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "whitespace_normalized",
+            });
         }
 
         // Strategy 4: Indentation flexible
-        if let Some(result) = Self::strategy_indentation_flexible(haystack, needle) {
-            return Some(result);
+        if let Some((start, end)) = Self::strategy_indentation_flexible(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "indentation_flexible",
+            });
         }
 
         // Strategy 5: Escape normalized
-        if let Some(result) = Self::strategy_escape_normalized(haystack, needle) {
-            return Some(result);
+        if let Some((start, end)) = Self::strategy_escape_normalized(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "escape_normalized",
+            });
         }
 
-        // Strategy 6: Trimmed boundary
-        if let Some(result) = Self::strategy_trimmed_boundary(haystack, needle) {
-            return Some(result);
+        // Strategy 6: Unicode normalized
+        if let Some((start, end)) = Self::strategy_unicode_normalized(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "unicode_normalized",
+            });
         }
 
-        // Strategy 7: Block anchor
-        if let Some(result) = Self::strategy_block_anchor(haystack, needle) {
-            return Some(result);
+        // Strategy 7: Trimmed boundary
+        if let Some((start, end)) = Self::strategy_trimmed_boundary(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "trimmed_boundary",
+            });
         }
 
-        // Strategy 8: Context-aware
-        Self::strategy_context_aware(haystack, needle)
+        // Strategy 8: Block anchor
+        if let Some((start, end)) = Self::strategy_block_anchor(haystack, needle) {
+            return Some(FuzzyMatch {
+                start,
+                end,
+                strategy: "block_anchor",
+            });
+        }
+
+        // Strategy 9: Context-aware
+        Self::strategy_context_aware(haystack, needle).map(|(start, end)| FuzzyMatch {
+            start,
+            end,
+            strategy: "context_aware",
+        })
     }
 
     /// Strategy 2: Match with line-by-line whitespace trimming.
@@ -157,6 +206,54 @@ impl LocalPatchBackend {
         haystack
             .find(&unescaped)
             .map(|pos| (pos, pos + unescaped.len()))
+    }
+
+    fn unicode_alias(ch: char) -> Option<&'static str> {
+        match ch {
+            '\u{2014}' | '\u{2013}' => Some("--"),
+            '\u{2018}' | '\u{2019}' => Some("'"),
+            '\u{201c}' | '\u{201d}' => Some("\""),
+            '\u{2026}' => Some("..."),
+            '\u{00a0}' => Some(" "),
+            _ => None,
+        }
+    }
+
+    fn unicode_normalize_with_spans(input: &str) -> (String, Vec<(usize, usize)>) {
+        let mut normalized = String::with_capacity(input.len());
+        let mut spans = Vec::new();
+        for (start, ch) in input.char_indices() {
+            let end = start + ch.len_utf8();
+            if let Some(alias) = Self::unicode_alias(ch) {
+                for alias_ch in alias.chars() {
+                    normalized.push(alias_ch);
+                    spans.push((start, end));
+                }
+            } else {
+                normalized.push(ch);
+                spans.push((start, end));
+            }
+        }
+        (normalized, spans)
+    }
+
+    fn normalized_byte_to_char_idx(value: &str, byte_idx: usize) -> usize {
+        value[..byte_idx.min(value.len())].chars().count()
+    }
+
+    fn strategy_unicode_normalized(haystack: &str, needle: &str) -> Option<(usize, usize)> {
+        let (norm_haystack, spans) = Self::unicode_normalize_with_spans(haystack);
+        let (norm_needle, _) = Self::unicode_normalize_with_spans(needle);
+        if norm_haystack == haystack && norm_needle == needle {
+            return None;
+        }
+        let pos = norm_haystack.find(&norm_needle)?;
+        let start_char = Self::normalized_byte_to_char_idx(&norm_haystack, pos);
+        let end_char = Self::normalized_byte_to_char_idx(&norm_haystack, pos + norm_needle.len());
+        if start_char >= spans.len() || end_char == 0 || end_char > spans.len() {
+            return None;
+        }
+        Some((spans[start_char].0, spans[end_char - 1].1))
     }
 
     /// Strategy 6: Trim whitespace from first and last lines only.
@@ -361,6 +458,12 @@ impl PatchBackend for LocalPatchBackend {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read '{}': {}", path, e)))?;
 
+        if old_string == new_string {
+            return Err(ToolError::InvalidParams(
+                "old_string and new_string are identical; no replacement needed".into(),
+            ));
+        }
+
         if old_string.is_empty() {
             // Empty old_string means create new file or append
             let new_content = if content.is_empty() {
@@ -392,18 +495,27 @@ impl PatchBackend for LocalPatchBackend {
         }
 
         // Single replacement with fuzzy matching
+        let exact_count = content.matches(old_string).count();
+        if exact_count > 1 {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Found {exact_count} matches for the specified text in '{path}'. Use replace_all=true to replace all occurrences."
+            )));
+        }
         match Self::fuzzy_find(&content, old_string) {
-            Some((start, end)) => {
+            Some(found) => {
                 let mut new_content = String::with_capacity(content.len());
-                new_content.push_str(&content[..start]);
+                new_content.push_str(&content[..found.start]);
                 new_content.push_str(new_string);
-                new_content.push_str(&content[end..]);
+                new_content.push_str(&content[found.end..]);
 
                 tokio::fs::write(path, &new_content).await.map_err(|e| {
                     ToolError::ExecutionFailed(format!("Failed to write '{}': {}", path, e))
                 })?;
 
-                Ok(json!({"status": "ok", "replacements": 1}).to_string())
+                Ok(
+                    json!({"status": "ok", "replacements": 1, "strategy": found.strategy})
+                        .to_string(),
+                )
             }
             None => Err(ToolError::ExecutionFailed(format!(
                 "Could not find a match for the specified text in '{}'",
@@ -937,5 +1049,67 @@ mod tests {
 
         assert!(files.iter().any(|p| p.ends_with("SKILL.md")));
         assert!(!files.iter().any(|p| p.contains(".hub")));
+    }
+
+    #[tokio::test]
+    async fn patch_file_errors_on_ambiguous_single_replacement() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("ambiguous.txt");
+        std::fs::write(&path, "aaa bbb aaa").expect("write file");
+
+        let backend = LocalPatchBackend::new();
+        let err = backend
+            .patch_file(path.to_str().unwrap(), "aaa", "ccc", false)
+            .await
+            .expect_err("ambiguous replacement should fail");
+        assert!(err.to_string().contains("Found 2 matches"));
+
+        let ok = backend
+            .patch_file(path.to_str().unwrap(), "aaa", "ccc", true)
+            .await
+            .expect("replace all");
+        let parsed: Value = serde_json::from_str(&ok).expect("json");
+        assert_eq!(parsed["replacements"], 2);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "ccc bbb ccc");
+    }
+
+    #[tokio::test]
+    async fn patch_file_reports_strategy_and_matches_unicode_aliases() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("unicode.txt");
+        std::fs::write(&path, "return value\u{2014}fallback").expect("write file");
+
+        let backend = LocalPatchBackend::new();
+        let ok = backend
+            .patch_file(
+                path.to_str().unwrap(),
+                "return value--fallback",
+                "return value or fallback",
+                false,
+            )
+            .await
+            .expect("unicode normalized patch");
+        let parsed: Value = serde_json::from_str(&ok).expect("json");
+        assert_eq!(parsed["replacements"], 1);
+        assert_eq!(parsed["strategy"], "unicode_normalized");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "return value or fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_file_rejects_identical_old_and_new_strings() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("same.txt");
+        std::fs::write(&path, "abc").expect("write file");
+
+        let backend = LocalPatchBackend::new();
+        let err = backend
+            .patch_file(path.to_str().unwrap(), "abc", "abc", false)
+            .await
+            .expect_err("identical strings should fail");
+        assert!(err.to_string().contains("identical"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "abc");
     }
 }

--- a/crates/hermes-tools/src/credential_guard.rs
+++ b/crates/hermes-tools/src/credential_guard.rs
@@ -50,8 +50,24 @@ const PROTECTED_FILE_NAMES: &[&str] = &[
 /// Directory names that are always protected.
 const PROTECTED_DIR_NAMES: &[&str] = &[".ssh", ".gnupg", ".aws", ".config/gcloud", ".kube"];
 
-const WRITE_DENY_EXACT_ABSOLUTE: &[&str] = &["/etc/shadow", "/etc/passwd", "/etc/sudoers"];
-const WRITE_DENY_PREFIX_ABSOLUTE: &[&str] = &["/etc/sudoers.d", "/etc/systemd/system"];
+const WRITE_DENY_EXACT_ABSOLUTE: &[&str] = &[
+    "/etc/hosts",
+    "/etc/shadow",
+    "/etc/passwd",
+    "/etc/sudoers",
+    "/private/etc/hosts",
+    "/private/etc/passwd",
+    "/private/etc/shadow",
+    "/private/etc/sudoers",
+];
+const WRITE_DENY_PREFIX_ABSOLUTE: &[&str] = &[
+    "/boot",
+    "/etc/sudoers.d",
+    "/etc/systemd",
+    "/private/etc/ssh",
+    "/private/etc/sudoers.d",
+    "/private/var",
+];
 const WRITE_DENY_HOME_EXACT: &[&str] = &[
     ".netrc",
     ".bashrc",
@@ -63,7 +79,15 @@ const WRITE_DENY_HOME_EXACT: &[&str] = &[
     ".pypirc",
     ".pgpass",
 ];
-const WRITE_DENY_HOME_PREFIX: &[&str] = &[".ssh", ".aws", ".gnupg", ".kube"];
+const WRITE_DENY_HOME_PREFIX: &[&str] = &[
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".kube",
+    ".docker",
+    ".azure",
+    ".config/gh",
+];
 
 // ---------------------------------------------------------------------------
 // Content secret patterns
@@ -234,10 +258,14 @@ pub fn is_protected_file(path: &Path) -> bool {
 /// file by name. This covers sensitive system files, shell profiles, package
 /// manager credential files, and profile-aware `$HERMES_HOME/.env`.
 pub fn is_write_denied(path: &Path) -> bool {
-    is_write_denied_with_roots(
+    is_write_denied_with_roots_and_safe_root(
         path,
         std::env::var_os("HOME").map(PathBuf::from).as_deref(),
         std::env::var_os("HERMES_HOME")
+            .map(PathBuf::from)
+            .as_deref(),
+        std::env::var_os("HERMES_WRITE_SAFE_ROOT")
+            .filter(|value| !value.is_empty())
             .map(PathBuf::from)
             .as_deref(),
     )
@@ -263,13 +291,7 @@ fn path_has_component_prefix(path: &Path, root: &Path, prefix: &str) -> bool {
         Ok(rel) => rel,
         Err(_) => return false,
     };
-    let Some(first) = rel.components().next().and_then(|c| match c {
-        std::path::Component::Normal(os) => os.to_str(),
-        _ => None,
-    }) else {
-        return false;
-    };
-    first == prefix
+    rel == Path::new(prefix) || rel.starts_with(Path::new(prefix))
 }
 
 /// Root-injected form for deterministic tests and callers that already know
@@ -278,6 +300,17 @@ pub fn is_write_denied_with_roots(
     path: &Path,
     home: Option<&Path>,
     hermes_home: Option<&Path>,
+) -> bool {
+    is_write_denied_with_roots_and_safe_root(path, home, hermes_home, None)
+}
+
+/// Root-injected form including the optional `HERMES_WRITE_SAFE_ROOT` sandbox.
+/// Static system and credential denies always win over the safe-root allowance.
+pub fn is_write_denied_with_roots_and_safe_root(
+    path: &Path,
+    home: Option<&Path>,
+    hermes_home: Option<&Path>,
+    safe_root: Option<&Path>,
 ) -> bool {
     let expanded = expand_home(path, home);
     let normalized = expanded.to_string_lossy();
@@ -315,6 +348,16 @@ pub fn is_write_denied_with_roots(
 
     if let Some(hermes_home) = hermes_home {
         if expanded == hermes_home.join(".env") {
+            return true;
+        }
+    }
+
+    if let Some(safe_root) = safe_root {
+        let expanded_safe_root = expand_home(safe_root, home);
+        if !expanded_safe_root.as_os_str().is_empty()
+            && expanded != expanded_safe_root
+            && !expanded.starts_with(&expanded_safe_root)
+        {
             return true;
         }
     }
@@ -553,6 +596,19 @@ mod tests {
                 Some(&hermes_home)
             ));
         }
+        for path in [
+            "/etc/hosts",
+            "/private/etc/hosts",
+            "/private/etc/passwd",
+            "/private/etc/shadow",
+            "/private/etc/sudoers",
+        ] {
+            assert!(is_write_denied_with_roots(
+                Path::new(path),
+                Some(&home),
+                Some(&hermes_home)
+            ));
+        }
         assert!(is_write_denied_with_roots(
             Path::new("/etc/sudoers.d/custom"),
             Some(&home),
@@ -563,6 +619,18 @@ mod tests {
             Some(&home),
             Some(&hermes_home)
         ));
+        for path in [
+            "/private/etc/ssh/sshd_config",
+            "/private/etc/sudoers.d/custom",
+            "/private/var/db/something",
+            "/boot/grub/grub.cfg",
+        ] {
+            assert!(is_write_denied_with_roots(
+                Path::new(path),
+                Some(&home),
+                Some(&hermes_home)
+            ));
+        }
 
         for rel in [
             ".ssh/authorized_keys",
@@ -570,6 +638,9 @@ mod tests {
             ".aws/credentials",
             ".gnupg/secring.gpg",
             ".kube/config",
+            ".docker/config.json",
+            ".azure/config",
+            ".config/gh/hosts.yml",
             ".netrc",
             ".bashrc",
             ".zshrc",
@@ -623,6 +694,62 @@ mod tests {
         assert!(is_write_denied_with_roots(
             Path::new("~/.netrc"),
             Some(&home),
+            None
+        ));
+    }
+
+    #[test]
+    fn write_safe_root_sandboxes_non_static_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let safe_root = tmp.path().join("workspace");
+        let outside = tmp.path().join("other/file.txt");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&safe_root).expect("safe root");
+
+        assert!(!is_write_denied_with_roots_and_safe_root(
+            &safe_root,
+            Some(&home),
+            None,
+            Some(&safe_root)
+        ));
+        assert!(!is_write_denied_with_roots_and_safe_root(
+            &safe_root.join("subdir/file.txt"),
+            Some(&home),
+            None,
+            Some(&safe_root)
+        ));
+        assert!(is_write_denied_with_roots_and_safe_root(
+            &outside,
+            Some(&home),
+            None,
+            Some(&safe_root)
+        ));
+        assert!(is_write_denied_with_roots_and_safe_root(
+            &home.join(".ssh/id_rsa"),
+            Some(&home),
+            None,
+            Some(&home)
+        ));
+    }
+
+    #[test]
+    fn write_safe_root_expands_tilde_and_ignores_absent_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let workspace = home.join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+
+        assert!(!is_write_denied_with_roots_and_safe_root(
+            &workspace.join("file.txt"),
+            Some(&home),
+            None,
+            Some(Path::new("~/workspace"))
+        ));
+        assert!(!is_write_denied_with_roots_and_safe_root(
+            &tmp.path().join("regular.txt"),
+            Some(&home),
+            None,
             None
         ));
     }

--- a/crates/hermes-tools/src/dispatch.rs
+++ b/crates/hermes-tools/src/dispatch.rs
@@ -10,6 +10,9 @@ use hermes_core::{BudgetConfig, ToolCall, ToolResult};
 use tokio::task::JoinSet;
 
 use crate::registry::ToolRegistry;
+use crate::tools::tool_result_storage::{
+    default_threshold_for_tool, enforce_turn_budget, maybe_persist_tool_result,
+};
 
 /// Result of dispatching a single tool call, including timing information.
 #[derive(Debug, Clone)]
@@ -61,16 +64,12 @@ pub async fn dispatch_tools(
 
     let mut collect_join = |res: Result<DispatchedResult, tokio::task::JoinError>| match res {
         Ok(dr) => {
-            let mut content = dr.content;
-            // Per-result truncation
-            if content.len() > budget.max_result_size_chars {
-                let truncated = &content[..budget.max_result_size_chars];
-                let removed = content.len() - budget.max_result_size_chars;
-                content = format!(
-                    "{}\n\n[... truncated {} characters ...]",
-                    truncated, removed
-                );
-            }
+            let content = maybe_persist_tool_result(
+                &dr.content,
+                &dr.tool_name,
+                &dr.tool_call_id,
+                default_threshold_for_tool(&dr.tool_name, budget.max_result_size_chars),
+            );
             results.push(ToolResult {
                 tool_call_id: dr.tool_call_id,
                 content,
@@ -125,23 +124,7 @@ pub async fn dispatch_tools(
         collect_join(res);
     }
 
-    // Aggregate budget enforcement
-    let total_chars: usize = results.iter().map(|r| r.content.len()).sum();
-    if total_chars > budget.max_aggregate_chars {
-        let ratio = budget.max_aggregate_chars as f64 / total_chars as f64;
-        for result in results.iter_mut() {
-            let target_len = ((result.content.len() as f64) * ratio) as usize;
-            let min_len = target_len.max(200);
-            if result.content.len() > min_len {
-                let removed = result.content.len() - min_len;
-                result.content = format!(
-                    "{}\n\n[... truncated {} characters ...]",
-                    &result.content[..min_len],
-                    removed
-                );
-            }
-        }
-    }
+    enforce_turn_budget(&mut results, &budget);
 
     results
 }
@@ -164,16 +147,12 @@ pub async fn dispatch_single(
 
     let is_error = result.starts_with(r#"{"error"#);
 
-    let content = if result.len() > max_result_size_chars {
-        let truncated = &result[..max_result_size_chars];
-        let removed = result.len() - max_result_size_chars;
-        format!(
-            "{}\n\n[... truncated {} characters ...]",
-            truncated, removed
-        )
-    } else {
-        result
-    };
+    let content = maybe_persist_tool_result(
+        &result,
+        &call.function.name,
+        &call.id,
+        default_threshold_for_tool(&call.function.name, max_result_size_chars),
+    );
 
     ToolResult {
         tool_call_id: call.id,
@@ -185,6 +164,25 @@ pub async fn dispatch_single(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use async_trait::async_trait;
+    use hermes_core::{tool_schema, FunctionCall, JsonSchema, ToolError, ToolHandler, ToolSchema};
+    use serde_json::Value;
+
+    use crate::tools::tool_result_storage::{PERSISTED_OUTPUT_TAG, STORAGE_ENV_LOCK};
+
+    struct LargeHandler;
+
+    #[async_trait]
+    impl ToolHandler for LargeHandler {
+        async fn execute(&self, _params: Value) -> Result<String, ToolError> {
+            Ok(format!("large-start-{}", "x".repeat(5_000)))
+        }
+
+        fn schema(&self) -> ToolSchema {
+            tool_schema("large", "Large test output", JsonSchema::new("object"))
+        }
+    }
 
     #[test]
     fn test_dispatched_result_conversion() {
@@ -198,5 +196,56 @@ mod tests {
         let tr: ToolResult = dr.into();
         assert_eq!(tr.tool_call_id, "call_1");
         assert!(!tr.is_error);
+    }
+
+    #[test]
+    fn dispatch_single_persists_oversized_result() {
+        let _guard = STORAGE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_TOOL_RESULT_STORAGE_DIR", tmp.path());
+
+        let registry = Arc::new(ToolRegistry::new());
+        let handler = Arc::new(LargeHandler);
+        registry.register(
+            "large",
+            "test",
+            handler.schema(),
+            handler,
+            Arc::new(|| true),
+            vec![],
+            false,
+            "Large output",
+            "",
+            None,
+        );
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = runtime.block_on(async {
+            dispatch_single(
+                ToolCall {
+                    id: "large_call".to_string(),
+                    function: FunctionCall {
+                        name: "large".to_string(),
+                        arguments: "{}".to_string(),
+                    },
+                    extra_content: None,
+                },
+                registry,
+                100,
+            )
+            .await
+        });
+
+        assert!(result.content.contains(PERSISTED_OUTPUT_TAG));
+        assert!(result.content.contains("large-start"));
+        let persisted =
+            std::fs::read_to_string(tmp.path().join("large_call.txt")).expect("persisted result");
+        assert!(persisted.contains("large-start-"));
+        assert!(persisted.contains(&"x".repeat(5_000)));
+
+        std::env::remove_var("HERMES_TOOL_RESULT_STORAGE_DIR");
     }
 }

--- a/crates/hermes-tools/src/tools/env_passthrough.rs
+++ b/crates/hermes-tools/src/tools/env_passthrough.rs
@@ -1,38 +1,284 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex};
+
 use async_trait::async_trait;
+use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
 use indexmap::IndexMap;
 use serde_json::{json, Value};
 
-use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+pub const SUBPROCESS_ENV_PASSTHROUGH_VAR: &str = "HERMES_SUBPROCESS_ENV_PASSTHROUGH";
+
+static SESSION_PASSTHROUGH: LazyLock<Mutex<BTreeSet<String>>> =
+    LazyLock::new(|| Mutex::new(BTreeSet::new()));
+static CONFIG_PASSTHROUGH: LazyLock<Mutex<Option<BTreeSet<String>>>> =
+    LazyLock::new(|| Mutex::new(None));
 
 pub struct EnvPassthroughHandler;
+
+fn normalize_name(name: &str) -> Option<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty()
+        || !trimmed
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn hermes_home() -> Option<PathBuf> {
+    std::env::var_os("HERMES_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".hermes")))
+}
+
+fn mapping_get<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a serde_yaml::Value> {
+    map.get(serde_yaml::Value::String(key.to_string()))
+}
+
+fn load_config_passthrough_uncached() -> BTreeSet<String> {
+    let Some(home) = hermes_home() else {
+        return BTreeSet::new();
+    };
+    let path = home.join("config.yaml");
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return BTreeSet::new();
+    };
+    let Ok(root) = serde_yaml::from_str::<serde_yaml::Value>(&raw) else {
+        return BTreeSet::new();
+    };
+    let serde_yaml::Value::Mapping(root) = root else {
+        return BTreeSet::new();
+    };
+    let Some(serde_yaml::Value::Mapping(terminal)) = mapping_get(&root, "terminal") else {
+        return BTreeSet::new();
+    };
+    let Some(serde_yaml::Value::Sequence(values)) = mapping_get(terminal, "env_passthrough") else {
+        return BTreeSet::new();
+    };
+
+    values
+        .iter()
+        .filter_map(serde_yaml::Value::as_str)
+        .filter_map(normalize_name)
+        .collect()
+}
+
+fn config_passthrough() -> BTreeSet<String> {
+    let mut guard = CONFIG_PASSTHROUGH.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(cached) = guard.as_ref() {
+        return cached.clone();
+    }
+    let loaded = load_config_passthrough_uncached();
+    *guard = Some(loaded.clone());
+    loaded
+}
+
+fn sync_process_env_from_set(values: &BTreeSet<String>) {
+    if values.is_empty() {
+        std::env::remove_var(SUBPROCESS_ENV_PASSTHROUGH_VAR);
+    } else {
+        std::env::set_var(
+            SUBPROCESS_ENV_PASSTHROUGH_VAR,
+            values.iter().cloned().collect::<Vec<_>>().join(" "),
+        );
+    }
+}
+
+pub fn register_env_passthrough<I, S>(var_names: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    {
+        let mut allowed = SESSION_PASSTHROUGH
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        for name in var_names
+            .into_iter()
+            .filter_map(|v| normalize_name(v.as_ref()))
+        {
+            allowed.insert(name);
+        }
+    }
+    sync_process_env_from_set(&get_all_passthrough());
+}
+
+pub fn clear_env_passthrough() {
+    SESSION_PASSTHROUGH
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+    sync_process_env_from_set(&get_all_passthrough());
+}
+
+pub fn is_env_passthrough(var_name: &str) -> bool {
+    let Some(name) = normalize_name(var_name) else {
+        return false;
+    };
+    if SESSION_PASSTHROUGH
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains(&name)
+    {
+        return true;
+    }
+    config_passthrough().contains(&name)
+}
+
+pub fn get_all_passthrough() -> BTreeSet<String> {
+    let mut all = config_passthrough();
+    all.extend(
+        SESSION_PASSTHROUGH
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .cloned(),
+    );
+    all
+}
+
+#[cfg(test)]
+pub fn reset_config_passthrough_cache_for_tests() {
+    *CONFIG_PASSTHROUGH.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    sync_process_env_from_set(&get_all_passthrough());
+}
 
 #[async_trait]
 impl ToolHandler for EnvPassthroughHandler {
     async fn execute(&self, params: Value) -> Result<String, ToolError> {
-        let keys = params
-            .get("keys")
-            .and_then(|v| v.as_array())
-            .ok_or_else(|| ToolError::InvalidParams("Missing 'keys'".into()))?;
+        let action = params
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("read");
 
-        let mut out = serde_json::Map::new();
-        for key in keys.iter().filter_map(|v| v.as_str()) {
-            if let Ok(value) = std::env::var(key) {
-                out.insert(key.to_string(), json!(value));
+        match action {
+            "register" => {
+                let keys = params
+                    .get("keys")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| ToolError::InvalidParams("Missing 'keys'".into()))?;
+                let names: Vec<String> = keys
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .filter_map(normalize_name)
+                    .collect();
+                register_env_passthrough(names.iter());
+                Ok(json!({"status":"registered","keys":names}).to_string())
             }
+            "clear" => {
+                clear_env_passthrough();
+                Ok(json!({"status":"cleared"}).to_string())
+            }
+            "list" => Ok(json!({"keys": get_all_passthrough()}).to_string()),
+            "read" | "get" => {
+                let keys = params
+                    .get("keys")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| ToolError::InvalidParams("Missing 'keys'".into()))?;
+
+                let mut out = serde_json::Map::new();
+                for key in keys
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .filter_map(normalize_name)
+                {
+                    if let Ok(value) = std::env::var(&key) {
+                        out.insert(key, json!(value));
+                    }
+                }
+                Ok(Value::Object(out).to_string())
+            }
+            other => Err(ToolError::InvalidParams(format!(
+                "Unsupported env_passthrough action '{other}'"
+            ))),
         }
-        Ok(Value::Object(out).to_string())
     }
 
     fn schema(&self) -> ToolSchema {
         let mut props = IndexMap::new();
+        props.insert(
+            "action".into(),
+            json!({"type":"string","enum":["read","get","list","register","clear"]}),
+        );
         props.insert(
             "keys".into(),
             json!({"type":"array","items":{"type":"string"}}),
         );
         tool_schema(
             "env_passthrough",
-            "Expose selected env vars to tool workflows.",
-            JsonSchema::object(props, vec!["keys".into()]),
+            "Expose selected env vars to tool workflows and register vars allowed through subprocess sanitizers.",
+            JsonSchema::object(props, vec![]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn reset() {
+        SESSION_PASSTHROUGH
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+        *CONFIG_PASSTHROUGH.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        std::env::remove_var(SUBPROCESS_ENV_PASSTHROUGH_VAR);
+    }
+
+    #[test]
+    fn registry_trims_skips_empty_and_clears_session_names() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset();
+
+        assert!(!is_env_passthrough("TENOR_API_KEY"));
+        register_env_passthrough(["  TENOR_API_KEY  ", "", "  ", "BAR_SECRET"]);
+        assert!(is_env_passthrough("TENOR_API_KEY"));
+        assert!(is_env_passthrough("BAR_SECRET"));
+        assert!(!is_env_passthrough(""));
+        assert_eq!(
+            std::env::var(SUBPROCESS_ENV_PASSTHROUGH_VAR).unwrap(),
+            "BAR_SECRET TENOR_API_KEY"
+        );
+
+        clear_env_passthrough();
+        assert!(!is_env_passthrough("TENOR_API_KEY"));
+        assert!(std::env::var(SUBPROCESS_ENV_PASSTHROUGH_VAR).is_err());
+    }
+
+    #[test]
+    fn config_passthrough_is_loaded_from_hermes_home() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            "terminal:\n  env_passthrough:\n    - MY_CUSTOM_KEY\n    - '  ANOTHER_TOKEN  '\n",
+        )
+        .expect("write config");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        reset_config_passthrough_cache_for_tests();
+
+        assert!(is_env_passthrough("MY_CUSTOM_KEY"));
+        assert!(is_env_passthrough("ANOTHER_TOKEN"));
+        assert!(!is_env_passthrough("UNRELATED_VAR"));
+
+        register_env_passthrough(["SKILL_KEY"]);
+        let all = get_all_passthrough();
+        assert!(all.contains("MY_CUSTOM_KEY"));
+        assert!(all.contains("SKILL_KEY"));
+        assert_eq!(
+            std::env::var(SUBPROCESS_ENV_PASSTHROUGH_VAR).unwrap(),
+            "ANOTHER_TOKEN MY_CUSTOM_KEY SKILL_KEY"
+        );
+
+        std::env::remove_var("HERMES_HOME");
+        reset();
     }
 }

--- a/crates/hermes-tools/src/tools/tool_result_storage.rs
+++ b/crates/hermes-tools/src/tools/tool_result_storage.rs
@@ -1,15 +1,284 @@
 use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use hermes_core::{
+    tool_schema, BudgetConfig, JsonSchema, ToolError, ToolHandler, ToolResult, ToolSchema,
+};
 use indexmap::IndexMap;
 use serde_json::{json, Value};
+use uuid::Uuid;
 
-use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+pub const PERSISTED_OUTPUT_TAG: &str = "<persisted-output>";
+pub const PERSISTED_OUTPUT_CLOSING_TAG: &str = "</persisted-output>";
+pub const STORAGE_DIR: &str = "/tmp/hermes-results";
+pub const HEREDOC_MARKER: &str = "HERMES_PERSIST_EOF";
+pub const DEFAULT_PREVIEW_SIZE_CHARS: usize = 2_000;
+const BUDGET_ENFORCEMENT_TOOL: &str = "__budget_enforcement__";
+
+#[cfg(test)]
+pub(crate) static STORAGE_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Preview {
+    pub content: String,
+    pub has_more: bool,
+}
 
 #[derive(Clone, Default)]
 pub struct ToolResultStorageHandler {
     store: Arc<Mutex<HashMap<String, String>>>,
+}
+
+pub fn char_count(content: &str) -> usize {
+    content.chars().count()
+}
+
+fn byte_index_at_char(content: &str, max_chars: usize) -> usize {
+    if max_chars == 0 {
+        return 0;
+    }
+    content
+        .char_indices()
+        .nth(max_chars)
+        .map(|(idx, _)| idx)
+        .unwrap_or(content.len())
+}
+
+pub fn generate_preview(content: &str, max_chars: usize) -> Preview {
+    if max_chars == 0 {
+        return Preview {
+            content: String::new(),
+            has_more: !content.is_empty(),
+        };
+    }
+    if char_count(content) <= max_chars {
+        return Preview {
+            content: content.to_string(),
+            has_more: false,
+        };
+    }
+
+    let end = byte_index_at_char(content, max_chars);
+    let mut preview = &content[..end];
+    if let Some(last_newline) = preview.rfind('\n') {
+        let newline_end = last_newline + '\n'.len_utf8();
+        if char_count(&preview[..newline_end]) > max_chars / 2 {
+            preview = &preview[..newline_end];
+        }
+    }
+
+    Preview {
+        content: preview.to_string(),
+        has_more: true,
+    }
+}
+
+pub fn heredoc_marker(content: &str) -> String {
+    if !content.contains(HEREDOC_MARKER) {
+        return HEREDOC_MARKER.to_string();
+    }
+    loop {
+        let candidate = format!("HERMES_PERSIST_{}", Uuid::new_v4().simple());
+        if !content.contains(&candidate) {
+            return candidate;
+        }
+    }
+}
+
+pub fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn build_sandbox_write_command(content: &str, remote_path: &str) -> String {
+    let marker = heredoc_marker(content);
+    let storage_dir = Path::new(remote_path)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| ".".to_string());
+    format!(
+        "mkdir -p {} && cat > {} << '{}'\n{}\n{}",
+        shell_quote(&storage_dir),
+        shell_quote(remote_path),
+        marker,
+        content,
+        marker
+    )
+}
+
+pub fn resolve_storage_dir() -> PathBuf {
+    std::env::var_os("HERMES_TOOL_RESULT_STORAGE_DIR")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| PathBuf::from(STORAGE_DIR))
+}
+
+fn safe_file_stem(tool_use_id: &str) -> String {
+    let sanitized: String = tool_use_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('.').trim_matches('_');
+    if trimmed.is_empty() {
+        "tool_result".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn persisted_file_path(tool_use_id: &str) -> PathBuf {
+    resolve_storage_dir().join(format!("{}.txt", safe_file_stem(tool_use_id)))
+}
+
+fn write_to_local_storage(content: &str, path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)
+}
+
+fn size_label(original_size: usize) -> String {
+    let kb = original_size as f64 / 1024.0;
+    if kb >= 1024.0 {
+        format!("{:.1} MB", kb / 1024.0)
+    } else {
+        format!("{:.1} KB", kb)
+    }
+}
+
+fn format_count(value: usize) -> String {
+    let raw = value.to_string();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    for (idx, ch) in raw.chars().enumerate() {
+        if idx > 0 && (raw.len() - idx).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+pub fn build_persisted_message(
+    preview: &str,
+    has_more: bool,
+    original_size: usize,
+    file_path: &Path,
+) -> String {
+    let mut msg = String::new();
+    msg.push_str(PERSISTED_OUTPUT_TAG);
+    msg.push('\n');
+    msg.push_str(&format!(
+        "This tool result was too large ({} characters, {}).\n",
+        format_count(original_size),
+        size_label(original_size)
+    ));
+    msg.push_str(&format!("Full output saved to: {}\n", file_path.display()));
+    msg.push_str(
+        "Use the read_file tool with offset and limit to access specific sections of this output.\n\n",
+    );
+    msg.push_str(&format!("Preview (first {} chars):\n", char_count(preview)));
+    msg.push_str(preview);
+    if has_more {
+        msg.push_str("\n...");
+    }
+    msg.push('\n');
+    msg.push_str(PERSISTED_OUTPUT_CLOSING_TAG);
+    msg
+}
+
+pub fn fallback_truncate(content: &str, preview_size_chars: usize) -> String {
+    let preview = generate_preview(content, preview_size_chars);
+    format!(
+        "{}\n\n[Truncated: tool response was {} chars. Full output could not be saved to disk.]",
+        preview.content,
+        format_count(char_count(content))
+    )
+}
+
+pub fn default_threshold_for_tool(tool_name: &str, default_threshold: usize) -> Option<usize> {
+    match tool_name {
+        "read_file" => None,
+        _ => Some(default_threshold),
+    }
+}
+
+pub fn maybe_persist_tool_result(
+    content: &str,
+    tool_name: &str,
+    tool_use_id: &str,
+    threshold: Option<usize>,
+) -> String {
+    let Some(threshold) = threshold else {
+        return content.to_string();
+    };
+    let content_size = char_count(content);
+    if content_size == 0 || content_size <= threshold {
+        return content.to_string();
+    }
+
+    let file_path = persisted_file_path(tool_use_id);
+    let preview = generate_preview(content, DEFAULT_PREVIEW_SIZE_CHARS);
+    match write_to_local_storage(content, &file_path) {
+        Ok(()) => {
+            build_persisted_message(&preview.content, preview.has_more, content_size, &file_path)
+        }
+        Err(err) => {
+            tracing::warn!(
+                tool_name,
+                tool_use_id,
+                path = %file_path.display(),
+                error = %err,
+                "failed to persist oversized tool result; falling back to inline truncation"
+            );
+            fallback_truncate(content, DEFAULT_PREVIEW_SIZE_CHARS)
+        }
+    }
+}
+
+pub fn is_persisted_output(content: &str) -> bool {
+    content.contains(PERSISTED_OUTPUT_TAG) && content.contains(PERSISTED_OUTPUT_CLOSING_TAG)
+}
+
+pub fn enforce_turn_budget(results: &mut [ToolResult], budget: &BudgetConfig) {
+    let mut total_chars: usize = results.iter().map(|r| char_count(&r.content)).sum();
+    if total_chars <= budget.max_aggregate_chars {
+        return;
+    }
+
+    let mut candidates: Vec<(usize, usize)> = results
+        .iter()
+        .enumerate()
+        .filter(|(_, result)| !is_persisted_output(&result.content))
+        .map(|(idx, result)| (idx, char_count(&result.content)))
+        .collect();
+    candidates.sort_by(|(_, left), (_, right)| right.cmp(left));
+
+    for (idx, original_size) in candidates {
+        if total_chars <= budget.max_aggregate_chars {
+            break;
+        }
+        let replacement = maybe_persist_tool_result(
+            &results[idx].content,
+            BUDGET_ENFORCEMENT_TOOL,
+            &results[idx].tool_call_id,
+            Some(0),
+        );
+        if replacement != results[idx].content {
+            total_chars = total_chars
+                .saturating_sub(original_size)
+                .saturating_add(char_count(&replacement));
+            results[idx].content = replacement;
+        }
+    }
 }
 
 #[async_trait]
@@ -57,5 +326,148 @@ impl ToolHandler for ToolResultStorageHandler {
             "Persist/retrieve tool results by key.",
             JsonSchema::object(props, vec!["key".into()]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_uses_newline_boundary_only_after_halfway() {
+        let late = format!("{}\n{}", "a".repeat(1500), "b".repeat(600));
+        let preview = generate_preview(&late, 2000);
+        assert_eq!(preview.content, format!("{}\n", "a".repeat(1500)));
+        assert!(preview.has_more);
+
+        let early = format!("{}\n{}", "a".repeat(100), "b".repeat(3000));
+        let preview = generate_preview(&early, 2000);
+        assert_eq!(char_count(&preview.content), 2000);
+        assert!(preview.has_more);
+    }
+
+    #[test]
+    fn preview_preserves_unicode_boundaries() {
+        let content = "日本語テスト ".repeat(10_000);
+        let preview = generate_preview(&content, 2_000);
+        assert!(preview.content.contains("日本語テスト"));
+        assert!(preview.has_more);
+        assert!(std::str::from_utf8(preview.content.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn heredoc_marker_avoids_content_collision() {
+        assert_eq!(heredoc_marker("normal content"), HEREDOC_MARKER);
+        let marker = heredoc_marker(&format!("content {HEREDOC_MARKER} embedded"));
+        assert_ne!(marker, HEREDOC_MARKER);
+        assert!(marker.starts_with("HERMES_PERSIST_"));
+    }
+
+    #[test]
+    fn sandbox_write_command_quotes_paths_and_uses_parent_dir() {
+        let command = build_sandbox_write_command("hello", "/tmp/hermes results/abc file.txt");
+        assert!(command.contains("mkdir -p '/tmp/hermes results'"));
+        assert!(command.contains("cat > '/tmp/hermes results/abc file.txt'"));
+        assert!(command.contains(HEREDOC_MARKER));
+
+        let malicious = build_sandbox_write_command("content", "/tmp/x; rm -rf /; echo .txt");
+        assert!(malicious.contains("'/tmp/x; rm -rf /; echo .txt'"));
+    }
+
+    #[test]
+    fn persisted_message_has_contract_shape() {
+        let msg = build_persisted_message(
+            "first 100 chars...",
+            true,
+            50_000,
+            Path::new("/tmp/hermes-results/test123.txt"),
+        );
+        assert!(msg.starts_with(PERSISTED_OUTPUT_TAG));
+        assert!(msg.ends_with(PERSISTED_OUTPUT_CLOSING_TAG));
+        assert!(msg.contains("50,000 characters"));
+        assert!(msg.contains("/tmp/hermes-results/test123.txt"));
+        assert!(msg.contains("read_file"));
+        assert!(msg.contains("first 100 chars..."));
+        assert!(msg.contains("KB"));
+
+        let large = build_persisted_message("x", true, 2_000_000, Path::new("/tmp/big.txt"));
+        assert!(large.contains("MB"));
+    }
+
+    #[test]
+    fn maybe_persist_writes_full_output_and_replaces_context() {
+        let _guard = STORAGE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_TOOL_RESULT_STORAGE_DIR", tmp.path());
+
+        let content = format!("DISTINCTIVE_START_MARKER{}", "x".repeat(60_000));
+        let result = maybe_persist_tool_result(&content, "terminal", "tc_456", Some(30_000));
+        assert!(result.contains(PERSISTED_OUTPUT_TAG));
+        assert!(result.contains("tc_456.txt"));
+        assert!(result.contains("DISTINCTIVE_START_MARKER"));
+        assert!(result.len() < content.len());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("tc_456.txt")).unwrap(),
+            content
+        );
+
+        std::env::remove_var("HERMES_TOOL_RESULT_STORAGE_DIR");
+    }
+
+    #[test]
+    fn threshold_none_never_persists_and_zero_forces_persist() {
+        let _guard = STORAGE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_TOOL_RESULT_STORAGE_DIR", tmp.path());
+
+        let large = "x".repeat(60_000);
+        assert_eq!(
+            maybe_persist_tool_result(&large, "read_file", "tc_rf", None),
+            large
+        );
+
+        let forced =
+            maybe_persist_tool_result("even short content", "terminal", "tc_zero", Some(0));
+        assert!(forced.contains(PERSISTED_OUTPUT_TAG));
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("tc_zero.txt")).unwrap(),
+            "even short content"
+        );
+
+        std::env::remove_var("HERMES_TOOL_RESULT_STORAGE_DIR");
+    }
+
+    #[test]
+    fn enforce_turn_budget_spills_largest_first_and_skips_existing() {
+        let _guard = STORAGE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_TOOL_RESULT_STORAGE_DIR", tmp.path());
+
+        let mut results = vec![
+            ToolResult::ok(
+                "t0",
+                format!(
+                    "{PERSISTED_OUTPUT_TAG}\nalready persisted\n{PERSISTED_OUTPUT_CLOSING_TAG}"
+                ),
+            ),
+            ToolResult::ok("t1", "a".repeat(80_000)),
+            ToolResult::ok("t2", "b".repeat(130_000)),
+        ];
+        enforce_turn_budget(
+            &mut results,
+            &BudgetConfig {
+                max_result_size_chars: 100_000,
+                max_aggregate_chars: 200_000,
+            },
+        );
+        assert!(results[0].content.contains("already persisted"));
+        assert!(!results[1].content.contains(PERSISTED_OUTPUT_TAG));
+        assert!(results[2].content.contains(PERSISTED_OUTPUT_TAG));
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("t2.txt")).unwrap(),
+            "b".repeat(130_000)
+        );
+
+        std::env::remove_var("HERMES_TOOL_RESULT_STORAGE_DIR");
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-02T09:26:41.172384+00:00",
+  "generated_at_utc": "2026-06-02T10:27:18.470295+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-02T09:26:41.172384+00:00`
+Generated: `2026-06-02T10:27:18.470295+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -10516,16 +10516,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_env_passthrough.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "eba84bdb2cb39437beb182cf7a3ef529a0ea8abc",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_env_passthrough.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "974911e588d32679289d50e7272b9aeec7067ac7",
       "workstream": "WS6"
@@ -10636,31 +10636,31 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_file_write_safety.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e2eef17ab1dbd3f336e8aa5ada1cb52493da05f1",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_file_write_safety.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "ac44dd1bc6b342bfbbdb7d363f2b034b21a13627",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_fuzzy_match.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "3f7d3158202ab3305c6033908824c5b3eb2dd61d",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_fuzzy_match.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f81d0437434285ac61f654b3b2db2cead8af0aae",
       "workstream": "WS6"
@@ -11656,16 +11656,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/tools",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools/test_tool_result_storage.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "17b6815c1d1768db12b646583300535df27f26dd",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_tool_result_storage.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0d80581dc2a7b17c83f2ab8c4a578f245c910d14",
       "workstream": "WS6"
@@ -15781,30 +15781,30 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-02T09:26:41.059773+00:00",
+  "generated_at_utc": "2026-06-02T10:27:18.354950+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "4007d56eef0a67c5eb05df43a3644d0c0d62ed09",
+    "local_ref": "HEAD",
+    "local_sha": "827a88bfdb76c9f553c6fb6e644ad178b8ed13e2",
     "upstream_ref": "upstream/main",
     "upstream_sha": "c6501c0f492c73313648df23417e9297cf91f868"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 386,
-      "intentional_divergence": 492,
+      "functional": 382,
+      "intentional_divergence": 496,
       "policy_only": 173
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 666,
-      "rust_equivalent_or_contract_test_required": 295,
+      "not_required_for_runtime": 670,
+      "rust_equivalent_or_contract_test_required": 291,
       "rust_native_runtime_parity_required_if_needed": 4,
       "rust_primary_ux_or_documented_divergence_required": 87
     },
     "by_status": {
-      "cleared_intentional_divergence": 492,
+      "cleared_intentional_divergence": 496,
       "cleared_non_runtime": 174,
-      "pending_review": 386
+      "pending_review": 382
     },
     "by_workstream": {
       "WS3": 58,
@@ -15813,10 +15813,10 @@
       "WS6": 698,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 492,
+    "cleared_intentional_divergence": 496,
     "cleared_non_runtime": 174,
     "pending_classification": 0,
-    "pending_review": 386,
+    "pending_review": 382,
     "total_shared_different": 1052
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-02T09:26:41.059773+00:00`
+Generated: `2026-06-02T10:27:18.354950+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1052`
 - Pending classification: `0`
-- Pending functional review: `386`
+- Pending functional review: `382`
 - Cleared non-runtime: `174`
-- Cleared intentional divergence: `492`
+- Cleared intentional divergence: `496`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 492 |
+| `cleared_intentional_divergence` | 496 |
 | `cleared_non_runtime` | 174 |
-| `pending_review` | 386 |
+| `pending_review` | 382 |
 
 ## Workstream Counts
 
@@ -39,7 +39,7 @@ Generated: `2026-06-02T09:26:41.059773+00:00`
 | --- | ---: |
 | `tests/hermes_cli` | 113 |
 | `ui-tui/src` | 64 |
-| `tests/tools` | 51 |
+| `tests/tools` | 47 |
 | `tests` | 39 |
 | `tests/cli` | 26 |
 | `tests/agent` | 22 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -3690,6 +3690,34 @@
       "rationale": "Ultra covers upstream web tools config behavior in Rust web backend tests for Exa/Tavily/Firecrawl/SearXNG/Brave/DDG/xAI selection, per-capability overrides, legacy generic backend fallback, managed Firecrawl gateway resolution, secret guards, singleton-free env re-resolution, and normalized provider payloads.",
       "owner": "sheawinkler",
       "ticket": 306
+    },
+    {
+      "path": "tests/tools/test_tool_result_storage.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream three-layer tool result persistence intent is covered by Rust tool_result_storage and dispatch contracts for newline-aware previews, heredoc delimiter safety, quoted sandbox write commands, local persisted-output blocks, read_file guidance, unicode-safe previews, threshold-zero persistence, read_file no-persist semantics, aggregate budget spilling, and dispatch-boundary persistence.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_env_passthrough.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream env passthrough registry/config intent is covered by Rust EnvPassthroughHandler registry contracts, terminal.env_passthrough YAML parsing, HERMES_SUBPROCESS_ENV_PASSTHROUGH mirroring, and LocalBackend sanitizer/profile-cleanup tests proving blocklisted provider and gateway-prefix vars remain blocked by default but pass through when explicitly allowed.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_file_write_safety.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream file write safety and HERMES_WRITE_SAFE_ROOT intent is covered by Rust CredentialGuard contracts for static credential/system write denies, macOS /private/etc and /private/var bypass protection, /boot protection, home credential prefixes, safe-root allow/deny behavior, tilde expansion, and static-deny precedence over safe-root.",
+      "owner": "sheawinkler",
+      "ticket": 25
+    },
+    {
+      "path": "tests/tools/test_fuzzy_match.py",
+      "classification": "intentional_divergence",
+      "rationale": "Upstream fuzzy replacement intent is covered by Rust LocalPatchBackend contracts for exact replacement, replace_all behavior, ambiguous single-replacement errors, identical old/new rejection, unicode-normalized smart punctuation matching with surfaced strategy names, and existing whitespace/indent/context fuzzy strategies.",
+      "owner": "sheawinkler",
+      "ticket": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Implement Rust-native tool result persistence contracts with persisted-output blocks, unicode-safe previews, sandbox write command construction, dispatch-boundary persistence, and aggregate budget spilling.
- Add Rust env passthrough registry/config/runtime support for `terminal.env_passthrough` and `HERMES_SUBPROCESS_ENV_PASSTHROUGH` across terminal sanitizers and shell cleanup.
- Harden file write safety with macOS `/private/*`, `/boot`, expanded credential prefixes, `HERMES_WRITE_SAFE_ROOT`, tilde expansion, and static-deny precedence.
- Extend fuzzy patch matching with unicode smart-punctuation normalization, strategy reporting, ambiguous single-replacement rejection, and identical replacement rejection.
- Clear four shared-diff backlog rows: `test_tool_result_storage.py`, `test_env_passthrough.py`, `test_file_write_safety.py`, `test_fuzzy_match.py`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo test -p hermes-tools`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, stale=4)

## Parity Delta
- `pending_review`: 386 -> 382
- `pending_classification`: 0
