### PR TITLE
parity(skills): add blank-slate runtime controls

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/honcho.rs
+++ b/crates/hermes-agent/src/memory_plugins/honcho.rs
@@ -1022,6 +1022,33 @@ mod tests {
     }
 
     #[test]
+    fn test_honcho_initialize_is_fail_open_and_does_not_contact_network() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("HONCHO_API_KEY");
+        let _url = EnvGuard::remove("HONCHO_BASE_URL");
+        std::fs::write(
+            tmp.path().join("honcho.json"),
+            r#"{"baseUrl":"http://10.255.255.1:9","enabled":true,"timeout":60,"recallMode":"hybrid"}"#,
+        )
+        .expect("write config");
+
+        let plugin = HonchoMemoryPlugin::new();
+        let started = std::time::Instant::now();
+        plugin.initialize("session-1", &tmp.path().to_string_lossy());
+
+        assert!(
+            started.elapsed() < Duration::from_millis(250),
+            "initialize should only load config and must not block on Honcho network/session startup"
+        );
+        assert!(plugin.config.lock().unwrap().is_some());
+        assert_eq!(*plugin.session_key.lock().unwrap(), "session-1");
+        assert_eq!(plugin.get_tool_schemas().len(), 4);
+        assert!(plugin.system_prompt_block().contains("hybrid mode"));
+    }
+
+    #[test]
     fn test_honcho_save_config_normalizes_key_and_writes_owner_only() {
         let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -560,13 +560,22 @@ pub enum CliCommand {
 
     /// Skills management.
     Skills {
-        /// Action: browse/search/install/inspect/list/check/update/audit/uninstall/publish/snapshot/tap/config/reset/subscribe
+        /// Action: browse/search/install/inspect/list/check/update/audit/uninstall/publish/snapshot/tap/config/reset/subscribe/sync/opt-out/opt-in
         action: Option<String>,
         /// Skill name or search query.
         name: Option<String>,
         /// Additional argument (e.g. tap URL, snapshot path).
         #[arg(long)]
         extra: Option<String>,
+        /// Also delete pristine bundled skills for `skills opt-out`.
+        #[arg(long)]
+        remove: bool,
+        /// Skip confirmation for destructive skills maintenance actions.
+        #[arg(short = 'y', long)]
+        yes: bool,
+        /// Re-seed bundled skills immediately for `skills opt-in`.
+        #[arg(long)]
+        sync: bool,
     },
 
     /// Plugin management.
@@ -1353,6 +1362,44 @@ mod tests {
                 assert!(!show);
             }
             _ => panic!("Expected Secrets command"),
+        }
+    }
+
+    #[test]
+    fn cli_parse_skills_blank_slate_flags() {
+        let cli =
+            Cli::try_parse_from(vec!["hermes", "skills", "opt-out", "--remove", "--yes"]).unwrap();
+        match cli.command {
+            Some(CliCommand::Skills {
+                action,
+                remove,
+                yes,
+                sync,
+                ..
+            }) => {
+                assert_eq!(action.as_deref(), Some("opt-out"));
+                assert!(remove);
+                assert!(yes);
+                assert!(!sync);
+            }
+            _ => panic!("Expected Skills opt-out command"),
+        }
+
+        let cli = Cli::try_parse_from(vec!["hermes", "skills", "opt-in", "--sync"]).unwrap();
+        match cli.command {
+            Some(CliCommand::Skills {
+                action,
+                remove,
+                yes,
+                sync,
+                ..
+            }) => {
+                assert_eq!(action.as_deref(), Some("opt-in"));
+                assert!(!remove);
+                assert!(!yes);
+                assert!(sync);
+            }
+            _ => panic!("Expected Skills opt-in command"),
         }
     }
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -5308,6 +5308,16 @@ fn parse_skills_slash_invocation(args: &[&str]) -> Result<SkillsSlashInvocation,
             name: build_joined(rest),
             extra: None,
         },
