### PR TITLE
feat(session): add active rewind undo parity

### DIFF
--- a/crates/hermes-agent/src/session_persistence.rs
+++ b/crates/hermes-agent/src/session_persistence.rs
@@ -57,6 +57,22 @@ pub struct AutoMaintenanceResult {
     pub error: Option<String>,
 }
 
+/// Result of a soft rewind operation against persisted session rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewindOutcome {
+    pub target_message_id: i64,
+    pub target_content: Option<String>,
+    pub inactive_count: u64,
+    pub active_message_count: u64,
+    pub rewind_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserMessageRef {
+    pub id: i64,
+    pub content: Option<String>,
+}
+
 impl SessionPersistence {
     fn is_fts5_unavailable_message(message: &str) -> bool {
         let lower = message.to_ascii_lowercase();
@@ -158,6 +174,33 @@ impl SessionPersistence {
         }
     }
 
+    fn ensure_integer_column(
+        conn: &rusqlite::Connection,
+        table: &str,
+        column: &str,
+        default_value: i64,
+        not_null: bool,
+    ) -> Result<(), AgentError> {
+        let mut sql = format!("ALTER TABLE {table} ADD COLUMN {column} INTEGER");
+        if not_null {
+            sql.push_str(" NOT NULL");
+        }
+        sql.push_str(&format!(" DEFAULT {default_value}"));
+        match conn.execute(&sql, []) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate column") {
+                    Ok(())
+                } else {
+                    Err(AgentError::Io(format!(
+                        "Failed to migrate {table}.{column}: {e}"
+                    )))
+                }
+            }
+        }
+    }
+
     /// Create a new persistence manager rooted at the given hermes home directory.
     pub fn new(hermes_home: impl AsRef<Path>) -> Self {
         let home = hermes_home.as_ref();
@@ -217,7 +260,8 @@ impl SessionPersistence {
                 parent_session_id TEXT,
                 model_config TEXT,
                 end_reason TEXT,
-                ended_at TEXT
+                ended_at TEXT,
+                rewind_count INTEGER NOT NULL DEFAULT 0
             );
 
             CREATE TABLE IF NOT EXISTS messages (
@@ -229,6 +273,7 @@ impl SessionPersistence {
                 tool_calls TEXT,
                 reasoning_content TEXT,
                 created_at TEXT NOT NULL,
+                active INTEGER NOT NULL DEFAULT 1,
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
 
@@ -259,6 +304,14 @@ impl SessionPersistence {
                 )));
             }
         }
+        Self::ensure_integer_column(&conn, "sessions", "rewind_count", 0, true)?;
+        Self::ensure_integer_column(&conn, "messages", "active", 1, true)?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_session_active
+                ON messages(session_id, active, id)",
+            [],
+        )
+        .map_err(|e| AgentError::Io(format!("Failed to create active message index: {e}")))?;
         Self::ensure_fts_schema(&conn, &self.db_path)?;
 
         Ok(())
@@ -513,6 +566,182 @@ impl SessionPersistence {
         }
     }
 
