### PR TITLE
feat(tools): add runtime runbook control tool

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -12467,10 +12467,7 @@ fn handle_telemetry_command(app: &mut App, args: &[&str]) -> Result<CommandResul
 fn handle_runbook_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     let action = args.first().copied().unwrap_or("list").to_ascii_lowercase();
     if action == "list" || action == "status" {
-        emit_command_output(
-            app,
-            "Runbooks\n- auth-refresh: provider auth/session rejected\n- model-not-found: catalog drift / unknown model\n- contextlattice-connect: local memory integration bootstrap\n- tool-policy-deny: blocked by policy or sandbox profile\n- stream-finalization: stream done but transcript not finalized\n\nUse `/runbook show <name>`.",
-        );
+        emit_command_output(app, hermes_tools::tools::runbook::render_runbook_list());
         return Ok(CommandResult::Handled);
     }
     if action == "show" {
@@ -12478,34 +12475,17 @@ fn handle_runbook_command(app: &mut App, args: &[&str]) -> Result<CommandResult,
             emit_command_output(app, "Usage: /runbook show <name>");
             return Ok(CommandResult::Handled);
         };
-        let body = match name.as_str() {
-            "auth-refresh" => {
-                "Runbook: auth-refresh\n1) `/auth status`\n2) `/auth refresh`\n3) retry prompt\n4) if still failing, run `/model` and confirm provider/model pair is valid for your account."
-            }
-            "model-not-found" => {
-                "Runbook: model-not-found\n1) `/model` and select a valid catalog model\n2) retry request\n3) if provider alias was stale, run `/auth verify` and re-check."
-            }
-            "contextlattice-connect" => {
-                "Runbook: contextlattice-connect\n1) ensure contextlattice tools are registered via `/tools`\n2) ask agent to run `contextlattice_search` first (not shell command `contextlattice`)\n3) checkpoint verified integration via `contextlattice_write`."
-            }
-            "tool-policy-deny" => {
-                "Runbook: tool-policy-deny\n1) inspect denial reason in tool card `[remediation]` section\n2) remove secret-like args from inline command payload\n3) retry with safer params or approved tool route (`/tools`)."
-            }
-            "stream-finalization" => {
-                "Runbook: stream-finalization\n1) wait for final transcript writeback (status shows `Finalizing response…`)\n2) avoid submitting a new prompt until finalization completes\n3) if UI appears stale, use Ctrl+G to refresh and jump latest."
-            }
-            _ => {
-                emit_command_output(
-                    app,
-                    format!(
-                        "Unknown runbook `{}`. Use `/runbook list` for available entries.",
-                        name
-                    ),
-                );
-                return Ok(CommandResult::Handled);
-            }
+        let Some(runbook) = hermes_tools::tools::runbook::find_runbook(&name) else {
+            emit_command_output(
+                app,
+                format!(
+                    "Unknown runbook `{}`. Use `/runbook list` for available entries.",
+                    name
+                ),
+            );
+            return Ok(CommandResult::Handled);
         };
-        emit_command_output(app, body);
+        emit_command_output(app, hermes_tools::tools::runbook::render_runbook(runbook));
         return Ok(CommandResult::Handled);
     }
     emit_command_output(app, "Usage: /runbook [list|show <name>]");

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -77,6 +77,7 @@ pub use tools::osv_check::OsvCheckHandler;
 pub use tools::process_registry::ProcessRegistryHandler;
 pub use tools::raw_trace_control::RawTraceControlHandler;
 pub use tools::replay_trace_control::ReplayTraceControlHandler;
+pub use tools::runbook::RunbookControlHandler;
 pub use tools::session_search::{SessionSearchBackend, SessionSearchHandler};
 pub use tools::skill_commands;
 pub use tools::skill_utils;

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -663,6 +663,15 @@ pub fn register_builtin_tools(
         vec![],
     );
 
