### PR TITLE
parity(runtime): wire retry config and MCP arg coercion

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4805,6 +4805,16 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_maps_agent_api_max_retries() {
+        let mut cfg = GatewayConfig::default();
+        cfg.agent.api_max_retries = Some(11);
+
+        let agent_cfg = build_agent_config(&cfg, "nous:openai/gpt-5.5");
+
+        assert_eq!(agent_cfg.retry.max_retries, 11);
+    }
+
+    #[test]
     fn test_resolve_provider_and_model_uses_single_provider_fallback() {
         let mut cfg = GatewayConfig::default();
         cfg.llm_providers
@@ -5881,6 +5891,9 @@ mod tests {
 
 fn build_retry_config(config: &GatewayConfig) -> hermes_agent::agent_loop::RetryConfig {
     let mut retry_cfg = hermes_agent::agent_loop::RetryConfig::default();
+    if let Some(max_retries) = config.agent.api_max_retries {
+        retry_cfg.max_retries = max_retries;
+    }
     let mut seen = std::collections::HashSet::new();
 
     let mut push_candidate =

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -672,6 +672,13 @@ pub struct AgentLoopBehaviorConfig {
     /// Optional provider request service tier. `fast` maps to provider `priority`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
+    /// Upstream-compatible API retry count for provider calls.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "apiMaxRetries"
+    )]
+    pub api_max_retries: Option<u32>,
 }
 
 fn default_agent_memory_nudge_interval() -> u32 {
@@ -723,6 +730,7 @@ impl Default for AgentLoopBehaviorConfig {
             lsp_context_enabled: default_agent_lsp_context_enabled(),
             lsp_context_max_chars: default_agent_lsp_context_max_chars(),
             service_tier: None,
+            api_max_retries: None,
         }
     }
 }

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -568,7 +568,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -760,6 +760,13 @@ fn apply_user_config_patch_dotted(
         ["kanban", "dispatch_in_gateway"] => {
             config.kanban.dispatch_in_gateway =
                 parse_config_bool("kanban.dispatch_in_gateway", value)?;
+        }
+        ["agent", "api_max_retries"] | ["agent", "apiMaxRetries"] => {
+            config.agent.api_max_retries = Some(value.parse().map_err(|_| {
+                ConfigError::ValidationError(format!(
+                    "agent.api_max_retries must be a non-negative integer: {value}"
+                ))
+            })?);
         }
         ["auxiliary", task, field] => {
             let entry = config
@@ -953,6 +960,11 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
         ["sessions", "vacuum_after_prune"] => Ok(config.sessions.vacuum_after_prune.to_string()),
         ["sessions", "min_interval_hours"] => Ok(config.sessions.min_interval_hours.to_string()),
         ["kanban", "dispatch_in_gateway"] => Ok(config.kanban.dispatch_in_gateway.to_string()),
+        ["agent", "api_max_retries"] | ["agent", "apiMaxRetries"] => Ok(config
+            .agent
+            .api_max_retries
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
         ["llm", provider, "api_key"] => Ok(
             match config
                 .llm_providers
@@ -1797,6 +1809,13 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
             config.kanban.dispatch_in_gateway = parsed;
         }
     }
+    if let Ok(v) = std::env::var("HERMES_AGENT_API_MAX_RETRIES") {
+        if let Ok(parsed) = v.parse::<u32>() {
+            config.agent.api_max_retries = Some(parsed);
+        } else {
+            tracing::warn!("HERMES_AGENT_API_MAX_RETRIES is not a valid u32: {v}");
+        }
+    }
     if env_truthy("HERMES_AGENT_SKIP_CONTEXT_FILES") || env_truthy("HERMES_IGNORE_RULES") {
         config.agent.skip_context_files = true;
     }
@@ -2578,6 +2597,36 @@ custom_providers:
     }
 
     #[test]
+    fn load_user_config_file_parses_agent_api_max_retries_aliases() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let snake_path = dir.path().join("snake.yaml");
+        std::fs::write(
+            &snake_path,
+            r#"
+agent:
+  api_max_retries: 6
+"#,
+        )
+        .unwrap();
+        let snake = load_user_config_file(&snake_path).unwrap();
+        assert_eq!(snake.agent.api_max_retries, Some(6));
+
+        let camel_path = dir.path().join("camel.yaml");
+        std::fs::write(
+            &camel_path,
+            r#"
+agent:
+  apiMaxRetries: 8
+"#,
+        )
+        .unwrap();
+        let camel = load_user_config_file(&camel_path).unwrap();
+        assert_eq!(camel.agent.api_max_retries, Some(8));
+    }
+
+    #[test]
     fn load_user_config_file_parses_auxiliary_task_overrides() {
         use tempfile::tempdir;
 
@@ -2747,6 +2796,21 @@ llm_providers:
             "false"
         );
         assert!(apply_user_config_patch(&mut c, "kanban.dispatch_in_gateway", "maybe").is_err());
