### PR TITLE
parity(models): refresh provider picker surfaces

### DIFF
--- a/crates/hermes-agent/src/auxiliary_builder.rs
+++ b/crates/hermes-agent/src/auxiliary_builder.rs
@@ -29,7 +29,7 @@ mod default_models {
     pub const ZAI: &str = "glm-4.5-flash";
     pub const KIMI: &str = "kimi-k2-turbo-preview";
     pub const MINIMAX: &str = "MiniMax-M2.7";
-    pub const GEMINI: &str = "gemini-3-flash-preview";
+    pub const GEMINI: &str = "gemini-3.5-flash";
     pub const GMI: &str = "google/gemini-3.1-flash-lite-preview";
     pub const TENCENT_TOKENHUB: &str = "hy3-preview";
 }
@@ -729,7 +729,20 @@ mod tests {
         std::env::remove_var("DEEPSEEK_API_KEY");
         std::env::remove_var("OPENROUTER_API_KEY");
 
-        // Scenario 6: full chain, deterministic order.
+        // Scenario 6: Gemini direct-key auxiliary default uses the renamed model.
+        std::env::set_var("GEMINI_API_KEY", "sk-gemini");
+        {
+            let (client, summary) = build_default_auxiliary_client(AuxiliaryConfig::default());
+            assert_eq!(client.chain_labels(), vec!["gemini"]);
+            assert_eq!(
+                client.chain_entries(),
+                vec![("gemini".to_string(), "gemini-3.5-flash".to_string(), true,)]
+            );
+            assert_eq!(summary.registered, vec!["gemini"]);
+        }
+        std::env::remove_var("GEMINI_API_KEY");
+
+        // Scenario 7: full chain, deterministic order.
         std::env::set_var("OPENROUTER_API_KEY", "sk-or");
         std::env::set_var("HERMES_OPENAI_API_KEY", "sk-hermes-oa");
         std::env::set_var("OPENAI_API_KEY", "sk-oa-legacy");

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -369,6 +369,8 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/sessions",
         "Browse saved sessions, or resume one by name (`/sessions [name]`)",
     ),
+    ("/session", "Alias for /sessions"),
+    ("/switch", "Alias for /sessions"),
     (
         "/background",
         "Run a task in the background (`status|tail <job-id> [N]`)",
@@ -3389,6 +3391,8 @@ fn canonical_command(cmd: &str) -> &str {
         "/skins" => "/skin",
         "/summary" => "/recap",
         "/whoami" => "/profile",
+        "/session" => "/sessions",
+        "/switch" => "/sessions",
         "/sb" => "/statusbar",
         "/pilot" => "/autopilot",
         "/rb" => "/runbook",
@@ -20045,6 +20049,8 @@ const COMMAND_CATALOG_SECTIONS: &[CommandCatalogSection] = &[
             "/load",
             "/resume",
             "/sessions",
+            "/session",
+            "/switch",
         ],
     },
     CommandCatalogSection {
@@ -27734,6 +27740,10 @@ mod tests {
         assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/sessions"));
         let results = autocomplete("/sess");
         assert!(results.contains(&"/sessions"));
+        assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/session"));
+        assert_eq!(canonical_command("/session"), "/sessions");
+        assert_eq!(canonical_command("/switch"), "/sessions");
+        assert!(autocomplete("/sw").contains(&"/switch"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -38,7 +38,7 @@ use hermes_cli::cli::{Cli, CliCommand};
 use hermes_cli::config_env::hydrate_env_from_config;
 use hermes_cli::model_switch::{
     cached_provider_catalog_status, curated_provider_slugs, normalize_provider_model,
-    provider_catalog_entries, provider_model_ids,
+    provider_catalog_entries, provider_model_ids, provider_picker_description,
 };
 use hermes_cli::platform_toolsets::{resolve_platform_tool_schemas, tool_definition_summary};
 use hermes_cli::providers::provider_capability_for;
@@ -1675,9 +1675,10 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
                     } else {
                         format!(" [{}]", caps.join(", "))
                     };
+                    let description = provider_picker_description(&entry.provider);
                     println!(
-                        "  {:<12} — {}{}{}",
-                        entry.provider, preview, suffix, cap_suffix
+                        "  {:<18} - {} - {}{}{}",
+                        entry.provider, description, preview, suffix, cap_suffix
                     );
                 }
             }
@@ -10579,9 +10580,10 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
                 "API key"
             };
             format!(
-                "{:<22} {:<18} {}",
+                "{:<22} {:<18} {} | default {}",
                 setup_provider_display(option.provider),
                 format!("({auth_label})"),
+                provider_picker_description(option.provider),
                 option.label
             )
         })

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -258,13 +258,26 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
         "gemini",
         &[
             "gemini-3.1-pro-preview",
-            "gemini-3-flash-preview",
+            "gemini-3-pro-preview",
+            "gemini-3.5-flash",
             "gemini-3.1-flash-lite-preview",
         ],
     ),
     (
+        "google-gemini-cli",
+        &[
+            "gemini-3.1-pro-preview",
+            "gemini-3-pro-preview",
+            "gemini-3.5-flash",
+        ],
+    ),
+    (
         "google",
-        &["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
+        &[
+            "gemini-3.1-pro-preview",
+            "gemini-3-pro-preview",
+            "gemini-3.5-flash",
+        ],
     ),
 ];
 
