### PR TITLE
parity(tui): export saved sessions and cap tool previews

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -1162,6 +1162,8 @@ struct ResumeSessionPayload {
     session_id: String,
     model: Option<String>,
     personality: Option<String>,
+    system_prompt: Option<String>,
+    session_start: Option<String>,
     messages: Vec<hermes_core::Message>,
 }
 
@@ -1287,6 +1289,20 @@ fn parse_resume_payload_file(
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
         });
+    let system_prompt = doc
+        .get("system_prompt")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let session_start = doc
+        .get("session_start")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            info.and_then(|v| v.get("created_at"))
+                .and_then(|v| v.as_str())
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
 
     let messages_value = doc
         .get("messages")
@@ -1306,6 +1322,8 @@ fn parse_resume_payload_file(
         session_id,
         model,
         personality,
+        system_prompt,
+        session_start,
         messages,
     })
 }
@@ -9739,20 +9757,44 @@ async fn run_dump(
         .as_deref()
         .map(std::path::PathBuf::from)
         .unwrap_or_else(hermes_config::hermes_home);
-    let sessions_dir = home.join("sessions");
-    let session = session.unwrap_or_else(|| "latest".to_string());
-    let out = output.unwrap_or_else(|| format!("{}.dump.json", session));
+    let requested = session.as_deref();
+    let payload = load_resume_payload(&cli, requested)?;
+    let out = output.map(PathBuf::from).unwrap_or_else(|| {
+        home.join("sessions").join("saved").join(format!(
+            "hermes_conversation_{}.json",
+            chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ")
+        ))
+    });
+    if let Some(parent) = out.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            AgentError::Io(format!(
+                "Failed to create dump output directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+    let system_prompt = payload
+        .system_prompt
+        .clone()
+        .or_else(|| leading_system_prompt_for_persist(&payload.messages));
     let payload = serde_json::json!({
-        "session": session,
-        "source_dir": sessions_dir,
-        "note": "Session export scaffold"
+        "session_id": payload.session_id,
+        "resolved_id": payload.resolved_id,
+        "source_path": payload.source_path,
+        "model": payload.model,
+        "personality": payload.personality,
+        "system_prompt": system_prompt,
+        "session_start": payload.session_start,
+        "exported_at": chrono::Utc::now().to_rfc3339(),
+        "messages": payload.messages,
     });
     std::fs::write(
         &out,
         serde_json::to_string_pretty(&payload).unwrap_or_default(),
     )
     .map_err(|e| AgentError::Io(format!("Failed to write dump: {}", e)))?;
-    println!("Wrote dump to {}", out);
+    println!("Wrote dump to {}", out.display());
     Ok(())
 }
 
@@ -16939,6 +16981,61 @@ max_turns: 50
             Some(home) => std::env::set_var("HOME", home),
             None => std::env::remove_var("HOME"),
         }
+    }
+
+    #[tokio::test]
+    async fn run_dump_writes_real_saved_session_export_with_system_prompt() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cli = cli_for_temp_state_root(tmp.path());
+        let sessions_dir = hermes_state_root(&cli).join("sessions");
+        std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+        std::fs::write(
+            sessions_dir.join("abc123.json"),
+            r#"{
+  "session_info": {
+    "session_id": "session-xyz",
+    "model": "nous:openai/gpt-5.5",
+    "personality": "technical",
+    "created_at": "2026-06-05T09:00:00Z"
+  },
+  "system_prompt": "persisted system prompt",
+  "messages": [
+    {"role":"User","content":"hello"},
+    {"role":"Assistant","content":"world"}
+  ]
+}"#,
+        )
+        .expect("write session");
+
+        run_dump(cli, Some("abc123".to_string()), None)
+            .await
+            .expect("dump session");
+
+        let saved_dir = tmp.path().join("sessions").join("saved");
+        let entries = std::fs::read_dir(&saved_dir)
+            .expect("saved dir")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("saved entries");
+        assert_eq!(entries.len(), 1);
+        let path = entries[0].path();
+        assert!(path
+            .file_name()
+            .and_then(|v| v.to_str())
+            .is_some_and(|name| name.starts_with("hermes_conversation_")));
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).expect("read dump"))
+                .expect("parse dump");
+        assert_eq!(doc["session_id"], "session-xyz");
+        assert_eq!(doc["resolved_id"], "abc123");
+        assert_eq!(doc["model"], "nous:openai/gpt-5.5");
+        assert_eq!(doc["personality"], "technical");
+        assert_eq!(doc["system_prompt"], "persisted system prompt");
+        assert_eq!(doc["session_start"], "2026-06-05T09:00:00Z");
+        assert_eq!(doc["messages"].as_array().map(Vec::len), Some(2));
+        assert!(doc["source_path"]
+            .as_str()
+            .is_some_and(|p| p.ends_with("abc123.json")));
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -1522,9 +1522,9 @@ const TRANSCRIPT_CONTENT_WRAP_COLS: usize = 76;
 const OFFSET_ANCHOR_SEARCH_RADIUS: usize = 1200;
 const DEFAULT_MAX_ASSISTANT_RENDER_LINES: usize = 260;
 const MAX_STREAM_RENDER_LINES: usize = 140;
-const DEFAULT_TOOL_OUTPUT_MAX_LINES: usize = 180;
+const DEFAULT_TOOL_OUTPUT_MAX_LINES: usize = 16;
 const DEFAULT_TOOL_OUTPUT_MAX_LINE_CHARS: usize = 600;