+        "sync" => SkillsSlashInvocation {
+            action: Some(action),
+            name: None,
+            extra: None,
+        },
+        "opt-out" | "opt-in" => SkillsSlashInvocation {
+            action: Some(action),
+            name: None,
+            extra: build_joined(rest),
+        },
         "check" => SkillsSlashInvocation {
             action: Some(action),
             name: rest.first().map(|s| s.to_string()),
@@ -5344,7 +5354,7 @@ fn parse_skills_slash_invocation(args: &[&str]) -> Result<SkillsSlashInvocation,
         },
         _ => {
             return Err(format!(
-                "Unknown /skills subcommand '{}'. Use `/skills list`, `/skills quality`, or `/skills search <query>`.",
+                "Unknown /skills subcommand '{}'. Use `/skills list`, `/skills sync`, `/skills opt-out`, `/skills opt-in`, `/skills quality`, or `/skills search <query>`.",
                 action
             ))
         }
@@ -5367,7 +5377,13 @@ async fn run_skills_subcommand_via_cli(
         cmd.arg(name);
     }
     if let Some(extra) = invocation.extra.as_deref() {
-        cmd.arg("--extra").arg(extra);
+        if matches!(invocation.action.as_deref(), Some("opt-out" | "opt-in")) {
+            for arg in extra.split_whitespace() {
+                cmd.arg(arg);
+            }
+        } else {
+            cmd.arg("--extra").arg(extra);
+        }
     }
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -6711,12 +6727,15 @@ fn skills_action_blocked_by_tier(
         SkillsExecutionTier::Trusted => {
             matches!(
                 action,
-                "install" | "update" | "publish" | "uninstall" | "reset" | "subscribe"
+                "install" | "update" | "sync" | "publish" | "uninstall" | "reset" | "subscribe"
             ) || (action == "tap" && matches!(name_lc.as_deref(), Some("add" | "remove")))
+                || (action == "opt-in" && matches!(name_lc.as_deref(), Some("--sync")))
+                || (action == "opt-out" && matches!(name_lc.as_deref(), Some("--remove")))
                 || (action == "snapshot" && matches!(name_lc.as_deref(), Some("import")))
         }
         SkillsExecutionTier::Balanced => {
             matches!(action, "publish" | "reset")
+                || (action == "opt-out" && matches!(name_lc.as_deref(), Some("--remove")))
                 || (action == "snapshot" && matches!(name_lc.as_deref(), Some("import")))
         }
         SkillsExecutionTier::Open => false,
@@ -21320,15 +21339,108 @@ pub async fn handle_cli_chat(
 }
 
 /// Handle `hermes skills [action] [name] [--extra ...]`.
+fn repo_root_for_skill_sync() -> PathBuf {
+    discover_repo_root_for_about().unwrap_or_else(|| {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf()
+    })
+}
+
+fn env_path_or_default(env_key: &str, default: PathBuf) -> PathBuf {
+    std::env::var(env_key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or(default)
+}
+
+fn skill_sync_config_for(skills_dir: &Path) -> hermes_skills::SkillSyncConfig {
+    let repo_root = repo_root_for_skill_sync();
+    let bundled_dir = env_path_or_default("HERMES_BUNDLED_SKILLS", repo_root.join("skills"));
+    let optional_dir =
+        env_path_or_default("HERMES_OPTIONAL_SKILLS", repo_root.join("optional-skills"));
+    hermes_skills::SkillSyncConfig::new(bundled_dir, optional_dir, skills_dir.to_path_buf())
+}
+
+fn skills_extra_has_flag(extra: Option<&str>, flag: &str) -> bool {
+    extra
+        .unwrap_or_default()
+        .split_whitespace()
+        .any(|part| part == flag)
+}
+
+fn print_skill_sync_summary(result: &hermes_skills::SkillSyncResult) {
+    if result.skipped_opt_out {
+        println!(
+            "Skipped bundled skill sync: profile opted out via {}.",
+            hermes_skills::NO_BUNDLED_SKILLS_MARKER
+        );
+        return;
+    }
+    println!(
+        "Skills sync complete: {} new, {} updated, {} unchanged, {} user-modified kept, {} manifest entries cleaned, {} total bundled.",
+        result.copied.len(),
+        result.updated.len(),
+        result.skipped,
+        result.user_modified.len(),
+        result.cleaned.len(),
+        result.total_bundled
+    );
+    if !result.copied.is_empty() {
+        println!("  Copied: {}", result.copied.join(", "));
+    }
+    if !result.updated.is_empty() {
+        println!("  Updated: {}", result.updated.join(", "));
+    }
+    if !result.user_modified.is_empty() {
+        println!("  User-modified kept: {}", result.user_modified.join(", "));
+    }
+    if !result.collisions.is_empty() {
+        println!("  Collisions kept: {}", result.collisions.join(", "));
+    }
+    if !result.errors.is_empty() {
+        println!("  Errors: {}", result.errors.join("; "));
+    }
+}
+
+fn confirm_pristine_skill_removal(count: usize) -> bool {
+    print!(
+        "Delete {} pristine bundled skill(s)? User-modified and local/hub skills are kept. [y/N]: ",
+        count
+    );
+    let _ = std::io::stdout().flush();
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
 pub async fn handle_cli_skills(
     action: Option<String>,
     name: Option<String>,
     extra: Option<String>,
+    remove: bool,
+    yes: bool,
+    sync_now: bool,
 ) -> Result<(), hermes_core::AgentError> {
     let requested_action = action.as_deref().unwrap_or("list");
     if !skills_tier_bypass_enabled() {
         let tier = skills_execution_tier();
-        let denied = skills_action_blocked_by_tier(tier, requested_action, name.as_deref());
+        let tier_name = match requested_action {
+            "opt-out" if remove || skills_extra_has_flag(extra.as_deref(), "--remove") => {
+                Some("--remove")
+            }
+            "opt-in" if sync_now || skills_extra_has_flag(extra.as_deref(), "--sync") => {
+                Some("--sync")
+            }
+            _ => name.as_deref(),
+        };
+        let denied = skills_action_blocked_by_tier(tier, requested_action, tier_name);
 
         if denied {
             return Err(hermes_core::AgentError::Config(format!(
@@ -21373,6 +21485,84 @@ pub async fn handle_cli_skills(
             }
             if count == 0 {
                 println!("  (no skills installed)");
+            }
+        }
+        "sync" => {
+            let cfg = skill_sync_config_for(&skills_dir);
+            let result = hermes_skills::sync_skills(&cfg, true)?;
+            print_skill_sync_summary(&result);
+        }
+        "opt-out" => {
+            let cfg = skill_sync_config_for(&skills_dir);
+            let remove_pristine = remove || skills_extra_has_flag(extra.as_deref(), "--remove");
+            let skip_confirm = yes
+                || skills_extra_has_flag(extra.as_deref(), "--yes")
+                || skills_extra_has_flag(extra.as_deref(), "-y");
+            let marker = hermes_skills::set_bundled_skills_opt_out(&cfg.hermes_home(), true)?;
+            println!("{}", marker.message);
+            println!("Marker: {}", marker.marker);
+
+            if !remove_pristine {
+                println!(
+                    "Existing skills on disk were left in place. Re-run with `--remove` to delete only unmodified bundled skills."
+                );
+                return Ok(());
+            }
+
+            let preview = hermes_skills::remove_pristine_bundled_skills(&cfg, true)?;
+            if preview.removed.is_empty() {
+                println!(
+                    "No pristine bundled skills to remove (nothing tracked, or all are user-modified/local)."
+                );
+                if !preview.skipped.is_empty() {
+                    println!("Kept {} skill(s).", preview.skipped.len());
+                }
+                return Ok(());
+            }
+
+            println!(
+                "Will remove {} unmodified bundled skill(s): {}",
+                preview.removed.len(),
+                preview.removed.join(", ")
+            );
+            if !preview.skipped.is_empty() {
+                let kept = preview
+                    .skipped
+                    .iter()
+                    .map(|item| format!("{} ({})", item.name, item.reason))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                println!("Keeping {} skill(s): {}", preview.skipped.len(), kept);
+            }
+            if !skip_confirm && !confirm_pristine_skill_removal(preview.removed.len()) {
+                println!("Marker kept; no skills deleted.");
+                return Ok(());
+            }
+
+            let removed = hermes_skills::remove_pristine_bundled_skills(&cfg, false)?;
+            println!("{}", removed.message);
+            if !removed.removed.is_empty() {
+                println!("Removed: {}", removed.removed.join(", "));
+            }
+            if !removed.skipped.is_empty() {
+                let kept = removed
+                    .skipped
+                    .iter()
+                    .map(|item| format!("{} ({})", item.name, item.reason))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                println!("Kept: {}", kept);
+            }
+        }
+        "opt-in" => {
+            let cfg = skill_sync_config_for(&skills_dir);
+            let sync_requested = sync_now || skills_extra_has_flag(extra.as_deref(), "--sync");
+            let marker = hermes_skills::set_bundled_skills_opt_out(&cfg.hermes_home(), false)?;
+            println!("{}", marker.message);
+            println!("Marker: {}", marker.marker);
+            if sync_requested {
+                let result = hermes_skills::sync_skills(&cfg, true)?;
+                print_skill_sync_summary(&result);
             }
         }
         "browse" => {
@@ -22860,7 +23050,7 @@ pub async fn handle_cli_skills(
         }
         other => {
             println!("Skills action '{}' is not recognized.", other);
-            println!("Available actions: list, browse, search, install, inspect, uninstall, check, update, publish, snapshot, tap, config, quality, audit");
+            println!("Available actions: list, browse, search, install, inspect, uninstall, check, update, sync, opt-out, opt-in, publish, snapshot, tap, config, quality, audit");
         }
     }
     Ok(())
@@ -29814,6 +30004,43 @@ install_command: "uv pip install -r requirements.txt"
             "publish",
             None
         ));
+        assert!(skills_action_blocked_by_tier(
+            SkillsExecutionTier::Trusted,
+            "sync",
+            None
+        ));
+        assert!(skills_action_blocked_by_tier(
+            SkillsExecutionTier::Trusted,
+            "opt-in",
+            Some("--sync")
+        ));
+        assert!(skills_action_blocked_by_tier(
+            SkillsExecutionTier::Balanced,
+            "opt-out",
+            Some("--remove")
+        ));
+        assert!(!skills_action_blocked_by_tier(
+            SkillsExecutionTier::Balanced,
+            "opt-out",
+            None
+        ));
+    }
+
+    #[test]
+    fn parse_skills_slash_invocation_supports_blank_slate_commands() {
+        let sync = parse_skills_slash_invocation(&["sync"]).expect("sync");
+        assert_eq!(sync.action.as_deref(), Some("sync"));
+        assert_eq!(sync.name, None);
+
+        let opt_out =
+            parse_skills_slash_invocation(&["opt-out", "--remove", "--yes"]).expect("opt-out");
+        assert_eq!(opt_out.action.as_deref(), Some("opt-out"));
+        assert_eq!(opt_out.name, None);
+        assert_eq!(opt_out.extra.as_deref(), Some("--remove --yes"));
+
+        let opt_in = parse_skills_slash_invocation(&["opt-in", "--sync"]).expect("opt-in");
+        assert_eq!(opt_in.action.as_deref(), Some("opt-in"));
+        assert_eq!(opt_in.extra.as_deref(), Some("--sync"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -615,7 +615,10 @@ async fn main() {
             action,
             name,
             extra,
-        } => hermes_cli::commands::handle_cli_skills(action, name, extra).await,
+            remove,
+            yes,
+            sync,
+        } => hermes_cli::commands::handle_cli_skills(action, name, extra, remove, yes, sync).await,
         CliCommand::Plugins {
             action,
             name,

--- a/crates/hermes-skills/src/lib.rs
+++ b/crates/hermes-skills/src/lib.rs
@@ -31,10 +31,12 @@ pub use provenance::{
 pub use skill::{SkillError, SkillManager, MAX_SKILL_CONTENT_CHARS};
 pub use store::{FileSkillStore, SkillStore, MAX_SKILL_NAME_LENGTH};
 pub use sync::{
-    compute_relative_dest, dir_hash, discover_bundled_skills, read_manifest, read_skill_name,
-    reset_bundled_skill, restore_official_optional_skill, sync_skills, write_manifest,
-    BundledSkill, OfficialOptionalRestoreResult, SkillResetResult, SkillSyncConfig,
-    SkillSyncResult,
+    bundled_skills_opt_out_marker, compute_relative_dest, dir_hash, discover_bundled_skills,
+    is_bundled_skills_opt_out, read_manifest, read_skill_name, remove_pristine_bundled_skills,
+    reset_bundled_skill, restore_official_optional_skill, set_bundled_skills_opt_out, sync_skills,
+    write_manifest, BundledSkill, BundledSkillsOptOutResult, OfficialOptionalRestoreResult,
+    PristineBundledSkillSkip, RemovePristineBundledSkillsResult, SkillResetResult, SkillSyncConfig,
+    SkillSyncResult, NO_BUNDLED_SKILLS_MARKER,
 };
 pub use usage::{
     agent_created_report, archive_skill, bump_patch, bump_use, bump_view, forget, get_record,

--- a/crates/hermes-skills/src/sync.rs
+++ b/crates/hermes-skills/src/sync.rs
@@ -11,6 +11,8 @@ use serde_json::Value;
 use crate::skill::SkillError;
 use crate::usage::{read_skill_name_from_dir, read_skill_name_from_file};
 
+pub const NO_BUNDLED_SKILLS_MARKER: &str = ".no-bundled-skills";
+
 #[derive(Debug, Clone)]
 pub struct SkillSyncConfig {
     pub bundled_dir: PathBuf,
@@ -28,6 +30,13 @@ impl SkillSyncConfig {
             skills_dir,
             manifest_file,
         }
+    }
+
+    pub fn hermes_home(&self) -> PathBuf {
+        self.skills_dir
+            .parent()
+            .unwrap_or(self.skills_dir.as_path())
+            .to_path_buf()
     }
 }
 
@@ -51,6 +60,8 @@ pub struct SkillSyncResult {
     pub collisions: Vec<String>,
     #[serde(default)]
     pub errors: Vec<String>,
+    #[serde(default)]
+    pub skipped_opt_out: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,6 +80,29 @@ pub struct OfficialOptionalRestoreResult {
     pub backfilled: Vec<String>,
     pub backed_up: Vec<String>,
     pub backup_dir: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BundledSkillsOptOutResult {
+    pub ok: bool,
+    pub changed: bool,
+    pub marker: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PristineBundledSkillSkip {
+    pub name: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemovePristineBundledSkillsResult {
+    pub ok: bool,
+    pub removed: Vec<String>,
+    pub skipped: Vec<PristineBundledSkillSkip>,
+    pub dry_run: bool,
     pub message: String,
 }
 
@@ -139,6 +173,57 @@ pub fn write_manifest(path: &Path, entries: &BTreeMap<String, String>) -> Result
     }
     fs::write(path, out)?;
     Ok(())
+}
+
+pub fn bundled_skills_opt_out_marker(hermes_home: &Path) -> PathBuf {
+    hermes_home.join(NO_BUNDLED_SKILLS_MARKER)
+}
+
+pub fn is_bundled_skills_opt_out(hermes_home: &Path) -> bool {
+    bundled_skills_opt_out_marker(hermes_home).exists()
+}
+
+pub fn set_bundled_skills_opt_out(
+    hermes_home: &Path,
+    enabled: bool,
+) -> Result<BundledSkillsOptOutResult, SkillError> {
+    let marker = bundled_skills_opt_out_marker(hermes_home);
+    let existed = marker.exists();
+    if enabled {
+        fs::create_dir_all(hermes_home)?;
+        fs::write(
+            &marker,
+            "This profile opted out of bundled-skill seeding (`hermes skills opt-out`).\n\
+             Delete this file to re-enable sync on the next `hermes update`.\n",
+        )?;
+        let changed = !existed;
+        let message = if changed {
+            "Opted out of bundled skills. Future install / update / sync runs will not seed bundled skills into this profile."
+        } else {
+            "Already opted out - marker was already present."
+        };
+        return Ok(BundledSkillsOptOutResult {
+            ok: true,
+            changed,
+            marker: marker.to_string_lossy().to_string(),
+            message: message.to_string(),
+        });
+    }
+
+    if existed {
+        fs::remove_file(&marker)?;
+    }
+    let message = if existed {
+        "Opted back in. The next `hermes update` (or `hermes skills opt-in --sync`) will re-seed bundled skills."
+    } else {
+        "Not opted out - no marker to remove."
+    };
+    Ok(BundledSkillsOptOutResult {
+        ok: true,
+        changed: existed,
+        marker: marker.to_string_lossy().to_string(),
+        message: message.to_string(),
+    })
 }
 
 pub fn dir_hash(dir: &Path) -> String {
@@ -316,6 +401,19 @@ fn copy_parent_descriptions(
 }
 
 pub fn sync_skills(config: &SkillSyncConfig, quiet: bool) -> Result<SkillSyncResult, SkillError> {
+    if is_bundled_skills_opt_out(&config.hermes_home()) {
+        if !quiet {
+            println!(
+                "  (skipped - profile opted out of bundled skills via {})",
+                NO_BUNDLED_SKILLS_MARKER
+            );
+        }
+        return Ok(SkillSyncResult {
+            skipped_opt_out: true,
+            ..Default::default()
+        });
+    }
+
     if !config.bundled_dir.exists() {
         return Ok(SkillSyncResult::default());
     }
@@ -402,6 +500,90 @@ pub fn sync_skills(config: &SkillSyncConfig, quiet: bool) -> Result<SkillSyncRes
     result.user_modified.sort();
     result.cleaned.sort();
     result.collisions.sort();
+    Ok(result)
+}
+
+pub fn remove_pristine_bundled_skills(
+    config: &SkillSyncConfig,
+    dry_run: bool,
+) -> Result<RemovePristineBundledSkillsResult, SkillError> {
+    let mut manifest = read_manifest(&config.manifest_file);
+    let bundled_by_name: BTreeMap<String, BundledSkill> =
+        discover_bundled_skills(&config.bundled_dir)
+            .into_iter()
+            .map(|skill| (skill.name.clone(), skill))
+            .collect();
+
+    let mut result = RemovePristineBundledSkillsResult {
+        ok: true,
+        dry_run,
+        ..Default::default()
+    };
+    let mut manifest_changed = false;
+
+    for (name, origin_hash) in manifest.clone() {
+        let Some(skill) = bundled_by_name.get(&name) else {
+            result.skipped.push(PristineBundledSkillSkip {
+                name,
+                reason: "no bundled source (removed upstream)".to_string(),
+            });
+            continue;
+        };
+        let dest = config.skills_dir.join(&skill.relative_dest);
+        if !dest.exists() {
+            if !dry_run {
+                manifest.remove(&name);
+                manifest_changed = true;
+            }
+            continue;
+        }
+        if origin_hash.is_empty() {
+            result.skipped.push(PristineBundledSkillSkip {
+                name,
+                reason: "legacy manifest without origin hash (kept)".to_string(),
+            });
+            continue;
+        }
+        let on_disk = dir_hash(&dest);
+        if on_disk != origin_hash {
+            result.skipped.push(PristineBundledSkillSkip {
+                name,
+                reason: "user-modified (kept)".to_string(),
+            });
+            continue;
+        }
+
+        if dry_run {
+            result.removed.push(name);
+            continue;
+        }
+
+        match fs::remove_dir_all(&dest) {
+            Ok(()) => {
+                manifest.remove(&name);
+                manifest_changed = true;
+                result.removed.push(name);
+            }
+            Err(err) => result.skipped.push(PristineBundledSkillSkip {
+                name,
+                reason: format!("delete failed: {err}"),
+            }),
+        }
+    }
+
+    if manifest_changed {
+        write_manifest(&config.manifest_file, &manifest)?;
+    }
+
+    result.removed.sort();
+    result.skipped.sort_by(|a, b| a.name.cmp(&b.name));
+    let verb = if dry_run { "Would remove" } else { "Removed" };
+    result.message = format!(
+        "{} {} pristine bundled skill(s); kept {}.",
+        verb,
+        result.removed.len(),
+        result.skipped.len()
+    );
     Ok(result)
 }
 
@@ -768,6 +950,44 @@ mod tests {
     }
 
     #[test]
+    fn sync_skills_honors_bundled_skills_opt_out_marker() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled);
+        set_bundled_skills_opt_out(dir.path(), true).unwrap();
+
+        let result = sync_skills(&cfg, true).unwrap();
+
+        assert!(result.skipped_opt_out);
+        assert_eq!(result.total_bundled, 0);
+        assert!(!cfg.skills_dir.join("category/new-skill/SKILL.md").exists());
+        assert!(is_bundled_skills_opt_out(dir.path()));
+
+        let disabled = set_bundled_skills_opt_out(dir.path(), false).unwrap();
+        assert!(disabled.changed);
+        assert!(!is_bundled_skills_opt_out(dir.path()));
+        let synced = sync_skills(&cfg, true).unwrap();
+        assert_eq!(synced.copied, vec!["new-skill", "old-skill"]);
+    }
+
+    #[test]
+    fn opt_out_marker_toggle_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let first = set_bundled_skills_opt_out(dir.path(), true).unwrap();
+        let second = set_bundled_skills_opt_out(dir.path(), true).unwrap();
+        assert!(first.ok);
+        assert!(first.changed);
+        assert!(!second.changed);
+        assert!(PathBuf::from(&second.marker).exists());
+
+        let third = set_bundled_skills_opt_out(dir.path(), false).unwrap();
+        let fourth = set_bundled_skills_opt_out(dir.path(), false).unwrap();
+        assert!(third.changed);
+        assert!(!fourth.changed);
+        assert!(!PathBuf::from(&fourth.marker).exists());
+    }
+
+    #[test]
     fn sync_updates_unmodified_and_preserves_user_modified() {
         let dir = tempdir().unwrap();
         let bundled = setup_bundled(dir.path());
@@ -806,6 +1026,59 @@ mod tests {
         assert!(!read_manifest(&cfg.manifest_file).contains_key("new-skill"));
         let second = sync_skills(&cfg, true).unwrap();
         assert!(!second.user_modified.contains(&"new-skill".to_string()));
+    }
+
+    #[test]
+    fn remove_pristine_bundled_skills_keeps_modified_and_local_then_opt_in_reseeds() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled);
+        sync_skills(&cfg, true).unwrap();
+        fs::write(cfg.skills_dir.join("old-skill/SKILL.md"), "# customized").unwrap();
+        let local = cfg.skills_dir.join("local-only");
+        fs::create_dir_all(&local).unwrap();
+        fs::write(local.join("SKILL.md"), "# Local").unwrap();
+        set_bundled_skills_opt_out(dir.path(), true).unwrap();
+
+        let dry_run = remove_pristine_bundled_skills(&cfg, true).unwrap();
+        assert_eq!(dry_run.removed, vec!["new-skill"]);
+        assert_eq!(dry_run.skipped[0].name, "old-skill");
+        assert!(cfg.skills_dir.join("category/new-skill/SKILL.md").exists());
+
+        let removed = remove_pristine_bundled_skills(&cfg, false).unwrap();
+        assert_eq!(removed.removed, vec!["new-skill"]);
+        assert!(!cfg.skills_dir.join("category/new-skill").exists());
+        assert!(cfg.skills_dir.join("old-skill/SKILL.md").exists());
+        assert!(cfg.skills_dir.join("local-only/SKILL.md").exists());
+        let manifest = read_manifest(&cfg.manifest_file);
+        assert!(!manifest.contains_key("new-skill"));
+        assert!(manifest.contains_key("old-skill"));
+
+        assert!(sync_skills(&cfg, true).unwrap().skipped_opt_out);
+        set_bundled_skills_opt_out(dir.path(), false).unwrap();
+        let reseeded = sync_skills(&cfg, true).unwrap();
+        assert_eq!(reseeded.copied, vec!["new-skill"]);
+        assert!(cfg.skills_dir.join("category/new-skill/SKILL.md").exists());
+        assert_eq!(
+            fs::read_to_string(cfg.skills_dir.join("old-skill/SKILL.md")).unwrap(),
+            "# customized"
+        );
+    }
+
+    #[test]
+    fn remove_pristine_bundled_skills_cleans_missing_manifest_entries() {
+        let dir = tempdir().unwrap();
+        let bundled = setup_bundled(dir.path());
+        let cfg = config(dir.path(), bundled);
+        sync_skills(&cfg, true).unwrap();
+        fs::remove_dir_all(cfg.skills_dir.join("old-skill")).unwrap();
+
+        let result = remove_pristine_bundled_skills(&cfg, false).unwrap();
+
+        assert_eq!(result.removed, vec!["new-skill"]);
+        let manifest = read_manifest(&cfg.manifest_file);
+        assert!(!manifest.contains_key("old-skill"));
+        assert!(!manifest.contains_key("new-skill"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -619,6 +619,18 @@
     "fabca0bdd82b": {
       "disposition": "ported",
       "notes": "Rust TUI already drives model selection through canonical /model provider/model modals; this batch added /session and /switch aliases to the existing /sessions surface while preserving /provider as a distinct provider-status command rather than the removed Python /model alias."
+    },
+    "2ed96372ade3": {
+      "disposition": "ported",
+      "notes": "ported in Rust: hermes-skills sync honors .no-bundled-skills, exposes marker toggle and safe pristine bundled-skill removal; hermes-cli adds skills sync/opt-out/opt-in CLI and slash surfaces with tier-gated destructive removal tests."
+    },
+    "f24b7ed9d953": {
+      "disposition": "ported",
+      "notes": "ported/superseded by Rust Honcho architecture: initialize only loads config and never blocks on network session startup; regression test proves fail-open startup while tools/context remain available."
+    },
+    "32032e1e2d9b": {
+      "disposition": "superseded",
+      "notes": "upstream SimpleX websocket reconnect delta is Python plugin-only in this fork; no Rust SimpleX platform adapter exists under crates, so there is no Rust runtime surface to port under the Rust-only parity policy."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Add Rust-native bundled-skill opt-out marker support in `hermes-skills`.
- Add safe pristine bundled-skill removal for `skills opt-out --remove`, preserving user-modified/local/hub skills and cleaning manifest entries for re-seed correctness.
- Expose `hermes skills sync`, `hermes skills opt-out`, and `hermes skills opt-in` through CLI and slash command paths with tier-gated destructive removal.
- Add Honcho fail-open startup regression coverage proving Rust initialization does not block on network/session setup.
- Mark handled upstream queue items for blank-slate skills, Honcho fail-open startup, and Python-only SimpleX divergence.

## Verification
- `cargo test -p hermes-agent test_honcho_initialize_is_fail_open_and_does_not_contact_network -- --nocapture`
- `cargo test -p hermes-skills bundled_skills -- --nocapture`
- `cargo test -p hermes-skills opt_out_marker_toggle_is_idempotent -- --nocapture`
- `cargo test -p hermes-cli skills_blank_slate -- --nocapture`
- `cargo test -p hermes-cli parse_skills_slash_invocation_supports_blank_slate_commands -- --nocapture`
- `cargo test -p hermes-cli skills_action_blocked_by_tier_enforces_expected_matrix -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-skills -p hermes-agent` (`seen=199 allowlist=204 new=0 stale=5`)
- `cargo build -p hermes-cli -p hermes-skills -p hermes-agent`
- CLI smoke with temporary `HERMES_HOME`: `skills opt-out` wrote `.no-bundled-skills`; `skills sync` reported skipped opt-out.

## Queue Proof
- `2ed96372ade3 ported sha_override`
- `f24b7ed9d953 ported sha_override`
- `32032e1e2d9b superseded sha_override`
- `pending_count 234`
