### PR TITLE
parity(providers): add Rust provider profile contracts

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -3335,7 +3335,9 @@ impl AgentLoop {
             "stepfun" => {
                 let url =
                     base_url.unwrap_or_else(|| "https://api.stepfun.ai/step_plan/v1".to_string());
-                Arc::new(GenericProvider::new(url, &api_key, model_name))
+                Arc::new(
+                    GenericProvider::new(url, &api_key, model_name).with_provider_profile(provider),
+                )
             }
             "nous" => {
                 let mut p = NousProvider::new(&api_key).with_model(model_name);
@@ -3363,7 +3365,8 @@ impl AgentLoop {
             }
             _ => {
                 let url = base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string());
-                let mut g = GenericProvider::new(url, &api_key, model_name);
+                let mut g =
+                    GenericProvider::new(url, &api_key, model_name).with_provider_profile(provider);
                 if let Some(pool) = credential_pool {
                     g = g.with_credential_pool(pool.clone());
                 }

--- a/crates/hermes-agent/src/lib.rs
+++ b/crates/hermes-agent/src/lib.rs
@@ -25,6 +25,7 @@ pub mod model_normalize;
 pub mod oauth;
 pub mod plugins;
 pub mod provider;
+pub mod provider_profiles;
 pub mod providers_extra;
 pub mod python_alignment;
 pub mod rate_limit;

--- a/crates/hermes-agent/src/plugins.rs
+++ b/crates/hermes-agent/src/plugins.rs
@@ -721,6 +721,27 @@ dependencies:
     }
 
     #[test]
+    fn test_discover_plugins_preserves_model_provider_kind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_dir = tmp.path().join("plugins").join("test-model-provider");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.yaml"),
+            "name: test-model-provider\nversion: \"0.1.0\"\ndescription: Test\nkind: model-provider\n",
+        )
+        .unwrap();
+        std::fs::write(
+            plugin_dir.join("__init__.py"),
+            "raise AssertionError('model-provider plugins are profile manifests, not generic runtime plugins')\n",
+        )
+        .unwrap();
+
+        let discovered = PluginManager::discover_plugins(tmp.path());
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].0.kind.as_deref(), Some("model-provider"));
+    }
+
+    #[test]
     fn test_discover_plugins_with_options_includes_project_when_enabled() {
         let home = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -30,8 +30,19 @@ use hermes_core::{
 };
 
 use crate::credential_pool::CredentialPool;
+use crate::provider_profiles;
 use crate::rate_limit::RateLimitTracker;
 use crate::tool_call_args::arguments_value_to_string;
+
+struct ChatRequestParams<'a> {
+    messages: &'a [Message],
+    tools: &'a [ToolSchema],
+    max_tokens: Option<u32>,
+    temperature: Option<f64>,
+    effective_model: &'a str,
+    extra_body: Option<&'a Value>,
+    stream: bool,
+}
 
 const ACP_MULTIMODAL_PREFIX: &str = "__hermes_acp_parts_json__:";
 pub const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
@@ -234,6 +245,8 @@ pub struct GenericProvider {
     pub rate_limiter: Option<Arc<RateLimitTracker>>,
     /// Optional credential pool for key rotation.
     pub credential_pool: Option<Arc<CredentialPool>>,
+    /// Optional OpenAI-compatible provider profile used for request shaping.
+    pub provider_profile: Option<String>,
 }
 
 impl GenericProvider {
@@ -252,6 +265,7 @@ impl GenericProvider {
             extra_headers: Vec::new(),
             rate_limiter: None,
             credential_pool: None,
+            provider_profile: None,
         }
     }
 
@@ -270,6 +284,13 @@ impl GenericProvider {
     /// Set the default model.
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = model.into();
+        self
+    }
+
+    /// Attach a Rust-native provider profile for request shaping.
+    pub fn with_provider_profile(mut self, profile: impl Into<String>) -> Self {
+        self.provider_profile =
+            provider_profiles::canonical_provider_profile_id(&profile.into()).map(str::to_string);
         self
     }
 
