### PR TITLE
fix(session): harden sqlite persistence parity

### DIFF
--- a/crates/hermes-agent/src/session_persistence.rs
+++ b/crates/hermes-agent/src/session_persistence.rs
@@ -1,6 +1,6 @@
 //! Session persistence — save and load conversation sessions.
 //!
-//! Provides SQLite-backed session storage with FTS5 indexing for search,
+//! Provides SQLite-backed session storage with optional FTS5 indexing for search,
 //! human-readable markdown session logs, and trajectory format for RL training.
 //!
 //! Corresponds to Python `run_agent.py`'s `_persist_session`, `_save_session_log`,
@@ -58,6 +58,86 @@ pub struct AutoMaintenanceResult {
 }
 
 impl SessionPersistence {
+    fn is_fts5_unavailable_message(message: &str) -> bool {
+        let lower = message.to_ascii_lowercase();
+        lower.contains("no such module")
+            || lower.contains("unknown tokenizer")
+            || lower.contains("fts5")
+    }
+
+    fn is_fts5_unavailable_error(error: &rusqlite::Error) -> bool {
+        Self::is_fts5_unavailable_message(&error.to_string())
+    }
+
+    fn fts_table_exists(conn: &rusqlite::Connection) -> Result<bool, AgentError> {
+        conn.query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages_fts' LIMIT 1",
+            [],
+            |_| Ok(true),
+        )
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(false),
+            other => Err(AgentError::Io(format!(
+                "Failed to inspect messages_fts availability: {other}"
+            ))),
+        })
+    }
+
+    fn ensure_fts_schema(conn: &rusqlite::Connection, db_path: &Path) -> Result<bool, AgentError> {
+        match conn.execute_batch(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                content,
+                session_id UNINDEXED,
+                role UNINDEXED,
+                content='messages',
+                content_rowid='id'
+            );
+
+            CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content, session_id, role)
+                VALUES (new.id, new.content, new.session_id, new.role);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+                DELETE FROM messages_fts WHERE rowid = old.id;
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+                DELETE FROM messages_fts WHERE rowid = old.id;
+                INSERT INTO messages_fts(rowid, content, session_id, role)
+                VALUES (new.id, new.content, new.session_id, new.role);
+            END;",
+        ) {
+            Ok(()) => Ok(true),
+            Err(err) if Self::is_fts5_unavailable_error(&err) => {
+                tracing::warn!(
+                    "SQLite FTS5 unavailable for {}; session persistence will continue without full-text indexing: {}",
+                    db_path.display(),
+                    err
+                );
+                Ok(false)
+            }
+            Err(err) => Err(AgentError::Io(format!(
+                "Failed to create FTS schema for sessions db: {err}"
+            ))),
+        }
+    }
+
+    fn delete_fts_rows_for_session(
+        conn: &rusqlite::Connection,
+        session_id: &str,
+    ) -> Result<(), AgentError> {
+        if !Self::fts_table_exists(conn)? {
+            return Ok(());
+        }
+        conn.execute(
+            "DELETE FROM messages_fts WHERE session_id = ?1",
+            rusqlite::params![session_id],
+        )
+        .map(|_| ())
+        .map_err(|e| AgentError::Io(format!("Failed to delete messages_fts rows: {e}")))
+    }
+
     fn ensure_text_column(
         conn: &rusqlite::Connection,
         table: &str,
@@ -155,19 +235,6 @@ impl SessionPersistence {
             CREATE INDEX IF NOT EXISTS idx_messages_session
                 ON messages(session_id);
 
-            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-                content,
-                session_id UNINDEXED,
-                role UNINDEXED,
-                content='messages',
-                content_rowid='id'
-            );
-
-            CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-                INSERT INTO messages_fts(rowid, content, session_id, role)
-                VALUES (new.id, new.content, new.session_id, new.role);
-            END;
-
             CREATE TABLE IF NOT EXISTS state_meta (
                 key TEXT PRIMARY KEY,
                 value TEXT
@@ -192,6 +259,7 @@ impl SessionPersistence {
                 )));
             }
         }
