### PR TITLE
parity(config): harden startup availability paths

### DIFF
--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -313,6 +313,7 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
 
     // Layer 3: environment variables (highest priority)
     apply_env_overrides(&mut config);
+    normalize_platform_aliases(&mut config);
     normalize_provider_secrets(&mut config);
 
     // Record the effective home dir
@@ -349,7 +350,8 @@ fn load_from_yaml_inner(path: &Path, expand_env_refs: bool) -> Result<GatewayCon
     }
     mark_platform_enabled_explicit(&mut root, "slack");
     mark_platform_enabled_explicit(&mut root, "ntfy");
-    let config: GatewayConfig = serde_yaml::from_value(root).map_err(yaml_to_config_error)?;
+    let mut config: GatewayConfig = serde_yaml::from_value(root).map_err(yaml_to_config_error)?;
+    normalize_platform_aliases(&mut config);
     Ok(config)
 }
 
@@ -435,10 +437,72 @@ fn mark_platform_enabled_explicit(root: &mut serde_yaml::Value, platform: &str) 
     }
 }
 
+fn normalize_platform_aliases(config: &mut GatewayConfig) {
+    normalize_discord_allow_from_alias(config);
+}
+
+fn normalize_discord_allow_from_alias(config: &mut GatewayConfig) {
+    let Some(discord) = config.platforms.get_mut("discord") else {
+        return;
+    };
+    if !discord.allowed_users.is_empty() {
+        return;
+    }
+
+    let alias_users = {
+        let direct = discord.extra.get("allow_from");
+        let nested = discord
+            .extra
+            .get("extra")
+            .and_then(|value| value.get("allow_from"));
+        direct
+            .and_then(json_value_to_string_list)
+            .or_else(|| nested.and_then(json_value_to_string_list))
+            .filter(|users| !users.is_empty())
+    };
+
+    if let Some(users) = alias_users {
+        discord.allowed_users = users;
+    }
+}
+
+fn json_value_to_string_list(value: &serde_json::Value) -> Option<Vec<String>> {
+    match value {
+        serde_json::Value::String(raw) => Some(comma_separated_values(raw)),
+        serde_json::Value::Array(items) => {
+            let values = items
+                .iter()
+                .filter_map(json_scalar_to_string)
+                .flat_map(|raw| comma_separated_values(&raw))
+                .collect::<Vec<_>>();
+            Some(values)
+        }
+        _ => json_scalar_to_string(value).map(|raw| comma_separated_values(&raw)),
+    }
+}
+
+fn json_scalar_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(raw) => Some(raw.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn comma_separated_values(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 /// Load `config.yaml` from disk if it exists; otherwise return defaults (no env merge).
 pub fn load_user_config_file(path: &Path) -> Result<GatewayConfig, ConfigError> {
     if path.exists() {
         let mut cfg = load_from_yaml_preserving_env_refs(path)?;
+        normalize_platform_aliases(&mut cfg);
         normalize_provider_secrets(&mut cfg);
         validate_config(&cfg)?;
         Ok(cfg)
@@ -1247,6 +1311,7 @@ fn validate_user_config_value(root: &serde_yaml::Value) -> Result<(), ConfigErro
     mark_platform_enabled_explicit(&mut normalized, "ntfy");
     let mut cfg: GatewayConfig =
         serde_yaml::from_value(normalized).map_err(yaml_to_config_error)?;
+    normalize_platform_aliases(&mut cfg);
     normalize_provider_secrets(&mut cfg);
     validate_config(&cfg)
 }
@@ -1355,7 +1420,9 @@ fn save_env_key_value(path: &Path, key: &str, value: &str) -> Result<(), ConfigE
 /// Load a GatewayConfig from a JSON file.
 pub fn load_from_json(path: &Path) -> Result<GatewayConfig, ConfigError> {
     let contents = std::fs::read_to_string(path).map_err(io_to_config_error)?;
-    let config: GatewayConfig = serde_json::from_str(&contents).map_err(json_to_config_error)?;
+    let mut config: GatewayConfig =
+        serde_json::from_str(&contents).map_err(json_to_config_error)?;
+    normalize_platform_aliases(&mut config);
     Ok(config)
 }
 
@@ -2370,6 +2437,66 @@ terminal:
             "false"
         );
         clear_terminal_env_bridge_vars();
+    }
+
+    #[test]
+    fn load_config_bridges_discord_allow_from_alias_to_allowed_users() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("DISCORD_ALLOWED_USERS");
+            std::env::remove_var("DISCORD_BOT_TOKEN");
+        }
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+platforms:
+  discord:
+    enabled: true
+    allow_from:
+      - "100"
+      - 200
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_config(Some(dir.path().to_string_lossy().as_ref())).unwrap();
+        let discord = cfg.platforms.get("discord").expect("discord config");
+        assert_eq!(discord.allowed_users, vec!["100", "200"]);
+        assert!(discord.extra.contains_key("allow_from"));
+    }
+
+    #[test]
+    fn load_config_bridges_discord_extra_allow_from_and_preserves_env_precedence() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var("DISCORD_ALLOWED_USERS", "env-user");
+            std::env::remove_var("DISCORD_BOT_TOKEN");
+        }
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+platforms:
+  discord:
+    enabled: true
+    extra:
+      allow_from: cfg-user-1,cfg-user-2
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_config(Some(dir.path().to_string_lossy().as_ref())).unwrap();
+        let discord = cfg.platforms.get("discord").expect("discord config");
+        assert_eq!(discord.allowed_users, vec!["env-user"]);
+
+        unsafe {
+            std::env::remove_var("DISCORD_ALLOWED_USERS");
+        }
     }
 
     #[test]

