### PR TITLE
fix(runtime): harden upstream resilience parity

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/openviking.rs
+++ b/crates/hermes-agent/src/memory_plugins/openviking.rs
@@ -11,6 +11,8 @@ use serde_json::{json, Value};
 use crate::memory_manager::MemoryProviderPlugin;
 
 const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:1933";
+const DEFAULT_AGENT: &str = "hermes";
+const DEFAULT_MEMORY_SUBDIR: &str = "preferences";
 
 fn search_schema() -> Value {
     json!({
@@ -62,7 +64,7 @@ fn browse_schema() -> Value {
 fn remember_schema() -> Value {
     json!({
         "name": "viking_remember",
-        "description": "Store a fact as a session message for later extraction.",
+        "description": "Store a fact directly in the OpenViking memory tree.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -96,6 +98,7 @@ struct VikingState {
     api_key: String,
     account: String,
     user: String,
+    agent: String,
     session_id: String,
     turn_count: u32,
 }
@@ -110,10 +113,69 @@ fn viking_headers(st: &VikingState) -> reqwest::header::HeaderMap {
     h.insert("Content-Type", "application/json".parse().expect("mime"));
     h.insert("X-OpenViking-Account", st.account.parse().expect("account"));
     h.insert("X-OpenViking-User", st.user.parse().expect("user"));
+    h.insert("X-OpenViking-Agent", st.agent.parse().expect("agent"));
     if !st.api_key.is_empty() {
         h.insert("X-API-Key", st.api_key.parse().expect("key"));
+        h.insert(
+            "Authorization",
+            format!("Bearer {}", st.api_key).parse().expect("bearer"),
+        );
     }
     h
+}
+
+fn viking_uri_segment(raw: &str) -> String {
+    let sanitized = raw
+        .trim()
+        .chars()
+        .map(|ch| match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '_' | '-' => ch,
+            _ => '_',
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "default".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn memory_subdir_for_category(category: &str) -> &'static str {
+    match category.trim().to_ascii_lowercase().as_str() {
+        "preference" | "preferences" => "preferences",
+        "entity" | "entities" => "entities",
+        "event" | "events" => "events",
+        "case" | "cases" => "cases",
+        "pattern" | "patterns" => "patterns",
+        _ => DEFAULT_MEMORY_SUBDIR,
+    }
+}
+
+fn memory_subdir_for_target(target: &str) -> &'static str {
+    match target.trim().to_ascii_lowercase().as_str() {
+        "memory" | "memories" => "patterns",
+        "user" | "preferences" => "preferences",
+        _ => DEFAULT_MEMORY_SUBDIR,
+    }
+}
+
+fn build_memory_uri(user: &str, agent: &str, subdir: &str) -> String {
+    let slug = uuid::Uuid::new_v4().simple().to_string();
+    format!(
+        "viking://user/{}/agent/{}/memories/{}/mem_{}.md",
+        viking_uri_segment(user),
+        viking_uri_segment(agent),
+        viking_uri_segment(subdir),
+        &slug[..12]
+    )
+}
+
+fn content_write_body(st: &VikingState, subdir: &str, content: &str) -> Value {
+    json!({
+        "uri": build_memory_uri(&st.user, &st.agent, subdir),
+        "content": content,
+        "mode": "create",
+    })
 }
 
 impl OpenVikingMemoryPlugin {
@@ -144,6 +206,7 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         let api_key = std::env::var("OPENVIKING_API_KEY").unwrap_or_default();
         let account = std::env::var("OPENVIKING_ACCOUNT").unwrap_or_else(|_| "root".into());
         let user = std::env::var("OPENVIKING_USER").unwrap_or_else(|_| "default".into());
+        let agent = std::env::var("OPENVIKING_AGENT").unwrap_or_else(|_| DEFAULT_AGENT.into());
         let client = match Client::builder().timeout(Duration::from_secs(45)).build() {
             Ok(c) => c,
             Err(e) => {
@@ -157,6 +220,7 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
             api_key,
             account,
             user,
+            agent,
             session_id: session_id.to_string(),
             turn_count: 0,
         };
@@ -267,6 +331,22 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         let _ = st.client.post(&url).headers(h).send();
     }
 
+    fn on_memory_write(&self, action: &str, target: &str, content: &str) {
+        if !action.trim().eq_ignore_ascii_case("add") || content.trim().is_empty() {
+            return;
+        }
+        let st = match self.state.lock().unwrap().clone() {
+            Some(s) => s,
+            None => return,
+        };
+        let h = viking_headers(&st);
+        let url = format!("{}/api/v1/content/write", st.endpoint);
+        let body = content_write_body(&st, memory_subdir_for_target(target), content);
+        std::thread::spawn(move || {
+            let _ = st.client.post(&url).headers(h).json(&body).send();
+        });
+    }
+
     fn get_tool_schemas(&self) -> Vec<Value> {
         vec![
             search_schema(),
@@ -364,15 +444,13 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
                     return json!({"error": "content is required"}).to_string();
                 }
                 let cat = args.get("category").and_then(|v| v.as_str()).unwrap_or("");
-                let text = if cat.is_empty() {
-                    format!("[Remember] {}", content)
-                } else {
-                    format!("[Remember — {}] {}", cat, content)
-                };
-                let url = format!("{}/api/v1/sessions/{}/messages", st.endpoint, st.session_id);
-                let body = json!({"role": "user", "parts": [{"type": "text", "text": text}]});
+                let body = content_write_body(&st, memory_subdir_for_category(cat), content);
+                let uri = body.get("uri").cloned().unwrap_or(Value::Null);
+                let url = format!("{}/api/v1/content/write", st.endpoint);
                 match st.client.post(&url).headers(h).json(&body).send() {
-                    Ok(r) if r.status().is_success() => json!({"status": "stored"}).to_string(),
+                    Ok(r) if r.status().is_success() => {
+                        json!({"status": "stored", "uri": uri}).to_string()
+                    }
                     Ok(r) => json!({"error": format!("HTTP {}", r.status())}).to_string(),
                     Err(e) => json!({"error": e.to_string()}).to_string(),
                 }
@@ -407,7 +485,8 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
     fn get_config_schema(&self) -> Option<Value> {
         Some(json!([
             {"key": "endpoint", "description": "OpenViking server URL", "env_var": "OPENVIKING_ENDPOINT", "default": DEFAULT_ENDPOINT},
-            {"key": "api_key", "description": "API key", "secret": true, "env_var": "OPENVIKING_API_KEY"}
+            {"key": "api_key", "description": "API key", "secret": true, "env_var": "OPENVIKING_API_KEY"},
+            {"key": "agent", "description": "OpenViking agent namespace", "env_var": "OPENVIKING_AGENT", "default": DEFAULT_AGENT}
         ]))
     }
 }
@@ -419,16 +498,7 @@ struct OpenVikingPrefetch {
 
 impl OpenVikingPrefetch {
     fn run(self) -> Result<String, ()> {
-        let h = {
-            let mut hm = reqwest::header::HeaderMap::new();
-            hm.insert("Content-Type", "application/json".parse().unwrap());
-            hm.insert("X-OpenViking-Account", self.st.account.parse().unwrap());
-            hm.insert("X-OpenViking-User", self.st.user.parse().unwrap());
-            if !self.st.api_key.is_empty() {
-                hm.insert("X-API-Key", self.st.api_key.parse().unwrap());
-            }
-            hm
-        };
+        let h = viking_headers(&self.st);
         let url = format!("{}/api/v1/search/find", self.st.endpoint);
         let body = json!({"query": self.q, "top_k": 5u64});
         let resp = self
@@ -473,5 +543,62 @@ mod tests {
     fn name() {
         let p = OpenVikingMemoryPlugin::new();
         assert_eq!(p.name(), "openviking");
+    }
+
+    #[test]
+    fn memory_uri_includes_agent_and_sanitizes_tenant_segments() {
+        let uri = build_memory_uri("user/name", "agent one", "patterns");
+        assert!(uri.starts_with("viking://user/user_name/agent/agent_one/memories/patterns/mem_"));
+        assert!(uri.ends_with(".md"));
+        assert!(!uri.contains("user/name"));
+        assert!(!uri.contains("agent one"));
+    }
+
+    #[test]
+    fn memory_subdir_mapping_matches_write_targets_and_categories() {
+        assert_eq!(memory_subdir_for_category("entity"), "entities");
+        assert_eq!(memory_subdir_for_category("event"), "events");
+        assert_eq!(memory_subdir_for_category("case"), "cases");
+        assert_eq!(memory_subdir_for_category("pattern"), "patterns");
+        assert_eq!(memory_subdir_for_category("unknown"), "preferences");
+        assert_eq!(memory_subdir_for_target("memory"), "patterns");
+        assert_eq!(memory_subdir_for_target("user"), "preferences");
+    }
+
+    #[test]
+    fn headers_include_agent_and_bearer_key() {
+        let st = VikingState {
+            client: Client::new(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            api_key: "secret".to_string(),
+            account: "acct".to_string(),
+            user: "user".to_string(),
+            agent: "agent".to_string(),
+            session_id: "session".to_string(),
+            turn_count: 0,
+        };
+        let headers = viking_headers(&st);
+        assert_eq!(headers["X-OpenViking-Agent"], "agent");
+        assert_eq!(headers["X-API-Key"], "secret");
+        assert_eq!(headers["Authorization"], "Bearer secret");
+    }
+
+    #[test]
+    fn content_write_body_uses_agent_scoped_create_uri() {
+        let st = VikingState {
+            client: Client::new(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            api_key: String::new(),
+            account: "acct".to_string(),
+            user: "she/a".to_string(),
+            agent: "hermes ultra".to_string(),
+            session_id: "session".to_string(),
+            turn_count: 0,
+        };
+        let body = content_write_body(&st, "patterns", "fact");
+        let uri = body["uri"].as_str().expect("uri");
+        assert!(uri.starts_with("viking://user/she_a/agent/hermes_ultra/memories/patterns/"));
+        assert_eq!(body["content"], "fact");
+        assert_eq!(body["mode"], "create");
     }
 }

--- a/crates/hermes-cli/src/runtime_tool_wiring.rs
+++ b/crates/hermes-cli/src/runtime_tool_wiring.rs
@@ -220,8 +220,10 @@ mod tests {
     use hermes_gateway::{gateway::GatewayConfig, DmManager, SessionManager};
     use tempfile::TempDir;
 
+    type SentRecord = (String, String, Option<String>);
+
     struct RecordingAdapter {
-        sent: Arc<Mutex<Vec<(String, String)>>>,
+        sent: Arc<Mutex<Vec<SentRecord>>>,
         running: bool,
         platform: String,
     }
@@ -255,7 +257,25 @@ mod tests {
             self.sent
                 .lock()
                 .expect("recording adapter lock poisoned")
-                .push((chat_id.to_string(), text.to_string()));
+                .push((chat_id.to_string(), text.to_string(), None));
+            Ok(())
+        }
+
+        async fn send_message_threaded(
+            &self,
+            chat_id: &str,
+            text: &str,
+            _parse_mode: Option<ParseMode>,
+            thread_id: Option<&str>,
+        ) -> Result<(), GatewayError> {
+            self.sent
+                .lock()
+                .expect("recording adapter lock poisoned")
+                .push((
+                    chat_id.to_string(),
+                    text.to_string(),
+                    thread_id.map(ToOwned::to_owned),
+                ));
             Ok(())
         }
 
@@ -318,6 +338,48 @@ mod tests {
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0].0, "12345");
         assert_eq!(sent[0].1, "hello");
+        assert_eq!(sent[0].2, None);
+    }
+
+    #[tokio::test]
+    async fn gateway_messaging_backend_preserves_slack_thread_id() {
+        let session_manager = Arc::new(SessionManager::new(
+            hermes_config::session::SessionConfig::default(),
+        ));
+        let dm = DmManager::with_pair_behavior();
+        let gateway = Arc::new(Gateway::new(session_manager, dm, GatewayConfig::default()));
+        let adapter = Arc::new(RecordingAdapter::new("slack"));
+        let recorder = adapter.sent.clone();
+        gateway.register_adapter("slack", adapter).await;
+
+        let registry = Arc::new(ToolRegistry::new());
+        wire_gateway_messaging_backend(&registry, gateway.clone());
+
+        let out = registry
+            .dispatch_async(
+                "send_message",
+                json!({
+                    "platform": "slack",
+                    "recipient": "C123",
+                    "message": "reply",
+                    "thread_ts": "171234.5"
+                }),
+            )
+            .await;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&out).expect("send_message output should be json");
+        assert_eq!(parsed["status"], "sent");
+        assert_eq!(parsed["thread_id"], "171234.5");
+
+        let sent = recorder.lock().expect("recording lock poisoned");
+        assert_eq!(
+            sent.as_slice(),
+            [(
+                "C123".to_string(),
+                "reply".to_string(),
+                Some("171234.5".to_string())
+            )]
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-core/src/traits.rs
+++ b/crates/hermes-core/src/traits.rs
@@ -79,6 +79,20 @@ pub trait PlatformAdapter: Send + Sync {
         parse_mode: Option<ParseMode>,
     ) -> Result<(), GatewayError>;
 
+    /// Send a text message with an optional platform-native thread id.
+    ///
+    /// Adapters without threaded replies inherit the plain send behavior.
+    async fn send_message_threaded(
+        &self,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        thread_id: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        let _ = thread_id;
+        self.send_message(chat_id, text, parse_mode).await
+    }
+
     /// Send or update a status message keyed by stable status type.
     ///
     /// Platforms that can edit messages should override this to keep noisy

--- a/crates/hermes-environments/src/docker.rs
+++ b/crates/hermes-environments/src/docker.rs
@@ -190,21 +190,24 @@ impl DockerBackend {
             s
         }
     }
-}
 
-#[async_trait]
-impl TerminalBackend for DockerBackend {
-    async fn execute_command(
+    fn clear_container_id(&self) {
+        *self.container_id.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+
+    fn should_recreate_after_exec_output(&self, output: &CommandOutput) -> bool {
+        self.container_persistent && output_indicates_container_gone(output)
+    }
+
+    async fn execute_in_container(
         &self,
+        container_id: &str,
         command: &str,
-        timeout: Option<u64>,
+        timeout_secs: u64,
         workdir: Option<&str>,
         background: bool,
         pty: bool,
     ) -> Result<CommandOutput, AgentError> {
-        let container_id = self.ensure_container().await?;
-        let timeout_secs = timeout.unwrap_or(self.default_timeout);
-
         let mut args = vec!["exec".to_string()];
 
         if pty {
@@ -253,6 +256,64 @@ impl TerminalBackend for DockerBackend {
                 timeout_secs
             ))),
         }
+    }
+}
+
+fn container_gone_message(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("no such container")
+        || lower.contains("no such object")
+        || lower.contains("is not running")
+}
+
+fn output_indicates_container_gone(output: &CommandOutput) -> bool {
+    output.exit_code != 0
+        && (container_gone_message(&output.stderr) || container_gone_message(&output.stdout))
+}
+
+#[async_trait]
+impl TerminalBackend for DockerBackend {
+    async fn execute_command(
+        &self,
+        command: &str,
+        timeout: Option<u64>,
+        workdir: Option<&str>,
+        background: bool,
+        pty: bool,
+    ) -> Result<CommandOutput, AgentError> {
+        let timeout_secs = timeout.unwrap_or(self.default_timeout);
+        let mut container_id = self.ensure_container().await?;
+        let mut output = self
+            .execute_in_container(
+                &container_id,
+                command,
+                timeout_secs,
+                workdir,
+                background,
+                pty,
+            )
+            .await?;
+
+        if self.should_recreate_after_exec_output(&output) {
+            tracing::warn!(
+                container_id = container_id,
+                "Docker persistent container disappeared; recreating and retrying command once"
+            );
+            self.clear_container_id();
+            container_id = self.ensure_container().await?;
+            output = self
+                .execute_in_container(
+                    &container_id,
+                    command,
+                    timeout_secs,
+                    workdir,
+                    background,
+                    pty,
+                )
+                .await?;
+        }
+
+        Ok(output)
     }
 
     async fn read_file(
@@ -454,5 +515,78 @@ mod tests {
         assert_eq!(shlex_quote(""), "''");
         assert_eq!(shlex_quote("/path/with spaces"), "'/path/with spaces'");
         assert_eq!(shlex_quote("/path/with'quote"), "'/path/with'\\''quote'");
+    }
+
+    #[test]
+    fn detects_docker_container_removed_or_stopped_messages() {
+        let missing = CommandOutput {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "Error response from daemon: No such container: abc".to_string(),
+        };
+        assert!(output_indicates_container_gone(&missing));
+
+        let stopped = CommandOutput {
+            exit_code: 1,
+            stdout: "Container abc is not running".to_string(),
+            stderr: String::new(),
+        };
+        assert!(output_indicates_container_gone(&stopped));
+
+        let normal_failure = CommandOutput {
+            exit_code: 2,
+            stdout: String::new(),
+            stderr: "command not found".to_string(),
+        };
+        assert!(!output_indicates_container_gone(&normal_failure));
+
+        let successful_text_match = CommandOutput {
+            exit_code: 0,
+            stdout: "No such container appeared in command output".to_string(),
+            stderr: String::new(),
+        };
+        assert!(!output_indicates_container_gone(&successful_text_match));
+    }
+
+    #[test]
+    fn retry_after_missing_container_is_persistent_only() {
+        let gone = CommandOutput {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "No such object: abc".to_string(),
+        };
+        let persistent = DockerBackend::new(
+            None,
+            Some("ubuntu:22.04".to_string()),
+            false,
+            false,
+            None,
+            None,
+            None,
+            true,
+            None,
+            Vec::new(),
+            Vec::new(),
+            30,
+            1024,
+        );
+        assert!(persistent.should_recreate_after_exec_output(&gone));
+
+        let ephemeral = DockerBackend::new(
+            None,
+            Some("ubuntu:22.04".to_string()),
+            false,
+            false,
+            None,
+            None,
+            None,
+            false,
+            None,
+            Vec::new(),
+            Vec::new(),
+            30,
+            1024,
+        );
+        assert!(!ephemeral.should_recreate_after_exec_output(&gone));
     }
 }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -2446,17 +2446,33 @@ impl Gateway {
         text: &str,
         parse_mode: Option<ParseMode>,
     ) -> Result<(), GatewayError> {
+        self.send_message_threaded(platform, chat_id, text, parse_mode, None)
+            .await
+    }
+
+    /// Send a text message to a specific platform chat, optionally preserving
+    /// the platform-native thread id for threaded platforms such as Slack.
+    pub async fn send_message_threaded(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        thread_id: Option<&str>,
+    ) -> Result<(), GatewayError> {
         let adapter = self.get_adapter(platform).await.ok_or_else(|| {
             GatewayError::Platform(format!("No adapter registered for platform: {}", platform))
         })?;
         let (cleaned, images) = extract_inline_images(text);
         if images.is_empty() {
-            return adapter.send_message(chat_id, text, parse_mode).await;
+            return adapter
+                .send_message_threaded(chat_id, text, parse_mode, thread_id)
+                .await;
         }
 
         if !cleaned.is_empty() {
             adapter
-                .send_message(chat_id, &cleaned, parse_mode.clone())
+                .send_message_threaded(chat_id, &cleaned, parse_mode.clone(), thread_id)
                 .await?;
         }
 
@@ -2478,7 +2494,7 @@ impl Gateway {
                     _ => image.url.clone(),
                 };
                 adapter
-                    .send_message(chat_id, &fallback, Some(ParseMode::Plain))
+                    .send_message_threaded(chat_id, &fallback, Some(ParseMode::Plain), thread_id)
                     .await?;
             }
         }

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -1263,6 +1263,17 @@ impl PlatformAdapter for SlackAdapter {
         Ok(())
     }
 
+    async fn send_message_threaded(
+        &self,
+        chat_id: &str,
+        text: &str,
+        _parse_mode: Option<ParseMode>,
+        thread_id: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        self.post_message(chat_id, text, thread_id).await?;
+        Ok(())
+    }
+
     async fn edit_message(
         &self,
         chat_id: &str,

--- a/crates/hermes-gateway/src/tool_backends.rs
+++ b/crates/hermes-gateway/src/tool_backends.rs
@@ -47,18 +47,22 @@ impl MessagingBackend for GatewayMessagingBackend {
         platform: &str,
         recipient: &str,
         message: &str,
+        thread_id: Option<&str>,
     ) -> Result<String, ToolError> {
         self.gateway
-            .send_message(platform, recipient, message, None)
+            .send_message_threaded(platform, recipient, message, None, thread_id)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("gateway send failed: {}", e)))?;
-        Ok(json!({
+        let mut response = json!({
             "type": "messaging_result",
             "platform": platform,
             "recipient": recipient,
             "status": "sent",
-        })
-        .to_string())
+        });
+        if let Some(thread_id) = thread_id {
+            response["thread_id"] = json!(thread_id);
+        }
+        Ok(response.to_string())
     }
 }
 

--- a/crates/hermes-intelligence/src/model_metadata.rs
+++ b/crates/hermes-intelligence/src/model_metadata.rs
@@ -610,6 +610,10 @@ pub fn is_local_endpoint(base_url: &str) -> bool {
         return true;
     }
 
+    if !host_lower.is_empty() && !host_lower.contains('.') {
+        return true;
+    }
+
     if let Ok(addr) = host.parse::<IpAddr>() {
         return match addr {
             IpAddr::V4(v4) => {
@@ -766,6 +770,10 @@ mod tests {
     fn test_is_local_endpoint() {
         assert!(is_local_endpoint("http://localhost:8080"));
         assert!(is_local_endpoint("http://127.0.0.1:11434"));
+        assert!(is_local_endpoint("ollama"));
+        assert!(is_local_endpoint("ollama:11434"));
+        assert!(is_local_endpoint("hermes-litellm/v1"));
+        assert!(is_local_endpoint("http://gateway:4000/v1"));
         assert!(is_local_endpoint("http://100.64.0.0:11434"));
         assert!(is_local_endpoint("http://100.64.0.1:11434/v1"));
         assert!(is_local_endpoint("http://100.77.243.5:11434"));

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -522,12 +522,37 @@ impl McpClient {
             return Err(McpError::ConnectionError("Already connected".to_string()));
         }
 
-        let mut transport = self.create_transport().await?;
+        let transport = self.create_transport().await?;
+        self.finish_connect_with_transport(transport).await
+    }
+
+    async fn finish_connect_with_transport(
+        &mut self,
+        mut transport: Box<dyn McpTransport>,
+    ) -> Result<(), McpError> {
         transport.start().await?;
         self.transport = Some(transport);
 
-        self.initialize().await?;
-        self.discover_tools().await?;
+        let discovery = match self.initialize().await {
+            Ok(_) => self.discover_tools().await,
+            Err(err) => Err(err),
+        };
+        if let Err(err) = discovery {
+            self.connected = false;
+            self.connected_at = None;
+            self.tools.clear();
+            self.resources.clear();
+            if let Some(mut transport) = self.transport.take() {
+                if let Err(close_err) = transport.close().await {
+                    warn!(
+                        "MCP transport close after failed connect also failed: {}",
+                        close_err
+                    );
+                }
+            }
+            return Err(err);
+        }
+
         self.connected = true;
         self.connected_at = Some(Instant::now());
 
@@ -1257,10 +1282,51 @@ impl McpManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{cache_mcp_image_block, is_stale_transport_error, McpClient};
+    use super::{cache_mcp_image_block, is_stale_transport_error, McpClient, McpServerConfig};
+    use crate::transport::McpTransport;
     use crate::McpError;
+    use async_trait::async_trait;
     use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use tempfile::TempDir;
+
+    struct FakeTransport {
+        responses: VecDeque<serde_json::Value>,
+        closed: Arc<AtomicBool>,
+    }
+
+    impl FakeTransport {
+        fn new(responses: Vec<serde_json::Value>, closed: Arc<AtomicBool>) -> Self {
+            Self {
+                responses: responses.into(),
+                closed,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl McpTransport for FakeTransport {
+        async fn start(&mut self) -> Result<(), McpError> {
+            Ok(())
+        }
+
+        async fn send(&mut self, _message: serde_json::Value) -> Result<(), McpError> {
+            Ok(())
+        }
+
+        async fn receive(&mut self) -> Result<serde_json::Value, McpError> {
+            self.responses
+                .pop_front()
+                .ok_or_else(|| McpError::ConnectionError("no fake response".to_string()))
+        }
+
+        async fn close(&mut self) -> Result<(), McpError> {
+            self.closed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
 
     #[test]
     fn classify_protocol_error_maps_forbidden() {
@@ -1299,6 +1365,42 @@ mod tests {
         assert!(is_stale_transport_error(&err));
         let err = McpError::ConnectionError("rate limited".to_string());
         assert!(!is_stale_transport_error(&err));
+    }
+
+    #[tokio::test]
+    async fn connect_closes_transport_when_discovery_fails() {
+        let closed = Arc::new(AtomicBool::new(false));
+        let transport = FakeTransport::new(
+            vec![
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {"name": "fake", "version": "0"}
+                    }
+                }),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "error": {"code": -32601, "message": "tools/list unavailable"}
+                }),
+            ],
+            closed.clone(),
+        );
+        let mut client = McpClient::new(McpServerConfig::stdio("fake", Vec::new()));
+
+        let err = client
+            .finish_connect_with_transport(Box::new(transport))
+            .await
+            .expect_err("discovery should fail");
+
+        assert!(matches!(err, McpError::MethodNotFound(_)));
+        assert!(closed.load(Ordering::SeqCst));
+        assert!(!client.is_connected());
+        assert!(client.cached_tools().is_empty());
+        assert!(client.cached_resources().is_empty());
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/messaging.rs
+++ b/crates/hermes-tools/src/backends/messaging.rs
@@ -29,14 +29,18 @@ impl MessagingBackend for SignalMessagingBackend {
         platform: &str,
         recipient: &str,
         message: &str,
+        thread_id: Option<&str>,
     ) -> Result<String, ToolError> {
-        Ok(json!({
+        let mut response = json!({
             "type": "messaging_request",
             "platform": platform,
             "recipient": recipient,
             "message": message,
             "status": "pending",
-        })
-        .to_string())
+        });
+        if let Some(thread_id) = thread_id {
+            response["thread_id"] = json!(thread_id);
+        }
+        Ok(response.to_string())
     }
 }

--- a/crates/hermes-tools/src/tools/messaging.rs
+++ b/crates/hermes-tools/src/tools/messaging.rs
@@ -44,6 +44,7 @@ pub trait MessagingBackend: Send + Sync {
         platform: &str,
         recipient: &str,
         message: &str,
+        thread_id: Option<&str>,
     ) -> Result<String, ToolError>;
 }
 
@@ -80,7 +81,16 @@ impl ToolHandler for SendMessageHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'message' parameter".into()))?;
 
-        self.backend.send(platform, recipient, message).await
+        let thread_id = params
+            .get("thread_id")
+            .or_else(|| params.get("thread_ts"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        self.backend
+            .send(platform, recipient, message, thread_id)
+            .await
     }
 
     fn schema(&self) -> ToolSchema {
@@ -107,6 +117,13 @@ impl ToolHandler for SendMessageHandler {
                 "description": "Message content to send"
             }),
         );
+        props.insert(
+            "thread_id".into(),
+            json!({
+                "type": "string",
+                "description": "Optional platform-native thread id (for Slack this maps to thread_ts)"
+            }),
+        );
 
         tool_schema(
             "send_message",
@@ -131,10 +148,14 @@ mod tests {
             platform: &str,
             recipient: &str,
             message: &str,
+            thread_id: Option<&str>,
         ) -> Result<String, ToolError> {
+            let thread_suffix = thread_id
+                .map(|thread| format!(" in thread {}", thread))
+                .unwrap_or_default();
             Ok(format!(
-                "Sent to {} on {}: {}",
-                recipient, platform, message
+                "Sent to {} on {}{}: {}",
+                recipient, platform, thread_suffix, message
             ))
         }
     }
@@ -158,5 +179,21 @@ mod tests {
             .unwrap();
         assert!(result.contains("telegram"));
         assert!(result.contains("12345"));
+    }
+
+    #[tokio::test]
+    async fn test_send_message_execute_accepts_thread_id_alias() {
+        let handler = SendMessageHandler::new(Arc::new(MockMessagingBackend));
+        let result = handler
+            .execute(json!({
+                "platform": "slack",
+                "recipient": "C123",
+                "message": "Hello!",
+                "thread_ts": "171234.5"
+            }))
+            .await
+            .unwrap();
+        assert!(result.contains("slack"));
+        assert!(result.contains("171234.5"));
     }
 }

--- a/crates/hermes-tools/tests/upstream_core_tool_contracts.rs
+++ b/crates/hermes-tools/tests/upstream_core_tool_contracts.rs
@@ -427,8 +427,10 @@ async fn memory_contract_validates_targets_and_dispatches_actions() {
 
 #[derive(Default)]
 struct CaptureMessagingBackend {
-    calls: Mutex<Vec<(String, String, String)>>,
+    calls: Mutex<Vec<CapturedMessageSend>>,
 }
+
+type CapturedMessageSend = (String, String, String, Option<String>);
 
 #[async_trait]
 impl MessagingBackend for CaptureMessagingBackend {
@@ -437,11 +439,13 @@ impl MessagingBackend for CaptureMessagingBackend {
         platform: &str,
         recipient: &str,
         message: &str,
+        thread_id: Option<&str>,
     ) -> Result<String, ToolError> {
         self.calls.lock().expect("calls").push((
             platform.to_string(),
             recipient.to_string(),
             message.to_string(),
+            thread_id.map(ToOwned::to_owned),
         ));
         Ok("sent".to_string())
     }
@@ -497,8 +501,27 @@ async fn messaging_contract_accepts_all_gateway_platform_schema_names() {
         [(
             "matrix".to_string(),
             "!room:example".to_string(),
-            "hello".to_string()
+            "hello".to_string(),
+            None
         )]
+    );
+    handler
+        .execute(json!({
+            "platform": "slack",
+            "recipient": "C123",
+            "message": "threaded",
+            "thread_id": "171234.5"
+        }))
+        .await
+        .expect("threaded send");
+    assert_eq!(
+        backend.calls.lock().expect("calls").last(),
+        Some(&(
+            "slack".to_string(),
+            "C123".to_string(),
+            "threaded".to_string(),
+            Some("171234.5".to_string())
+        ))
     );
     assert_err_contains(
         handler

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -552,6 +552,10 @@
       "disposition": "ported",
       "notes": "Rust disk-cleanup auto categorization only marks cron/cronjobs output subtrees as cron-output and explicitly leaves cron/jobs.json plus .tick.lock as control-plane state; covered by hermes-tools disk_cleanup tests."
     },
+    "c14c37d46b902": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking memory provider now scopes direct content-write URIs under viking://user/{user}/agent/{agent}/memories/{subdir}/..., sends X-OpenViking-Agent and bearer auth headers, maps memory-write targets to OpenViking subdirectories, and covers URI/header/body contracts in crates/hermes-agent/src/memory_plugins/openviking.rs tests."
+    },
     "7de8cd4c5f67": {
       "disposition": "ported",
       "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync."


### PR DESCRIPTION
## Summary

Ports the current Rust-owned upstream runtime resilience batch:

- Treat unqualified local hostnames like `ollama`, `ollama:11434`, and `hermes-litellm/v1` as local model endpoints.
- Add OpenViking agent-scoped direct memory writes with `viking://user/{user}/agent/{agent}/memories/{subdir}/...` URIs, `X-OpenViking-Agent`, and bearer auth headers.
- Thread Slack `thread_ts` / generic `thread_id` through the standalone `send_message` tool, gateway backend, gateway adapter API, and Slack adapter.
- Close MCP transports when initialize/discovery fails after transport start, clearing cached state before returning the original failure.
- Recover Docker persistent terminal containers when `docker exec` reports an out-of-band removed/stopped cached container.
- Mark upstream OpenViking commit `c14c37d46b902` as ported in queue overrides without regenerating the stale full queue in this PR.

## Tests

- `cargo test -p hermes-intelligence test_is_local_endpoint -- --nocapture`
- `cargo test -p hermes-agent openviking -- --nocapture`
- `cargo test -p hermes-tools tools::messaging -- --nocapture`
- `cargo test -p hermes-tools messaging_contract_accepts_all_gateway_platform_schema_names --test upstream_core_tool_contracts -- --nocapture`
- `cargo test -p hermes-cli gateway_messaging_backend -- --nocapture`
- `cargo test -p hermes-mcp connect_closes_transport_when_discovery_fails -- --nocapture`
- `cargo test -p hermes-environments --features docker detects_docker_container_removed_or_stopped_messages -- --nocapture`
- `cargo test -p hermes-environments --features docker retry_after_missing_container_is_persistent_only -- --nocapture`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/queue-overrides.validated.json`
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --max-commits 0 --out-json /tmp/hermes-override-check-queue.json --out-md /tmp/hermes-override-check-queue.md` verified `c14c37d46` => `ported` / `sha_override`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check` (`seen=199 allowlist=204 new=0 stale=5`)
- `cargo build --workspace`
- `cargo test --workspace --quiet` (`cargo_status=0 elapsed=1297s`)
