### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-config"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "hermes-cli",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "once_cell",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/crates/hermes-gateway/src/media.rs
+++ b/crates/hermes-gateway/src/media.rs
@@ -1022,7 +1022,7 @@ mod tests {
         std::fs::create_dir_all(&ssh_dir).unwrap();
         std::fs::create_dir_all(&hermes_home).unwrap();
         let key = ssh_dir.join("id_rsa");
-        std::fs::write(&key, b"-----BEGIN OPENSSH PRIVATE KEY-----").unwrap();
+        std::fs::write(&key, b"test fixture credential marker").unwrap();
         let policy = test_media_policy(&fake_home, &hermes_home, vec![fake_home.clone()]);
 
         assert!(
@@ -1081,7 +1081,7 @@ mod tests {
         std::fs::create_dir_all(&workdir).unwrap();
         std::fs::create_dir_all(&hermes_home).unwrap();
         let key = ssh_dir.join("id_rsa");
-        std::fs::write(&key, b"-----BEGIN OPENSSH PRIVATE KEY-----").unwrap();
+        std::fs::write(&key, b"test fixture credential marker").unwrap();
         let link = workdir.join("innocent.pdf");
         std::os::unix::fs::symlink(&key, &link).unwrap();
         let policy = test_media_policy(&fake_home, &hermes_home, vec![fake_home.clone()]);

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -47,7 +47,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-03T01:37:11.037Z",
+  "generated_at_utc": "2026-06-05T19:35:15.967398+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-03T01:37:11.037Z`
+Generated: `2026-06-05T19:35:15.967398+00:00`
 
 ## Gate Status
 

--- a/docs/releases/v0.16.0.md
+++ b/docs/releases/v0.16.0.md
@@ -1,0 +1,73 @@
+# Hermes Agent Ultra v0.16.0
+
+Release date: 2026-06-05
+
+This release picks up the post-`v0.15.0` parity closes on `main`: Honcho/Kanban runtime surfaces, configurable agent API retry behavior, MCP tool-argument coercion, and TUI/session export hardening. It is intentionally small relative to `v0.15.0`; the goal is to publish the newly merged Rust runtime parity work before the next backlog batch continues.
+
+## Release Slice
+
+```mermaid
+flowchart LR
+    A[v0.15.0 parity sprint] --> B[#454 Honcho/Kanban runtime surfaces]
+    B --> C[#455 Retry config + MCP coercion]
+    C --> D[#456 TUI session export + tool preview caps]
+    D --> E[v0.16.0 release]
+
+    C --> C1[agent.api_max_retries]
+    C --> C2[stringified MCP arrays/objects]
+    D --> D1[Hermes home saved exports]
+    D --> D2[bounded verbose tool output]
+```
+
+| Signal | v0.16.0 State |
+| --- | --- |
+| First-parent commits since `v0.15.0` | 3 |
+| Release coverage | PRs `#454`, `#455`, `#456` |
+| Upstream queue total | 9,781 |
+| Queue dispositions | 45 ported / 7,595 superseded / 162 mirrored / 1,979 pending |
+| Runtime language posture | Rust-first; no Python runtime fallback added |
+| Coexistence posture | Ultra aliases remain `hermes-agent-ultra` / `hermes-ultra` by default |
+| Global release gate | PASS |
+
+## What Changed
+
+- Added Honcho/Kanban Rust runtime parity surfaces from the preceding merged batch.
+- Added `agent.api_max_retries` configuration, including YAML alias support, environment override support, config-display coverage, and mapping into the Rust agent retry config.
+- Added MCP tool argument coercion so stringified JSON arrays/objects are normalized before Rust MCP tool invocation.
+- Reworked `hermes dump` into a real saved-session export under the Hermes home, preserving session metadata, model/personality fields, source path, system prompt, and message history.
+- Bounded verbose TUI tool-output previews to avoid persisting or rendering pathological full-output trails.
+- Preserved upstream coexistence: default installs expose Ultra as `hermes-agent-ultra` / `hermes-ultra` and do not clobber upstream NousResearch `hermes` unless users opt into the legacy alias.
+
+## Verification
+
+Post-merge parity verification for PRs `#455` and `#456` covered the runtime behavior:
+
+```bash
+cargo fmt --all --check
+git diff --check
+scripts/check-rust-runtime-no-python.sh
+scripts/check-runtime-placeholders.sh
+cargo test -p hermes-config agent_api_max_retries -- --nocapture
+cargo test -p hermes-cli test_build_agent_config_maps_agent_api_max_retries -- --nocapture
+cargo test -p hermes-mcp stringified_mcp_arguments -- --nocapture
+cargo test -p hermes-mcp tools_call_coerces_stringified_object -- --nocapture
+cargo test -p hermes-cli run_dump_writes_real_saved_session_export_with_system_prompt -- --nocapture
+cargo test -p hermes-cli test_format_tool_message_lines_keeps_verbose_preview_small -- --nocapture
+cargo build -p hermes-config -p hermes-cli -p hermes-mcp
+cargo build -p hermes-cli
+```
+
+Release-prep verification for this tag covered the metadata bump, parity gates, release scan, and the fixture-only media test adjustment:
+
+```bash
+cargo metadata --format-version 1 --no-deps
+python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release
+cargo fmt --all --check
+git diff --check
+scripts/check-rust-runtime-no-python.sh
+scripts/check-runtime-placeholders.sh
+python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan-v0.16.0.json
+cargo test -p hermes-gateway media_delivery_blocks -- --nocapture
+```
+
+The GitHub release workflow builds platform artifacts, signs release archives, attaches the SBOM, and publishes the generated release assets for tag `v0.16.0`.

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       in {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "hermes-agent";
-          version = "0.15.0";
+          version = "0.16.0";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
 


### PR DESCRIPTION
## Summary
- bump Hermes workspace metadata from `0.15.0` to `0.16.0`
- add `docs/releases/v0.16.0.md` covering PRs #454, #455, and #456
- regenerate global parity proof timestamps/gates
- de-literalize two test-only OpenSSH private-key fixture markers so the release secret scan remains strict

## Parity / Release Status
- latest prior GitHub Release: `v0.15.0`, published `2026-06-03T08:40:34Z`
- current release coverage: 3 first-parent commits since `v0.15.0`
- queue proof: `total=9781`, `ported=45`, `superseded=7595`, `mirrored=162`, `pending=1979`
- global parity proof: CI `PASS`, release `PASS`

## Verification
- `cargo metadata --format-version 1 --no-deps`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan-v0.16.0.json`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-release-v016 CARGO_INCREMENTAL=0 cargo test -p hermes-gateway media_delivery_blocks -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-release-v016 CARGO_INCREMENTAL=0 cargo build -p hermes-cli`
