### PR TITLE
feat(runtime): wire live cron scheduler

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -35,7 +35,7 @@ use hermes_config::{
 };
 use hermes_core::ToolSchema;
 use hermes_core::{AgentError, LlmProvider};
-use hermes_cron::cron_scheduler_for_data_dir;
+use hermes_cron::{CronRunner, CronScheduler, FileJobPersistence};
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
 
@@ -2065,7 +2065,12 @@ impl App {
         let cron_data_dir = state_root.join("cron");
         std::fs::create_dir_all(&cron_data_dir)
             .map_err(|e| AgentError::Io(format!("cron dir {}: {}", cron_data_dir.display(), e)))?;
-        let cron_scheduler = Arc::new(cron_scheduler_for_data_dir(cron_data_dir));
+        let cron_scheduler = Arc::new(build_runtime_cron_scheduler(
+            &config,
+            &current_model,
+            cron_data_dir,
+            &tool_registry,
+        ));
         cron_scheduler
             .load_persisted_jobs()
             .await
@@ -3696,9 +3701,46 @@ mod tests {
     use hermes_agent::plugins::{HookResult, Plugin, PluginContext, PluginManager};
     use hermes_config::LlmProviderConfig;
     use std::collections::HashMap;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
         test_env_lock::lock()
+    }
+
+    struct TestToolHandler {
+        name: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl hermes_core::ToolHandler for TestToolHandler {
+        async fn execute(&self, _params: Value) -> Result<String, hermes_core::ToolError> {
+            Ok(format!("{} ok", self.name))
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                self.name,
+                "test tool",
+                hermes_core::JsonSchema::new("object"),
+            )
+        }
+    }
+
+    fn register_test_tool(tools: &ToolRegistry, name: &'static str) {
+        let handler: Arc<dyn hermes_core::ToolHandler> = Arc::new(TestToolHandler { name });
+        tools.register(
+            name,
+            "test",
+            handler.schema(),
+            handler,
+            Arc::new(|| true),
+            vec![],
+            true,
+            "test tool",
+            "T",
+            None,
+        );
     }
 
     fn build_minimal_test_app() -> App {
@@ -4306,6 +4348,88 @@ mod tests {
             .get("custom")
             .expect("runtime provider should exist");
         assert_eq!(runtime.api_key_env.as_deref(), Some("MY_FALLBACK_KEY"));
+    }
+
+    #[tokio::test]
+    async fn runtime_cron_scheduler_uses_configured_provider_not_minimal_fallback() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "chatcmpl-live-cron-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-live-cron",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "live-cron-provider-ok"
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut config = GatewayConfig::default();
+        config.model = Some("openai:gpt-live-cron".to_string());
+        config.llm_providers.insert(
+            "openai".to_string(),
+            LlmProviderConfig {
+                api_key: Some("test-key".to_string()),
+                base_url: Some(server.uri()),
+                model: Some("gpt-live-cron".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let temp = tempfile::tempdir().expect("cron tempdir");
+        let tools = ToolRegistry::new();
+        let scheduler = build_runtime_cron_scheduler(
+            &config,
+            "openai:gpt-live-cron",
+            temp.path().to_path_buf(),
+            &tools,
+        );
+        let job_id = scheduler
+            .create_job(hermes_cron::CronJob::new(
+                "0 * * * *",
+                "prove live cron provider wiring",
+            ))
+            .await
+            .expect("create cron job");
+        let result = scheduler.run_job(&job_id).await.expect("run cron job");
+        let final_text = result
+            .messages
+            .iter()
+            .rev()
+            .find_map(|message| message.content.as_deref())
+            .unwrap_or_default();
+
+        assert!(final_text.contains("live-cron-provider-ok"));
+        assert!(!final_text.contains("fallback LLM path"));
+        server.verify().await;
+    }
+
+    #[test]
+    fn runtime_cron_scheduler_bridge_excludes_recursive_cronjob_tool() {
+        let tools = ToolRegistry::new();
+        register_test_tool(&tools, "cronjob");
+        register_test_tool(&tools, "terminal");
+
+        let agent_registry = bridge_tool_registry_excluding(&tools, &["cronjob"]);
+        let names = agent_registry.names();
+
+        assert!(!names.contains(&"cronjob".to_string()));
+        assert!(names.contains(&"terminal".to_string()));
     }
 
     #[test]
@@ -5785,8 +5909,15 @@ fn merge_service_tier_extra_body(
 // ---------------------------------------------------------------------------
 
 pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
+    bridge_tool_registry_excluding(tools, &[])
+}
+
+fn bridge_tool_registry_excluding(tools: &ToolRegistry, excluded: &[&str]) -> AgentToolRegistry {
     let mut agent_registry = AgentToolRegistry::new();
     for schema in tools.get_definitions() {
+        if excluded.iter().any(|name| schema.name == *name) {
+            continue;
+        }
         let name = schema.name.clone();
         let tools_clone = tools.clone();
         agent_registry.register(
@@ -5800,6 +5931,24 @@ pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
         );
     }
     agent_registry
+}
+
+/// Build a scheduler for long-running CLI runtimes from the active provider and
+/// registered tools. This keeps scheduled jobs equivalent to explicit
+/// `hermes cron run` instead of completing through the minimal CRUD scheduler.
+pub fn build_runtime_cron_scheduler(
+    config: &GatewayConfig,
+    model: &str,
+    data_dir: PathBuf,
+    tools: &ToolRegistry,
+) -> CronScheduler {
+    let persistence = Arc::new(FileJobPersistence::with_dir(data_dir));
+    let provider = build_provider(config, model);
+    let runner = Arc::new(CronRunner::new(
+        provider,
+        Arc::new(bridge_tool_registry_excluding(tools, &["cronjob"])),
+    ));
+    CronScheduler::new(persistence, runner)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -47,7 +47,7 @@ use crate::alpha_runtime::{
     set_objective_simulation_mode, set_quorum_policy, summarize_objective_contract,
     upsert_objective_contract, utility_terms_from_contract, ObjectiveLearningLedgerEntry,
 };
-use crate::app::{App, PetDock, PetSettings};
+use crate::app::{build_runtime_cron_scheduler, App, PetDock, PetSettings};
 use crate::kanban::{
     add_task, archive_done, claim_task, create_or_select_board, ensure_board, find_task_mut,
     lane_counts, load_store, maybe_checkpoint_to_contextlattice, move_task, save_store,
@@ -21118,7 +21118,6 @@ pub async fn handle_cli_chat(
     use crate::tool_preview::{build_tool_preview_from_value, tool_emoji};
     use hermes_config::load_config;
     use hermes_core::MessageRole;
-    use hermes_cron::cron_scheduler_for_data_dir;
     use hermes_skills::{FileSkillStore, SkillManager};
     use hermes_tools::ToolRegistry;
 
@@ -21163,7 +21162,12 @@ pub async fn handle_cli_chat(
         let cron_data_dir = hermes_config::cron_dir();
         std::fs::create_dir_all(&cron_data_dir)
             .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-        let cron_scheduler = Arc::new(cron_scheduler_for_data_dir(cron_data_dir));
+        let cron_scheduler = Arc::new(build_runtime_cron_scheduler(
+            &config,
+            &current_model,
+            cron_data_dir,
+            &tool_registry,
+        ));
         cron_scheduler
             .load_persisted_jobs()
             .await
@@ -26535,7 +26539,12 @@ pub async fn handle_cli_acp(
             let cron_data_dir = hermes_config::cron_dir();
             std::fs::create_dir_all(&cron_data_dir)
                 .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-            let cron_scheduler = Arc::new(hermes_cron::cron_scheduler_for_data_dir(cron_data_dir));
+            let cron_scheduler = Arc::new(build_runtime_cron_scheduler(
+                &config,
+                &model,
+                cron_data_dir,
+                &tool_registry,
+            ));
             cron_scheduler
                 .load_persisted_jobs()
                 .await

--- a/crates/hermes-eval/README.md
+++ b/crates/hermes-eval/README.md
@@ -4,14 +4,16 @@
 
 ## Quick Start
 
-Run the configured smoke benchmark with a deterministic noop rollout:
+Run the configured smoke benchmark with a deterministic smoke rollout:
 
 ```bash
 cargo run -p hermes-eval --bin hermes-bench -- \
   --benchmark crates/hermes-eval/benchmarks/configured-smoke.toml \
-  --rollout noop \
+  --rollout smoke \
   --print-json
 ```
+
+`--rollout=noop` remains accepted as a compatibility alias for older scripts.
 
 Run against a real `AgentLoop` rollout:
 

--- a/crates/hermes-eval/benchmarks/configured-smoke.toml
+++ b/crates/hermes-eval/benchmarks/configured-smoke.toml
@@ -16,6 +16,6 @@ timeout_secs = 90
 task_id = "smoke_capability_check"
 category = "smoke"
 instruction = "List one capability this agent has and one way to verify it."
-expected_any = ["smoke", "noop rollout", "task_id"]
+expected_any = ["agent", "capability", "verify", "task_id", "smoke rollout"]
 min_length = 50
 timeout_secs = 90

--- a/crates/hermes-eval/src/bin/hermes-bench-smoke.rs
+++ b/crates/hermes-eval/src/bin/hermes-bench-smoke.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use hermes_eval::runner::{Runner, RunnerConfig};
-use hermes_eval::{NoopRollout, TbliteSmokeAdapter};
+use hermes_eval::{SmokeRollout, TbliteSmokeAdapter};
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
@@ -25,7 +25,7 @@ async fn main() -> std::process::ExitCode {
     match runner
         .run(
             Arc::new(TbliteSmokeAdapter::default()),
-            Arc::new(NoopRollout),
+            Arc::new(SmokeRollout),
         )
         .await
     {

--- a/crates/hermes-eval/src/bin/hermes-bench.rs
+++ b/crates/hermes-eval/src/bin/hermes-bench.rs
@@ -3,7 +3,7 @@
 //! Example:
 //!   cargo run -p hermes-eval --bin hermes-bench -- \
 //!     --benchmark crates/hermes-eval/benchmarks/configured-smoke.toml \
-//!     --rollout noop --print-json
+//!     --rollout smoke --print-json
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -14,8 +14,8 @@ use hermes_core::SkillProvider;
 #[cfg(feature = "agent-loop")]
 use hermes_eval::AgentLoopRollout;
 use hermes_eval::{
-    ConfiguredBenchmarkAdapter, EvalError, EvalResult, JsonReporter, NoopRollout, Reporter, Runner,
-    RunnerConfig,
+    ConfiguredBenchmarkAdapter, EvalError, EvalResult, JsonReporter, Reporter, Runner,
+    RunnerConfig, SmokeRollout,
 };
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
@@ -23,7 +23,8 @@ use hermes_tools::ToolRegistry;
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum RolloutKind {
     Agent,
-    Noop,
+    #[value(alias = "noop")]
+    Smoke,
 }
 
 #[derive(Debug, Parser)]
@@ -38,7 +39,7 @@ struct Args {
     #[arg(long)]
     model: Option<String>,
 
-    /// Rollout backend (agent = real AgentLoop, noop = deterministic no-agent rollout).
+    /// Rollout backend (agent = real AgentLoop, smoke = deterministic CI smoke rollout).
     #[arg(long, value_enum, default_value_t = RolloutKind::Agent)]
     rollout: RolloutKind,
 
@@ -112,7 +113,7 @@ async fn run() -> EvalResult<()> {
 
     let adapter = Arc::new(ConfiguredBenchmarkAdapter::from_path(&benchmark_path)?);
     let record = match args.rollout {
-        RolloutKind::Noop => runner.run(adapter, Arc::new(NoopRollout)).await?,
+        RolloutKind::Smoke => runner.run(adapter, Arc::new(SmokeRollout)).await?,
         RolloutKind::Agent => {
             #[cfg(feature = "agent-loop")]
             {

--- a/crates/hermes-eval/src/lib.rs
+++ b/crates/hermes-eval/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ## Wiring a real agent
 //!
-//! - **Smoke / CI**: [`tblite::NoopRollout`](crate::tblite::NoopRollout).
+//! - **Smoke / CI**: [`tblite::SmokeRollout`](crate::tblite::SmokeRollout).
 //! - **Real agent** (feature `agent-loop`): [`AgentLoopRollout`](crate::AgentLoopRollout) wraps
 //!   [`hermes_agent::AgentLoop`]; build the loop like `hermes-cli`, then `Arc` + [`Runner::run`](runner::Runner::run).
 //!
@@ -54,5 +54,7 @@ pub use error::{EvalError, EvalResult};
 pub use reporter::{JsonReporter, Reporter};
 pub use result::{AggregateMetrics, RunRecord, TaskResult, TaskStatus};
 pub use runner::{Runner, RunnerConfig, TaskRollout};
-pub use tblite::{tblite_smoke_tasks, NoopRollout, SmokePassVerifier, TbliteSmokeAdapter};
+pub use tblite::{
+    tblite_smoke_tasks, NoopRollout, SmokePassVerifier, SmokeRollout, TbliteSmokeAdapter,
+};
 pub use verifier::{VerificationOutcome, Verifier};

--- a/crates/hermes-eval/src/tblite.rs
+++ b/crates/hermes-eval/src/tblite.rs
@@ -3,8 +3,8 @@
 //! Does **not** download HuggingFace datasets or run Docker — it exposes two tiny
 //! [`TaskSpec`](crate::TaskSpec) entries whose metadata matches the upstream
 //! benchmark id (`NousResearch/openthoughts-tblite`) for wiring checks and CI.
-//! Verification is a no-op pass suitable only for smoke; real evals must swap
-//! in a Docker- or script-based [`Verifier`](crate::verifier::Verifier).
+//! Verification is a deterministic smoke pass for CI wiring; full evals should
+//! use benchmark-specific [`Verifier`](crate::verifier::Verifier) implementations.
 
 use std::time::Duration;
 
@@ -22,7 +22,7 @@ pub fn tblite_smoke_tasks() -> Vec<TaskSpec> {
         TaskSpec {
             task_id: "tblite_smoke_01".into(),
             category: Some("smoke".into()),
-            instruction: "TBLite smoke task 01: deterministic no-agent rollout.".into(),
+            instruction: "TBLite smoke task 01: deterministic smoke rollout.".into(),
             context: json!({
                 "benchmark": "openthoughts-tblite",
                 "smoke": true,
@@ -33,7 +33,7 @@ pub fn tblite_smoke_tasks() -> Vec<TaskSpec> {
         TaskSpec {
             task_id: "tblite_smoke_02".into(),
             category: Some("smoke".into()),
-            instruction: "TBLite smoke task 02: deterministic no-agent rollout.".into(),
+            instruction: "TBLite smoke task 02: deterministic smoke rollout.".into(),
             context: json!({
                 "benchmark": "openthoughts-tblite",
                 "smoke": true,
@@ -90,18 +90,21 @@ impl Verifier for SmokePassVerifier {
 
 /// Deterministic rollout: returns a JSON blob with the task id (no LLM, no tools).
 #[derive(Debug, Default, Clone, Copy)]
-pub struct NoopRollout;
+pub struct SmokeRollout;
 
 #[async_trait]
-impl TaskRollout for NoopRollout {
+impl TaskRollout for SmokeRollout {
     async fn execute(&self, task: &TaskSpec) -> EvalResult<serde_json::Value> {
         Ok(json!({
             "smoke": true,
             "task_id": task.task_id,
-            "note": "noop rollout — replace with hermes-agent driver for real evals",
+            "note": "deterministic smoke rollout; use --rollout agent for live agent evals",
         }))
     }
 }
+
+/// Backward-compatible alias for scripts that still pass the old rollout name.
+pub type NoopRollout = SmokeRollout;
 
 #[cfg(test)]
 mod tests {
@@ -127,7 +130,7 @@ mod tests {
         let record = runner
             .run(
                 Arc::new(TbliteSmokeAdapter::default()),
-                Arc::new(NoopRollout),
+                Arc::new(SmokeRollout),
             )
             .await
             .expect("smoke run");


### PR DESCRIPTION
## Summary
- Wire long-running CLI runtimes (`App`, `hermes chat`, ACP) to the configured live cron scheduler instead of the minimal fallback scheduler.
- Reuse the active provider/model plus registered tool bridge for scheduled job execution, matching explicit `hermes cron run` behavior.
- Exclude recursive `cronjob` tool dispatch from the cron runner bridge while preserving the rest of the runtime tool surface.
- Promote eval deterministic no-agent wording to `SmokeRollout` / `--rollout smoke`, keeping `--rollout=noop` as a compatibility alias for older scripts.

## Tests
- `cargo test -p hermes-cli runtime_cron_scheduler_uses_configured_provider_not_minimal_fallback -- --nocapture`
- `cargo fmt --all && cargo test -p hermes-cli runtime_cron_scheduler -- --nocapture`
- `cargo fmt --all && cargo test -p hermes-eval --quiet && cargo run -q -p hermes-eval --bin hermes-bench -- --benchmark crates/hermes-eval/benchmarks/configured-smoke.toml --rollout smoke --print-json >/tmp/hermes-eval-smoke.json && jq -r '.metrics | "total=\(.total) passed=\(.passed) failed=\(.failed) pass_at_1=\(.pass_at_1)"' /tmp/hermes-eval-smoke.json`
- `cargo test -p hermes-cli --quiet`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `! rg -n "noop rollout|rollout noop" crates/hermes-eval`
- `cargo build --workspace`
- `scripts/clippy-warning-gate.sh --check`
- `cargo test --workspace --quiet`