--- a/crates/hermes-config/src/managed_gateway/auth.rs
+++ b/crates/hermes-config/src/managed_gateway/auth.rs
@@ -161,6 +161,30 @@ pub fn read_nous_access_token(reader: Option<&dyn TokenReader>) -> Option<String
     cached
 }
 
+/// Read the currently cached Nous OAuth subscriber access token without
+/// expiry checks or refresh callbacks.
+///
+/// Availability probes use this lighter path so slow/interactive refresh
+/// mechanisms never run while merely deciding whether a managed gateway is
+/// present. Actual request paths should continue to call
+/// [`read_nous_access_token`] so they can use fresh credentials when a
+/// caller wires in a refresh-capable [`TokenReader`].
+pub fn peek_nous_access_token() -> Option<String> {
+    if let Ok(explicit) = std::env::var(TOKEN_OVERRIDE_ENV) {
+        let trimmed = explicit.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    read_nous_provider_state()
+        .access_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -291,6 +315,20 @@ mod tests {
     }
 
     #[test]
+    fn peek_returns_cached_token_without_expiry_validation() {
+        let payload = json!({
+            "providers": {
+                "nous": {
+                    "access_token": "stale-tok",
+                    "expires_at": iso_seconds_from_now(-3600),
+                }
+            }
+        });
+        let _g = AuthGuard::new(Some(&payload));
+        assert_eq!(peek_nous_access_token(), Some("stale-tok".to_string()));
+    }
+
+    #[test]
     fn explicit_env_override_wins() {
         let payload = json!({
             "providers": {"nous": {"access_token": "from-disk"}}
@@ -301,6 +339,16 @@ mod tests {
             read_nous_access_token(None),
             Some("override-token".to_string())
         );
+    }
+
+    #[test]
+    fn peek_env_override_wins_over_disk() {
+        let payload = json!({
+            "providers": {"nous": {"access_token": "from-disk"}}
+        });
+        let _g = AuthGuard::new(Some(&payload));
+        std::env::set_var(TOKEN_OVERRIDE_ENV, "  override-token  ");
+        assert_eq!(peek_nous_access_token(), Some("override-token".to_string()));
     }
 
     #[test]

--- a/crates/hermes-config/src/managed_gateway/mod.rs
+++ b/crates/hermes-config/src/managed_gateway/mod.rs
@@ -50,7 +50,7 @@ pub mod test_lock {
     }
 }
 
-pub use auth::{read_nous_access_token, NousProviderState, TokenReader};
+pub use auth::{peek_nous_access_token, read_nous_access_token, NousProviderState, TokenReader};
 pub use config::{
     build_vendor_gateway_url, get_tool_gateway_scheme, GatewayBuilder, GatewaySchemeError,
     ManagedToolGatewayConfig, DEFAULT_TOOL_GATEWAY_DOMAIN,

--- a/crates/hermes-config/src/managed_gateway/resolver.rs
+++ b/crates/hermes-config/src/managed_gateway/resolver.rs
@@ -4,7 +4,7 @@
 //! Mirrors Python's `tools.managed_tool_gateway.resolve_managed_tool_gateway`
 //! and `is_managed_tool_gateway_ready`.
 
-use super::auth::{read_nous_access_token, TokenReader};
+use super::auth::{peek_nous_access_token, read_nous_access_token, TokenReader};
 use super::config::{build_vendor_gateway_url, GatewayBuilder, ManagedToolGatewayConfig};
 use super::selection::managed_nous_tools_enabled;
 
@@ -30,6 +30,14 @@ pub fn resolve_managed_tool_gateway(
     vendor: &str,
     opts: ResolveOptions<'_>,
 ) -> Option<ManagedToolGatewayConfig> {
+    resolve_managed_tool_gateway_with_token(vendor, opts, read_nous_access_token)
+}
+
+fn resolve_managed_tool_gateway_with_token(
+    vendor: &str,
+    opts: ResolveOptions<'_>,
+    token_reader_fn: impl FnOnce(Option<&dyn TokenReader>) -> Option<String>,
+) -> Option<ManagedToolGatewayConfig> {
     if !managed_nous_tools_enabled() {
         return None;
     }
@@ -42,7 +50,7 @@ pub fn resolve_managed_tool_gateway(
         return None;
     }
 
-    let token = read_nous_access_token(opts.token_reader)?;
+    let token = token_reader_fn(opts.token_reader)?;
     if token.is_empty() {
         return None;
     }
@@ -57,7 +65,7 @@ pub fn resolve_managed_tool_gateway(
 
 /// Convenience predicate. Mirrors Python's `is_managed_tool_gateway_ready`.
 pub fn is_managed_tool_gateway_ready(vendor: &str, opts: ResolveOptions<'_>) -> bool {
-    resolve_managed_tool_gateway(vendor, opts).is_some()
+    resolve_managed_tool_gateway_with_token(vendor, opts, |_| peek_nous_access_token()).is_some()
 }
 
 // ---------------------------------------------------------------------------
@@ -256,6 +264,30 @@ mod tests {
             "firecrawl",
             ResolveOptions::default()
         ));
+    }
+
+    #[test]
+    fn is_ready_peeks_expired_cached_token_without_refreshing() {
+        struct PanickingReader;
+        impl TokenReader for PanickingReader {
+            fn refresh(&self, _: i64) -> Option<String> {
+                panic!("availability checks must not refresh Nous OAuth tokens");
+            }
+        }
+
+        let payload = json!({
+            "providers": {"nous": {
+                "access_token": "expired-but-present",
+                "expires_at": iso_in(-3600),
+            }}
+        });
+        let _g = Guard::new(Some(&payload));
+        std::env::set_var("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+        let opts = ResolveOptions {
+            gateway_builder: None,
+            token_reader: Some(&PanickingReader),
+        };
+        assert!(is_managed_tool_gateway_ready("firecrawl", opts));
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/browser.rs
+++ b/crates/hermes-tools/src/backends/browser.rs
@@ -5,8 +5,8 @@
 
 use async_trait::async_trait;
 use hermes_config::{
-    cli_config_path, config_path, managed_nous_tools_enabled, resolve_managed_tool_gateway,
-    ManagedToolGatewayConfig, ResolveOptions,
+    cli_config_path, config_path, is_managed_tool_gateway_ready, managed_nous_tools_enabled,
+    resolve_managed_tool_gateway, ManagedToolGatewayConfig, ResolveOptions,
 };
 use regex::Regex;
 use serde_json::{json, Value};
@@ -681,7 +681,7 @@ impl BrowserUseConfig {
 
     pub fn is_configured_from_env_or_managed() -> bool {
         env_optional_nonempty("BROWSER_USE_API_KEY").is_some()
-            || resolve_managed_tool_gateway("browser-use", ResolveOptions::default()).is_some()
+            || is_managed_tool_gateway_ready("browser-use", ResolveOptions::default())
     }
 
     pub fn base_url(&self) -> &str {
@@ -2093,6 +2093,28 @@ mod tests {
         assert_eq!(cfg.api_key, "nous-token");
         assert_eq!(cfg.base_url(), "http://127.0.0.1:3009");
         assert!(cfg.managed_mode());
+    }
+
+    #[test]
+    fn browser_use_availability_accepts_expired_cached_nous_token() {
+        let _scope = EnvScope::new();
+        let home = tempfile::tempdir().expect("temp hermes home");
+        std::fs::write(
+            home.path().join("auth.json"),
+            serde_json::to_vec_pretty(&json!({
+                "providers": {"nous": {
+                    "access_token": "expired-but-present",
+                    "expires_at": "2000-01-01T00:00:00Z",
+                }}
+            }))
+            .expect("auth json serializes"),
+        )
+        .expect("write auth.json");
+        std::env::set_var("HERMES_HOME", home.path());
+        std::env::set_var("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+
+        assert!(BrowserUseConfig::is_configured_from_env_or_managed());
+        assert_eq!(browser_backend_choice_from_env(), "browser-use");
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/web.rs
+++ b/crates/hermes-tools/src/backends/web.rs
@@ -10,7 +10,8 @@ use url::Url;
 
 use crate::tools::web::{WebCrawlBackend, WebExtractBackend, WebSearchBackend};
 use hermes_config::managed_gateway::{
-    resolve_managed_tool_gateway, ManagedToolGatewayConfig, ResolveOptions,
+    is_managed_tool_gateway_ready, resolve_managed_tool_gateway, ManagedToolGatewayConfig,
+    ResolveOptions,
 };
 use hermes_core::ToolError;
 
@@ -1757,7 +1758,7 @@ fn firecrawl_direct_config_present() -> bool {
 }
 
 fn firecrawl_managed_config_present() -> bool {
-    resolve_managed_tool_gateway("firecrawl", ResolveOptions::default()).is_some()
+    is_managed_tool_gateway_ready("firecrawl", ResolveOptions::default())
 }
 
 fn firecrawl_transport_from_env_or_managed() -> Result<FirecrawlTransport, ToolError> {
@@ -2414,6 +2415,7 @@ mod web_search_env_tests {
 mod firecrawl_managed_tests {
     use super::*;
     use hermes_config::managed_gateway::test_lock;
+    use serde_json::json;
 
     /// Hermetic env scope: HERMES_HOME → tempdir + flag/token cleared.
     struct EnvScope {
@@ -2459,6 +2461,14 @@ mod firecrawl_managed_tests {
         }
     }
 
+    fn write_auth_json(home: &std::path::Path, payload: serde_json::Value) {
+        std::fs::write(
+            home.join("auth.json"),
+            serde_json::to_vec_pretty(&payload).expect("auth json serializes"),
+        )
+        .expect("write auth.json");
+    }
+
     #[test]
     fn from_env_or_managed_prefers_direct_key() {
         let _g = EnvScope::new();
@@ -2475,6 +2485,25 @@ mod firecrawl_managed_tests {
         std::env::set_var("TOOL_GATEWAY_USER_TOKEN", "nous-tok");
         let b = FirecrawlExtractBackend::from_env_or_managed().unwrap();
         assert_eq!(b.transport_label(), "managed");
+    }
+
+    #[test]
+    fn availability_accepts_expired_cached_nous_token_without_refresh() {
+        let scope = EnvScope::new();
+        write_auth_json(
+            scope._tmp.path(),
+            json!({
+                "providers": {"nous": {
+                    "access_token": "expired-but-present",
+                    "expires_at": "2000-01-01T00:00:00Z",
+                }}
+            }),
+        );
+        std::env::set_var("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1");
+
+        assert!(firecrawl_managed_config_present());
+        assert_eq!(search_backend_choice_from_env(), "firecrawl");
+        assert_eq!(extract_backend_choice_from_env(), "firecrawl");
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -587,6 +587,22 @@
     "3f7d1c801ddf": {
       "disposition": "ported",
       "notes": "Rust /undo [N] and /rewind [N] clamp to active user turns, truncate in-memory context, soft-delete persisted rows, preserve inactive audit rows, and stage the backed-up prompt for editing."
+    },
+    "6a72af044c44": {
+      "disposition": "ported",
+      "notes": "Rust managed gateway availability now uses peek_nous_access_token/is_managed_tool_gateway_ready so Firecrawl and Browser Use availability checks do not run refresh-capable Nous OAuth readers; actual request resolution remains refresh-aware and tests cover expired cached token availability."
+    },
+    "6d2727ef1ce1": {
+      "disposition": "ported",
+      "notes": "Rust config loading normalizes Discord allow_from aliases from platforms.discord.allow_from and platforms.discord.extra.allow_from into allowed_users while preserving DISCORD_ALLOWED_USERS/env precedence, with loader regression coverage."
+    },
+    "8bd00607dc53": {
+      "disposition": "superseded",
+      "notes": "Gmail header casing delta applies to upstream Python Google Workspace bridge; this Rust workspace has no Gmail/Google Workspace runtime tool surface in crates beyond bundled skill synchronization/reference content, so there is no Rust header parser/sender to port."
+    },
+    "cbf851ae1d72": {
+      "disposition": "superseded",
+      "notes": "Upstream patch bounds Python TUI startup MCP discovery; Rust TUI startup does not connect/discover configured MCP servers on App::new, and hermes-mcp discovery remains explicit client/CLI behavior with transport/call timeouts, so the freeze path is absent in current Rust runtime."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Add Rust managed-gateway token peeking for availability checks so Firecrawl/Browser Use probes do not trigger refresh-capable Nous OAuth readers.
- Preserve refresh-aware managed-gateway resolution for actual request paths.
- Normalize Discord `allow_from` aliases from `platforms.discord.allow_from` and `platforms.discord.extra.allow_from` into canonical `allowed_users` while preserving `DISCORD_ALLOWED_USERS` precedence.
- Update parity queue overrides for managed gateway, Discord allow_from, Gmail reference-only, and Rust MCP startup-discovery non-surface.

## Verification
- `cargo test -p hermes-config managed_gateway -- --nocapture`
- `cargo test -p hermes-config load_config_bridges_discord -- --nocapture`
- `cargo test -p hermes-tools firecrawl_managed_tests::availability_accepts_expired_cached_nous_token_without_refresh -- --nocapture`
- `cargo test -p hermes-tools browser_use_availability_accepts_expired_cached_nous_token -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-tools` (`new=0`, stale=5 pre-existing)
- `cargo build -p hermes-config -p hermes-tools`
- seeded queue proof: `8bd00607dc53 superseded`, `cbf851ae1d72 superseded`, `6d2727ef1ce1 ported`, `6a72af044c44 ported`, `pending_count 241`