### PR TITLE
parity(video): add xAI video backend

### DIFF
--- a/crates/hermes-tools/src/backends/video_gen.rs
+++ b/crates/hermes-tools/src/backends/video_gen.rs
@@ -6,10 +6,12 @@
 //! `fal-queue` gateway resolver.
 
 use async_trait::async_trait;
+use base64::Engine;
 use reqwest::Client;
 use serde_json::{Map, Value};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
+use uuid::Uuid;
 
 use crate::tools::video::{VideoGenerateBackend, VideoGenerateRequest};
 use hermes_config::managed_gateway::{
@@ -20,6 +22,19 @@ use hermes_core::ToolError;
 const DEFAULT_FAL_VIDEO_MODEL: &str = "pixverse-v6";
 const DEFAULT_TIMEOUT_SECONDS: u64 = 600;
 const DEFAULT_POLL_INTERVAL_SECONDS: u64 = 2;
+
+const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
+const DEFAULT_XAI_TEXT_TO_VIDEO_MODEL: &str = "grok-imagine-video";
+const DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL: &str = "grok-imagine-video-1.5-preview";
+const XAI_IMAGE_TO_VIDEO_MODEL_ALIAS: &str = "grok-imagine-video-1.5-2026-05-30";
+const DEFAULT_XAI_DURATION: u32 = 8;
+const DEFAULT_XAI_ASPECT_RATIO: &str = "16:9";
+const DEFAULT_XAI_RESOLUTION: &str = "720p";
+const DEFAULT_XAI_TIMEOUT_SECONDS: u64 = 240;
+const DEFAULT_XAI_POLL_INTERVAL_SECONDS: u64 = 5;
+const XAI_MAX_REFERENCE_IMAGES: usize = 7;
+const XAI_VALID_ASPECT_RATIOS: &[&str] = &["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"];
+const XAI_VALID_RESOLUTIONS: &[&str] = &["480p", "720p"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DurationSpec {
@@ -316,6 +331,247 @@ impl FalVideoGenBackend {
     }
 }
 
+/// xAI Grok Imagine video credentials resolved from env or Hermes auth store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XaiVideoCredentials {
+    pub api_key: String,
+    pub base_url: String,
+    pub source: String,
+}
+
+/// xAI video generation backend using `/videos/generations`.
+#[derive(Debug)]
+pub struct XaiVideoGenBackend {
+    client: Client,
+    credentials: Option<XaiVideoCredentials>,
+}
+
+impl XaiVideoGenBackend {
+    pub fn new(credentials: XaiVideoCredentials) -> Self {
+        Self {
+            client: Client::new(),
+            credentials: Some(credentials),
+        }
+    }
+
+    pub fn unconfigured() -> Self {
+        Self {
+            client: Client::new(),
+            credentials: None,
+        }
+    }
+
+    pub fn from_env_or_auth_store() -> Result<Self, ToolError> {
+        Ok(Self::new(resolve_xai_video_credentials()?))
+    }
+
+    pub fn credentials(&self) -> Option<&XaiVideoCredentials> {
+        self.credentials.as_ref()
+    }
+
+    pub fn transport_label(&self) -> &'static str {
+        match self.credentials.as_ref().map(|creds| creds.source.as_str()) {
+            Some("env") => "direct",
+            Some(_) => "auth-store",
+            None => "unconfigured",
+        }
+    }
+
+    async fn submit_xai_generation(
+        &self,
+        credentials: &XaiVideoCredentials,
+        payload: &Value,
+    ) -> Result<String, ToolError> {
+        let url = format!("{}/videos/generations", credentials.base_url);
+        let resp = self
+            .client
+            .post(url)
+            .bearer_auth(&credentials.api_key)
+            .header("Content-Type", "application/json")
+            .header("User-Agent", xai_user_agent())
+            .header("x-idempotency-key", Uuid::new_v4().to_string())
+            .json(payload)
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("xAI video submit failed: {e}")))?;
+        let body = read_json_response(resp, "xAI video submit").await?;
+        body.get("request_id")
+            .or_else(|| body.get("id"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| {
+                ToolError::ExecutionFailed("xAI video response did not include request_id".into())
+            })
+    }
+
+    async fn poll_xai_generation(
+        &self,
+        credentials: &XaiVideoCredentials,
+        request_id: &str,
+    ) -> Result<Value, ToolError> {
+        let timeout = env_u64("XAI_VIDEO_TIMEOUT_SECONDS").unwrap_or(DEFAULT_XAI_TIMEOUT_SECONDS);
+        let poll_interval =
+            env_u64("XAI_VIDEO_POLL_INTERVAL_SECONDS").unwrap_or(DEFAULT_XAI_POLL_INTERVAL_SECONDS);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
+        let url = format!("{}/videos/{request_id}", credentials.base_url);
+        let mut last_status = String::from("queued");
+
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                return Err(ToolError::ExecutionFailed(format!(
+                    "Timed out waiting for xAI video generation after {timeout}s; last status: {last_status}"
+                )));
+            }
+
+            let resp = self
+                .client
+                .get(&url)
+                .bearer_auth(&credentials.api_key)
+                .header("User-Agent", xai_user_agent())
+                .send()
+                .await
+                .map_err(|e| {
+                    ToolError::ExecutionFailed(format!("xAI video status request failed: {e}"))
+                })?;
+            let body = read_json_response(resp, "xAI video status").await?;
+            last_status = body
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+
+            match last_status.as_str() {
+                "done" | "completed" | "succeeded" => return Ok(body),
+                "failed" | "error" | "expired" | "cancelled" | "canceled" => {
+                    let message = extract_xai_failure_message(&body)
+                        .unwrap_or_else(|| format!("xAI video generation failed: {last_status}"));
+                    return Err(ToolError::ExecutionFailed(message));
+                }
+                _ => tokio::time::sleep(Duration::from_secs(poll_interval.max(1))).await,
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl VideoGenerateBackend for XaiVideoGenBackend {
+    async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError> {
+        let credentials = self.credentials.as_ref().ok_or_else(|| {
+            ToolError::ExecutionFailed(
+                "No xAI credentials found. Sign in via `hermes auth add xai-oauth` or set XAI_API_KEY.".into(),
+            )
+        })?;
+
+        let prompt = request.prompt.trim();
+        if prompt.is_empty() {
+            return Err(ToolError::InvalidParams(
+                "prompt is required for xAI video generation.".into(),
+            ));
+        }
+
+        let xai_payload = build_xai_payload(&request)?;
+        let payload = Value::Object(xai_payload.payload);
+        let request_id = self.submit_xai_generation(credentials, &payload).await?;
+        let response = self
+            .poll_xai_generation(credentials, request_id.as_str())
+            .await?;
+        let video = extract_video(&response).ok_or_else(|| {
+            ToolError::ExecutionFailed("xAI returned no video URL in response".into())
+        })?;
+
+        let mut out = Map::new();
+        out.insert("success".into(), Value::Bool(true));
+        out.insert("video".into(), Value::String(video.url));
+        out.insert("model".into(), Value::String(xai_payload.model));
+        out.insert("prompt".into(), Value::String(prompt.to_string()));
+        out.insert("modality".into(), Value::String(xai_payload.modality));
+        out.insert(
+            "aspect_ratio".into(),
+            Value::String(xai_payload.aspect_ratio),
+        );
+        out.insert(
+            "duration".into(),
+            Value::Number(xai_payload.duration.into()),
+        );
+        out.insert("provider".into(), Value::String("xai".into()));
+        out.insert("request_id".into(), Value::String(request_id));
+        out.insert("resolution".into(), Value::String(xai_payload.resolution));
+        out.insert(
+            "transport".into(),
+            Value::String(self.transport_label().to_string()),
+        );
+        if let Some(file_size) = video.file_size {
+            out.insert("file_size".into(), Value::Number(file_size.into()));
+        }
+        if let Some(content_type) = video.content_type {
+            out.insert("content_type".into(), Value::String(content_type));
+        }
+        if let Some(usage) = response.get("usage").cloned() {
+            out.insert("usage".into(), usage);
+        }
+
+        Ok(Value::Object(out).to_string())
+    }
+}
+
+/// Configured built-in video generation backend.
+#[derive(Debug)]
+pub enum VideoGenBackend {
+    Fal(FalVideoGenBackend),
+    Xai(XaiVideoGenBackend),
+}
+
+impl VideoGenBackend {
+    pub fn from_env_or_managed() -> Self {
+        match selected_video_provider() {
+            Some("xai") => XaiVideoGenBackend::from_env_or_auth_store()
+                .unwrap_or_else(|_| XaiVideoGenBackend::unconfigured())
+                .into(),
+            _ => FalVideoGenBackend::from_env_or_managed()
+                .unwrap_or_else(|_| FalVideoGenBackend::unconfigured())
+                .into(),
+        }
+    }
+
+    pub fn provider_label(&self) -> &'static str {
+        match self {
+            Self::Fal(_) => "fal",
+            Self::Xai(_) => "xai",
+        }
+    }
+
+    pub fn required_env_vars(&self) -> Vec<String> {
+        match self {
+            Self::Fal(_) => vec!["FAL_KEY".into()],
+            Self::Xai(_) => vec!["XAI_API_KEY".into()],
+        }
+    }
+}
+
+impl From<FalVideoGenBackend> for VideoGenBackend {
+    fn from(value: FalVideoGenBackend) -> Self {
+        Self::Fal(value)
+    }
+}
+
+impl From<XaiVideoGenBackend> for VideoGenBackend {
+    fn from(value: XaiVideoGenBackend) -> Self {
+        Self::Xai(value)
+    }
+}
+
+#[async_trait]
+impl VideoGenerateBackend for VideoGenBackend {
+    async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError> {
+        match self {
+            Self::Fal(backend) => backend.generate_video(request).await,
+            Self::Xai(backend) => backend.generate_video(request).await,
+        }
+    }
+}
+
 #[async_trait]
 impl VideoGenerateBackend for FalVideoGenBackend {
     async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError> {
@@ -462,6 +718,204 @@ fn build_payload(family: &FalVideoFamily, request: &VideoGenerateRequest) -> Pay
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct XaiPayloadMeta {
+    payload: Map<String, Value>,
+    model: String,
+    modality: String,
+    aspect_ratio: String,
+    resolution: String,
+    duration: u32,
+}
+
+fn build_xai_payload(request: &VideoGenerateRequest) -> Result<XaiPayloadMeta, ToolError> {
+    let prompt = request.prompt.trim();
+    if prompt.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "prompt is required for xAI video generation.".into(),
+        ));
+    }
+
+    let image_url = request
+        .image_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let reference_images = normalize_xai_reference_images(&request.reference_image_urls);
+    if image_url.is_some() && !reference_images.is_empty() {
+        return Err(ToolError::InvalidParams(
+            "image_url and reference_image_urls cannot be combined on xAI.".into(),
+        ));
+    }
+    if reference_images.len() > XAI_MAX_REFERENCE_IMAGES {
+        return Err(ToolError::InvalidParams(format!(
+            "reference_image_urls supports at most {XAI_MAX_REFERENCE_IMAGES} images on xAI."
+        )));
+    }
+
+    let modality = if image_url.is_some() || !reference_images.is_empty() {
+        "image"
+    } else {
+        "text"
+    };
+    let model =
+        resolve_xai_model_for_modality(request.model.as_deref(), modality, request.model_explicit);
+    let aspect_ratio = normalize_xai_choice(
+        request.aspect_ratio.as_str(),
+        XAI_VALID_ASPECT_RATIOS,
+        DEFAULT_XAI_ASPECT_RATIO,
+    );
+    let resolution = normalize_xai_choice(
+        request.resolution.as_str(),
+        XAI_VALID_RESOLUTIONS,
+        DEFAULT_XAI_RESOLUTION,
+    )
+    .to_ascii_lowercase();
+    let duration = clamp_xai_duration(request.duration, !reference_images.is_empty());
+
+    let mut payload = Map::new();
+    payload.insert("model".into(), Value::String(model.clone()));
+    payload.insert("prompt".into(), Value::String(prompt.to_string()));
+    payload.insert("duration".into(), Value::Number(duration.into()));
+    payload.insert("aspect_ratio".into(), Value::String(aspect_ratio.clone()));
+    payload.insert("resolution".into(), Value::String(resolution.clone()));
+    if let Some(image_url) = image_url {
+        let mut image = Map::new();
+        image.insert("url".into(), Value::String(image_ref_to_xai_url(image_url)));
+        payload.insert("image".into(), Value::Object(image));
+    }
+    if !reference_images.is_empty() {
+        payload.insert(
+            "reference_images".into(),
+            Value::Array(
+                reference_images
+                    .into_iter()
+                    .map(|url| {
+                        let mut image = Map::new();
+                        image.insert("url".into(), Value::String(url));
+                        Value::Object(image)
+                    })
+                    .collect(),
+            ),
+        );
+    }
+
+    Ok(XaiPayloadMeta {
+        payload,
+        model,
+        modality: modality.to_string(),
+        aspect_ratio,
+        resolution,
+        duration,
+    })
+}
+
+fn normalize_xai_reference_images(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| image_ref_to_xai_url(value))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn image_ref_to_xai_url(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with("data:image/")
+    {
+        return trimmed.to_string();
+    }
+
+    let expanded = expand_user_path(trimmed);
+    if !expanded.is_file() {
+        return trimmed.to_string();
+    }
+    let Some(mime) = image_mime_for_path(&expanded).filter(|mime| mime.starts_with("image/"))
+    else {
+        return trimmed.to_string();
+    };
+    let Ok(bytes) = std::fs::read(&expanded) else {
+        return trimmed.to_string();
+    };
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:{mime};base64,{encoded}")
+}
+
+fn expand_user_path(value: &str) -> PathBuf {
+    if value == "~" {
+        return user_home_dir().unwrap_or_else(|| PathBuf::from(value));
+    }
+    if let Some(stripped) = value.strip_prefix("~/") {
+        if let Some(home) = user_home_dir() {
+            return home.join(stripped);
+        }
+    }
+    PathBuf::from(value)
+}
+
+fn image_mime_for_path(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("jpg" | "jpeg") => Some("image/jpeg"),
+        Some("png") => Some("image/png"),
+        Some("gif") => Some("image/gif"),
+        Some("webp") => Some("image/webp"),
+        Some("bmp") => Some("image/bmp"),
+        Some("avif") => Some("image/avif"),
+        Some("svg") => Some("image/svg+xml"),
+        _ => None,
+    }
+}
+
+fn clamp_xai_duration(duration: Option<u32>, has_reference_images: bool) -> u32 {
+    let mut value = duration.unwrap_or(DEFAULT_XAI_DURATION).clamp(1, 15);
+    if has_reference_images {
+        value = value.min(10);
+    }
+    value
+}
+
+fn normalize_xai_choice(value: &str, valid: &[&str], default: &str) -> String {
+    let trimmed = value.trim();
+    if valid.contains(&trimmed) {
+        trimmed.to_string()
+    } else {
+        default.to_string()
+    }
+}
+
+fn resolve_xai_model_for_modality(
+    model: Option<&str>,
+    modality: &str,
+    explicit_model: bool,
+) -> String {
+    let requested = model.map(str::trim).filter(|value| !value.is_empty());
+    if explicit_model {
+        if let Some(requested) = requested {
+            return requested.to_string();
+        }
+    }
+    if modality == "image" {
+        return DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL.to_string();
+    }
+    match requested {
+        Some(DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL | XAI_IMAGE_TO_VIDEO_MODEL_ALIAS) => {
+            DEFAULT_XAI_TEXT_TO_VIDEO_MODEL.to_string()
+        }
+        Some(requested) => requested.to_string(),
+        None => DEFAULT_XAI_TEXT_TO_VIDEO_MODEL.to_string(),
+    }
+}
+
 fn clamp_duration(spec: Option<DurationSpec>, duration: Option<u32>) -> Option<u32> {
     match spec {
         None => None,
@@ -505,6 +959,31 @@ fn configured_video_model_candidates() -> Vec<String> {
     out
 }
 
+fn selected_video_provider() -> Option<&'static str> {
+    let mut candidates = Vec::new();
+    if let Some(provider) =
+        env_string("HERMES_VIDEO_GEN_BACKEND").or_else(|| env_string("VIDEO_GEN_BACKEND"))
+    {
+        candidates.push(provider);
+    }
+    candidates.extend(configured_video_provider_candidates());
+
+    candidates
+        .into_iter()
+        .find_map(|candidate| normalize_video_provider(candidate.as_str()))
+}
+
+fn configured_video_provider_candidates() -> Vec<String> {
+    let mut out = Vec::new();
+    for path in [
+        hermes_config::cli_config_path(),
+        hermes_config::config_path(),
+    ] {
+        collect_video_provider_candidates(&path, &mut out);
+    }
+    out
+}
+
 fn collect_video_model_candidates(path: &Path, out: &mut Vec<String>) {
     let Ok(raw) = std::fs::read_to_string(path) else {
         return;
@@ -527,8 +1006,151 @@ fn collect_video_model_candidates(path: &Path, out: &mut Vec<String>) {
     }
 }
 
+fn collect_video_provider_candidates(path: &Path, out: &mut Vec<String>) {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(root) = serde_yaml::from_str::<serde_yaml::Value>(&raw) else {
+        return;
+    };
+    let Some(video_gen) = root.get("video_gen") else {
+        return;
+    };
+    for key in ["provider", "backend"] {
+        if let Some(provider) = video_gen.get(key).and_then(serde_yaml::Value::as_str) {
+            out.push(provider.to_string());
+        }
+    }
+}
+
+fn normalize_video_provider(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "xai" | "x.ai" | "grok" | "grok-imagine" | "grok-imagine-video" => Some("xai"),
+        "fal" | "fal-ai" | "fal_ai" | "fal-queue" => Some("fal"),
+        _ => None,
+    }
+}
+
 fn env_u64(name: &str) -> Option<u64> {
     std::env::var(name).ok()?.trim().parse::<u64>().ok()
+}
+
+fn env_string(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn resolve_xai_video_credentials() -> Result<XaiVideoCredentials, ToolError> {
+    if let Some(api_key) = env_string("HERMES_XAI_API_KEY").or_else(|| env_string("XAI_API_KEY")) {
+        return Ok(XaiVideoCredentials {
+            api_key,
+            base_url: env_string("HERMES_XAI_BASE_URL")
+                .or_else(|| env_string("XAI_BASE_URL"))
+                .unwrap_or_else(|| DEFAULT_XAI_BASE_URL.to_string())
+                .trim_end_matches('/')
+                .to_string(),
+            source: "env".to_string(),
+        });
+    }
+
+    for path in auth_store_candidates() {
+        if let Some(credentials) = read_xai_credentials_from_auth_store(&path) {
+            return Ok(credentials);
+        }
+    }
+
+    Err(ToolError::ExecutionFailed(
+        "No xAI credentials found. Sign in via `hermes auth add xai-oauth` or set XAI_API_KEY."
+            .into(),
+    ))
+}
+
+fn auth_store_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = env_string("HERMES_AUTH_FILE") {
+        candidates.push(PathBuf::from(path));
+    }
+    candidates.push(hermes_config::paths::auth_json_path());
+    if let Some(home) = user_home_dir() {
+        candidates.push(home.join(".hermes-agent-ultra").join("auth.json"));
+        candidates.push(home.join(".hermes").join("auth.json"));
+    }
+
+    let mut seen = Vec::<PathBuf>::new();
+    candidates
+        .into_iter()
+        .filter(|path| path.is_file())
+        .filter(|path| {
+            if seen.contains(path) {
+                false
+            } else {
+                seen.push(path.clone());
+                true
+            }
+        })
+        .collect()
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn read_xai_credentials_from_auth_store(path: &PathBuf) -> Option<XaiVideoCredentials> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<Value>(&raw).ok()?;
+    let providers = value.get("providers").and_then(Value::as_object)?;
+    let provider = ["xai", "xai-oauth", "xai_oauth"]
+        .into_iter()
+        .find_map(|name| providers.get(name).and_then(Value::as_object))?;
+    let api_key = provider
+        .get("api_key")
+        .or_else(|| provider.get("access_token"))
+        .or_else(|| provider.get("token"))
+        .or_else(|| provider.get("bearer_token"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    let base_url = provider
+        .get("base_url")
+        .or_else(|| provider.get("api_base_url"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_XAI_BASE_URL)
+        .trim_end_matches('/')
+        .to_string();
+    Some(XaiVideoCredentials {
+        api_key,
+        base_url,
+        source: path.display().to_string(),
+    })
+}
+
+fn xai_user_agent() -> &'static str {
+    "hermes-agent/video_gen"
+}
+
+fn extract_xai_failure_message(value: &Value) -> Option<String> {
+    value
+        .get("error")
+        .and_then(|error| {
+            error
+                .as_object()
+                .and_then(|object| object.get("message").and_then(Value::as_str))
+                .or_else(|| error.as_str())
+        })
+        .or_else(|| value.get("message").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 async fn read_json_response(resp: reqwest::Response, label: &str) -> Result<Value, ToolError> {
@@ -600,10 +1222,20 @@ mod tests {
             let tmp = tempfile::tempdir().unwrap();
             let keys = [
                 "HERMES_HOME",
+                "HOME",
+                "HERMES_AUTH_FILE",
                 "FAL_KEY",
                 "FAL_VIDEO_MODEL",
                 "FAL_VIDEO_TIMEOUT_SECONDS",
                 "FAL_VIDEO_POLL_INTERVAL_SECONDS",
+                "HERMES_VIDEO_GEN_BACKEND",
+                "VIDEO_GEN_BACKEND",
+                "HERMES_XAI_API_KEY",
+                "XAI_API_KEY",
+                "HERMES_XAI_BASE_URL",
+                "XAI_BASE_URL",
+                "XAI_VIDEO_TIMEOUT_SECONDS",
+                "XAI_VIDEO_POLL_INTERVAL_SECONDS",
                 "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
                 "TOOL_GATEWAY_USER_TOKEN",
                 "TOOL_GATEWAY_DOMAIN",
@@ -637,7 +1269,9 @@ mod tests {
         VideoGenerateRequest {
             prompt: "make a trailer".into(),
             model: model.map(ToOwned::to_owned),
+            model_explicit: model.is_some(),
             image_url: None,
+            reference_image_urls: Vec::new(),
             duration: None,
             aspect_ratio: "16:9".into(),
             resolution: "720p".into(),
@@ -785,5 +1419,147 @@ mod tests {
                 .url,
             "https://cdn.example/v.mp4"
         );
+    }
+
+    #[test]
+    fn xai_routes_default_models_by_modality() {
+        assert_eq!(
+            resolve_xai_model_for_modality(Some(DEFAULT_XAI_TEXT_TO_VIDEO_MODEL), "text", false),
+            DEFAULT_XAI_TEXT_TO_VIDEO_MODEL
+        );
+        assert_eq!(
+            resolve_xai_model_for_modality(Some(DEFAULT_XAI_TEXT_TO_VIDEO_MODEL), "image", false),
+            DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL
+        );
+        assert_eq!(
+            resolve_xai_model_for_modality(Some(DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL), "text", false),
+            DEFAULT_XAI_TEXT_TO_VIDEO_MODEL
+        );
+        assert_eq!(
+            resolve_xai_model_for_modality(Some(DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL), "text", true),
+            DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL
+        );
+    }
+
+    #[test]
+    fn xai_payload_normalizes_references_duration_resolution_and_aspect() {
+        let mut req = request(None);
+        req.reference_image_urls = vec!["https://example.com/a.png".into()];
+        req.duration = Some(15);
+        req.aspect_ratio = "not-valid".into();
+        req.resolution = "1080p".into();
+
+        let meta = build_xai_payload(&req).unwrap();
+        assert_eq!(meta.model, DEFAULT_XAI_IMAGE_TO_VIDEO_MODEL);
+        assert_eq!(meta.modality, "image");
+        assert_eq!(meta.duration, 10);
+        assert_eq!(meta.aspect_ratio, DEFAULT_XAI_ASPECT_RATIO);
+        assert_eq!(meta.resolution, DEFAULT_XAI_RESOLUTION);
+        assert_eq!(
+            meta.payload.get("reference_images"),
+            Some(&json!([
+                {"url": "https://example.com/a.png"}
+            ]))
+        );
+    }
+
+    #[test]
+    fn xai_payload_rejects_conflicting_or_too_many_image_inputs() {
+        let mut req = request(None);
+        req.image_url = Some("https://example.com/start.png".into());
+        req.reference_image_urls = vec!["https://example.com/a.png".into()];
+        assert!(build_xai_payload(&req)
+            .unwrap_err()
+            .to_string()
+            .contains("cannot be combined"));
+
+        let mut req = request(None);
+        req.reference_image_urls = (0..=XAI_MAX_REFERENCE_IMAGES)
+            .map(|idx| format!("https://example.com/{idx}.png"))
+            .collect();
+        assert!(build_xai_payload(&req)
+            .unwrap_err()
+            .to_string()
+            .contains("at most"));
+    }
+
+    #[test]
+    fn xai_local_image_paths_are_encoded_as_data_urls() {
+        let _env = EnvScope::new();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tiny.png");
+        std::fs::write(&path, b"png-bytes").unwrap();
+
+        let encoded = image_ref_to_xai_url(path.to_str().unwrap());
+        assert!(encoded.starts_with("data:image/png;base64,"));
+        assert!(encoded.ends_with("cG5nLWJ5dGVz"));
+    }
+
+    #[test]
+    fn xai_credentials_resolve_from_env_and_auth_store() {
+        let _env = EnvScope::new();
+        std::env::set_var("XAI_API_KEY", "env-xai-key");
+        std::env::set_var("XAI_BASE_URL", "https://xai.env.test/v1/");
+        let credentials = resolve_xai_video_credentials().unwrap();
+        assert_eq!(credentials.api_key, "env-xai-key");
+        assert_eq!(credentials.base_url, "https://xai.env.test/v1");
+        assert_eq!(credentials.source, "env");
+
+        std::env::remove_var("XAI_API_KEY");
+        std::env::remove_var("XAI_BASE_URL");
+        let path = hermes_config::paths::auth_json_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "providers": {
+                    "xai-oauth": {
+                        "access_token": "oauth-xai-token",
+                        "api_base_url": "https://xai.store.test/v1/"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let credentials = resolve_xai_video_credentials().unwrap();
+        assert_eq!(credentials.api_key, "oauth-xai-token");
+        assert_eq!(credentials.base_url, "https://xai.store.test/v1");
+        assert_eq!(credentials.source, path.display().to_string());
+    }
+
+    #[test]
+    fn video_gen_backend_selection_requires_explicit_xai_choice() {
+        let _env = EnvScope::new();
+        std::env::set_var("XAI_API_KEY", "xai-key");
+        assert_eq!(
+            VideoGenBackend::from_env_or_managed().provider_label(),
+            "fal"
+        );
+
+        std::env::set_var("HERMES_VIDEO_GEN_BACKEND", "xai");
+        let selected = VideoGenBackend::from_env_or_managed();
+        assert_eq!(selected.provider_label(), "xai");
+        assert_eq!(
+            selected.required_env_vars(),
+            vec!["XAI_API_KEY".to_string()]
+        );
+    }
+
+    #[test]
+    fn video_gen_provider_selection_reads_config_candidates() {
+        let _env = EnvScope::new();
+        let config = hermes_config::config_path();
+        std::fs::write(config, "video_gen:\n  provider: grok-imagine\n").unwrap();
+        assert_eq!(selected_video_provider(), Some("xai"));
+    }
+
+    #[tokio::test]
+    async fn xai_unconfigured_backend_errors_before_network() {
+        let _env = EnvScope::new();
+        let backend = XaiVideoGenBackend::unconfigured();
+        let err = backend.generate_video(request(None)).await.unwrap_err();
+        assert!(err.to_string().contains("No xAI credentials"));
     }
 }

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -119,7 +119,9 @@ pub use backends::spotify::{SpotifyRuntimeCredentials, SpotifyWebApiBackend};
 pub use backends::todo::FileTodoBackend;
 pub use backends::tts::MultiTtsBackend;
 pub use backends::video::VisionFrameSamplingVideoBackend;
-pub use backends::video_gen::FalVideoGenBackend;
+pub use backends::video_gen::{
+    FalVideoGenBackend, VideoGenBackend, XaiVideoCredentials, XaiVideoGenBackend,
+};
 pub use backends::vision::OpenAiVisionBackend;
 pub use backends::web::{
     crawl_backend_from_env_or_fallback, extract_backend_from_env_or_fallback,

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -205,8 +205,8 @@ pub fn register_builtin_tools(
 
     // -- Video generation ----------------------------------------------------
     {
-        let backend = crate::backends::video_gen::FalVideoGenBackend::from_env_or_managed()
-            .unwrap_or_else(|_| crate::backends::video_gen::FalVideoGenBackend::unconfigured());
+        let backend = crate::backends::video_gen::VideoGenBackend::from_env_or_managed();
+        let env_deps = backend.required_env_vars();
         reg(
             registry,
             "video_gen",
@@ -214,7 +214,7 @@ pub fn register_builtin_tools(
                 backend,
             ))),
             "🎞️",
-            vec!["FAL_KEY".into()],
+            env_deps,
         );
     }
 

--- a/crates/hermes-tools/src/tools/dashboard_control.rs
+++ b/crates/hermes-tools/src/tools/dashboard_control.rs
@@ -221,13 +221,26 @@ impl ToolHandler for DashboardControlHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use hermes_config::managed_gateway::test_lock;
+    use std::path::Path;
 
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("env lock poisoned")
+    struct HermesHomeScope(Option<String>);
+
+    impl HermesHomeScope {
+        fn set(path: &Path) -> Self {
+            let original = std::env::var("HERMES_HOME").ok();
+            std::env::set_var("HERMES_HOME", path);
+            Self(original)
+        }
+    }
+
+    impl Drop for HermesHomeScope {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("HERMES_HOME", value),
+                None => std::env::remove_var("HERMES_HOME"),
+            }
+        }
     }
 
     fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
@@ -240,9 +253,9 @@ mod tests {
 
     #[test]
     fn enable_status_disable_roundtrip() {
-        let _guard = env_lock();
+        let _guard = test_lock::lock();
         let temp = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", temp.path());
+        let _home = HermesHomeScope::set(temp.path());
 
         block_on(async {
             let handler = DashboardControlHandler;
@@ -274,9 +287,9 @@ mod tests {
 
     #[test]
     fn rejects_non_local_without_insecure() {
-        let _guard = env_lock();
+        let _guard = test_lock::lock();
         let temp = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("HERMES_HOME", temp.path());
+        let _home = HermesHomeScope::set(temp.path());
 
         let handler = DashboardControlHandler;
         let err =

--- a/crates/hermes-tools/src/tools/env_passthrough.rs
+++ b/crates/hermes-tools/src/tools/env_passthrough.rs
@@ -223,6 +223,28 @@ mod tests {
 
     static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     fn reset() {
         SESSION_PASSTHROUGH
             .lock()
@@ -254,6 +276,7 @@ mod tests {
 
     #[test]
     fn config_passthrough_is_loaded_from_hermes_home() {
+        let _global_env = hermes_config::managed_gateway::test_lock::lock();
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset();
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -262,7 +285,7 @@ mod tests {
             "terminal:\n  env_passthrough:\n    - MY_CUSTOM_KEY\n    - '  ANOTHER_TOKEN  '\n",
         )
         .expect("write config");
-        std::env::set_var("HERMES_HOME", tmp.path());
+        let _home = EnvVarGuard::set("HERMES_HOME", tmp.path());
         reset_config_passthrough_cache_for_tests();
 
         assert!(is_env_passthrough("MY_CUSTOM_KEY"));
@@ -278,7 +301,6 @@ mod tests {
             "ANOTHER_TOKEN MY_CUSTOM_KEY SKILL_KEY"
         );
 
-        std::env::remove_var("HERMES_HOME");
         reset();
     }
 }

--- a/crates/hermes-tools/src/tools/video.rs
+++ b/crates/hermes-tools/src/tools/video.rs
@@ -28,7 +28,9 @@ pub trait VideoBackend: Send + Sync {
 pub struct VideoGenerateRequest {
     pub prompt: String,
     pub model: Option<String>,
+    pub model_explicit: bool,
     pub image_url: Option<String>,
+    pub reference_image_urls: Vec<String>,
     pub duration: Option<u32>,
     pub aspect_ratio: String,
     pub resolution: String,
@@ -76,6 +78,22 @@ fn optional_string(params: &Value, key: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn optional_string_list(params: &Value, key: &str) -> Vec<String> {
+    params
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn optional_u32(params: &Value, key: &str) -> Option<u32> {
     params.get(key).and_then(|v| {
         v.as_u64()
@@ -102,10 +120,18 @@ impl ToolHandler for VideoGenerateHandler {
             .filter(|s| !s.is_empty())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'prompt' parameter".into()))?;
 
+        let mut reference_image_urls = optional_string_list(&params, "reference_image_urls");
+        if reference_image_urls.is_empty() {
+            reference_image_urls = optional_string_list(&params, "reference_images");
+        }
+
+        let model = optional_string(&params, "model");
         let request = VideoGenerateRequest {
             prompt: prompt.to_string(),
-            model: optional_string(&params, "model"),
+            model_explicit: model.is_some(),
+            model,
             image_url: optional_string(&params, "image_url"),
+            reference_image_urls,
             duration: optional_u32(&params, "duration"),
             aspect_ratio: optional_string(&params, "aspect_ratio")
                 .unwrap_or_else(|| "16:9".to_string()),
@@ -132,8 +158,8 @@ impl ToolHandler for VideoGenerateHandler {
             "model".into(),
             json!({
                 "type": "string",
-                "description": "FAL model family to use.",
-                "enum": ["ltx-2.3", "pixverse-v6", "veo3.1", "seedance-2.0", "kling-v3-4k", "happy-horse"],
+                "description": "Provider model/family to use. FAL families are used by default; xAI models are honored when the video backend is configured for xAI.",
+                "enum": ["ltx-2.3", "pixverse-v6", "veo3.1", "seedance-2.0", "kling-v3-4k", "happy-horse", "grok-imagine-video", "grok-imagine-video-1.5-preview", "grok-imagine-video-1.5-2026-05-30"],
                 "default": "pixverse-v6"
             }),
         );
@@ -142,6 +168,14 @@ impl ToolHandler for VideoGenerateHandler {
             json!({
                 "type": "string",
                 "description": "Optional starting image URL for image-to-video generation."
+            }),
+        );
+        props.insert(
+            "reference_image_urls".into(),
+            json!({
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional reference image URLs or local paths for providers that support reference-guided generation."
             }),
         );
         props.insert(
@@ -298,10 +332,12 @@ mod tests {
     impl VideoGenerateBackend for MockVideoGenerateBackend {
         async fn generate_video(&self, request: VideoGenerateRequest) -> Result<String, ToolError> {
             Ok(format!(
-                "{}|{}|{}|{}|{}",
+                "{}|{}|{}|{}|{}|{}|{}",
                 request.prompt,
                 request.model.unwrap_or_default(),
+                request.model_explicit,
                 request.image_url.unwrap_or_default(),
+                request.reference_image_urls.join(","),
                 request.duration.unwrap_or_default(),
                 request.aspect_ratio
             ))
@@ -345,6 +381,7 @@ mod tests {
                 "prompt": " cinematic city ",
                 "model": "veo3.1",
                 "image_url": " https://example.com/start.png ",
+                "reference_image_urls": [" https://example.com/ref.png ", "", 123],
                 "duration": "8",
                 "aspect_ratio": "9:16"
             }))
@@ -352,7 +389,23 @@ mod tests {
             .expect("execute");
         assert_eq!(
             out,
-            "cinematic city|veo3.1|https://example.com/start.png|8|9:16"
+            "cinematic city|veo3.1|true|https://example.com/start.png|https://example.com/ref.png|8|9:16"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_execute_accepts_reference_images_alias() {
+        let handler = VideoGenerateHandler::new(Arc::new(MockVideoGenerateBackend));
+        let out = handler
+            .execute(json!({
+                "prompt": "city",
+                "reference_images": ["https://example.com/a.png", " https://example.com/b.png "]
+            }))
+            .await
+            .expect("execute");
+        assert_eq!(
+            out,
+            "city||false||https://example.com/a.png,https://example.com/b.png|0|16:9"
         );
     }
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-02T16:27:30.320571+00:00",
+  "generated_at_utc": "2026-06-02T20:04:11.919081+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-02T16:27:30.320571+00:00`
+Generated: `2026-06-02T20:04:11.919081+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -1201,16 +1201,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
+      "action": "Rust-native xAI VideoGenBackend now covers provider selection, xAI env/auth-store credentials, modality-specific model defaults, reference-image validation, local image data URIs, xAI submit/poll execution, and video_generate schema contracts; keep Python plugin manifest as reference-only divergence.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/video_gen",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "existing_coverage": "crates/hermes-tools/src/backends/video_gen.rs::XaiVideoGenBackend + crates/hermes-tools/src/tools/video.rs contracts",
       "local_blob": "85aa6e68f13dfa48153b675185635b4ed7a6db3a",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/video_gen/xai/plugin.yaml",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "5e3e8b1ac214fb3b995c7cd9b3363a9c02e6ca7e",
       "workstream": "WS3"
@@ -15781,7 +15781,7 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-02T16:27:30.320571+00:00",
+  "generated_at_utc": "2026-06-02T20:04:11.919081+00:00",
   "refs": {
     "local_ref": "HEAD",
     "local_sha": "827a88bfdb76c9f553c6fb6e644ad178b8ed13e2",
@@ -15791,20 +15791,20 @@
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 376,
-      "intentional_divergence": 502,
+      "functional": 375,
+      "intentional_divergence": 503,
       "policy_only": 173
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 676,
+      "not_required_for_runtime": 677,
       "rust_equivalent_or_contract_test_required": 287,
-      "rust_native_runtime_parity_required_if_needed": 2,
+      "rust_native_runtime_parity_required_if_needed": 1,
       "rust_primary_ux_or_documented_divergence_required": 87
     },
     "by_status": {
-      "cleared_intentional_divergence": 502,
+      "cleared_intentional_divergence": 503,
       "cleared_non_runtime": 174,
-      "pending_review": 376
+      "pending_review": 375
     },
     "by_workstream": {
       "WS3": 58,
@@ -15813,10 +15813,10 @@
       "WS6": 698,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 502,
+    "cleared_intentional_divergence": 503,
     "cleared_non_runtime": 174,
     "pending_classification": 0,
-    "pending_review": 376,
+    "pending_review": 375,
     "total_shared_different": 1052
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,21 +1,21 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-02T16:27:30.320571+00:00`
+Generated: `2026-06-02T20:04:11.919081+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1052`
 - Pending classification: `0`
-- Pending functional review: `376`
+- Pending functional review: `375`
 - Cleared non-runtime: `174`
-- Cleared intentional divergence: `502`
+- Cleared intentional divergence: `503`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 502 |
-| `pending_review` | 376 |
+| `cleared_intentional_divergence` | 503 |
+| `pending_review` | 375 |
 | `cleared_non_runtime` | 174 |
 
 ## Workstream Counts
@@ -53,5 +53,4 @@ Generated: `2026-06-02T16:27:30.320571+00:00`
 | `ui-tui` | 3 |
 | `tests/e2e` | 2 |
 | `plugins/observability` | 1 |
-| `plugins/video_gen` | 1 |
 | `tests/run_agent` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -614,7 +614,7 @@
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "plugins/video_gen/xai/__init__.py",
-      "rationale": "Local xAI video generation wording intentionally refers to the SuperGrok subscription credential path while preserving shared xAI credential resolution behavior.",
+      "rationale": "xAI video generation behavior is now covered by the Rust-native video_generate tool and XaiVideoGenBackend, including provider selection, shared env/auth-store credential resolution, modality-specific model defaults, reference image validation, local image data URI conversion, and xAI submit/poll contracts; the Python plugin remains reference-only compatibility material.",
       "ticket": 304
     },
     {


### PR DESCRIPTION
## Summary
- add a Rust-native xAI video generation backend behind the existing `video_generate` tool
- keep FAL as the default backend; xAI is selected only by explicit provider config/env
- cover xAI env/auth-store credential resolution, modality-specific model defaults, reference image validation, local image data-URI conversion, submit/poll execution, and response envelope contracts
- harden `HERMES_HOME`-mutating tests with shared env locking/RAII guards
- clear `plugins/video_gen/xai/plugin.yaml` from the parity backlog: `pending_review` 376 -> 375

## Verification
- `cargo test -p hermes-tools video_gen --lib` passed: 18/18
- `cargo test -p hermes-tools --lib` passed: 501/501
- `cargo test -p hermes-tools tools::dashboard_control::tests::enable_status_disable_roundtrip --lib -- --exact --nocapture` passed: 1/1
- `cargo test -p hermes-tools tools::env_passthrough::tests::config_passthrough_is_loaded_from_hermes_home --lib -- --exact --nocapture` passed: 1/1
- `cargo test --workspace` exited 0
- `cargo fmt --all --check` exited 0
- `git diff --check` exited 0
- `scripts/check-rust-runtime-no-python.sh` passed: `No Rust runtime Python execution paths detected.`
- `scripts/check-runtime-placeholders.sh` passed: `No runtime placeholder markers detected.`
- `rg -n "max_shared_different" .` returned no matches
- `scripts/clippy-warning-gate.sh --check` passed: `seen=200 allowlist=204 new=0 stale=4`
- `cargo build --workspace` exited 0

## Risk
- No live xAI API call was made; coverage is Rust unit/contract/local behavior plus build/test/lint gates.