+    }
+
+    #[test]
+    fn apply_patch_dotted_agent_api_max_retries() {
+        let mut c = GatewayConfig::default();
+        assert_eq!(c.agent.api_max_retries, None);
+
+        apply_user_config_patch(&mut c, "agent.api_max_retries", "7").unwrap();
+
+        assert_eq!(c.agent.api_max_retries, Some(7));
+        assert_eq!(
+            user_config_field_display(&c, "agent.api_max_retries").unwrap(),
+            "7"
+        );
+        assert!(apply_user_config_patch(&mut c, "agent.api_max_retries", "nope").is_err());
     }
 
     #[test]
@@ -2925,6 +2989,23 @@ llm_providers:
 
         unsafe {
             std::env::remove_var("HERMES_KANBAN_DISPATCH_IN_GATEWAY");
+        }
+    }
+
+    #[test]
+    fn apply_env_overrides_supports_agent_api_max_retries() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        unsafe {
+            std::env::set_var("HERMES_AGENT_API_MAX_RETRIES", "9");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.agent.api_max_retries, Some(9));
+
+        unsafe {
+            std::env::remove_var("HERMES_AGENT_API_MAX_RETRIES");
         }
     }
 

--- a/crates/hermes-mcp/src/lib.rs
+++ b/crates/hermes-mcp/src/lib.rs
@@ -14,6 +14,16 @@ pub mod serve;
 pub mod server;
 pub mod transport;
 