@@ -341,10 +362,9 @@ impl GenericProvider {
         // Vision preprocessing: if user content contains local file-like paths,
         // add a hint field used by downstream adapters.
         let needs_vision_preprocess = messages.iter().any(|m| {
-            m.content
-                .as_deref()
-                .map(|c| c.contains(".png") || c.contains(".jpg") || c.contains("data:image/"))
-                .unwrap_or(false)
+            m.content.as_ref().is_some_and(|c| {
+                c.contains(".png") || c.contains(".jpg") || c.contains("data:image/")
+            })
         });
         if needs_vision_preprocess {
             body["vision_preprocessed"] = serde_json::json!(true);
@@ -497,6 +517,7 @@ impl GenericProvider {
 
     fn is_local_request_control_key(key: &str) -> bool {
         matches!(key, "strict_tool_calls" | "strict_api" | "provider_strict")
+            || provider_profiles::local_control_key_for_profile(None, key)
     }
 
     fn merge_extra_body_fields(body: &mut Value, extra_body: Option<&Value>) {
@@ -509,6 +530,23 @@ impl GenericProvider {
             }
             body[k] = v.clone();
         }
+    }
+
+    fn profile_for_extra_body<'a>(&'a self, extra_body: Option<&'a Value>) -> Option<&'a str> {
+        extra_body
+            .and_then(|value| value.get("provider_profile"))
+            .and_then(Value::as_str)
+            .and_then(provider_profiles::canonical_provider_profile_id)
+            .or(self.provider_profile.as_deref())
+    }
+
+    fn merge_extra_body_fields_for_profile(
+        body: &mut Value,
+        profile: Option<&str>,
+        extra_body: Option<&Value>,
+    ) {
+        let cleaned = provider_profiles::clean_extra_body_for_profile(profile, extra_body);
+        Self::merge_extra_body_fields(body, cleaned.as_ref());
     }
 
     fn sanitize_messages_for_api(
@@ -590,6 +628,51 @@ impl GenericProvider {
                 .collect(),
         );
         hermes_core::sanitize_tool_schemas(Some(&formatted)).unwrap_or(formatted)
+    }
+
+    fn chat_request_body(&self, request: ChatRequestParams<'_>) -> Value {
+        let ChatRequestParams {
+            messages,
+            tools,
+            max_tokens,
+            temperature,
+            effective_model,
+            extra_body,
+            stream,
+        } = request;
+        let profile = self.profile_for_extra_body(extra_body);
+        let strict_tool_sanitize = Self::should_sanitize_tool_calls(extra_body);
+        let mut api_messages =
+            Self::sanitize_messages_for_api(messages, strict_tool_sanitize, effective_model);
+        provider_profiles::normalize_messages_for_profile(profile, &mut api_messages);
+
+        let mut body = serde_json::json!({
+            "model": effective_model,
+            "messages": api_messages,
+        });
+        if stream {
+            body["stream"] = Value::Bool(true);
+        }
+
+        if let Some(mt) =
+            max_tokens.or_else(|| profile.and_then(provider_profiles::default_max_tokens))
+        {
+            body["max_tokens"] = serde_json::json!(mt);
+        }
+        if !profile.is_some_and(provider_profiles::omit_temperature) {
+            if let Some(temp) = temperature {
+                body["temperature"] = serde_json::json!(temp);
+            }
+        }
+        if !tools.is_empty() {
+            body["tools"] =
+                format_tools_for_openai_api_with_model(tools, effective_model, &self.base_url);
+        }
+        Self::merge_extra_body_fields_for_profile(&mut body, profile, extra_body);
+        self.apply_runtime_hints(&mut body, messages, extra_body);
+        provider_profiles::apply_profile_to_body(profile, &mut body, effective_model, extra_body);
+        self.apply_opencode_go_reasoning_controls(&mut body, effective_model);
+        body
     }
 
     fn build_request(
@@ -871,28 +954,15 @@ impl LlmProvider for GenericProvider {
 
         let effective_model = model.unwrap_or(&self.model);
         let api_key = self.effective_api_key();
-        let strict_tool_sanitize = Self::should_sanitize_tool_calls(extra_body);
-        let api_messages =
-            Self::sanitize_messages_for_api(messages, strict_tool_sanitize, effective_model);
-
-        let mut body = serde_json::json!({
-            "model": effective_model,
-            "messages": api_messages,
+        let body = self.chat_request_body(ChatRequestParams {
+            messages,
+            tools,
+            max_tokens,
+            temperature,
+            effective_model,
+            extra_body,
+            stream: false,
         });
-
-        if let Some(mt) = max_tokens {
-            body["max_tokens"] = serde_json::json!(mt);
-        }
-        if let Some(temp) = temperature {
-            body["temperature"] = serde_json::json!(temp);
-        }
-        if !tools.is_empty() {
-            body["tools"] =
-                format_tools_for_openai_api_with_model(tools, effective_model, &self.base_url);
-        }
-        Self::merge_extra_body_fields(&mut body, extra_body);
-        self.apply_runtime_hints(&mut body, messages, extra_body);
-        self.apply_opencode_go_reasoning_controls(&mut body, effective_model);
 
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
 
@@ -941,36 +1011,15 @@ impl LlmProvider for GenericProvider {
 
             let effective_model = model.as_deref().unwrap_or(&provider.model);
             let api_key = provider.effective_api_key();
-            let strict_tool_sanitize = GenericProvider::should_sanitize_tool_calls(extra_body.as_ref());
-            let api_messages =
-                GenericProvider::sanitize_messages_for_api(
-                    &messages,
-                    strict_tool_sanitize,
-                    effective_model,
-                );
-
-            let mut body = serde_json::json!({
-                "model": effective_model,
-                "messages": api_messages,
-                "stream": true,
+            let mut body = provider.chat_request_body(ChatRequestParams {
+                messages: &messages,
+                tools: &tools,
+                max_tokens,
+                temperature,
+                effective_model,
+                extra_body: extra_body.as_ref(),
+                stream: true,
             });
-
-            if let Some(mt) = max_tokens {
-                body["max_tokens"] = serde_json::json!(mt);
-            }
-            if let Some(temp) = temperature {
-                body["temperature"] = serde_json::json!(temp);
-            }
-            if !tools.is_empty() {
-                body["tools"] = format_tools_for_openai_api_with_model(
-                    &tools,
-                    effective_model,
-                    &provider.base_url,
-                );
-            }
-            GenericProvider::merge_extra_body_fields(&mut body, extra_body.as_ref());
-            provider.apply_runtime_hints(&mut body, &messages, extra_body.as_ref());
-            provider.apply_opencode_go_reasoning_controls(&mut body, effective_model);
             // Request usage in the final streaming chunk
             body["stream_options"] = serde_json::json!({"include_usage": true});
 
@@ -2008,7 +2057,8 @@ impl OpenRouterProvider {
     /// Create a new OpenRouter provider with the given API key.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            inner: GenericProvider::new("https://openrouter.ai/api/v1", api_key, "openai/gpt-4o"),
+            inner: GenericProvider::new("https://openrouter.ai/api/v1", api_key, "openai/gpt-4o")
+                .with_provider_profile("openrouter"),
             http_referer: None,
             x_title: None,
         }
@@ -2228,6 +2278,14 @@ impl LlmProvider for OpenRouterProvider {
         // Build a provider clone with OpenRouter headers
         let mut provider = self.inner.clone();
         provider.extra_headers = self.build_headers();
+        let effective_model = model.unwrap_or(&self.inner.model);
+        provider
+            .extra_headers
+            .extend(provider_profiles::extra_headers_for_profile(
+                Some("openrouter"),
+                effective_model,
+                extra_body,
+            ));
         let cache_control = Self::parse_response_cache_control(extra_body);
         if cache_control.enabled {
             provider
@@ -2243,34 +2301,18 @@ impl LlmProvider for OpenRouterProvider {
         let merged_extra = Self::merge_extra_body(extra_body);
 
         // Use GenericProvider for the actual request
-        let effective_model = model.unwrap_or(&self.inner.model);
         provider.check_rate_limit().await;
 
         let api_key = provider.effective_api_key();
-        let strict_tool_sanitize =
-            GenericProvider::should_sanitize_tool_calls(merged_extra.as_ref());
-        let api_messages = GenericProvider::sanitize_messages_for_api(
+        let body = provider.chat_request_body(ChatRequestParams {
             messages,
-            strict_tool_sanitize,
+            tools,
+            max_tokens,
+            temperature,
             effective_model,
-        );
-
-        let mut body = serde_json::json!({
-            "model": effective_model,
-            "messages": api_messages,
+            extra_body: merged_extra.as_ref(),
+            stream: false,
         });
-
-        if let Some(mt) = max_tokens {
-            body["max_tokens"] = serde_json::json!(mt);
-        }
-        if let Some(temp) = temperature {
-            body["temperature"] = serde_json::json!(temp);
-        }
-        if !tools.is_empty() {
-            body["tools"] =
-                format_tools_for_openai_api_with_model(tools, effective_model, &provider.base_url);
-        }
-        GenericProvider::merge_extra_body_fields(&mut body, merged_extra.as_ref());
 
         let cache_key = if cache_control.enabled && !cache_control.clear {
             Self::response_cache_key(effective_model, &body)
@@ -2328,6 +2370,14 @@ impl LlmProvider for OpenRouterProvider {
         // Use GenericProvider's streaming with OpenRouter headers
         let mut provider = self.inner.clone();
         provider.extra_headers = self.build_headers();
+        let effective_model = model.unwrap_or(&self.inner.model);
+        provider
+            .extra_headers
+            .extend(provider_profiles::extra_headers_for_profile(
+                Some("openrouter"),
+                effective_model,
+                extra_body,
+            ));
         let merged_extra = Self::merge_extra_body(extra_body);
 
         provider.chat_completion_stream(
@@ -2773,6 +2823,8 @@ mod tests {
             "strict_api": true,
             "strict_tool_calls": true,
             "provider_strict": true,
+            "provider_profile": "openrouter",
+            "provider_preferences": {"allow": ["anthropic"]},
             "temperature": 0.2
         });
         let mut body = serde_json::json!({"model": "m", "messages": []});
@@ -2780,7 +2832,165 @@ mod tests {
         assert!(body.get("strict_api").is_none());
         assert!(body.get("strict_tool_calls").is_none());
         assert!(body.get("provider_strict").is_none());
+        assert!(body.get("provider_profile").is_none());
+        assert!(body.get("provider_preferences").is_none());
         assert_eq!(body["temperature"], 0.2);
+    }
+
+    #[test]
+    fn test_provider_profile_request_body_defaults_and_qwen_messages() {
+        let provider = GenericProvider::new("https://dashscope.example/v1", "key", "qwen3.5")
+            .with_provider_profile("qwen-oauth");
+        let messages = vec![Message::system("Be helpful"), Message::user("hello")];
+        let extra = serde_json::json!({
+            "qwen_session_metadata": {"sessionId": "s123", "promptId": "p456"},
+            "provider_profile": "qwen-oauth"
+        });
+
+        let body = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: Some(0.4),
+            effective_model: "qwen3.5",
+            extra_body: Some(&extra),
+            stream: false,
+        });
+
+        assert_eq!(body["max_tokens"], 65_536);
+        assert_eq!(body["temperature"], 0.4);
+        assert_eq!(body["vl_high_resolution_images"], true);
+        assert_eq!(
+            body["metadata"],
+            serde_json::json!({"sessionId": "s123", "promptId": "p456"})
+        );
+        assert!(body.get("qwen_session_metadata").is_none());
+        assert!(body.get("provider_profile").is_none());
+        assert_eq!(
+            body["messages"][0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert_eq!(
+            body["messages"][1]["content"][0],
+            serde_json::json!({"type": "text", "text": "hello"})
+        );
+    }
+
+    #[test]
+    fn test_provider_profile_request_body_kimi_reasoning_contract() {
+        let provider = GenericProvider::new("https://api.moonshot.ai/v1", "key", "kimi-k2")
+            .with_provider_profile("kimi");
+        let messages = vec![Message::user("hello")];
+
+        let enabled = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: Some(0.7),
+            effective_model: "kimi-k2",
+            extra_body: Some(
+                &serde_json::json!({"reasoning": {"enabled": true, "effort": "high"}}),
+            ),
+            stream: false,
+        });
+        assert_eq!(enabled["max_tokens"], 32_000);
+        assert!(enabled.get("temperature").is_none());
+        assert_eq!(enabled["thinking"], serde_json::json!({"type": "enabled"}));
+        assert_eq!(enabled["reasoning_effort"], "high");
+        assert!(enabled.get("reasoning").is_none());
+
+        let disabled = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: Some(0.7),
+            effective_model: "kimi-k2",
+            extra_body: Some(&serde_json::json!({"reasoning_config": {"enabled": false}})),
+            stream: false,
+        });
+        assert_eq!(
+            disabled["thinking"],
+            serde_json::json!({"type": "disabled"})
+        );
+        assert!(disabled.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_provider_profile_request_body_openrouter_nous_and_custom_contracts() {
+        let messages = vec![Message::user("hello")];
+
+        let openrouter = GenericProvider::new(
+            "https://openrouter.ai/api/v1",
+            "key",
+            "openrouter/pareto-code",
+        )
+        .with_provider_profile("openrouter");
+        let or_body = openrouter.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "openrouter/pareto-code",
+            extra_body: Some(&serde_json::json!({
+                "provider_preferences": {"allow": ["anthropic"], "sort": "price"},
+                "openrouter_min_coding_score": 0.65,
+                "supports_reasoning": true,
+                "session_id": "sess-123"
+            })),
+            stream: false,
+        });
+        assert_eq!(
+            or_body["provider"],
+            serde_json::json!({"allow": ["anthropic"], "sort": "price"})
+        );
+        assert_eq!(or_body["session_id"], "sess-123");
+        assert_eq!(
+            or_body["plugins"],
+            serde_json::json!([{"id": "pareto-router", "min_coding_score": 0.65}])
+        );
+        assert_eq!(
+            or_body["reasoning"],
+            serde_json::json!({"enabled": true, "effort": "medium"})
+        );
+        assert!(or_body.get("provider_preferences").is_none());
+
+        let nous = GenericProvider::new(
+            "https://inference-api.nousresearch.com/v1",
+            "key",
+            "hermes-3",
+        )
+        .with_provider_profile("nous");
+        let nous_body = nous.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "hermes-3",
+            extra_body: Some(&serde_json::json!({
+                "supports_reasoning": true,
+                "reasoning": {"enabled": false}
+            })),
+            stream: false,
+        });
+        assert_eq!(
+            nous_body["tags"],
+            serde_json::json!(["product=hermes-agent"])
+        );
+        assert!(nous_body.get("reasoning").is_none());
+
+        let custom = GenericProvider::new("http://127.0.0.1:11434/v1", "key", "qwen3:72b")
+            .with_provider_profile("ollama-local");
+        let custom_body = custom.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "qwen3:72b",
+            extra_body: Some(&serde_json::json!({"ollama_num_ctx": 131072})),
+            stream: false,
+        });
+        assert_eq!(custom_body["options"]["num_ctx"], 131_072);
+        assert!(custom_body.get("ollama_num_ctx").is_none());
     }
 
     #[test]

--- a/crates/hermes-agent/src/provider_profiles.rs
+++ b/crates/hermes-agent/src/provider_profiles.rs
@@ -1,0 +1,403 @@
+//! Rust-native request-profile contracts for OpenAI-compatible providers.
+//!
+//! Upstream Python keeps this behavior in provider plugin profiles. Hermes
+//! Ultra runs the agent loop in Rust, so the request-shaping contracts live
+//! here instead of importing Python provider plugins at runtime.
+
+use serde_json::{Map, Value};
+
+pub const NOUS_PRODUCT_TAG: &str = "product=hermes-agent";
+
+pub fn canonical_provider_profile_id(provider: &str) -> Option<&'static str> {
+    let normalized = provider.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+    match normalized.as_str() {
+        "nvidia" | "nvidia-nim" => Some("nvidia"),
+        "kimi" | "moonshot" | "moonshot-ai" | "kimi-coding" => Some("kimi-coding"),
+        "kimi-coding-cn" | "kimi-cn" | "moonshot-cn" => Some("kimi-coding-cn"),
+        "openrouter" | "or" => Some("openrouter"),
+        "nous" | "nous-portal" => Some("nous"),
+        "qwen" | "qwen-oauth" | "qwen-portal" | "qwen-cli" => Some("qwen-oauth"),
+        "custom" | "ollama" | "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane"
+        | "sglang" | "tgi" => Some("custom"),
+        _ => None,
+    }
+}
+
+pub fn default_max_tokens(profile: &str) -> Option<u32> {
+    match canonical_provider_profile_id(profile)? {
+        "nvidia" => Some(16_384),
+        "kimi-coding" | "kimi-coding-cn" => Some(32_000),
+        "qwen-oauth" => Some(65_536),
+        _ => None,
+    }
+}
+
+pub fn omit_temperature(profile: &str) -> bool {
+    matches!(
+        canonical_provider_profile_id(profile),
+        Some("kimi-coding" | "kimi-coding-cn")
+    )
+}
+
+pub fn profile_auth_type(profile: &str) -> Option<&'static str> {
+    match canonical_provider_profile_id(profile)? {
+        "nous" => Some("oauth_device_code"),
+        "qwen-oauth" => Some("oauth_external"),
+        "nvidia" | "kimi-coding" | "kimi-coding-cn" | "openrouter" | "custom" => Some("api_key"),
+        _ => None,
+    }
+}
+
+pub fn profile_base_url(profile: &str) -> Option<&'static str> {
+    match canonical_provider_profile_id(profile)? {
+        "nvidia" => Some("https://integrate.api.nvidia.com/v1"),
+        "kimi-coding" => Some("https://api.moonshot.ai/v1"),
+        "kimi-coding-cn" => Some("https://api.moonshot.cn/v1"),
+        "openrouter" => Some("https://openrouter.ai/api/v1"),
+        "nous" => Some("https://inference-api.nousresearch.com/v1"),
+        "qwen-oauth" => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+        _ => None,
+    }
+}
+
+pub fn nous_portal_tags() -> Value {
+    Value::Array(vec![Value::String(NOUS_PRODUCT_TAG.to_string())])
+}
+
+pub fn local_control_key_for_profile(profile: Option<&str>, key: &str) -> bool {
+    if matches!(
+        key,
+        "provider_profile"
+            | "supports_reasoning"
+            | "reasoning_config"
+            | "provider_preferences"
+            | "openrouter_min_coding_score"
+            | "session_id"
+            | "qwen_session_metadata"
+            | "ollama_num_ctx"
+    ) {
+        return true;
+    }
+
+    match profile.and_then(canonical_provider_profile_id) {
+        Some("kimi-coding" | "kimi-coding-cn" | "nous" | "openrouter") => {
+            matches!(key, "reasoning" | "reasoning_effort")
+        }
+        _ => false,
+    }
+}
+
+pub fn clean_extra_body_for_profile(
+    profile: Option<&str>,
+    extra_body: Option<&Value>,
+) -> Option<Value> {
+    let Some(Value::Object(map)) = extra_body else {
+        return extra_body.cloned();
+    };
+    let mut cleaned = Map::new();
+    for (key, value) in map {
+        if !local_control_key_for_profile(profile, key) {
+            cleaned.insert(key.clone(), value.clone());
+        }
+    }
+    Some(Value::Object(cleaned))
+}
+
+pub fn normalize_messages_for_profile(profile: Option<&str>, messages: &mut Value) {
+    let Some("qwen-oauth") = profile.and_then(canonical_provider_profile_id) else {
+        return;
+    };
+    let Some(items) = messages.as_array_mut() else {
+        return;
+    };
+    for item in items {
+        let Some(obj) = item.as_object_mut() else {
+            continue;
+        };
+        let is_system = obj
+            .get("role")
+            .and_then(Value::as_str)
+            .is_some_and(|role| role.eq_ignore_ascii_case("system"));
+        match obj.get_mut("content") {
+            Some(Value::String(text)) => {
+                let mut part = Map::new();
+                part.insert("type".to_string(), Value::String("text".to_string()));
+                part.insert("text".to_string(), Value::String(text.clone()));
+                if is_system {
+                    part.insert(
+                        "cache_control".to_string(),
+                        serde_json::json!({"type": "ephemeral"}),
+                    );
+                }
+                *obj.get_mut("content").expect("content exists") =
+                    Value::Array(vec![Value::Object(part)]);
+            }
+            Some(Value::Array(parts)) if is_system => {
+                if let Some(last) = parts.last_mut().and_then(Value::as_object_mut) {
+                    last.entry("cache_control".to_string())
+                        .or_insert_with(|| serde_json::json!({"type": "ephemeral"}));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn apply_profile_to_body(
+    profile: Option<&str>,
+    body: &mut Value,
+    effective_model: &str,
+    extra_body: Option<&Value>,
+) {
+    let Some(profile) = profile.and_then(canonical_provider_profile_id) else {
+        return;
+    };
+    match profile {
+        "kimi-coding" | "kimi-coding-cn" => apply_kimi_profile(body, extra_body),
+        "openrouter" => apply_openrouter_profile(body, effective_model, extra_body),
+        "nous" => apply_nous_profile(body, extra_body),
+        "qwen-oauth" => apply_qwen_profile(body, extra_body),
+        "custom" => apply_custom_profile(body, extra_body),
+        "nvidia" => {}
+        _ => {}
+    }
+}
+
+pub fn extra_headers_for_profile(
+    profile: Option<&str>,
+    effective_model: &str,
+    extra_body: Option<&Value>,
+) -> Vec<(String, String)> {
+    let Some("openrouter") = profile.and_then(canonical_provider_profile_id) else {
+        return Vec::new();
+    };
+    let Some(session_id) = string_field(extra_body, "session_id") else {
+        return Vec::new();
+    };
+    if is_grok_model(effective_model) {
+        vec![("x-grok-conv-id".to_string(), session_id.to_string())]
+    } else {
+        Vec::new()
+    }
+}
+
+fn apply_kimi_profile(body: &mut Value, extra_body: Option<&Value>) {
+    remove_key(body, "temperature");
+    remove_key(body, "reasoning");
+    let reasoning = reasoning_config(extra_body);
+    let enabled = reasoning
+        .and_then(|cfg| cfg.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    body["thinking"] = serde_json::json!({
+        "type": if enabled { "enabled" } else { "disabled" },
+    });
+    if enabled {
+        let effort = reasoning
+            .and_then(|cfg| cfg.get("effort"))
+            .and_then(Value::as_str)
+            .or_else(|| string_field(extra_body, "reasoning_effort"))
+            .unwrap_or("medium");
+        body["reasoning_effort"] = Value::String(effort.to_string());
+    } else {
+        remove_key(body, "reasoning_effort");
+    }
+}
+
+fn apply_openrouter_profile(body: &mut Value, effective_model: &str, extra_body: Option<&Value>) {
+    if let Some(preferences) = extra_body.and_then(|v| v.get("provider_preferences")) {
+        body["provider"] = preferences.clone();
+    }
+    if let Some(session_id) = string_field(extra_body, "session_id") {
+        body["session_id"] = Value::String(session_id.to_string());
+    }
+    if is_pareto_code_model(effective_model) {
+        if let Some(score) = extra_body
+            .and_then(|v| v.get("openrouter_min_coding_score"))
+            .and_then(parse_score)
+        {
+            body["plugins"] =
+                serde_json::json!([{"id": "pareto-router", "min_coding_score": score}]);
+        }
+    }
+
+    let supports_reasoning = bool_field(extra_body, "supports_reasoning").unwrap_or(false);
+    if let Some(reasoning) = reasoning_config(extra_body) {
+        body["reasoning"] = reasoning.clone();
+    } else if let Some(effort) = string_field(extra_body, "reasoning_effort") {
+        body["reasoning"] = serde_json::json!({"enabled": true, "effort": effort});
+    } else if supports_reasoning {
+        body["reasoning"] = serde_json::json!({"enabled": true, "effort": "medium"});
+    }
+}
+
+fn apply_nous_profile(body: &mut Value, extra_body: Option<&Value>) {
+    body["tags"] = nous_portal_tags();
+
+    let supports_reasoning = bool_field(extra_body, "supports_reasoning").unwrap_or(false);
+    let reasoning = reasoning_config(extra_body);
+    let enabled = reasoning
+        .and_then(|cfg| cfg.get("enabled"))
+        .and_then(Value::as_bool);
+
+    match (supports_reasoning, reasoning, enabled) {
+        (_, Some(_), Some(false)) => remove_key(body, "reasoning"),
+        (true, Some(cfg), _) => body["reasoning"] = cfg.clone(),
+        (true, None, _) => {
+            if let Some(effort) = string_field(extra_body, "reasoning_effort") {
+                body["reasoning"] = serde_json::json!({"effort": effort});
+            }
+        }
+        _ => remove_key(body, "reasoning"),
+    }
+}
+
+fn apply_qwen_profile(body: &mut Value, extra_body: Option<&Value>) {
+    body["vl_high_resolution_images"] = Value::Bool(true);
+    if let Some(metadata) = extra_body.and_then(|v| v.get("qwen_session_metadata")) {
+        body["metadata"] = metadata.clone();
+    }
+}
+
+fn apply_custom_profile(body: &mut Value, extra_body: Option<&Value>) {
+    let Some(num_ctx) = extra_body
+        .and_then(|v| v.get("ollama_num_ctx"))
+        .and_then(|v| v.as_u64())
+    else {
+        return;
+    };
+    let options = body
+        .as_object_mut()
+        .expect("request body should be an object")
+        .entry("options".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !options.is_object() {
+        *options = Value::Object(Map::new());
+    }
+    options["num_ctx"] = Value::Number(num_ctx.into());
+}
+
+fn reasoning_config(extra_body: Option<&Value>) -> Option<&Value> {
+    extra_body
+        .and_then(|v| v.get("reasoning_config"))
+        .or_else(|| extra_body.and_then(|v| v.get("reasoning")))
+}
+
+fn string_field<'a>(value: Option<&'a Value>, key: &str) -> Option<&'a str> {
+    value
+        .and_then(|v| v.get(key))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+}
+
+fn bool_field(value: Option<&Value>, key: &str) -> Option<bool> {
+    value.and_then(|v| v.get(key)).and_then(Value::as_bool)
+}
+
+fn parse_score(value: &Value) -> Option<f64> {
+    let score = value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|v| v.trim().parse::<f64>().ok()))?;
+    if (0.0..=1.0).contains(&score) {
+        Some(score)
+    } else {
+        None
+    }
+}
+
+fn is_grok_model(model: &str) -> bool {
+    let lower = model.trim().to_ascii_lowercase();
+    lower.starts_with("x-ai/grok")
+        || lower.starts_with("xai/grok")
+        || lower.starts_with("grok")
+        || lower.contains("/grok")
+}
+
+fn is_pareto_code_model(model: &str) -> bool {
+    let lower = model.trim().to_ascii_lowercase();
+    lower == "openrouter/pareto-code" || lower.ends_with("/pareto-code")
+}
+
+fn remove_key(body: &mut Value, key: &str) {
+    if let Some(obj) = body.as_object_mut() {
+        obj.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aliases_match_upstream_provider_profiles() {
+        assert_eq!(canonical_provider_profile_id("kimi"), Some("kimi-coding"));
+        assert_eq!(
+            canonical_provider_profile_id("moonshot"),
+            Some("kimi-coding")
+        );
+        assert_eq!(
+            canonical_provider_profile_id("kimi-coding-cn"),
+            Some("kimi-coding-cn")
+        );
+        assert_eq!(canonical_provider_profile_id("or"), Some("openrouter"));
+        assert_eq!(canonical_provider_profile_id("nous-portal"), Some("nous"));
+        assert_eq!(canonical_provider_profile_id("qwen"), Some("qwen-oauth"));
+        assert_eq!(
+            canonical_provider_profile_id("qwen-portal"),
+            Some("qwen-oauth")
+        );
+        assert_eq!(canonical_provider_profile_id("missing"), None);
+    }
+
+    #[test]
+    fn profile_static_metadata_matches_runtime_contracts() {
+        assert_eq!(default_max_tokens("nvidia"), Some(16_384));
+        assert_eq!(default_max_tokens("kimi"), Some(32_000));
+        assert_eq!(default_max_tokens("qwen-oauth"), Some(65_536));
+        assert!(omit_temperature("kimi"));
+        assert_eq!(profile_auth_type("nous"), Some("oauth_device_code"));
+        assert_eq!(profile_auth_type("qwen-oauth"), Some("oauth_external"));
+        assert!(profile_base_url("nvidia").unwrap().contains("nvidia.com"));
+        assert!(profile_base_url("kimi-coding-cn")
+            .unwrap()
+            .contains("moonshot.cn"));
+    }
+
+    #[test]
+    fn qwen_message_normalization_adds_parts_and_cache_control() {
+        let mut messages = serde_json::json!([
+            {"role": "system", "content": "Be helpful"},
+            {"role": "user", "content": "hello"}
+        ]);
+        normalize_messages_for_profile(Some("qwen-oauth"), &mut messages);
+        assert!(messages[0]["content"].is_array());
+        assert_eq!(messages[0]["content"][0]["text"], "Be helpful");
+        assert_eq!(
+            messages[0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert_eq!(
+            messages[1]["content"][0],
+            serde_json::json!({"type": "text", "text": "hello"})
+        );
+    }
+
+    #[test]
+    fn openrouter_grok_session_affinity_header_is_profile_scoped() {
+        let extra = serde_json::json!({"session_id": "sess-abc"});
+        assert_eq!(
+            extra_headers_for_profile(Some("openrouter"), "x-ai/grok-4", Some(&extra)),
+            vec![("x-grok-conv-id".to_string(), "sess-abc".to_string())]
+        );
+        assert!(extra_headers_for_profile(
+            Some("openrouter"),
+            "anthropic/claude-sonnet-4.6",
+            Some(&extra)
+        )
+        .is_empty());
+    }
+}

--- a/crates/hermes-agent/src/providers_extra.rs
+++ b/crates/hermes-agent/src/providers_extra.rs
@@ -61,7 +61,8 @@ impl QwenProvider {
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
                 api_key,
                 "qwen-turbo",
-            ),
+            )
+            .with_provider_profile("qwen-oauth"),
         }
     }
 
@@ -130,7 +131,8 @@ pub struct KimiProvider {
 impl KimiProvider {
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            inner: GenericProvider::new("https://api.moonshot.cn/v1", api_key, "moonshot-v1-8k"),
+            inner: GenericProvider::new("https://api.moonshot.cn/v1", api_key, "moonshot-v1-8k")
+                .with_provider_profile("kimi-coding"),
         }
     }
 
@@ -272,7 +274,8 @@ impl NousProvider {
                 "https://inference-api.nousresearch.com/v1",
                 api_key,
                 "hermes-3-llama-3.1-405b",
-            ),
+            )
+            .with_provider_profile("nous"),
         }
     }
 

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4855,6 +4855,11 @@ mod tests {
         );
         assert_eq!(normalize_runtime_provider_name("arcee-ai"), "arcee");
         assert_eq!(normalize_runtime_provider_name("arceeai"), "arcee");
+        assert_eq!(normalize_runtime_provider_name("azure"), "azure-foundry");
+        assert_eq!(
+            normalize_runtime_provider_name("azure-ai-foundry"),
+            "azure-foundry"
+        );
         assert_eq!(normalize_runtime_provider_name("mimo"), "xiaomi");
         assert_eq!(normalize_runtime_provider_name("xiaomi-mimo"), "xiaomi");
         assert_eq!(
@@ -5783,6 +5788,7 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
+        "azure" | "azure-ai-foundry" | "azure_ai_foundry" => "azure-foundry".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
@@ -6407,7 +6413,10 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         }
         "stepfun" => {
             let url = base_url.unwrap_or_else(|| STEPFUN_BASE_URL.to_string());
-            Arc::new(GenericProvider::new(url, &api_key, model_name.as_str()))
+            Arc::new(
+                GenericProvider::new(url, &api_key, model_name.as_str())
+                    .with_provider_profile(runtime_provider.as_str()),
+            )
         }
         "nous" => {
             let mut p = NousProvider::new(&api_key).with_model(model_name.as_str());
@@ -6426,11 +6435,17 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         }
         "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi" => {
             let url = base_url.unwrap_or_else(|| "http://127.0.0.1:11434/v1".to_string());
-            Arc::new(GenericProvider::new(url, &api_key, model_name.as_str()))
+            Arc::new(
+                GenericProvider::new(url, &api_key, model_name.as_str())
+                    .with_provider_profile(runtime_provider.as_str()),
+            )
         }
         _ => {
             let url = base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string());
-            Arc::new(GenericProvider::new(url, &api_key, model_name.as_str()))
+            Arc::new(
+                GenericProvider::new(url, &api_key, model_name.as_str())
+                    .with_provider_profile(runtime_provider.as_str()),
+            )
         }
     }
 }

--- a/crates/hermes-cli/src/providers.rs
+++ b/crates/hermes-cli/src/providers.rs
@@ -4,6 +4,7 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "openrouter",
     "codex",
     "openai-codex",
+    "custom",
     "qwen",
     "qwen-oauth",
     "google-gemini-cli",
@@ -22,6 +23,7 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "alibaba",
     "alibaba-coding-plan",
     "arcee",
+    "azure-foundry",
     "bedrock",
     "deepseek",
     "huggingface",
@@ -95,6 +97,7 @@ pub fn canonical_provider_id(provider: &str) -> String {
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
+        "azure" | "azure-ai-foundry" | "azure_ai_foundry" => "azure-foundry".to_string(),
         "step" | "step-plan" => "stepfun".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "alibaba" | "alibaba-coding-plan" => "qwen".to_string(),
@@ -298,6 +301,8 @@ mod tests {
         assert_eq!(canonical_provider_id("google-ai-studio"), "gemini");
         assert_eq!(canonical_provider_id("arcee-ai"), "arcee");
         assert_eq!(canonical_provider_id("arceeai"), "arcee");
+        assert_eq!(canonical_provider_id("azure"), "azure-foundry");
+        assert_eq!(canonical_provider_id("azure-ai-foundry"), "azure-foundry");
         assert_eq!(canonical_provider_id("mimo"), "xiaomi");
         assert_eq!(canonical_provider_id("xiaomi-mimo"), "xiaomi");
         assert_eq!(canonical_provider_id("tencent-cloud"), "tencent-tokenhub");
@@ -307,5 +312,55 @@ mod tests {
         assert_eq!(canonical_provider_id("amazon-bedrock"), "bedrock");
         assert_eq!(canonical_provider_id("amazon"), "bedrock");
         assert_eq!(canonical_provider_id("minimax_cn"), "minimax-cn");
+    }
+
+    #[test]
+    fn bundled_model_provider_plugin_dirs_are_known() {
+        let plugins_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../plugins/model-providers");
+        let mut plugin_dirs = Vec::new();
+        for entry in std::fs::read_dir(&plugins_dir)
+            .unwrap_or_else(|err| panic!("read {} failed: {}", plugins_dir.display(), err))
+        {
+            let path = entry.expect("dir entry").path();
+            if !path.is_dir() {
+                continue;
+            }
+            assert!(
+                path.join("__init__.py").exists(),
+                "{} missing __init__.py",
+                path.display()
+            );
+            assert!(
+                path.join("plugin.yaml").exists(),
+                "{} missing plugin.yaml",
+                path.display()
+            );
+            plugin_dirs.push(
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .expect("utf8 provider dir")
+                    .to_string(),
+            );
+        }
+        assert!(
+            plugin_dirs.len() >= 28,
+            "expected at least 28 bundled provider plugins, got {}",
+            plugin_dirs.len()
+        );
+
+        let known: BTreeSet<String> = known_providers()
+            .into_iter()
+            .map(|provider| provider.to_string())
+            .collect();
+        let missing: Vec<String> = plugin_dirs
+            .into_iter()
+            .filter(|provider| !known.contains(provider))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "bundled model-provider plugin dirs missing from Rust known_providers: {:?}",
+            missing
+        );
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-02T10:27:18.470295+00:00",
+  "generated_at_utc": "2026-06-02T16:27:30.320571+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-02T10:27:18.470295+00:00`
+Generated: `2026-06-02T16:27:30.320571+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -826,16 +826,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; Rust-native provider/profile contracts cover upstream intent.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/model-providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "rust_provider_profile_contracts",
       "local_blob": "607439a365e54be6b88124f47ba43b10164dfcdb",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/alibaba-coding-plan/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "17744aeca5d5d3dad12575d70565c34d48fe7e29",
       "workstream": "WS3"
@@ -871,16 +871,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "No vendoring; Rust-native provider/profile contracts cover upstream intent.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/model-providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "rust_provider_profile_contracts",
       "local_blob": "0812f07ba5f127b01433e9c27aed8f1c6d61ea84",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/gemini/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "f7ae696154c64ead8f714f7c187a37b29120bf9a",
       "workstream": "WS3"
@@ -8281,61 +8281,61 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
+      "action": "No vendoring; Rust-native provider/profile contracts cover upstream intent.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "rust_provider_profile_contracts",
       "local_blob": "0faf83d446e902e8068955d51cc4f330b3c2c640",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/providers/test_plugin_discovery.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "fba5a02df11cba8dc2649a613a029ee62e0d0b34",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
+      "action": "No vendoring; Rust-native provider/profile contracts cover upstream intent.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "rust_provider_profile_contracts",
       "local_blob": "9096c82b6a3f25773213880ea155c691fa5ba9d7",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/providers/test_profile_wiring.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "258ff531806db0850d737851adaf28ce5bbe0104",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
+      "action": "No vendoring; Rust-native provider/profile contracts cover upstream intent.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "rust_provider_profile_contracts",
       "local_blob": "68f7b5f4970655e4834559ceaad767798ef1c139",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/providers/test_provider_profiles.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c9e9daa623d2334105fd0b1e06f4d029af875756",
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
+      "action": "No vendoring; Rust-native provider/profile contracts cover upstream intent.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/providers",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "rust_provider_profile_contracts",
       "local_blob": "be88bc580a156cff93b8392ec71ebe48c87a78aa",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/providers/test_transport_parity.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "5d1856cd84b32f2d6974bced493eb842d056b4a9",
       "workstream": "WS6"
@@ -15781,7 +15781,7 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-02T10:27:18.354950+00:00",
+  "generated_at_utc": "2026-06-02T16:27:30.320571+00:00",
   "refs": {
     "local_ref": "HEAD",
     "local_sha": "827a88bfdb76c9f553c6fb6e644ad178b8ed13e2",
@@ -15791,20 +15791,20 @@
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 382,
-      "intentional_divergence": 496,
+      "functional": 376,
+      "intentional_divergence": 502,
       "policy_only": 173
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 670,
-      "rust_equivalent_or_contract_test_required": 291,
-      "rust_native_runtime_parity_required_if_needed": 4,
+      "not_required_for_runtime": 676,
+      "rust_equivalent_or_contract_test_required": 287,
+      "rust_native_runtime_parity_required_if_needed": 2,
       "rust_primary_ux_or_documented_divergence_required": 87
     },
     "by_status": {
-      "cleared_intentional_divergence": 496,
+      "cleared_intentional_divergence": 502,
       "cleared_non_runtime": 174,
-      "pending_review": 382
+      "pending_review": 376
     },
     "by_workstream": {
       "WS3": 58,
@@ -15813,10 +15813,10 @@
       "WS6": 698,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 496,
+    "cleared_intentional_divergence": 502,
     "cleared_non_runtime": 174,
     "pending_classification": 0,
-    "pending_review": 382,
+    "pending_review": 376,
     "total_shared_different": 1052
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-02T10:27:18.354950+00:00`
+Generated: `2026-06-02T16:27:30.320571+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1052`
 - Pending classification: `0`
-- Pending functional review: `382`
+- Pending functional review: `376`
 - Cleared non-runtime: `174`
-- Cleared intentional divergence: `496`
+- Cleared intentional divergence: `502`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 496 |
+| `cleared_intentional_divergence` | 502 |
+| `pending_review` | 376 |
 | `cleared_non_runtime` | 174 |
-| `pending_review` | 382 |
 
 ## Workstream Counts
 
@@ -48,11 +48,9 @@ Generated: `2026-06-02T10:27:18.354950+00:00`
 | `tests/skills` | 6 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |
-| `tests/providers` | 4 |
 | `tests/tui_gateway` | 4 |
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
-| `plugins/model-providers` | 2 |
 | `tests/e2e` | 2 |
 | `plugins/observability` | 1 |
 | `plugins/video_gen` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -1,3723 +1,3765 @@
 {
-  "schema_version": 1,
-  "generated_from": "docs/parity/parity-matrix.json",
+  "generated_from": "docs/parity/shared-diff-backlog.json",
   "items": [
     {
-      "path": ".gitignore",
-      "classification": "branding_only",
-      "rationale": "Repository-local ignore patterns and generated artifacts do not affect runtime parity behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "AGENTS.md",
       "classification": "policy_only",
-      "rationale": "Local operator guidance; not part of Hermes runtime behavior.",
       "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "CONTRIBUTING.md",
-      "classification": "policy_only",
-      "rationale": "Contributor process guidance and release policy; no runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "Dockerfile",
-      "classification": "intentional_divergence",
-      "rationale": "Hermes Agent Ultra intentionally ships a Rust multi-stage container with tini/gosu and /data state instead of upstream's Python uv+s6-overlay image; Rust-native container contracts cover the retained runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "LICENSE",
-      "classification": "policy_only",
-      "rationale": "Licensing and attribution metadata; no runtime effect.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "README.md",
-      "classification": "intentional_divergence",
-      "rationale": "README.md intentionally describes Ultra's Rust-first runtime, release installer, and parity workflow rather than upstream's Python product positioning; install/readme contracts cover the actionable setup guidance.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "docker-compose.yml",
-      "classification": "intentional_divergence",
-      "rationale": "Compose defaults intentionally target the Ultra Rust image, /data volume, and hermes-agent-ultra naming while preserving localhost dashboard and UID/GID runtime controls.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "docker/entrypoint.sh",
-      "classification": "intentional_divergence",
-      "rationale": "The entrypoint intentionally implements the Rust image's direct tini/gosu startup path instead of upstream's s6 stage2 hook; entrypoint contracts cover home setup, UID/GID remap, and privilege drop.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "flake.nix",
-      "classification": "intentional_divergence",
-      "rationale": "Nix packaging intentionally builds the Rust workspace with the Hermes Ultra release version rather than upstream's Python flake-parts packaging stack.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "packaging/homebrew/hermes-agent.rb",
-      "classification": "intentional_divergence",
-      "rationale": "Homebrew packaging uses Hermes Ultra's checksummed Rust release artifacts instead of upstream's Python virtualenv formula.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "packaging/homebrew",
-      "classification": "functional",
-      "rationale": "Distribution packaging path impacts install parity for Homebrew users.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "optional-skills",
-      "classification": "intentional_divergence",
-      "rationale": "Optional skill catalog content is curated locally; Hermes Ultra tracks runtime parity through native skill-loader contracts instead of vendoring every upstream Python skill implementation.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "optional-skills/blockchain",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream optional-skills blockchain tree is Python-skill-store content; Hermes Ultra keeps Rust-first runtime parity and supports external skill registries via native loader paths.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "optional-skills/mlops",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream optional-skills MLOps content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "optional-skills/research",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream optional-skills research content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "optional-skills/finance",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream optional-skills finance content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "optional-skills/health",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream optional-skills health content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "scripts/install.sh",
-      "classification": "intentional_divergence",
-      "rationale": "Installer intentionally downloads or builds Hermes Agent Ultra Rust release binaries instead of cloning upstream's Python/uv environment; installer contracts cover release assets, symlinks, PATH guard, Termux pathing, and post-install probes.",
-      "owner": "sheawinkler",
-      "ticket": 305
-    },
-    {
-      "path": "tests",
-      "classification": "functional",
-      "rationale": "Top-level test differences can encode behavior contracts and must be mapped to Rust-native or local contract-test coverage before being cleared.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/test_honcho_client_config.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python Honcho config permission coverage is mapped to Rust tests for owner-only atomic honcho.json writes and explicit config-file activation in crates/hermes-agent/src/memory_plugins/honcho.rs.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "tests/plugins/memory/test_hindsight_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Hindsight recall-type defaults and secure config writes are covered by Rust memory plugin tests, including observation-only recall payloads and owner-only $HERMES_HOME/hindsight/config.json writes.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "tests/plugins/memory/test_mem0_v2.py",
-      "classification": "intentional_divergence",
-      "rationale": "Mem0 v2 behavior and secure config persistence are covered by Rust memory plugin tests for result normalization, owner-only atomic mem0.json writes, merge semantics, and config-file activation.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "tests/plugins/memory/test_supermemory_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Supermemory provider setup persistence is covered by Rust tests for owner-only atomic supermemory.json writes and config-file activation; the Python test file is retained as upstream reference.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "tests/gateway",
-      "classification": "functional",
-      "rationale": "Gateway test deltas exercise platform adapter behavior and must be reviewed as runtime parity coverage.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_allowed_channels_widening.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram, DingTalk, Mattermost, and Matrix allowed-chat/channel/room gating is covered by Rust config-env import tests and gateway platform access policy tests for aliases, no-restriction defaults, blocked non-allowlisted group traffic, mention non-bypass, and DM bypass of channel restrictions.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_allowlist_startup_check.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream startup allowlist warning semantics are covered by Rust gateway startup warning helper tests for no-config warning, SIGNAL_GROUP_ALLOWED_USERS suppression, platform allow-all suppression, global allow-all suppression, and false-like allow-all rejection; runtime gateway startup emits the warning when chat platforms are enabled without a user allowlist or explicit allow-all override.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_unauthorized_dm_behavior.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream unauthorized-DM behavior is covered by Rust DmManager, Gateway route, and CLI builder tests for platform/global allowlists, wildcard allowlists, WhatsApp LID-to-phone mapping, Telegram group sender allowlists, Telegram legacy group-chat IDs, QQ group chat allowlists, allowlist-derived ignore defaults, explicit pair overrides, pairing-code replies, and pairing rate-limit suppression.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_signal_format.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Signal markdown formatting is covered by Rust Signal gateway tests for bold, italic, strikethrough, monospace, fenced code blocks with language tags, heading-to-bold conversion, UTF-16 body ranges, newline collapse, link preservation, and italic false-positive regressions for snake_case, bullet lists, and cross-line spans.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_signal_rate_limit.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Signal attachment rate-limit behavior is covered by Rust token-bucket scheduler tests for default capacity/refill, wait estimation, zero/in-capacity/over-capacity acquire, post-RPC deduction, retry-after feedback calibration, refill clamping, rate-limit detection, wait formatting, and process-wide scheduler reset.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_hooks.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream gateway hook discovery, wildcard emit ordering, error containment, default empty context, and emit_collect decision hooks are covered by Rust HookRegistry tests; user hook loading intentionally uses zero-Python HOOK.yaml command handlers instead of dynamic handler.py imports.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_delivery.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream delivery target parsing is covered by Rust DeliveryTarget tests for origin resolution, local fallback, platform-home targets, explicit chat IDs, thread IDs, case-insensitive platform names, case-preserving chat IDs, Matrix-style colon splitting, target string roundtrips, and unknown-platform local fallback.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_channel_directory.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream channel-directory cache behavior is covered by Rust tests for missing/corrupt load fallback, atomic writes, session-derived channel discovery with topic composite IDs, exact/display/guild/prefix/id resolution, channel-type lookup, display formatting, provider error isolation, provider/session merge dedupe, and Slack users.conversations pagination.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_platform_http_client_limits.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream persistent-platform HTTP pool limits are covered by Rust BasePlatformAdapter reqwest pool-limit tests for default keepalive tightening, env overrides, malformed env fallback, and shared builder use by long-lived adapters; Python httpx import failure and aiohttp response-leak checks are not part of the Rust runtime.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_agent_cache.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream gateway agent-cache invalidation is covered by Rust GatewayAgentCache and agent_config_signature tests for stable model/provider/toolset/system/cache-key signatures, full-token secret-safe hashing, documented cache-busting config extraction, signature misses, LRU eviction, idle TTL cleanup, and release hooks.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_base_topic_sessions.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream base-topic session behavior is covered by Rust session-control and Telegram bridge tests that preserve distinct thread/topic session keys, encode incoming Telegram group topics as composite chat IDs, split them back into Bot API chat_id/message_thread_id on send, and keep invalid or lobby thread suffixes unchanged.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_busy_session_ack.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream active-session busy acknowledgement behavior is covered by Rust BusySessionCoordinator tests for queue, interrupt, and steer modes, acknowledgement cooldown/debounce, pending follow-up replacement, agent interrupt/steer handoff, status-rich interrupt acknowledgements, command bypass, and pending replay after finish.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_command_bypass_active_session.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream command-bypass behavior is covered by Rust gateway command registry tests for canonical slash commands, Telegram bot suffix stripping, hyphen-to-underscore normalization, registered command bypass decisions, unknown-command rejection, file-path false positives, and active-session bypass integration.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_api_server_toolset.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream's API-server toolset contract is covered by Rust toolset and platform-toolset tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_approve_deny_commands.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream blocking command approvals are covered by Rust hermes-tools gateway approval queue contracts and hermes-gateway slash command tests for FIFO resolution, resolve-all behavior, timeout/no-listener fallback, /approve and /deny command resolution, and session-boundary denial; Python-only stale _pending_approvals cleanup has no Rust runtime equivalent.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_boundary_hooks.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream gateway session-boundary lifecycle intent is covered by Rust hermes-gateway contracts for reset ordering, old logical session finalize hooks, new logical session reset hooks, hook error containment, shutdown finalization for active sessions, and idle-expiry finalization before session removal.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_caption_merge.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram caption exact-dedupe intent is covered by Rust TelegramAdapter::merge_caption tests for empty captions, whitespace-normalized exact duplicates, substring regressions, and multi-caption albums.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_reactions.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram reaction lifecycle intent is covered by Rust Telegram adapter setMessageReaction contracts, disabled-by-default no-op behavior, config/env reaction hydration, and gateway lifecycle tests requiring explicit Telegram reactions policy.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_reply_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram reply_to_mode behavior is covered by Rust Telegram reply-mode parsing, chunk-reference policy tests for off/first/all/invalid modes, CLI config hydration, and env/YAML boolean-off bridging.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_webhook_secret.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram webhook-secret guard is covered by Rust TelegramConfig webhook validation requiring webhook_secret/TELEGRAM_WEBHOOK_SECRET with GHSA remediation text while leaving polling mode unaffected.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_approval_buttons.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram approval-button behavior is covered by Rust Telegram inline approval request and callback handling, including approval:once/session/deny callback parsing, per-adapter approval ID state, answerCallbackQuery acknowledgement, and FIFO gateway approval resolution.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_conflict.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram polling-conflict and webhook cleanup intent is covered by Rust polling startup deleteWebhook, polling conflict detection/logging, and deterministic poll-with-backoff retry behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_documents.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram document and media routing intent is covered by Rust parse_update document metadata extraction, document-size/extension acceptance checks, sendDocument fallback for wav/flac, and caption truncation/thread fallback multipart send contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_format.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram formatting intent is covered by Rust MarkdownV2 escaping, code-block preservation tests, and send/edit message paths that escape outgoing MarkdownV2 text before Telegram API submission.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_group_gating.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram group gating intent is covered by Rust should_process_message/update tests for required mentions, mention entities, custom wake regexes, allowed/guest chats, ignored threads, allowed topics, reply-to-bot handling, and env/config access-policy hydration.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_network.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram network fallback intent is covered by Rust Telegram fallback IP parsing/deduplication and reqwest DNS override wiring for api.telegram.org while preserving proxy configuration.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_photo_interrupts.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram photo interrupt intent is covered by Rust parse_update photo extraction, group-gating support for observe_unmentioned_group_messages, media placeholder routing, and image URL send path with reply/thread fallback.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_text_batching.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram text batching intent is covered by Rust TelegramTextBatcher aggregation keyed by chat/user/thread and the CLI polling loop wiring that drains batched text before gateway routing.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_thread_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram thread fallback intent is covered by Rust sendMessage/edit/multipart retry contracts that drop message_thread_id and reply_to_message_id only after Telegram thread/reply-not-found errors while preserving keyboard and parse-mode payloads.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_telegram_topic_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Telegram topic-mode intent is covered by Rust TelegramTopicBindingStore enable/bind/list/remove/recover contracts, allowed-topic gating, and CLI/config hydration for allowed_topics and ignored_threads.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_allowed_mentions.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord allowed_mentions safe-default intent is covered by Rust hermes-gateway DiscordAllowedMentions payload construction and env-style parsing tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_bot_auth_bypass.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord bot-allowance auth bypass intent is covered by Rust Gateway route_message_from_sender tests for Discord bot senders, human allowlists, and non-Discord isolation, with DISCORD_ALLOW_BOTS env bridging into platform policy.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_bot_filter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream DISCORD_ALLOW_BOTS filtering semantics are covered by Rust DiscordBotMessagePolicy parsing and DiscordAdapter::should_accept_message tests for own messages, humans, all bots, mentioned bots, and default rejection.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_attachment_download.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord authenticated attachment download behavior is covered by Rust Discord attachment handling contracts for image, audio, and document attachments that prefer bot-session reads and fall back through SSRF-gated fetch paths.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_component_auth.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord component user-or-role authorization and fail-closed behavior is covered by Rust DiscordInteractionAuthPolicy component checks for empty allowlists, user matches, role-only matches, missing role data, and missing users.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_channel_controls.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord ignored_channels and no_thread_channels behavior is covered by Rust DiscordChannelControls tests for CSV/YAML parsing, DM bypass, thread-parent matching, auto-thread suppression, config env bridging, and config-to-env hydration precedence.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_channel_prompts.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord channel_prompts behavior is covered by Rust channel prompt resolution and ephemeral prompt composition tests for exact channel matches, parent fallback, blank-prompt suppression, retry preservation intent, and context/channel/global prompt ordering.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_channel_skills.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord channel_skill_bindings resolver intent is covered by Rust DiscordChannelSkillBinding parsing and DiscordAdapter::resolve_channel_skills tests for channel matches, parent matches, single-skill shorthand, no-match, and ordered deduplication.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_connect.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord connect and slash-sync lifecycle behavior is covered by Rust contracts for member-intent selection, reconnect client closure, slash sync opt-out policy, command diff planning, metadata/context recreation, mutation summaries, fingerprint skip state, and retry-after cooldown state.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_document_handling.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord document attachment behavior is covered by Rust document handling contracts for document classification, SSRF-gated fallback, small text/markdown/log content injection, PDF non-injection, and caption ordering.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_free_response.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord free-response and mention-gating behavior is covered by Rust DiscordChannelControls and discord_allows_message_without_mention tests for DM bypass, channel and wildcard free-response lists, forum/thread parents, participated threads, reply auto-thread suppression, and voice-linked text channels.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_imports.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream discord.py-missing import safety is covered by the Rust-only hermes-gateway Discord module compiling and testing behind the discord feature without any discord.py runtime dependency.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_media_metadata.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord media metadata signature intent is covered by Rust hermes-gateway DiscordSendMetadata routing tests plus metadata-aware send_voice, send_image_file, and send_image method contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_reply_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord reply_to_mode behavior is covered by Rust hermes-gateway reply-reference construction/retry tests, DiscordConfig defaults, CLI config hydration, Python-platform env bridging, and reply-text extraction contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_reactions.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord processing-reaction lifecycle is covered by Rust Gateway Discord reaction lifecycle tests, platform-specific Discord emoji mapping, reactions_enabled policy tests, and Discord REST reaction parser/adapter contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_model_picker.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord model picker control-clearing behavior is covered by Rust model picker transition tests that clear the view before switch dispatch and clear it again on final success edit.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_opus.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord Opus loading and decode-error behavior is covered by Rust Opus candidate tests that prefer find_library results, only use Homebrew fallbacks for macOS when lookup fails, and require decode errors to be loggable.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_race_polish.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord concurrent voice-join race behavior is covered by the Rust DiscordVoiceJoinTracker contract that permits one connect per guild, treats concurrent joins as existing-move waits, and reports already-connected after completion.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_roles_dm_scope.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord role allowlist scoping is covered by Rust DiscordInteractionAuthPolicy tests that reject cross-guild guild and DM role matches, require dm_role_auth_guild opt-in for DMs, allow same-guild role matches, and preserve user-ID allowlist behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_send.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord send retry and forum-post behavior is covered by Rust hermes-gateway reply-reference retry classifiers, chunk reference-mode payload tests, forum thread payload contracts, and DiscordAdapter forum send outcome handling.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_slash_auth.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord slash authorization is covered by Rust DiscordInteractionAuthPolicy and gateway access-policy tests for user/role/channel allowlists, ignored-channel precedence, wildcard channels, malformed context fail-closed behavior, owner-only visibility semantics, notification soft-failure handling, and /skill autocomplete/handler auth-before-lookup decisions.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_slash_commands.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord slash command behavior is covered by Rust contracts for native command auto-registration, plugin conflict skipping, optional args dispatch, flat /skill routing/autocomplete/auth, auto-thread naming, thread feedback, and command sync reconciliation.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_system_messages.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord system-message filtering is covered by Rust DiscordAdapter::should_accept_message tests accepting default/reply message types and rejecting thread rename, pin, join, and boost-style system message types.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_discord_thread_persistence.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Discord thread participation persistence is covered by Rust ThreadParticipationTracker tests for missing/corrupt state, duplicate no-op marks, ordered newest retention, capacity eviction, restart reload, and missing-parent save creation.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_credential_files.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream credential-file mount behavior is covered by Rust credential file contracts for path/name/string entries, missing reporting, path precedence, traversal rejection, absolute-path rejection, symlink escape rejection, filtered hidden skill components, and component-boundary symlink checks.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_file_operations.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream file operation safety behavior is covered by Rust file-tool contracts for pagination normalization, sensitive write-deny paths, hidden descendant search exclusion, hidden-root visible file search, and JSON search output modes.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_file_ops_cwd_tracking.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream live-cwd behavior is covered by Rust LocalBackend and file-tool path contracts that resolve relative file operations against TERMINAL_CWD or the live terminal cwd before process cwd.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_file_read_guards.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream read safety guards are covered by Rust contracts for device-path rejection before backend I/O, unbounded read size limits with offset/limit guidance, and internal read_file status text write rejection.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_file_tools.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream file tool facade behavior is covered by Rust handler contracts for read/write schemas, missing parameter errors, normalized read/search pagination, patch backend behavior, search output modes, and status-dominated write rejection.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_hidden_dir_filter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream hidden directory filtering is covered by Rust component-based hidden path contracts that catch .git, .github, and .hub on Unix and Windows-style paths without rejecting unrelated dotted skill names.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_resolve_path.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream path resolution behavior is covered by Rust resolve_tool_path and LocalBackend contracts for absolute paths, tilde expansion, relative TERMINAL_CWD joins, live cwd precedence, and lexical parent cleanup.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_search_hidden_dirs.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream hidden search exclusion is covered by Rust LocalSearchBackend contracts that skip .hub/.git-style hidden descendants while preserving visible files under a hidden root and visible skill content.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_symlink_prefix_confusion.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream symlink prefix-confusion regression is covered by Rust root-boundary contracts using Path strip_prefix semantics so sibling directories sharing a prefix escape while real subpaths and the root itself pass.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_write_deny.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream write-deny behavior is covered by Rust CredentialGuard contracts for /etc sensitive files, sudoers/systemd prefixes, SSH/AWS/GnuPG/Kube home prefixes, shell/package credential files, profile-aware HERMES_HOME/.env, and allowed project/config paths.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_managed_media_gateways.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream managed media gateway behavior is covered by Rust OpenAI-audio managed endpoint contracts for TTS and transcription plus FAL managed video-generation contracts; direct keys still override managed gateways where required.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_signal_media.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Signal media behavior is covered by Rust gateway SignalAdapter attachment upload, image-url download, text fallback, and platform registration contracts; the Python send_message_tool tests remain reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_transcription.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream transcription behavior is covered by Rust transcription handler contracts for audio extension mapping, credential/gateway endpoint resolution, missing-path errors, and model-specific response parsing.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_transcription_dotenv_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream transcription key fallback behavior is covered by Rust openai-audio credential resolution contracts that prefer VOICE_TOOLS_OPENAI_KEY before HERMES_OPENAI_API_KEY and legacy OPENAI_API_KEY.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_transcription_tools.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream STT provider semantics are covered by Rust transcription contracts for explicit OpenAI-audio routing, managed/direct credential order, extension MIME mapping, and whisper text versus GPT transcribe JSON response formats.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_tts_command_providers.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream command-provider TTS behavior is covered by Rust MultiTtsBackend contracts for provider lookup, reserved built-in names, command template quoting, timeout/output validation, output format, voice-compatible media tags, and max_text_length.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_tts_dotenv_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream TTS credential fallback behavior is covered by Rust openai-audio contracts that prefer VOICE_TOOLS_OPENAI_KEY, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY, with Nous-managed audio gateway support.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_tts_kittentts.py",
-      "classification": "intentional_divergence",
-      "rationale": "KittenTTS remains an intentional Python-provider divergence in Hermes Agent Ultra; Rust TTS contracts reject Python-only providers with migration guidance while retaining Rust-native OpenAI, ElevenLabs, MiniMax, Piper, and command-provider paths.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_tts_max_text_length.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream per-provider TTS length behavior is covered by Rust resolve_max_text_length contracts for OpenAI, xAI, MiniMax, ElevenLabs model-specific limits, Piper, command providers, overrides, and fallback limits.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_tts_piper.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Piper behavior is covered by Rust-native Piper contracts using the local piper binary and PIPER_MODEL/PIPER_* knobs, with model-required errors and zero-Python runtime enforcement.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_tts_speed.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream TTS speed behavior is covered by Rust contracts for provider/global speed precedence, OpenAI speed clamping, command-provider speed placeholder rendering, and MiniMax raw-audio payload shape without legacy voice_setting.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_video_analyze.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream video analysis behavior is covered by Rust VideoAnalyzeHandler and VisionFrameSamplingVideoBackend contracts for schema/aliases, safe prompt defaults, max frame clamping, MIME detection, data-url encoding, unsupported formats, and frame-sampled vision synthesis.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_vision_native_fast_path.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream native-vision intent is covered by Rust ACP/provider multimodal contracts and OpenAI-compatible vision backend contracts for data URLs, image MIME detection, unsafe URL rejection, and auxiliary vision model selection.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_vision_tools.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream vision tool behavior is covered by Rust VisionAnalyzeHandler and OpenAiVisionBackend contracts for schemas, question forwarding, AUXILIARY_VISION_MODEL precedence, local image base64 data URLs, MIME detection, and URL safety.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_voice_cli_integration.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream CLI voice integration is covered by Rust voice_mode toggle, TTS streaming pipeline, markdown/think scrubbing, CLI /voice status, and tool-preview contracts; Python microphone-loop tests remain reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_voice_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream voice-mode behavior is covered by Rust voice_mode state contracts plus gateway voice manager STT/TTS join/leave/VAD contracts; local Python audio-stack detection is intentionally not part of the Rust runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "website/docs",
-      "classification": "policy_only",
-      "rationale": "Documentation-site content differs by project positioning and release policy; runtime behavior is unaffected.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools",
-      "classification": "functional",
-      "rationale": "Tool tests cover command, policy, and backend semantics that affect runtime parity.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli",
-      "classification": "functional",
-      "rationale": "CLI tests define user-facing command and setup behavior and must stay parity-reviewed.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_atomic_json_write.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream crash-safe JSON write intent is covered by Rust hermes-config atomic_json_write/atomic_json_write_pretty helpers using sibling temp files, fsync-before-rename, cleanup on failure, parent directory creation, and roundtrip/no-temp-file tests.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/hermes_cli/test_atomic_yaml_write.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream crash-safe YAML write intent is covered by Rust hermes-config atomic_yaml_write and save_config_yaml using sibling temp files, fsync-before-rename, cleanup on failure, parent directory creation, optional trailing content, and focused YAML write tests.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/hermes_cli/test_config_env_expansion.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream config ${ENV_VAR} expansion is covered by Rust load_from_yaml/load_config recursive value-only expansion for strings, nested mappings, lists, multiple placeholders, and unresolved placeholders while load_user_config_file preserves templates for edit paths.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/hermes_cli/test_env_loader.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream dotenv loader precedence and sanitization intent is covered by Rust load_dotenv/load_dotenv_file tests for user-env precedence, project fallback, sanitized concatenated assignments before loading, and atomic sanitized-file rewrite.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/hermes_cli/test_set_config_value.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream set_config_value routing intent is covered by Rust set_user_config_value and CLI e2e tests for secret-like keys to .env, uppercase normalization, env-bridged terminal keys, raw YAML config writes, falsy scalar handling, llm.* canonicalization to llm_providers, and list-index updates that preserve sibling entries.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/hermes_cli/test_bedrock_model_picker.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Bedrock model-picker intent is covered by Rust provider canonicalization, region-aware curated fallback, best-effort signed live Bedrock catalog discovery, AWS credential-signal gating, and setup/model catalog tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_api_key_providers.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream API-key provider registry behavior is covered by Rust provider canonicalization, CLI setup metadata, config env hydration, ACP auth discovery, and runtime provider tests for Copilot, Z.AI/GLM, Hugging Face, AI Gateway, MiniMax CN, GMI, and local backend aliases.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_arcee_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Arcee provider alias, ARCEEAI_API_KEY/ARCEE_API_KEY, base URL, model catalog, URL inference, config hydration, ACP auth, and runtime resolution intent is covered by Rust provider, CLI, config, ACP, intelligence, AgentLoop, and HTTP gateway tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_gemini_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Gemini provider alias and GOOGLE_API_KEY/GEMINI_API_KEY compatibility intent is covered by Rust provider canonicalization, CLI env/base-url resolution, config hydration, AgentLoop runtime defaults, and HTTP gateway alias tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_gmi_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream GMI provider aliases, GMI_API_KEY/GMI_BASE_URL handling, curated/live model catalog, auxiliary default, config hydration, ACP auth, and runtime/base URL resolution are covered by Rust CLI, config, ACP, auxiliary, AgentLoop, intelligence, and HTTP gateway tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_tencent_tokenhub_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Tencent TokenHub canonical provider, aliases, TOKENHUB_API_KEY/TOKENHUB_BASE_URL, hy3-preview catalog/default/context metadata, URL inference, config hydration, ACP auth, auxiliary default, and runtime/base URL resolution are covered by Rust provider, CLI, config, ACP, auxiliary, AgentLoop, intelligence, and HTTP gateway tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_xiaomi_provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Xiaomi/MiMo aliases, XIAOMI_API_KEY/XIAOMI_BASE_URL handling, model catalog, URL inference, config hydration, ACP auth, and runtime/base URL resolution are covered by Rust provider, CLI, config, ACP, intelligence, AgentLoop, and HTTP gateway tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "ui-tui",
-      "classification": "functional",
-      "rationale": "TUI package and documentation deltas can affect distributed interactive UX behavior and must be reviewed against Hermes Ultra's Rust-primary UX surface.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "ui-tui/src",
-      "classification": "functional",
-      "rationale": "TUI source differences affect interactive UX/runtime surfaces.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent",
-      "classification": "functional",
-      "rationale": "Agent tests cover model routing, provider, memory, and loop semantics.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_bedrock_1m_context.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Bedrock 1M-context beta intent is covered by Rust Bedrock Converse request/header contracts and existing Anthropic/MiniMax beta filtering tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_bedrock_integration.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Bedrock registry, alias, runtime-provider, auth-marker, base-URL, context, model-id normalization, and error-classification intent is covered by Rust hermes-cli provider/model tests, hermes-agent Bedrock provider contracts, and hermes-intelligence metadata/normalization tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/transports/test_bedrock_transport.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Bedrock transport build-kwargs, tool conversion, response validation, finish-reason mapping, reasoningContent preservation, toolUse normalization, usage mapping, and SigV4 request contract are covered by Rust hermes-agent Bedrock provider tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_anthropic_adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Anthropic adapter endpoint, auth, beta-header, OAuth-token, 4.8 sampling, and fast-mode intent is covered by Rust hermes-intelligence adapter contracts and hermes-agent provider request construction tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_anthropic_keychain.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Claude Code macOS Keychain discovery, malformed-entry rejection, JSON fallback, and Keychain-priority intent is covered by Rust hermes-cli auth discovery and parser tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_auxiliary_config_bridge.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream auxiliary config/default-shape and config-to-AUXILIARY_* bridge intent is covered by Rust hermes-config auxiliary task override parsing, default task metadata, and bridge contract tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_auxiliary_main_first.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream auxiliary main-provider-first auto-routing intent is covered by Rust hermes-agent auxiliary main runtime wiring and hermes-intelligence auxiliary chain contracts for fallback, explicit provider/model override, and vision-capability filtering; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_auxiliary_named_custom_providers.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream named custom provider and custom:<name> main-provider alias intent is covered by Rust hermes-config Python-YAML compatibility normalization plus hermes-cli provider/model and runtime-provider contract tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_auxiliary_client.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream auxiliary client routing, OAuth token selection, fallback, payment/rate-limit classification, Kimi temperature omission, Anthropic-compatible image conversion, and credential-refresh retry intent is covered by Rust hermes-intelligence auxiliary client contracts plus hermes-agent auxiliary_builder/provider auth-routing tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_codex_cloudflare_headers.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Codex Cloudflare mitigation header intent is covered by Rust hermes-agent Codex header extraction/build-request tests plus shared openai-codex provider wiring used by primary and auxiliary runtime construction; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_compressor_image_tokens.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream image-aware compression-budget intent is covered by Rust hermes-intelligence context_engine contracts that charge fixed image-block budgets for OpenAI, Responses, and Anthropic image shapes without counting base64 payload bytes; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_context_compressor.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream context compressor thresholding, summary fallback, cooldown, tool-pair sanitization, handoff-prefix, and collision-avoidance intent is covered by Rust hermes-agent ContextCompressor state-machine tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_context_compressor_summary_continuity.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream iterative context-summary continuity intent is covered by Rust hermes-agent ContextCompressor tests for same-process previous-summary reuse, resume handoff rehydration, protected-head handoffs, and exclusion of existing handoff messages from the new-turn summary block; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_context_engine.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream context-engine ABC/default behavior is represented in Rust by hermes-intelligence ContextEngine trait implementations plus Default and Importance engine compression contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_credential_pool.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream credential-pool selection, rate-limit clearing, round-robin, single-key, and pool-fallback intent is covered by Rust hermes-agent CredentialPool and agent-loop fallback tests; persistent Python OAuth pool migration tests remain reference-only for Rust auth-store contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_deepseek_anthropic_thinking.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream DeepSeek Anthropic-compatible thinking replay intent is covered by Rust hermes-agent AnthropicProvider message conversion tests that preserve Kimi/DeepSeek-style reasoning content only for compatible endpoints while stripping stale thinking for non-compatible endpoints; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_display.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream display formatting, tool preview, terminal preview length, and edit-diff rendering intent is covered by Rust hermes-intelligence display contracts and hermes-cli tool_preview/rendering tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_error_classifier.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream failover-reason, status/body extraction, billing/rate-limit/auth/context/format classification, provider metadata, wrapped OpenRouter errors, SSL, and adversarial shape intent is covered by Rust hermes-intelligence ErrorClassifier property/unit tests and hermes-cli provider-error guards; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_gemini_fast_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream CloudCode/Gemini CLI rate-limit fallback intent is covered by Rust hermes-agent retry tests for google-gemini-cli, cloudcode-pa:// base URLs, non-CloudCode multi-key pool retries, and single-key fallback; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_gemini_cloudcode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Gemini CloudCode OAuth, packed refresh, project resolution, provider registration, request/response translation, and auth-status intent is covered by Rust hermes-cli google-gemini-cli auth/runtime-provider tests plus hermes-agent provider request-shape and fallback contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_image_routing.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream image-routing mode, native multimodal content, MIME sniffing, path hints, and large-image non-resize intent is covered by Rust ACP multimodal preservation, Anthropic/OpenAI image block conversion, fixed image-token accounting, and CLI image hint contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_model_metadata.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream model-metadata token estimation, image-token bounding, default context table, 256K probe tiers, provider-prefix stripping, error-limit parsing, and model context fallback intent is covered by Rust hermes-intelligence model_metadata contracts including Unicode-aware token counting and bounded image-content estimates; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_models_dev.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream models.dev provider mapping, disk/in-memory cache, context extraction, provider-aware lookup, and capability parsing intent is covered by Rust hermes-intelligence models_dev mapping/cache/parse/client tests and CLI provider registry contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_moonshot_schema.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Moonshot/Kimi tool-schema sanitizer intent is covered by Rust hermes-agent provider contracts that detect Kimi/Moonshot models, fill missing property types, collapse nullable anyOf branches, preserve $ref nodes, strip invalid scalar enum values, and sanitize OpenAI-format tools before request construction; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_prompt_builder.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream prompt-builder context-file, injection scan, skill prompt, subscription prompt, and truncation intent is covered by Rust hermes-agent context/context_files/skill_orchestrator tests and CLI prompt assembly contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_prompt_caching.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Anthropic cache-control breakpoint intent is covered by Rust hermes-agent provider message conversion and cache_control request-shape tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_rate_limit_tracker.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream rate-limit header parsing, waiting, compact display, and provider-integration intent is covered by Rust hermes-agent RateLimitTracker and provider/API-bridge rate-limit tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_redact.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_skill_commands.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill-command discovery, platform filtering, command-key resolution, invocation rendering, setup guidance, file hints, and template substitution intent is covered by Rust hermes-agent SkillOrchestrator and hermes-tools skill command tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_skill_utils.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill metadata and platform-matching intent is covered by Rust hermes-tools skill_utils contracts for frontmatter parsing, disabled skill names, platform scopes, config extraction, and Termux-compatible matching; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_streaming_context_scrubber.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream memory-context streaming leak prevention is covered by Rust hermes-agent StreamingContextScrubber contracts and run_stream UI-delta scrubbing; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_subagent_progress.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream sub-agent progress relay intent is covered by Rust hermes-agent sub-agent lineage/orchestration tests and hermes-cli TUI progress/phase-stream contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_subdirectory_hints.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream subdirectory hint discovery, workspace-boundary rejection, command path extraction, duplicate suppression, and truncation intent is covered by Rust hermes-agent subdirectory_hints tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_tool_guardrails.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream repeated tool failure/no-progress guardrail intent is covered by Rust hermes-agent tool-loop guard tests for exact repeated failures, varied args, idempotent outputs, success reset, and hard-stop toggles; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_title_generator.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream title-generation sanitization, truncation, provider-error, and prompt-budget intent is covered by Rust hermes-intelligence TitleGenerator tests; Python thread/session DB worker tests remain reference-only because Hermes Ultra owns session title orchestration in Rust CLI/session code.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_unsupported_temperature_retry.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream's unsupported-temperature and OpenAI-compatible max-token omission regression intent is covered by Rust auxiliary-client tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/agent/test_usage_pricing.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream usage-pricing normalization, subscription billing, cache-rate safety, and DeepSeek v4 Pro pricing intent is covered by Rust hermes-intelligence usage_pricing tests; dynamic Python metadata monkeypatch tests remain reference-only for Hermes Ultra's Rust pricing snapshot path.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent",
-      "classification": "functional",
-      "rationale": "Run-agent tests cover orchestration and provider execution semantics.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_compression_trigger_excludes_reasoning.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream compression-trigger prompt-token-only intent is covered by Rust hermes-agent ContextCompressor threshold tests: usage updates track prompt tokens only, completion/reasoning tokens are not accepted by the trigger path, and explicit prompt-token values gate compression; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "ui-tui/packages",
-      "classification": "functional",
-      "rationale": "TUI package differences affect distributed interactive UI behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cli",
-      "classification": "functional",
-      "rationale": "CLI test deltas cover command contracts and user-visible runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cli/test_session_boundary_hooks.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream CLI session-boundary hook intent is covered by Rust hermes-agent HookType registration and panic containment plus Rust hermes-cli App tests that invoke on_session_finalize and on_session_reset for /new-style session rotation and same-session reset.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cli/test_quick_commands.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream quick-command behavior is covered by Rust shared quick_commands config, CLI slash dispatch that runs exec commands before built-ins, alias forwarding, no-output and timeout replies, plus gateway quick-command exec/alias handling from runtime config.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/tui_gateway",
-      "classification": "functional",
-      "rationale": "TUI gateway tests cover interactive gateway behavior and must stay parity-reviewed against Rust-native UX/runtime contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/integration",
-      "classification": "functional",
-      "rationale": "Integration tests cover cross-component runtime behavior and must stay parity-reviewed before clearance.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/e2e",
-      "classification": "functional",
-      "rationale": "End-to-end tests cover user-visible runtime workflows and must stay parity-reviewed before clearance.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "skills/autonomous-ai-agents",
-      "classification": "intentional_divergence",
-      "rationale": "Autonomous-agent skill catalog content is curated locally while runtime behavior is governed by Hermes Ultra's native skill loader and execution contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "skills/creative",
-      "classification": "intentional_divergence",
-      "rationale": "Skill catalog content is curated locally while Rust runtime parity is tracked through native skill loader contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/disk-cleanup",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra supersedes the upstream Python disk-cleanup plugin with Rust-native cleanup in crates/hermes-tools/src/tools/disk_cleanup.rs, including safe path scope, cron/output-only cleanup categorization, tracked.json persistence, quick/dry-run/status handling, registry post-tool auto-tracking, TUI session-end quick cleanup, and the /disk-cleanup command.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/disk-cleanup/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local disk-cleanup delta is a behavior-equivalent tuple membership form covered by focused plugin contracts; no upstream runtime feature is missing.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/hermes-achievements",
-      "classification": "functional",
-      "rationale": "Achievements plugin dashboard differences affect bundled plugin UX and packaging behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/hermes-achievements/dashboard/dist/index.js",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra keeps the bundled achievements dashboard on its local static-English bearer-token bundle because this Rust-first tree does not vendor upstream's dashboard i18n/auth Python source stack; focused contracts cover the retained host-SDK and auth assumptions.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/video_gen",
-      "classification": "functional",
-      "rationale": "Video generation plugin differences affect media tool routing and provider packaging behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/video_gen/xai/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local xAI video generation wording intentionally refers to the SuperGrok subscription credential path while preserving shared xAI credential resolution behavior.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory",
-      "classification": "functional",
-      "rationale": "Memory plugin differences affect recall/provider integration behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/memory/honcho/README.md",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra documents the Rust-native `hermes memory setup honcho` path and dot-separated profile host keys used by crates/hermes-agent/src/memory_plugins/honcho.rs; legacy Python `hermes honcho ...` command dispatch remains disabled.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/byterover/__init__.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for action and role guards; no ByteRover runtime behavior is missing.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/hindsight/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra keeps stdlib asyncio/getpass fallbacks so Hindsight remains importable in the Rust-first tree without upstream-only agent.async_utils or hermes_cli.secret_prompt source modules.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/honcho/__init__.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for cron/flush and recall-mode guards.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/honcho/cli.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra keeps stdlib getpass for secret prompts so the Honcho CLI remains usable in the Rust-first tree without the upstream-only hermes_cli.secret_prompt source module; other diffs are behavior-equivalent membership guards.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/honcho/client.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra resolves the default Honcho config path with Path.home() instead of importing upstream-only hermes_cli.profiles._get_default_hermes_home, preserving profile fallback behavior in the Rust-first tree.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/honcho/session.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra supersedes the upstream Python Honcho gateway identity resolver with the Rust Honcho memory provider resolver in crates/hermes-agent/src/memory_plugins/honcho.rs, including pinUserPeer, userPeerAliases, runtimePeerPrefix, and hash-escalated collision handling.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/memory/mem0/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "The remaining Python Mem0 diff is legacy save_config write mechanics; Ultra implements Rust-native owner-only atomic config writes, merge semantics, and config-file activation in crates/hermes-agent/src/memory_plugins/mem0.rs.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/memory/supermemory/__init__.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for boolean parsing, context guards, and session-role filtering.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/model-providers",
-      "classification": "functional",
-      "rationale": "Model-provider plugin differences affect runtime provider compatibility.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/model-providers/azure-foundry/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Azure Foundry provider profile intentionally uses Azure AI Foundry naming while preserving the upstream OpenAI-compatible endpoint contract.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/model-providers/opencode-zen/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "OpenCode Zen and Go provider behavior is covered by Rust provider normalization, env-key resolution, default base URLs, model catalog merge, and GenericProvider OpenCode Go reasoning controls; this legacy upstream Python provider profile is reference-only and is not used by the Rust-only runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/model-providers/azure-foundry/plugin.yaml",
-      "classification": "intentional_divergence",
-      "rationale": "Local Azure Foundry manifest intentionally uses Azure AI Foundry naming while preserving provider registration metadata.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/model-providers/kimi-coding/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Kimi provider delta is a behavior-equivalent tuple membership guard covered by focused model-provider contracts.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/model-providers/nous/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Nous provider keeps a static Hermes product tag because the upstream agent.portal_tags helper is not present in this Rust checkout; focused contracts cover the emitted tag.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "skills/productivity",
-      "classification": "intentional_divergence",
-      "rationale": "Skill catalog content is curated locally while loader and execution contracts carry runtime parity.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp",
-      "classification": "functional",
-      "rationale": "ACP tests cover protocol compatibility and session behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_approval_isolation.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP approval-isolation regressions are covered by Rust ACP permission-store and server-instance tests: pending and resolved approvals are scoped to explicit PermissionStore instances, overlapping sessions resolve independently, and no Python module-global callback/runtime path exists.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_auth.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP auth helper behavior is covered by Rust ACP auth-method and initialize/authenticate tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_entry.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP entry startup intent is covered by Rust CLI ACP actions and flags: check/version avoid server startup, setup routes through Rust model configuration, and setup-browser validates node/browser dependencies with interactive and --yes paths.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_events.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP event callback intent is covered by Rust ACP event emission tests: prompt executor events are enqueued, test transports flush session/update notifications, and CLI ACP output derives paired tool start/complete events from Rust AgentResult messages.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_mcp_e2e.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP MCP E2E tool-event expectations are covered by Rust ACP prompt/session-update tests and CLI AgentResult-to-ACP tool event extraction; Python MCP mocking mechanics are reference-only for the Rust runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_permissions.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP permission option and outcome-mapping contracts are covered by Rust ACP permission tests; Python async scheduler mechanics are reference-only for the Rust runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_server.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP server lifecycle intent is covered by Rust ACP JSON-RPC server and handler tests: initialize/authenticate, camelCase wire aliases, session create/load/resume/fork/list/cancel, list filtering and pagination, prompt content aliases, refusal handling for missing sessions, usage serialization, slash commands, and MCP/server event flushing.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/acp/test_tools.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP tool metadata and rendering intent is covered by Rust ACP tool helpers and event metadata: common tool kind mapping, stable tc-* call IDs, human-readable titles, structured failure status detection, and tool_kind/title/status fields on emitted ACP tool events.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/google_meet",
-      "classification": "functional",
-      "rationale": "Google Meet plugin differences affect connector/plugin runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/google_meet/__init__.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is realtime-capable documentation wording plus behavior-equivalent tuple membership for the supported-platform gate.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/cli.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra uses the plugin-local Hermes home helper so the Google Meet CLI remains importable in the Rust-first tree without vendoring upstream hermes_constants; other shared diffs are behavior-equivalent tuple membership.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/meet_bot.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for headed-mode parsing and bot-speaker filtering.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/node/cli.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for node status and ping command dispatch.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/node/registry.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra uses the plugin-local Hermes home helper so node registry storage remains importable in the Rust-first tree without vendoring upstream hermes_constants.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/node/server.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra keeps plugin-local Hermes home resolution plus remote realtime-mode passthrough and stricter meet_say validation for node-hosted meetings.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/process_manager.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra uses the plugin-local Hermes home helper so local meeting state remains importable in the Rust-first tree without vendoring upstream hermes_constants.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/realtime/openai_client.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for terminal OpenAI Realtime response frame handling.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/google_meet/tools.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership for local platform and mode validation; tool behavior remains covered by Google Meet plugin tests.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/image_gen",
-      "classification": "functional",
-      "rationale": "Image generation plugin differences affect media tool routing, packaging, and runtime connector behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/platforms",
-      "classification": "functional",
-      "rationale": "Platform plugin differences affect adapter surface parity.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/web",
-      "classification": "functional",
-      "rationale": "Web-search plugin differences affect provider routing, credential handling, and tool result behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/web/firecrawl/provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Rust-native Firecrawl search/extract backends now cover direct, self-hosted, and Nous-managed routing; the Python plugin remains reference/compatibility code in the Rust-only runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/web/tavily/__init__.py",
-      "classification": "intentional_divergence",
-      "rationale": "Tavily search, extract, and crawl are covered by Rust-native web backends and the built-in web_crawl tool; this legacy upstream Python package is reference-only and is not used by the Rust-only runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/web/tavily/provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Tavily search, extract, and crawl are covered by Rust-native web backends, including /crawl Bearer auth plus body api_key and standard document/error normalization; this legacy upstream Python provider is reference-only and is not used by the Rust-only runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/web/xai/provider.py",
-      "classification": "intentional_divergence",
-      "rationale": "Rust-native xAI web search now routes through the Responses API server-side web_search tool with deterministic result normalization; the Python plugin remains reference/compatibility code.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/platforms/discord/adapter.py",
-      "classification": "policy_only",
-      "rationale": "The remaining shared diff is whitespace-only and does not change Discord adapter behavior; runtime message filtering remains covered by Discord gateway tests.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/google_chat/adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra retains a Rust-first loop bridge that avoids the absent agent.async_utils module and rejects unsupported standalone attachments explicitly while preserving upstream proxy-env support.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/google_chat/oauth.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra implements the upstream private-token write contract locally with os.replace because the upstream utils.py helper is absent from the Rust-first tree.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/irc/adapter.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is behavior-equivalent tuple membership in IRC boolean and numeric-code guards; standalone send behavior remains covered by IRC adapter tests.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/line/adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra retains stdlib getpass and the local create_source bridge for the Rust-first source tree while porting upstream proxy-env support for LINE HTTP calls.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/ntfy/adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra supersedes the upstream Python ntfy adapter with the Rust-native gateway adapter in crates/hermes-gateway/src/platforms/ntfy.rs, including X-Tags echo-loop prevention, auth/header handling, inbound event filtering, env enablement, and cron delivery target parsing.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/ntfy/plugin.yaml",
-      "classification": "policy_only",
-      "rationale": "The shared diff is ASCII punctuation in plugin metadata descriptions and does not change plugin loading or runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/simplex/adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra uses stdlib getpass in setup because hermes_cli.secret_prompt.py is absent from the Rust-first source tree.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/platforms/teams/adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra keeps explicit standalone attachment rejection and tuple membership contracts while porting upstream proxy-env support and resilient Teams port coercion.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "tests/plugins",
-      "classification": "functional",
-      "rationale": "Plugin tests cover loader, hook, and runtime integration behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/teams_pipeline",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra uses the Rust-native Teams pipeline runtime and CLI in crates/hermes-tools/src/teams_pipeline.rs and crates/hermes-cli/src/teams_pipeline_cli.rs; the Python plugin package is retained as upstream reference material only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/teams_pipeline/cli.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Teams CLI delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/teams_pipeline/meetings.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Teams meeting error handling delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/teams_pipeline/models.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Teams artifact model delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/teams_pipeline/runtime.py",
-      "classification": "intentional_divergence",
-      "rationale": "Local Teams runtime config delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "tests/cron",
-      "classification": "functional",
-      "rationale": "Cron tests cover scheduling/runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_codex_execution_paths.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cron/Codex execution-path intent is covered by Rust cron runner isolation plus Rust provider/auth refresh contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_cron_context_from.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream context_from create/update/prompt-injection intent is covered by Rust CronJob context_from persistence, scheduler prefix assembly, invalid-ref filtering, and truncation tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_cron_inactivity_timeout.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cron inactivity-timeout intent is covered by Rust cron script timeout controls and scheduler execution/error delivery contracts; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_cron_no_agent.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream no_agent script-only intent is covered by Rust CronJob validation, cronjob tool plumbing, runner short-circuit execution, wakeAgent silence gating, bash/Python path execution, and traversal blocking tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_cron_prompt_injection_skill.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream assembled cron skill prompt scanning intent is covered by Rust cron skill loading, SkillGuard checks, invisible-Unicode blocking, and prompt-injection regression tests before agent execution; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_cron_script.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cron script field, script output injection, relative Hermes scripts path resolution, absolute/tilde/traversal/symlink containment, and env cleanup intent is covered by Rust CronJob storage, runner script execution, and script-path guard tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_cron_workdir.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream per-job workdir normalization, create/update roundtrip, TERMINAL_CWD scoping, and workspace-context opt-in intent is covered by Rust CronJob workdir normalization, scheduler persistence tests, CLI/tool plumbing, and runner environment/current_dir handling; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_file_permissions.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cron file-permission hardening intent is covered by Rust FileJobPersistence 0700 directory and 0600 job-file tests on Unix; broader config permission contracts live in Rust auth/config code.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_jobs.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cron job CRUD, validation, persistence, status, repeat, no_agent, script, context_from, and workdir intent is covered by Rust CronJob, FileJobPersistence, SqliteJobPersistence, ScheduledCronjobBackend, and CronScheduler tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_scheduler.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream scheduler tick/run/delivery/history intent is covered by Rust CronScheduler create/update/run/manual-trigger, context prefix, completion broadcast, delivery suppression, and runner contract tests; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/cron/test_scheduler_mcp_init.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream no_agent scheduler MCP-skip intent is covered by Rust CronRunner no_agent short-circuiting before AgentLoop construction and tool filtering tests that exclude recursive cron scheduling; the Python test file remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_schema_sanitizer.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream tool schema sanitizer intent is covered by Rust hermes-core schema sanitizer contracts for OpenAI and Responses tool formats, object/default-property repair, nullable type collapse, required pruning, nested anyOf/items/additionalProperties, reactive pattern/format stripping, slash-enum stripping, and provider formatting integration.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_local_env_blocklist.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream LocalEnvironment subprocess env-scrubbing intent is covered by Rust hermes-environments contracts for Hermes-managed provider, tool, gateway, GitHub, Modal, Daytona, and Bedrock bearer-token stripping; explicit _HERMES_FORCE_ reinjection; general AWS credential-chain passthrough; and Homebrew PATH fallback preservation.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_local_background_child_hang.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream local background-child pipe-hang intent is covered by Rust LocalBackend foreground collector contracts for shell-background child prompt return, high-volume output, timeout behavior, multibyte and invalid UTF-8 preservation, and process-group timeout cleanup.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_terminal_compound_background.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream compound-background rewrite intent is covered by Rust LocalBackend rewrite_compound_background contracts for &&/|| chains, redirects, quoting, idempotence, newlines, pipes, and simple-background passthrough.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_terminal_foreground_timeout_cap.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream foreground timeout cap and background-wrapper/server guard intent is covered by Rust TerminalHandler contracts for explicit >600s foreground rejection, background exemption, schema hint, nohup/& wrapper rejection, long-lived server detection, and help passthrough.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_local_interrupt_cleanup.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream local interrupt-cleanup intent is covered by Rust LocalBackend foreground child ownership: foreground process groups are killed on timeout and when the command future is aborted, with regression coverage proving marker child processes are gone after cancellation.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_local_shell_init.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream local shell init intent is covered by Rust LocalBackend config-driven shell startup sourcing: explicit shell_init_files, auto_source_bashrc disablement, HOME/env expansion, bash/zsh/profile ordering, and an execution test that sources an explicit init file before the command.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_terminal_config_env_sync.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream terminal config/env drift intent is covered by Rust hermes-config central bridge mapping, config-set env sync, YAML-to-env load bridging without overriding existing env, Docker resource/env/volume consumption, and backend manager plumbing for terminal runtime keys.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_terminal_requirements.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream terminal requirements intent is covered by Rust terminal_requirements gates for local, docker, singularity/apptainer, ssh host/user, modal direct/managed selection, daytona API-key presence, and unknown backend rejection; local Vercel Sandbox Python salvage is intentionally not exposed because no Rust terminal backend exists for it.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_terminal_task_cwd.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ACP task cwd intent is covered by Rust TerminalHandler task cwd registration: commands with task_id inherit registered cwd when workdir is omitted, and explicit workdir keeps precedence.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_terminal_tool_requirements.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream tool availability intent is covered by Rust ToolRegistry check_fn gating for terminal-backed tools: local and managed-modal backends expose terminal/process/file tools, invalid terminal backends hide terminal/process/read_file/write_file/process_registry, and Rust execute_code remains independently available as local non-Python execution.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_url_safety.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream URL safety/SSRF intent is covered by Rust hermes-tools url_safety contracts for http/https-only parsing, DNS fail-closed behavior, private/reserved IPv4 and IPv6 blocking including CGNAT, benchmark, multicast, and IPv4-mapped IPv6 ranges, metadata hostname/IP always-blocking, allow_private_urls toggle semantics, and the exact QQ multimedia benchmark-IP exception.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_hardline_blocklist.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream hardline command-blocklist intent is covered by Rust hermes-tools approval contracts for protected-path recursive deletes, block-device mkfs/dd/redirection, fork bombs, system shutdown/reboot/halt, hardline-before-yolo semantics, container backend bypass, recoverable-dangerous yolo bypass, and sudo stdin/askpass denial unless SUDO_PASSWORD is explicitly configured.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_command_guards.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream combined Tirith plus dangerous-command guard intent is covered by Rust hermes-tools approval contracts for container bypass, noninteractive external-scan skip, Tirith allow/warn/block handling, combined warning prompts, session and process approval persistence, scanner-unavailable allow behavior, and scanner programming-error propagation.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_approval.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream dangerous-command approval behavior is covered and superseded by Rust hermes-tools approval contracts for hardline denials, recoverable confirmations, session/permanent approvals, yolo and session-yolo gates, container backend bypass, multiline shell/disk/write patterns, sensitive env/config writes, SQL/delete/find/killall refinements, sudo stdin floors, unmanaged gateway-run service-manager protection, and gateway approval queues. Python LLM smart-approval and input-prompt mechanics are intentionally not ported into the Rust safety path.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_approval_plugin_hooks.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream pre_approval_request/post_approval_response plugin-hook intent is covered by Rust approval observer contracts: pre/post lifecycle events include surface, session key, command, pattern keys, description, permanent-allow flag, and resolved choice for CLI and gateway approval paths, while observer panics are contained and cannot alter approval decisions.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_cron_approval_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cron approval-mode behavior is covered by Rust approval contracts for cron default-deny semantics, approve/off/allow/yes aliases for recoverable commands, hardline denial preservation, and cron-origin precedence over gateway approval routing so scheduled jobs block or allow deterministically without hanging on gateway approval listeners.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_approval_heartbeat.py",
-      "classification": "intentional_divergence",
-      "rationale": "Current upstream heartbeat file contains setup helpers but no executable test methods; Hermes Ultra's Rust terminal approval path fail-closes without entering Python's blocking gateway approval wait, so the inactivity-heartbeat wait loop is not a Rust runtime surface.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_yolo_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream yolo approval-bypass intent is covered by Rust hermes-tools and hermes-gateway contracts for truthy and false-like HERMES_YOLO_MODE handling, recoverable-command bypass, hardline and sudo-stdin floors, session-scoped /yolo state, terminal handler session bypass, and session cleanup. Python's combined Tirith hook path is not a separate Rust runtime boundary.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_env_passthrough.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill required-environment metadata normalization is covered by Rust skill_utils required-env parsing while Ultra exposes env_passthrough as an explicit Rust tool instead of Python's implicit global registry.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_improvements.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill fuzzy-patch intent is covered by the Rust generic patch backend plus skill storage/path guards; Ultra does not vendor the Python-only skill_manager_tool helper.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_manager_tool.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill create/edit/delete validation intent is covered by Rust SkillManager, FileSkillStore, and skill_manage contracts for canonical names/categories, traversal rejection, duplicate creation rejection, managed content size limits, update/delete, and generic fuzzy file patching.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_provenance.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill write-origin ContextVar intent is covered by Rust write-origin provenance guards with foreground fallback, nested restoration, background-review detection, and thread-isolated scope tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_size_limits.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream managed skill content-size guard intent is covered by Rust SkillManager MAX_SKILL_CONTENT_CHARS tests while hand-placed skill files remain loadable through the store path.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_usage.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill usage sidecar, curator provenance filtering, protected bundled/hub exclusions, archiving, restore, pin/state, and agent-created reporting intent is covered by Rust SkillUsageRecord and usage module contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skill_view_traversal.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill_view traversal regression intent is covered by Rust SkillViewHandler tests for dot-dot traversal, legitimate in-skill file reads, symlink escape rejection, and secret non-leakage.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skills_guard.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skill security scanner intent is covered by Rust SkillGuard install policy, trust-level resolution, file and directory scanning, content hashing, symlink escape detection, invisible Unicode, prompt-injection, credential, eval, reverse-shell, and destructive command findings.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skills_hub.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skills hub trust, content hashing, and remote skill integrity intent is covered by Rust SkillsHubClient search/download/upload/update contracts, Ed25519 signature verification, trusted source resolution, and scan-before-use policy; Python source-adapter breadth remains reference-only.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skills_hub_clawhub.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream ClawHub listing/detail/search repair/version/file mapping intent is covered by Rust ClawHub registry metadata parsing, exact-slug repair, hyphenated query normalization, latest-version extraction, and inline/raw file reference contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skills_sync.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream bundled skill manifest sync/reset/optional provenance intent is covered by Rust sync contracts for v1/v2 manifests, stable hashes, category-preserving copy, collision non-poisoning, user-modified protection, reset/restore, and official optional lock backfill.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_skills_tool.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream skills_tool discovery/frontmatter/tag/platform/view intent is covered by Rust skill_utils frontmatter fallback, tag parsing, recursive safe discovery, required-env metadata parsing, platform matching, and SkillViewHandler/SkillsListHandler contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/providers",
-      "classification": "functional",
-      "rationale": "Provider tests cover model transport compatibility and error handling.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/kanban",
-      "classification": "functional",
-      "rationale": "Kanban plugin differences affect plugin runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/kanban/dashboard/dist/index.js",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra intentionally keeps the local kanban dashboard bundle as a legacy Python-dashboard shim while the Rust CLI owns kanban runtime behavior; upstream's expanded i18n, bulk drag/delete, and Python kanban_db API additions are not vendored into this Rust-first tree.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/kanban/dashboard/dist/style.css",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra intentionally preserves the local kanban dashboard layout and theme overrides instead of adopting upstream's newer multi-drag/trash CSS, because the corresponding Python dashboard interactions are not vendored in the Rust-first runtime.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/kanban/dashboard/plugin_api.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra retains the local kanban dashboard API shim against absent upstream hermes_cli Python sources; Rust kanban command behavior is tracked separately, so upstream's expanded Python dashboard endpoints are not copied wholesale.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/observability",
-      "classification": "functional",
-      "rationale": "Observability plugin differences affect telemetry/runtime diagnostics.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/observability/langfuse/README.md",
-      "classification": "intentional_divergence",
-      "rationale": "Local Langfuse README intentionally documents the Hermes tools credential flow while preserving the manual enable path.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/observability/langfuse/plugin.yaml",
-      "classification": "intentional_divergence",
-      "rationale": "Local Langfuse manifest intentionally advertises the Hermes tools enablement path in addition to manual plugin enablement.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "website",
-      "classification": "policy_only",
-      "rationale": "Website top-level package, sidebar, localization, and static API files support documentation publishing and are not Rust runtime behavior unless covered by more specific functional classifications.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "website/scripts",
-      "classification": "policy_only",
-      "rationale": "Website build/generation scripts differ for local documentation publishing and do not affect Hermes runtime.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/example-dashboard",
-      "classification": "functional",
-      "rationale": "Example dashboard plugin differences affect plugin packaging and UI integration samples.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "plugins/example-dashboard/dashboard/manifest.json",
-      "classification": "intentional_divergence",
-      "rationale": "Local example dashboard intentionally advertises the sessions:top slot so the bundled SDK demo exercises page-scoped slot injection; contract tests verify the manifest and dist bundle stay aligned.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "plugins/example-dashboard/dashboard/plugin_api.py",
-      "classification": "policy_only",
-      "rationale": "The shared diff is module docstring wording only; the /hello route behavior remains unchanged and is covered by the example dashboard contract test.",
-      "owner": "sheawinkler",
-      "ticket": 304
-    },
-    {
-      "path": "skills/devops",
-      "classification": "intentional_divergence",
-      "rationale": "Skill catalog content is curated locally while runtime skill contracts remain tracked separately.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "skills/research",
-      "classification": "intentional_divergence",
-      "rationale": "Skill catalog content is curated locally while runtime skill contracts remain tracked separately.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/honcho_plugin",
-      "classification": "functional",
-      "rationale": "Honcho plugin tests cover memory/plugin behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/skills",
-      "classification": "functional",
-      "rationale": "Skill tests cover loader, guard, and execution semantics.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/stress",
-      "classification": "functional",
-      "rationale": "Stress tests cover runtime reliability envelopes.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "website/src",
-      "classification": "policy_only",
-      "rationale": "Website source differs for documentation/product presentation and does not change Rust runtime behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
       "path": ".gitattributes",
-      "classification": "policy_only",
       "rationale": "Repository metadata affects text normalization and generated artifact handling, not runtime behavior.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": ".github/workflows/uv-lockfile-check.yml",
-      "classification": "intentional_divergence",
-      "rationale": "The upstream Python uv lock check is retained but adapted to skip cleanly when this Rust-first repo has no root pyproject.toml or uv.lock, while still failing partial uv project files.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": ".github/workflows",
+      "rationale": "CI workflow differences affect release and parity gate enforcement.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": ".github/workflows/uv-lockfile-check.yml",
+      "rationale": "The upstream Python uv lock check is retained but adapted to skip cleanly when this Rust-first repo has no root pyproject.toml or uv.lock, while still failing partial uv project files.",
       "ticket": 305
     },
     {
-      "path": ".github/workflows",
-      "classification": "functional",
-      "rationale": "CI workflow differences affect release and parity gate enforcement.",
+      "classification": "branding_only",
       "owner": "sheawinkler",
+      "path": ".gitignore",
+      "rationale": "Repository-local ignore patterns and generated artifacts do not affect runtime parity behavior.",
       "ticket": 25
     },
     {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "AGENTS.md",
+      "rationale": "Local operator guidance; not part of Hermes runtime behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "CONTRIBUTING.md",
+      "rationale": "Contributor process guidance and release policy; no runtime behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "Dockerfile",
+      "rationale": "Hermes Agent Ultra intentionally ships a Rust multi-stage container with tini/gosu and /data state instead of upstream's Python uv+s6-overlay image; Rust-native container contracts cover the retained runtime behavior.",
+      "ticket": 305
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "LICENSE",
+      "rationale": "Licensing and attribution metadata; no runtime effect.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "README.md",
+      "rationale": "README.md intentionally describes Ultra's Rust-first runtime, release installer, and parity workflow rather than upstream's Python product positioning; install/readme contracts cover the actionable setup guidance.",
+      "ticket": 305
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "docker-compose.yml",
+      "rationale": "Compose defaults intentionally target the Ultra Rust image, /data volume, and hermes-agent-ultra naming while preserving localhost dashboard and UID/GID runtime controls.",
+      "ticket": 305
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "docker/entrypoint.sh",
+      "rationale": "The entrypoint intentionally implements the Rust image's direct tini/gosu startup path instead of upstream's s6 stage2 hook; entrypoint contracts cover home setup, UID/GID remap, and privilege drop.",
+      "ticket": 305
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
       "path": "docs/security/network-egress-isolation.md",
-      "classification": "policy_only",
       "rationale": "The network-egress guide is deployment hardening documentation adapted to Hermes Agent Ultra Docker/OrbStack usage and does not change runtime behavior.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "flake.nix",
+      "rationale": "Nix packaging intentionally builds the Rust workspace with the Hermes Ultra release version rather than upstream's Python flake-parts packaging stack.",
+      "ticket": 305
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills",
+      "rationale": "Optional skill catalog content is curated locally; Hermes Ultra tracks runtime parity through native skill-loader contracts instead of vendoring every upstream Python skill implementation.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills/blockchain",
+      "rationale": "Upstream optional-skills blockchain tree is Python-skill-store content; Hermes Ultra keeps Rust-first runtime parity and supports external skill registries via native loader paths.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills/finance",
+      "rationale": "Upstream optional-skills finance content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills/health",
+      "rationale": "Upstream optional-skills health content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "optional-skills/migration",
-      "classification": "intentional_divergence",
       "rationale": "Optional migration skill content is curated locally for Hermes Agent Ultra migration workflows while runtime skill loading remains governed by native skill-loader contracts.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "plugins/browser",
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills/mlops",
+      "rationale": "Upstream optional-skills MLOps content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "optional-skills/research",
+      "rationale": "Upstream optional-skills research content is curated catalog material; Hermes Ultra tracks it through skill catalog governance while keeping runtime execution Rust-first.",
+      "ticket": 25
+    },
+    {
       "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "packaging/homebrew",
+      "rationale": "Distribution packaging path impacts install parity for Homebrew users.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "packaging/homebrew/hermes-agent.rb",
+      "rationale": "Homebrew packaging uses Hermes Ultra's checksummed Rust release artifacts instead of upstream's Python virtualenv formula.",
+      "ticket": 305
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/browser",
       "rationale": "Browser provider plugin differences can affect runtime cloud browser provider discovery, auth routing, and session lifecycle behavior; each provider path must be ported or covered by Rust-native browser backend contracts before clearing.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "plugins/browser/browserbase/provider.py",
       "classification": "intentional_divergence",
-      "rationale": "Browserbase runtime behavior is now covered by the Rust-native browser backend, including direct env config, seconds timeout, keepAlive/proxies/advanced-stealth feature knobs, 402 fallbacks, and session release; the Python plugin remains reference-only compatibility material.",
       "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
       "path": "plugins/browser/browser_use/provider.py",
-      "classification": "intentional_divergence",
       "rationale": "Browser Use runtime behavior is now covered by the Rust-native browser backend, including browser-use provider selection, direct BROWSER_USE_API_KEY auth, managed Nous gateway fallback/preference, managed timeout/proxy payload, idempotency-key retry preservation, external-call-id capture, and stop-session PATCH; the Python plugin remains reference-only compatibility material.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "plugins/video_gen/fal/__init__.py",
       "classification": "intentional_divergence",
-      "rationale": "FAL video generation behavior is now covered by the Rust-native video_generate tool and FalVideoGenBackend, including family routing, family-specific payload filtering, direct queue.fal.run polling, and Nous-managed fal-queue routing; the Python plugin remains reference-only compatibility material.",
       "owner": "sheawinkler",
+      "path": "plugins/browser/browserbase/provider.py",
+      "rationale": "Browserbase runtime behavior is now covered by the Rust-native browser backend, including direct env config, seconds timeout, keepAlive/proxies/advanced-stealth feature knobs, 402 fallbacks, and session release; the Python plugin remains reference-only compatibility material.",
       "ticket": 25
     },
     {
-      "path": "plugins/context_engine/__init__.py",
       "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/context_engine/__init__.py",
       "rationale": "No current shared-different content remains for this upstream file; the Rust-first command surface rejects Python plugin dispatch and the Python context-engine loader is retained only as upstream reference material.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/disk-cleanup",
+      "rationale": "Ultra supersedes the upstream Python disk-cleanup plugin with Rust-native cleanup in crates/hermes-tools/src/tools/disk_cleanup.rs, including safe path scope, cron/output-only cleanup categorization, tracked.json persistence, quick/dry-run/status handling, registry post-tool auto-tracking, TUI session-end quick cleanup, and the /disk-cleanup command.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/disk-cleanup/__init__.py",
+      "rationale": "Local disk-cleanup delta is a behavior-equivalent tuple membership form covered by focused plugin contracts; no upstream runtime feature is missing.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/example-dashboard",
+      "rationale": "Example dashboard plugin differences affect plugin packaging and UI integration samples.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/example-dashboard/dashboard/manifest.json",
+      "rationale": "Local example dashboard intentionally advertises the sessions:top slot so the bundled SDK demo exercises page-scoped slot injection; contract tests verify the manifest and dist bundle stay aligned.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/example-dashboard/dashboard/plugin_api.py",
+      "rationale": "The shared diff is module docstring wording only; the /hello route behavior remains unchanged and is covered by the example dashboard contract test.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet",
+      "rationale": "Google Meet plugin differences affect connector/plugin runtime behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/__init__.py",
+      "rationale": "The shared diff is realtime-capable documentation wording plus behavior-equivalent tuple membership for the supported-platform gate.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/cli.py",
+      "rationale": "Ultra uses the plugin-local Hermes home helper so the Google Meet CLI remains importable in the Rust-first tree without vendoring upstream hermes_constants; other shared diffs are behavior-equivalent tuple membership.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/meet_bot.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for headed-mode parsing and bot-speaker filtering.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/node/cli.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for node status and ping command dispatch.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/node/registry.py",
+      "rationale": "Ultra uses the plugin-local Hermes home helper so node registry storage remains importable in the Rust-first tree without vendoring upstream hermes_constants.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/node/server.py",
+      "rationale": "Ultra keeps plugin-local Hermes home resolution plus remote realtime-mode passthrough and stricter meet_say validation for node-hosted meetings.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/process_manager.py",
+      "rationale": "Ultra uses the plugin-local Hermes home helper so local meeting state remains importable in the Rust-first tree without vendoring upstream hermes_constants.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/realtime/openai_client.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for terminal OpenAI Realtime response frame handling.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/google_meet/tools.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for local platform and mode validation; tool behavior remains covered by Google Meet plugin tests.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/hermes-achievements",
+      "rationale": "Achievements plugin dashboard differences affect bundled plugin UX and packaging behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/hermes-achievements/dashboard/dist/index.js",
+      "rationale": "Ultra keeps the bundled achievements dashboard on its local static-English bearer-token bundle because this Rust-first tree does not vendor upstream's dashboard i18n/auth Python source stack; focused contracts cover the retained host-SDK and auth assumptions.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/image_gen",
+      "rationale": "Image generation plugin differences affect media tool routing, packaging, and runtime connector behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/kanban",
+      "rationale": "Kanban plugin differences affect plugin runtime behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/kanban/dashboard/dist/index.js",
+      "rationale": "Ultra intentionally keeps the local kanban dashboard bundle as a legacy Python-dashboard shim while the Rust CLI owns kanban runtime behavior; upstream's expanded i18n, bulk drag/delete, and Python kanban_db API additions are not vendored into this Rust-first tree.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/kanban/dashboard/dist/style.css",
+      "rationale": "Ultra intentionally preserves the local kanban dashboard layout and theme overrides instead of adopting upstream's newer multi-drag/trash CSS, because the corresponding Python dashboard interactions are not vendored in the Rust-first runtime.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/kanban/dashboard/plugin_api.py",
+      "rationale": "Ultra retains the local kanban dashboard API shim against absent upstream hermes_cli Python sources; Rust kanban command behavior is tracked separately, so upstream's expanded Python dashboard endpoints are not copied wholesale.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/memory",
+      "rationale": "Memory plugin differences affect recall/provider integration behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/byterover/__init__.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for action and role guards; no ByteRover runtime behavior is missing.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/hindsight/__init__.py",
+      "rationale": "Ultra keeps stdlib asyncio/getpass fallbacks so Hindsight remains importable in the Rust-first tree without upstream-only agent.async_utils or hermes_cli.secret_prompt source modules.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/README.md",
+      "rationale": "Ultra documents the Rust-native `hermes memory setup honcho` path and dot-separated profile host keys used by crates/hermes-agent/src/memory_plugins/honcho.rs; legacy Python `hermes honcho ...` command dispatch remains disabled.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/__init__.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for cron/flush and recall-mode guards.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/cli.py",
+      "rationale": "Ultra keeps stdlib getpass for secret prompts so the Honcho CLI remains usable in the Rust-first tree without the upstream-only hermes_cli.secret_prompt source module; other diffs are behavior-equivalent membership guards.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/client.py",
+      "rationale": "Ultra resolves the default Honcho config path with Path.home() instead of importing upstream-only hermes_cli.profiles._get_default_hermes_home, preserving profile fallback behavior in the Rust-first tree.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/session.py",
+      "rationale": "Ultra supersedes the upstream Python Honcho gateway identity resolver with the Rust Honcho memory provider resolver in crates/hermes-agent/src/memory_plugins/honcho.rs, including pinUserPeer, userPeerAliases, runtimePeerPrefix, and hash-escalated collision handling.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/mem0/__init__.py",
+      "rationale": "The remaining Python Mem0 diff is legacy save_config write mechanics; Ultra implements Rust-native owner-only atomic config writes, merge semantics, and config-file activation in crates/hermes-agent/src/memory_plugins/mem0.rs.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/supermemory/__init__.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership for boolean parsing, context guards, and session-role filtering.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers",
+      "rationale": "Model-provider plugin differences affect runtime provider compatibility.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/alibaba-coding-plan/__init__.py",
+      "rationale": "Bundled Alibaba Coding Plan provider parity is covered by Rust provider registry and CLI routing contracts: the manifest directory is known, the provider alias is normalized, and the provider-specific default base URL routes through the Rust Qwen-compatible runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/azure-foundry/__init__.py",
+      "rationale": "Local Azure Foundry provider profile intentionally uses Azure AI Foundry naming while preserving the upstream OpenAI-compatible endpoint contract.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/azure-foundry/plugin.yaml",
+      "rationale": "Local Azure Foundry manifest intentionally uses Azure AI Foundry naming while preserving provider registration metadata.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/gemini/__init__.py",
+      "rationale": "Bundled Gemini provider parity is covered by Rust provider registry and CLI routing contracts: the manifest directory is known, Google/Gemini aliases normalize consistently, and the Rust runtime selects the Gemini provider defaults without Python plugin imports.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/kimi-coding/__init__.py",
+      "rationale": "Local Kimi provider delta is a behavior-equivalent tuple membership guard covered by focused model-provider contracts.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/nous/__init__.py",
+      "rationale": "Local Nous provider keeps a static Hermes product tag because the upstream agent.portal_tags helper is not present in this Rust checkout; focused contracts cover the emitted tag.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/opencode-zen/__init__.py",
+      "rationale": "OpenCode Zen and Go provider behavior is covered by Rust provider normalization, env-key resolution, default base URLs, model catalog merge, and GenericProvider OpenCode Go reasoning controls; this legacy upstream Python provider profile is reference-only and is not used by the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/observability",
+      "rationale": "Observability plugin differences affect telemetry/runtime diagnostics.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/observability/langfuse/README.md",
+      "rationale": "Local Langfuse README intentionally documents the Hermes tools credential flow while preserving the manual enable path.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/observability/langfuse/plugin.yaml",
+      "rationale": "Local Langfuse manifest intentionally advertises the Hermes tools enablement path in addition to manual plugin enablement.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms",
+      "rationale": "Platform plugin differences affect adapter surface parity.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/discord/adapter.py",
+      "rationale": "The remaining shared diff is whitespace-only and does not change Discord adapter behavior; runtime message filtering remains covered by Discord gateway tests.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/google_chat/adapter.py",
+      "rationale": "Ultra retains a Rust-first loop bridge that avoids the absent agent.async_utils module and rejects unsupported standalone attachments explicitly while preserving upstream proxy-env support.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/google_chat/oauth.py",
+      "rationale": "Ultra implements the upstream private-token write contract locally with os.replace because the upstream utils.py helper is absent from the Rust-first tree.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/irc/adapter.py",
+      "rationale": "The shared diff is behavior-equivalent tuple membership in IRC boolean and numeric-code guards; standalone send behavior remains covered by IRC adapter tests.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/line/adapter.py",
+      "rationale": "Ultra retains stdlib getpass and the local create_source bridge for the Rust-first source tree while porting upstream proxy-env support for LINE HTTP calls.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/ntfy/adapter.py",
+      "rationale": "Ultra supersedes the upstream Python ntfy adapter with the Rust-native gateway adapter in crates/hermes-gateway/src/platforms/ntfy.rs, including X-Tags echo-loop prevention, auth/header handling, inbound event filtering, env enablement, and cron delivery target parsing.",
+      "ticket": 304
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/ntfy/plugin.yaml",
+      "rationale": "The shared diff is ASCII punctuation in plugin metadata descriptions and does not change plugin loading or runtime behavior.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/simplex/adapter.py",
+      "rationale": "Ultra uses stdlib getpass in setup because hermes_cli.secret_prompt.py is absent from the Rust-first source tree.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/teams/adapter.py",
+      "rationale": "Ultra keeps explicit standalone attachment rejection and tuple membership contracts while porting upstream proxy-env support and resilient Teams port coercion.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "plugins/spotify/tools.py",
-      "classification": "intentional_divergence",
       "rationale": "Spotify tool behavior is now covered by Rust-native spotify_* built-ins and SpotifyWebApiBackend, including playback, devices, queue, search, playlists, albums, library normalization, auth-store/env token resolution, and friendly API errors; the Python plugin remains reference-only compatibility material.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/teams_pipeline",
+      "rationale": "Ultra uses the Rust-native Teams pipeline runtime and CLI in crates/hermes-tools/src/teams_pipeline.rs and crates/hermes-cli/src/teams_pipeline_cli.rs; the Python plugin package is retained as upstream reference material only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/teams_pipeline/cli.py",
+      "rationale": "Local Teams CLI delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/teams_pipeline/meetings.py",
+      "rationale": "Local Teams meeting error handling delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/teams_pipeline/models.py",
+      "rationale": "Local Teams artifact model delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/teams_pipeline/runtime.py",
+      "rationale": "Local Teams runtime config delta is a behavior-equivalent tuple membership guard covered by focused plugin contracts.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/video_gen",
+      "rationale": "Video generation plugin differences affect media tool routing and provider packaging behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/video_gen/fal/__init__.py",
+      "rationale": "FAL video generation behavior is now covered by the Rust-native video_generate tool and FalVideoGenBackend, including family routing, family-specific payload filtering, direct queue.fal.run polling, and Nous-managed fal-queue routing; the Python plugin remains reference-only compatibility material.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/video_gen/xai/__init__.py",
+      "rationale": "Local xAI video generation wording intentionally refers to the SuperGrok subscription credential path while preserving shared xAI credential resolution behavior.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "plugins/web",
+      "rationale": "Web-search plugin differences affect provider routing, credential handling, and tool result behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/firecrawl/provider.py",
+      "rationale": "Rust-native Firecrawl search/extract backends now cover direct, self-hosted, and Nous-managed routing; the Python plugin remains reference/compatibility code in the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/tavily/__init__.py",
+      "rationale": "Tavily search, extract, and crawl are covered by Rust-native web backends and the built-in web_crawl tool; this legacy upstream Python package is reference-only and is not used by the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/tavily/provider.py",
+      "rationale": "Tavily search, extract, and crawl are covered by Rust-native web backends, including /crawl Bearer auth plus body api_key and standard document/error normalization; this legacy upstream Python provider is reference-only and is not used by the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/xai/provider.py",
+      "rationale": "Rust-native xAI web search now routes through the Responses API server-side web_search tool with deterministic result normalization; the Python plugin remains reference/compatibility code.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "scripts/install.sh",
+      "rationale": "Installer intentionally downloads or builds Hermes Agent Ultra Rust release binaries instead of cloning upstream's Python/uv environment; installer contracts cover release assets, symlinks, PATH guard, Termux pathing, and post-install probes.",
+      "ticket": 305
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "skills/apple/apple-reminders/SKILL.md",
-      "classification": "intentional_divergence",
       "rationale": "Apple Reminders skill documentation is curated locally; skill catalog drift is tracked separately from the Rust runtime skill-loader contract.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/autonomous-ai-agents",
+      "rationale": "Autonomous-agent skill catalog content is curated locally while runtime behavior is governed by Hermes Ultra's native skill loader and execution contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/creative",
+      "rationale": "Skill catalog content is curated locally while Rust runtime parity is tracked through native skill loader contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/devops",
+      "rationale": "Skill catalog content is curated locally while runtime skill contracts remain tracked separately.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "skills/email/himalaya/SKILL.md",
-      "classification": "intentional_divergence",
       "rationale": "Himalaya skill documentation is curated locally while the runtime skill execution contract remains tracked by skill catalog governance.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/productivity",
+      "rationale": "Skill catalog content is curated locally while loader and execution contracts carry runtime parity.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/research",
+      "rationale": "Skill catalog content is curated locally while runtime skill contracts remain tracked separately.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "skills/social-media/xurl/SKILL.md",
-      "classification": "intentional_divergence",
       "rationale": "xurl skill documentation is curated locally for Hermes Agent Ultra safety guidance while skill loading and execution are governed separately.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_base_environment.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python base environment wrapper tests are covered by the Rust TerminalBackend contract and hermes-environments local backend tests, including command execution, cwd handling, stdin defaults, background process lifecycle, env sanitization, and file read/write behavior.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": "tests",
+      "rationale": "Top-level test differences can encode behavior contracts and must be mapped to Rust-native or local contract-test coverage before being cleared.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_clarify_tool.py",
-      "classification": "intentional_divergence",
-      "rationale": "Clarify tool behavior is covered by Rust-native ClarifyHandler contracts, including schema naming, required question validation, question trimming, choices normalization/limiting, invalid choices rejection, and backend callback forwarding.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": "tests/acp",
+      "rationale": "ACP tests cover protocol compatibility and session behavior.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_code_execution.py",
       "classification": "intentional_divergence",
-      "rationale": "Code execution is intentionally Rust-only and excludes Python execution by schema/validation; Rust ExecuteCodeHandler contracts cover explicit language requirements, supported JavaScript/TypeScript/shell schema, timeout forwarding, and backend dispatch.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_approval_isolation.py",
+      "rationale": "Upstream ACP approval-isolation regressions are covered by Rust ACP permission-store and server-instance tests: pending and resolved approvals are scoped to explicit PermissionStore instances, overlapping sessions resolve independently, and no Python module-global callback/runtime path exists.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_cronjob_tools.py",
       "classification": "intentional_divergence",
-      "rationale": "Cron job tool behavior is covered by Rust CronjobHandler and hermes-cron contracts, including create/list/update/pause/resume/remove/run action dispatch, extended create/update fields, no-agent script mode, context_from forwarding, workdir handling, and prompt-injection guards.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_auth.py",
+      "rationale": "Upstream ACP auth helper behavior is covered by Rust ACP auth-method and initialize/authenticate tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_homeassistant_tool.py",
       "classification": "intentional_divergence",
-      "rationale": "Home Assistant tool behavior is covered by Rust Ha* handlers and HaRestBackend contracts, including list/get/service/call schemas, required entity/service parameters, entity/service validation, blocked service domains, env configuration, auth headers, and REST response parsing.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_entry.py",
+      "rationale": "Upstream ACP entry startup intent is covered by Rust CLI ACP actions and flags: check/version avoid server startup, setup routes through Rust model configuration, and setup-browser validates node/browser dependencies with interactive and --yes paths.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_memory_tool.py",
       "classification": "intentional_divergence",
-      "rationale": "Memory tool behavior is covered by Rust MemoryHandler and FileMemoryBackend contracts, including add/replace/remove schema and dispatch, memory/user target validation, persistence formatting, snapshot sanitization, and external drift guards.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_events.py",
+      "rationale": "Upstream ACP event callback intent is covered by Rust ACP event emission tests: prompt executor events are enqueued, test transports flush session/update notifications, and CLI ACP output derives paired tool start/complete events from Rust AgentResult messages.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_process_registry.py",
       "classification": "intentional_divergence",
-      "rationale": "Process registry behavior is covered by Rust ProcessRegistryHandler, terminal/process backend, and notification formatting contracts, including register/get/poll/update/list/remove/clear actions, status normalization, pid validation, background process lifecycle, log reads, and event draining semantics.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_mcp_e2e.py",
+      "rationale": "Upstream ACP MCP E2E tool-event expectations are covered by Rust ACP prompt/session-update tests and CLI AgentResult-to-ACP tool event extraction; Python MCP mocking mechanics are reference-only for the Rust runtime.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_registry.py",
       "classification": "intentional_divergence",
-      "rationale": "Tool registry behavior is covered by Rust ToolRegistry and dispatch contracts, including registration, availability, lookup/listing, JSON success/error wrapping, unknown-tool errors, result truncation, policy audit/simulation/deny paths, and builtin tool discovery.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_permissions.py",
+      "rationale": "Upstream ACP permission option and outcome-mapping contracts are covered by Rust ACP permission tests; Python async scheduler mechanics are reference-only for the Rust runtime.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_send_message_missing_platforms.py",
       "classification": "intentional_divergence",
-      "rationale": "Missing-platform send-message behavior is covered by the Rust gateway-backed messaging tool and platform adapters; SendMessageHandler now exposes all supported gateway platform names, while matrix, mattermost, dingtalk, and homeassistant delivery contracts live in Rust gateway adapter tests.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_server.py",
+      "rationale": "Upstream ACP server lifecycle intent is covered by Rust ACP JSON-RPC server and handler tests: initialize/authenticate, camelCase wire aliases, session create/load/resume/fork/list/cancel, list filtering and pagination, prompt content aliases, refusal handling for missing sessions, usage serialization, slash commands, and MCP/server event flushing.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_send_message_tool.py",
       "classification": "intentional_divergence",
-      "rationale": "Send message tool behavior is covered by Rust SendMessageHandler, GatewayMessagingBackend, and platform adapter contracts, including required platform/recipient/message parameters, schema platform coverage, backend forwarding, gateway dispatch, chunking/media fallbacks, and platform-specific delivery tests.",
       "owner": "sheawinkler",
+      "path": "tests/acp/test_tools.py",
+      "rationale": "Upstream ACP tool metadata and rendering intent is covered by Rust ACP tool helpers and event metadata: common tool kind mapping, stable tc-* call IDs, human-readable titles, structured failure status detection, and tool_kind/title/status fields on emitted ACP tool events.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_session_search.py",
-      "classification": "intentional_divergence",
-      "rationale": "Session search behavior is covered by Rust SessionSearchHandler and SqliteSessionSearchBackend contracts, including schema shape, browse/search modes, role filters, current-session exclusion, result limit capping, timestamp formatting, scrolling, pattern matching, and hidden-source filtering.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": "tests/agent",
+      "rationale": "Agent tests cover model routing, provider, memory, and loop semantics.",
       "ticket": 25
     },
     {
-      "path": "tests/gateway/test_fast_command.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream gateway fast-command priority behavior is covered by Rust gateway /fast handling: command parsing accepts fast/priority and off modes, stores service_tier=priority in gateway runtime state/context, injects the service tier into agent extra_body, and exposes it in runtime hints/status.",
       "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_api_server_bind_guard.py",
-      "classification": "intentional_divergence",
-      "rationale": "API-server bind-address guard behavior is covered by Rust ApiServerAdapter contracts: network-accessible IPv4/IPv6 and mapped addresses require auth tokens, loopback binds remain allowed without auth, hostname resolution fails closed, and start() rejects unsafe non-loopback binds without an auth token.",
-      "owner": "sheawinkler",
-      "ticket": 303
-    },
-    {
-      "path": "tests/gateway/test_api_server_runs.py",
-      "classification": "intentional_divergence",
-      "rationale": "API-server /v1/runs behavior is covered by Rust-native TCP contracts for run start/status/events/stop, explicit session IDs, inbound gateway dispatch, completion usage/output, cancellation event closure, approval-no-pending conflicts, bool-like approval parsing, invalid conversation-history rejection without allocation, and auth gating.",
-      "owner": "sheawinkler",
-      "ticket": 303
-    },
-    {
-      "path": "tests/gateway/test_gateway_command_help.py",
-      "classification": "intentional_divergence",
-      "rationale": "Gateway help/start command behavior is covered by Rust gateway command contracts: /start is a no-op platform start event, /commands aliases /help, registered command bypass recognizes aliases, and generated help exposes normalized lowercase command names.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_verbose_command.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream gateway /verbose tool-progress behavior is covered by Rust DisplayConfig and gateway runtime tests: bool-like display.tool_progress_command gating, quoted false disablement, per-platform/default tool_progress resolution, off/new/all/verbose cycling, and runtime verbose/tool_progress state updates.",
-      "owner": "sheawinkler",
-      "ticket": 302
-    },
-    {
-      "path": "tests/gateway/test_api_server_jobs.py",
-      "classification": "intentional_divergence",
-      "rationale": "API-server cron jobs behavior is covered by Rust-native gateway contracts backed by hermes_cron: list/create/get/update/delete, include_disabled filtering, pause/resume/manual run, default local delivery, whitelisted updates including skill aliases, required-field and length validation, repeat validation, invalid-ID rejection with source-context logging, and bearer-auth gating. Python-only cron-unavailable and mock self-binding branches are not applicable because the Rust gateway links the scheduler directly and exercises real scheduler calls.",
-      "owner": "sheawinkler",
-      "ticket": 303
-    },
-    {
-      "path": "tests/tools/test_web_providers_brave_free.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Brave free provider intent is covered by Rust BraveFreeSearchBackend contracts for BRAVE_SEARCH_API_KEY gating, X-Subscription-Token requests, count clamping, result normalization, explicit/generic backend selection, auto-detect priority, and search-only extract/crawl error routing.",
-      "owner": "sheawinkler",
+      "path": "tests/agent/test_anthropic_adapter.py",
+      "rationale": "Upstream Anthropic adapter endpoint, auth, beta-header, OAuth-token, 4.8 sampling, and fast-mode intent is covered by Rust hermes-intelligence adapter contracts and hermes-agent provider request construction tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_web_providers_ddgs.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream ddgs provider intent is covered by Rust DuckDuckGoSearchBackend contracts for keyless DuckDuckGo search, abstract/related-topic normalization, one-indexed positions, explicit/generic ddgs and duckduckgo backend aliases, last-resort auto-detect, and search-only extract/crawl error routing.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_anthropic_keychain.py",
+      "rationale": "Upstream Claude Code macOS Keychain discovery, malformed-entry rejection, JSON fallback, and Keychain-priority intent is covered by Rust hermes-cli auth discovery and parser tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_web_providers_searxng.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream SearXNG provider intent is covered by Rust SearxngSearchBackend contracts for SEARXNG_BASE_URL and SEARXNG_URL aliases, trailing-slash normalization, score-descending sorting, limit truncation, result normalization, availability checks, and search-only extract/crawl errors.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_auxiliary_client.py",
+      "rationale": "Upstream auxiliary client routing, OAuth token selection, fallback, payment/rate-limit classification, Kimi temperature omission, Anthropic-compatible image conversion, and credential-refresh retry intent is covered by Rust hermes-intelligence auxiliary client contracts plus hermes-agent auxiliary_builder/provider auth-routing tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_web_tools_tavily.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Tavily web-tool intent is covered by Rust Tavily search/extract/crawl backend contracts for API-key body payloads, base URL handling, search result normalization, extracted document and failed-result normalization, and handler dispatch through the Rust web tool backend registry.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_auxiliary_config_bridge.py",
+      "rationale": "Upstream auxiliary config/default-shape and config-to-AUXILIARY_* bridge intent is covered by Rust hermes-config auxiliary task override parsing, default task metadata, and bridge contract tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_website_policy.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream website blocklist policy intent is covered by Rust website_policy contracts for security.website_blocklist defaults, inline and shared-file domain loading, malformed config errors, invalid shape errors, parent-domain matching, wildcard-subdomain semantics, and unreadable shared-file warning behavior.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_auxiliary_main_first.py",
+      "rationale": "Upstream auxiliary main-provider-first auto-routing intent is covered by Rust hermes-agent auxiliary main runtime wiring and hermes-intelligence auxiliary chain contracts for fallback, explicit provider/model override, and vision-capability filtering; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_tool_output_limits.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream configurable tool-output limit intent is covered by Rust ToolOutputConfig defaults and tolerant parsing plus read_file pagination clamping through tool_output.max_lines; Rust keeps agent budget truncation separate from tool display limits.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_auxiliary_named_custom_providers.py",
+      "rationale": "Upstream named custom provider and custom:<name> main-provider alias intent is covered by Rust hermes-config Python-YAML compatibility normalization plus hermes-cli provider/model and runtime-provider contract tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_browser_content_none_guard.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream browser_tool LLM-content None guard intent is superseded by Rust browser vision design: browser backends return a deterministic screenshot payload without dereferencing LLM message.content, and the shared vision response parser converts null or blank multimodal analysis content to a non-empty fallback string.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_bedrock_1m_context.py",
+      "rationale": "Upstream Bedrock 1M-context beta intent is covered by Rust Bedrock Converse request/header contracts and existing Anthropic/MiniMax beta filtering tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_config_null_guard.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream config null-coalescing intent is covered by Rust typed config null guards: web backend selectors deserialize null as defaults, auxiliary provider/model/base_url/api_key deserialize null as safe defaults, tts.provider null falls through provider resolution, and unknown MCP auth:null does not crash parsing.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_bedrock_integration.py",
+      "rationale": "Upstream Bedrock registry, alias, runtime-provider, auth-marker, base-URL, context, model-id normalization, and error-classification intent is covered by Rust hermes-cli provider/model tests, hermes-agent Bedrock provider contracts, and hermes-intelligence metadata/normalization tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_llm_content_none_guard.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream OpenAI-compatible message.content None guard intent is covered centrally by Rust OpenAI/OpenRouter response parsing: null assistant content becomes an empty string without panicking, tool-call-only responses keep tool calls, and reasoning-only OpenRouter responses preserve reasoning_content for downstream use.",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_codex_cloudflare_headers.py",
+      "rationale": "Upstream Codex Cloudflare mitigation header intent is covered by Rust hermes-agent Codex header extraction/build-request tests plus shared openai-codex provider wiring used by primary and auxiliary runtime construction; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_compressor_image_tokens.py",
+      "rationale": "Upstream image-aware compression-budget intent is covered by Rust hermes-intelligence context_engine contracts that charge fixed image-block budgets for OpenAI, Responses, and Anthropic image shapes without counting base64 payload bytes; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_context_compressor.py",
+      "rationale": "Upstream context compressor thresholding, summary fallback, cooldown, tool-pair sanitization, handoff-prefix, and collision-avoidance intent is covered by Rust hermes-agent ContextCompressor state-machine tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_context_compressor_summary_continuity.py",
+      "rationale": "Upstream iterative context-summary continuity intent is covered by Rust hermes-agent ContextCompressor tests for same-process previous-summary reuse, resume handoff rehydration, protected-head handoffs, and exclusion of existing handoff messages from the new-turn summary block; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_context_engine.py",
+      "rationale": "Upstream context-engine ABC/default behavior is represented in Rust by hermes-intelligence ContextEngine trait implementations plus Default and Importance engine compression contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_credential_pool.py",
+      "rationale": "Upstream credential-pool selection, rate-limit clearing, round-robin, single-key, and pool-fallback intent is covered by Rust hermes-agent CredentialPool and agent-loop fallback tests; persistent Python OAuth pool migration tests remain reference-only for Rust auth-store contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_deepseek_anthropic_thinking.py",
+      "rationale": "Upstream DeepSeek Anthropic-compatible thinking replay intent is covered by Rust hermes-agent AnthropicProvider message conversion tests that preserve Kimi/DeepSeek-style reasoning content only for compatible endpoints while stripping stale thinking for non-compatible endpoints; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_display.py",
+      "rationale": "Upstream display formatting, tool preview, terminal preview length, and edit-diff rendering intent is covered by Rust hermes-intelligence display contracts and hermes-cli tool_preview/rendering tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_error_classifier.py",
+      "rationale": "Upstream failover-reason, status/body extraction, billing/rate-limit/auth/context/format classification, provider metadata, wrapped OpenRouter errors, SSL, and adversarial shape intent is covered by Rust hermes-intelligence ErrorClassifier property/unit tests and hermes-cli provider-error guards; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_gemini_cloudcode.py",
+      "rationale": "Upstream Gemini CloudCode OAuth, packed refresh, project resolution, provider registration, request/response translation, and auth-status intent is covered by Rust hermes-cli google-gemini-cli auth/runtime-provider tests plus hermes-agent provider request-shape and fallback contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_gemini_fast_fallback.py",
+      "rationale": "Upstream CloudCode/Gemini CLI rate-limit fallback intent is covered by Rust hermes-agent retry tests for google-gemini-cli, cloudcode-pa:// base URLs, non-CloudCode multi-key pool retries, and single-key fallback; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_image_routing.py",
+      "rationale": "Upstream image-routing mode, native multimodal content, MIME sniffing, path hints, and large-image non-resize intent is covered by Rust ACP multimodal preservation, Anthropic/OpenAI image block conversion, fixed image-token accounting, and CLI image hint contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_model_metadata.py",
+      "rationale": "Upstream model-metadata token estimation, image-token bounding, default context table, 256K probe tiers, provider-prefix stripping, error-limit parsing, and model context fallback intent is covered by Rust hermes-intelligence model_metadata contracts including Unicode-aware token counting and bounded image-content estimates; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_models_dev.py",
+      "rationale": "Upstream models.dev provider mapping, disk/in-memory cache, context extraction, provider-aware lookup, and capability parsing intent is covered by Rust hermes-intelligence models_dev mapping/cache/parse/client tests and CLI provider registry contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_moonshot_schema.py",
+      "rationale": "Upstream Moonshot/Kimi tool-schema sanitizer intent is covered by Rust hermes-agent provider contracts that detect Kimi/Moonshot models, fill missing property types, collapse nullable anyOf branches, preserve $ref nodes, strip invalid scalar enum values, and sanitize OpenAI-format tools before request construction; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_prompt_builder.py",
+      "rationale": "Upstream prompt-builder context-file, injection scan, skill prompt, subscription prompt, and truncation intent is covered by Rust hermes-agent context/context_files/skill_orchestrator tests and CLI prompt assembly contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_prompt_caching.py",
+      "rationale": "Upstream Anthropic cache-control breakpoint intent is covered by Rust hermes-agent provider message conversion and cache_control request-shape tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_rate_limit_tracker.py",
+      "rationale": "Upstream rate-limit header parsing, waiting, compact display, and provider-integration intent is covered by Rust hermes-agent RateLimitTracker and provider/API-bridge rate-limit tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_redact.py",
+      "rationale": "Upstream redaction test intent is covered by Rust hermes-intelligence redaction contracts for vendor prefixes, env/json/auth tokens, JWTs, Discord IDs, URL query/userinfo, DB connection strings, and form bodies; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_skill_commands.py",
+      "rationale": "Upstream skill-command discovery, platform filtering, command-key resolution, invocation rendering, setup guidance, file hints, and template substitution intent is covered by Rust hermes-agent SkillOrchestrator and hermes-tools skill command tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_skill_utils.py",
+      "rationale": "Upstream skill metadata and platform-matching intent is covered by Rust hermes-tools skill_utils contracts for frontmatter parsing, disabled skill names, platform scopes, config extraction, and Termux-compatible matching; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_streaming_context_scrubber.py",
+      "rationale": "Upstream memory-context streaming leak prevention is covered by Rust hermes-agent StreamingContextScrubber contracts and run_stream UI-delta scrubbing; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_subagent_progress.py",
+      "rationale": "Upstream sub-agent progress relay intent is covered by Rust hermes-agent sub-agent lineage/orchestration tests and hermes-cli TUI progress/phase-stream contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_subdirectory_hints.py",
+      "rationale": "Upstream subdirectory hint discovery, workspace-boundary rejection, command path extraction, duplicate suppression, and truncation intent is covered by Rust hermes-agent subdirectory_hints tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_title_generator.py",
+      "rationale": "Upstream title-generation sanitization, truncation, provider-error, and prompt-budget intent is covered by Rust hermes-intelligence TitleGenerator tests; Python thread/session DB worker tests remain reference-only because Hermes Ultra owns session title orchestration in Rust CLI/session code.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_tool_guardrails.py",
+      "rationale": "Upstream repeated tool failure/no-progress guardrail intent is covered by Rust hermes-agent tool-loop guard tests for exact repeated failures, varied args, idempotent outputs, success reset, and hard-stop toggles; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_unsupported_temperature_retry.py",
+      "rationale": "Upstream's unsupported-temperature and OpenAI-compatible max-token omission regression intent is covered by Rust auxiliary-client tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_usage_pricing.py",
+      "rationale": "Upstream usage-pricing normalization, subscription billing, cache-rate safety, and DeepSeek v4 Pro pricing intent is covered by Rust hermes-intelligence usage_pricing tests; dynamic Python metadata monkeypatch tests remain reference-only for Hermes Ultra's Rust pricing snapshot path.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/transports/test_bedrock_transport.py",
+      "rationale": "Upstream Bedrock transport build-kwargs, tool conversion, response validation, finish-reason mapping, reasoningContent preservation, toolUse normalization, usage mapping, and SigV4 request contract are covered by Rust hermes-agent Bedrock provider tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/cli",
+      "rationale": "CLI test deltas cover command contracts and user-visible runtime behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/cli/test_cli_browser_connect.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream CLI browser-connect intent is covered by Rust /browser CDP helpers: websocket/http probe normalization, Chrome/Chromium/Brave/Edge candidate ordering across macOS/Linux/Windows/WSL paths, shell-safe manual command rendering, detached launch support, /browser launch, and persisted CHROME_CDP_URL connect/disconnect behavior.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_browser_chromium_check.py",
-      "classification": "intentional_divergence",
-      "rationale": "Python Playwright/agent-browser Chromium install checks are superseded by the Rust browser backend model: local browser support is CDP-first, /browser launch discovers installed Chromium-family browsers directly, websocket/http CDP probes validate readiness, cloud providers do not require local Chromium, and explicit CDP override bypasses auto cloud/Camofox routing.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_browser_cloud_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream cloud-fallback intent is covered by Rust CloudFallbackBrowserBackend and backend selection contracts: Browserbase/Browser Use runtime command failures warn and retry local CDP, fallback responses preserve local success with fallback_from_cloud/provider/reason metadata, CDP override bypasses auto cloud detection, and explicit provider selection still remains explicit.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_browser_homebrew_paths.py",
-      "classification": "intentional_divergence",
-      "rationale": "Python Homebrew/Termux agent-browser PATH construction is intentionally not required in Rust because browser automation no longer shells through the Node agent-browser CLI; Rust uses direct CDP, /browser launch discovers native Chromium-family browser binaries, and CDP probes verify readiness instead of relying on npx/node path fallbacks.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_browser_secret_exfil.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream browser/web secret-exfiltration intent is covered by Rust URL and observation guards: browser navigation and web extract reject secret-like query parameters such as api_key/token/access_token, snapshot/web content redaction removes secret assignments and bearer/provider tokens before returning observations, and normal non-secret URLs remain allowed.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/tools/test_managed_browserbase_and_modal.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream managed Browserbase/Browser Use/Modal intent is covered by Rust provider contracts: Browserbase remains direct-credential only, Browser Use supports direct and Nous-managed gateway modes with timeout/proxy payloads, idempotency-key preservation across timeout/in-progress conflicts, external-call-id persistence, and Modal backend selection is covered by hermes-config managed gateway and hermes-tools terminal/register_builtins contracts.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_model_normalize.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream provider-aware model normalization intent is now implemented in Rust hermes-agent::model_normalize and wired into CLI build_provider, AgentLoop runtime provider construction, and auxiliary main-runtime providers. Rust tests cover dot preservation for opencode-go, Anthropic dot-to-hyphen conversion, Copilot bare dot notation, aggregator vendor-prefix insertion, matching-only native prefix stripping, vendor detection, and DeepSeek V-series/reasoner folding.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_model_validation.py",
-      "classification": "intentional_divergence",
-      "rationale": "Python /model validation behavior is superseded by Rust CLI model-switch contracts: provider aliases/capabilities are covered by crates/hermes-cli providers/model_switch/commands tests, provider catalogs are resolved through curated/models.dev/live OpenAI-compatible helpers, unlisted Codex models are soft-accepted, and runtime-facing model IDs now pass through shared Rust provider-aware normalization before provider construction.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_runtime_provider_resolution.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream runtime-provider resolution intent is covered by Rust AgentLoop and CLI runtime provider contracts: provider aliases, api_key/api_key_env/base_url precedence, OAuth token-store refresh for openai-codex and qwen-oauth, credential-pool fallback, local no-key providers, and StepFun/Copilot/direct provider defaults are tested; this tranche adds shared model normalization to runtime-routed provider construction.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_models.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream hermes_cli.models catalog/model-id intent is covered by Rust provider registry and model_switch contracts: known provider and OAuth snapshots, curated provider model lists, models.dev merge ordering and deduplication, OpenRouter curated-only safety, Nous/OpenRouter agentic merge, local provider fallbacks, signed provider catalog cache verification, and provider-aware model normalization for runtime IDs.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/hermes_cli/test_model_catalog.py",
-      "classification": "intentional_divergence",
-      "rationale": "Python remote manifest/cache behavior is intentionally replaced by Rust provider catalog resolution: curated models plus models.dev/live provider discovery are cached in a signed provider-model cache, stale or tampered cache payloads are rejected, and provider_catalog_entries exposes bounded previews with total model counts for CLI/TUI listing.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_1630_context_overflow_loop.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_413_compression.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_860_dedup.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_anthropic_prompt_cache_policy.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_anthropic_truncation_continuation.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_api_max_retries_config.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_async_httpx_del_neuter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_background_review.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_background_review_toolset_restriction.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_compress_focus_plugin_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_compression_boundary.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_compression_boundary_hook.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_compression_feasibility.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_compression_persistence.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_concurrent_interrupt.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_context_token_tracking.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_create_openai_client_reuse.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_deepseek_reasoning_content_echo.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_dict_tool_call_args.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_empty_response_recovery_persistence.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_exit_cleanup_interrupt.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_image_rejection_fallback.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_image_shrink_recovery.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_interactive_interrupt.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_interrupt_propagation.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_invalid_context_length_warning.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_iteration_budget_race.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_jsondecodeerror_retryable.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_long_context_tier_429.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_memory_nudge_counter_hydration.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_memory_provider_init.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_memory_sync_interrupted.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_openai_client_lifecycle.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_plugin_context_engine_init.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
+      "path": "tests/cli/test_quick_commands.py",
+      "rationale": "Upstream quick-command behavior is covered by Rust shared quick_commands config, CLI slash dispatch that runs exec commands before built-ins, alias forwarding, no-output and timeout replies, plus gateway quick-command exec/alias handling from runtime config.",
+      "ticket": 302
     },
     {
-      "path": "tests/run_agent/test_primary_runtime_restore.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cli/test_session_boundary_hooks.py",
+      "rationale": "Upstream CLI session-boundary hook intent is covered by Rust hermes-agent HookType registration and panic containment plus Rust hermes-cli App tests that invoke on_session_finalize and on_session_reset for /new-style session rotation and same-session reset.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_provider_attribution_headers.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_provider_parity.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_real_interrupt_subagent.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_repair_tool_call_arguments.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_run_agent.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/run_agent/test_run_agent_codex_responses.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": "tests/cron",
+      "rationale": "Cron tests cover scheduling/runtime behavior.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_session_meta_filtering.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_codex_execution_paths.py",
+      "rationale": "Upstream cron/Codex execution-path intent is covered by Rust cron runner isolation plus Rust provider/auth refresh contracts; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_session_reset_fix.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_cron_context_from.py",
+      "rationale": "Upstream context_from create/update/prompt-injection intent is covered by Rust CronJob context_from persistence, scheduler prefix assembly, invalid-ref filtering, and truncation tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_steer.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_cron_inactivity_timeout.py",
+      "rationale": "Upstream cron inactivity-timeout intent is covered by Rust cron script timeout controls and scheduler execution/error delivery contracts; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_stream_drop_logging.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_cron_no_agent.py",
+      "rationale": "Upstream no_agent script-only intent is covered by Rust CronJob validation, cronjob tool plumbing, runner short-circuit execution, wakeAgent silence gating, bash/Python path execution, and traversal blocking tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_streaming.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_cron_prompt_injection_skill.py",
+      "rationale": "Upstream assembled cron skill prompt scanning intent is covered by Rust cron skill loading, SkillGuard checks, invisible-Unicode blocking, and prompt-injection regression tests before agent execution; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_streaming_tool_call_repair.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_cron_script.py",
+      "rationale": "Upstream cron script field, script output injection, relative Hermes scripts path resolution, absolute/tilde/traversal/symlink containment, and env cleanup intent is covered by Rust CronJob storage, runner script execution, and script-path guard tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_strict_api_validation.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_cron_workdir.py",
+      "rationale": "Upstream per-job workdir normalization, create/update roundtrip, TERMINAL_CWD scoping, and workspace-context opt-in intent is covered by Rust CronJob workdir normalization, scheduler persistence tests, CLI/tool plumbing, and runner environment/current_dir handling; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_strip_reasoning_tags_cli.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_file_permissions.py",
+      "rationale": "Upstream cron file-permission hardening intent is covered by Rust FileJobPersistence 0700 directory and 0600 job-file tests on Unix; broader config permission contracts live in Rust auth/config code.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_switch_model_context.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_jobs.py",
+      "rationale": "Upstream cron job CRUD, validation, persistence, status, repeat, no_agent, script, context_from, and workdir intent is covered by Rust CronJob, FileJobPersistence, SqliteJobPersistence, ScheduledCronjobBackend, and CronScheduler tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_tool_arg_coercion.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_scheduler.py",
+      "rationale": "Upstream scheduler tick/run/delivery/history intent is covered by Rust CronScheduler create/update/run/manual-trigger, context prefix, completion broadcast, delivery suppression, and runner contract tests; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_tool_call_args_sanitizer.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_scheduler_mcp_init.py",
+      "rationale": "Upstream no_agent scheduler MCP-skip intent is covered by Rust CronRunner no_agent short-circuiting before AgentLoop construction and tool filtering tests that exclude recursive cron scheduling; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_tool_call_guardrail_runtime.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": "tests/e2e",
+      "rationale": "End-to-end tests cover user-visible runtime workflows and must stay parity-reviewed before clearance.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_tool_executor_contextvar_propagation.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "classification": "functional",
       "owner": "sheawinkler",
+      "path": "tests/gateway",
+      "rationale": "Gateway test deltas exercise platform adapter behavior and must be reviewed as runtime parity coverage.",
       "ticket": 25
     },
     {
-      "path": "tests/run_agent/test_vision_aware_preprocessing.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
       "path": "tests/gateway/conftest.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/restart_test_helpers.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_7100_transient_failure_transcript.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_agent_cache.py",
+      "rationale": "Upstream gateway agent-cache invalidation is covered by Rust GatewayAgentCache and agent_config_signature tests for stable model/provider/toolset/system/cache-key signatures, full-token secret-safe hashing, documented cache-busting config extraction, signature misses, LRU eviction, idle TTL cleanup, and release hooks.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_allowed_channels_widening.py",
+      "rationale": "Upstream Telegram, DingTalk, Mattermost, and Matrix allowed-chat/channel/room gating is covered by Rust config-env import tests and gateway platform access policy tests for aliases, no-restriction defaults, blocked non-allowlisted group traffic, mention non-bypass, and DM bypass of channel restrictions.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_allowlist_startup_check.py",
+      "rationale": "Upstream startup allowlist warning semantics are covered by Rust gateway startup warning helper tests for no-config warning, SIGNAL_GROUP_ALLOWED_USERS suppression, platform allow-all suppression, global allow-all suppression, and false-like allow-all rejection; runtime gateway startup emits the warning when chat platforms are enabled without a user allowlist or explicit allow-all override.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_api_server.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server_bind_guard.py",
+      "rationale": "API-server bind-address guard behavior is covered by Rust ApiServerAdapter contracts: network-accessible IPv4/IPv6 and mapped addresses require auth tokens, loopback binds remain allowed without auth, hostname resolution fails closed, and start() rejects unsafe non-loopback binds without an auth token.",
+      "ticket": 303
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server_jobs.py",
+      "rationale": "API-server cron jobs behavior is covered by Rust-native gateway contracts backed by hermes_cron: list/create/get/update/delete, include_disabled filtering, pause/resume/manual run, default local delivery, whitelisted updates including skill aliases, required-field and length validation, repeat validation, invalid-ID rejection with source-context logging, and bearer-auth gating. Python-only cron-unavailable and mock self-binding branches are not applicable because the Rust gateway links the scheduler directly and exercises real scheduler calls.",
+      "ticket": 303
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server_runs.py",
+      "rationale": "API-server /v1/runs behavior is covered by Rust-native TCP contracts for run start/status/events/stop, explicit session IDs, inbound gateway dispatch, completion usage/output, cancellation event closure, approval-no-pending conflicts, bool-like approval parsing, invalid conversation-history rejection without allocation, and auth gating.",
+      "ticket": 303
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server_toolset.py",
+      "rationale": "Upstream's API-server toolset contract is covered by Rust toolset and platform-toolset tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_approve_deny_commands.py",
+      "rationale": "Upstream blocking command approvals are covered by Rust hermes-tools gateway approval queue contracts and hermes-gateway slash command tests for FIFO resolution, resolve-all behavior, timeout/no-listener fallback, /approve and /deny command resolution, and session-boundary denial; Python-only stale _pending_approvals cleanup has no Rust runtime equivalent.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_auth_fallback.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_auto_continue.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_background_command.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_background_process_notifications.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_base_topic_sessions.py",
+      "rationale": "Upstream base-topic session behavior is covered by Rust session-control and Telegram bridge tests that preserve distinct thread/topic session keys, encode incoming Telegram group topics as composite chat IDs, split them back into Bot API chat_id/message_thread_id on send, and keep invalid or lobby thread suffixes unchanged.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_bluebubbles.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_busy_session_ack.py",
+      "rationale": "Upstream active-session busy acknowledgement behavior is covered by Rust BusySessionCoordinator tests for queue, interrupt, and steer modes, acknowledgement cooldown/debounce, pending follow-up replacement, agent interrupt/steer handoff, status-rich interrupt acknowledgements, command bypass, and pending replay after finish.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_busy_session_auth_bypass.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_channel_directory.py",
+      "rationale": "Upstream channel-directory cache behavior is covered by Rust tests for missing/corrupt load fallback, atomic writes, session-derived channel discovery with topic composite IDs, exact/display/guild/prefix/id resolution, channel-type lookup, display formatting, provider error isolation, provider/session merge dedupe, and Slack users.conversations pagination.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_clean_shutdown_marker.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_command_bypass_active_session.py",
+      "rationale": "Upstream command-bypass behavior is covered by Rust gateway command registry tests for canonical slash commands, Telegram bot suffix stripping, hyphen-to-underscore normalization, registered command bypass decisions, unknown-command rejection, file-path false positives, and active-session bypass integration.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_compress_command.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_config.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_config_cwd_bridge.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_config_env_bridge_authority.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_delivery.py",
+      "rationale": "Upstream delivery target parsing is covered by Rust DeliveryTarget tests for origin resolution, local fallback, platform-home targets, explicit chat IDs, thread IDs, case-insensitive platform names, case-preserving chat IDs, Matrix-style colon splitting, target string roundtrips, and unknown-platform local fallback.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_dingtalk.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_allowed_mentions.py",
+      "rationale": "Upstream Discord allowed_mentions safe-default intent is covered by Rust hermes-gateway DiscordAllowedMentions payload construction and env-style parsing tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_attachment_download.py",
+      "rationale": "Upstream Discord authenticated attachment download behavior is covered by Rust Discord attachment handling contracts for image, audio, and document attachments that prefer bot-session reads and fall back through SSRF-gated fetch paths.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_bot_auth_bypass.py",
+      "rationale": "Upstream Discord bot-allowance auth bypass intent is covered by Rust Gateway route_message_from_sender tests for Discord bot senders, human allowlists, and non-Discord isolation, with DISCORD_ALLOW_BOTS env bridging into platform policy.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_bot_filter.py",
+      "rationale": "Upstream DISCORD_ALLOW_BOTS filtering semantics are covered by Rust DiscordBotMessagePolicy parsing and DiscordAdapter::should_accept_message tests for own messages, humans, all bots, mentioned bots, and default rejection.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_channel_controls.py",
+      "rationale": "Upstream Discord ignored_channels and no_thread_channels behavior is covered by Rust DiscordChannelControls tests for CSV/YAML parsing, DM bypass, thread-parent matching, auto-thread suppression, config env bridging, and config-to-env hydration precedence.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_channel_prompts.py",
+      "rationale": "Upstream Discord channel_prompts behavior is covered by Rust channel prompt resolution and ephemeral prompt composition tests for exact channel matches, parent fallback, blank-prompt suppression, retry preservation intent, and context/channel/global prompt ordering.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_channel_skills.py",
+      "rationale": "Upstream Discord channel_skill_bindings resolver intent is covered by Rust DiscordChannelSkillBinding parsing and DiscordAdapter::resolve_channel_skills tests for channel matches, parent matches, single-skill shorthand, no-match, and ordered deduplication.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_component_auth.py",
+      "rationale": "Upstream Discord component user-or-role authorization and fail-closed behavior is covered by Rust DiscordInteractionAuthPolicy component checks for empty allowlists, user matches, role-only matches, missing role data, and missing users.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_connect.py",
+      "rationale": "Upstream Discord connect and slash-sync lifecycle behavior is covered by Rust contracts for member-intent selection, reconnect client closure, slash sync opt-out policy, command diff planning, metadata/context recreation, mutation summaries, fingerprint skip state, and retry-after cooldown state.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_document_handling.py",
+      "rationale": "Upstream Discord document attachment behavior is covered by Rust document handling contracts for document classification, SSRF-gated fallback, small text/markdown/log content injection, PDF non-injection, and caption ordering.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_free_response.py",
+      "rationale": "Upstream Discord free-response and mention-gating behavior is covered by Rust DiscordChannelControls and discord_allows_message_without_mention tests for DM bypass, channel and wildcard free-response lists, forum/thread parents, participated threads, reply auto-thread suppression, and voice-linked text channels.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_imports.py",
+      "rationale": "Upstream discord.py-missing import safety is covered by the Rust-only hermes-gateway Discord module compiling and testing behind the discord feature without any discord.py runtime dependency.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_media_metadata.py",
+      "rationale": "Upstream Discord media metadata signature intent is covered by Rust hermes-gateway DiscordSendMetadata routing tests plus metadata-aware send_voice, send_image_file, and send_image method contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_model_picker.py",
+      "rationale": "Upstream Discord model picker control-clearing behavior is covered by Rust model picker transition tests that clear the view before switch dispatch and clear it again on final success edit.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_opus.py",
+      "rationale": "Upstream Discord Opus loading and decode-error behavior is covered by Rust Opus candidate tests that prefer find_library results, only use Homebrew fallbacks for macOS when lookup fails, and require decode errors to be loggable.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_race_polish.py",
+      "rationale": "Upstream Discord concurrent voice-join race behavior is covered by the Rust DiscordVoiceJoinTracker contract that permits one connect per guild, treats concurrent joins as existing-move waits, and reports already-connected after completion.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_reactions.py",
+      "rationale": "Upstream Discord processing-reaction lifecycle is covered by Rust Gateway Discord reaction lifecycle tests, platform-specific Discord emoji mapping, reactions_enabled policy tests, and Discord REST reaction parser/adapter contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_reply_mode.py",
+      "rationale": "Upstream Discord reply_to_mode behavior is covered by Rust hermes-gateway reply-reference construction/retry tests, DiscordConfig defaults, CLI config hydration, Python-platform env bridging, and reply-text extraction contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_roles_dm_scope.py",
+      "rationale": "Upstream Discord role allowlist scoping is covered by Rust DiscordInteractionAuthPolicy tests that reject cross-guild guild and DM role matches, require dm_role_auth_guild opt-in for DMs, allow same-guild role matches, and preserve user-ID allowlist behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_send.py",
+      "rationale": "Upstream Discord send retry and forum-post behavior is covered by Rust hermes-gateway reply-reference retry classifiers, chunk reference-mode payload tests, forum thread payload contracts, and DiscordAdapter forum send outcome handling.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_slash_auth.py",
+      "rationale": "Upstream Discord slash authorization is covered by Rust DiscordInteractionAuthPolicy and gateway access-policy tests for user/role/channel allowlists, ignored-channel precedence, wildcard channels, malformed context fail-closed behavior, owner-only visibility semantics, notification soft-failure handling, and /skill autocomplete/handler auth-before-lookup decisions.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_slash_commands.py",
+      "rationale": "Upstream Discord slash command behavior is covered by Rust contracts for native command auto-registration, plugin conflict skipping, optional args dispatch, flat /skill routing/autocomplete/auth, auto-thread naming, thread feedback, and command sync reconciliation.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_system_messages.py",
+      "rationale": "Upstream Discord system-message filtering is covered by Rust DiscordAdapter::should_accept_message tests accepting default/reply message types and rejecting thread rename, pin, join, and boost-style system message types.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_discord_thread_persistence.py",
+      "rationale": "Upstream Discord thread participation persistence is covered by Rust ThreadParticipationTracker tests for missing/corrupt state, duplicate no-op marks, ordered newest retention, capacity eviction, restart reload, and missing-parent save creation.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_display_config.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_dm_topics.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_duplicate_reply_suppression.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_email.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_ephemeral_reply.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_extract_local_files.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_fallback_eviction.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_feishu.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_feishu_approval_buttons.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_feishu_bot_admission.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_feishu_comment.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_fresh_reset_skill_injection.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_gateway_inactivity_timeout.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_google_chat.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_internal_event_bypass_pairing.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_interrupt_key_match.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_irc_adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_matrix.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_matrix_mention.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_matrix_voice.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_mattermost.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_media_download_retry.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_media_extraction.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_message_deduplicator.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_mirror.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_model_switch_persistence.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_msgraph_webhook.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_ntfy_plugin.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_pairing.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_platform_base.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_platform_connected_checkers.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_platform_reconnect.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_platform_registry.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_proxy_mode.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_qqbot.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_queue_consumption.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_reload_skills_discord_resync.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_replay_entry_fields.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_restart_drain.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_restart_notification.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_restart_redelivery_dedup.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_restart_resume_pending.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_resume_command.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_retry_replacement.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_run_cleanup_progress.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_run_progress_interrupt.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_run_progress_topics.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_runner_fatal_adapter.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_runner_startup_failures.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_send_image_file.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_send_multiple_images.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_dm_thread_seeding.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_hygiene.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_info.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_model_override_routing.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_race_guard.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_reset_notify.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_split_brain_11016.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_state_cleanup.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_session_store_prune.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_shutdown_cache_cleanup.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_signal.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_slack.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_slack_approval_buttons.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_sms.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_sse_agent_cancel.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_ssl_certs.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_status.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_status_command.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_step_callback_compat.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_sticker_cache.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_stream_consumer.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_stt_config.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_stuck_loop.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_teams.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_text_batching.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_title_command.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_transcript_offset.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_tts_media_routing.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_update_command.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_update_streaming.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
-      "path": "tests/gateway/test_usage_command.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "tests/gateway/test_voice_command.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "owner": "sheawinkler",
-      "ticket": 25
-    },
-    {
       "path": "tests/gateway/test_document_cache.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream document-cache intent is covered by Rust MediaCache byte-cache contracts: safe leaf-name preservation, path traversal stripping, null-byte stripping, unique filenames, supported document MIME/extension mapping, image/document routing, and invalid-image rejection.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_duplicate_reply_suppression.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_email.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_ephemeral_reply.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_extract_local_files.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_fallback_eviction.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_fast_command.py",
+      "rationale": "Upstream gateway fast-command priority behavior is covered by Rust gateway /fast handling: command parsing accepts fast/priority and off modes, stores service_tier=priority in gateway runtime state/context, injects the service tier into agent extra_body, and exposes it in runtime hints/status.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_feishu.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_feishu_approval_buttons.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_feishu_bot_admission.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_feishu_comment.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_fresh_reset_skill_injection.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_gateway_command_help.py",
+      "rationale": "Gateway help/start command behavior is covered by Rust gateway command contracts: /start is a no-op platform start event, /commands aliases /help, registered command bypass recognizes aliases, and generated help exposes normalized lowercase command names.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_gateway_inactivity_timeout.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_gateway_shutdown.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream gateway shutdown/resource-drain intent is covered by Rust Gateway stop_all/session-finalize contracts and existing runtime shutdown tests for active session finalization, adapter stop isolation, idle expiry finalization, and hook containment; Rust process/tool cleanup uses native runtime registries instead of Python runner mocks.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_google_chat.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_hooks.py",
+      "rationale": "Upstream gateway hook discovery, wildcard emit ordering, error containment, default empty context, and emit_collect decision hooks are covered by Rust HookRegistry tests; user hook loading intentionally uses zero-Python HOOK.yaml command handlers instead of dynamic handler.py imports.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_internal_event_bypass_pairing.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_interrupt_key_match.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_irc_adapter.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_matrix.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_matrix_mention.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_matrix_voice.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_mattermost.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_media_download_retry.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_media_extraction.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_message_deduplicator.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_mirror.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_model_switch_persistence.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_msgraph_webhook.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_ntfy_plugin.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_pairing.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_platform_base.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_platform_connected_checkers.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_platform_http_client_limits.py",
+      "rationale": "Upstream persistent-platform HTTP pool limits are covered by Rust BasePlatformAdapter reqwest pool-limit tests for default keepalive tightening, env overrides, malformed env fallback, and shared builder use by long-lived adapters; Python httpx import failure and aiohttp response-leak checks are not part of the Rust runtime.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_platform_reconnect.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_platform_registry.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_proxy_mode.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_qqbot.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_queue_consumption.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_reload_skills_discord_resync.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_replay_entry_fields.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_restart_drain.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_restart_notification.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_restart_redelivery_dedup.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_restart_resume_pending.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_resume_command.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_retry_replacement.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_run_cleanup_progress.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_run_progress_interrupt.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_run_progress_topics.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_runner_fatal_adapter.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_runner_startup_failures.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_send_image_file.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_send_multiple_images.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_boundary_hooks.py",
+      "rationale": "Upstream gateway session-boundary lifecycle intent is covered by Rust hermes-gateway contracts for reset ordering, old logical session finalize hooks, new logical session reset hooks, hook error containment, shutdown finalization for active sessions, and idle-expiry finalization before session removal.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_dm_thread_seeding.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_hygiene.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_info.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_model_override_routing.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_race_guard.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_reset_notify.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_split_brain_11016.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_state_cleanup.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_store_prune.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_shutdown_cache_cleanup.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_signal.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_signal_format.py",
+      "rationale": "Upstream Signal markdown formatting is covered by Rust Signal gateway tests for bold, italic, strikethrough, monospace, fenced code blocks with language tags, heading-to-bold conversion, UTF-16 body ranges, newline collapse, link preservation, and italic false-positive regressions for snake_case, bullet lists, and cross-line spans.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_signal_rate_limit.py",
+      "rationale": "Upstream Signal attachment rate-limit behavior is covered by Rust token-bucket scheduler tests for default capacity/refill, wait estimation, zero/in-capacity/over-capacity acquire, post-RPC deduction, retry-after feedback calibration, refill clamping, rate-limit detection, wait formatting, and process-wide scheduler reset.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_slack.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_slack_approval_buttons.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_sms.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_sse_agent_cancel.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_ssl_certs.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_status.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_status_command.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_step_callback_compat.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_sticker_cache.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_stream_consumer.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_stream_consumer_fresh_final.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream fresh-final streaming intent is covered by Rust StreamConfig/StreamConsumer contracts for configurable fresh_final_after_seconds, no-edit sentinel safety, stale-preview fresh-final decisions, non-final segment behavior, turn-final delivery marking, reset clearing, and Telegram delete_message support for best-effort stale preview cleanup.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_stt_config.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_stuck_loop.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_teams.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_approval_buttons.py",
+      "rationale": "Upstream Telegram approval-button behavior is covered by Rust Telegram inline approval request and callback handling, including approval:once/session/deny callback parsing, per-adapter approval ID state, answerCallbackQuery acknowledgement, and FIFO gateway approval resolution.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_caption_merge.py",
+      "rationale": "Upstream Telegram caption exact-dedupe intent is covered by Rust TelegramAdapter::merge_caption tests for empty captions, whitespace-normalized exact duplicates, substring regressions, and multi-caption albums.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_conflict.py",
+      "rationale": "Upstream Telegram polling-conflict and webhook cleanup intent is covered by Rust polling startup deleteWebhook, polling conflict detection/logging, and deterministic poll-with-backoff retry behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_documents.py",
+      "rationale": "Upstream Telegram document and media routing intent is covered by Rust parse_update document metadata extraction, document-size/extension acceptance checks, sendDocument fallback for wav/flac, and caption truncation/thread fallback multipart send contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_format.py",
+      "rationale": "Upstream Telegram formatting intent is covered by Rust MarkdownV2 escaping, code-block preservation tests, and send/edit message paths that escape outgoing MarkdownV2 text before Telegram API submission.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_group_gating.py",
+      "rationale": "Upstream Telegram group gating intent is covered by Rust should_process_message/update tests for required mentions, mention entities, custom wake regexes, allowed/guest chats, ignored threads, allowed topics, reply-to-bot handling, and env/config access-policy hydration.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_network.py",
+      "rationale": "Upstream Telegram network fallback intent is covered by Rust Telegram fallback IP parsing/deduplication and reqwest DNS override wiring for api.telegram.org while preserving proxy configuration.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_photo_interrupts.py",
+      "rationale": "Upstream Telegram photo interrupt intent is covered by Rust parse_update photo extraction, group-gating support for observe_unmentioned_group_messages, media placeholder routing, and image URL send path with reply/thread fallback.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_reactions.py",
+      "rationale": "Upstream Telegram reaction lifecycle intent is covered by Rust Telegram adapter setMessageReaction contracts, disabled-by-default no-op behavior, config/env reaction hydration, and gateway lifecycle tests requiring explicit Telegram reactions policy.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_reply_mode.py",
+      "rationale": "Upstream Telegram reply_to_mode behavior is covered by Rust Telegram reply-mode parsing, chunk-reference policy tests for off/first/all/invalid modes, CLI config hydration, and env/YAML boolean-off bridging.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_text_batching.py",
+      "rationale": "Upstream Telegram text batching intent is covered by Rust TelegramTextBatcher aggregation keyed by chat/user/thread and the CLI polling loop wiring that drains batched text before gateway routing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_thread_fallback.py",
+      "rationale": "Upstream Telegram thread fallback intent is covered by Rust sendMessage/edit/multipart retry contracts that drop message_thread_id and reply_to_message_id only after Telegram thread/reply-not-found errors while preserving keyboard and parse-mode payloads.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_topic_mode.py",
+      "rationale": "Upstream Telegram topic-mode intent is covered by Rust TelegramTopicBindingStore enable/bind/list/remove/recover contracts, allowed-topic gating, and CLI/config hydration for allowed_topics and ignored_threads.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_telegram_webhook_secret.py",
+      "rationale": "Upstream Telegram webhook-secret guard is covered by Rust TelegramConfig webhook validation requiring webhook_secret/TELEGRAM_WEBHOOK_SECRET with GHSA remediation text while leaving polling mode unaffected.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_text_batching.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_title_command.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_transcript_offset.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_tts_media_routing.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_unauthorized_dm_behavior.py",
+      "rationale": "Upstream unauthorized-DM behavior is covered by Rust DmManager, Gateway route, and CLI builder tests for platform/global allowlists, wildcard allowlists, WhatsApp LID-to-phone mapping, Telegram group sender allowlists, Telegram legacy group-chat IDs, QQ group chat allowlists, allowlist-derived ignore defaults, explicit pair overrides, pairing-code replies, and pairing rate-limit suppression.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_update_command.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_update_streaming.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_usage_command.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_verbose_command.py",
+      "rationale": "Upstream gateway /verbose tool-progress behavior is covered by Rust DisplayConfig and gateway runtime tests: bool-like display.tool_progress_command gating, quoted false disablement, per-platform/default tool_progress resolution, off/new/all/verbose cycling, and runtime verbose/tool_progress state updates.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_voice_command.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_voice_mode_platform_isolation.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream voice-mode platform-isolation intent is covered by Rust VoiceManager platform-keyed joined-channel state and voice command contracts; platform/channel identifiers are normalized separately so same chat/channel IDs on different platforms do not collide.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_adapter.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream generic webhook adapter intent is covered by Rust WebhookAdapter contracts for GitHub/GitLab/generic/Svix signature validation, INSECURE_NO_AUTH loopback-only guard, body-size limits, route prompt rendering, event filtering, idempotency, fixed-window rate limiting, health/outbound endpoints, and handler dispatch.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_deliver_only.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream webhook deliver_only intent is covered by Rust WebhookRouteConfig and adapter contracts that render target chat/user templates, enqueue direct outbound delivery messages with platform targeting, preserve auth/idempotency/rate-limit checks, and bypass agent invocation.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_dynamic_routes.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream dynamic webhook route intent is covered by Rust WebhookConfig route hydration from platform config plus dynamic /webhooks/{route} dispatch, static route resolution, per-route secrets, route-specific prompt/event/delivery settings, and CLI config bridging.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_webhook_integration.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream webhook integration intent is covered by Rust end-to-end webhook route handling: signed provider payload validation, dot-notation template rendering into MessageEvent text, route event filtering, deliver/log/direct outbound handling, health checks, and route-specific chat/user/session isolation.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_wecom.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream WeCom outbound-media intent is covered by Rust WeCom adapter contracts for image URL fallback text, content-type-derived filenames, existing-extension preservation, and feature-gated adapter compilation with gateway delivery routing.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_wecom_callback.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream WeCom callback intent is covered by Rust WeCom callback contracts for signature stability, encrypted callback rejection on bad signatures, group-mention stripping, image fallback text, and remote image filename/content-type normalization.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_weixin.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream Weixin crypto/media/file-send intent is covered by Rust Weixin contracts for AES key parsing and AES-128-ECB roundtrips, malformed ciphertext rejection, image URL fallback/filename normalization, group policy behavior, and iLink file upload parameter routing.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_connect.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream WhatsApp connect/config intent is covered by Rust WhatsApp config and bridge contracts for reply_prefix, mention gating, DM/group policies, allowlists, bridge send body construction, link media body behavior, and startup/runtime adapter compilation behind the whatsapp feature.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_formatting.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream WhatsApp formatting/chunking intent is covered by Rust WhatsAppAdapter contracts for Markdown-to-WhatsApp conversion, header/link/strike/bold conversion, inline/fenced-code protection, reply prefix application, and char-boundary-safe message chunking.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_group_gating.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream WhatsApp DM/group gating intent is covered by Rust should_process_message contracts for require_mention, custom mention regexes, free-response chats, DM disabled/allowlist policies, group disabled/allowlist policies, normalized WhatsApp IDs, bot mentions, quoted bot replies, slash-command bypass, and mention-text cleanup.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_whatsapp_reply_prefix.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream WhatsApp reply_prefix intent is covered by Rust CLI config hydration and WhatsApp formatted_outbound_text tests that preserve explicit prefixes, support empty prefixes, and apply prefixes before WhatsApp formatting/chunking.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_ws_auth_retry.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream auth-aware retry intent is covered by Rust Matrix sync_loop auth failure handling for 401/403 and Rust Mattermost WebSocket reconnect contracts that stop immediately on auth errors while retrying transient failures with backoff.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli",
+      "rationale": "CLI tests define user-facing command and setup behavior and must stay parity-reviewed.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_api_key_providers.py",
+      "rationale": "Upstream API-key provider registry behavior is covered by Rust provider canonicalization, CLI setup metadata, config env hydration, ACP auth discovery, and runtime provider tests for Copilot, Z.AI/GLM, Hugging Face, AI Gateway, MiniMax CN, GMI, and local backend aliases.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_arcee_provider.py",
+      "rationale": "Upstream Arcee provider alias, ARCEEAI_API_KEY/ARCEE_API_KEY, base URL, model catalog, URL inference, config hydration, ACP auth, and runtime resolution intent is covered by Rust provider, CLI, config, ACP, intelligence, AgentLoop, and HTTP gateway tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_atomic_json_write.py",
+      "rationale": "Upstream crash-safe JSON write intent is covered by Rust hermes-config atomic_json_write/atomic_json_write_pretty helpers using sibling temp files, fsync-before-rename, cleanup on failure, parent directory creation, and roundtrip/no-temp-file tests.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_atomic_yaml_write.py",
+      "rationale": "Upstream crash-safe YAML write intent is covered by Rust hermes-config atomic_yaml_write and save_config_yaml using sibling temp files, fsync-before-rename, cleanup on failure, parent directory creation, optional trailing content, and focused YAML write tests.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_bedrock_model_picker.py",
+      "rationale": "Upstream Bedrock model-picker intent is covered by Rust provider canonicalization, region-aware curated fallback, best-effort signed live Bedrock catalog discovery, AWS credential-signal gating, and setup/model catalog tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_config_env_expansion.py",
+      "rationale": "Upstream config ${ENV_VAR} expansion is covered by Rust load_from_yaml/load_config recursive value-only expansion for strings, nested mappings, lists, multiple placeholders, and unresolved placeholders while load_user_config_file preserves templates for edit paths.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_env_loader.py",
+      "rationale": "Upstream dotenv loader precedence and sanitization intent is covered by Rust load_dotenv/load_dotenv_file tests for user-env precedence, project fallback, sanitized concatenated assignments before loading, and atomic sanitized-file rewrite.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_gemini_provider.py",
+      "rationale": "Upstream Gemini provider alias and GOOGLE_API_KEY/GEMINI_API_KEY compatibility intent is covered by Rust provider canonicalization, CLI env/base-url resolution, config hydration, AgentLoop runtime defaults, and HTTP gateway alias tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_gmi_provider.py",
+      "rationale": "Upstream GMI provider aliases, GMI_API_KEY/GMI_BASE_URL handling, curated/live model catalog, auxiliary default, config hydration, ACP auth, and runtime/base URL resolution are covered by Rust CLI, config, ACP, auxiliary, AgentLoop, intelligence, and HTTP gateway tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_model_catalog.py",
+      "rationale": "Python remote manifest/cache behavior is intentionally replaced by Rust provider catalog resolution: curated models plus models.dev/live provider discovery are cached in a signed provider-model cache, stale or tampered cache payloads are rejected, and provider_catalog_entries exposes bounded previews with total model counts for CLI/TUI listing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_model_normalize.py",
+      "rationale": "Upstream provider-aware model normalization intent is now implemented in Rust hermes-agent::model_normalize and wired into CLI build_provider, AgentLoop runtime provider construction, and auxiliary main-runtime providers. Rust tests cover dot preservation for opencode-go, Anthropic dot-to-hyphen conversion, Copilot bare dot notation, aggregator vendor-prefix insertion, matching-only native prefix stripping, vendor detection, and DeepSeek V-series/reasoner folding.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_model_validation.py",
+      "rationale": "Python /model validation behavior is superseded by Rust CLI model-switch contracts: provider aliases/capabilities are covered by crates/hermes-cli providers/model_switch/commands tests, provider catalogs are resolved through curated/models.dev/live OpenAI-compatible helpers, unlisted Codex models are soft-accepted, and runtime-facing model IDs now pass through shared Rust provider-aware normalization before provider construction.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_models.py",
+      "rationale": "Upstream hermes_cli.models catalog/model-id intent is covered by Rust provider registry and model_switch contracts: known provider and OAuth snapshots, curated provider model lists, models.dev merge ordering and deduplication, OpenRouter curated-only safety, Nous/OpenRouter agentic merge, local provider fallbacks, signed provider catalog cache verification, and provider-aware model normalization for runtime IDs.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_runtime_provider_resolution.py",
+      "rationale": "Upstream runtime-provider resolution intent is covered by Rust AgentLoop and CLI runtime provider contracts: provider aliases, api_key/api_key_env/base_url precedence, OAuth token-store refresh for openai-codex and qwen-oauth, credential-pool fallback, local no-key providers, and StepFun/Copilot/direct provider defaults are tested; this tranche adds shared model normalization to runtime-routed provider construction.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_set_config_value.py",
+      "rationale": "Upstream set_config_value routing intent is covered by Rust set_user_config_value and CLI e2e tests for secret-like keys to .env, uppercase normalization, env-bridged terminal keys, raw YAML config writes, falsy scalar handling, llm.* canonicalization to llm_providers, and list-index updates that preserve sibling entries.",
+      "ticket": 302
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_tencent_tokenhub_provider.py",
+      "rationale": "Upstream Tencent TokenHub canonical provider, aliases, TOKENHUB_API_KEY/TOKENHUB_BASE_URL, hy3-preview catalog/default/context metadata, URL inference, config hydration, ACP auth, auxiliary default, and runtime/base URL resolution are covered by Rust provider, CLI, config, ACP, auxiliary, AgentLoop, intelligence, and HTTP gateway tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_xiaomi_provider.py",
+      "rationale": "Upstream Xiaomi/MiMo aliases, XIAOMI_API_KEY/XIAOMI_BASE_URL handling, model catalog, URL inference, config hydration, ACP auth, and runtime/base URL resolution are covered by Rust provider, CLI, config, ACP, intelligence, AgentLoop, and HTTP gateway tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/honcho_plugin",
+      "rationale": "Honcho plugin tests cover memory/plugin behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/integration",
+      "rationale": "Integration tests cover cross-component runtime behavior and must stay parity-reviewed before clearance.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/plugins",
+      "rationale": "Plugin tests cover loader, hook, and runtime integration behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/plugins/memory/test_hindsight_provider.py",
+      "rationale": "Hindsight recall-type defaults and secure config writes are covered by Rust memory plugin tests, including observation-only recall payloads and owner-only $HERMES_HOME/hindsight/config.json writes.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/plugins/memory/test_mem0_v2.py",
+      "rationale": "Mem0 v2 behavior and secure config persistence are covered by Rust memory plugin tests for result normalization, owner-only atomic mem0.json writes, merge semantics, and config-file activation.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/plugins/memory/test_supermemory_provider.py",
+      "rationale": "Supermemory provider setup persistence is covered by Rust tests for owner-only atomic supermemory.json writes and config-file activation; the Python test file is retained as upstream reference.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/providers",
+      "rationale": "Provider tests cover model transport compatibility and error handling.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/providers/test_plugin_discovery.py",
+      "rationale": "Upstream model-provider plugin discovery intent is covered by Rust bundled provider-manifest registry coverage and PluginManager model-provider kind preservation; Hermes Ultra uses Rust profiles/config for runtime provider resolution instead of importing Python provider plugins.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/providers/test_profile_wiring.py",
+      "rationale": "Upstream profile-path request wiring is covered by Rust provider_profiles and GenericProvider request-body contracts that apply profile defaults without leaking local control keys and preserve profile-specific extra body/top-level placement.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/providers/test_provider_profiles.py",
+      "rationale": "Upstream Python provider-profile registry and profile behavior is covered by Rust provider_profiles and GenericProvider request-body contracts for aliases, default max tokens, auth types, base URLs, Kimi temperature/reasoning, OpenRouter provider preferences/reasoning/Pareto/session affinity, Nous tags/reasoning, Qwen metadata/message normalization, and custom Ollama num_ctx.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/providers/test_transport_parity.py",
+      "rationale": "Upstream provider transport parity is covered by Rust GenericProvider/OpenRouterProvider request contracts for NVIDIA max tokens, Kimi thinking/reasoning_effort, OpenRouter provider preferences/reasoning, Nous tags/disabled reasoning omission, Qwen metadata and vision defaults, and custom Ollama options.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent",
+      "rationale": "Run-agent tests cover orchestration and provider execution semantics.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_1630_context_overflow_loop.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_413_compression.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_860_dedup.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_anthropic_prompt_cache_policy.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_anthropic_truncation_continuation.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_api_max_retries_config.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_async_httpx_del_neuter.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_background_review.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_background_review_toolset_restriction.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_compress_focus_plugin_fallback.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_compression_boundary.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_compression_boundary_hook.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_compression_feasibility.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_compression_persistence.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_compression_trigger_excludes_reasoning.py",
+      "rationale": "Upstream compression-trigger prompt-token-only intent is covered by Rust hermes-agent ContextCompressor threshold tests: usage updates track prompt tokens only, completion/reasoning tokens are not accepted by the trigger path, and explicit prompt-token values gate compression; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_concurrent_interrupt.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_context_token_tracking.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_create_openai_client_reuse.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_deepseek_reasoning_content_echo.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_dict_tool_call_args.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_empty_response_recovery_persistence.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_exit_cleanup_interrupt.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_image_rejection_fallback.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_image_shrink_recovery.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_interactive_interrupt.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_interrupt_propagation.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_invalid_context_length_warning.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_iteration_budget_race.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_jsondecodeerror_retryable.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_long_context_tier_429.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_memory_nudge_counter_hydration.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_memory_provider_init.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_memory_sync_interrupted.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_openai_client_lifecycle.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_plugin_context_engine_init.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_primary_runtime_restore.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_provider_attribution_headers.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_provider_parity.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_real_interrupt_subagent.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_repair_tool_call_arguments.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_run_agent.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_run_agent_codex_responses.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_session_meta_filtering.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_session_reset_fix.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_steer.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_stream_drop_logging.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_streaming.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_streaming_tool_call_repair.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_strict_api_validation.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_strip_reasoning_tags_cli.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_switch_model_context.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_tool_arg_coercion.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_tool_call_args_sanitizer.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_tool_call_guardrail_runtime.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_tool_executor_contextvar_propagation.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_vision_aware_preprocessing.py",
+      "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/skills",
+      "rationale": "Skill tests cover loader, guard, and execution semantics.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/stress",
+      "rationale": "Stress tests cover runtime reliability envelopes.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/test_honcho_client_config.py",
+      "rationale": "Upstream Python Honcho config permission coverage is mapped to Rust tests for owner-only atomic honcho.json writes and explicit config-file activation in crates/hermes-agent/src/memory_plugins/honcho.rs.",
+      "ticket": 304
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/tools",
+      "rationale": "Tool tests cover command, policy, and backend semantics that affect runtime parity.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_approval.py",
+      "rationale": "Upstream dangerous-command approval behavior is covered and superseded by Rust hermes-tools approval contracts for hardline denials, recoverable confirmations, session/permanent approvals, yolo and session-yolo gates, container backend bypass, multiline shell/disk/write patterns, sensitive env/config writes, SQL/delete/find/killall refinements, sudo stdin floors, unmanaged gateway-run service-manager protection, and gateway approval queues. Python LLM smart-approval and input-prompt mechanics are intentionally not ported into the Rust safety path.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_approval_heartbeat.py",
+      "rationale": "Current upstream heartbeat file contains setup helpers but no executable test methods; Hermes Ultra's Rust terminal approval path fail-closes without entering Python's blocking gateway approval wait, so the inactivity-heartbeat wait loop is not a Rust runtime surface.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_approval_plugin_hooks.py",
+      "rationale": "Upstream pre_approval_request/post_approval_response plugin-hook intent is covered by Rust approval observer contracts: pre/post lifecycle events include surface, session key, command, pattern keys, description, permanent-allow flag, and resolved choice for CLI and gateway approval paths, while observer panics are contained and cannot alter approval decisions.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_base_environment.py",
+      "rationale": "Upstream Python base environment wrapper tests are covered by the Rust TerminalBackend contract and hermes-environments local backend tests, including command execution, cwd handling, stdin defaults, background process lifecycle, env sanitization, and file read/write behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_camofox.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra supersedes upstream Python Camofox HTTP facade tests with Rust browser backend contracts in crates/hermes-tools/src/backends/browser.rs and crates/hermes-tools/src/tools/browser.rs, covering Camofox env selection, CDP override precedence, named profile wiring, loopback URL rewriting, secret exfiltration guards, and handler forwarding for navigate/click/type/scroll/back/press/images/vision/console.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_camofox_persistence.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra uses Rust-native Camofox identity/profile contracts instead of Python session dictionaries: camofox_identity_for_home proves profile-scoped stable user IDs, per-task session keys, and profile isolation, while CamoFoxBrowserBackend::from_env proves named profile/CDP endpoint wiring.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_camofox_state.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra maps upstream Camofox state helpers to Rust camofox_state_dir_for_home and camofox_identity_for_home contracts, proving $HERMES_HOME/browser_auth/camofox pathing, deterministic identity, task/session separation, and profile separation without Python state modules.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_browser_chromium_check.py",
+      "rationale": "Python Playwright/agent-browser Chromium install checks are superseded by the Rust browser backend model: local browser support is CDP-first, /browser launch discovers installed Chromium-family browsers directly, websocket/http CDP probes validate readiness, cloud providers do not require local Chromium, and explicit CDP override bypasses auto cloud/Camofox routing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_browser_cloud_fallback.py",
+      "rationale": "Upstream cloud-fallback intent is covered by Rust CloudFallbackBrowserBackend and backend selection contracts: Browserbase/Browser Use runtime command failures warn and retry local CDP, fallback responses preserve local success with fallback_from_cloud/provider/reason metadata, CDP override bypasses auto cloud detection, and explicit provider selection still remains explicit.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_console.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra covers upstream browser console compatibility with Rust BrowserConsoleHandler tests for action=clear and clear=true alias handling plus Cdp/Browserbase/Browser Use console command implementations that reject unknown actions.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_browser_content_none_guard.py",
+      "rationale": "Upstream browser_tool LLM-content None guard intent is superseded by Rust browser vision design: browser backends return a deterministic screenshot payload without dereferencing LLM message.content, and the shared vision response parser converts null or blank multimodal analysis content to a non-empty fallback string.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_hardening.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra supersedes upstream Python browser_tool hardening with Rust browser contracts for no legacy browser_close registration, URL secret exfiltration blocking, observation redaction, line-safe handler schemas, CDP override precedence, and cloud fallback metadata.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_browser_homebrew_paths.py",
+      "rationale": "Python Homebrew/Termux agent-browser PATH construction is intentionally not required in Rust because browser automation no longer shells through the Node agent-browser CLI; Rust uses direct CDP, /browser launch discovers native Chromium-family browser binaries, and CDP probes verify readiness instead of relying on npx/node path fallbacks.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_orphan_reaper.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra intentionally avoids Python agent-browser daemon/socket lifecycle by routing Camofox through the Rust CDP backend; Rust contracts prove Camofox CDP/profile construction and registered browser commands without spawning a Python supervisor process that would require orphan reaping.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_browser_secret_exfil.py",
+      "rationale": "Upstream browser/web secret-exfiltration intent is covered by Rust URL and observation guards: browser navigation and web extract reject secret-like query parameters such as api_key/token/access_token, snapshot/web content redaction removes secret assignments and bearer/provider tokens before returning observations, and normal non-secret URLs remain allowed.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_browser_supervisor.py",
-      "classification": "intentional_divergence",
       "rationale": "Ultra replaces the Python browser_supervisor integration surface with Rust CDP, Browserbase, Browser Use, and Camofox backend contracts; handler forwarding and backend selection tests cover the supported browser command surface while live Chrome supervisor E2E remains a Python-upstream-only test shape.",
-      "owner": "sheawinkler",
       "ticket": 306
     },
     {
-      "path": "tests/tools/test_web_providers.py",
       "classification": "intentional_divergence",
-      "rationale": "Ultra supersedes upstream Python WebSearchProvider/WebExtractProvider ABC tests with Rust WebSearchBackend, WebExtractBackend, and WebCrawlBackend traits plus handler tests; Rust backend env tests prove per-capability search/extract selection over the generic web backend.",
       "owner": "sheawinkler",
-      "ticket": 306
-    },
-    {
-      "path": "tests/tools/test_web_tools_config.py",
-      "classification": "intentional_divergence",
-      "rationale": "Ultra covers upstream web tools config behavior in Rust web backend tests for Exa/Tavily/Firecrawl/SearXNG/Brave/DDG/xAI selection, per-capability overrides, legacy generic backend fallback, managed Firecrawl gateway resolution, secret guards, singleton-free env re-resolution, and normalized provider payloads.",
-      "owner": "sheawinkler",
-      "ticket": 306
-    },
-    {
-      "path": "tests/tools/test_tool_result_storage.py",
-      "classification": "intentional_divergence",
-      "rationale": "Upstream three-layer tool result persistence intent is covered by Rust tool_result_storage and dispatch contracts for newline-aware previews, heredoc delimiter safety, quoted sandbox write commands, local persisted-output blocks, read_file guidance, unicode-safe previews, threshold-zero persistence, read_file no-persist semantics, aggregate budget spilling, and dispatch-boundary persistence.",
-      "owner": "sheawinkler",
+      "path": "tests/tools/test_clarify_tool.py",
+      "rationale": "Clarify tool behavior is covered by Rust-native ClarifyHandler contracts, including schema naming, required question validation, question trimming, choices normalization/limiting, invalid choices rejection, and backend callback forwarding.",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_code_execution.py",
+      "rationale": "Code execution is intentionally Rust-only and excludes Python execution by schema/validation; Rust ExecuteCodeHandler contracts cover explicit language requirements, supported JavaScript/TypeScript/shell schema, timeout forwarding, and backend dispatch.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_command_guards.py",
+      "rationale": "Upstream combined Tirith plus dangerous-command guard intent is covered by Rust hermes-tools approval contracts for container bypass, noninteractive external-scan skip, Tirith allow/warn/block handling, combined warning prompts, session and process approval persistence, scanner-unavailable allow behavior, and scanner programming-error propagation.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_config_null_guard.py",
+      "rationale": "Upstream config null-coalescing intent is covered by Rust typed config null guards: web backend selectors deserialize null as defaults, auxiliary provider/model/base_url/api_key deserialize null as safe defaults, tts.provider null falls through provider resolution, and unknown MCP auth:null does not crash parsing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_credential_files.py",
+      "rationale": "Upstream credential-file mount behavior is covered by Rust credential file contracts for path/name/string entries, missing reporting, path precedence, traversal rejection, absolute-path rejection, symlink escape rejection, filtered hidden skill components, and component-boundary symlink checks.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_cron_approval_mode.py",
+      "rationale": "Upstream cron approval-mode behavior is covered by Rust approval contracts for cron default-deny semantics, approve/off/allow/yes aliases for recoverable commands, hardline denial preservation, and cron-origin precedence over gateway approval routing so scheduled jobs block or allow deterministically without hanging on gateway approval listeners.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_cronjob_tools.py",
+      "rationale": "Cron job tool behavior is covered by Rust CronjobHandler and hermes-cron contracts, including create/list/update/pause/resume/remove/run action dispatch, extended create/update fields, no-agent script mode, context_from forwarding, workdir handling, and prompt-injection guards.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_env_passthrough.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream env passthrough registry/config intent is covered by Rust EnvPassthroughHandler registry contracts, terminal.env_passthrough YAML parsing, HERMES_SUBPROCESS_ENV_PASSTHROUGH mirroring, and LocalBackend sanitizer/profile-cleanup tests proving blocklisted provider and gateway-prefix vars remain blocked by default but pass through when explicitly allowed.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_operations.py",
+      "rationale": "Upstream file operation safety behavior is covered by Rust file-tool contracts for pagination normalization, sensitive write-deny paths, hidden descendant search exclusion, hidden-root visible file search, and JSON search output modes.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_ops_cwd_tracking.py",
+      "rationale": "Upstream live-cwd behavior is covered by Rust LocalBackend and file-tool path contracts that resolve relative file operations against TERMINAL_CWD or the live terminal cwd before process cwd.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_read_guards.py",
+      "rationale": "Upstream read safety guards are covered by Rust contracts for device-path rejection before backend I/O, unbounded read size limits with offset/limit guidance, and internal read_file status text write rejection.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_tools.py",
+      "rationale": "Upstream file tool facade behavior is covered by Rust handler contracts for read/write schemas, missing parameter errors, normalized read/search pagination, patch backend behavior, search output modes, and status-dominated write rejection.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/tools/test_file_write_safety.py",
-      "classification": "intentional_divergence",
       "rationale": "Upstream file write safety and HERMES_WRITE_SAFE_ROOT intent is covered by Rust CredentialGuard contracts for static credential/system write denies, macOS /private/etc and /private/var bypass protection, /boot protection, home credential prefixes, safe-root allow/deny behavior, tilde expansion, and static-deny precedence over safe-root.",
-      "owner": "sheawinkler",
       "ticket": 25
     },
     {
-      "path": "tests/tools/test_fuzzy_match.py",
       "classification": "intentional_divergence",
-      "rationale": "Upstream fuzzy replacement intent is covered by Rust LocalPatchBackend contracts for exact replacement, replace_all behavior, ambiguous single-replacement errors, identical old/new rejection, unicode-normalized smart punctuation matching with surfaced strategy names, and existing whitespace/indent/context fuzzy strategies.",
       "owner": "sheawinkler",
+      "path": "tests/tools/test_fuzzy_match.py",
+      "rationale": "Upstream fuzzy replacement intent is covered by Rust LocalPatchBackend contracts for exact replacement, replace_all behavior, ambiguous single-replacement errors, identical old/new rejection, unicode-normalized smart punctuation matching with surfaced strategy names, and existing whitespace/indent/context fuzzy strategies.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_hardline_blocklist.py",
+      "rationale": "Upstream hardline command-blocklist intent is covered by Rust hermes-tools approval contracts for protected-path recursive deletes, block-device mkfs/dd/redirection, fork bombs, system shutdown/reboot/halt, hardline-before-yolo semantics, container backend bypass, recoverable-dangerous yolo bypass, and sudo stdin/askpass denial unless SUDO_PASSWORD is explicitly configured.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_hidden_dir_filter.py",
+      "rationale": "Upstream hidden directory filtering is covered by Rust component-based hidden path contracts that catch .git, .github, and .hub on Unix and Windows-style paths without rejecting unrelated dotted skill names.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_homeassistant_tool.py",
+      "rationale": "Home Assistant tool behavior is covered by Rust Ha* handlers and HaRestBackend contracts, including list/get/service/call schemas, required entity/service parameters, entity/service validation, blocked service domains, env configuration, auth headers, and REST response parsing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_llm_content_none_guard.py",
+      "rationale": "Upstream OpenAI-compatible message.content None guard intent is covered centrally by Rust OpenAI/OpenRouter response parsing: null assistant content becomes an empty string without panicking, tool-call-only responses keep tool calls, and reasoning-only OpenRouter responses preserve reasoning_content for downstream use.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_local_background_child_hang.py",
+      "rationale": "Upstream local background-child pipe-hang intent is covered by Rust LocalBackend foreground collector contracts for shell-background child prompt return, high-volume output, timeout behavior, multibyte and invalid UTF-8 preservation, and process-group timeout cleanup.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_local_env_blocklist.py",
+      "rationale": "Upstream LocalEnvironment subprocess env-scrubbing intent is covered by Rust hermes-environments contracts for Hermes-managed provider, tool, gateway, GitHub, Modal, Daytona, and Bedrock bearer-token stripping; explicit _HERMES_FORCE_ reinjection; general AWS credential-chain passthrough; and Homebrew PATH fallback preservation.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_local_interrupt_cleanup.py",
+      "rationale": "Upstream local interrupt-cleanup intent is covered by Rust LocalBackend foreground child ownership: foreground process groups are killed on timeout and when the command future is aborted, with regression coverage proving marker child processes are gone after cancellation.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_local_shell_init.py",
+      "rationale": "Upstream local shell init intent is covered by Rust LocalBackend config-driven shell startup sourcing: explicit shell_init_files, auto_source_bashrc disablement, HOME/env expansion, bash/zsh/profile ordering, and an execution test that sources an explicit init file before the command.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_managed_browserbase_and_modal.py",
+      "rationale": "Upstream managed Browserbase/Browser Use/Modal intent is covered by Rust provider contracts: Browserbase remains direct-credential only, Browser Use supports direct and Nous-managed gateway modes with timeout/proxy payloads, idempotency-key preservation across timeout/in-progress conflicts, external-call-id persistence, and Modal backend selection is covered by hermes-config managed gateway and hermes-tools terminal/register_builtins contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_managed_media_gateways.py",
+      "rationale": "Upstream managed media gateway behavior is covered by Rust OpenAI-audio managed endpoint contracts for TTS and transcription plus FAL managed video-generation contracts; direct keys still override managed gateways where required.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_memory_tool.py",
+      "rationale": "Memory tool behavior is covered by Rust MemoryHandler and FileMemoryBackend contracts, including add/replace/remove schema and dispatch, memory/user target validation, persistence formatting, snapshot sanitization, and external drift guards.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_process_registry.py",
+      "rationale": "Process registry behavior is covered by Rust ProcessRegistryHandler, terminal/process backend, and notification formatting contracts, including register/get/poll/update/list/remove/clear actions, status normalization, pid validation, background process lifecycle, log reads, and event draining semantics.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_registry.py",
+      "rationale": "Tool registry behavior is covered by Rust ToolRegistry and dispatch contracts, including registration, availability, lookup/listing, JSON success/error wrapping, unknown-tool errors, result truncation, policy audit/simulation/deny paths, and builtin tool discovery.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_resolve_path.py",
+      "rationale": "Upstream path resolution behavior is covered by Rust resolve_tool_path and LocalBackend contracts for absolute paths, tilde expansion, relative TERMINAL_CWD joins, live cwd precedence, and lexical parent cleanup.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_schema_sanitizer.py",
+      "rationale": "Upstream tool schema sanitizer intent is covered by Rust hermes-core schema sanitizer contracts for OpenAI and Responses tool formats, object/default-property repair, nullable type collapse, required pruning, nested anyOf/items/additionalProperties, reactive pattern/format stripping, slash-enum stripping, and provider formatting integration.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_search_hidden_dirs.py",
+      "rationale": "Upstream hidden search exclusion is covered by Rust LocalSearchBackend contracts that skip .hub/.git-style hidden descendants while preserving visible files under a hidden root and visible skill content.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_send_message_missing_platforms.py",
+      "rationale": "Missing-platform send-message behavior is covered by the Rust gateway-backed messaging tool and platform adapters; SendMessageHandler now exposes all supported gateway platform names, while matrix, mattermost, dingtalk, and homeassistant delivery contracts live in Rust gateway adapter tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_send_message_tool.py",
+      "rationale": "Send message tool behavior is covered by Rust SendMessageHandler, GatewayMessagingBackend, and platform adapter contracts, including required platform/recipient/message parameters, schema platform coverage, backend forwarding, gateway dispatch, chunking/media fallbacks, and platform-specific delivery tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_session_search.py",
+      "rationale": "Session search behavior is covered by Rust SessionSearchHandler and SqliteSessionSearchBackend contracts, including schema shape, browse/search modes, role filters, current-session exclusion, result limit capping, timestamp formatting, scrolling, pattern matching, and hidden-source filtering.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_signal_media.py",
+      "rationale": "Upstream Signal media behavior is covered by Rust gateway SignalAdapter attachment upload, image-url download, text fallback, and platform registration contracts; the Python send_message_tool tests remain reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_env_passthrough.py",
+      "rationale": "Upstream skill required-environment metadata normalization is covered by Rust skill_utils required-env parsing while Ultra exposes env_passthrough as an explicit Rust tool instead of Python's implicit global registry.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_improvements.py",
+      "rationale": "Upstream skill fuzzy-patch intent is covered by the Rust generic patch backend plus skill storage/path guards; Ultra does not vendor the Python-only skill_manager_tool helper.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_manager_tool.py",
+      "rationale": "Upstream skill create/edit/delete validation intent is covered by Rust SkillManager, FileSkillStore, and skill_manage contracts for canonical names/categories, traversal rejection, duplicate creation rejection, managed content size limits, update/delete, and generic fuzzy file patching.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_provenance.py",
+      "rationale": "Upstream skill write-origin ContextVar intent is covered by Rust write-origin provenance guards with foreground fallback, nested restoration, background-review detection, and thread-isolated scope tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_size_limits.py",
+      "rationale": "Upstream managed skill content-size guard intent is covered by Rust SkillManager MAX_SKILL_CONTENT_CHARS tests while hand-placed skill files remain loadable through the store path.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_usage.py",
+      "rationale": "Upstream skill usage sidecar, curator provenance filtering, protected bundled/hub exclusions, archiving, restore, pin/state, and agent-created reporting intent is covered by Rust SkillUsageRecord and usage module contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skill_view_traversal.py",
+      "rationale": "Upstream skill_view traversal regression intent is covered by Rust SkillViewHandler tests for dot-dot traversal, legitimate in-skill file reads, symlink escape rejection, and secret non-leakage.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skills_guard.py",
+      "rationale": "Upstream skill security scanner intent is covered by Rust SkillGuard install policy, trust-level resolution, file and directory scanning, content hashing, symlink escape detection, invisible Unicode, prompt-injection, credential, eval, reverse-shell, and destructive command findings.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skills_hub.py",
+      "rationale": "Upstream skills hub trust, content hashing, and remote skill integrity intent is covered by Rust SkillsHubClient search/download/upload/update contracts, Ed25519 signature verification, trusted source resolution, and scan-before-use policy; Python source-adapter breadth remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skills_hub_clawhub.py",
+      "rationale": "Upstream ClawHub listing/detail/search repair/version/file mapping intent is covered by Rust ClawHub registry metadata parsing, exact-slug repair, hyphenated query normalization, latest-version extraction, and inline/raw file reference contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skills_sync.py",
+      "rationale": "Upstream bundled skill manifest sync/reset/optional provenance intent is covered by Rust sync contracts for v1/v2 manifests, stable hashes, category-preserving copy, collision non-poisoning, user-modified protection, reset/restore, and official optional lock backfill.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_skills_tool.py",
+      "rationale": "Upstream skills_tool discovery/frontmatter/tag/platform/view intent is covered by Rust skill_utils frontmatter fallback, tag parsing, recursive safe discovery, required-env metadata parsing, platform matching, and SkillViewHandler/SkillsListHandler contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_symlink_prefix_confusion.py",
+      "rationale": "Upstream symlink prefix-confusion regression is covered by Rust root-boundary contracts using Path strip_prefix semantics so sibling directories sharing a prefix escape while real subpaths and the root itself pass.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_compound_background.py",
+      "rationale": "Upstream compound-background rewrite intent is covered by Rust LocalBackend rewrite_compound_background contracts for &&/|| chains, redirects, quoting, idempotence, newlines, pipes, and simple-background passthrough.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_config_env_sync.py",
+      "rationale": "Upstream terminal config/env drift intent is covered by Rust hermes-config central bridge mapping, config-set env sync, YAML-to-env load bridging without overriding existing env, Docker resource/env/volume consumption, and backend manager plumbing for terminal runtime keys.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_foreground_timeout_cap.py",
+      "rationale": "Upstream foreground timeout cap and background-wrapper/server guard intent is covered by Rust TerminalHandler contracts for explicit >600s foreground rejection, background exemption, schema hint, nohup/& wrapper rejection, long-lived server detection, and help passthrough.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_requirements.py",
+      "rationale": "Upstream terminal requirements intent is covered by Rust terminal_requirements gates for local, docker, singularity/apptainer, ssh host/user, modal direct/managed selection, daytona API-key presence, and unknown backend rejection; local Vercel Sandbox Python salvage is intentionally not exposed because no Rust terminal backend exists for it.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_task_cwd.py",
+      "rationale": "Upstream ACP task cwd intent is covered by Rust TerminalHandler task cwd registration: commands with task_id inherit registered cwd when workdir is omitted, and explicit workdir keeps precedence.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_terminal_tool_requirements.py",
+      "rationale": "Upstream tool availability intent is covered by Rust ToolRegistry check_fn gating for terminal-backed tools: local and managed-modal backends expose terminal/process/file tools, invalid terminal backends hide terminal/process/read_file/write_file/process_registry, and Rust execute_code remains independently available as local non-Python execution.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tool_output_limits.py",
+      "rationale": "Upstream configurable tool-output limit intent is covered by Rust ToolOutputConfig defaults and tolerant parsing plus read_file pagination clamping through tool_output.max_lines; Rust keeps agent budget truncation separate from tool display limits.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tool_result_storage.py",
+      "rationale": "Upstream three-layer tool result persistence intent is covered by Rust tool_result_storage and dispatch contracts for newline-aware previews, heredoc delimiter safety, quoted sandbox write commands, local persisted-output blocks, read_file guidance, unicode-safe previews, threshold-zero persistence, read_file no-persist semantics, aggregate budget spilling, and dispatch-boundary persistence.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_transcription.py",
+      "rationale": "Upstream transcription behavior is covered by Rust transcription handler contracts for audio extension mapping, credential/gateway endpoint resolution, missing-path errors, and model-specific response parsing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_transcription_dotenv_fallback.py",
+      "rationale": "Upstream transcription key fallback behavior is covered by Rust openai-audio credential resolution contracts that prefer VOICE_TOOLS_OPENAI_KEY before HERMES_OPENAI_API_KEY and legacy OPENAI_API_KEY.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_transcription_tools.py",
+      "rationale": "Upstream STT provider semantics are covered by Rust transcription contracts for explicit OpenAI-audio routing, managed/direct credential order, extension MIME mapping, and whisper text versus GPT transcribe JSON response formats.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tts_command_providers.py",
+      "rationale": "Upstream command-provider TTS behavior is covered by Rust MultiTtsBackend contracts for provider lookup, reserved built-in names, command template quoting, timeout/output validation, output format, voice-compatible media tags, and max_text_length.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tts_dotenv_fallback.py",
+      "rationale": "Upstream TTS credential fallback behavior is covered by Rust openai-audio contracts that prefer VOICE_TOOLS_OPENAI_KEY, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY, with Nous-managed audio gateway support.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tts_kittentts.py",
+      "rationale": "KittenTTS remains an intentional Python-provider divergence in Hermes Agent Ultra; Rust TTS contracts reject Python-only providers with migration guidance while retaining Rust-native OpenAI, ElevenLabs, MiniMax, Piper, and command-provider paths.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tts_max_text_length.py",
+      "rationale": "Upstream per-provider TTS length behavior is covered by Rust resolve_max_text_length contracts for OpenAI, xAI, MiniMax, ElevenLabs model-specific limits, Piper, command providers, overrides, and fallback limits.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tts_piper.py",
+      "rationale": "Upstream Piper behavior is covered by Rust-native Piper contracts using the local piper binary and PIPER_MODEL/PIPER_* knobs, with model-required errors and zero-Python runtime enforcement.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_tts_speed.py",
+      "rationale": "Upstream TTS speed behavior is covered by Rust contracts for provider/global speed precedence, OpenAI speed clamping, command-provider speed placeholder rendering, and MiniMax raw-audio payload shape without legacy voice_setting.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_url_safety.py",
+      "rationale": "Upstream URL safety/SSRF intent is covered by Rust hermes-tools url_safety contracts for http/https-only parsing, DNS fail-closed behavior, private/reserved IPv4 and IPv6 blocking including CGNAT, benchmark, multicast, and IPv4-mapped IPv6 ranges, metadata hostname/IP always-blocking, allow_private_urls toggle semantics, and the exact QQ multimedia benchmark-IP exception.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_video_analyze.py",
+      "rationale": "Upstream video analysis behavior is covered by Rust VideoAnalyzeHandler and VisionFrameSamplingVideoBackend contracts for schema/aliases, safe prompt defaults, max frame clamping, MIME detection, data-url encoding, unsupported formats, and frame-sampled vision synthesis.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_vision_native_fast_path.py",
+      "rationale": "Upstream native-vision intent is covered by Rust ACP/provider multimodal contracts and OpenAI-compatible vision backend contracts for data URLs, image MIME detection, unsafe URL rejection, and auxiliary vision model selection.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_vision_tools.py",
+      "rationale": "Upstream vision tool behavior is covered by Rust VisionAnalyzeHandler and OpenAiVisionBackend contracts for schemas, question forwarding, AUXILIARY_VISION_MODEL precedence, local image base64 data URLs, MIME detection, and URL safety.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_voice_cli_integration.py",
+      "rationale": "Upstream CLI voice integration is covered by Rust voice_mode toggle, TTS streaming pipeline, markdown/think scrubbing, CLI /voice status, and tool-preview contracts; Python microphone-loop tests remain reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_voice_mode.py",
+      "rationale": "Upstream voice-mode behavior is covered by Rust voice_mode state contracts plus gateway voice manager STT/TTS join/leave/VAD contracts; local Python audio-stack detection is intentionally not part of the Rust runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_providers.py",
+      "rationale": "Ultra supersedes upstream Python WebSearchProvider/WebExtractProvider ABC tests with Rust WebSearchBackend, WebExtractBackend, and WebCrawlBackend traits plus handler tests; Rust backend env tests prove per-capability search/extract selection over the generic web backend.",
+      "ticket": 306
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_providers_brave_free.py",
+      "rationale": "Upstream Brave free provider intent is covered by Rust BraveFreeSearchBackend contracts for BRAVE_SEARCH_API_KEY gating, X-Subscription-Token requests, count clamping, result normalization, explicit/generic backend selection, auto-detect priority, and search-only extract/crawl error routing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_providers_ddgs.py",
+      "rationale": "Upstream ddgs provider intent is covered by Rust DuckDuckGoSearchBackend contracts for keyless DuckDuckGo search, abstract/related-topic normalization, one-indexed positions, explicit/generic ddgs and duckduckgo backend aliases, last-resort auto-detect, and search-only extract/crawl error routing.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_providers_searxng.py",
+      "rationale": "Upstream SearXNG provider intent is covered by Rust SearxngSearchBackend contracts for SEARXNG_BASE_URL and SEARXNG_URL aliases, trailing-slash normalization, score-descending sorting, limit truncation, result normalization, availability checks, and search-only extract/crawl errors.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_tools_config.py",
+      "rationale": "Ultra covers upstream web tools config behavior in Rust web backend tests for Exa/Tavily/Firecrawl/SearXNG/Brave/DDG/xAI selection, per-capability overrides, legacy generic backend fallback, managed Firecrawl gateway resolution, secret guards, singleton-free env re-resolution, and normalized provider payloads.",
+      "ticket": 306
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_tools_tavily.py",
+      "rationale": "Upstream Tavily web-tool intent is covered by Rust Tavily search/extract/crawl backend contracts for API-key body payloads, base URL handling, search result normalization, extracted document and failed-result normalization, and handler dispatch through the Rust web tool backend registry.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_website_policy.py",
+      "rationale": "Upstream website blocklist policy intent is covered by Rust website_policy contracts for security.website_blocklist defaults, inline and shared-file domain loading, malformed config errors, invalid shape errors, parent-domain matching, wildcard-subdomain semantics, and unreadable shared-file warning behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_write_deny.py",
+      "rationale": "Upstream write-deny behavior is covered by Rust CredentialGuard contracts for /etc sensitive files, sudoers/systemd prefixes, SSH/AWS/GnuPG/Kube home prefixes, shell/package credential files, profile-aware HERMES_HOME/.env, and allowed project/config paths.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_yolo_mode.py",
+      "rationale": "Upstream yolo approval-bypass intent is covered by Rust hermes-tools and hermes-gateway contracts for truthy and false-like HERMES_YOLO_MODE handling, recoverable-command bypass, hardline and sudo-stdin floors, session-scoped /yolo state, terminal handler session bypass, and session cleanup. Python's combined Tirith hook path is not a separate Rust runtime boundary.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/tui_gateway",
+      "rationale": "TUI gateway tests cover interactive gateway behavior and must stay parity-reviewed against Rust-native UX/runtime contracts.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "ui-tui",
+      "rationale": "TUI package and documentation deltas can affect distributed interactive UX behavior and must be reviewed against Hermes Ultra's Rust-primary UX surface.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "ui-tui/packages",
+      "rationale": "TUI package differences affect distributed interactive UI behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src",
+      "rationale": "TUI source differences affect interactive UX/runtime surfaces.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "website",
+      "rationale": "Website top-level package, sidebar, localization, and static API files support documentation publishing and are not Rust runtime behavior unless covered by more specific functional classifications.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "website/docs",
+      "rationale": "Documentation-site content differs by project positioning and release policy; runtime behavior is unaffected.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "website/scripts",
+      "rationale": "Website build/generation scripts differ for local documentation publishing and do not affect Hermes runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "website/src",
+      "rationale": "Website source differs for documentation/product presentation and does not change Rust runtime behavior.",
       "ticket": 25
     }
-  ]
+  ],
+  "schema_version": 1
 }


### PR DESCRIPTION
## Summary
- add Rust-native provider profile request shaping for Qwen, Kimi, Nous, OpenRouter, and local/custom providers
- wire provider profiles through runtime GenericProvider construction, bundled provider wrappers, OpenRouter headers, and CLI provider aliases
- add Rust contract coverage for provider profiles, model-provider plugin discovery, bundled provider directories, and azure-foundry aliases
- update parity ledgers, reducing `pending_review` from 382 to 376 for the provider/profile slice

## Verification
- `cargo build --workspace` passed
- `cargo test --workspace` passed before final one-line clippy cleanup
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p hermes-agent provider_profile_request_body -- --nocapture`
- `scripts/clippy-warning-gate.sh --check` (`new=0`, `stale=4` pre-existing safe-to-prune entries)
