### PR TITLE
parity(provider): preserve vision tool results for Xiaomi

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -553,8 +553,11 @@ impl GenericProvider {
         messages: &[Message],
         enabled: bool,
         effective_model: &str,
+        profile: Option<&str>,
+        extra_body: Option<&Value>,
     ) -> Value {
-        let model_supports_vision = supports_vision(effective_model);
+        let model_supports_vision =
+            Self::supports_multimodal_tool_results(profile, effective_model, extra_body);
         let mut out = Vec::with_capacity(messages.len());
         for msg in messages {
             let mut api_msg = serde_json::to_value(msg).unwrap_or_else(|_| serde_json::json!({}));
@@ -611,6 +614,20 @@ impl GenericProvider {
         Value::Array(out)
     }
 
+    fn supports_multimodal_tool_results(
+        profile: Option<&str>,
+        effective_model: &str,
+        extra_body: Option<&Value>,
+    ) -> bool {
+        if let Some(value) = extra_body
+            .and_then(|body| body.get("supports_vision"))
+            .and_then(Value::as_bool)
+        {
+            return value;
+        }
+        profile.is_some_and(provider_profiles::supports_vision) || supports_vision(effective_model)
+    }
+
     fn format_tools_for_openai_api(tools: &[ToolSchema]) -> Value {
         let formatted = Value::Array(
             tools
@@ -642,8 +659,13 @@ impl GenericProvider {
         } = request;
         let profile = self.profile_for_extra_body(extra_body);
         let strict_tool_sanitize = Self::should_sanitize_tool_calls(extra_body);
-        let mut api_messages =
-            Self::sanitize_messages_for_api(messages, strict_tool_sanitize, effective_model);
+        let mut api_messages = Self::sanitize_messages_for_api(
+            messages,
+            strict_tool_sanitize,
+            effective_model,
+            profile,
+            extra_body,
+        );
         provider_profiles::normalize_messages_for_profile(profile, &mut api_messages);
 
         let mut body = serde_json::json!({
@@ -2825,6 +2847,7 @@ mod tests {
             "provider_strict": true,
             "provider_profile": "openrouter",
             "provider_preferences": {"allow": ["anthropic"]},
+            "supports_vision": true,
             "temperature": 0.2
         });
         let mut body = serde_json::json!({"model": "m", "messages": []});
@@ -2834,6 +2857,7 @@ mod tests {
         assert!(body.get("provider_strict").is_none());
         assert!(body.get("provider_profile").is_none());
         assert!(body.get("provider_preferences").is_none());
+        assert!(body.get("supports_vision").is_none());
         assert_eq!(body["temperature"], 0.2);
     }
 
@@ -3065,7 +3089,8 @@ mod tests {
             }],
         )];
 
-        let sanitized = GenericProvider::sanitize_messages_for_api(&messages, true, "gpt-4o");
+        let sanitized =
+            GenericProvider::sanitize_messages_for_api(&messages, true, "gpt-4o", None, None);
         let tc = &sanitized[0]["tool_calls"][0];
         assert_eq!(tc["id"], "call_123");
         assert_eq!(tc["type"], "function");
@@ -3088,7 +3113,8 @@ mod tests {
                 extra_content: None,
             }],
         )];
-        let sanitized = GenericProvider::sanitize_messages_for_api(&messages, false, "gpt-4o");
+        let sanitized =
+            GenericProvider::sanitize_messages_for_api(&messages, false, "gpt-4o", None, None);
         let tc = &sanitized[0]["tool_calls"][0];
         assert_eq!(tc["name"], "read_file");
         assert_eq!(tc["arguments"], "{\"path\":\"a.txt\"}");
@@ -3103,7 +3129,8 @@ mod tests {
         ]);
         let marker = format!("{}{}", ACP_MULTIMODAL_PREFIX, parts);
         let messages = vec![Message::user(marker)];
-        let sanitized = GenericProvider::sanitize_messages_for_api(&messages, false, "gpt-4o");
+        let sanitized =
+            GenericProvider::sanitize_messages_for_api(&messages, false, "gpt-4o", None, None);
         assert!(sanitized[0]["content"].is_array());
         assert_eq!(sanitized[0]["content"][1]["type"], "image_url");
     }