+pub(crate) fn coerce_mcp_tool_arguments(arguments: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::String(raw) = arguments else {
+        return arguments;
+    };
+    match serde_json::from_str::<serde_json::Value>(raw.trim()) {
+        Ok(parsed @ (serde_json::Value::Object(_) | serde_json::Value::Array(_))) => parsed,
+        _ => serde_json::Value::String(raw),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // McpError
 // ---------------------------------------------------------------------------

--- a/crates/hermes-mcp/src/serve.rs
+++ b/crates/hermes-mcp/src/serve.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::McpError;
+use crate::{coerce_mcp_tool_arguments, McpError};
 
 // ---------------------------------------------------------------------------
 // EventBridge — in-memory event queue with cursor-based polling
@@ -591,7 +591,9 @@ impl HermesMcpServe {
                     .get("name")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| McpError::InvalidParams("missing tool name".into()))?;
-                let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
+                let arguments = coerce_mcp_tool_arguments(
+                    params.get("arguments").cloned().unwrap_or(json!({})),
+                );
                 let result = self.handle_tool_call(tool_name, arguments).await?;
                 Ok(json!({
                     "content": [{"type": "text", "text": serde_json::to_string(&result).unwrap_or_default()}],
@@ -738,5 +740,32 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result["events"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_tools_call_coerces_stringified_object_args() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let serve = HermesMcpServe::new(store);
+
+        let result = serve
+            .handle_request(
+                "tools/call",
+                json!({
+                    "name": "session_send",
+                    "arguments": "{\"session_key\":\"s1\",\"message\":\"hello\"}"
+                }),
+            )
+            .await
+            .expect("tools/call with stringified object args");
+
+        assert!(!result["isError"].as_bool().unwrap_or(true));
+        let text = result["content"][0]["text"].as_str().unwrap_or("");
+        let payload: Value = serde_json::from_str(text).expect("tool result json");
+        assert_eq!(payload["sent"], true);
+        assert_eq!(payload["session_key"], "s1");
+
+        let (events, _) = serve.event_bridge.poll(0, Some("s1"), 10);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data["content"], "hello");
     }
 }

--- a/crates/hermes-mcp/src/server.rs
+++ b/crates/hermes-mcp/src/server.rs
@@ -18,7 +18,7 @@ use hermes_tools::ToolRegistry;
 
 use crate::client::ResourceInfo;
 use crate::transport::McpTransport;
-use crate::McpError;
+use crate::{coerce_mcp_tool_arguments, McpError};
 
 // ---------------------------------------------------------------------------
 // MCP tool format (for exposing to clients)
@@ -233,6 +233,7 @@ impl McpServer {
             .get("arguments")
             .cloned()
             .unwrap_or(Value::Object(serde_json::Map::new()));
+        let arguments = coerce_mcp_tool_arguments(arguments);
 
         debug!("MCP tools/call: {} with args: {}", tool_name, arguments);
 
@@ -473,9 +474,93 @@ impl McpServer {
 mod tests {
     use super::{McpCapabilityPolicy, McpPromptInfo, McpServer};
     use crate::client::ResourceInfo;
+    use crate::coerce_mcp_tool_arguments;
+    use async_trait::async_trait;
+    use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
     use hermes_tools::ToolRegistry;
-    use serde_json::json;
+    use serde_json::{json, Value};
     use std::sync::Arc;
+
+    struct EchoArgsHandler;
+
+    #[async_trait]
+    impl ToolHandler for EchoArgsHandler {
+        async fn execute(&self, params: Value) -> Result<String, ToolError> {
+            let kind = match &params {
+                Value::Object(_) => "object",
+                Value::Array(_) => "array",
+                Value::String(_) => "string",
+                _ => "other",
+            };
+            Ok(json!({
+                "kind": kind,
+                "params": params,
+            })
+            .to_string())
+        }
+
+        fn schema(&self) -> ToolSchema {
+            tool_schema("echo_args", "Echo args", JsonSchema::new("object"))
+        }
+    }
+
+    fn registry_with_echo_args() -> Arc<ToolRegistry> {
+        let registry = ToolRegistry::new();
+        let handler = Arc::new(EchoArgsHandler);
+        registry.register(
+            "echo_args",
+            "test",
+            handler.schema(),
+            handler,
+            Arc::new(|| true),
+            vec![],
+            false,
+            "Echo args",
+            "test",
+            None,
+        );
+        Arc::new(registry)
+    }
+
+    #[test]
+    fn stringified_mcp_arguments_coerce_only_objects_and_arrays() {
+        assert_eq!(
+            coerce_mcp_tool_arguments(Value::String(r#"{"path":"Cargo.toml"}"#.to_string())),
+            json!({"path":"Cargo.toml"})
+        );
+        assert_eq!(
+            coerce_mcp_tool_arguments(Value::String(r#"[{"x":1}]"#.to_string())),
+            json!([{"x":1}])
+        );
+        assert_eq!(
+            coerce_mcp_tool_arguments(Value::String(r#""plain""#.to_string())),
+            Value::String(r#""plain""#.to_string())
+        );
+        assert_eq!(
+            coerce_mcp_tool_arguments(Value::String("not json".to_string())),
+            Value::String("not json".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn tools_call_coerces_stringified_object_arguments_before_dispatch() {
+        let server = McpServer::new(registry_with_echo_args());
+        let result = server
+            .handle_request(
+                "tools/call",
+                json!({
+                    "name": "echo_args",
+                    "arguments": "{\"path\":\"Cargo.toml\"}"
+                }),
+            )
+            .await
+            .expect("tools/call");
+
+        let text = result["content"][0]["text"].as_str().expect("text");
+        let payload: Value = serde_json::from_str(text).expect("tool json");
+        assert_eq!(payload["kind"], "object");
+        assert_eq!(payload["params"], json!({"path":"Cargo.toml"}));
+    }
 
     #[tokio::test]
     async fn prompts_get_returns_not_found() {

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -647,6 +647,14 @@
     "a5aecf26fa21": {
       "disposition": "ported",
       "notes": "Rust config/runtime gateway surface now exposes kanban.dispatch_in_gateway with HERMES_KANBAN_DISPATCH_IN_GATEWAY env override, propagates it into GatewayConfig, and includes it in gateway agent cache-busting signatures; Rust has no separate Kanban DB notifier loop to gate."
+    },
+    "165b2e481afa": {
+      "disposition": "ported",
+      "notes": "Rust config/runtime now exposes agent.api_max_retries with apiMaxRetries alias, config patch/display support, HERMES_AGENT_API_MAX_RETRIES env override, and build_agent_config propagation into RetryConfig.max_retries with focused hermes-config/hermes-cli regression coverage."
+    },
+    "9ff21437a03a": {
+      "disposition": "ported",
+      "notes": "Rust MCP tools/call now coerces stringified object/array arguments before dispatch in both exported MCP server paths, leaves non-object scalar strings untouched, and has focused helper plus JSON-RPC runtime regression coverage."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary

Implements two upstream runtime parity commits in Rust:

- `165b2e481afa` / `feat(agent): make API retry count configurable via agent.api_max_retries (#14730)`
- `9ff21437a03a` / `fix(mcp): coerce stringified arrays/objects in tool args`

## Runtime changes

- Added `agent.api_max_retries` / `agent.apiMaxRetries` to Rust config with YAML load, config patch/display, env override via `HERMES_AGENT_API_MAX_RETRIES`, and `build_agent_config` propagation into `RetryConfig.max_retries`.
- Added shared Rust MCP argument coercion for `tools/call` so stringified JSON objects/arrays are parsed before dispatch while scalar/non-JSON strings remain unchanged.
- Applied MCP coercion to both exported server paths: `McpServer` and `HermesMcpServe`.
- Marked both upstream hashes `ported` in `docs/parity/queue-overrides.json`.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr455 CARGO_INCREMENTAL=0 cargo test -p hermes-config agent_api_max_retries -- --nocapture` -> 3 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr455 CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_build_agent_config_maps_agent_api_max_retries -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr455 CARGO_INCREMENTAL=0 cargo test -p hermes-mcp stringified_mcp_arguments -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr455 CARGO_INCREMENTAL=0 cargo test -p hermes-mcp tools_call_coerces_stringified_object -- --nocapture` -> 2 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr455 CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-cli -p hermes-mcp` -> `new=0`, stale allowlist entries unchanged at 5
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr455 CARGO_INCREMENTAL=0 cargo build -p hermes-config -p hermes-cli -p hermes-mcp`
- Queue proof regenerated from fetched `upstream/main`: both target hashes `ported`; `total_commits 9781`; dispositions `{"mirrored": 162, "pending": 1984, "ported": 43, "superseded": 7592}`

## Notes

- Work was completed from `/tmp/hermes-agent-ultra-parity-next` because the original Documents checkout hit a macOS TCC Documents access block in the current Codex process. No recursive chmod or permission churn was used.
