### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-config"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "clap",
  "hermes-cli",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "once_cell",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/releases/v0.15.0.md
+++ b/docs/releases/v0.15.0.md
@@ -1,0 +1,79 @@
+# Hermes Agent Ultra v0.15.0
+
+Release date: 2026-06-03
+
+This release is the parity-sprint release: `v0.14.2..v0.15.0` carries 199 first-parent commits and moves the current Rust workspace from broad parity backlog burn-down into release-gated, test-owned coverage. The headline is not one feature; it is the Rust runtime now owning the important upstream-compatible surfaces with explicit contracts instead of Python fallback behavior.
+
+## Parity Sprint At A Glance
+
+```mermaid
+flowchart LR
+    A[Upstream Hermes surface drift] --> B[Classify runtime vs non-runtime]
+    B --> C[Rust implementations]
+    B --> D[Owned intentional divergence]
+    C --> E[Rust contract tests]
+    D --> E
+    E --> F[Global parity proof]
+    F --> G[v0.15.0 release]
+
+    C --> C1[Browser/Web providers]
+    C --> C2[Gateway + platform adapters]
+    C --> C3[ACP/MCP + CLI/TUI contracts]
+    C --> C4[Tools, providers, memory, observability]
+```
+
+| Signal | v0.15.0 State |
+| --- | --- |
+| First-parent commits since `v0.14.2` | 199 |
+| Shared-diff ledger rows owned | 1,052 |
+| Shared-diff pending classification | 0 |
+| Shared-diff pending review | 0 |
+| Test intent mapping ratio | 1.0 |
+| Global release gate | PASS |
+| Global CI gate | PASS |
+| Runtime language posture | Rust-first; release gate keeps Python runtime hot paths out |
+
+## What Changed
+
+- Browser and web provider parity moved into Rust, including Browser Use provider wiring, Browserbase/local CDP policy, keyless/free web providers, and local browser guardrails.
+- Gateway parity advanced across session cache/control, blocking approvals, access control, delivery/channel directories, command surfaces, API server lifecycle, cron jobs, webhooks, HTTP pool limits, and platform-specific behavior.
+- Discord, Telegram, Signal, WeCom/QQBot, webhook, and API-server surfaces gained Rust contracts for authorization, channel policy, media, reactions, rate limits, dynamic routes, and topic/session behavior.
+- ACP/MCP surfaces gained Rust test ownership for auth methods, tool rendering/events, permission isolation/options, server wire behavior, resources/prompts, and handler contracts.
+- Tools/runtime safety was hardened across terminal approvals, yolo scoping, command guards, schema sanitization, file/device safety, output limits, environment isolation, and tool-result persistence.
+- Provider/runtime parity expanded across Anthropic, Bedrock, Tencent/TokenHub, API-key provider mapping, model normalization, provider profiles, OpenRouter/Nous routing, auxiliary clients, pricing, redaction, and compression continuity.
+- CLI/TUI/source coverage was promoted into Rust parity contracts, including coverage manifests for former Python test-suite rows, TUI source rows, and CLI command/action rows.
+- Observability and release-readiness improved with Langfuse/OTLP telemetry contracts, release security gates, SBOM workflow coverage, clippy warning gating, placeholder gates, and Rust no-Python runtime checks.
+- Installer behavior is safer for real users: non-interactive `curl | bash` installs no longer hang in post-install probes, explicit `--setup` still runs bounded verification, and default installs preserve upstream NousResearch `hermes` while exposing `hermes-agent-ultra` and `hermes-ultra`.
+
+## Install / Coexistence
+
+Default install remains safe on machines that also have upstream NousResearch Hermes installed as `hermes`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sheawinkler/hermes-agent-ultra/main/scripts/install.sh | bash
+hermes-ultra setup
+```
+
+By default, Ultra installs `hermes-agent-ultra` plus `hermes-ultra` and does not replace an existing `hermes` command. Users who explicitly want the legacy alias can still opt in with `INSTALL_LEGACY_ALIAS=1`.
+
+## Verification Used For The Release Prep
+
+```bash
+bash -n scripts/install.sh
+bash scripts/install.sh --help
+cargo fmt --all --check
+cargo test -p hermes-parity-tests --test installer_contract
+cargo test -p hermes-parity-tests --test python_test_suite_coverage_contract
+git diff --check
+scripts/check-rust-runtime-no-python.sh
+scripts/check-runtime-placeholders.sh
+scripts/clippy-warning-gate.sh --check
+cargo build --workspace
+cargo test --workspace
+```
+
+Post-merge verification for the installer PR also passed `cargo build --workspace` and `cargo test --workspace` on `main` before release prep began.
+
+## Release Asset Notes
+
+The GitHub release workflow builds Linux, macOS, musl, and Windows artifacts, signs the archives with keyless Cosign, publishes the SBOM, and generates the checksummed Homebrew formula from the actual release artifacts. The static `packaging/homebrew/hermes-agent.rb` file in the repository may still point at the last published artifact set until the generated formula is attached to this release.

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       in {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "hermes-agent";
-          version = "0.14.2";
+          version = "0.15.0";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
 

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -1,17 +1,17 @@
 from pathlib import Path
 import re
-import tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_homebrew_formula_tracks_workspace_release_version():
-    cargo = tomllib.loads((REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8"))
-    version = cargo["workspace"]["package"]["version"]
+def test_homebrew_formula_release_urls_match_formula_version():
     formula = (REPO_ROOT / "packaging/homebrew/hermes-agent.rb").read_text(
         encoding="utf-8"
     )
+    version_match = re.search(r'version "([^"]+)"', formula)
+    assert version_match is not None
+    version = version_match.group(1)
 
     assert f'version "{version}"' in formula
     assert f"/releases/download/v{version}/" in formula


### PR DESCRIPTION
## Summary
- bump workspace, lockfile, and Nix package metadata to `0.15.0`
- add `docs/releases/v0.15.0.md` with the parity-sprint release summary, Mermaid flow, and release signals table
- adjust the static Homebrew formula test to assert formula self-consistency while generated release formulas remain artifact/checksum driven

## Release Signals
- latest published tag before this PR: `v0.14.2`
- new release target: `v0.15.0`
- first-parent commits since `v0.14.2`: 199
- shared-diff ledger rows owned: 1,052
- pending classification/review: 0/0
- global release gate: PASS
- global CI gate: PASS
- runtime posture: Rust-first, no Python runtime hot paths per gate

## Verification
- `bash -n scripts/install.sh`
- `bash scripts/install.sh --help`
- `cargo metadata --locked --no-deps`
- `cargo run -p hermes-cli --bin hermes-agent-ultra -- --version`
- `cargo fmt --all --check`
- `python3 -m py_compile tests/test_homebrew_formula.py scripts/release_secret_scan.py scripts/run-security-release-gate-v2.py`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check`
- `python3 scripts/run-security-release-gate-v2.py --repo-root .`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo test -p hermes-parity-tests --test installer_contract`
- `cargo test -p hermes-parity-tests --test python_test_suite_coverage_contract`