+    // -- Runtime recovery runbooks ------------------------------------------
+    reg(
+        registry,
+        "system",
+        Arc::new(crate::tools::runbook::RunbookControlHandler::new()),
+        "📘",
+        vec![],
+    );
+
     // -- Tool result storage -------------------------------------------------
     reg(
         registry,
@@ -899,6 +908,10 @@ mod tests {
         assert!(
             names.contains(&"replay_trace_control".to_string()),
             "invalid backend should keep replay trace control"
+        );
+        assert!(
+            names.contains(&"runbook_control".to_string()),
+            "invalid backend should keep runtime runbooks"
         );
     }
 

--- a/crates/hermes-tools/src/tools/mod.rs
+++ b/crates/hermes-tools/src/tools/mod.rs
@@ -23,6 +23,7 @@ pub mod osv_check;
 pub mod process_registry;
 pub mod raw_trace_control;
 pub mod replay_trace_control;
+pub mod runbook;
 pub mod session_search;
 pub mod skill_commands;
 pub mod skill_utils;

--- a/crates/hermes-tools/src/tools/runbook.rs
+++ b/crates/hermes-tools/src/tools/runbook.rs
@@ -1,0 +1,324 @@
+//! First-class runtime runbooks for common operator recovery paths.
+//!
+//! The CLI exposes these through `/runbook`; this tool makes the same catalog
+//! available to agents without requiring a TUI slash command round-trip.
+
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde_json::{json, Value};
+
+use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+
+const TOOL_NAME: &str = "runbook_control";
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeRunbook {
+    pub name: &'static str,
+    pub title: &'static str,
+    pub summary: &'static str,
+    pub steps: &'static [&'static str],
+    pub related_commands: &'static [&'static str],
+    pub tags: &'static [&'static str],
+}
+
+const RUNBOOKS: &[RuntimeRunbook] = &[
+    RuntimeRunbook {
+        name: "auth-refresh",
+        title: "Provider auth/session rejected",
+        summary: "Recover from expired provider credentials or OAuth session drift.",
+        steps: &[
+            "`/auth status`",
+            "`/auth refresh`",
+            "retry prompt",
+            "if still failing, run `/model` and confirm provider/model pair is valid for your account",
+        ],
+        related_commands: &["/auth status", "/auth refresh", "/model"],
+        tags: &["auth", "provider", "oauth"],
+    },
+    RuntimeRunbook {
+        name: "model-not-found",
+        title: "Catalog drift or unknown model",
+        summary: "Recover when the configured model is absent from the active provider catalog.",
+        steps: &[
+            "`/model` and select a valid catalog model",
+            "retry request",
+            "if provider alias was stale, run `/auth verify` and re-check",
+        ],
+        related_commands: &["/model", "/auth verify"],
+        tags: &["model", "provider", "catalog"],
+    },
+    RuntimeRunbook {
+        name: "contextlattice-connect",
+        title: "Local memory integration bootstrap",
+        summary: "Verify ContextLattice integration through registered tools and durable checkpointing.",
+        steps: &[
+            "ensure ContextLattice tools are registered via `/tools`",
+            "ask agent to run `contextlattice_search` first, not shell command `contextlattice`",
+            "checkpoint verified integration via `contextlattice_write`",
+        ],
+        related_commands: &["/tools", "contextlattice_search", "contextlattice_write"],
+        tags: &["memory", "contextlattice", "checkpoint"],
+    },
+    RuntimeRunbook {
+        name: "tool-policy-deny",
+        title: "Blocked by policy or sandbox profile",
+        summary: "Recover from policy denials without weakening the active safety posture.",
+        steps: &[
+            "inspect denial reason in tool card `[remediation]` section",
+            "remove secret-like args from inline command payload",
+            "retry with safer params or approved tool route (`/tools`)",
+        ],
+        related_commands: &["/tools", "/policy status", "tool_policy_simulate"],
+        tags: &["policy", "sandbox", "tools"],
+    },
+    RuntimeRunbook {
+        name: "stream-finalization",
+        title: "Stream done but transcript not finalized",
+        summary: "Recover when streamed output has completed but the transcript still appears stale.",
+        steps: &[
+            "wait for final transcript writeback; status shows `Finalizing response...`",
+            "avoid submitting a new prompt until finalization completes",
+            "if UI appears stale, use Ctrl+G to refresh and jump latest",
+        ],
+        related_commands: &["Ctrl+G", "/telemetry lane"],
+        tags: &["tui", "streaming", "transcript"],
+    },
+    RuntimeRunbook {
+        name: "replay-trace",
+        title: "Deterministic replay trace investigation",
+        summary: "Inspect, verify, export, and diff replay traces for runtime reproducibility evidence.",
+        steps: &[
+            "`/raw trace status` or `replay_trace_control {\"action\":\"status\"}`",
+            "`/raw trace verify` or `replay_trace_control {\"action\":\"verify\"}`",
+            "export a bounded trace window with `/raw trace export` or `replay_trace_control {\"action\":\"export\"}`",
+            "compare exports with `/studio replay diff` or `replay_trace_control {\"action\":\"diff\"}`",
+        ],
+        related_commands: &[
+            "/raw trace status",
+            "/raw trace verify",
+            "/raw trace export",
+            "/studio replay diff",
+            "replay_trace_control",
+        ],
+        tags: &["replay", "trace", "debugging"],
+    },
+];
+
+#[derive(Clone, Default)]
+pub struct RunbookControlHandler;
+
+impl RunbookControlHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ToolHandler for RunbookControlHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        let action = params
+            .get("action")
+            .and_then(Value::as_str)
+            .unwrap_or("list")
+            .trim()
+            .to_ascii_lowercase();
+
+        match action.as_str() {
+            "list" | "status" => Ok(json!({
+                "status": "ok",
+                "count": RUNBOOKS.len(),
+                "runbooks": RUNBOOKS.iter().map(runbook_summary_json).collect::<Vec<_>>(),
+                "usage": "runbook_control {\"action\":\"show\",\"name\":\"auth-refresh\"}",
+            })
+            .to_string()),
+            "show" => {
+                let name = params
+                    .get("name")
+                    .or_else(|| params.get("runbook"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| ToolError::InvalidParams("show requires name".to_string()))?;
+                let runbook = find_runbook(name).ok_or_else(|| {
+                    ToolError::InvalidParams(format!(
+                        "unknown runbook '{name}'; use action=list for available runbooks"
+                    ))
+                })?;
+                Ok(json!({
+                    "status": "ok",
+                    "runbook": runbook_json(runbook),
+                })
+                .to_string())
+            }
+            "help" => Ok(json!({
+                "status": "ok",
+                "tool": TOOL_NAME,
+                "actions": ["list", "status", "show", "help"],
+                "notes": [
+                    "mirrors `/runbook` recovery guidance without requiring a TUI",
+                    "use action=show with a runbook name for structured recovery steps"
+                ],
+            })
+            .to_string()),
+            _ => Err(ToolError::InvalidParams(format!(
+                "unknown action '{action}'; expected list|status|show|help"
+            ))),
+        }
+    }
+
+    fn schema(&self) -> ToolSchema {
+        let mut props = IndexMap::new();
+        props.insert(
+            "action".into(),
+            json!({
+                "type": "string",
+                "enum": ["list", "status", "show", "help"],
+                "description": "Runbook action. Defaults to list."
+            }),
+        );
+        props.insert(
+            "name".into(),
+            json!({
+                "type": "string",
+                "description": "Runbook name for show action."
+            }),
+        );
+        tool_schema(
+            TOOL_NAME,
+            "List and show deterministic runtime recovery runbooks.",
+            JsonSchema::object(props, vec![]),
+        )
+    }
+}
+
+pub fn runbooks() -> &'static [RuntimeRunbook] {
+    RUNBOOKS
+}
+
+pub fn find_runbook(name: &str) -> Option<&'static RuntimeRunbook> {
+    let token = normalize_name(name);
+    RUNBOOKS
+        .iter()
+        .find(|runbook| normalize_name(runbook.name) == token)
+}
+
+pub fn render_runbook_list() -> String {
+    let mut out = String::from("Runbooks\n");
+    for runbook in RUNBOOKS {
+        out.push_str("- ");
+        out.push_str(runbook.name);
+        out.push_str(": ");
+        out.push_str(runbook.title);
+        out.push('\n');
+    }
+    out.push_str("\nUse `/runbook show <name>`.");
+    out
+}
+
+pub fn render_runbook(runbook: &RuntimeRunbook) -> String {
+    let mut out = format!("Runbook: {}\n{}", runbook.name, runbook.summary);
+    for (idx, step) in runbook.steps.iter().enumerate() {
+        out.push('\n');
+        out.push_str(&(idx + 1).to_string());
+        out.push_str(") ");
+        out.push_str(step);
+    }
+    if !runbook.related_commands.is_empty() {
+        out.push_str("\nrelated: ");
+        out.push_str(&runbook.related_commands.join(", "));
+    }
+    out
+}
+
+fn normalize_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase().replace(['_', ' '], "-")
+}
+
+fn runbook_summary_json(runbook: &RuntimeRunbook) -> Value {
+    json!({
+        "name": runbook.name,
+        "title": runbook.title,
+        "summary": runbook.summary,
+        "tags": runbook.tags,
+    })
+}
+
+fn runbook_json(runbook: &RuntimeRunbook) -> Value {
+    json!({
+        "name": runbook.name,
+        "title": runbook.title,
+        "summary": runbook.summary,
+        "steps": runbook.steps,
+        "related_commands": runbook.related_commands,
+        "tags": runbook.tags,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_returns_structured_runbook_catalog() {
+        let handler = RunbookControlHandler::new();
+        let payload: Value =
+            serde_json::from_str(&handler.execute(json!({"action":"list"})).await.unwrap())
+                .expect("json");
+
+        assert_eq!(payload["status"], "ok");
+        assert!(payload["count"].as_u64().unwrap() >= 5);
+        assert!(payload["runbooks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|row| row["name"] == "auth-refresh"));
+    }
+
+    #[tokio::test]
+    async fn show_accepts_normalized_names_and_returns_steps() {
+        let handler = RunbookControlHandler::new();
+        let payload: Value = serde_json::from_str(
+            &handler
+                .execute(json!({"action":"show","name":"tool_policy_deny"}))
+                .await
+                .unwrap(),
+        )
+        .expect("json");
+
+        assert_eq!(payload["status"], "ok");
+        assert_eq!(payload["runbook"]["name"], "tool-policy-deny");
+        assert!(payload["runbook"]["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|step| step.as_str().unwrap().contains("remediation")));
+    }
+
+    #[tokio::test]
+    async fn unknown_runbook_is_invalid_params() {
+        let handler = RunbookControlHandler::new();
+        let err = handler
+            .execute(json!({"action":"show","name":"missing"}))
+            .await
+            .expect_err("unknown runbook should fail");
+        match err {
+            ToolError::InvalidParams(message) => {
+                assert!(message.contains("unknown runbook"));
+                assert!(message.contains("action=list"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_renderers_share_the_tool_catalog() {
+        let list = render_runbook_list();
+        assert!(list.contains("auth-refresh"));
+        assert!(list.contains("replay-trace"));
+
+        let runbook = find_runbook("contextlattice connect").expect("runbook");
+        let rendered = render_runbook(runbook);
+        assert!(rendered.contains("contextlattice_search"));
+        assert!(rendered.contains("contextlattice_write"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `runbook_control` as a Rust-native system tool for deterministic runtime recovery guidance.
- Moves `/runbook` rendering onto the shared `hermes-tools::tools::runbook` catalog so CLI and agent tool output cannot drift.
- Adds a replay-trace runbook covering the newly first-class replay trace control/diff workflow.
- Registers and exports the tool, and keeps it available even when terminal-backed tools are hidden.

## Tests
- `cargo test -p hermes-tools runbook -- --nocapture`
- `cargo test -p hermes-tools invalid_backend_hides_terminal_backed_tools_but_keeps_local_file_tools -- --nocapture`
- `cargo test -p hermes-cli slash_runbook_and_telemetry_commands_are_handled -- --nocapture`
- `cargo test -p hermes-tools`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` (`seen=199 allowlist=204 new=0 stale=5`)
- `cargo build --workspace`