+    /// Soft-delete the target user turn and all later active rows.
+    ///
+    /// `user_turns_back = 1` targets the latest active user message. Larger
+    /// counts walk farther back and clamp to the oldest active user turn.
+    pub fn rewind_active_user_turns(
+        &self,
+        session_id: &str,
+        user_turns_back: usize,
+    ) -> Result<Option<RewindOutcome>, AgentError> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() || !self.db_path.exists() {
+            return Ok(None);
+        }
+        self.ensure_db()?;
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+
+        let active_user_rows = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, content FROM messages
+                     WHERE session_id = ?1 AND role = 'user' AND active = 1
+                     ORDER BY id ASC",
+                )
+                .map_err(|e| {
+                    AgentError::Io(format!("Failed to prepare rewind target query: {e}"))
+                })?;
+            let rows = stmt
+                .query_map(rusqlite::params![session_id], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?))
+                })
+                .map_err(|e| AgentError::Io(format!("Failed to query rewind targets: {e}")))?;
+            let mut rows_out = Vec::new();
+            for row in rows {
+                rows_out.push(row.map_err(|e| {
+                    AgentError::Io(format!("Failed to read rewind target row: {e}"))
+                })?);
+            }
+            rows_out
+        };
+        if active_user_rows.is_empty() {
+            return Ok(None);
+        }
+        let count = user_turns_back.max(1);
+        let target_index = active_user_rows.len().saturating_sub(count);
+        let (target_message_id, target_content) = active_user_rows[target_index].clone();
+
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| AgentError::Io(format!("Failed to open rewind transaction: {e}")))?;
+        let inactive_count = tx
+            .execute(
+                "UPDATE messages
+                 SET active = 0
+                 WHERE session_id = ?1 AND active = 1 AND id >= ?2",
+                rusqlite::params![session_id, target_message_id],
+            )
+            .map_err(|e| AgentError::Io(format!("Failed to soft-delete rewound rows: {e}")))?
+            as u64;
+        let active_message_count: u64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?1 AND active = 1",
+                rusqlite::params![session_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|e| AgentError::Io(format!("Failed to count active messages: {e}")))?
+            .max(0) as u64;
+        let rewind_count: u64 = tx
+            .query_row(
+                "SELECT COALESCE(rewind_count, 0) + 1 FROM sessions WHERE id = ?1",
+                rusqlite::params![session_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(1)
+            .max(0) as u64;
+        tx.execute(
+            "UPDATE sessions
+             SET rewind_count = ?1, message_count = ?2, updated_at = ?3
+             WHERE id = ?4",
+            rusqlite::params![
+                rewind_count as i64,
+                active_message_count as i64,
+                Utc::now().to_rfc3339(),
+                session_id
+            ],
+        )
+        .map_err(|e| AgentError::Io(format!("Failed to update rewound session row: {e}")))?;
+        tx.commit()
+            .map_err(|e| AgentError::Io(format!("Failed to commit rewind transaction: {e}")))?;
+
+        Ok(Some(RewindOutcome {
+            target_message_id,
+            target_content,
+            inactive_count,
+            active_message_count,
+            rewind_count,
+        }))
+    }
+
+    /// List active user messages newest-first for rewind picker surfaces.
+    pub fn list_recent_user_messages(
+        &self,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<UserMessageRef>, AgentError> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() || limit == 0 || !self.db_path.exists() {
+            return Ok(Vec::new());
+        }
+        self.ensure_db()?;
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, content FROM messages
+                 WHERE session_id = ?1 AND role = 'user' AND active = 1
+                 ORDER BY id DESC
+                 LIMIT ?2",
+            )
+            .map_err(|e| AgentError::Io(format!("Failed to prepare recent user query: {e}")))?;
+        let rows = stmt
+            .query_map(rusqlite::params![session_id, limit as i64], |row| {
+                Ok(UserMessageRef {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                })
+            })
+            .map_err(|e| AgentError::Io(format!("Failed to query recent user messages: {e}")))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(
+                row.map_err(|e| {
+                    AgentError::Io(format!("Failed to read recent user message: {e}"))
+                })?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Restore inactive rows at or after a message id.
+    pub fn restore_rewound_since(
+        &self,
+        session_id: &str,
+        since_message_id: i64,
+    ) -> Result<u64, AgentError> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() || since_message_id <= 0 || !self.db_path.exists() {
+            return Ok(0);
+        }
+        self.ensure_db()?;
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+        let restored = conn
+            .execute(
+                "UPDATE messages
+                 SET active = 1
+                 WHERE session_id = ?1 AND active = 0 AND id >= ?2",
+                rusqlite::params![session_id, since_message_id],
+            )
+            .map_err(|e| AgentError::Io(format!("Failed to restore rewound rows: {e}")))?
+            as u64;
+        let active_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?1 AND active = 1",
+                rusqlite::params![session_id],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        conn.execute(
+            "UPDATE sessions SET message_count = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![active_count, Utc::now().to_rfc3339(), session_id],
+        )
+        .map_err(|e| AgentError::Io(format!("Failed to update restored session row: {e}")))?;
+        Ok(restored)
+    }
+
     /// Batch insert messages into the database for FTS5 indexing.
     fn flush_messages_to_session_db(
         &self,
@@ -520,10 +749,10 @@ impl SessionPersistence {
         session_id: &str,
         messages: &[Message],
     ) -> Result<(), AgentError> {
-        // Delete existing messages for this session (full replace)
+        // Replace the live transcript while preserving inactive rewind audit rows.
         Self::delete_fts_rows_for_session(conn, session_id)?;
         conn.execute(
-            "DELETE FROM messages WHERE session_id = ?1",
+            "DELETE FROM messages WHERE session_id = ?1 AND active = 1",
             rusqlite::params![session_id],
         )
         .map_err(|e| AgentError::Io(format!("Failed to clear old messages: {e}")))?;
@@ -532,8 +761,8 @@ impl SessionPersistence {
 
         let mut stmt = conn
             .prepare(
-                "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls, reasoning_content, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls, reasoning_content, created_at, active)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1)",
             )
             .map_err(|e| AgentError::Io(format!("Failed to prepare insert: {e}")))?;
 
@@ -672,6 +901,7 @@ impl SessionPersistence {
 
     /// Load a previous session from SQLite.
     pub fn load_session(&self, session_id: &str) -> Result<Vec<Message>, AgentError> {
+        self.ensure_db()?;
         let conn = rusqlite::Connection::open(&self.db_path)
             .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
 
@@ -679,7 +909,7 @@ impl SessionPersistence {
             .prepare(
                 "SELECT role, content, tool_call_id, tool_calls, reasoning_content
                  FROM messages
-                 WHERE session_id = ?1
+                 WHERE session_id = ?1 AND active = 1
                  ORDER BY id ASC",
             )
             .map_err(|e| AgentError::Io(format!("Failed to prepare query: {e}")))?;
@@ -985,6 +1215,110 @@ mod tests {
             )
             .unwrap();
         assert_eq!(model, "anthropic:claude-sonnet");
+    }
+
+    #[test]
+    fn test_rewind_soft_deletes_n_user_turns_and_loads_only_active_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        let messages = vec![
+            Message::system("sys"),
+            Message::user("question 1"),
+            Message::assistant("answer 1"),
+            Message::user("question 2"),
+            Message::assistant("answer 2"),
+            Message::user("question 3"),
+            Message::assistant("answer 3"),
+        ];
+        sp.persist_session("rewind-n", &messages, None, None, None, None)
+            .unwrap();
+
+        let recent = sp.list_recent_user_messages("rewind-n", 2).unwrap();
+        assert_eq!(
+            recent
+                .iter()
+                .filter_map(|row| row.content.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["question 3", "question 2"]
+        );
+
+        let outcome = sp.rewind_active_user_turns("rewind-n", 2).unwrap().unwrap();
+        assert_eq!(outcome.target_content.as_deref(), Some("question 2"));
+        assert_eq!(outcome.inactive_count, 4);
+        assert_eq!(outcome.active_message_count, 3);
+        assert_eq!(outcome.rewind_count, 1);
+
+        let loaded = sp.load_session("rewind-n").unwrap();
+        assert_eq!(
+            loaded
+                .iter()
+                .filter_map(|m| m.content.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["sys", "question 1", "answer 1"]
+        );
+
+        let conn = rusqlite::Connection::open(&sp.db_path).unwrap();
+        let inactive: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE session_id='rewind-n' AND active=0",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(inactive, 4);
+        let rewind_count: i64 = conn
+            .query_row(
+                "SELECT rewind_count FROM sessions WHERE id='rewind-n'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rewind_count, 1);
+
+        assert_eq!(
+            sp.restore_rewound_since("rewind-n", outcome.target_message_id)
+                .unwrap(),
+            4
+        );
+        assert_eq!(sp.load_session("rewind-n").unwrap().len(), messages.len());
+    }
+
+    #[test]
+    fn test_persist_session_preserves_inactive_rewind_audit_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        let messages = vec![
+            Message::user("keep"),
+            Message::assistant("kept"),
+            Message::user("rewind me"),
+            Message::assistant("rewound"),
+        ];
+        sp.persist_session("audit-preserve", &messages, None, None, None, None)
+            .unwrap();
+        sp.rewind_active_user_turns("audit-preserve", 1)
+            .unwrap()
+            .unwrap();
+
+        sp.persist_session(
+            "audit-preserve",
+            &[Message::user("keep"), Message::assistant("replacement")],
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = rusqlite::Connection::open(&sp.db_path).unwrap();
+        let inactive: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE session_id='audit-preserve' AND active=0",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(inactive, 2);
+        assert_eq!(sp.load_session("audit-preserve").unwrap().len(), 2);
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -301,6 +301,8 @@ pub struct App {
     pub pending_image_hint: Option<String>,
     /// Optional durable objective for the current interactive session.
     pub session_objective: Option<String>,
+    /// User text staged back into the composer by commands such as `/undo`.
+    pending_input_prefill: Option<String>,
     /// One-shot quorum arm state set by `/quorum run`.
     pub quorum_armed_once: bool,
     /// Animated companion pet settings.
@@ -320,6 +322,7 @@ impl std::fmt::Debug for App {
             .field("pending_theme", &self.pending_theme)
             .field("pending_image_hint", &self.pending_image_hint)
             .field("session_objective", &self.session_objective)
+            .field("pending_input_prefill", &self.pending_input_prefill)
             .field("quorum_armed_once", &self.quorum_armed_once)
             .field("pet_settings", &self.pet_settings)
             .finish_non_exhaustive()
@@ -349,6 +352,7 @@ impl Clone for App {
             pending_theme: self.pending_theme.clone(),
             pending_image_hint: self.pending_image_hint.clone(),
             session_objective: self.session_objective.clone(),
+            pending_input_prefill: self.pending_input_prefill.clone(),
             quorum_armed_once: self.quorum_armed_once,
             pet_settings: self.pet_settings.clone(),
         }
@@ -2125,6 +2129,7 @@ impl App {
             pending_theme: None,
             pending_image_hint: None,
             session_objective: None,
+            pending_input_prefill: None,
             quorum_armed_once: false,
             pet_settings: load_pet_settings(),
         };
@@ -2177,6 +2182,10 @@ impl App {
     /// Clear queued image hint.
     pub fn clear_pending_image_hint(&mut self) {
         self.pending_image_hint = None;
+    }
+
+    pub fn take_pending_input_prefill(&mut self) -> Option<String> {
+        self.pending_input_prefill.take()
     }
 
     /// Prepare outbound user text, consuming any queued image hint.
@@ -2398,18 +2407,55 @@ impl App {
         Ok(())
     }
 
-    /// Undo the last exchange (remove the last user message and its response).
-    pub fn undo_last(&mut self) {
-        // Find the last user message
-        if let Some(idx) = self
+    /// Undo one or more user turns, returning the text staged for editing.
+    pub fn undo_last(&mut self) -> Option<String> {
+        self.undo_last_n(1)
+    }
+
+    pub fn undo_last_n(&mut self, user_turns: usize) -> Option<String> {
+        let user_indices: Vec<usize> = self
             .messages
             .iter()
-            .rposition(|m| m.role == hermes_core::MessageRole::User)
-        {
-            // Remove everything from the last user message onward
-            self.messages.truncate(idx);
-            self.prune_ui_after_current_messages();
+            .enumerate()
+            .filter_map(|(idx, msg)| (msg.role == hermes_core::MessageRole::User).then_some(idx))
+            .collect();
+        if user_indices.is_empty() {
+            return None;
         }
+        let count = user_turns.max(1);
+        let target_pos = user_indices.len().saturating_sub(count);
+        let target_idx = user_indices[target_pos];
+        let prefill = self.messages[target_idx]
+            .content
+            .as_deref()
+            .unwrap_or_default()
+            .to_string();
+
+        match SessionPersistence::new(&self.state_root)
+            .rewind_active_user_turns(&self.session_id, count)
+        {
+            Ok(Some(outcome)) => tracing::debug!(
+                "Soft-rewound session {} at message {} (inactive={}, active={})",
+                self.session_id,
+                outcome.target_message_id,
+                outcome.inactive_count,
+                outcome.active_message_count
+            ),
+            Ok(None) => tracing::debug!(
+                "No persisted session row available for undo in session {}",
+                self.session_id
+            ),
+            Err(err) => tracing::debug!("Failed to soft-rewind persisted session: {}", err),
+        }
+
+        self.messages.truncate(target_idx);
+        self.prune_ui_after_current_messages();
+        if prefill.trim().is_empty() {
+            self.pending_input_prefill = None;
+        } else {
+            self.pending_input_prefill = Some(prefill.clone());
+        }
+        Some(prefill)
     }
 
     /// Switch the active model, rebuilding the provider and agent loop.
@@ -3800,6 +3846,7 @@ mod tests {
             pending_theme: None,
             pending_image_hint: None,
             session_objective: None,
+            pending_input_prefill: None,
             quorum_armed_once: false,
             pet_settings: PetSettings::default(),
         }
@@ -3846,6 +3893,58 @@ mod tests {
                 None => std::env::remove_var(key),
             }
         }
+    }
+
+    #[test]
+    fn test_undo_last_n_soft_rewinds_and_sets_prefill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = build_minimal_test_app_with_state_root(tmp.path().to_path_buf());
+        app.messages = vec![
+            hermes_core::Message::system("sys"),
+            hermes_core::Message::user("question 1"),
+            hermes_core::Message::assistant("answer 1"),
+            hermes_core::Message::user("question 2"),
+            hermes_core::Message::assistant("answer 2"),
+            hermes_core::Message::user("question 3"),
+            hermes_core::Message::assistant("answer 3"),
+        ];
+        let persistence = SessionPersistence::new(tmp.path());
+        persistence
+            .persist_session(
+                &app.session_id,
+                &app.messages,
+                None,
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let prefill = app.undo_last_n(2).expect("undo");
+
+        assert_eq!(prefill, "question 2");
+        assert_eq!(
+            app.take_pending_input_prefill().as_deref(),
+            Some("question 2")
+        );
+        assert_eq!(
+            app.messages
+                .iter()
+                .filter_map(|m| m.content.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["sys", "question 1", "answer 1"]
+        );
+        assert_eq!(persistence.load_session(&app.session_id).unwrap().len(), 3);
+        let recent = persistence
+            .list_recent_user_messages(&app.session_id, 5)
+            .unwrap();
+        assert_eq!(
+            recent
+                .iter()
+                .filter_map(|row| row.content.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["question 1"]
+        );
     }
 
     struct LifecycleHookPlugin {

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -115,7 +115,8 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "Clear screen/session state and start a fresh session",
     ),
     ("/retry", "Retry the last user message"),
-    ("/undo", "Undo the last exchange"),
+    ("/undo", "Undo the last N user turns and prefill the latest undone prompt"),
+    ("/rewind", "Alias for /undo [N]"),
     ("/history", "Show recent conversation history"),
     (
         "/recap",
@@ -3559,9 +3560,36 @@ async fn dispatch_slash_command(
             app.retry_last().await?;
             Ok(CommandResult::Handled)
         }
-        "/undo" => {
-            app.undo_last();
-            emit_command_output(app, "[Last exchange undone]");
+        "/undo" | "/rewind" => {
+            let count = match args.first() {
+                Some(raw) => match raw.parse::<usize>() {
+                    Ok(value) if value > 0 => value,
+                    _ => {
+                        emit_command_output(app, "Usage: /undo [positive-turn-count]");
+                        return Ok(CommandResult::Handled);
+                    }
+                },
+                None => 1,
+            };
+            match app.undo_last_n(count) {
+                Some(prefill) if !prefill.trim().is_empty() => emit_command_output(
+                    app,
+                    format!(
+                        "[Undid {} user turn{}; prompt restored to composer for editing]",
+                        count,
+                        if count == 1 { "" } else { "s" }
+                    ),
+                ),
+                Some(_) => emit_command_output(
+                    app,
+                    format!(
+                        "[Undid {} user turn{}]",
+                        count,
+                        if count == 1 { "" } else { "s" }
+                    ),
+                ),
+                None => emit_command_output(app, "[No user turns to undo]"),
+            }
             Ok(CommandResult::Handled)
         }
         "/history" => handle_history_command(app),
@@ -18336,9 +18364,7 @@ fn handle_rollback_command(app: &mut App, args: &[&str]) -> Result<CommandResult
             sub.parse::<usize>().unwrap_or(1)
         };
         let bounded = steps.clamp(1, 64);
-        for _ in 0..bounded {
-            app.undo_last();
-        }
+        let _ = app.undo_last_n(bounded);
         emit_command_output(
             app,
             format!("Rolled back {} exchange(s) via undo.", bounded),
@@ -20004,6 +20030,7 @@ const COMMAND_CATALOG_SECTIONS: &[CommandCatalogSection] = &[
             "/reset",
             "/retry",
             "/undo",
+            "/rewind",
             "/history",
             "/recap",
             "/context",

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -5352,7 +5352,17 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                                         match app.handle_input(&input).await {
                                             Ok(_) => {
                                                 state.finish_processing_cycle("✔ completed in");
-                                                state.status_message.clear();
+                                                if let Some(prefill) =
+                                                    app.take_pending_input_prefill()
+                                                {
+                                                    state.input = prefill;
+                                                    state.cursor_position =
+                                                        state.input.chars().count();
+                                                    state.status_message =
+                                                        "Prompt restored for editing. Press Enter to send.".to_string();
+                                                } else {
+                                                    state.status_message.clear();
+                                                }
                                             }
                                             Err(e) => {
                                                 state.finish_processing_cycle("✖ failed after");

--- a/crates/hermes-tools/src/backends/session_search.rs
+++ b/crates/hermes-tools/src/backends/session_search.rs
@@ -132,6 +132,33 @@ impl SqliteSessionSearchBackend {
         }
     }
 
+    fn ensure_integer_column(
+        conn: &Connection,
+        table: &str,
+        column: &str,
+        default_value: i64,
+        not_null: bool,
+    ) -> Result<(), ToolError> {
+        let mut sql = format!("ALTER TABLE {table} ADD COLUMN {column} INTEGER");
+        if not_null {
+            sql.push_str(" NOT NULL");
+        }
+        sql.push_str(&format!(" DEFAULT {default_value}"));
+        match conn.execute(&sql, []) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate column name") {
+                    Ok(())
+                } else {
+                    Err(ToolError::ExecutionFailed(format!(
+                        "Failed to ensure {table}.{column}: {e}"
+                    )))
+                }
+            }
+        }
+    }
+
     fn ensure_session_compat_columns(conn: &Connection) -> Result<(), ToolError> {
         for column in [
             "parent_session_id",
@@ -141,6 +168,16 @@ impl SqliteSessionSearchBackend {
         ] {
             Self::ensure_text_column(conn, "sessions", column)?;
         }
+        Self::ensure_integer_column(conn, "sessions", "rewind_count", 0, true)?;
+        Self::ensure_integer_column(conn, "messages", "active", 1, true)?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_session_active
+                ON messages(session_id, active, id)",
+            [],
+        )
+        .map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to ensure active message index: {e}"))
+        })?;
         Ok(())
     }
 
@@ -513,7 +550,9 @@ impl SqliteSessionSearchBackend {
         let mut msg_stmt = conn
             .prepare(
                 "SELECT role, COALESCE(content, ''), tool_calls
-                 FROM messages WHERE session_id = ?1 ORDER BY id ASC",
+                 FROM messages
+                 WHERE session_id = ?1 AND active = 1
+                 ORDER BY id ASC",
             )
             .map_err(|e| {
                 ToolError::ExecutionFailed(format!("Failed to prepare messages query: {e}"))
@@ -829,7 +868,8 @@ impl SqliteSessionSearchBackend {
                 parent_session_id TEXT,
                 model_config TEXT,
                 end_reason TEXT,
-                ended_at TEXT
+                ended_at TEXT,
+                rewind_count INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE IF NOT EXISTS messages (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -839,6 +879,7 @@ impl SqliteSessionSearchBackend {
                 tool_call_id TEXT,
                 tool_calls TEXT,
                 created_at TEXT NOT NULL,
+                active INTEGER NOT NULL DEFAULT 1,
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
             CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);",
@@ -1003,6 +1044,7 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
                         .query_row(
                             "SELECT COALESCE(content, '') FROM messages
                              WHERE session_id = ?1 AND content IS NOT NULL
+                               AND active = 1
                              ORDER BY id DESC LIMIT 1",
                             rusqlite::params![session_id.clone()],
                             |r| r.get::<_, String>(0),
@@ -1098,6 +1140,7 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
                          WHERE messages_fts MATCH ?1
                            AND m.content IS NOT NULL
                            AND m.content != ''
+                           AND m.active = 1
                            AND COALESCE(s.platform, '') NOT IN (",
                     );
                     sql.push_str(&hidden_placeholders);
@@ -1333,7 +1376,8 @@ mod tests {
                 parent_session_id TEXT,
                 model_config TEXT,
                 end_reason TEXT,
-                ended_at TEXT
+                ended_at TEXT,
+                rewind_count INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE messages (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1342,7 +1386,8 @@ mod tests {
                 content TEXT,
                 tool_call_id TEXT,
                 tool_calls TEXT,
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                active INTEGER NOT NULL DEFAULT 1
             );
             CREATE INDEX idx_messages_session ON messages(session_id);",
         )
@@ -1397,11 +1442,28 @@ mod tests {
         .expect("insert message");
         conn.execute(
             "UPDATE sessions SET message_count = (
-                SELECT COUNT(*) FROM messages WHERE session_id = ?1
+                SELECT COUNT(*) FROM messages WHERE session_id = ?1 AND active = 1
              ) WHERE id = ?1",
             rusqlite::params![session_id],
         )
         .expect("update message count");
+    }
+
+    fn insert_inactive_message(conn: &Connection, session_id: &str, role: &str, content: &str) {
+        insert_message(conn, session_id, role, content);
+        conn.execute(
+            "UPDATE messages SET active = 0
+             WHERE id = (SELECT MAX(id) FROM messages WHERE session_id = ?1)",
+            rusqlite::params![session_id],
+        )
+        .expect("mark inactive");
+        conn.execute(
+            "UPDATE sessions SET message_count = (
+                SELECT COUNT(*) FROM messages WHERE session_id = ?1 AND active = 1
+             ) WHERE id = ?1",
+            rusqlite::params![session_id],
+        )
+        .expect("update active count");
     }
 
     fn result_ids(output: &str) -> Vec<String> {
@@ -1646,6 +1708,65 @@ mod tests {
         assert_eq!(value["success"], true);
         assert_eq!(value["count"], 0);
         assert_eq!(value["search_degraded"], "fts5_unavailable");
+    }
+
+    #[tokio::test]
+    async fn search_ignores_inactive_rewound_messages() {
+        let (_tmp, backend) = backend_with_db();
+        {
+            let conn = backend.conn.lock().unwrap();
+            insert_session(
+                &conn,
+                "rewound-search",
+                None,
+                None,
+                None,
+                None,
+                "2026-01-01T00:00:00Z",
+            );
+            insert_message(&conn, "rewound-search", "user", "visible active phrase");
+            insert_inactive_message(&conn, "rewound-search", "user", "hiddenrewoundphrase");
+        }
+
+        let output = backend
+            .search(Some("hiddenrewoundphrase"), None, 5, None)
+            .await
+            .expect("search");
+        let value = parsed(&output);
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn recent_preview_uses_latest_active_message() {
+        let (_tmp, backend) = backend_with_db();
+        {
+            let conn = backend.conn.lock().unwrap();
+            insert_session(
+                &conn,
+                "rewound-recent",
+                None,
+                None,
+                None,
+                None,
+                "2026-01-01T00:00:00Z",
+            );
+            insert_message(&conn, "rewound-recent", "user", "visible preview");
+            insert_inactive_message(&conn, "rewound-recent", "user", "hidden preview");
+        }
+
+        let output = backend.search(None, None, 5, None).await.expect("recent");
+        let value = parsed(&output);
+        let preview = value["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["session_id"] == "rewound-recent")
+            .and_then(|row| row["preview"].as_str())
+            .unwrap();
+
+        assert_eq!(preview, "visible preview");
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -575,6 +575,18 @@
     "794519c6ad49": {
       "disposition": "ported",
       "notes": "Rust SessionPersistence updates sessions.model on persisted session conflicts, exposes update_session_model/get_session_model, and App::switch_model immediately refreshes existing persisted session metadata."
+    },
+    "3e59be0c412b": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence now adds messages.active and sessions.rewind_count, filters loads/search to active rows, preserves inactive audit rows, and exposes soft rewind/recent-user/restore primitives with regression coverage."
+    },
+    "243e836dce95": {
+      "disposition": "ported",
+      "notes": "Rust TUI consumes App pending prefill after /rewind or /undo, restoring the rewound prompt into the composer without auto-submitting while App soft-rewinds active session rows."
+    },
+    "3f7d1c801ddf": {
+      "disposition": "ported",
+      "notes": "Rust /undo [N] and /rewind [N] clamp to active user turns, truncate in-memory context, soft-delete persisted rows, preserve inactive audit rows, and stage the backed-up prompt for editing."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary

Implements Rust-native session rewind/undo parity for upstream active-message soft rewind work:

- Adds `messages.active` and `sessions.rewind_count` session DB compatibility columns with migration/index setup.
- Adds `SessionPersistence` soft-rewind primitives, active user listing, inactive-row restore, and active-only session loading while preserving inactive audit rows.
- Filters session search/recent previews/content hits to active messages.
- Wires `/undo [N]` and `/rewind [N]` through the Rust CLI/App/TUI path, truncating active context and restoring the backed-up prompt into the composer for editing.
- Records queue overrides for upstream SHAs `3e59be0c412b`, `243e836dce95`, and `3f7d1c801ddf`.

## Verification

- `cargo test -p hermes-agent session_persistence -- --nocapture` -> 18 passed, 0 failed
- `cargo test -p hermes-tools session_search -- --nocapture` -> 17 unit tests + 1 contract passed
- `cargo test -p hermes-cli test_undo_last_n_soft_rewinds_and_sets_prefill -- --nocapture` -> 1 passed, 0 failed
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-tools -p hermes-cli` -> pass, `new=0`, stale=5 pre-existing allowlist entries
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-agent -p hermes-tools -p hermes-cli`
- Queue proof: target SHAs are `ported sha_override`; pending count `245`