+        Self::ensure_fts_schema(&conn, &self.db_path)?;
 
         Ok(())
     }
@@ -266,11 +334,7 @@ impl SessionPersistence {
             .unchecked_transaction()
             .map_err(|e| AgentError::Io(format!("Failed to open prune transaction: {e}")))?;
         for sid in &session_ids {
-            tx.execute(
-                "DELETE FROM messages_fts WHERE session_id = ?1",
-                rusqlite::params![sid],
-            )
-            .map_err(|e| AgentError::Io(format!("Failed to delete messages_fts rows: {e}")))?;
+            Self::delete_fts_rows_for_session(&tx, sid)?;
             tx.execute(
                 "DELETE FROM messages WHERE session_id = ?1",
                 rusqlite::params![sid],
@@ -363,16 +427,18 @@ impl SessionPersistence {
         // Upsert session record
         conn.execute(
             "INSERT INTO sessions (id, model, platform, created_at, updated_at, title, message_count, system_prompt)
-             VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?6, ?7)
+             VALUES (?1, COALESCE(?2, 'unknown'), COALESCE(?3, 'cli'), ?4, ?4, ?5, ?6, ?7)
              ON CONFLICT(id) DO UPDATE SET
                 updated_at = ?4,
+                model = COALESCE(?2, sessions.model),
+                platform = COALESCE(?3, sessions.platform),
                 message_count = ?6,
                 title = COALESCE(?5, sessions.title),
                 system_prompt = COALESCE(?7, sessions.system_prompt)",
             rusqlite::params![
                 session_id,
-                model.unwrap_or("unknown"),
-                platform.unwrap_or("cli"),
+                model,
+                platform,
                 now,
                 title,
                 messages.len() as i64,
@@ -387,6 +453,66 @@ impl SessionPersistence {
         Ok(())
     }
 
+    /// Update the persisted model for an existing session after a mid-session switch.
+    ///
+    /// This intentionally does not create a new session row: callers use it as a
+    /// best-effort dashboard/search metadata refresh for sessions that have
+    /// already been persisted.
+    pub fn update_session_model(&self, session_id: &str, model: &str) -> Result<bool, AgentError> {
+        let model = model.trim();
+        if session_id.trim().is_empty() || model.is_empty() {
+            return Ok(false);
+        }
+        if !self.db_path.exists() {
+            return Ok(false);
+        }
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+        match conn.execute(
+            "UPDATE sessions SET model = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![model, Utc::now().to_rfc3339(), session_id],
+        ) {
+            Ok(changed) => Ok(changed > 0),
+            Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+                if message.contains("no such table") =>
+            {
+                Ok(false)
+            }
+            Err(e) => Err(AgentError::Io(format!(
+                "Failed to update session model: {e}"
+            ))),
+        }
+    }
+
+    /// Read the persisted model metadata for a session without creating a database.
+    pub fn get_session_model(&self, session_id: &str) -> Result<Option<String>, AgentError> {
+        if session_id.trim().is_empty() || !self.db_path.exists() {
+            return Ok(None);
+        }
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+        let mut stmt = match conn.prepare("SELECT model FROM sessions WHERE id = ?1") {
+            Ok(stmt) => stmt,
+            Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+                if message.contains("no such table") =>
+            {
+                return Ok(None);
+            }
+            Err(e) => {
+                return Err(AgentError::Io(format!(
+                    "Failed to prepare session model query: {e}"
+                )));
+            }
+        };
+        match stmt.query_row(rusqlite::params![session_id], |r| {
+            r.get::<_, Option<String>>(0)
+        }) {
+            Ok(model) => Ok(model.filter(|value| !value.trim().is_empty())),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(AgentError::Io(format!("Failed to read session model: {e}"))),
+        }
+    }
+
     /// Batch insert messages into the database for FTS5 indexing.
     fn flush_messages_to_session_db(
         &self,
@@ -395,6 +521,7 @@ impl SessionPersistence {
         messages: &[Message],
     ) -> Result<(), AgentError> {
         // Delete existing messages for this session (full replace)
+        Self::delete_fts_rows_for_session(conn, session_id)?;
         conn.execute(
             "DELETE FROM messages WHERE session_id = ?1",
             rusqlite::params![session_id],
@@ -788,6 +915,149 @@ mod tests {
 
         let loaded = sp.load_session("replace-test").unwrap();
         assert_eq!(loaded.len(), 3);
+    }
+
+    #[test]
+    fn test_persist_session_updates_existing_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        let messages = vec![Message::user("hello")];
+
+        sp.persist_session(
+            "model-update",
+            &messages,
+            Some("openai:gpt-4o"),
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        sp.persist_session(
+            "model-update",
+            &messages,
+            Some("nous:hermes-4"),
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = rusqlite::Connection::open(&sp.db_path).unwrap();
+        let model: String = conn
+            .query_row(
+                "SELECT model FROM sessions WHERE id='model-update'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(model, "nous:hermes-4");
+    }
+
+    #[test]
+    fn test_update_session_model_only_updates_existing_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        let messages = vec![Message::user("hello")];
+
+        assert!(!sp
+            .update_session_model("missing-session", "openai:gpt-4o")
+            .unwrap());
+
+        sp.persist_session(
+            "existing-session",
+            &messages,
+            Some("openai:gpt-4o"),
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(sp
+            .update_session_model("existing-session", "anthropic:claude-sonnet")
+            .unwrap());
+
+        let conn = rusqlite::Connection::open(&sp.db_path).unwrap();
+        let model: String = conn
+            .query_row(
+                "SELECT model FROM sessions WHERE id='existing-session'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(model, "anthropic:claude-sonnet");
+    }
+
+    #[test]
+    fn test_replacing_messages_clears_old_fts_rows_when_available() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+
+        sp.persist_session(
+            "fts-replace",
+            &[Message::user("needlebefore")],
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        sp.persist_session(
+            "fts-replace",
+            &[Message::user("needleafter")],
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = rusqlite::Connection::open(&sp.db_path).unwrap();
+        if SessionPersistence::fts_table_exists(&conn).unwrap() {
+            let old_hits: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'needlebefore'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            let new_hits: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'needleafter'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(old_hits, 0);
+            assert_eq!(new_hits, 1);
+        }
+    }
+
+    #[test]
+    fn test_delete_fts_rows_ignores_missing_fts_table() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                created_at TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        SessionPersistence::delete_fts_rows_for_session(&conn, "no-fts").unwrap();
+    }
+
+    #[test]
+    fn test_fts_unavailable_error_classifier_matches_missing_modules() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        let err = conn
+            .execute_batch(
+                "CREATE VIRTUAL TABLE broken_fts USING definitely_missing_module(content);",
+            )
+            .expect_err("missing virtual table module should fail");
+        assert!(SessionPersistence::is_fts5_unavailable_error(&err));
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2433,6 +2433,18 @@ impl App {
         ));
         self.agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
 
+        match SessionPersistence::new(&self.state_root)
+            .update_session_model(&self.session_id, &self.current_model)
+        {
+            Ok(true) => tracing::debug!(
+                "Persisted model switch for session {} to {}",
+                self.session_id,
+                self.current_model
+            ),
+            Ok(false) => {}
+            Err(err) => tracing::debug!("Failed to persist model switch to session DB: {}", err),
+        }
+
         tracing::info!("Switched model to: {}", provider_model);
     }
 
@@ -3744,6 +3756,10 @@ mod tests {
     }
 
     fn build_minimal_test_app() -> App {
+        build_minimal_test_app_with_state_root(hermes_home_dir())
+    }
+
+    fn build_minimal_test_app_with_state_root(state_root: PathBuf) -> App {
         let config = Arc::new(GatewayConfig::default());
         let tool_registry = Arc::new(ToolRegistry::new());
         let agent_tool_registry = Arc::new(bridge_tool_registry(&tool_registry));
@@ -3759,12 +3775,12 @@ mod tests {
         .with_callbacks(App::stream_callbacks(Arc::new(StdMutex::new(None))));
         let orchestrator = Arc::new(SubAgentOrchestrator::from_parent(
             &agent_inner,
-            hermes_home_dir(),
+            state_root.clone(),
         ));
         let agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
 
         App {
-            state_root: hermes_home_dir(),
+            state_root,
             config,
             agent,
             tool_registry,
@@ -3786,6 +3802,49 @@ mod tests {
             session_objective: None,
             quorum_armed_once: false,
             pet_settings: PetSettings::default(),
+        }
+    }
+
+    #[test]
+    fn test_switch_model_updates_existing_session_db_row() {
+        let _guard = env_test_lock();
+        let env_keys = [
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+            "HERMES_TUI_PROVIDER",
+        ];
+        let saved_env: Vec<(&str, Option<String>)> = env_keys
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = build_minimal_test_app_with_state_root(tmp.path().to_path_buf());
+        let persistence = SessionPersistence::new(tmp.path());
+        persistence
+            .persist_session(
+                &app.session_id,
+                &[hermes_core::Message::user("hello")],
+                Some(&app.current_model),
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+
+        app.switch_model("anthropic:claude-sonnet-4-6");
+
+        assert_eq!(
+            persistence.get_session_model(&app.session_id).unwrap(),
+            Some("anthropic:claude-sonnet-4-6".to_string())
+        );
+
+        for (key, value) in saved_env {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
         }
     }
 

--- a/crates/hermes-tools/src/backends/session_search.rs
+++ b/crates/hermes-tools/src/backends/session_search.rs
@@ -19,6 +19,7 @@ const HIDDEN_SESSION_SOURCES: &[&str] = &["tool", "internal"];
 /// Real session search backend using SQLite FTS5.
 pub struct SqliteSessionSearchBackend {
     conn: Mutex<Connection>,
+    fts_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -50,6 +51,68 @@ struct SessionRowContext {
 }
 
 impl SqliteSessionSearchBackend {
+    fn is_fts5_unavailable_message(message: &str) -> bool {
+        let lower = message.to_ascii_lowercase();
+        lower.contains("no such module")
+            || lower.contains("unknown tokenizer")
+            || lower.contains("fts5")
+    }
+
+    fn is_fts5_unavailable_error(error: &rusqlite::Error) -> bool {
+        Self::is_fts5_unavailable_message(&error.to_string())
+    }
+
+    fn fts_table_exists(conn: &Connection) -> Result<bool, ToolError> {
+        conn.query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages_fts' LIMIT 1",
+            [],
+            |_| Ok(true),
+        )
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(false),
+            other => Err(ToolError::ExecutionFailed(format!(
+                "Failed to inspect messages_fts availability: {other}"
+            ))),
+        })
+    }
+
+    fn ensure_fts_schema(conn: &Connection, db_path: &str) -> Result<bool, ToolError> {
+        match conn.execute_batch(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                content,
+                session_id UNINDEXED,
+                role UNINDEXED,
+                content='messages',
+                content_rowid='id'
+            );
+            CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content, session_id, role)
+                VALUES (new.id, new.content, new.session_id, new.role);
+            END;
+            CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+                DELETE FROM messages_fts WHERE rowid = old.id;
+            END;
+            CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+                DELETE FROM messages_fts WHERE rowid = old.id;
+                INSERT INTO messages_fts(rowid, content, session_id, role)
+                VALUES (new.id, new.content, new.session_id, new.role);
+            END;",
+        ) {
+            Ok(()) => Ok(true),
+            Err(err) if Self::is_fts5_unavailable_error(&err) => {
+                tracing::warn!(
+                    "SQLite FTS5 unavailable for {}; session_search will use recent/id lookup only: {}",
+                    db_path,
+                    err
+                );
+                Ok(false)
+            }
+            Err(err) => Err(ToolError::ExecutionFailed(format!(
+                "Failed to ensure session FTS schema: {err}"
+            ))),
+        }
+    }
+
     fn ensure_text_column(conn: &Connection, table: &str, column: &str) -> Result<(), ToolError> {
         match conn.execute(
             &format!("ALTER TABLE {table} ADD COLUMN {column} TEXT"),
@@ -778,27 +841,18 @@ impl SqliteSessionSearchBackend {
                 created_at TEXT NOT NULL,
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
-            CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
-            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-                content,
-                session_id UNINDEXED,
-                role UNINDEXED,
-                content='messages',
-                content_rowid='id'
-            );
-            CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-                INSERT INTO messages_fts(rowid, content, session_id, role)
-                VALUES (new.id, new.content, new.session_id, new.role);
-            END;",
+            CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);",
         )
         .map_err(|e| {
             ToolError::ExecutionFailed(format!("Failed to ensure session schema: {}", e))
         })?;
 
         Self::ensure_session_compat_columns(&conn)?;
+        let fts_enabled = Self::ensure_fts_schema(&conn, db_path)?;
 
         Ok(Self {
             conn: Mutex::new(conn),
+            fts_enabled,
         })
     }
 
@@ -846,7 +900,12 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
         let query = query.map(str::trim).unwrap_or("");
         let limit = limit.min(5).max(1);
 
-        let (tasks, sessions_searched, recent_payload): (Vec<SummaryTask>, usize, Option<Value>) = {
+        let (tasks, sessions_searched, recent_payload, search_degraded): (
+            Vec<SummaryTask>,
+            usize,
+            Option<Value>,
+            Option<&'static str>,
+        ) = {
             let conn = self
                 .conn
                 .lock()
@@ -977,7 +1036,7 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
                         results.len()
                     ),
                 });
-                (Vec::new(), 0, Some(payload))
+                (Vec::new(), 0, Some(payload), None)
             } else {
                 let mut seen = HashSet::new();
                 let current_lineage_root = current_session_id
@@ -1019,7 +1078,9 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
                     }
                 }
 
-                if tasks.len() < limit {
+                let fts_available = self.fts_enabled && Self::fts_table_exists(&conn)?;
+                let mut search_degraded = None;
+                if tasks.len() < limit && fts_available {
                     let hidden_placeholders = HIDDEN_SESSION_SOURCES
                         .iter()
                         .map(|_| "?".to_string())
@@ -1145,10 +1206,12 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
                             tasks.push(task);
                         }
                     }
+                } else if !fts_available {
+                    search_degraded = Some("fts5_unavailable");
                 }
 
                 let searched = seen.len();
-                (tasks, searched, None)
+                (tasks, searched, None, search_degraded)
             }
         };
 
@@ -1221,14 +1284,17 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
             }
         }
 