@@ -505,6 +518,66 @@ pub fn curated_provider_slugs() -> Vec<&'static str> {
         .iter()
         .map(|(provider, _)| *provider)
         .collect()
+}
+
+pub fn provider_picker_description(provider: &str) -> &'static str {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "alibaba-coding-plan" => {
+            "Alibaba Coding Plan (coding models via DashScope Coding Plan API)"
+        }
+        "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => {
+            "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"
+        }
+        "kimi-coding" => "Kimi Coding Plan (api.kimi.com & Moonshot API)",
+        "kimi-coding-cn" => "Kimi / Moonshot China (Domestic direct API)",
+        "lmstudio" | "lm-studio" => "LM Studio (Local desktop app with built-in model server)",
+        "minimax-cn" | "minimax_cn" => "MiniMax China (Domestic direct API)",
+        "xai-oauth" => "xAI Grok OAuth (SuperGrok / Premium+ subscription)",
+        raw => match canonical_provider_id(raw).as_str() {
+            "nous" => {
+                "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"
+            }
+            "openrouter" => "OpenRouter (Pay-per-use API aggregator)",
+            "novita" => "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)",
+            "anthropic" => "Anthropic (Claude models via API key or Claude Code)",
+            "openai-codex" => "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)",
+            "openai" => "OpenAI API (api.openai.com, API key)",
+            "qwen" => "Qwen Cloud / DashScope (Qwen + multi-provider)",
+            "qwen-oauth" => "Qwen OAuth (Reuses local Qwen CLI login)",
+            "xiaomi" => "Xiaomi MiMo (MiMo-V2.5 and V2 models: pro, omni, flash)",
+            "tencent-tokenhub" => "Tencent TokenHub (Hy3 Preview via tokenhub.tencentmaas.com)",
+            "nvidia" => "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)",
+            "copilot" => "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)",
+            "copilot-acp" => "GitHub Copilot ACP (Spawns copilot --acp --stdio)",
+            "huggingface" => "Hugging Face Inference Providers",
+            "gemini" => "Google AI Studio (Native Gemini API)",
+            "deepseek" => "DeepSeek (V3, R1, coder, direct API)",
+            "xai" => "xAI Grok (Direct API)",
+            "zai" => "Z.AI / GLM (Zhipu direct API)",
+            "kimi" => "Kimi Coding Plan (api.kimi.com & Moonshot API)",
+            "stepfun" => "StepFun Step Plan (Agent / coding models via Step Plan API)",
+            "minimax" => "MiniMax (Global direct API)",
+            "ollama-cloud" => "Ollama Cloud (Cloud-hosted open models, ollama.com)",
+            "arcee" => "Arcee AI (Trinity models, direct API)",
+            "gmi" => "GMI Cloud (Multi-model direct API)",
+            "kilocode" => "Kilo Code (Kilo Gateway API)",
+            "opencode-zen" => "OpenCode Zen (Curated models, pay-as-you-go)",
+            "opencode-go" => "OpenCode Go (Open models subscription)",
+            "bedrock" => "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)",
+            "azure-foundry" => {
+                "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"
+            }
+            "ai-gateway" => "Vercel AI Gateway (OpenAI-compatible gateway)",
+            "ollama-local" => "Ollama Local (local OpenAI-compatible server)",
+            "llama-cpp" => "llama.cpp Server (local OpenAI-compatible endpoint)",
+            "vllm" => "vLLM Server (local/self-host OpenAI-compatible endpoint)",
+            "mlx" => "MLX Server (Apple Silicon local endpoint)",
+            "apple-ane" => "Apple ANE Endpoint (private local endpoint)",
+            "sglang" => "SGLang Server (local/self-host OpenAI-compatible endpoint)",
+            "tgi" => "Text Generation Inference (local/self-host endpoint)",
+            _ => "Provider catalog entry",
+        },
+    }
 }
 
 pub fn is_models_dev_preferred_provider(provider: &str) -> bool {
@@ -1050,7 +1123,7 @@ mod tests {
         cached_provider_catalog_status, is_models_dev_preferred_provider,
         load_provider_catalog_cache, merge_with_models_dev, normalize_provider_model,
         persist_provider_catalog_cache, provider_catalog_cache_path, provider_catalog_entries,
-        provider_curated_models, provider_model_ids_with_client,
+        provider_curated_models, provider_model_ids_with_client, provider_picker_description,
         resolve_huggingface_catalog_endpoint_and_token,
     };
 
@@ -1204,6 +1277,30 @@ mod tests {
         assert!(provider_curated_models("arcee-ai").contains(&"trinity-mini"));
         assert!(provider_curated_models("mimo").contains(&"mimo-v2.5-pro"));
         assert!(provider_curated_models("tokenhub").contains(&"hy3-preview"));
+    }
+
+    #[test]
+    fn gemini_curated_models_expose_35_flash_for_api_key_and_oauth_pickers() {
+        for provider in ["gemini", "google-gemini-cli"] {
+            let models = provider_curated_models(provider);
+            assert!(
+                models.contains(&"gemini-3.5-flash"),
+                "{provider} picker should include gemini-3.5-flash"
+            );
+            assert!(
+                !models.contains(&"gemini-3-flash-preview"),
+                "{provider} picker should not offer retired gemini-3-flash-preview"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_picker_descriptions_match_refreshed_upstream_copy() {
+        assert!(provider_picker_description("nous").contains("300+ models"));
+        assert!(provider_picker_description("openrouter").contains("Pay-per-use API aggregator"));
+        assert!(provider_picker_description("google-gemini-cli").contains("Code Assist OAuth flow"));
+        assert!(provider_picker_description("xai").contains("Grok"));
+        assert!(provider_picker_description("qwen-oauth").contains("Reuses local Qwen CLI login"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -4489,19 +4489,24 @@ async fn open_model_provider_modal(state: &mut TuiState, app: &App) {
             .iter()
             .find(|entry| entry.provider.eq_ignore_ascii_case(provider));
         let auth_detail = provider_auth_detail(provider, &token_store_providers);
+        let description = crate::model_switch::provider_picker_description(provider);
         let detail = if let Some(entry) = entry {
             if entry.models.is_empty() {
-                format!("{} models • {}", entry.total_models, auth_detail)
+                format!(
+                    "{} • {} models • {}",
+                    description, entry.total_models, auth_detail
+                )
             } else {
                 format!(
-                    "{} models • {} • {}",
+                    "{} • {} models • {} • {}",
+                    description,
                     entry.total_models,
                     entry.models.join(", "),
                     auth_detail
                 )
             }
         } else {
-            format!("catalog unavailable • {}", auth_detail)
+            format!("{} • catalog unavailable • {}", description, auth_detail)
         };
         items.push(PickerItem {
             label: provider.to_string(),

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -603,6 +603,22 @@
     "cbf851ae1d72": {
       "disposition": "superseded",
       "notes": "Upstream patch bounds Python TUI startup MCP discovery; Rust TUI startup does not connect/discover configured MCP servers on App::new, and hermes-mcp discovery remains explicit client/CLI behavior with transport/call timeouts, so the freeze path is absent in current Rust runtime."
+    },
+    "47d2d05892ef": {
+      "disposition": "ported",
+      "notes": "Rust provider picker copy now has provider_picker_description wired into hermes model output, setup provider labels, and the TUI provider modal; tests pin refreshed Nous/OpenRouter/Gemini/xAI/Qwen descriptions."
+    },
+    "e946f49ab550": {
+      "disposition": "ported",
+      "notes": "Rust Gemini API-key and google-gemini-cli OAuth model catalogs now expose gemini-3.5-flash and stop offering retired gemini-3-flash-preview; Gemini auxiliary direct-key default also uses gemini-3.5-flash with regression coverage."
+    },
+    "8104b202691": {
+      "disposition": "ported",
+      "notes": "Rust xAI video generation routes default text vs image models by modality, honors explicit overrides, normalizes local image files to data:image URLs, and has focused video_gen regression coverage for those contracts."
+    },
+    "fabca0bdd82b": {
+      "disposition": "ported",
+      "notes": "Rust TUI already drives model selection through canonical /model provider/model modals; this batch added /session and /switch aliases to the existing /sessions surface while preserving /provider as a distinct provider-status command rather than the removed Python /model alias."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- refresh Rust provider picker descriptions and wire them into `hermes model`, setup, and the TUI provider modal
- add `gemini-3.5-flash` to Gemini API-key and Google Gemini OAuth picker catalogs; remove the retired bare `gemini-3-flash-preview` from those paths
- update Gemini direct-key auxiliary default to `gemini-3.5-flash`
- add `/session` and `/switch` aliases to the existing Rust `/sessions` surface while preserving `/provider` as a distinct provider-status command
- mark upstream provider/model/video/TUI SHAs handled in the parity queue overrides

## Queue Proof
- `47d2d05892ef` -> `ported`
- `e946f49ab550` -> `ported`
- `8104b202691` -> `ported`
- `fabca0bdd82b` -> `ported`
- pending count: `241 -> 237`

## Verification
- `cargo test -p hermes-agent build_default_auxiliary_client_scenarios -- --nocapture`
- `cargo test -p hermes-cli gemini_curated_models_expose_35_flash_for_api_key_and_oauth_pickers -- --nocapture`
- `cargo test -p hermes-cli provider_picker_descriptions_match_refreshed_upstream_copy -- --nocapture`
- `cargo test -p hermes-cli test_sessions_command_is_registered_and_completable -- --nocapture`
- `cargo test -p hermes-tools xai_routes_default_models_by_modality -- --nocapture`
- `cargo test -p hermes-tools xai_payload_normalizes_references_duration_resolution_and_aspect -- --nocapture`
- `cargo test -p hermes-tools xai_local_image_paths_are_encoded_as_data_urls -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-agent -p hermes-tools` (`seen=199 allowlist=204 new=0 stale=5`)
- `cargo build -p hermes-cli -p hermes-agent -p hermes-tools`
