### PR TITLE
parity(kanban,honcho): add runtime parity surfaces

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/honcho.rs
+++ b/crates/hermes-agent/src/memory_plugins/honcho.rs
@@ -105,6 +105,7 @@ struct HonchoConfig {
     runtime_peer_prefix: String,
     timeout_secs: f64,
     endpoints: HashMap<String, String>,
+    host_had_explicit_api_key: bool,
 }
 
 impl HonchoConfig {
@@ -153,6 +154,7 @@ impl HonchoConfig {
             runtime_peer_prefix: String::new(),
             timeout_secs,
             endpoints,
+            host_had_explicit_api_key: false,
         }
     }
 
@@ -165,14 +167,21 @@ impl HonchoConfig {
         if let Ok(content) = std::fs::read_to_string(&config_path) {
             if let Ok(raw) = serde_json::from_str::<Value>(&content) {
                 Self::apply_config_value(&mut config, &raw);
-                if let Some(host_block) = raw.get("hosts").and_then(|v| v.get(&host)) {
+                if let Some(host_block) = honcho_host_block(&raw, &host) {
+                    config.host_had_explicit_api_key = value_has_nonempty_api_key(host_block);
                     Self::apply_config_value(&mut config, host_block);
                 }
             }
         }
-        config.base_url = config.base_url.trim_end_matches('/').to_string();
+        config.base_url = strip_honcho_base_url_version(&config.base_url);
         if config.base_url.is_empty() {
             config.base_url = DEFAULT_BASE_URL.to_string();
+        }
+        if honcho_base_url_is_loopback(&config.base_url) && !config.host_had_explicit_api_key {
+            // Top-level API keys are usually cloud credentials. Do not send
+            // them to a no-auth loopback Honcho unless hosts.<host>.apiKey
+            // opted into local JWT/bearer auth.
+            config.api_key.clear();
         }
         config
     }
@@ -278,14 +287,83 @@ fn active_host() -> String {
         }
     }
     let profile = std::env::var("HERMES_PROFILE").unwrap_or_default();