-        Ok(json!({
+        let mut payload = json!({
             "success": true,
             "query": query,
             "results": summaries,
             "count": summaries.len(),
             "sessions_searched": sessions_searched,
-        })
-        .to_string())
+        });
+        if let Some(reason) = search_degraded {
+            payload["search_degraded"] = json!(reason);
+        }
+        Ok(payload.to_string())
     }
 }
 
@@ -1238,6 +1304,7 @@ mod tests {
     use crate::tools::session_search::SessionSearchBackend;
     use rusqlite::Connection;
     use serde_json::Value;
+    use std::sync::Mutex;
     use tempfile::TempDir;
 
     fn backend_with_db() -> (TempDir, SqliteSessionSearchBackend) {
@@ -1250,6 +1317,55 @@ mod tests {
 
     fn db_conn(tmp: &TempDir) -> Connection {
         Connection::open(tmp.path().join("sessions.db")).expect("open db")
+    }
+
+    fn no_fts_backend_with_seeded_db() -> SqliteSessionSearchBackend {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                model TEXT,
+                platform TEXT DEFAULT 'cli',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                title TEXT,
+                message_count INTEGER DEFAULT 0,
+                parent_session_id TEXT,
+                model_config TEXT,
+                end_reason TEXT,
+                ended_at TEXT
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE INDEX idx_messages_session ON messages(session_id);",
+        )
+        .expect("schema");
+        insert_session(
+            &conn,
+            "nofts-session",
+            None,
+            None,
+            None,
+            None,
+            "2026-01-01T00:00:00Z",
+        );
+        insert_message(
+            &conn,
+            "nofts-session",
+            "user",
+            "uniquephrase only exists in plain messages",
+        );
+        SqliteSessionSearchBackend {
+            conn: Mutex::new(conn),
+            fts_enabled: false,
+        }
     }
 
     fn insert_session(
@@ -1300,6 +1416,10 @@ mod tests {
                     .map(ToString::to_string)
             })
             .collect()
+    }
+
+    fn parsed(output: &str) -> Value {
+        serde_json::from_str(output).expect("json output")
     }
 
     #[test]
@@ -1497,6 +1617,35 @@ mod tests {
             ],
             "{output}"
         );
