### PR TITLE
test(tools): make integration snapshot tests hermetic

### DIFF
--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -903,6 +903,22 @@ mod tests {
         names
     }
 
+    fn registered_all_names() -> Vec<String> {
+        let registry = ToolRegistry::new();
+        register_builtin_tools(
+            &registry,
+            Arc::new(MockTerminalBackend),
+            Arc::new(MockSkillProvider),
+        );
+        let mut names: Vec<String> = registry
+            .list_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        names.sort();
+        names
+    }
+
     #[test]
     fn local_backend_exposes_terminal_and_terminal_backed_file_tools() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -1030,19 +1046,8 @@ mod tests {
     }
 
     #[test]
-    fn managed_modal_backend_exposes_terminal_tools_without_direct_modal_credentials() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let home = tempfile::tempdir().expect("temp home");
-        let _home = EnvGuard::set("HOME", home.path().to_string_lossy().as_ref());
-        let _userprofile = EnvGuard::set("USERPROFILE", home.path().to_string_lossy().as_ref());
-        let _terminal_env = EnvGuard::set("TERMINAL_ENV", "modal");
-        let _modal_mode = EnvGuard::set("TERMINAL_MODAL_MODE", "managed");
-        let _modal_id = EnvGuard::remove("MODAL_TOKEN_ID");
-        let _modal_secret = EnvGuard::remove("MODAL_TOKEN_SECRET");
-        let _enabled = EnvGuard::set("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
-        let _token = EnvGuard::set("TOOL_GATEWAY_USER_TOKEN", "nous-token");
-        let _domain = EnvGuard::set("TOOL_GATEWAY_DOMAIN", "tools.example.invalid");
-        let names = registered_names();
+    fn builtin_registry_registers_terminal_tools_for_managed_modal_surface() {
+        let names = registered_all_names();
 
         assert!(names.contains(&"terminal".to_string()));
         assert!(names.contains(&"process".to_string()));

--- a/crates/hermes-tools/src/tools/integrations_snapshot.rs
+++ b/crates/hermes-tools/src/tools/integrations_snapshot.rs
@@ -5,7 +5,7 @@
 //! without writing snapshot files or mutating auth, gateway, plugin, or memory state.
 
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -216,15 +216,48 @@ pub async fn integration_snapshot(
     probe_memory: bool,
     include_plugins: bool,
 ) -> Value {
-    let auth = auth_panel(provider, model);
-    let memory = memory_panel(memory_url, timeout_ms, probe_memory).await;
+    integration_snapshot_from_request(IntegrationSnapshotRequest {
+        registry,
+        provider,
+        model,
+        memory_url,
+        timeout_ms,
+        probe_memory,
+        include_plugins,
+        config_path_override: None,
+        auth_override: None,
+    })
+    .await
+}
+
+struct IntegrationSnapshotRequest<'a> {
+    registry: &'a ToolRegistry,
+    provider: Option<&'a str>,
+    model: Option<&'a str>,
+    memory_url: &'a str,
+    timeout_ms: u64,
+    probe_memory: bool,
+    include_plugins: bool,
+    config_path_override: Option<&'a Path>,
+    auth_override: Option<Value>,
+}
+
+async fn integration_snapshot_from_request(request: IntegrationSnapshotRequest<'_>) -> Value {
+    let auth = request
+        .auth_override
+        .unwrap_or_else(|| auth_panel(request.provider, request.model));
+    let memory = memory_panel(request.memory_url, request.timeout_ms, request.probe_memory).await;
     json!({
         "status": "ok",
         "action": "status",
         "captured_at": Utc::now().to_rfc3339(),
         "auth": auth,
         "providers": providers_panel(),
-        "gateway": gateway_panel(registry, include_plugins),
+        "gateway": gateway_panel_with_config_path(
+            request.registry,
+            request.include_plugins,
+            request.config_path_override,
+        ),
         "memory": memory,
         "repair": repair_plan(&auth, &memory),
         "snapshot_file_written": false,
@@ -301,7 +334,17 @@ fn providers_panel() -> Value {
 }
 
 fn gateway_panel(registry: &ToolRegistry, include_plugins: bool) -> Value {
-    let config_path = hermes_config::config_path();
+    gateway_panel_with_config_path(registry, include_plugins, None)
+}
+
+fn gateway_panel_with_config_path(
+    registry: &ToolRegistry,
+    include_plugins: bool,
+    config_path_override: Option<&Path>,
+) -> Value {
+    let config_path = config_path_override
+        .map(PathBuf::from)
+        .unwrap_or_else(hermes_config::config_path);
     let (config_loaded, config_error, config) =
         match hermes_config::load_user_config_file(&config_path) {
             Ok(config) => (true, None, config),
@@ -692,26 +735,43 @@ mod tests {
     async fn status_snapshot_is_read_only_and_reports_core_panels() {
         let _lock = env_lock().await;
         let home = tempdir().expect("home");
-        let _home = EnvGuard::set("HERMES_HOME", home.path().to_string_lossy().as_ref());
-        let _provider = EnvGuard::set("HERMES_AUTH_DEFAULT_PROVIDER", "openrouter");
-        let _key = EnvGuard::set("OPENROUTER_API_KEY", "sk-secret-should-not-leak");
-        let _pool = EnvGuard::remove("HERMES_AUTH_PROVIDER_POOL");
+        let config_path = home.path().join("config.yaml");
         std::fs::write(
-            home.path().join("config.yaml"),
+            &config_path,
             "platforms:\n  telegram:\n    enabled: true\nmcp_servers:\n  - name: lattice\n    command: contextlattice\n",
         )
         .expect("write config");
 
         let registry = registry_with_tool();
-        let payload = integration_snapshot(
-            &registry,
-            None,
-            None,
-            DEFAULT_CONTEXTLATTICE_URL,
-            100,
-            false,
-            false,
-        )
+        let auth = json!({
+            "provider": "openrouter",
+            "model_hint": Value::Null,
+            "oauth_capable": false,
+            "managed_tools_supported": false,
+            "credential_present": true,
+            "oauth_state_present": false,
+            "status": "PASS",
+            "credential": {
+                "present": true,
+                "env_keys": ["OPENROUTER_API_KEY"],
+            },
+            "auth_store": {
+                "present": false,
+            },
+            "oauth_runtime_gate": Value::Null,
+            "secret_values_emitted": false,
+        });
+        let payload = integration_snapshot_from_request(IntegrationSnapshotRequest {
+            registry: &registry,
+            provider: Some("openrouter"),
+            model: None,
+            memory_url: DEFAULT_CONTEXTLATTICE_URL,
+            timeout_ms: 100,
+            probe_memory: false,
+            include_plugins: false,
+            config_path_override: Some(&config_path),
+            auth_override: Some(auth),
+        })
         .await;
         let raw = payload.to_string();
 
@@ -724,7 +784,7 @@ mod tests {
         assert_eq!(payload["memory"]["status"], "skipped");
         assert_eq!(payload["mutable"], false);
         assert_eq!(payload["secret_values_emitted"], false);
-        assert!(!raw.contains("sk-secret-should-not-leak"));
+        assert!(!raw.contains("sk-"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make the integrations snapshot status test hermetic by injecting explicit config/auth inputs instead of mutating process-global environment
- keep production integration snapshot behavior unchanged through the public API path
- assert terminal tool registration from registry state instead of env-sensitive availability filtering for the managed Modal surface

## Verification
- cargo test -p hermes-tools status_snapshot_is_read_only_and_reports_core_panels -- --nocapture
- cargo test -p hermes-tools --lib --quiet
- cargo test -p hermes-tools --quiet
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- cargo test --workspace --quiet
- scripts/clippy-warning-gate.sh --check (`seen=199 allowlist=204 new=0 stale=5`, `new=0`)
