### PR TITLE
parity(gateway): deliver media markers

### DIFF
--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -28,7 +28,7 @@ use crate::commands::{handle_command, GatewayCommandResult};
 use crate::dm::{DmDecision, DmManager};
 use crate::hooks::{HookEvent, HookRegistry};
 use crate::media::validate_media_delivery_path;
-use crate::platforms::helpers::extract_inline_images;
+use crate::platforms::helpers::{extract_inline_images, extract_media_markers};
 use crate::session::{Session, SessionManager};
 use crate::stream::{StreamConfig, StreamManager};
 
@@ -2468,10 +2468,16 @@ impl Gateway {
         let adapter = self.get_adapter(platform).await.ok_or_else(|| {
             GatewayError::Platform(format!("No adapter registered for platform: {}", platform))
         })?;
-        let (cleaned, images) = extract_inline_images(text);
-        if images.is_empty() {
+        let (without_media, media_files) = extract_media_markers(text);
+        let (cleaned, images) = extract_inline_images(&without_media);
+        if images.is_empty() && media_files.is_empty() {
+            if without_media == text {
+                return adapter
+                    .send_message_threaded(chat_id, text, parse_mode, thread_id)
+                    .await;
+            }
             return adapter
-                .send_message_threaded(chat_id, text, parse_mode, thread_id)
+                .send_message_threaded(chat_id, &cleaned, parse_mode, thread_id)
                 .await;
         }
 
@@ -2500,6 +2506,64 @@ impl Gateway {
                 };
                 adapter
                     .send_message_threaded(chat_id, &fallback, Some(ParseMode::Plain), thread_id)
+                    .await?;
+            }
+        }
+
+        for media in media_files {
+            let Some(validated_path) = validate_media_delivery_path(&media.path) else {
+                warn!(
+                    platform = platform,
+                    chat_id = chat_id,
+                    media_path = %media.path,
+                    as_voice = media.as_voice,
+                    "refusing to deliver unsafe MEDIA marker path"
+                );
+                adapter
+                    .send_message_threaded(
+                        chat_id,
+                        "[media attachment blocked: unsafe local file path]",
+                        Some(ParseMode::Plain),
+                        thread_id,
+                    )
+                    .await?;
+                continue;
+            };
+            let Some(validated_path) = validated_path.to_str() else {
+                warn!(
+                    platform = platform,
+                    chat_id = chat_id,
+                    media_path = %media.path,
+                    as_voice = media.as_voice,
+                    "refusing to deliver non-UTF-8 MEDIA marker path"
+                );
+                adapter
+                    .send_message_threaded(
+                        chat_id,
+                        "[media attachment blocked: non-UTF-8 local file path]",
+                        Some(ParseMode::Plain),
+                        thread_id,
+                    )
+                    .await?;
+                continue;
+            };
+
+            if let Err(err) = adapter.send_file(chat_id, validated_path, None).await {
+                warn!(
+                    platform = platform,
+                    chat_id = chat_id,
+                    media_path = %validated_path,
+                    as_voice = media.as_voice,
+                    error = %err,
+                    "native media file send failed; falling back to plain file marker"
+                );
+                adapter
+                    .send_message_threaded(
+                        chat_id,
+                        &format!("[media attachment] {validated_path}"),
+                        Some(ParseMode::Plain),
+                        thread_id,
+                    )
                     .await?;
             }
         }
@@ -2765,6 +2829,11 @@ mod tests {
         files: Arc<Mutex<Vec<String>>>,
     }
 
+    struct MediaMarkerTestAdapter {
+        messages: Arc<Mutex<Vec<(String, String)>>>,
+        files: Arc<Mutex<Vec<String>>>,
+    }
+
     struct RecordingHook {
         seen: Arc<Mutex<Vec<(String, serde_json::Value)>>>,
     }
@@ -2908,6 +2977,60 @@ mod tests {
 
         fn platform_name(&self) -> &str {
             "file-test"
+        }
+    }
+
+    #[async_trait]
+    impl PlatformAdapter for MediaMarkerTestAdapter {
+        async fn start(&self) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn send_message(
+            &self,
+            chat_id: &str,
+            text: &str,
+            _parse_mode: Option<ParseMode>,
+        ) -> Result<(), GatewayError> {
+            self.messages
+                .lock()
+                .unwrap()
+                .push((chat_id.to_string(), text.to_string()));
+            Ok(())
+        }
+
+        async fn edit_message(
+            &self,
+            _chat_id: &str,
+            _message_id: &str,
+            _text: &str,
+        ) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn send_file(
+            &self,
+            chat_id: &str,
+            file_path: &str,
+            _caption: Option<&str>,
+        ) -> Result<(), GatewayError> {
+            self.files
+                .lock()
+                .unwrap()
+                .push(format!("{chat_id}:{file_path}"));
+            Ok(())
+        }
+
+        fn is_running(&self) -> bool {
+            true
+        }
+
+        fn platform_name(&self) -> &str {
+            "media-marker-test"
         }
     }
 