+    }
+
+    #[tokio::test]
+    async fn no_fts_backend_still_supports_session_id_lookup() {
+        let backend = no_fts_backend_with_seeded_db();
+
+        let output = backend
+            .search(Some("nofts-session"), None, 5, None)
+            .await
+            .expect("search");
+        let value = parsed(&output);
+
+        assert_eq!(result_ids(&output), vec!["nofts-session".to_string()]);
+        assert_eq!(value["search_degraded"], "fts5_unavailable");
+    }
+
+    #[tokio::test]
+    async fn no_fts_backend_degrades_content_search_to_empty_success() {
+        let backend = no_fts_backend_with_seeded_db();
+
+        let output = backend
+            .search(Some("uniquephrase"), None, 5, None)
+            .await
+            .expect("search");
+        let value = parsed(&output);
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["count"], 0);
+        assert_eq!(value["search_degraded"], "fts5_unavailable");
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -559,6 +559,22 @@
     "7de8cd4c5f67": {
       "disposition": "ported",
       "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync."
+    },
+    "5ad2b4c6dab7": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence now treats SQLite FTS5 as optional: base session persistence remains available without FTS, FTS deletes are guarded, and tests cover no-FTS degradation helpers."
+    },
+    "97ecfa0fc487": {
+      "disposition": "ported",
+      "notes": "Rust session search degrades content search when FTS is unavailable while keeping recent/session-id lookup live; no separate trigram table exists in Rust."
+    },
+    "355af2c20f49": {
+      "disposition": "ported",
+      "notes": "Rust session DB and search survive missing FTS5 by creating base tables first, optional FTS schema second, and returning search_degraded=fts5_unavailable rather than failing registration/search."
+    },
+    "794519c6ad49": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence updates sessions.model on persisted session conflicts, exposes update_session_model/get_session_model, and App::switch_model immediately refreshes existing persisted session metadata."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary

