### PR TITLE
parity(observability): add Langfuse telemetry coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
 name = "hermes-telemetry"
 version = "0.14.2"
 dependencies = [
+ "base64 0.22.1",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -4884,6 +4884,15 @@ impl AgentLoop {
             self.inject_hook_context(&pre_results, &mut ctx);
 
             // --- LLM API call with transport retry + semantic empty/thinking recovery (Python parity) ---
+            let llm_span = tracing::info_span!(
+                "hermes.llm",
+                turn = total_turns,
+                request_model = %active_model,
+                response_model = tracing::field::Empty,
+                api_time_ms = tracing::field::Empty,
+                finish_reason = tracing::field::Empty,
+                tool_call_count = tracing::field::Empty
+            );
             let api_start = Instant::now();
             let mut inner_empty = 0u32;
             let mut inner_thinking = 0u32;
@@ -5001,6 +5010,30 @@ impl AgentLoop {
                 api_elapsed,
                 governor_window_limit,
             );
+            let response_tool_call_count = response
+                .message
+                .tool_calls
+                .as_ref()
+                .map(|v| v.len())
+                .unwrap_or(0);
+            llm_span.record("response_model", response.model.as_str());
+            llm_span.record("api_time_ms", api_elapsed);
+            if let Some(finish_reason) = response.finish_reason.as_deref() {
+                llm_span.record("finish_reason", finish_reason);
+            }
+            llm_span.record("tool_call_count", response_tool_call_count);
+            llm_span.in_scope(|| {
+                tracing::info!(
+                    target: "hermes.langfuse",
+                    turn = total_turns,
+                    model = %response.model,
+                    api_time_ms = api_elapsed,
+                    tool_call_count = response_tool_call_count,
+                    finish_reason = response.finish_reason.as_deref().unwrap_or(""),
+                    "llm response"
+                );
+            });
+            drop(llm_span);
             replay.record(
                 "llm_response",
                 serde_json::json!({
@@ -5008,7 +5041,7 @@ impl AgentLoop {
                     "model": response.model,
                     "finish_reason": response.finish_reason,
                     "api_time_ms": api_elapsed,
-                    "tool_call_count": response.message.tool_calls.as_ref().map(|v| v.len()).unwrap_or(0),
+                    "tool_call_count": response_tool_call_count,
                     "has_visible_text": Self::assistant_visible_text(&response.message),
                     "route_learning": self.route_learning_snapshot(
                         turn_runtime_route.as_ref(),
@@ -5431,6 +5464,15 @@ impl AgentLoop {
                     persist_user_idx,
                 ));
             }
+            let tool_span = tracing::info_span!(
+                "hermes.tool_batch",
+                turn = total_turns,
+                tool_count = tool_calls.len(),
+                tool_concurrency = tracing::field::Empty,
+                tool_time_ms = tracing::field::Empty,
+                errors = tracing::field::Empty,
+                error_rate = tracing::field::Empty
+            );
             let tool_start = Instant::now();
             let tool_governor = governor_for_turn(
                 &self.config,
@@ -5469,6 +5511,23 @@ impl AgentLoop {
             } else {
                 governor_consecutive_error_turns = 0;
             }
+            tool_span.record("tool_concurrency", tool_governor.tool_concurrency);
+            tool_span.record("tool_time_ms", tool_elapsed);
+            tool_span.record("errors", turn_tool_error_count);
+            tool_span.record("error_rate", turn_tool_error_rate);
+            tool_span.in_scope(|| {
+                tracing::info!(
+                    target: "hermes.langfuse",
+                    turn = total_turns,
+                    tool_count = tool_calls.len(),
+                    tool_concurrency = tool_governor.tool_concurrency,
+                    tool_time_ms = tool_elapsed,
+                    errors = turn_tool_error_count,
+                    error_rate = turn_tool_error_rate,
+                    "tool batch"
+                );
+            });
+            drop(tool_span);
             replay.record(
                 "tool_batch",
                 serde_json::json!({
@@ -6000,6 +6059,16 @@ impl AgentLoop {
             self.inject_hook_context(&pre_results, &mut ctx);
 
             // --- Streaming first attempt + same D-step semantic recovery as `run()` (retries use non-stream) ---
+            let llm_span = tracing::info_span!(
+                "hermes.llm",
+                turn = total_turns,
+                request_model = %active_model,
+                response_model = tracing::field::Empty,
+                api_time_ms = tracing::field::Empty,
+                finish_reason = tracing::field::Empty,
+                tool_call_count = tracing::field::Empty,
+                streaming = true
+            );
             let api_start = Instant::now();
             let mut inner_empty = 0u32;
             let mut inner_thinking = 0u32;
@@ -6165,6 +6234,31 @@ impl AgentLoop {
                 _api_elapsed_ms,
                 governor_window_limit,
             );
+            let response_tool_call_count = response
+                .message
+                .tool_calls
+                .as_ref()
+                .map(|v| v.len())
+                .unwrap_or(0);
+            llm_span.record("response_model", response.model.as_str());
+            llm_span.record("api_time_ms", _api_elapsed_ms);
+            if let Some(finish_reason) = response.finish_reason.as_deref() {
+                llm_span.record("finish_reason", finish_reason);
+            }
+            llm_span.record("tool_call_count", response_tool_call_count);
+            llm_span.in_scope(|| {
+                tracing::info!(
+                    target: "hermes.langfuse",
+                    turn = total_turns,
+                    model = %response.model,
+                    api_time_ms = _api_elapsed_ms,
+                    tool_call_count = response_tool_call_count,
+                    finish_reason = response.finish_reason.as_deref().unwrap_or(""),
+                    streaming = true,
+                    "llm response"
+                );
+            });
+            drop(llm_span);
             replay.record(
                 "llm_response",
                 serde_json::json!({
@@ -6172,7 +6266,7 @@ impl AgentLoop {
                     "model": response.model,
                     "finish_reason": response.finish_reason,
                     "api_time_ms": _api_elapsed_ms,
-                    "tool_call_count": response.message.tool_calls.as_ref().map(|v| v.len()).unwrap_or(0),
+                    "tool_call_count": response_tool_call_count,
                     "has_visible_text": Self::assistant_visible_text(&response.message),
                     "route_learning": self.route_learning_snapshot(
                         turn_runtime_route.as_ref(),
@@ -6650,17 +6744,29 @@ impl AgentLoop {
                 ));
             }
 
+            let tool_span = tracing::info_span!(
+                "hermes.tool_batch",
+                turn = total_turns,
+                tool_count = tool_calls.len(),
+                tool_concurrency = tracing::field::Empty,
+                tool_time_ms = tracing::field::Empty,
+                errors = tracing::field::Empty,
+                error_rate = tracing::field::Empty,
+                streaming = true
+            );
+            let tool_concurrency = governor_for_turn(
+                &self.config,
+                &ctx,
+                tool_calls.len(),
+                Some(&turn_governor_runtime),
+            )
+            .tool_concurrency;
+            let tool_start = Instant::now();
             let mut results = self
                 .execute_tool_calls(
                     &tool_calls,
                     total_turns,
-                    governor_for_turn(
-                        &self.config,
-                        &ctx,
-                        tool_calls.len(),
-                        Some(&turn_governor_runtime),
-                    )
-                    .tool_concurrency,
+                    tool_concurrency,
                     contextlattice_connect_intent,
                     self.config
                         .max_cost_usd
@@ -6668,6 +6774,7 @@ impl AgentLoop {
                     &mut tool_errors,
                 )
                 .await;
+            let tool_elapsed = tool_start.elapsed().as_millis() as u64;
             let turn_tool_error_count = results.iter().filter(|r| r.is_error).count() as u32;
             let turn_tool_error_rate = if results.is_empty() {
                 0.0
@@ -6685,18 +6792,31 @@ impl AgentLoop {
             } else {
                 governor_consecutive_error_turns = 0;
             }
+            tool_span.record("tool_concurrency", tool_concurrency);
+            tool_span.record("tool_time_ms", tool_elapsed);
+            tool_span.record("errors", turn_tool_error_count);
+            tool_span.record("error_rate", turn_tool_error_rate);
+            tool_span.in_scope(|| {
+                tracing::info!(
+                    target: "hermes.langfuse",
+                    turn = total_turns,
+                    tool_count = tool_calls.len(),
+                    tool_concurrency,
+                    tool_time_ms = tool_elapsed,
+                    errors = turn_tool_error_count,
+                    error_rate = turn_tool_error_rate,
+                    streaming = true,
+                    "tool batch"
+                );
+            });
+            drop(tool_span);
             replay.record(
                 "tool_batch",
                 serde_json::json!({
                     "turn": total_turns,
                     "tool_count": tool_calls.len(),
-                    "tool_concurrency": governor_for_turn(
-                        &self.config,
-                        &ctx,
-                        tool_calls.len(),
-                        Some(&turn_governor_runtime),
-                    )
-                    .tool_concurrency,
+                    "tool_concurrency": tool_concurrency,
+                    "tool_time_ms": tool_elapsed,
                     "errors": turn_tool_error_count,
                     "error_rate": turn_tool_error_rate,
                 }),

--- a/crates/hermes-telemetry/Cargo.toml
+++ b/crates/hermes-telemetry/Cargo.toml
@@ -16,6 +16,7 @@ otlp = [
 ]
 
 [dependencies]
+base64 = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/hermes-telemetry/src/lib.rs
+++ b/crates/hermes-telemetry/src/lib.rs
@@ -1,5 +1,6 @@
 //! Telemetry bootstrap and in-process metrics registry.
 
+use base64::Engine;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -11,6 +12,11 @@ use tracing_subscriber::Registry;
 #[cfg(feature = "otlp")]
 mod otlp;
 
+const DEFAULT_LANGFUSE_BASE_URL: &str = "https://cloud.langfuse.com";
+const LANGFUSE_PUBLIC_KEY_PREFIX: &str = "pk-lf-";
+const LANGFUSE_SECRET_KEY_PREFIX: &str = "sk-lf-";
+const LANGFUSE_INGESTION_VERSION: &str = "4";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryConfig {
     pub level: String,
@@ -19,6 +25,16 @@ pub struct TelemetryConfig {
     /// OTLP HTTP traces URL base (`http://host:4318`) or full path (`.../v1/traces`).
     /// Active when crate is built with `--features otlp`.
     pub otlp_endpoint: Option<String>,
+    /// Additional OTLP HTTP headers. Used for Langfuse Basic auth and supported
+    /// for explicit OTLP endpoints through `HERMES_OTLP_HEADERS`.
+    #[serde(default)]
+    pub otlp_headers: Vec<(String, String)>,
+    /// Optional trace-id-ratio sampler. Values are clamped to `0.0..=1.0`.
+    #[serde(default)]
+    pub otlp_sample_rate: Option<f64>,
+    /// Resource attributes attached to exported OTLP traces.
+    #[serde(default)]
+    pub resource_attributes: Vec<(String, String)>,
 }
 
 impl Default for TelemetryConfig {
@@ -28,22 +44,102 @@ impl Default for TelemetryConfig {
             json: false,
             service_name: "hermes".to_string(),
             otlp_endpoint: None,
+            otlp_headers: Vec::new(),
+            otlp_sample_rate: None,
+            resource_attributes: Vec::new(),
         }
     }
 }
 
+#[derive(Clone, PartialEq)]
+pub struct LangfuseTraceConfig {
+    pub public_key: String,
+    secret_key: String,
+    pub base_url: String,
+    pub endpoint: String,
+    pub environment: Option<String>,
+    pub release: Option<String>,
+    pub sample_rate: Option<f64>,
+}
+
+impl std::fmt::Debug for LangfuseTraceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LangfuseTraceConfig")
+            .field("public_key", &redact_key_preview(&self.public_key))
+            .field("secret_key", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("endpoint", &self.endpoint)
+            .field("environment", &self.environment)
+            .field("release", &self.release)
+            .field("sample_rate", &self.sample_rate)
+            .finish()
+    }
+}
+
+impl LangfuseTraceConfig {
+    pub fn otlp_headers(&self) -> Vec<(String, String)> {
+        vec![
+            (
+                "Authorization".to_string(),
+                format!("Basic {}", self.basic_auth_token()),
+            ),
+            (
+                "x-langfuse-ingestion-version".to_string(),
+                LANGFUSE_INGESTION_VERSION.to_string(),
+            ),
+        ]
+    }
+
+    pub fn resource_attributes(&self) -> Vec<(String, String)> {
+        let mut attrs = vec![("hermes.observability.provider".into(), "langfuse".into())];
+        if let Some(environment) = &self.environment {
+            attrs.push(("deployment.environment.name".into(), environment.clone()));
+            attrs.push(("langfuse.environment".into(), environment.clone()));
+        }
+        if let Some(release) = &self.release {
+            attrs.push(("service.version".into(), release.clone()));
+            attrs.push(("langfuse.release".into(), release.clone()));
+        }
+        attrs
+    }
+
+    fn basic_auth_token(&self) -> String {
+        base64::engine::general_purpose::STANDARD
+            .encode(format!("{}:{}", self.public_key, self.secret_key))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LangfuseConfigError {
+    pub issues: Vec<String>,
+}
+
+impl std::fmt::Display for LangfuseConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.issues.join("; "))
+    }
+}
+
+impl std::error::Error for LangfuseConfigError {}
+
 /// Build [`TelemetryConfig`] from environment and call [`init_telemetry`].
 ///
-/// Honors `RUST_LOG` / `HERMES_LOG_JSON` / `HERMES_OTLP_ENDPOINT` like the CLI and HTTP binaries.
+/// Honors `RUST_LOG`, `HERMES_LOG_JSON`, explicit OTLP env, and
+/// `HERMES_LANGFUSE_*`/`LANGFUSE_*` credentials. Langfuse maps to its native
+/// OTLP/HTTP traces endpoint (`/api/public/otel/v1/traces`) and uses Basic auth.
 pub fn init_telemetry_from_env(service_name: impl Into<String>, default_level: impl AsRef<str>) {
     let level = tracing_subscriber::EnvFilter::try_from_default_env()
         .map(|f| f.to_string())
         .unwrap_or_else(|_| default_level.as_ref().to_string());
+    let trace_export = trace_export_from_env();
     let cfg = TelemetryConfig {
         level,
         json: std::env::var("HERMES_LOG_JSON").ok().as_deref() == Some("1"),
         service_name: service_name.into(),
-        otlp_endpoint: std::env::var("HERMES_OTLP_ENDPOINT").ok(),
+        otlp_endpoint: trace_export.endpoint,
+        otlp_headers: trace_export.headers,
+        otlp_sample_rate: trace_export.sample_rate,
+        resource_attributes: trace_export.resource_attributes,
     };
     init_telemetry(&cfg);
 }
@@ -55,19 +151,23 @@ pub fn init_telemetry(config: &TelemetryConfig) {
     #[cfg(feature = "otlp")]
     let reg = {
         use tracing_subscriber::layer::Identity;
-        let otel: Box<dyn tracing_subscriber::layer::Layer<Registry> + Send + Sync> = match config
-            .otlp_endpoint
-            .as_deref()
-        {
-            Some(ep) if !ep.is_empty() => match otlp::build_otel_layer(&config.service_name, ep) {
-                Ok(layer) => Box::new(layer),
-                Err(e) => {
-                    eprintln!("hermes-telemetry: OTLP init failed: {}", e);
-                    Box::new(Identity::default())
-                }
-            },
-            _ => Box::new(Identity::default()),
-        };
+        let otel: Box<dyn tracing_subscriber::layer::Layer<Registry> + Send + Sync> =
+            match config.otlp_endpoint.as_deref() {
+                Some(ep) if !ep.is_empty() => match otlp::build_otel_layer(
+                    &config.service_name,
+                    ep,
+                    &config.otlp_headers,
+                    config.otlp_sample_rate,
+                    &config.resource_attributes,
+                ) {
+                    Ok(layer) => Box::new(layer),
+                    Err(e) => {
+                        eprintln!("hermes-telemetry: OTLP init failed: {}", e);
+                        Box::new(Identity::default())
+                    }
+                },
+                _ => Box::new(Identity::default()),
+            };
         Registry::default().with(otel)
     };
 
@@ -235,9 +335,206 @@ pub fn prometheus_text() -> String {
     out
 }
 
+#[derive(Default)]
+struct TraceExport {
+    endpoint: Option<String>,
+    headers: Vec<(String, String)>,
+    sample_rate: Option<f64>,
+    resource_attributes: Vec<(String, String)>,
+}
+
+fn trace_export_from_env() -> TraceExport {
+    let explicit_endpoint = first_env([
+        "HERMES_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+    ]);
+
+    if let Some(endpoint) = explicit_endpoint {
+        return TraceExport {
+            endpoint: Some(endpoint),
+            headers: first_env(["HERMES_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_HEADERS"])
+                .map(|raw| parse_otlp_headers(&raw))
+                .unwrap_or_default(),
+            sample_rate: first_env(["HERMES_OTLP_SAMPLE_RATE", "OTEL_TRACES_SAMPLER_ARG"])
+                .and_then(|raw| parse_sample_rate(&raw)),
+            resource_attributes: Vec::new(),
+        };
+    }
+
+    match langfuse_trace_config_from_env() {
+        Ok(Some(langfuse)) => TraceExport {
+            endpoint: Some(langfuse.endpoint.clone()),
+            headers: langfuse.otlp_headers(),
+            sample_rate: langfuse.sample_rate,
+            resource_attributes: langfuse.resource_attributes(),
+        },
+        Ok(None) => TraceExport::default(),
+        Err(err) => {
+            eprintln!(
+                "hermes-telemetry: Langfuse disabled because credentials are invalid: {}",
+                err
+            );
+            TraceExport::default()
+        }
+    }
+}
+
+pub fn langfuse_trace_config_from_env() -> Result<Option<LangfuseTraceConfig>, LangfuseConfigError>
+{
+    resolve_langfuse_trace_config(|name| std::env::var(name).ok())
+}
+
+fn resolve_langfuse_trace_config<F>(
+    mut get_env: F,
+) -> Result<Option<LangfuseTraceConfig>, LangfuseConfigError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let public_key = first_env_from(
+        &mut get_env,
+        ["HERMES_LANGFUSE_PUBLIC_KEY", "LANGFUSE_PUBLIC_KEY"],
+    );
+    let secret_key = first_env_from(
+        &mut get_env,
+        ["HERMES_LANGFUSE_SECRET_KEY", "LANGFUSE_SECRET_KEY"],
+    );
+
+    let (public_key, secret_key) = match (public_key, secret_key) {
+        (None, None) => return Ok(None),
+        (Some(public_key), Some(secret_key)) => (public_key, secret_key),
+        (Some(_), None) => {
+            return Err(LangfuseConfigError {
+                issues: vec!["missing HERMES_LANGFUSE_SECRET_KEY/LANGFUSE_SECRET_KEY".into()],
+            })
+        }
+        (None, Some(_)) => {
+            return Err(LangfuseConfigError {
+                issues: vec!["missing HERMES_LANGFUSE_PUBLIC_KEY/LANGFUSE_PUBLIC_KEY".into()],
+            })
+        }
+    };
+
+    let mut issues = Vec::new();
+    if !public_key.starts_with(LANGFUSE_PUBLIC_KEY_PREFIX) {
+        issues.push(format!(
+            "HERMES_LANGFUSE_PUBLIC_KEY={} (expected {:?} prefix)",
+            redact_key_preview(&public_key),
+            LANGFUSE_PUBLIC_KEY_PREFIX
+        ));
+    }
+    if !secret_key.starts_with(LANGFUSE_SECRET_KEY_PREFIX) {
+        issues.push(format!(
+            "HERMES_LANGFUSE_SECRET_KEY={} (expected {:?} prefix)",
+            redact_key_preview(&secret_key),
+            LANGFUSE_SECRET_KEY_PREFIX
+        ));
+    }
+    if !issues.is_empty() {
+        return Err(LangfuseConfigError { issues });
+    }
+
+    let base_url = first_env_from(
+        &mut get_env,
+        [
+            "HERMES_LANGFUSE_BASE_URL",
+            "LANGFUSE_BASE_URL",
+            "LANGFUSE_HOST",
+        ],
+    )
+    .unwrap_or_else(|| DEFAULT_LANGFUSE_BASE_URL.to_string());
+    let endpoint = langfuse_otlp_traces_endpoint(&base_url);
+    let environment = first_env_from(&mut get_env, ["HERMES_LANGFUSE_ENV", "LANGFUSE_ENV"]);
+    let release = first_env_from(
+        &mut get_env,
+        ["HERMES_LANGFUSE_RELEASE", "LANGFUSE_RELEASE"],
+    );
+    let sample_rate = first_env_from(
+        &mut get_env,
+        ["HERMES_LANGFUSE_SAMPLE_RATE", "LANGFUSE_SAMPLE_RATE"],
+    )
+    .and_then(|raw| parse_sample_rate(&raw));
+
+    Ok(Some(LangfuseTraceConfig {
+        public_key,
+        secret_key,
+        base_url,
+        endpoint,
+        environment,
+        release,
+        sample_rate,
+    }))
+}
+
+fn first_env<const N: usize>(names: [&str; N]) -> Option<String> {
+    let mut get = |name: &str| std::env::var(name).ok();
+    first_env_from(&mut get, names)
+}
+
+fn first_env_from<F, const N: usize>(get_env: &mut F, names: [&str; N]) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    names.into_iter().find_map(|name| {
+        get_env(name).and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+    })
+}
+
+fn langfuse_otlp_traces_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.ends_with("/api/public/otel/v1/traces") {
+        trimmed.to_string()
+    } else if trimmed.ends_with("/api/public/otel") {
+        format!("{trimmed}/v1/traces")
+    } else {
+        format!("{trimmed}/api/public/otel/v1/traces")
+    }
+}
+
+fn parse_otlp_headers(raw: &str) -> Vec<(String, String)> {
+    raw.split(',')
+        .filter_map(|pair| {
+            let (key, value) = pair.split_once('=')?;
+            let key = key.trim();
+            let value = value.trim();
+            (!key.is_empty() && !value.is_empty()).then(|| (key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+fn parse_sample_rate(raw: &str) -> Option<f64> {
+    raw.trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite())
+        .map(|value| value.clamp(0.0, 1.0))
+}
+
+fn redact_key_preview(value: &str) -> String {
+    if value.is_empty() {
+        return "<empty>".into();
+    }
+    if value.len() <= 12 {
+        return format!("{value:?}");
+    }
+    let prefix = value.chars().take(6).collect::<String>();
+    format!("{:?}", format!("{prefix}..."))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    fn map_env(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
 
     #[test]
     fn prometheus_text_includes_counters() {
@@ -248,5 +545,165 @@ mod tests {
         assert!(t.contains("hermes_http_requests_total"));
         assert!(t.contains("hermes_llm_requests_total"));
         assert!(t.contains("hermes_http_rejects_total"));
+    }
+
+    #[test]
+    fn langfuse_config_resolves_endpoint_headers_and_resource_attrs() {
+        let env = map_env(&[
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-public"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-secret"),
+            ("HERMES_LANGFUSE_BASE_URL", "https://us.cloud.langfuse.com/"),
+            ("HERMES_LANGFUSE_ENV", "local"),
+            ("HERMES_LANGFUSE_RELEASE", "v1.2.3"),
+            ("HERMES_LANGFUSE_SAMPLE_RATE", "0.25"),
+        ]);
+        let cfg = resolve_langfuse_trace_config(|name| env.get(name).cloned())
+            .expect("valid langfuse config")
+            .expect("configured");
+
+        assert_eq!(
+            cfg.endpoint,
+            "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+        );
+        assert_eq!(cfg.sample_rate, Some(0.25));
+        let headers = cfg.otlp_headers();
+        assert!(headers
+            .iter()
+            .any(|(k, v)| k == "Authorization" && v.starts_with("Basic ")));
+        assert!(headers.iter().any(|(k, v)| {
+            k == "x-langfuse-ingestion-version" && v == LANGFUSE_INGESTION_VERSION
+        }));
+        assert!(cfg
+            .resource_attributes()
+            .contains(&("deployment.environment.name".into(), "local".into())));
+        assert!(cfg
+            .resource_attributes()
+            .contains(&("service.version".into(), "v1.2.3".into())));
+    }
+
+    #[test]
+    fn langfuse_config_rejects_missing_or_placeholder_credentials() {
+        let env = map_env(&[
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "test-secret"),
+        ]);
+        let err = resolve_langfuse_trace_config(|name| env.get(name).cloned())
+            .expect_err("placeholder credentials rejected");
+        assert!(err
+            .issues
+            .iter()
+            .any(|issue| issue.contains("expected \"pk-lf-\" prefix")));
+        assert!(err
+            .issues
+            .iter()
+            .any(|issue| issue.contains("expected \"sk-lf-\" prefix")));
+
+        let env = map_env(&[("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-public")]);
+        let err = resolve_langfuse_trace_config(|name| env.get(name).cloned())
+            .expect_err("half config rejected");
+        assert!(err
+            .to_string()
+            .contains("missing HERMES_LANGFUSE_SECRET_KEY"));
+    }
+
+    #[test]
+    fn langfuse_endpoint_normalizes_full_otel_paths() {
+        assert_eq!(
+            langfuse_otlp_traces_endpoint("https://cloud.langfuse.com"),
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
+        assert_eq!(
+            langfuse_otlp_traces_endpoint("https://cloud.langfuse.com/api/public/otel"),
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
+        assert_eq!(
+            langfuse_otlp_traces_endpoint("https://cloud.langfuse.com/api/public/otel/v1/traces"),
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
+    }
+
+    #[test]
+    fn sample_rate_and_otlp_header_parsing_are_tolerant() {
+        assert_eq!(parse_sample_rate("1.5"), Some(1.0));
+        assert_eq!(parse_sample_rate("-2"), Some(0.0));
+        assert_eq!(parse_sample_rate("nan"), None);
+        assert_eq!(parse_sample_rate("garbage"), None);
+
+        assert_eq!(
+            parse_otlp_headers("Authorization=Basic abc, x-langfuse-ingestion-version=4,broken"),
+            vec![
+                ("Authorization".into(), "Basic abc".into()),
+                ("x-langfuse-ingestion-version".into(), "4".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_otlp_endpoint_takes_precedence_over_langfuse() {
+        let _guard = EnvGuard::set_many(&[
+            ("HERMES_OTLP_ENDPOINT", "http://collector:4318"),
+            ("HERMES_OTLP_HEADERS", "Authorization=Bearer direct"),
+            ("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-public"),
+            ("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-secret"),
+        ]);
+
+        let export = trace_export_from_env();
+        assert_eq!(export.endpoint.as_deref(), Some("http://collector:4318"));
+        assert_eq!(
+            export.headers,
+            vec![("Authorization".into(), "Bearer direct".into())]
+        );
+        assert!(export.resource_attributes.is_empty());
+    }
+
+    struct EnvGuard {
+        originals: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set_many(entries: &[(&'static str, &'static str)]) -> Self {
+            let keys = [
+                "HERMES_OTLP_ENDPOINT",
+                "HERMES_OTLP_HEADERS",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_HEADERS",
+                "HERMES_LANGFUSE_PUBLIC_KEY",
+                "HERMES_LANGFUSE_SECRET_KEY",
+                "HERMES_LANGFUSE_BASE_URL",
+                "HERMES_LANGFUSE_ENV",
+                "HERMES_LANGFUSE_RELEASE",
+                "HERMES_LANGFUSE_SAMPLE_RATE",
+                "LANGFUSE_PUBLIC_KEY",
+                "LANGFUSE_SECRET_KEY",
+                "LANGFUSE_BASE_URL",
+                "LANGFUSE_HOST",
+                "LANGFUSE_ENV",
+                "LANGFUSE_RELEASE",
+                "LANGFUSE_SAMPLE_RATE",
+            ];
+            let originals = keys
+                .into_iter()
+                .map(|key| (key, std::env::var(key).ok()))
+                .collect::<Vec<_>>();
+            for key in keys {
+                std::env::remove_var(key);
+            }
+            for (key, value) in entries {
+                std::env::set_var(key, value);
+            }
+            Self { originals }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.originals {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
     }
 }

--- a/crates/hermes-telemetry/src/otlp.rs
+++ b/crates/hermes-telemetry/src/otlp.rs
@@ -1,8 +1,11 @@
 //! OTLP HTTP trace export (`otlp` Cargo feature).
 
+use std::collections::HashMap;
+
 use opentelemetry::global;
-use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
@@ -11,23 +14,38 @@ use tracing_subscriber::Registry;
 pub fn build_otel_layer(
     service_name: &str,
     endpoint: &str,
+    headers: &[(String, String)],
+    sample_rate: Option<f64>,
+    resource_attributes: &[(String, String)],
 ) -> Result<impl Layer<Registry> + Send + Sync, Box<dyn std::error::Error + Send + Sync + 'static>>
 {
     let endpoint = normalize_traces_endpoint(endpoint);
+    let headers = headers.iter().cloned().collect::<HashMap<_, _>>();
 
-    let exporter = opentelemetry_otlp::SpanExporter::builder()
+    let mut exporter_builder = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
-        .with_endpoint(endpoint)
-        .build()?;
+        .with_endpoint(endpoint);
+    if !headers.is_empty() {
+        exporter_builder = exporter_builder.with_headers(headers);
+    }
+    let exporter = exporter_builder.build()?;
 
-    let resource = Resource::builder_empty()
-        .with_service_name(service_name.to_string())
-        .build();
+    let mut resource_builder =
+        Resource::builder_empty().with_service_name(service_name.to_string());
+    for (key, value) in resource_attributes {
+        resource_builder =
+            resource_builder.with_attribute(KeyValue::new(key.clone(), value.clone()));
+    }
+    let resource = resource_builder.build();
 
-    let provider = SdkTracerProvider::builder()
+    let mut provider_builder = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
-        .with_resource(resource)
-        .build();
+        .with_resource(resource);
+    if let Some(sample_rate) = sample_rate {
+        provider_builder =
+            provider_builder.with_sampler(Sampler::TraceIdRatioBased(sample_rate.clamp(0.0, 1.0)));
+    }
+    let provider = provider_builder.build();
 
     global::set_tracer_provider(provider);
     let tracer = global::tracer(service_name.to_string());

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-02T20:04:11.919081+00:00",
+  "generated_at_utc": "2026-06-02T21:15:55.338064+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-02T20:04:11.919081+00:00`
+Generated: `2026-06-02T21:15:55.338064+00:00`
 
 ## Gate Status
 

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -931,16 +931,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/observability",
-      "existing_coverage": "claimed_by_shared_diff_classification",
+      "action": "Rust-native Langfuse observability now covers HERMES_LANGFUSE/LANGFUSE credential resolution, placeholder-key rejection, Langfuse OTLP endpoint/header construction, sample/resource metadata, and structured Rust LLM/tool spans; keep the Python SDK plugin as reference-only divergence.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/observability/langfuse/__init__.py",
+      "existing_coverage": "crates/hermes-telemetry/src/lib.rs::LangfuseTraceConfig + crates/hermes-agent/src/agent_loop.rs structured spans",
       "local_blob": "a99a8eb9279144f873704a98e3768f1f15c4e990",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/observability/langfuse/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8516030fb019768c2145ea2f4e5f9145a7dea683",
       "workstream": "WS3"
@@ -15781,7 +15781,7 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-02T20:04:11.919081+00:00",
+  "generated_at_utc": "2026-06-02T21:15:55.338064+00:00",
   "refs": {
     "local_ref": "HEAD",
     "local_sha": "827a88bfdb76c9f553c6fb6e644ad178b8ed13e2",
@@ -15791,20 +15791,19 @@
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 375,
-      "intentional_divergence": 503,
+      "functional": 374,
+      "intentional_divergence": 504,
       "policy_only": 173
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 677,
+      "not_required_for_runtime": 678,
       "rust_equivalent_or_contract_test_required": 287,
-      "rust_native_runtime_parity_required_if_needed": 1,
       "rust_primary_ux_or_documented_divergence_required": 87
     },
     "by_status": {
-      "cleared_intentional_divergence": 503,
+      "cleared_intentional_divergence": 504,
       "cleared_non_runtime": 174,
-      "pending_review": 375
+      "pending_review": 374
     },
     "by_workstream": {
       "WS3": 58,
@@ -15813,10 +15812,10 @@
       "WS6": 698,
       "WS8": 13
     },
-    "cleared_intentional_divergence": 503,
+    "cleared_intentional_divergence": 504,
     "cleared_non_runtime": 174,
     "pending_classification": 0,
-    "pending_review": 375,
+    "pending_review": 374,
     "total_shared_different": 1052
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,22 +1,22 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-02T20:04:11.919081+00:00`
+Generated: `2026-06-02T21:15:55.338064+00:00`
 
 ## Summary
 
 - Total shared-different paths: `1052`
 - Pending classification: `0`
-- Pending functional review: `375`
+- Pending functional review: `374`
 - Cleared non-runtime: `174`
-- Cleared intentional divergence: `503`
+- Cleared intentional divergence: `504`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 503 |
-| `pending_review` | 375 |
+| `cleared_intentional_divergence` | 504 |
 | `cleared_non_runtime` | 174 |
+| `pending_review` | 374 |
 
 ## Workstream Counts
 
@@ -52,5 +52,4 @@ Generated: `2026-06-02T20:04:11.919081+00:00`
 | `tests/integration` | 3 |
 | `ui-tui` | 3 |
 | `tests/e2e` | 2 |
-| `plugins/observability` | 1 |
 | `tests/run_agent` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -473,6 +473,13 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "plugins/observability/langfuse/__init__.py",
+      "rationale": "Langfuse observability runtime is covered by Rust-native telemetry: HERMES_LANGFUSE/LANGFUSE credential resolution with placeholder-key rejection, Langfuse OTLP endpoint/header construction, sampling/resource attributes, and structured agent LLM/tool spans; the Python SDK plugin remains reference-only compatibility material.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "plugins/observability/langfuse/README.md",
       "rationale": "Local Langfuse README intentionally documents the Hermes tools credential flow while preserving the manual enable path.",
       "ticket": 304


### PR DESCRIPTION
## Summary
- add Rust-native Langfuse OTLP env resolution, credential validation, endpoint normalization, auth/header wiring, sampling, and resource metadata
- add structured LLM/tool tracing spans for both streaming and non-streaming agent paths
- clear `plugins/observability/langfuse/__init__.py`, moving parity backlog `pending_review` from 375 to 374

## Verification
- `cargo test -p hermes-telemetry --features otlp --lib` passed 6/6
- `cargo test --workspace` exited 0
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `rg -n "max_shared_different" .` returned no matches
- `scripts/clippy-warning-gate.sh --check` passed with `seen=200 allowlist=204 new=0 stale=4`
- `cargo build --workspace`

## Risk
No live Langfuse ingestion call was made; behavior is covered by Rust unit/feature tests and local deterministic workspace gates.