@@ -3184,6 +3307,81 @@ mod tests {
             "[image] https://cdn.example.com/x.png | caption=diagram"
         );
         assert_eq!(sent[2].1, "[image] https://fal.media/abc");
+    }
+
+    #[tokio::test]
+    async fn gateway_send_message_extracts_media_markers_and_delivers_files() {
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let files = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(MediaMarkerTestAdapter {
+            messages: messages.clone(),
+            files: files.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let gw = Gateway::with_defaults(session_mgr, GatewayConfig::default());
+        gw.register_adapter("media-marker-test", adapter).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let audio = tmp.path().join("reply.ogg");
+        let image = tmp.path().join("browser-shot.png");
+        std::fs::write(&audio, b"ogg").unwrap();
+        std::fs::write(&image, b"png").unwrap();
+
+        gw.send_message(
+            "media-marker-test",
+            "chat1",
+            &format!(
+                "Here is the result.\n[[audio_as_voice]]\nMEDIA:{}\nMEDIA:\"{}\",\nDone",
+                audio.display(),
+                image.display()
+            ),
+            Some(ParseMode::Markdown),
+        )
+        .await
+        .expect("send should succeed");
+
+        assert_eq!(
+            messages.lock().unwrap().as_slice(),
+            &[("chat1".to_string(), "Here is the result. Done".to_string())]
+        );
+        assert_eq!(
+            files.lock().unwrap().as_slice(),
+            &[
+                format!("chat1:{}", std::fs::canonicalize(&audio).unwrap().display()),
+                format!("chat1:{}", std::fs::canonicalize(&image).unwrap().display()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_send_message_blocks_unsafe_media_marker_paths() {
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let files = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(MediaMarkerTestAdapter {
+            messages: messages.clone(),
+            files: files.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let gw = Gateway::with_defaults(session_mgr, GatewayConfig::default());
+        gw.register_adapter("media-marker-test", adapter).await;
+
+        gw.send_message(
+            "media-marker-test",
+            "chat1",
+            "MEDIA:/etc/passwd",
+            Some(ParseMode::Plain),
+        )
+        .await
+        .expect("blocked media marker should not fail entire message send");
+
+        assert!(files.lock().unwrap().is_empty());
+        assert_eq!(
+            messages.lock().unwrap().as_slice(),
+            &[(
+                "chat1".to_string(),
+                "[media attachment blocked: unsafe local file path]".to_string()
+            )]
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/helpers.rs
+++ b/crates/hermes-gateway/src/platforms/helpers.rs
@@ -11,6 +11,12 @@ pub struct InlineImageRef {
     pub alt_text: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaMarkerRef {
+    pub path: String,
+    pub as_voice: bool,
+}
+
 /// Split a long message into chunks that respect word and sentence boundaries.
 ///
 /// Prefers breaking at sentence endings (`. `, `! `, `? `), then at newlines,
@@ -202,6 +208,53 @@ pub fn extract_inline_images(text: &str) -> (String, Vec<InlineImageRef>) {
     (cleaned, images)
 }
 
+fn clean_media_marker_path(raw: &str) -> String {
+    let mut cleaned = raw
+        .trim()
+        .trim_matches(|c| matches!(c, '"' | '\'' | '`'))
+        .to_string();
+    while cleaned
+        .chars()
+        .last()
+        .is_some_and(|c| matches!(c, ',' | '}' | ']' | '"' | '\'' | '`'))
+    {
+        cleaned.pop();
+    }
+    cleaned.trim().to_string()
+}
+
+/// Extract `MEDIA:<path>` output markers and `[[audio_as_voice]]` directives.
+///
+/// Tool backends such as browser screenshots and TTS can return media paths
+/// inside tool JSON or plain text. The gateway strips these markers from the
+/// chat text and delivers the local paths through platform-native file APIs.
+pub fn extract_media_markers(text: &str) -> (String, Vec<MediaMarkerRef>) {
+    let as_voice = text.contains("[[audio_as_voice]]");
+    let voice_re = Regex::new(r"\[\[audio_as_voice\]\]").expect("valid regex");
+    let media_re = Regex::new(r"MEDIA:([^\r\n]+)").expect("valid regex");
+    let blank_re = Regex::new(r"\n{3,}").expect("valid regex");
+
+    let mut media = Vec::new();
+    for caps in media_re.captures_iter(text) {
+        let path = caps
+            .get(1)
+            .map(|m| clean_media_marker_path(m.as_str()))
+            .unwrap_or_default();
+        if !path.is_empty() {
+            media.push(MediaMarkerRef { path, as_voice });
+        }
+    }
+
+    let without_voice = voice_re.replace_all(text, "");
+    let without_media = media_re.replace_all(&without_voice, "");
+    let cleaned = blank_re
+        .replace_all(&without_media, "\n\n")
+        .trim()
+        .to_string();
+
+    (cleaned, media)
+}
+
 /// Format a code block with optional language tag.
 pub fn format_code_block(code: &str, lang: Option<&str>) -> String {
     match lang {
@@ -350,6 +403,27 @@ mod tests {
         let (cleaned, images) = extract_inline_images(text);
         assert_eq!(images.len(), 0);
         assert_eq!(cleaned, "A <img src=\"https://example.com/not-image\"> B");
+    }
+
+    #[test]
+    fn test_extract_media_markers_strips_tags_and_preserves_voice_directive() {
+        let text =
+            "Here\n[[audio_as_voice]]\nMEDIA:/tmp/audio.ogg\nMEDIA:\"/tmp/screenshot.png\",\nDone";
+        let (cleaned, media) = extract_media_markers(text);
+        assert_eq!(cleaned, "Here\n\nDone");
+        assert_eq!(
+            media,
+            vec![
+                MediaMarkerRef {
+                    path: "/tmp/audio.ogg".to_string(),
+                    as_voice: true,
+                },
+                MediaMarkerRef {
+                    path: "/tmp/screenshot.png".to_string(),
+                    as_voice: true,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -739,6 +739,26 @@
     "9e85408c7bfd": {
       "disposition": "ported",
       "notes": "rust todo tool remains first-class in CLI/API toolsets and builtin registration; existing toolset tests and new registry/schema contract cover create/update/list parity"
+    },
+    "ada0b4f131ba": {
+      "disposition": "ported",
+      "notes": "rust gateway/platform adapter surface sends inline image URLs natively and now strips/delivers local MEDIA image markers through validated send_file paths; tests cover inline image extraction and media marker delivery"
+    },
+    "5404a8fcd8a5": {
+      "disposition": "ported",
+      "notes": "rust gateway already supports vision/image URL handling and platform media send paths; this slice adds MEDIA marker extraction/routing with unsafe path blocking to close generated screenshot/image delivery parity"
+    },
+    "b8c3bc78417c": {
+      "disposition": "ported",
+      "notes": "rust browser screenshot/TTS output markers can now be delivered as native platform files via Gateway::send_message_threaded MEDIA extraction; tests cover MEDIA path stripping, canonicalized file delivery, blocked unsafe paths, and existing inline image routing"
+    },
+    "586b0a7047ea": {
+      "disposition": "ported",
+      "notes": "rust text_to_speech/tts_premium providers and gateway MEDIA marker delivery cover TTS audio handoff without Python Edge TTS runtime; existing TTS tests plus gateway media marker tests prove audio file delivery path"
+    },
+    "eb49936a60aa": {
+      "disposition": "superseded",
+      "notes": "upstream docs/install audio-format update is superseded by rust-native TTS providers, media_category/send_file adapter routing, and gateway MEDIA marker delivery tests; no Python install-script runtime remains to port"
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add Rust gateway extraction for MEDIA markers and audio-as-voice directives
- strip marker syntax from chat responses while preserving plain messages without markers
- deliver validated local media paths through PlatformAdapter::send_file with unsafe/non-UTF-8 blocking fallbacks
- add tests for marker parsing, canonicalized file delivery, unsafe path blocking, and existing inline image routing

## Queue Delta
- pending: 1963 -> 1958
- ported: 56 -> 60
- superseded: 7600 -> 7601

## Targeted Dispositions
- ada0b4f131ba ported
- 5404a8fcd8a5 ported
- b8c3bc78417c ported
- 586b0a7047ea ported
- eb49936a60aa superseded

## Verification
- cargo fmt --all --check
- python3 -m json.tool docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-gateway-media-queue.json --out-md /tmp/hermes-gateway-media-queue.md
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-gateway-media CARGO_INCREMENTAL=0 cargo test -p hermes-gateway test_extract_media_markers -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-gateway-media CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_send_message_extracts_media_markers_and_delivers_files -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-gateway-media CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_send_message_blocks_unsafe_media_marker_paths -- --nocapture
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-gateway-media CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_send_message_extracts_inline_images -- --nocapture
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-gateway-media CARGO_INCREMENTAL=0 cargo build -p hermes-gateway
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-gateway-media-clippy CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-gateway (new=0, stale=5)