@@ -3116,12 +3143,67 @@ mod tests {
         ]);
         let marker = format!("{}{}", ACP_MULTIMODAL_PREFIX, parts);
         let messages = vec![Message::user(marker)];
-        let sanitized =
-            GenericProvider::sanitize_messages_for_api(&messages, false, "deepseek-chat");
+        let sanitized = GenericProvider::sanitize_messages_for_api(
+            &messages,
+            false,
+            "deepseek-chat",
+            None,
+            None,
+        );
         let content = sanitized[0]["content"].as_str().expect("collapsed text");
         assert!(content.contains("inspect"));
         assert!(content.contains("[Attached image]"));
         assert!(!content.contains("image_url"));
+    }
+
+    #[test]
+    fn test_provider_profile_vision_preserves_acp_multimodal_parts() {
+        let parts = serde_json::json!([
+            {"type": "text", "text": "inspect"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+        ]);
+        let messages = vec![Message::user(format!("{ACP_MULTIMODAL_PREFIX}{parts}"))];
+        let provider = GenericProvider::new("https://api.xiaomimimo.com/v1", "key", "mimo-v2-omni")
+            .with_provider_profile("mimo");
+
+        let body = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "mimo-v2-omni",
+            extra_body: None,
+            stream: false,
+        });
+
+        assert_eq!(body["messages"][0]["content"][1]["type"], "image_url");
+    }
+
+    #[test]
+    fn test_supports_vision_override_can_disable_multimodal_parts() {
+        let parts = serde_json::json!([
+            {"type": "text", "text": "inspect"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+        ]);
+        let messages = vec![Message::user(format!("{ACP_MULTIMODAL_PREFIX}{parts}"))];
+        let provider = GenericProvider::new("https://api.openai.com/v1", "key", "gpt-4o");
+        let extra = serde_json::json!({"supports_vision": false});
+
+        let body = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "gpt-4o",
+            extra_body: Some(&extra),
+            stream: false,
+        });
+
+        let content = body["messages"][0]["content"]
+            .as_str()
+            .expect("collapsed text");
+        assert!(content.contains("[Attached image]"));
+        assert!(body.get("supports_vision").is_none());
     }
 
     #[test]

--- a/crates/hermes-agent/src/provider_profiles.rs
+++ b/crates/hermes-agent/src/provider_profiles.rs
@@ -20,6 +20,7 @@ pub fn canonical_provider_profile_id(provider: &str) -> Option<&'static str> {
         "openrouter" | "or" => Some("openrouter"),
         "nous" | "nous-portal" => Some("nous"),
         "qwen" | "qwen-oauth" | "qwen-portal" | "qwen-cli" => Some("qwen-oauth"),
+        "xiaomi" | "mimo" | "xiaomi-mimo" => Some("xiaomi"),
         "custom" | "ollama" | "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane"
         | "sglang" | "tgi" => Some("custom"),
         _ => None,
@@ -42,11 +43,20 @@ pub fn omit_temperature(profile: &str) -> bool {
     )
 }
 
+pub fn supports_vision(profile: &str) -> bool {
+    matches!(
+        canonical_provider_profile_id(profile),
+        Some("anthropic" | "nous" | "openrouter" | "qwen-oauth" | "xiaomi")
+    )
+}
+
 pub fn profile_auth_type(profile: &str) -> Option<&'static str> {
     match canonical_provider_profile_id(profile)? {
         "nous" => Some("oauth_device_code"),
         "qwen-oauth" => Some("oauth_external"),
-        "nvidia" | "kimi-coding" | "kimi-coding-cn" | "openrouter" | "custom" => Some("api_key"),
+        "nvidia" | "kimi-coding" | "kimi-coding-cn" | "openrouter" | "xiaomi" | "custom" => {
+            Some("api_key")
+        }
         _ => None,
     }
 }
@@ -59,6 +69,7 @@ pub fn profile_base_url(profile: &str) -> Option<&'static str> {
         "openrouter" => Some("https://openrouter.ai/api/v1"),
         "nous" => Some("https://inference-api.nousresearch.com/v1"),
         "qwen-oauth" => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+        "xiaomi" => Some("https://api.xiaomimimo.com/v1"),
         _ => None,
     }
 }