-const DEFAULT_TOOL_OUTPUT_MAX_TOTAL_CHARS: usize = 48_000;
+const DEFAULT_TOOL_OUTPUT_MAX_TOTAL_CHARS: usize = 1_024;
 
 fn env_usize_with_bounds(key: &str, default: usize, min: usize, max: usize) -> usize {
     std::env::var(key)
@@ -6280,6 +6280,23 @@ mod tests {
         let joined = lines.join("\n");
         assert!(joined.contains("tool output truncated"));
         assert!(lines.len() <= cap + 8);
+    }
+
+    #[test]
+    fn test_format_tool_message_lines_keeps_verbose_preview_small() {
+        let long = (0..80)
+            .map(|idx| format!("row-{idx}-{}", "x".repeat(120)))
+            .collect::<Vec<_>>()
+            .join("\\n");
+        let payload = format!(r#"{{"result":"{}"}}"#, long);
+        let lines = format_tool_message_lines(&payload);
+        let joined = lines.join("\n");
+
+        assert!(joined.contains("tool output truncated"));
+        assert!(
+            joined.chars().count() < 2_000,
+            "tool preview should stay small enough for retained TUI transcript lines"
+        );
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -655,6 +655,26 @@
     "9ff21437a03a": {
       "disposition": "ported",
       "notes": "Rust MCP tools/call now coerces stringified object/array arguments before dispatch in both exported MCP server paths, leaves non-object scalar strings untouched, and has focused helper plus JSON-RPC runtime regression coverage."
+    },
+    "e02a6038a420": {
+      "disposition": "ported",
+      "notes": "Rust hermes dump now resolves real session snapshots, defaults exports under HERMES_HOME/sessions/saved/hermes_conversation_<timestamp>.json, and includes system_prompt, session_id, session_start, source_path, model/personality, exported_at, and messages with regression coverage."
+    },
+    "e76d8bf5aaa9": {
+      "disposition": "ported",
+      "notes": "Rust TUI tool-output rendering now defaults to a small 16-line/1KiB retained preview while preserving full agent context/session storage; regression coverage pins truncation and preview-size behavior."
+    },
+    "98903d03139d": {
+      "disposition": "superseded",
+      "notes": "Upstream Python/Node TUI gateway live-session reuse fix targets a separate gateway/socket runtime; Rust resume restores persisted snapshots directly into a single App under the interactive-session lock with existing load_resume_payload/run_resume coverage."
+    },
+    "bd6d0987629e": {
+      "disposition": "superseded",
+      "notes": "Upstream Python TUI gateway live-history hydration race is absent in Rust's direct resume path: resumed messages become App.messages before the TUI loop starts, and subsequent turns append to the same Rust state vector."
+    },
+    "8077e7d2fbbb": {
+      "disposition": "superseded",
+      "notes": "Upstream _session_resume_lock narrowing applies to Python TUI gateway concurrent live-agent construction; Rust interactive resume is guarded by the process-level interactive session lock and has no session.close RPC lock path to port."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary

Implements the next Rust TUI/session parity slice:

- `e02a6038a420` / `fix(tui): save TUI /save snapshots under Hermes home with system prompt (#38251)` -> ported via real Rust `hermes dump` exports
- `e76d8bf5aaa9` / `fix(tui): stop persisting full tool output in trail lines (silent OOM death)` -> ported via smaller Rust TUI tool-output previews
- `98903d03139d`, `bd6d0987629e`, `8077e7d2fbbb` -> superseded by Rust's direct resume architecture / process-level interactive lock rather than Python TUI gateway live-session locks

## Runtime changes

- Replaced the `hermes dump` scaffold with a real session export:
  - resolves the requested/latest persisted session
  - defaults to `<HERMES_HOME>/sessions/saved/hermes_conversation_<timestamp>.json`
  - includes `system_prompt`, `session_id`, `session_start`, source path, model/personality, `exported_at`, and messages
- Extended resume snapshot parsing to carry optional `system_prompt` and `session_start` metadata.
- Reduced Rust TUI tool-output preview defaults from 180 lines / 48 KiB to 16 lines / 1 KiB while preserving full agent context/session storage.
- Updated `docs/parity/queue-overrides.json` for the five upstream hashes.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr456 CARGO_INCREMENTAL=0 cargo test -p hermes-cli run_dump_writes_real_saved_session_export_with_system_prompt -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr456 CARGO_INCREMENTAL=0 cargo test -p hermes-cli load_resume_payload_restores_metadata_and_messages -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr456 CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_format_tool_message_lines_keeps_verbose_preview_small -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr456 CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_format_tool_message_lines_truncates_large_payload -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr456 CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli` -> `new=0`, stale allowlist entries unchanged at 5
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-pr456 CARGO_INCREMENTAL=0 cargo build -p hermes-cli`
- Queue proof regenerated: `e02a6038a420` ported; `e76d8bf5aaa9` ported; `98903d03139d`, `bd6d0987629e`, `8077e7d2fbbb` superseded; `total_commits 9781`; dispositions `{"mirrored": 162, "pending": 1979, "ported": 45, "superseded": 7595}`

## Notes

- Autosave/resume snapshots remain under `<HERMES_HOME>/sessions`; moving those would regress Rust `resume`. This patch ports the explicit saved export behavior through `hermes dump`.
- No live TUI session was started; coverage is focused Rust unit/runtime export/render behavior.
