### PR TITLE
fix(tools): protect stale cron cleanup entries

### DIFF
--- a/crates/hermes-tools/src/tools/dashboard_control.rs
+++ b/crates/hermes-tools/src/tools/dashboard_control.rs
@@ -52,12 +52,18 @@ fn dashboard_url(host: &str, port: u16) -> String {
     format!("http://{}:{}/", display_host, port)
 }
 
-fn read_dashboard_platform() -> Result<(std::path::PathBuf, PlatformConfig), ToolError> {
-    let cfg_path = hermes_home().join("config.yaml");
+fn read_dashboard_platform_from_home(
+    home: &std::path::Path,
+) -> Result<(std::path::PathBuf, PlatformConfig), ToolError> {
+    let cfg_path = home.join("config.yaml");
     let cfg = load_user_config_file(&cfg_path)
         .map_err(|e| ToolError::ExecutionFailed(format!("load config: {e}")))?;
     let platform = cfg.platforms.get("api_server").cloned().unwrap_or_default();
     Ok((cfg_path, platform))
+}
+
+fn read_dashboard_platform() -> Result<(std::path::PathBuf, PlatformConfig), ToolError> {
+    read_dashboard_platform_from_home(&hermes_home())
 }
 
 fn current_host_and_port(platform: &PlatformConfig) -> (String, u16) {
@@ -91,7 +97,8 @@ fn emit_status_payload(cfg_path: &std::path::Path, platform: &PlatformConfig) ->
     .to_string()
 }
 
-fn persist_dashboard_platform(
+fn persist_dashboard_platform_in_home(
+    home: &std::path::Path,
     enabled: bool,
     host: String,
     port: u16,
@@ -103,7 +110,7 @@ fn persist_dashboard_platform(
         ));
     }
 
-    let cfg_path = hermes_home().join("config.yaml");
+    let cfg_path = home.join("config.yaml");
     let mut cfg = load_user_config_file(&cfg_path)
         .map_err(|e| ToolError::ExecutionFailed(format!("load config: {e}")))?;
 
@@ -131,6 +138,15 @@ fn persist_dashboard_platform(
         "config_path": cfg_path.display().to_string(),
     })
     .to_string())
+}
+
+fn persist_dashboard_platform(
+    enabled: bool,
+    host: String,
+    port: u16,
+    insecure: bool,
+) -> Result<String, ToolError> {
+    persist_dashboard_platform_in_home(&hermes_home(), enabled, host, port, insecure)
 }
 
 #[derive(Default)]