@@ -75,6 +86,7 @@ pub fn local_control_key_for_profile(profile: Option<&str>, key: &str) -> bool {
             | "reasoning_config"
             | "provider_preferences"
             | "openrouter_min_coding_score"
+            | "supports_vision"
             | "session_id"
             | "qwen_session_metadata"
             | "ollama_num_ctx"
@@ -346,6 +358,8 @@ mod tests {
         assert_eq!(canonical_provider_profile_id("or"), Some("openrouter"));
         assert_eq!(canonical_provider_profile_id("nous-portal"), Some("nous"));
         assert_eq!(canonical_provider_profile_id("qwen"), Some("qwen-oauth"));
+        assert_eq!(canonical_provider_profile_id("mimo"), Some("xiaomi"));
+        assert_eq!(canonical_provider_profile_id("xiaomi-mimo"), Some("xiaomi"));
         assert_eq!(
             canonical_provider_profile_id("qwen-portal"),
             Some("qwen-oauth")
@@ -365,6 +379,9 @@ mod tests {
         assert!(profile_base_url("kimi-coding-cn")
             .unwrap()
             .contains("moonshot.cn"));
+        assert!(profile_base_url("mimo").unwrap().contains("xiaomimimo.com"));
+        assert!(supports_vision("xiaomi"));
+        assert!(!supports_vision("kimi"));
     }
 
     #[test]

--- a/crates/hermes-intelligence/src/auxiliary/candidate.rs
+++ b/crates/hermes-intelligence/src/auxiliary/candidate.rs
@@ -260,4 +260,16 @@ mod tests {
         let v = chain.vision_only();
         assert_eq!(v.labels(), vec!["openrouter"]);
     }
+
+    #[test]
+    fn custom_and_direct_key_candidates_default_to_vision_capable() {
+        let custom = cand(AuxiliarySource::Custom, "custom-vision-model");
+        let xiaomi = cand(AuxiliarySource::DirectKey("xiaomi".into()), "mimo-v2.5-pro");
+        let kimi =
+            cand(AuxiliarySource::DirectKey("kimi".into()), "kimi-k2").with_supports_vision(false);
+
+        assert!(custom.supports_vision);
+        assert!(xiaomi.supports_vision);
+        assert!(!kimi.supports_vision);
+    }
 }

--- a/crates/hermes-intelligence/src/model_metadata.rs
+++ b/crates/hermes-intelligence/src/model_metadata.rs
@@ -306,6 +306,30 @@ pub fn known_models() -> Vec<ModelInfo> {
             output_cost_per_million: Some(0.40),
         },
         ModelInfo {
+            name: "mimo-v2.5-pro".into(),
+            provider: "xiaomi".into(),
+            context_window: 1_000_000,
+            max_output_tokens: None,
+            supports_vision: true,
+            supports_tools: true,
+            supports_streaming: true,
+            supports_reasoning: false,
+            input_cost_per_million: None,
+            output_cost_per_million: None,
+        },
+        ModelInfo {
+            name: "mimo-v2.5".into(),
+            provider: "xiaomi".into(),
+            context_window: 1_000_000,
+            max_output_tokens: None,
+            supports_vision: true,
+            supports_tools: true,
+            supports_streaming: true,
+            supports_reasoning: false,
+            input_cost_per_million: None,
+            output_cost_per_million: None,
+        },
+        ModelInfo {
             name: "deepseek-chat".into(),
             provider: "deepseek".into(),
             context_window: 128_000,
@@ -705,12 +729,18 @@ mod tests {
         let info = get_model_info("gpt-4o").unwrap();
         assert_eq!(info.context_window, 128_000);
         assert!(info.supports_vision);
+        let mimo = get_model_info("xiaomi/mimo-v2.5-pro").unwrap();
+        assert_eq!(mimo.provider, "xiaomi");
+        assert_eq!(mimo.context_window, 1_000_000);
+        assert!(mimo.supports_vision);
     }
 
     #[test]
     fn test_supports_vision() {
         assert!(supports_vision("gpt-4o"));
         assert!(supports_vision("claude-opus-4-6"));
+        assert!(supports_vision("xiaomi/mimo-v2.5-pro"));
+        assert!(supports_vision("mimo-v2.5"));
         assert!(!supports_vision("deepseek-chat"));
     }
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -683,6 +683,26 @@
     "46b2afc56b79": {
       "disposition": "ported",
       "notes": "Rust session persistence now runs PRAGMA wal_checkpoint(TRUNCATE) after startup auto-maintenance and exposes truncate_wal_checkpoint(); regression tests force WAL growth and assert the sessions.db-wal sidecar shrinks to zero."
+    },
+    "86c64cfb5bd5": {
+      "disposition": "superseded",
+      "notes": "Upstream Discord timeout fix targets Python discord.ui.View message editing. Rust Discord interactions are stateless REST responses/edits and have no discord.ui.View lifecycle; the existing model-picker edit contract already clears components when edits are sent."
+    },
+    "fff0561441d2": {
+      "disposition": "superseded",
+      "notes": "Google Chat OAuth client-secret anchoring is Python adapter-only in upstream; this Rust gateway surface has no Google Chat platform adapter or OAuth helper under crates/hermes-gateway, so no Rust runtime path exists to port."
+    },
+    "7309f3bef7d7": {
+      "disposition": "superseded",
+      "notes": "LINE inbound message-type mapping is Python adapter-only in upstream; this Rust gateway surface has no LINE platform adapter under crates/hermes-gateway and no MessageType.IMAGE crash path to port."
+    },
+    "f736d2be86b8": {
+      "disposition": "ported",
+      "notes": "Rust provider profiles now expose Xiaomi/MiMo as vision-capable, supports_vision can be overridden locally without leaking to provider requests, Xiaomi MiMo models carry vision metadata, and focused Rust tests prove ACP multimodal image parts stay native for vision providers."
+    },
+    "96cd37e212e8": {
+      "disposition": "superseded",
+      "notes": "Upstream leak fix targets Python TUI gateway detached transports and _SlashWorker subprocesses. Rust HTTP websocket handling has no detached slash-worker subprocess lifecycle; in-process SessionManager already exposes explicit remove/idle-expire cleanup APIs."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Ported upstream provider-vision parity for Xiaomi/MiMo into the Rust runtime.
- Added provider-profile and model-metadata vision capability gates so ACP multimodal image tool results stay native for Xiaomi/MiMo and other explicitly vision-capable profiles.
- Added focused Rust regression tests and recorded evidence-backed queue dispositions for Python-only gateway deltas with no Rust adapter/runtime surface.

## Queue Delta
- `pending`: 1977 -> 1972
- `ported`: 47 -> 48
- `superseded`: 7595 -> 7599

## Verification
- `cargo fmt --all --check`
- `python3 -m json.tool docs/parity/queue-overrides.json`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-provider-gateway CARGO_INCREMENTAL=0 cargo test -p hermes-agent vision -- --nocapture` -> 4 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-provider-gateway CARGO_INCREMENTAL=0 cargo test -p hermes-agent provider_profile -- --nocapture` -> 8 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-provider-gateway-intel CARGO_INCREMENTAL=0 cargo test -p hermes-intelligence vision -- --nocapture` -> 5 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-provider-gateway-intel CARGO_INCREMENTAL=0 cargo test -p hermes-intelligence test_get_model_info -- --nocapture` -> 1 passed
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-provider-gateway-queue.json --out-md /tmp/hermes-provider-gateway-queue.md`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-provider-gateway CARGO_INCREMENTAL=0 cargo build -p hermes-agent -p hermes-intelligence`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-provider-gateway CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-intelligence` -> `seen=199 allowlist=204 new=0 stale=5`

## ContextLattice
- Checkpoint: `notes/codex_gpt5/provider-gateway-runtime-pr.md`
- Object: `obj_b138d2b58f1b379d28edcd4c`
- Content hash: `0bb9356f37ad07bd2f660e91eaee0880042442051284b2f1d70836c88cdc19e6`