Ports the current upstream session persistence resilience slice into the Rust runtime:

- makes SQLite FTS5 optional for session persistence and search instead of failing DB/tool initialization
- guards FTS deletes and removes stale FTS rows when replacing messages
- preserves recent/session-id session search when content FTS is unavailable and returns `search_degraded=fts5_unavailable`
- updates persisted session model metadata on session upsert and immediately from `App::switch_model` for existing sessions
- records upstream SHA overrides for the four ported commits

## Upstream commits covered

| upstream SHA | disposition | Rust coverage |
| --- | --- | --- |
| `5ad2b4c6dab7` | `ported` | optional FTS5 session DB init and guarded FTS cleanup |
| `97ecfa0fc487` | `ported` | no-FTS search degradation; Rust has no separate trigram table |
| `355af2c20f49` | `ported` | base tables first, optional FTS schema second, degraded search output |
| `794519c6ad49` | `ported` | conflict-time and command-time persisted model metadata refresh |

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-agent session_persistence -- --nocapture`
- `cargo test -p hermes-tools session_search -- --nocapture`
- `cargo test -p hermes-cli test_switch_model_updates_existing_session_db_row -- --nocapture`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-tools -p hermes-cli` passed with `new=0` (`stale=5` pre-existing allowlist entries)
- `cargo build -p hermes-agent -p hermes-tools -p hermes-cli`
- seeded queue proof in `/tmp/hermes-seeded-upstream-queue-after.json`: all four target SHAs classified `ported sha_override`; `pending_count 248`

## Notes

No live provider/API calls were made. This is Rust-native deterministic coverage for the session DB/search/model-switch parity behavior.