@@ -221,80 +237,53 @@ impl ToolHandler for DashboardControlHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hermes_config::managed_gateway::test_lock;
-    use std::path::Path;
-
-    struct HermesHomeScope(Option<String>);
-
-    impl HermesHomeScope {
-        fn set(path: &Path) -> Self {
-            let original = std::env::var("HERMES_HOME").ok();
-            std::env::set_var("HERMES_HOME", path);
-            Self(original)
-        }
-    }
-
-    impl Drop for HermesHomeScope {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("HERMES_HOME", value),
-                None => std::env::remove_var("HERMES_HOME"),
-            }
-        }
-    }
-
-    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime")
-            .block_on(future)
-    }
 
     #[test]
     fn enable_status_disable_roundtrip() {
-        let _guard = test_lock::lock();
         let temp = tempfile::tempdir().expect("tempdir");
-        let _home = HermesHomeScope::set(temp.path());
 
-        block_on(async {
-            let handler = DashboardControlHandler;
-            let enabled = handler
-                .execute(json!({"action":"enable","host":"127.0.0.1","port":9191}))
-                .await
-                .expect("enable");
-            let enabled_json: Value = serde_json::from_str(&enabled).expect("json");
-            assert_eq!(enabled_json["enabled"], true);
-            assert_eq!(enabled_json["port"], 9191);
+        let enabled = persist_dashboard_platform_in_home(
+            temp.path(),
+            true,
+            "127.0.0.1".to_string(),
+            9191,
+            false,
+        )
+        .expect("enable");
+        let enabled_json: Value = serde_json::from_str(&enabled).expect("json");
+        assert_eq!(enabled_json["enabled"], true);
+        assert_eq!(enabled_json["port"], 9191);
 
-            let status = handler
-                .execute(json!({"action":"status"}))
-                .await
-                .expect("status");
-            let status_json: Value = serde_json::from_str(&status).expect("json");
-            assert_eq!(status_json["enabled"], true);
-            assert_eq!(status_json["host"], "127.0.0.1");
-            assert_eq!(status_json["port"], 9191);
+        let (cfg_path, platform) = read_dashboard_platform_from_home(temp.path()).expect("status");
+        let status_json: Value =
+            serde_json::from_str(&emit_status_payload(&cfg_path, &platform)).expect("json");
+        assert_eq!(status_json["enabled"], true);
+        assert_eq!(status_json["host"], "127.0.0.1");
+        assert_eq!(status_json["port"], 9191);
 
-            let disabled = handler
-                .execute(json!({"action":"disable"}))
-                .await
-                .expect("disable");
-            let disabled_json: Value = serde_json::from_str(&disabled).expect("json");
-            assert_eq!(disabled_json["enabled"], false);
-        });
+        let disabled = persist_dashboard_platform_in_home(
+            temp.path(),
+            false,
+            "127.0.0.1".to_string(),
+            9191,
+            true,
+        )
+        .expect("disable");
+        let disabled_json: Value = serde_json::from_str(&disabled).expect("json");
+        assert_eq!(disabled_json["enabled"], false);
     }
 
     #[test]
     fn rejects_non_local_without_insecure() {
-        let _guard = test_lock::lock();
         let temp = tempfile::tempdir().expect("tempdir");
-        let _home = HermesHomeScope::set(temp.path());
-
-        let handler = DashboardControlHandler;
-        let err =
-            block_on(handler.execute(json!({"action":"enable","host":"0.0.0.0","port":8080})))
-                .expect_err("non-local should fail");
+        let err = persist_dashboard_platform_in_home(
+            temp.path(),
+            true,
+            "0.0.0.0".to_string(),
+            8080,
+            false,
+        )
+        .expect_err("non-local should fail");
         match err {
             ToolError::InvalidParams(msg) => assert!(msg.contains("non-localhost")),
             other => panic!("unexpected error: {other:?}"),

--- a/crates/hermes-tools/src/tools/disk_cleanup.rs
+++ b/crates/hermes-tools/src/tools/disk_cleanup.rs
@@ -311,7 +311,14 @@ impl DiskCleanup {
         let mut auto = Vec::new();
         let mut prompt = Vec::new();
         for item in self.load_tracked() {
-            if !Path::new(&item.path).exists() {
+            let path = Path::new(&item.path);
+            if !path.exists() {
+                continue;
+            }
+            if item.category == "cron-output" && self.guess_category(path) != Some("cron-output") {
+                continue;
+            }
+            if self.is_protected_cron_path(path) {
                 continue;
             }
             let age_days = age_days(&item.timestamp, now).unwrap_or(0);
@@ -346,6 +353,14 @@ impl DiskCleanup {
                 continue;
             }
             let age_days = age_days(&item.timestamp, now).unwrap_or(0);
+            if item.category == "cron-output" && self.guess_category(path) != Some("cron-output") {
+                self.audit_log(&format!("SKIP stale cron-output entry: {}", path.display()));
+                continue;
+            }
+            if self.is_protected_cron_path(path) {
+                self.audit_log(&format!("SKIP protected cron path: {}", path.display()));
+                continue;
+            }
             let should_delete = item.category == "test"
                 || (item.category == "temp" && age_days > 7)
                 || (item.category == "cron-output" && age_days > 14);
@@ -423,6 +438,32 @@ impl DiskCleanup {
             top10: existing,
             total_tracked: tracked.len(),
         }
+    }
+
+    fn is_protected_cron_path(&self, path: &Path) -> bool {
+        let Ok(abs) = normalized_path(path) else {
+            return false;
+        };
+        let home = fs::canonicalize(&self.hermes_home).unwrap_or_else(|_| {
+            absolute_path(&self.hermes_home).unwrap_or(self.hermes_home.clone())
+        });
+        let Ok(rel) = abs.strip_prefix(&home) else {
+            return false;
+        };
+        let parts: Vec<_> = rel
+            .components()
+            .filter_map(|c| c.as_os_str().to_str())
+            .collect();
+
+        matches!(
+            parts.as_slice(),
+            ["cron"]
+                | ["cronjobs"]
+                | ["cron", "jobs.json"]
+                | ["cronjobs", "jobs.json"]
+                | ["cron", ".tick.lock"]
+                | ["cronjobs", ".tick.lock"]
+        )
     }
 
     fn remove_empty_dirs(&self) -> usize {
@@ -936,6 +977,108 @@ mod tests {
         assert_eq!(cleaner.guess_category(&jobs), None);
         assert_eq!(cleaner.guess_category(&lock), None);
         assert_eq!(cleaner.guess_category(&output), Some("cron-output"));
+    }
+
+    fn stale_item(path: &Path, category: &str, size: u64) -> TrackedItem {
+        TrackedItem {
+            path: path.to_string_lossy().to_string(),
+            timestamp: (Utc::now() - chrono::Duration::days(20)).to_rfc3339(),
+            category: category.to_string(),
+            size,
+        }
+    }
+
+    #[test]
+    fn quick_skips_stale_cron_output_jobs_json_and_drops_tracking() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let cron_dir = cleaner.hermes_home().join("cron");
+        fs::create_dir_all(&cron_dir).unwrap();
+        let jobs = cron_dir.join("jobs.json");
+        fs::write(&jobs, "{\"jobs\":[]}").unwrap();
+        cleaner
+            .save_tracked(&[stale_item(&jobs, "cron-output", 123)])
+            .unwrap();
+
+        let summary = cleaner.quick();
+
+        assert_eq!(summary.deleted, 0);
+        assert!(jobs.exists(), "cron/jobs.json must never be deleted");
+        assert!(cleaner.load_tracked().is_empty());
+    }
+
+    #[test]
+    fn quick_skips_stale_cron_output_cron_dir_and_drops_tracking() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let cron_dir = cleaner.hermes_home().join("cron");
+        let output_dir = cron_dir.join("output/job-1");
+        fs::create_dir_all(&output_dir).unwrap();
+        fs::write(output_dir.join("run.md"), "x").unwrap();
+        cleaner
+            .save_tracked(&[stale_item(&cron_dir, "cron-output", 0)])
+            .unwrap();
+
+        let summary = cleaner.quick();
+
+        assert_eq!(summary.deleted, 0);
+        assert!(cron_dir.exists(), "cron/ control-plane dir must remain");
+        assert!(cleaner.load_tracked().is_empty());
+    }
+
+    #[test]
+    fn quick_skips_protected_cron_path_even_with_auto_delete_category() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let cron_dir = cleaner.hermes_home().join("cron");
+        fs::create_dir_all(&cron_dir).unwrap();
+        let tick_lock = cron_dir.join(".tick.lock");
+        fs::write(&tick_lock, "").unwrap();
+        cleaner
+            .save_tracked(&[stale_item(&tick_lock, "test", 0)])
+            .unwrap();
+
+        let summary = cleaner.quick();
+
+        assert_eq!(summary.deleted, 0);
+        assert!(tick_lock.exists(), ".tick.lock must never be deleted");
+        assert!(cleaner.load_tracked().is_empty());
+    }
+
+    #[test]
+    fn dry_run_omits_stale_cron_output_control_plane_entries() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let cron_dir = cleaner.hermes_home().join("cron");
+        fs::create_dir_all(&cron_dir).unwrap();
+        let jobs = cron_dir.join("jobs.json");
+        fs::write(&jobs, "[]").unwrap();
+        cleaner
+            .save_tracked(&[stale_item(&jobs, "cron-output", 123)])
+            .unwrap();
+
+        let (auto, prompt) = cleaner.dry_run();
+
+        assert!(auto.is_empty());
+        assert!(prompt.is_empty());
+    }
+
+    #[test]
+    fn quick_deletes_legitimate_old_cron_output() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let output_dir = cleaner.hermes_home().join("cron/output/job-1");
+        fs::create_dir_all(&output_dir).unwrap();
+        let run_md = output_dir.join("run.md");
+        fs::write(&run_md, "x").unwrap();
+        cleaner
+            .save_tracked(&[stale_item(&run_md, "cron-output", 10)])
+            .unwrap();
+
+        let summary = cleaner.quick();
+
+        assert_eq!(summary.deleted, 1);
+        assert!(!run_md.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- revalidate stale tracked `cron-output` entries before cleanup so stale cron control-plane records are dropped instead of deleted
- protect cron control-plane roots and files (`cron/`, `cronjobs/`, `jobs.json`, `.tick.lock`) from auto-delete even if misclassified
- keep legitimate aged `cron/output/**` cleanup behavior intact
- make dashboard-control tests path-bound instead of mutating `HERMES_HOME`, removing a parallel-test race exposed by the full gate

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-tools --quiet` (`538 passed; 0 failed` in the main hermes-tools block)
- `scripts/clippy-warning-gate.sh --check` (`seen=199 allowlist=204 new=0 stale=5`)
- `cargo build --workspace` (`Finished dev profile`)
- `cargo test --workspace --quiet` (workspace test process exited `0`; observed large passing blocks including `559 passed`, `538 passed`, `480 passed`, `199 passed`, `146 passed`, `93 passed`, `61 passed`, all `0 failed`)
