### PR TITLE
parity(tools): prove core tool surfaces

### DIFF
--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -1101,6 +1101,39 @@ mod tests {
     }
 
     #[test]
+    fn builtin_registry_registers_core_tool_surfaces_for_parity() {
+        let _lock = lock_env();
+        let home = tempfile::tempdir().expect("temp home");
+        let _home = EnvGuard::set("HOME", home.path().to_string_lossy().as_ref());
+        let _terminal_env = EnvGuard::set("TERMINAL_ENV", "local");
+        let names = registered_names();
+
+        for expected in [
+            "terminal",
+            "process",
+            "process_registry",
+            "todo",
+            "text_to_speech",
+            "tts_premium",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
+        ] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "builtin registry should expose {expected}"
+            );
+        }
+    }
+
+    #[test]
     fn browser_tool_surface_exposes_current_commands_without_legacy_close() {
         let _lock = lock_env();
         let home = tempfile::tempdir().expect("temp home");

--- a/crates/hermes-tools/tests/upstream_core_tool_contracts.rs
+++ b/crates/hermes-tools/tests/upstream_core_tool_contracts.rs
@@ -7,8 +7,9 @@ use hermes_tools::{
     ClarifyBackend, ClarifyHandler, CodeExecutionBackend, CronjobBackend, CronjobHandler,
     ExecuteCodeHandler, HaCallServiceHandler, HaGetStateHandler, HaListEntitiesHandler,
     HaListServicesHandler, HomeAssistantBackend, MemoryBackend, MemoryHandler, MessagingBackend,
-    ProcessRegistryHandler, SendMessageHandler, SessionSearchBackend, SessionSearchHandler,
-    ToolRegistry,
+    ProcessBackend, ProcessHandler, ProcessRegistryHandler, SendMessageHandler,
+    SessionSearchBackend, SessionSearchHandler, TerminalHandler, TextToSpeechHandler, TodoBackend,
+    TodoHandler, ToolRegistry, TtsBackend,
 };
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
@@ -732,6 +733,189 @@ impl TerminalBackend for MinimalTerminalBackend {
 
     async fn file_exists(&self, _path: &str) -> Result<bool, AgentError> {
         Ok(true)
+    }
+}
+
+struct MinimalProcessBackend;
+
+#[async_trait]
+impl ProcessBackend for MinimalProcessBackend {
+    async fn list_processes(&self) -> Result<String, ToolError> {
+        Ok("[]".to_string())
+    }
+
+    async fn poll_process(&self, session_id: &str) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "status": "running"}).to_string())
+    }
+
+    async fn read_process_log(
+        &self,
+        session_id: &str,
+        offset: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "offset": offset, "limit": limit}).to_string())
+    }
+
+    async fn wait_process(
+        &self,
+        session_id: &str,
+        timeout: Option<u64>,
+    ) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "timeout": timeout, "status": "exited"}).to_string())
+    }
+
+    async fn kill_process(&self, session_id: &str) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "status": "killed"}).to_string())
+    }
+
+    async fn write_stdin(&self, session_id: &str, data: &str) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "data": data}).to_string())
+    }
+
+    async fn submit_process(&self, session_id: &str, input: &str) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "input": input}).to_string())
+    }
+
+    async fn close_process(&self, session_id: &str) -> Result<String, ToolError> {
+        Ok(json!({"session_id": session_id, "closed": true}).to_string())
+    }
+}
+
+struct MinimalTodoBackend;
+
+#[async_trait]
+impl TodoBackend for MinimalTodoBackend {
+    async fn create(
+        &self,
+        title: &str,
+        _description: Option<&str>,
+        _priority: Option<&str>,
+    ) -> Result<String, ToolError> {
+        Ok(json!({"created": title}).to_string())
+    }
+
+    async fn update(
+        &self,
+        id: &str,
+        _title: Option<&str>,
+        _description: Option<&str>,
+        _status: Option<&str>,
+        _priority: Option<&str>,
+    ) -> Result<String, ToolError> {
+        Ok(json!({"updated": id}).to_string())
+    }
+
+    async fn list(&self, status: Option<&str>) -> Result<String, ToolError> {
+        Ok(json!({"status": status, "items": []}).to_string())
+    }
+}
+
+struct MinimalTtsBackend;
+
+#[async_trait]
+impl TtsBackend for MinimalTtsBackend {
+    async fn synthesize(
+        &self,
+        text: &str,
+        voice: Option<&str>,
+        provider: Option<&str>,
+        output_path: Option<&str>,
+        speed: Option<f64>,
+    ) -> Result<String, ToolError> {
+        Ok(json!({
+            "text": text,
+            "voice": voice,
+            "provider": provider,
+            "output_path": output_path,
+            "speed": speed
+        })
+        .to_string())
+    }
+}
+
+fn rendered_schema(handler: &dyn ToolHandler) -> (String, String) {
+    let schema = handler.schema();
+    let rendered = serde_json::to_string(&schema.parameters).expect("schema json");
+    (schema.name, rendered)
+}
+
+#[test]
+fn core_runtime_tool_schemas_cover_terminal_process_todo_and_tts_parity() {
+    let (terminal_name, terminal_schema) =
+        rendered_schema(&TerminalHandler::new(Arc::new(MinimalTerminalBackend)));
+    assert_eq!(terminal_name, "terminal");
+    for expected in [
+        "\"command\"",
+        "\"timeout\"",
+        "\"background\"",
+        "\"pty\"",
+        "\"stdin_data\"",
+        "background=true",
+    ] {
+        assert!(
+            terminal_schema.contains(expected),
+            "terminal schema should include {expected}"
+        );
+    }
+
+    let (process_name, process_schema) =
+        rendered_schema(&ProcessHandler::new(Arc::new(MinimalProcessBackend)));
+    assert_eq!(process_name, "process");
+    for expected in [
+        "\"list\"",
+        "\"poll\"",
+        "\"log\"",
+        "\"wait\"",
+        "\"kill\"",
+        "\"write\"",
+        "\"submit\"",
+        "\"close\"",
+        "\"session_id\"",
+        "\"data\"",
+        "\"input\"",
+        "terminal(background=true)",
+    ] {
+        assert!(
+            process_schema.contains(expected),
+            "process schema should include {expected}"
+        );
+    }
+
+    let (todo_name, todo_schema) = rendered_schema(&TodoHandler::new(Arc::new(MinimalTodoBackend)));
+    assert_eq!(todo_name, "todo");
+    for expected in [
+        "\"create\"",
+        "\"update\"",
+        "\"list\"",
+        "\"title\"",
+        "\"status\"",
+        "\"priority\"",
+    ] {
+        assert!(
+            todo_schema.contains(expected),
+            "todo schema should include {expected}"
+        );
+    }
+
+    let (tts_name, tts_schema) =
+        rendered_schema(&TextToSpeechHandler::new(Arc::new(MinimalTtsBackend)));
+    assert_eq!(tts_name, "text_to_speech");
+    for expected in [
+        "\"text\"",
+        "\"voice\"",
+        "\"provider\"",
+        "\"output_path\"",
+        "\"speed\"",
+        "\"elevenlabs\"",
+        "\"openai\"",
+        "\"minimax\"",
+        "\"piper\"",
+    ] {
+        assert!(
+            tts_schema.contains(expected),
+            "tts schema should include {expected}"
+        );
     }
 }
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -703,6 +703,42 @@
     "96cd37e212e8": {
       "disposition": "superseded",
       "notes": "Upstream leak fix targets Python TUI gateway detached transports and _SlashWorker subprocesses. Rust HTTP websocket handling has no detached slash-worker subprocess lifecycle; in-process SessionManager already exposes explicit remove/idle-expire cleanup APIs."
+    },
+    "122d8788ae23": {
+      "disposition": "ported",
+      "notes": "rust terminal handler provides first-class terminal command execution through TerminalHandler, TOOLSET_TERMINAL, and builtin registry coverage; upstream_core_tool_contracts verifies command/timeout/background/pty/stdin_data schema surface"
+    },
+    "a49596cbb2c1": {
+      "disposition": "ported",
+      "notes": "rust terminal tool refinement is covered by the same TerminalHandler/runtime registry surface, with tests for foreground timeout caps, background guidance, stdin_data, and schema parity"
+    },
+    "20f287547275": {
+      "disposition": "superseded",
+      "notes": "rust browser runtime does not use the Python browser_tool session supervisor; Browserbase/Browser Use backends manage sessions with provider timeout/close contracts and builtin browser surface tests cover the current browser commands without legacy browser_close"
+    },
+    "971ed2bbdf61": {
+      "disposition": "ported",
+      "notes": "rust terminal handler supports sudo password transformation via SUDO_PASSWORD with shell quoting and approval safeguards; crates/hermes-tools/src/tools/terminal.rs tests cover sudo denial, yolo boundaries, and password quoting"
+    },
+    "76d929e17725": {
+      "disposition": "ported",
+      "notes": "rust approval manager and terminal handler implement dangerous command confirmation/denial, hardline blocks, gateway approvals, and session yolo controls with extensive tests in crates/hermes-tools/src/approval.rs and terminal handler tests"
+    },
+    "f5be6177b231": {
+      "disposition": "ported",
+      "notes": "rust text_to_speech/tts_premium tools, MultiTtsBackend providers, gateway voice send surfaces, and voice-compatible media tags cover the upstream TTS product surface; new registry/schema contract proves first-class TTS exposure"
+    },
+    "061fa7090720": {
+      "disposition": "ported",
+      "notes": "rust terminal/process/process_registry surface implements background=true, process list/poll/log/wait/kill/write/submit/close, PTY, stdin_data, and registry exposure; new core runtime schema contract plus terminal/process tests cover it"
+    },
+    "e184f5ab3a51": {
+      "disposition": "ported",
+      "notes": "rust TodoHandler and FileTodoBackend provide create/update/list task management with TOOLSET_TODO and builtin registry exposure; new schema contract proves first-class todo runtime surface"
+    },
+    "9e85408c7bfd": {
+      "disposition": "ported",
+      "notes": "rust todo tool remains first-class in CLI/API toolsets and builtin registration; existing toolset tests and new registry/schema contract cover create/update/list parity"
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add Rust contract coverage proving first-class terminal/process/todo/TTS/browser tool registration
- add schema coverage for terminal background/PTY/stdin, process lifecycle actions, todo actions, and TTS provider/output controls
- update parity queue overrides for 9 upstream tool-surface commits: 8 ported, 1 superseded

## Queue Delta
- pending: 1972 -> 1963
- ported: 48 -> 56
- superseded: 7599 -> 7600

## Verification
- cargo fmt --all --check
- python3 -m json.tool docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-core-tool-queue.json --out-md /tmp/hermes-core-tool-queue.md
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo test -p hermes-tools core_runtime_tool_schemas_cover_terminal_process_todo_and_tts_parity -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo test -p hermes-tools builtin_registry_registers_core_tool_surfaces_for_parity -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_terminal_handler -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_process_handler -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo test -p hermes-tools tts -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo test -p hermes-tools todo -- --nocapture
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core CARGO_INCREMENTAL=0 cargo build -p hermes-tools
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-tools-core-clippy CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-tools (new=0, stale=5)

## Notes
- Marginal diff helper was not present in this checkout, so that check was skipped explicitly.