-    let profile = profile.trim();
-    if profile.is_empty() || matches!(profile, "default" | "custom") {
-        HOST.to_string()
-    } else if profile == HOST || profile.starts_with("hermes.") {
-        profile.to_string()
-    } else {
-        format!("{HOST}.{profile}")
+    profile_host_key(Some(profile.trim()))
+}
+
+fn profile_host_key(profile: Option<&str>) -> String {
+    let Some(profile) = profile.map(str::trim).filter(|profile| !profile.is_empty()) else {
+        return HOST.to_string();
+    };
+    if matches!(profile, "default" | "custom" | HOST) {
+        return HOST.to_string();
     }
+    let sanitized = profile
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('_')
+        .to_string();
+    format!(
+        "{HOST}_{}",
+        if sanitized.is_empty() {
+            "profile"
+        } else {
+            &sanitized
+        }
+    )
+}
+
+fn legacy_profile_host_key(host: &str) -> Option<String> {
+    let suffix = host.strip_prefix(&format!("{HOST}_"))?;
+    if suffix.trim().is_empty() {
+        None
+    } else {
+        Some(format!("{HOST}.{suffix}"))
+    }
+}
+
+fn honcho_host_block<'a>(raw: &'a Value, host: &str) -> Option<&'a Value> {
+    let hosts = raw.get("hosts").and_then(Value::as_object)?;
+    if let Some(block) = hosts.get(host) {
+        return Some(block);
+    }
+    legacy_profile_host_key(host).and_then(|legacy| hosts.get(&legacy))
+}
+
+fn value_has_nonempty_api_key(raw: &Value) -> bool {
+    raw.get("apiKey")
+        .or_else(|| raw.get("api_key"))
+        .and_then(Value::as_str)
+        .is_some_and(|key| !key.trim().is_empty())
+}
+
+fn strip_honcho_base_url_version(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    let Some((prefix, tail)) = trimmed.rsplit_once('/') else {
+        return trimmed.to_string();
+    };
+    let Some(digits) = tail.strip_prefix('v') else {
+        return trimmed.to_string();
+    };
+    if !digits.is_empty() && digits.chars().all(|ch| ch.is_ascii_digit()) {
+        prefix.trim_end_matches('/').to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn honcho_base_url_is_loopback(base_url: &str) -> bool {
+    let normalized = base_url.trim().to_ascii_lowercase();
+    normalized.contains("localhost")
+        || normalized.contains("127.0.0.1")
+        || normalized.contains("[::1]")
+        || normalized.contains("://::1")
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,7 +1219,80 @@ mod tests {
             runtime_peer_prefix: String::new(),
             timeout_secs: 12.0,
             endpoints: HashMap::new(),
+            host_had_explicit_api_key: false,
         }
+    }
+
+    #[test]
+    fn test_honcho_profile_host_key_uses_safe_underscore_form() {
+        assert_eq!(profile_host_key(None), "hermes");
+        assert_eq!(profile_host_key(Some("default")), "hermes");
+        assert_eq!(profile_host_key(Some("coder")), "hermes_coder");
+        assert_eq!(
+            profile_host_key(Some("research.team/v1")),
+            "hermes_research_team_v1"
+        );
+        assert_eq!(
+            legacy_profile_host_key("hermes_research_team").as_deref(),
+            Some("hermes.research_team")
+        );
+    }
+
+    #[test]
+    fn test_honcho_config_reads_legacy_dot_host_and_strips_version_suffix() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _profile = EnvGuard::set("HERMES_PROFILE", "coder");
+        let _api = EnvGuard::remove("HONCHO_API_KEY");
+        let _url = EnvGuard::remove("HONCHO_BASE_URL");
+        std::fs::write(
+            tmp.path().join("honcho.json"),
+            r#"{
+                "baseUrl":"https://honcho.internal/v3/",
+                "enabled":true,
+                "hosts":{
+                    "hermes.coder":{
+                        "apiKey":"local-jwt",
+                        "aiPeer":"coder-ai",
+                        "peerName":"operator"
+                    }
+                }
+            }"#,
+        )
+        .expect("write config");
+
+        let cfg = HonchoConfig::from_config_file(&tmp.path().to_string_lossy());
+        assert_eq!(cfg.base_url, "https://honcho.internal");
+        assert_eq!(cfg.api_key, "local-jwt");
+        assert_eq!(cfg.ai_peer, "coder-ai");
+        assert_eq!(cfg.peer_name.as_deref(), Some("operator"));
+        assert!(cfg.host_had_explicit_api_key);
+    }
+
+    #[test]
+    fn test_honcho_loopback_config_skips_top_level_cloud_key_without_host_jwt() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _profile = EnvGuard::remove("HERMES_PROFILE");
+        let _api = EnvGuard::remove("HONCHO_API_KEY");
+        let _url = EnvGuard::remove("HONCHO_BASE_URL");
+        std::fs::write(
+            tmp.path().join("honcho.json"),
+            r#"{
+                "baseUrl":"http://localhost:8000/v3",
+                "apiKey":"cloud-key",
+                "enabled":true,
+                "hosts":{"hermes":{"enabled":true}}
+            }"#,
+        )
+        .expect("write config");
+
+        let cfg = HonchoConfig::from_config_file(&tmp.path().to_string_lossy());
+        assert_eq!(cfg.base_url, "http://localhost:8000");
+        assert_eq!(cfg.api_key, "");
+        assert!(!cfg.host_had_explicit_api_key);
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -49,8 +49,9 @@ use crate::alpha_runtime::{
 };
 use crate::app::{build_runtime_cron_scheduler, App, PetDock, PetSettings};
 use crate::kanban::{
-    add_task, archive_done, claim_task, create_or_select_board, ensure_board, find_task_mut,
-    lane_counts, load_store, maybe_checkpoint_to_contextlattice, move_task, save_store,
+    add_attachment_to_task, add_task, archive_done, build_worker_context, claim_task,
+    create_or_select_board, ensure_board, find_task_mut, lane_counts, load_store,
+    maybe_checkpoint_to_contextlattice, move_task, remove_attachment_from_task, save_store,
     set_blocked, KanbanActionInput, KanbanBoard, KanbanLane, NewKanbanTaskInput,
 };
 use crate::model_switch::{
@@ -14775,7 +14776,7 @@ fn render_kanban_status(board: &KanbanBoard) -> String {
 fn parse_kanban_add(args: &[&str]) -> Result<NewKanbanTaskInput, AgentError> {
     if args.is_empty() {
         return Err(AgentError::Config(
-            "Usage: /kanban add <title> [--lane <todo|doing|blocked|done>] [--priority <1..5>] [--assignee <name>] [--depends K-0001,K-0002] [--desc <text>]".to_string(),
+            "Usage: /kanban add <title> [--lane <todo|doing|blocked|done>] [--priority <1..5>] [--assignee <name>] [--depends K-0001,K-0002] [--desc <text>] [--goal] [--goal-max-turns N]".to_string(),
         ));
     }
     let mut lane = KanbanLane::Todo;
@@ -14783,6 +14784,8 @@ fn parse_kanban_add(args: &[&str]) -> Result<NewKanbanTaskInput, AgentError> {
     let mut assignee: Option<String> = None;
     let mut depends_on: Vec<String> = Vec::new();
     let mut description: Option<String> = None;
+    let mut goal_mode = false;
+    let mut goal_max_turns: Option<u32> = None;
     let mut title_parts: Vec<String> = Vec::new();
 
     let mut idx = 0usize;
@@ -14829,6 +14832,26 @@ fn parse_kanban_add(args: &[&str]) -> Result<NewKanbanTaskInput, AgentError> {
         } else if token == "--desc" || token == "--description" {
             idx = idx.saturating_add(1);
             description = args.get(idx).map(|s| s.to_string());
+        } else if token == "--goal" || token == "--goal-mode" {
+            goal_mode = true;
+        } else if token == "--goal-max-turns" {
+            idx = idx.saturating_add(1);
+            let Some(raw) = args.get(idx) else {
+                return Err(AgentError::Config(
+                    "Missing value for --goal-max-turns".to_string(),
+                ));
+            };
+            let turns = raw.parse::<u32>().map_err(|_| {
+                AgentError::Config(format!(
+                    "Invalid goal max turns `{raw}`. Expected positive integer."
+                ))
+            })?;
+            if turns == 0 {
+                return Err(AgentError::Config(
+                    "Invalid goal max turns `0`. Expected positive integer.".to_string(),
+                ));
+            }
+            goal_max_turns = Some(turns);
         } else {
             title_parts.push(token.to_string());
         }
@@ -14847,6 +14870,8 @@ fn parse_kanban_add(args: &[&str]) -> Result<NewKanbanTaskInput, AgentError> {
         assignee,
         description,
         depends_on,
+        goal_mode,
+        goal_max_turns,
     })
 }
 
@@ -14921,7 +14946,7 @@ pub fn run_kanban_command(args: &[&str]) -> Result<String, AgentError> {
         }
         "add" => {
             let input = parse_kanban_add(args.get(1..).unwrap_or_default())?;
-            let (task_id, task_lane, task_priority, task_title, board_snapshot) = {
+            let (task_id, task_lane, task_priority, task_title, task_goal_mode, board_snapshot) = {
                 let board = ensure_board(&mut store, None);
                 let task = add_task(board, input);
                 (
@@ -14929,6 +14954,7 @@ pub fn run_kanban_command(args: &[&str]) -> Result<String, AgentError> {
                     task.lane,
                     task.priority,
                     task.title.clone(),
+                    task.goal_mode,
                     board.clone(),
                 )
             };
@@ -14943,13 +14969,121 @@ pub fn run_kanban_command(args: &[&str]) -> Result<String, AgentError> {
                 },
             );
             Ok(format!(
-                "Added task {} [{}] p{}: {}\n{}",
+                "Added task {} [{}] p{}{}: {}\n{}",
                 task_id,
                 task_lane.as_str(),
                 task_priority,
+                if task_goal_mode { " goal" } else { "" },
                 task_title,
                 checkpoint.detail
             ))
+        }
+        "attach" | "attachment" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                return Ok("Usage: kanban attach <task-id|title> <file-path>".to_string());
+            };
+            let Some(path) = args.get(2).copied() else {
+                return Ok("Usage: kanban attach <task-id|title> <file-path>".to_string());
+            };
+            let (task_id, attachment, board_snapshot) = {
+                let board = ensure_board(&mut store, None);
+                let attachment = add_attachment_to_task(
+                    board,
+                    task_ref,
+                    path,
+                    std::env::var("HERMES_PROFILE").ok(),
+                )?;
+                let task_id = find_task_mut(board, task_ref)
+                    .map(|task| task.id.clone())
+                    .unwrap_or_else(|| task_ref.to_string());
+                (task_id, attachment, board.clone())
+            };
+            save_store(&store)?;
+            let checkpoint = maybe_checkpoint_to_contextlattice(
+                &board_snapshot,
+                KanbanActionInput {
+                    action: "attach".to_string(),
+                    task_id: Some(task_id.clone()),
+                    lane: None,
+                    summary: format!(
+                        "attachment_id={} filename={} path={}",
+                        attachment.id, attachment.filename, attachment.stored_path
+                    ),
+                },
+            );
+            Ok(format!(
+                "Attached {} to {} as {} ({})\nPath: {}\n{}",
+                attachment.filename,
+                task_id,
+                attachment.id,
+                attachment.size,
+                attachment.stored_path,
+                checkpoint.detail
+            ))
+        }
+        "attachments" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                return Ok("Usage: kanban attachments <task-id|title>".to_string());
+            };
+            let board = ensure_board(&mut store, None);
+            let Some(task) = board.tasks.iter().find(|task| {
+                task.id.eq_ignore_ascii_case(task_ref) || task.title.eq_ignore_ascii_case(task_ref)
+            }) else {
+                return Ok(format!("Task not found: {task_ref}"));
+            };
+            if task.attachments.is_empty() {
+                return Ok(format!("No attachments for {}.", task.id));
+            }
+            let mut out = format!("Attachments for {}:\n", task.id);
+            for attachment in &task.attachments {
+                let _ = writeln!(
+                    &mut out,
+                    "- {} {} size={} path={}",
+                    attachment.id, attachment.filename, attachment.size, attachment.stored_path
+                );
+            }
+            Ok(out.trim_end().to_string())
+        }
+        "detach" | "remove-attachment" => {
+            let Some(task_ref) = args.get(1).copied() else {
+                return Ok(
+                    "Usage: kanban detach <task-id|title> <attachment-id|filename>".to_string(),
+                );
+            };
+            let Some(attachment_ref) = args.get(2).copied() else {
+                return Ok(
+                    "Usage: kanban detach <task-id|title> <attachment-id|filename>".to_string(),
+                );
+            };
+            let removed = {
+                let board = ensure_board(&mut store, None);
+                remove_attachment_from_task(board, task_ref, attachment_ref)?
+                    .map(|attachment| (attachment, board.clone()))
+            };
+            if let Some((attachment, board_snapshot)) = removed {
+                save_store(&store)?;
+                let checkpoint = maybe_checkpoint_to_contextlattice(
+                    &board_snapshot,
+                    KanbanActionInput {
+                        action: "detach".to_string(),
+                        task_id: Some(task_ref.to_string()),
+                        lane: None,
+                        summary: format!(
+                            "attachment_id={} filename={}",
+                            attachment.id, attachment.filename
+                        ),
+                    },
+                );
+                Ok(format!(
+                    "Removed attachment {} ({})\n{}",
+                    attachment.id, attachment.filename, checkpoint.detail
+                ))
+            } else {
+                Ok(format!(
+                    "Attachment not found: task={} attachment={}",
+                    task_ref, attachment_ref
+                ))
+            }
         }
         "move" => {
             let Some(task_ref) = args.get(1).copied() else {
@@ -15148,18 +15282,7 @@ pub fn run_kanban_command(args: &[&str]) -> Result<String, AgentError> {
                 let board = ensure_board(&mut store, None);
                 if let Some(task) = find_task_mut(board, task_ref) {
                     let task_message = if override_msg.trim().is_empty() {
-                        let mut prompt = format!("Execute Kanban task {}: {}", task.id, task.title);
-                        if let Some(desc) = task.description.as_deref() {
-                            let _ = write!(&mut prompt, "\nDetails: {}", desc.trim());
-                        }
-                        if !task.depends_on.is_empty() {
-                            let _ = write!(
-                                &mut prompt,
-                                "\nDependencies: {}",
-                                task.depends_on.join(", ")
-                            );
-                        }
-                        prompt
+                        build_worker_context(task)
                     } else {
                         override_msg.clone()
                     };
@@ -15225,7 +15348,7 @@ fn handle_kanban_command(app: &mut App, args: &[&str]) -> Result<CommandResult, 
 }
 
 fn kanban_help_text() -> &'static str {
-    "Kanban commands:\n  hermes kanban status [board]\n  hermes kanban boards\n  hermes kanban init <name> [project-path]\n  hermes kanban use <name-or-id>\n  hermes kanban add <title> [--lane <todo|doing|blocked|done>] [--priority <1..5>] [--assignee <name>] [--depends K-0001,K-0002] [--desc <text>]\n  hermes kanban move <task-id|title> <todo|doing|blocked|done> [summary]\n  hermes kanban claim <task-id|title> [assignee]\n  hermes kanban block <task-id|title> <reason>\n  hermes kanban done <task-id|title> [summary]\n  hermes kanban archive-done\n  hermes kanban dispatch <task-id|title> [background-task-override]\n  hermes kanban sync\n\nInteractive alias: /kanban <command>"
+    "Kanban commands:\n  hermes kanban status [board]\n  hermes kanban boards\n  hermes kanban init <name> [project-path]\n  hermes kanban use <name-or-id>\n  hermes kanban add <title> [--lane <todo|doing|blocked|done>] [--priority <1..5>] [--assignee <name>] [--depends K-0001,K-0002] [--desc <text>] [--goal] [--goal-max-turns N]\n  hermes kanban attach <task-id|title> <file-path>\n  hermes kanban attachments <task-id|title>\n  hermes kanban detach <task-id|title> <attachment-id|filename>\n  hermes kanban move <task-id|title> <todo|doing|blocked|done> [summary]\n  hermes kanban claim <task-id|title> [assignee]\n  hermes kanban block <task-id|title> <reason>\n  hermes kanban done <task-id|title> [summary]\n  hermes kanban archive-done\n  hermes kanban dispatch <task-id|title> [background-task-override]\n  hermes kanban sync\n\nInteractive alias: /kanban <command>"
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24203,15 +24326,33 @@ fn active_honcho_host_key_for_cli() -> String {
     let profile = profile.trim();
     if profile.is_empty() || matches!(profile, "default" | "custom") {
         "hermes".to_string()
-    } else if profile == "hermes" || profile.starts_with("hermes.") {
-        profile.to_string()
     } else {
-        format!("hermes.{profile}")
+        let sanitized = profile
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                    ch
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>()
+            .trim_matches('_')
+            .to_string();
+        format!(
+            "hermes_{}",
+            if sanitized.is_empty() {
+                "profile"
+            } else {
+                sanitized.as_str()
+            }
+        )
     }
 }
 
 fn honcho_ai_peer_for_host(host: &str) -> String {
     host.strip_prefix("hermes.")
+        .or_else(|| host.strip_prefix("hermes_"))
         .filter(|profile| !profile.trim().is_empty())
         .unwrap_or(host)
         .to_string()
@@ -27053,7 +27194,7 @@ mod tests {
     fn memory_honcho_setup_config_keeps_gateway_aliases_for_hybrid_shape() {
         let aliases = parse_honcho_aliases("telegram-1=operator, discord-2=operator");
         let cfg = build_honcho_setup_config(HonchoSetupConfigInput {
-            host: "hermes.coder",
+            host: "hermes_coder",
             deployment: "cloud",
             api_key: "cloud-key",
             base_url: "",
@@ -27064,16 +27205,40 @@ mod tests {
         });
 
         assert_eq!(cfg["apiKey"], "cloud-key");
-        assert_eq!(cfg["hosts"]["hermes.coder"]["aiPeer"], "coder");
-        assert_eq!(cfg["hosts"]["hermes.coder"]["pinUserPeer"], false);
+        assert_eq!(cfg["hosts"]["hermes_coder"]["aiPeer"], "coder");
+        assert_eq!(cfg["hosts"]["hermes_coder"]["pinUserPeer"], false);
         assert_eq!(
-            cfg["hosts"]["hermes.coder"]["userPeerAliases"]["telegram-1"],
+            cfg["hosts"]["hermes_coder"]["userPeerAliases"]["telegram-1"],
             "operator"
         );
         assert_eq!(
-            cfg["hosts"]["hermes.coder"]["runtimePeerPrefix"],
+            cfg["hosts"]["hermes_coder"]["runtimePeerPrefix"],
             "gateway_"
         );
+    }
+
+    #[test]
+    fn memory_honcho_profile_host_key_is_honcho_safe() {
+        let _guard = env_test_lock();
+        let prev_profile = std::env::var("HERMES_PROFILE").ok();
+        let prev_host = std::env::var("HERMES_HONCHO_HOST").ok();
+        std::env::set_var("HERMES_PROFILE", "research.team/v1");
+        std::env::remove_var("HERMES_HONCHO_HOST");
+
+        assert_eq!(active_honcho_host_key_for_cli(), "hermes_research_team_v1");
+        assert_eq!(
+            honcho_ai_peer_for_host("hermes_research_team_v1"),
+            "research_team_v1"
+        );
+
+        match prev_profile {
+            Some(value) => std::env::set_var("HERMES_PROFILE", value),
+            None => std::env::remove_var("HERMES_PROFILE"),
+        }
+        match prev_host {
+            Some(value) => std::env::set_var("HERMES_HONCHO_HOST", value),
+            None => std::env::remove_var("HERMES_HONCHO_HOST"),
+        }
     }
 
     #[test]
@@ -27742,6 +27907,8 @@ mod tests {
         assert_eq!(input.title, "Ship kanban");
         assert_eq!(input.lane, KanbanLane::Todo);
         assert_eq!(input.priority, 3);
+        assert!(!input.goal_mode);
+        assert_eq!(input.goal_max_turns, None);
     }
 
     #[test]
@@ -27758,6 +27925,9 @@ mod tests {
             "K-0001,K-0002",
             "--desc",
             "note",
+            "--goal",
+            "--goal-max-turns",
+            "7",
         ])
         .expect("parse");
         assert_eq!(input.title, "Task");
@@ -27766,6 +27936,8 @@ mod tests {
         assert_eq!(input.assignee.as_deref(), Some("runner"));
         assert_eq!(input.depends_on, vec!["K-0001", "K-0002"]);
         assert_eq!(input.description.as_deref(), Some("note"));
+        assert!(input.goal_mode);
+        assert_eq!(input.goal_max_turns, Some(7));
     }
 
     #[test]

--- a/crates/hermes-cli/src/kanban.rs
+++ b/crates/hermes-cli/src/kanban.rs
@@ -12,6 +12,8 @@ const KANBAN_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_BOARD_ID: &str = "main";
 const CONTEXTLATTICE_DEFAULT_ORCHESTRATOR_URL: &str = "http://127.0.0.1:8075";
 const CONTEXTLATTICE_KANBAN_FILE: &str = "notes/hermes-kanban.md";
+const KANBAN_ATTACHMENTS_ENV: &str = "HERMES_KANBAN_ATTACHMENTS_ROOT";
+const DEFAULT_GOAL_MAX_TURNS: u32 = 20;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -63,6 +65,25 @@ pub struct KanbanTask {
     pub updated_at: String,
     pub started_at: Option<String>,
     pub completed_at: Option<String>,
+    #[serde(default)]
+    pub attachments: Vec<KanbanAttachment>,
+    #[serde(default)]
+    pub goal_mode: bool,
+    #[serde(default)]
+    pub goal_max_turns: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KanbanAttachment {
+    pub id: String,
+    pub filename: String,
+    pub stored_path: String,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    pub size: u64,
+    #[serde(default)]
+    pub uploaded_by: Option<String>,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,6 +128,8 @@ pub struct NewKanbanTaskInput {
     pub assignee: Option<String>,
     pub description: Option<String>,
     pub depends_on: Vec<String>,
+    pub goal_mode: bool,
+    pub goal_max_turns: Option<u32>,
 }
 
 impl Default for KanbanStore {
@@ -264,6 +287,9 @@ pub fn add_task(board: &mut KanbanBoard, input: NewKanbanTaskInput) -> KanbanTas
         updated_at: now.clone(),
         started_at: (input.lane == KanbanLane::Doing).then_some(now.clone()),
         completed_at: (input.lane == KanbanLane::Done).then_some(now),
+        attachments: Vec::new(),
+        goal_mode: input.goal_mode,
+        goal_max_turns: input.goal_max_turns,
     };
     board.updated_at = now_rfc3339();
     board.tasks.push(task.clone());
@@ -324,6 +350,302 @@ pub fn claim_task(task: &mut KanbanTask, assignee: Option<String>) {
         task.started_at = Some(now_rfc3339());
     }
     task.updated_at = now_rfc3339();
+}
+
+pub fn attachments_root(board: &KanbanBoard) -> PathBuf {
+    if let Ok(override_root) = std::env::var(KANBAN_ATTACHMENTS_ENV) {
+        let trimmed = override_root.trim();
+        if !trimmed.is_empty() {
+            return expand_tilde_path(trimmed);
+        }
+    }
+    hermes_config::hermes_home()
+        .join(KANBAN_STATE_DIR)
+        .join("attachments")
+        .join(slugify_board_id(&board.id))
+}
+
+pub fn task_attachments_dir(board: &KanbanBoard, task_id: &str) -> PathBuf {
+    attachments_root(board).join(sanitize_path_segment(task_id))
+}
+
+pub fn add_attachment_to_task(
+    board: &mut KanbanBoard,
+    task_ref: &str,
+    source_path: impl AsRef<Path>,
+    uploaded_by: Option<String>,
+) -> Result<KanbanAttachment, AgentError> {
+    let task_idx = board
+        .tasks
+        .iter()
+        .position(|task| {
+            task.id.eq_ignore_ascii_case(task_ref) || task.title.eq_ignore_ascii_case(task_ref)
+        })
+        .ok_or_else(|| AgentError::Config(format!("Task not found: {task_ref}")))?;
+    let source = expand_tilde_path(source_path.as_ref().to_string_lossy().as_ref());
+    let metadata = std::fs::metadata(&source).map_err(|e| {
+        AgentError::Io(format!(
+            "read attachment {} failed: {}",
+            source.display(),
+            e
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(AgentError::Config(format!(
+            "Attachment source is not a file: {}",
+            source.display()
+        )));
+    }
+    let raw_name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| AgentError::Config("attachment filename is required".to_string()))?;
+    let safe_name = sanitize_filename(raw_name);
+    if safe_name.is_empty() {
+        return Err(AgentError::Config(
+            "attachment filename is required".to_string(),
+        ));
+    }
+
+    let task_id = board.tasks[task_idx].id.clone();
+    let dest_dir = task_attachments_dir(board, &task_id);
+    std::fs::create_dir_all(&dest_dir)
+        .map_err(|e| AgentError::Io(format!("create {} failed: {}", dest_dir.display(), e)))?;
+    let dest = unique_attachment_path(&dest_dir, &safe_name);
+    std::fs::copy(&source, &dest).map_err(|e| {
+        AgentError::Io(format!(
+            "copy attachment {} -> {} failed: {}",
+            source.display(),
+            dest.display(),
+            e
+        ))
+    })?;
+    let stored_path = dest.canonicalize().unwrap_or(dest);
+    let stored_name = stored_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&safe_name)
+        .to_string();
+    let attachment = KanbanAttachment {
+        id: next_attachment_id(&board.tasks[task_idx]),
+        filename: stored_name,
+        stored_path: stored_path.display().to_string(),
+        content_type: guess_content_type(&source),
+        size: metadata.len(),
+        uploaded_by: normalize_optional(uploaded_by),
+        created_at: now_rfc3339(),
+    };
+    let now = now_rfc3339();
+    board.tasks[task_idx].attachments.push(attachment.clone());
+    board.tasks[task_idx].updated_at = now.clone();
+    board.updated_at = now;
+    Ok(attachment)
+}
+
+pub fn remove_attachment_from_task(
+    board: &mut KanbanBoard,
+    task_ref: &str,
+    attachment_ref: &str,
+) -> Result<Option<KanbanAttachment>, AgentError> {
+    let Some(task_idx) = board.tasks.iter().position(|task| {
+        task.id.eq_ignore_ascii_case(task_ref) || task.title.eq_ignore_ascii_case(task_ref)
+    }) else {
+        return Ok(None);
+    };
+    let Some(att_idx) = board.tasks[task_idx]
+        .attachments
+        .iter()
+        .position(|attachment| {
+            attachment.id.eq_ignore_ascii_case(attachment_ref)
+                || attachment.filename.eq_ignore_ascii_case(attachment_ref)
+        })
+    else {
+        return Ok(None);
+    };
+    let attachment = board.tasks[task_idx].attachments.remove(att_idx);
+    let stored = PathBuf::from(&attachment.stored_path);
+    if stored.is_file() {
+        let _ = std::fs::remove_file(&stored);
+    }
+    let now = now_rfc3339();
+    board.tasks[task_idx].updated_at = now.clone();
+    board.updated_at = now;
+    Ok(Some(attachment))
+}
+
+pub fn build_worker_context(task: &KanbanTask) -> String {
+    let mut lines = vec![format!("Execute Kanban task {}: {}", task.id, task.title)];
+    if let Some(desc) = task
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        lines.push(format!("Details: {desc}"));
+    }
+    if !task.depends_on.is_empty() {
+        lines.push(format!("Dependencies: {}", task.depends_on.join(", ")));
+    }
+    if !task.attachments.is_empty() {
+        lines.push("Attachments:".to_string());
+        lines.push(
+            "Read attached files with file or terminal tools at these absolute paths:".to_string(),
+        );
+        for attachment in &task.attachments {
+            let size_kb = attachment.size.div_ceil(1024);
+            let content_type = attachment
+                .content_type
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|s| format!(", {s}"))
+                .unwrap_or_default();
+            let size = if size_kb == 0 {
+                String::new()
+            } else {
+                format!(", {size_kb} KB")
+            };
+            lines.push(format!(
+                "- {}{}{} -> {}",
+                attachment.filename, content_type, size, attachment.stored_path
+            ));
+        }
+    }
+    if task.goal_mode {
+        let max_turns = task.goal_max_turns.unwrap_or(DEFAULT_GOAL_MAX_TURNS);
+        lines.push(format!(
+            "Goal mode: enabled (max {max_turns} turns). Continue in this same work session until the task is genuinely done, then mark it done with a summary; if blocked, mark it blocked with the reason. Do not silently stop while work remains."
+        ));
+    }
+    lines.join("\n")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KanbanGoalLoopOutcome {
+    CompletedByWorker,
+    BlockedByWorker,
+    BlockedBudget,
+    Stopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KanbanGoalLoopResult {
+    pub outcome: KanbanGoalLoopOutcome,
+    pub turns_used: u32,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KanbanGoalJudgment {
+    Done(String),
+    Continue(String),
+}
+
+pub type KanbanGoalStatusFn<'a> = Box<dyn FnMut() -> KanbanLane + 'a>;
+pub type KanbanGoalJudgeFn<'a> = Box<dyn FnMut(&str, &str) -> KanbanGoalJudgment + 'a>;
+pub type KanbanGoalRunTurnFn<'a> = Box<dyn FnMut(&str) -> String + 'a>;
+pub type KanbanGoalBlockFn<'a> = Box<dyn FnMut(&str) + 'a>;
+
+pub struct KanbanGoalLoopCallbacks<'a> {
+    pub task_status: KanbanGoalStatusFn<'a>,
+    pub judge: KanbanGoalJudgeFn<'a>,
+    pub run_turn: KanbanGoalRunTurnFn<'a>,
+    pub block_task: KanbanGoalBlockFn<'a>,
+}
+
+pub fn run_kanban_goal_loop(
+    task_id: &str,
+    goal_text: &str,
+    first_response: &str,
+    max_turns: u32,
+    callbacks: KanbanGoalLoopCallbacks<'_>,
+) -> KanbanGoalLoopResult {
+    let KanbanGoalLoopCallbacks {
+        mut task_status,
+        mut judge,
+        mut run_turn,
+        mut block_task,
+    } = callbacks;
+    let max_turns = max_turns.max(1);
+    let mut turns_used = 1u32;
+    let mut last_response = first_response.to_string();
+    let mut nudged_to_finalize = false;
+
+    loop {
+        match task_status() {
+            KanbanLane::Done => {
+                return KanbanGoalLoopResult {
+                    outcome: KanbanGoalLoopOutcome::CompletedByWorker,
+                    turns_used,
+                    reason: "worker completed the task".to_string(),
+                };
+            }
+            KanbanLane::Blocked => {
+                return KanbanGoalLoopResult {
+                    outcome: KanbanGoalLoopOutcome::BlockedByWorker,
+                    turns_used,
+                    reason: "worker blocked the task".to_string(),
+                };
+            }
+            KanbanLane::Todo | KanbanLane::Doing => {}
+        }
+
+        let (prompt, reason) = match judge(goal_text, &last_response) {
+            KanbanGoalJudgment::Done(reason) => {
+                if nudged_to_finalize {
+                    let reason = format!(
+                        "Goal-mode worker output looked complete but task {task_id} never moved to done after finalize nudge: {reason}"
+                    );
+                    block_task(&reason);
+                    return KanbanGoalLoopResult {
+                        outcome: KanbanGoalLoopOutcome::BlockedBudget,
+                        turns_used,
+                        reason,
+                    };
+                }
+                nudged_to_finalize = true;
+                (
+                    format!(
+                        "[The kanban task appears complete, but it is still open]\nReason: {}\n\nMark task {} done with a concise summary, or block it with the remaining blocker.",
+                        truncate_for_prompt(&reason, 400),
+                        task_id
+                    ),
+                    reason,
+                )
+            }
+            KanbanGoalJudgment::Continue(reason) => (
+                format!(
+                    "[Continuing kanban goal-mode task {}]\nReason: {}\n\nTake the next concrete step toward completing the task. When finished, mark it done; if blocked, mark it blocked. Do not stop without changing task state.",
+                    task_id,
+                    truncate_for_prompt(&reason, 400)
+                ),
+                reason,
+            ),
+        };
+
+        if turns_used >= max_turns {
+            let reason = format!(
+                "Goal-mode worker exhausted its turn budget ({turns_used}/{max_turns}) without completing task {task_id}. Last judge reason: {}",
+                truncate_for_prompt(&reason, 300)
+            );
+            block_task(&reason);
+            return KanbanGoalLoopResult {
+                outcome: KanbanGoalLoopOutcome::BlockedBudget,
+                turns_used,
+                reason,
+            };
+        }
+
+        last_response = run_turn(&prompt);
+        turns_used = turns_used.saturating_add(1);
+
+        if last_response.trim().is_empty() {
+            return KanbanGoalLoopResult {
+                outcome: KanbanGoalLoopOutcome::Stopped,
+                turns_used,
+                reason: "worker returned empty response".to_string(),
+            };
+        }
+    }
 }
 
 pub fn archive_done(board: &mut KanbanBoard) -> usize {
@@ -477,6 +799,112 @@ fn slugify_board_id(raw: &str) -> String {
         }
     }
     out.trim_matches('-').to_string()
+}
+
+fn expand_tilde_path(raw: &str) -> PathBuf {
+    if raw == "~" {
+        return std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(raw));
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(raw)
+}
+
+fn sanitize_path_segment(raw: &str) -> String {
+    let sanitized = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('.')
+        .trim_matches('_')
+        .to_string();
+    if sanitized.is_empty() {
+        "item".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn sanitize_filename(raw: &str) -> String {
+    sanitize_path_segment(
+        Path::new(raw)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(raw),
+    )
+}
+
+fn unique_attachment_path(dir: &Path, filename: &str) -> PathBuf {
+    let base = Path::new(filename);
+    let stem = base
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("attachment");
+    let ext = base.extension().and_then(|s| s.to_str()).unwrap_or("");
+    let first = dir.join(filename);
+    if !first.exists() {
+        return first;
+    }
+    for idx in 1..10_000 {
+        let candidate_name = if ext.is_empty() {
+            format!("{stem}-{idx}")
+        } else {
+            format!("{stem}-{idx}.{ext}")
+        };
+        let candidate = dir.join(candidate_name);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    dir.join(format!("{}-{}", stem, uuid::Uuid::new_v4().simple()))
+}
+
+fn next_attachment_id(task: &KanbanTask) -> String {
+    let mut max_seen = 0u64;
+    for attachment in &task.attachments {
+        if let Some(raw) = attachment.id.strip_prefix("A-") {
+            if let Ok(value) = raw.parse::<u64>() {
+                max_seen = max_seen.max(value);
+            }
+        }
+    }
+    format!("A-{:04}", max_seen.saturating_add(1))
+}
+
+fn guess_content_type(path: &Path) -> Option<String> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    let content_type = match ext.as_str() {
+        "txt" | "md" | "rs" | "py" | "js" | "ts" | "tsx" | "jsx" | "json" | "yaml" | "yml"
+        | "toml" => "text/plain",
+        "pdf" => "application/pdf",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "csv" => "text/csv",
+        "html" | "htm" => "text/html",
+        _ => return None,
+    };
+    Some(content_type.to_string())
+}
+
+fn truncate_for_prompt(raw: &str, max_chars: usize) -> String {
+    let mut out = raw.chars().take(max_chars).collect::<String>();
+    if raw.chars().count() > max_chars {
+        out.push_str("...");
+    }
+    out
 }
 
 fn dedupe_strings(values: Vec<String>) -> Vec<String> {
@@ -651,6 +1079,8 @@ mod tests {
                     assignee: None,
                     description: None,
                     depends_on: vec![],
+                    goal_mode: false,
+                    goal_max_turns: None,
                 },
             );
             assert_eq!(task.id, "K-0001");
@@ -694,6 +1124,148 @@ mod tests {
             assert!(!res.attempted);
             std::env::remove_var("HERMES_KANBAN_CONTEXTLATTICE_SYNC");
         });
+    }
+
+    #[test]
+    fn attachments_copy_with_safe_unique_names_and_surface_in_worker_context() {
+        with_temp_home(|| {
+            let mut store = load_store().expect("load");
+            let board = ensure_board(&mut store, None);
+            let task = add_task(
+                board,
+                NewKanbanTaskInput {
+                    title: "Read source".to_string(),
+                    lane: KanbanLane::Todo,
+                    priority: 3,
+                    assignee: Some("worker".to_string()),
+                    description: Some("summarize attached file".to_string()),
+                    depends_on: vec![],
+                    goal_mode: false,
+                    goal_max_turns: None,
+                },
+            );
+            let source_dir = tempfile::tempdir().expect("source tempdir");
+            let source = source_dir.path().join("notes.txt");
+            std::fs::write(&source, "hello attachment").expect("write source");
+
+            let first =
+                add_attachment_to_task(board, &task.id, &source, Some("tester".to_string()))
+                    .expect("attach first");
+            let second =
+                add_attachment_to_task(board, &task.id, &source, None).expect("attach second");
+
+            assert_eq!(first.id, "A-0001");
+            assert_eq!(second.id, "A-0002");
+            assert_eq!(first.filename, "notes.txt");
+            assert_eq!(second.filename, "notes-1.txt");
+            assert!(Path::new(&first.stored_path).is_file());
+            assert!(Path::new(&second.stored_path).is_file());
+
+            let task = find_task_mut(board, &task.id).expect("task");
+            let context = build_worker_context(task);
+            assert!(context.contains("Attachments:"));
+            assert!(context.contains(&first.stored_path));
+            assert!(context.contains("notes-1.txt"));
+        });
+    }
+
+    #[test]
+    fn remove_attachment_deletes_row_and_blob() {
+        with_temp_home(|| {
+            let mut store = load_store().expect("load");
+            let board = ensure_board(&mut store, None);
+            let task = add_task(
+                board,
+                NewKanbanTaskInput {
+                    title: "Task".to_string(),
+                    lane: KanbanLane::Todo,
+                    priority: 3,
+                    assignee: None,
+                    description: None,
+                    depends_on: vec![],
+                    goal_mode: false,
+                    goal_max_turns: None,
+                },
+            );
+            let source_dir = tempfile::tempdir().expect("source tempdir");
+            let source = source_dir.path().join("data.pdf");
+            std::fs::write(&source, b"%PDF-1.4").expect("write source");
+            let attachment =
+                add_attachment_to_task(board, &task.id, &source, None).expect("attach");
+            let stored = PathBuf::from(&attachment.stored_path);
+
+            let removed =
+                remove_attachment_from_task(board, &task.id, &attachment.id).expect("remove");
+            assert_eq!(removed.expect("removed").id, attachment.id);
+            assert!(!stored.exists());
+            assert!(find_task_mut(board, &task.id)
+                .expect("task")
+                .attachments
+                .is_empty());
+        });
+    }
+
+    #[test]
+    fn goal_mode_context_and_loop_cover_continue_complete_and_budget() {
+        let task = KanbanTask {
+            id: "K-0007".to_string(),
+            title: "Ship feature".to_string(),
+            lane: KanbanLane::Doing,
+            priority: 1,
+            assignee: Some("worker".to_string()),
+            description: Some("must pass tests".to_string()),
+            depends_on: vec!["K-0001".to_string()],
+            blocked_reason: None,
+            background_job_id: None,
+            run_summary: None,
+            created_at: now_rfc3339(),
+            updated_at: now_rfc3339(),
+            started_at: Some(now_rfc3339()),
+            completed_at: None,
+            attachments: Vec::new(),
+            goal_mode: true,
+            goal_max_turns: Some(3),
+        };
+        let context = build_worker_context(&task);
+        assert!(context.contains("Goal mode: enabled (max 3 turns)"));
+        assert!(context.contains("Dependencies: K-0001"));
+
+        let mut statuses = [KanbanLane::Doing, KanbanLane::Done].into_iter();
+        let mut prompts = Vec::new();
+        let result = run_kanban_goal_loop(
+            &task.id,
+            "Ship feature",
+            "started",
+            5,
+            KanbanGoalLoopCallbacks {
+                task_status: Box::new(|| statuses.next().unwrap_or(KanbanLane::Done)),
+                judge: Box::new(|_, _| KanbanGoalJudgment::Continue("needs more work".to_string())),
+                run_turn: Box::new(|prompt: &str| {
+                    prompts.push(prompt.to_string());
+                    "continued".to_string()
+                }),
+                block_task: Box::new(|_| panic!("should not block")),
+            },
+        );
+        assert_eq!(result.outcome, KanbanGoalLoopOutcome::CompletedByWorker);
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0].contains("Continuing kanban goal-mode task"));
+
+        let mut blocked_reason = String::new();
+        let budget = run_kanban_goal_loop(
+            &task.id,
+            "Ship feature",
+            "started",
+            2,
+            KanbanGoalLoopCallbacks {
+                task_status: Box::new(|| KanbanLane::Doing),
+                judge: Box::new(|_, _| KanbanGoalJudgment::Continue("not done".to_string())),
+                run_turn: Box::new(|_| "still going".to_string()),
+                block_task: Box::new(|reason: &str| blocked_reason = reason.to_string()),
+            },
+        );
+        assert_eq!(budget.outcome, KanbanGoalLoopOutcome::BlockedBudget);
+        assert!(blocked_reason.contains("turn budget"));
     }
 
     fn corrupt_store_backups(parent: &Path) -> Vec<PathBuf> {

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -2767,6 +2767,7 @@ async fn run_gateway(
                 display: config.display.clone(),
                 service_tier: config.agent.normalized_service_tier(),
                 quick_commands: config.quick_commands.clone(),
+                kanban_dispatch_in_gateway: config.kanban.dispatch_in_gateway,
                 ..RuntimeGatewayConfig::default()
             };
             let session_manager = Arc::new(SessionManager::new(config.session.clone()));

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -105,6 +105,10 @@ pub struct GatewayConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub quick_commands: BTreeMap<String, QuickCommandConfig>,
 
+    /// Kanban dispatcher/notifier behavior for multi-gateway deployments.
+    #[serde(default)]
+    pub kanban: KanbanConfig,
+
     /// Upstream-compatible TTS configuration block.
     ///
     /// Kept as structured JSON because upstream accepts provider-specific
@@ -176,6 +180,7 @@ impl Default for GatewayConfig {
             smart_model_routing: SmartModelRoutingConfig::default(),
             auxiliary: BTreeMap::new(),
             quick_commands: BTreeMap::new(),
+            kanban: KanbanConfig::default(),
             tts: serde_json::Value::Null,
             proxy: None,
             approval: ApprovalConfig::default(),
@@ -186,6 +191,21 @@ impl Default for GatewayConfig {
             profile: ProfileConfig::default(),
             agent: AgentLoopBehaviorConfig::default(),
             home_dir: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KanbanConfig {
+    /// When false, this process must not own Kanban dispatch/notifier polling.
+    #[serde(default = "default_true")]
+    pub dispatch_in_gateway: bool,
+}
+
+impl Default for KanbanConfig {
+    fn default() -> Self {
+        Self {
+            dispatch_in_gateway: true,
         }
     }
 }
@@ -1177,6 +1197,10 @@ fn is_false(value: &bool) -> bool {
 
 fn is_true(value: &bool) -> bool {
     *value
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_terminal_timeout() -> u64 {

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -568,7 +568,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -578,6 +578,16 @@ fn mask_secret(s: &str) -> String {
         "***".to_string()
     } else {
         format!("***{}", &s[s.len() - 4..])
+    }
+}
+
+fn parse_config_bool(key: &str, value: &str) -> Result<bool, ConfigError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(ConfigError::ValidationError(format!(
+            "{key} must be a boolean: {value}"
+        ))),
     }
 }
 
@@ -746,6 +756,10 @@ fn apply_user_config_patch_dotted(
                     value
                 ))
             })?;
+        }
+        ["kanban", "dispatch_in_gateway"] => {
+            config.kanban.dispatch_in_gateway =
+                parse_config_bool("kanban.dispatch_in_gateway", value)?;
         }
         ["auxiliary", task, field] => {
             let entry = config
@@ -938,6 +952,7 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
         ["sessions", "retention_days"] => Ok(config.sessions.retention_days.to_string()),
         ["sessions", "vacuum_after_prune"] => Ok(config.sessions.vacuum_after_prune.to_string()),
         ["sessions", "min_interval_hours"] => Ok(config.sessions.min_interval_hours.to_string()),
+        ["kanban", "dispatch_in_gateway"] => Ok(config.kanban.dispatch_in_gateway.to_string()),
         ["llm", provider, "api_key"] => Ok(
             match config
                 .llm_providers
@@ -1776,6 +1791,11 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
     }
     if let Ok(v) = std::env::var("HERMES_SYSTEM_PROMPT") {
         config.system_prompt = Some(v);
+    }
+    if let Ok(v) = std::env::var("HERMES_KANBAN_DISPATCH_IN_GATEWAY") {
+        if let Some(parsed) = parse_bool_env("HERMES_KANBAN_DISPATCH_IN_GATEWAY", &v) {
+            config.kanban.dispatch_in_gateway = parsed;
+        }
     }
     if env_truthy("HERMES_AGENT_SKIP_CONTEXT_FILES") || env_truthy("HERMES_IGNORE_RULES") {
         config.agent.skip_context_files = true;
@@ -2715,6 +2735,21 @@ llm_providers:
     }
 
     #[test]
+    fn apply_patch_dotted_kanban_dispatch_gate() {
+        let mut c = GatewayConfig::default();
+        assert!(c.kanban.dispatch_in_gateway);
+
+        apply_user_config_patch(&mut c, "kanban.dispatch_in_gateway", "false").unwrap();
+
+        assert!(!c.kanban.dispatch_in_gateway);
+        assert_eq!(
+            user_config_field_display(&c, "kanban.dispatch_in_gateway").unwrap(),
+            "false"
+        );
+        assert!(apply_user_config_patch(&mut c, "kanban.dispatch_in_gateway", "maybe").is_err());
+    }
+
+    #[test]
     fn apply_patch_dotted_auxiliary_values() {
         let mut c = GatewayConfig::default();
         apply_user_config_patch(&mut c, "auxiliary.vision.provider", "openrouter").unwrap();
@@ -2873,6 +2908,23 @@ llm_providers:
         unsafe {
             std::env::remove_var("OPENROUTER_API_KEY");
             std::env::remove_var("MINIMAX_API_KEY");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_supports_kanban_dispatch_gate() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        unsafe {
+            std::env::set_var("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "false");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_env_overrides(&mut cfg);
+        assert!(!cfg.kanban.dispatch_in_gateway);
+
+        unsafe {
+            std::env::remove_var("HERMES_KANBAN_DISPATCH_IN_GATEWAY");
         }
     }
 

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -130,6 +130,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 smart_model_routing: SmartModelRoutingConfig::default(),
                 auxiliary: Default::default(),
                 quick_commands: Default::default(),
+                kanban: Default::default(),
                 tts: serde_json::Value::Null,
                 proxy: None,
                 approval: ApprovalConfig::default(),

--- a/crates/hermes-gateway/src/agent_cache.rs
+++ b/crates/hermes-gateway/src/agent_cache.rs
@@ -19,6 +19,8 @@ pub const CACHE_BUSTING_CONFIG_KEYS: &[(&str, &str)] = &[
     ("compression", "threshold"),
     ("compression", "target_ratio"),
     ("compression", "protect_last_n"),
+    ("memory", "provider"),
+    ("kanban", "dispatch_in_gateway"),
 ];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -429,7 +431,9 @@ mod tests {
     fn cache_busting_config_reads_documented_keys_and_missing_nulls() {
         let cfg = serde_json::json!({
             "model": {"context_length": 272000, "max_tokens": 4096},
-            "compression": {"enabled": false, "threshold": 0.6, "target_ratio": 0.3, "protect_last_n": 25, "ignored": true}
+            "compression": {"enabled": false, "threshold": 0.6, "target_ratio": 0.3, "protect_last_n": 25, "ignored": true},
+            "memory": {"provider": "honcho"},
+            "kanban": {"dispatch_in_gateway": false}
         });
         let out = extract_cache_busting_config(Some(&cfg), Some(123));
         assert_eq!(out["model.context_length"], Value::from(272000));
@@ -438,6 +442,8 @@ mod tests {
         assert_eq!(out["compression.threshold"], Value::from(0.6));
         assert_eq!(out["compression.target_ratio"], Value::from(0.3));
         assert_eq!(out["compression.protect_last_n"], Value::from(25));
+        assert_eq!(out["memory.provider"], Value::from("honcho"));
+        assert_eq!(out["kanban.dispatch_in_gateway"], Value::from(false));
         assert_eq!(out["tools.registry_generation"], Value::from(123));
 
         let missing = extract_cache_busting_config(None, None);

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -72,6 +72,10 @@ pub struct GatewayConfig {
     /// User-defined slash commands that bypass the agent loop.
     #[serde(default)]
     pub quick_commands: BTreeMap<String, QuickCommandConfig>,
+
+    /// Whether this gateway process owns Kanban dispatch/notifier duties.
+    #[serde(default = "default_true")]
+    pub kanban_dispatch_in_gateway: bool,
 }
 
 impl Default for GatewayConfig {
@@ -85,6 +89,7 @@ impl Default for GatewayConfig {
             display: DisplayConfig::default(),
             service_tier: None,
             quick_commands: BTreeMap::new(),
+            kanban_dispatch_in_gateway: true,
         }
     }
 }

--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -1,0 +1,31 @@
+# Multi-Gateway Kanban Dispatch
+
+Hermes Ultra can run multiple gateway processes on one machine, usually one per profile. Only one process should own Kanban dispatch/notifier responsibilities.
+
+## Dispatch Owner
+
+Leave the owning gateway at the default:
+
+```yaml
+kanban:
+  dispatch_in_gateway: true
+```
+
+For every non-owning gateway, set:
+
+```yaml
+kanban:
+  dispatch_in_gateway: false
+```
+
+Or set the environment override:
+
+```sh
+HERMES_KANBAN_DISPATCH_IN_GATEWAY=false
+```
+
+## Runtime Behavior
+
+The Rust config loader parses `kanban.dispatch_in_gateway`, applies the env override, propagates the flag into the runtime gateway config, and includes it in gateway-agent cache signatures. Non-dispatch gateway profiles can still run platform adapters; they should not own Kanban dispatch duties.
+
+The current Rust Kanban store is JSON-backed under Hermes home rather than the upstream Python SQLite board database, so there is no separate Rust per-board DB notifier loop to gate.

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -631,6 +631,22 @@
     "32032e1e2d9b": {
       "disposition": "superseded",
       "notes": "upstream SimpleX websocket reconnect delta is Python plugin-only in this fork; no Rust SimpleX platform adapter exists under crates, so there is no Rust runtime surface to port under the Rust-only parity policy."
+    },
+    "827ce602dbed": {
+      "disposition": "ported",
+      "notes": "Rust Honcho runtime now strips trailing /vN baseUrl suffixes, derives underscore-safe profile host keys while reading legacy dot-form host blocks, skips loopback auth unless hosts.<host>.apiKey explicitly opts in, and setup/config writes remain owner-only with targeted regression coverage."
+    },
+    "b47cb1bbf279": {
+      "disposition": "ported",
+      "notes": "Rust Kanban JSON store now supports per-task file attachments with path-safe copy, unique filenames, metadata, list/remove commands, worker-context absolute path surfacing, and regression tests for copy/collision/delete/context behavior."
+    },
+    "0cd7d54b0010": {
+      "disposition": "ported",
+      "notes": "Rust Kanban tasks now carry goal_mode and goal_max_turns, CLI add parses --goal/--goal-max-turns, dispatch worker context emits goal-loop instructions, and a callback-injected Rust goal loop covers continue, completion, finalize, and budget-block behavior."
+    },
+    "a5aecf26fa21": {
+      "disposition": "ported",
+      "notes": "Rust config/runtime gateway surface now exposes kanban.dispatch_in_gateway with HERMES_KANBAN_DISPATCH_IN_GATEWAY env override, propagates it into GatewayConfig, and includes it in gateway agent cache-busting signatures; Rust has no separate Kanban DB notifier loop to gate."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary

Adds Rust-native runtime parity surfaces for the next Kanban/Honcho upstream batch:

- Honcho self-host hardening for `827ce602dbed`:
  - underscore-safe profile host keys, with legacy dot-form host-block reads
  - trailing `/vN` baseUrl stripping
  - loopback Honcho auth suppression unless `hosts.<host>.apiKey` explicitly opts in
- Kanban attachments for `b47cb1bbf279`:
  - per-task attachment metadata in the JSON Kanban store
  - path-safe copy into Hermes-owned attachment storage
  - unique filename collision handling
  - `kanban attach`, `kanban attachments`, and `kanban detach`
  - worker-context absolute path surfacing
- Kanban goal mode for `0cd7d54b0010`:
  - `goal_mode` and `goal_max_turns` task fields
  - `--goal` / `--goal-max-turns` CLI parsing
  - goal-mode worker context and callback-injected goal-loop behavior
- Multi-gateway Kanban dispatch gate for `a5aecf26fa21`:
  - `kanban.dispatch_in_gateway` config + user patch + display path
  - `HERMES_KANBAN_DISPATCH_IN_GATEWAY` env override
  - runtime gateway propagation
  - cache-busting signature coverage for `memory.provider` and `kanban.dispatch_in_gateway`
  - Rust-accurate docs for the JSON-backed Kanban store/no separate SQLite notifier loop

Updates `docs/parity/queue-overrides.json` to mark those four upstream hashes `ported`.

## Verification

Passed:

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
  - `No Rust runtime Python execution paths detected.`
- `scripts/check-runtime-placeholders.sh`
  - `No runtime placeholder markers detected.`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr454 CARGO_INCREMENTAL=0 cargo test -p hermes-config kanban_dispatch_gate -- --nocapture`
  - `2 passed; 0 failed`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr454 CARGO_INCREMENTAL=0 cargo test -p hermes-agent honcho -- --nocapture`
  - `21 passed; 0 failed`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr454 CARGO_INCREMENTAL=0 cargo test -p hermes-cli kanban -- --nocapture`
  - `12 passed; 0 failed`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr454 CARGO_INCREMENTAL=0 cargo test -p hermes-gateway cache_busting_config_reads_documented_keys_and_missing_nulls -- --nocapture`
  - `1 passed; 0 failed`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr454 CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-agent -p hermes-config -p hermes-gateway`
  - `seen=199 allowlist=204 new=0 stale=5`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr454 CARGO_INCREMENTAL=0 cargo build -p hermes-cli -p hermes-agent -p hermes-config -p hermes-gateway`
  - `Finished dev profile in 19.99s`
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-seeded-upstream-queue-kanban-honcho.json --out-md /tmp/hermes-seeded-upstream-queue-kanban-honcho.md`
  - `827ce602dbed ported`
  - `b47cb1bbf279 ported`
  - `0cd7d54b0010 ported`
  - `a5aecf26fa21 ported`
  - `total_commits 4903`
  - `by_disposition {"mirrored":56,"pending":952,"ported":36,"superseded":3859}`

Note: the default Cargo target under `/Volumes/wd_black/cargo-targets` previously failed with `Operation not permitted (os error 1)`, so validation was rerun with the isolated `/tmp/hermes-agent-ultra-target-pr454` target directory.

## Residual Risk

- No live Honcho API call was made; this is covered by config/unit behavior and fail-open local tests.
- Kanban goal-loop behavior is callback/unit tested rather than live worker E2E tested.
- Rust Kanban is JSON-backed; there is no Rust SQLite notifier loop to gate, so the dispatch parity surface is config/runtime/cache ownership rather than a DB watcher port.
