### PR TITLE
parity(stt): add provider-aware Rust transcription

### DIFF
--- a/crates/hermes-gateway/src/voice.rs
+++ b/crates/hermes-gateway/src/voice.rs
@@ -2,6 +2,7 @@
 //!
 //! Handles voice message transcription (STT) and text-to-speech (TTS) responses.
 
+use hermes_config::managed_gateway::resolve_openai_audio_api_key;
 use hermes_core::AgentError;
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
@@ -45,6 +46,8 @@ impl Default for VoiceConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SttProvider {
     Whisper,
+    GroqWhisper,
+    MistralVoxtral,
     DeepgramNova,
     Custom(String),
 }
@@ -54,6 +57,110 @@ pub enum TtsProvider {
     OpenAi,
     ElevenLabs,
     Custom(String),
+}
+
+const OPENAI_STT_MODELS: &[&str] = &["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"];
+const GROQ_STT_MODELS: &[&str] = &[
+    "whisper-large-v3",
+    "whisper-large-v3-turbo",
+    "distil-whisper-large-v3-en",
+];
+const MISTRAL_STT_MODELS: &[&str] = &[
+    "voxtral-mini-latest",
+    "voxtral-mini-2507",
+    "voxtral-mini-2602",
+];
+
+fn env_trimmed(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn env_or_default(keys: &[&str], default: &str) -> String {
+    keys.iter()
+        .find_map(|key| env_trimmed(key))
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn endpoint_from_base(base: String) -> String {
+    let base = base.trim_end_matches('/');
+    if base.ends_with("/audio/transcriptions") {
+        base.to_string()
+    } else {
+        format!("{base}/audio/transcriptions")
+    }
+}
+
+fn known_model(model: &str, models: &[&str]) -> bool {
+    models.iter().any(|m| model.eq_ignore_ascii_case(m))
+}
+
+fn normalize_gateway_stt_model(provider: &str, requested: Option<&str>) -> String {
+    let requested = requested.map(str::trim).filter(|s| !s.is_empty());
+    match provider {
+        "groq" => {
+            let default = env_or_default(&["STT_GROQ_MODEL"], "whisper-large-v3-turbo");
+            match requested {
+                Some(model)
+                    if known_model(model, OPENAI_STT_MODELS)
+                        || known_model(model, MISTRAL_STT_MODELS) =>
+                {
+                    default
+                }
+                Some(model) => model.to_string(),
+                None => default,
+            }
+        }
+        "mistral" => {
+            let default = env_or_default(&["STT_MISTRAL_MODEL"], "voxtral-mini-latest");
+            match requested {
+                Some(model)
+                    if known_model(model, OPENAI_STT_MODELS)
+                        || known_model(model, GROQ_STT_MODELS) =>
+                {
+                    default
+                }
+                Some(model) => model.to_string(),
+                None => default,
+            }
+        }
+        _ => {
+            let default = env_or_default(&["STT_OPENAI_MODEL"], "whisper-1");
+            match requested {
+                Some(model)
+                    if known_model(model, GROQ_STT_MODELS)
+                        || known_model(model, MISTRAL_STT_MODELS) =>
+                {
+                    default
+                }
+                Some(model) => model.to_string(),
+                None => default,
+            }
+        }
+    }
+}
+
+fn configured_gateway_stt_model(provider: &str) -> String {
+    let provider_key = match provider {
+        "groq" => "STT_GROQ_MODEL",
+        "mistral" => "STT_MISTRAL_MODEL",
+        _ => "STT_OPENAI_MODEL",
+    };
+    let requested = env_trimmed(provider_key)
+        .or_else(|| env_trimmed("HERMES_STT_MODEL"))
+        .or_else(|| env_trimmed("STT_MODEL"));
+    normalize_gateway_stt_model(provider, requested.as_deref())
+}
+
+fn gateway_transcription_response_format(provider: &str, model: &str) -> &'static str {
+    match provider {
+        "groq" => "text",
+        "mistral" => "json",
+        _ if model.eq_ignore_ascii_case("whisper-1") => "text",
+        _ => "json",
+    }
 }
 
 /// Voice mode manager.
@@ -87,6 +194,8 @@ impl VoiceManager {
     pub async fn transcribe(&self, audio_data: &[u8], format: &str) -> Result<String, AgentError> {
         match &self.config.stt_provider {
             SttProvider::Whisper => self.transcribe_whisper(audio_data, format).await,
+            SttProvider::GroqWhisper => self.transcribe_groq(audio_data, format).await,
+            SttProvider::MistralVoxtral => self.transcribe_mistral(audio_data, format).await,
             SttProvider::DeepgramNova => self.transcribe_deepgram(audio_data, format).await,
             SttProvider::Custom(url) => self.transcribe_custom(url, audio_data, format).await,
         }
@@ -305,49 +414,135 @@ impl VoiceManager {
         audio_data: &[u8],
         format: &str,
     ) -> Result<String, AgentError> {
-        let api_key = std::env::var("HERMES_OPENAI_API_KEY")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
-            .ok_or_else(|| {
-                AgentError::Config(
-                    "HERMES_OPENAI_API_KEY (or OPENAI_API_KEY) not set for Whisper STT".into(),
-                )
-            })?;
+        let api_key = resolve_openai_audio_api_key();
+        if api_key.is_empty() {
+            return Err(AgentError::Config(
+                "VOICE_TOOLS_OPENAI_KEY / HERMES_OPENAI_API_KEY (or OPENAI_API_KEY) not set for Whisper STT"
+                    .into(),
+            ));
+        }
+        let endpoint = endpoint_from_base(env_or_default(
+            &["STT_OPENAI_BASE_URL", "OPENAI_BASE_URL"],
+            "https://api.openai.com/v1",
+        ));
+        let model = configured_gateway_stt_model("openai");
+        let response_format = gateway_transcription_response_format("openai", &model);
+        self.transcribe_multipart_endpoint(
+            "OpenAI Whisper",
+            &endpoint,
+            &api_key,
+            audio_data,
+            format,
+            &model,
+            response_format,
+            true,
+        )
+        .await
+    }
 
+    async fn transcribe_groq(&self, audio_data: &[u8], format: &str) -> Result<String, AgentError> {
+        let api_key = env_trimmed("GROQ_API_KEY")
+            .ok_or_else(|| AgentError::Config("GROQ_API_KEY not set for Groq STT".into()))?;
+        let endpoint = endpoint_from_base(env_or_default(
+            &["STT_GROQ_BASE_URL", "GROQ_BASE_URL"],
+            "https://api.groq.com/openai/v1",
+        ));
+        let model = configured_gateway_stt_model("groq");
+        let response_format = gateway_transcription_response_format("groq", &model);
+        self.transcribe_multipart_endpoint(
+            "Groq Whisper",
+            &endpoint,
+            &api_key,
+            audio_data,
+            format,
+            &model,
+            response_format,
+            true,
+        )
+        .await
+    }
+
+    async fn transcribe_mistral(
+        &self,
+        audio_data: &[u8],
+        format: &str,
+    ) -> Result<String, AgentError> {
+        let api_key = env_trimmed("MISTRAL_API_KEY")
+            .ok_or_else(|| AgentError::Config("MISTRAL_API_KEY not set for Mistral STT".into()))?;
+        let endpoint = endpoint_from_base(env_or_default(
+            &["STT_MISTRAL_BASE_URL", "MISTRAL_BASE_URL"],
+            "https://api.mistral.ai/v1",
+        ));
+        let model = configured_gateway_stt_model("mistral");
+        let response_format = gateway_transcription_response_format("mistral", &model);
+        self.transcribe_multipart_endpoint(
+            "Mistral Voxtral",
+            &endpoint,
+            &api_key,
+            audio_data,
+            format,
+            &model,
+            response_format,
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn transcribe_multipart_endpoint(
+        &self,
+        provider_label: &str,
+        endpoint: &str,
+        api_key: &str,
+        audio_data: &[u8],
+        format: &str,
+        model: &str,
+        response_format: &str,
+        send_response_format: bool,
+    ) -> Result<String, AgentError> {
         let client = reqwest::Client::new();
         let part = reqwest::multipart::Part::bytes(audio_data.to_vec())
             .file_name(format!("audio.{}", format))
             .mime_str(&format!("audio/{}", format))
             .map_err(|e| AgentError::LlmApi(e.to_string()))?;
 
-        let form = reqwest::multipart::Form::new()
+        let mut form = reqwest::multipart::Form::new()
             .part("file", part)
-            .text("model", "whisper-1");
-
-        let form = if let Some(ref lang) = self.config.language {
-            form.text("language", lang.clone())
-        } else {
-            form
-        };
+            .text("model", model.to_string());
+        if send_response_format {
+            form = form.text("response_format", response_format.to_string());
+        }
+        if let Some(ref lang) = self.config.language {
+            form = form.text("language", lang.clone());
+        }
 
         let resp = client
-            .post("https://api.openai.com/v1/audio/transcriptions")
+            .post(endpoint)
             .header("Authorization", format!("Bearer {}", api_key))
             .multipart(form)
             .send()
             .await
-            .map_err(|e| AgentError::LlmApi(format!("Whisper API error: {e}")))?;
+            .map_err(|e| AgentError::LlmApi(format!("{provider_label} API error: {e}")))?;
 
         if !resp.status().is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(AgentError::LlmApi(format!("Whisper error: {body}")));
+            return Err(AgentError::LlmApi(format!(
+                "{provider_label} error: {body}"
+            )));
+        }
+
+        if response_format.eq_ignore_ascii_case("text") {
+            let text = resp
+                .text()
+                .await
+                .map_err(|e| AgentError::LlmApi(format!("{provider_label} read body: {e}")))?;
+            return Ok(text.trim().to_string());
         }
 
         let json: serde_json::Value = resp
             .json()
             .await
-            .map_err(|e| AgentError::LlmApi(format!("Parse error: {e}")))?;
+            .map_err(|e| AgentError::LlmApi(format!("{provider_label} parse error: {e}")))?;
         Ok(json
             .get("text")
             .and_then(|t| t.as_str())
@@ -472,15 +667,13 @@ impl VoiceManager {
     }
 
     async fn tts_openai(&self, text: &str) -> Result<Vec<u8>, AgentError> {
-        let api_key = std::env::var("HERMES_OPENAI_API_KEY")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
-            .ok_or_else(|| {
-                AgentError::Config(
-                    "HERMES_OPENAI_API_KEY (or OPENAI_API_KEY) not set for TTS".into(),
-                )
-            })?;
+        let api_key = resolve_openai_audio_api_key();
+        if api_key.is_empty() {
+            return Err(AgentError::Config(
+                "VOICE_TOOLS_OPENAI_KEY / HERMES_OPENAI_API_KEY (or OPENAI_API_KEY) not set for TTS"
+                    .into(),
+            ));
+        }
 
         let client = reqwest::Client::new();
         let body = serde_json::json!({
@@ -595,11 +788,67 @@ impl VoiceManager {
 mod tests {
     use super::*;
     use std::f32::consts::PI;
+    use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
+
+    static ENV_LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK
+            .get_or_init(|| StdMutex::new(()))
+            .lock()
+            .expect("env lock poisoned")
+    }
+
+    struct EnvGuard {
+        original: Vec<(&'static str, Option<String>)>,
+        _g: MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let g = env_lock();
+            let keys = [
+                "VOICE_TOOLS_OPENAI_KEY",
+                "HERMES_OPENAI_API_KEY",
+                "OPENAI_API_KEY",
+                "GROQ_API_KEY",
+                "MISTRAL_API_KEY",
+                "STT_MODEL",
+                "HERMES_STT_MODEL",
+                "STT_OPENAI_MODEL",
+                "STT_GROQ_MODEL",
+                "STT_MISTRAL_MODEL",
+                "STT_OPENAI_BASE_URL",
+                "OPENAI_BASE_URL",
+                "STT_GROQ_BASE_URL",
+                "GROQ_BASE_URL",
+                "STT_MISTRAL_BASE_URL",
+                "MISTRAL_BASE_URL",
+            ];
+            let original = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+            for key in keys {
+                std::env::remove_var(key);
+            }
+            Self { original, _g: g }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.original {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_voice_state_default() {
         let config = VoiceConfig::default();
         assert_eq!(config.state, VoiceState::Disabled);
+        assert_eq!(config.stt_provider, SttProvider::Whisper);
     }
 
     #[test]
@@ -664,5 +913,69 @@ mod tests {
             pcm.extend_from_slice(&sample.to_le_bytes());
         }
         assert!(mgr.detect_voice_activity(&pcm));
+    }
+
+    #[test]
+    fn gateway_stt_model_normalizes_provider_mismatches() {
+        let _g = EnvGuard::new();
+        assert_eq!(normalize_gateway_stt_model("openai", None), "whisper-1");
+        assert_eq!(
+            normalize_gateway_stt_model("groq", Some("whisper-1")),
+            "whisper-large-v3-turbo"
+        );
+        assert_eq!(
+            normalize_gateway_stt_model("mistral", Some("whisper-large-v3")),
+            "voxtral-mini-latest"
+        );
+        assert_eq!(
+            normalize_gateway_stt_model("openai", Some("gpt-4o-mini-transcribe")),
+            "gpt-4o-mini-transcribe"
+        );
+    }
+
+    #[test]
+    fn gateway_stt_endpoint_builds_from_provider_base_urls() {
+        let _g = EnvGuard::new();
+        assert_eq!(
+            endpoint_from_base("https://api.groq.com/openai/v1".into()),
+            "https://api.groq.com/openai/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            endpoint_from_base("https://api.mistral.ai/v1/audio/transcriptions".into()),
+            "https://api.mistral.ai/v1/audio/transcriptions"
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_whisper_prefers_voice_tools_key_and_reports_missing_keys() {
+        let _g = EnvGuard::new();
+        let mgr = VoiceManager::new(VoiceConfig::default());
+        let err = mgr.transcribe(&[1, 2, 3, 4], "wav").await.unwrap_err();
+        assert!(err.to_string().contains("VOICE_TOOLS_OPENAI_KEY"));
+
+        std::env::set_var("VOICE_TOOLS_OPENAI_KEY", "voice-key");
+        std::env::set_var("HERMES_OPENAI_API_KEY", "hermes-key");
+        assert_eq!(resolve_openai_audio_api_key(), "voice-key");
+    }
+
+    #[tokio::test]
+    async fn gateway_groq_and_mistral_stt_report_provider_credentials() {
+        let _g = EnvGuard::new();
+
+        let mut cfg = VoiceConfig::default();
+        cfg.stt_provider = SttProvider::GroqWhisper;
+        let groq = VoiceManager::new(cfg)
+            .transcribe(&[1, 2, 3, 4], "wav")
+            .await
+            .unwrap_err();
+        assert!(groq.to_string().contains("GROQ_API_KEY"));
+
+        let mut cfg = VoiceConfig::default();
+        cfg.stt_provider = SttProvider::MistralVoxtral;
+        let mistral = VoiceManager::new(cfg)
+            .transcribe(&[1, 2, 3, 4], "wav")
+            .await
+            .unwrap_err();
+        assert!(mistral.to_string().contains("MISTRAL_API_KEY"));
     }
 }

--- a/crates/hermes-tools/src/tools/transcription.rs
+++ b/crates/hermes-tools/src/tools/transcription.rs
@@ -1,5 +1,6 @@
-//! Whisper-style transcription via OpenAI's `/audio/transcriptions`
-//! endpoint, with optional Nous-managed gateway routing.
+//! Speech-to-text transcription through OpenAI-compatible and Voxtral
+//! `/audio/transcriptions` endpoints, with optional Nous-managed gateway
+//! routing for OpenAI audio.
 //!
 //! Resolution order at request time:
 //!
@@ -7,9 +8,10 @@
 //!    Nous OAuth token resolves for the `openai-audio` vendor, the call
 //!    is routed through `{gateway}/audio/transcriptions` with a Nous
 //!    `Bearer` header.
-//! 2. **Direct**: otherwise, falls back to `VOICE_TOOLS_OPENAI_KEY`,
-//!    then `HERMES_OPENAI_API_KEY`, then legacy `OPENAI_API_KEY`,
-//!    calling `https://api.openai.com/v1/audio/...`.
+//! 2. **Direct OpenAI**: otherwise, falls back to `VOICE_TOOLS_OPENAI_KEY`,
+//!    then `HERMES_OPENAI_API_KEY`, then legacy `OPENAI_API_KEY`.
+//! 3. **Direct Groq/Mistral**: explicit `provider` (or STT provider env)
+//!    can route to Groq Whisper or Mistral Voxtral Transcribe.
 //!
 //! The output JSON includes `transport: "managed" | "direct"` for
 //! observability.
@@ -27,6 +29,29 @@ use hermes_config::managed_gateway::{
 use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
 
 pub struct TranscriptionHandler;
+
+const OPENAI_STT_MODELS: &[&str] = &["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"];
+const GROQ_STT_MODELS: &[&str] = &[
+    "whisper-large-v3",
+    "whisper-large-v3-turbo",
+    "distil-whisper-large-v3-en",
+];
+const MISTRAL_STT_MODELS: &[&str] = &[
+    "voxtral-mini-latest",
+    "voxtral-mini-2507",
+    "voxtral-mini-2602",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TranscriptionEndpoint {
+    pub endpoint: String,
+    pub bearer: String,
+    pub transport: &'static str,
+    pub provider: &'static str,
+    pub model: String,
+    pub response_format: String,
+    pub send_response_format: bool,
+}
 
 fn audio_extension_format(path: &str) -> &'static str {
     Path::new(path)
@@ -54,6 +79,102 @@ pub(crate) fn transcription_response_format_for_model(model: &str) -> &'static s
     }
 }
 
+fn known_model(model: &str, models: &[&str]) -> bool {
+    models.iter().any(|m| model.eq_ignore_ascii_case(m))
+}
+
+fn env_trimmed(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn env_or_default(keys: &[&str], default: &str) -> String {
+    keys.iter()
+        .find_map(|key| env_trimmed(key))
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn endpoint_from_base(base: String) -> String {
+    let base = base.trim_end_matches('/');
+    if base.ends_with("/audio/transcriptions") {
+        base.to_string()
+    } else {
+        format!("{base}/audio/transcriptions")
+    }
+}
+
+fn normalize_provider_name(provider: &str) -> Option<&'static str> {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "" => None,
+        "openai" | "whisper" => Some("openai"),
+        "groq" | "groq_whisper" | "groq-whisper" => Some("groq"),
+        "mistral" | "voxtral" | "mistral_voxtral" | "mistral-voxtral" => Some("mistral"),
+        _ => None,
+    }
+}
+
+fn requested_provider_from_env() -> Option<String> {
+    env_trimmed("HERMES_STT_PROVIDER").or_else(|| env_trimmed("STT_PROVIDER"))
+}
+
+pub(crate) fn normalize_stt_model(provider: &str, requested: Option<&str>) -> String {
+    let requested = requested.map(str::trim).filter(|s| !s.is_empty());
+    match provider {
+        "groq" => {
+            let default = env_or_default(&["STT_GROQ_MODEL"], "whisper-large-v3-turbo");
+            match requested {
+                Some(model)
+                    if known_model(model, OPENAI_STT_MODELS)
+                        || known_model(model, MISTRAL_STT_MODELS) =>
+                {
+                    default
+                }
+                Some(model) => model.to_string(),
+                None => default,
+            }
+        }
+        "mistral" => {
+            let default = env_or_default(&["STT_MISTRAL_MODEL"], "voxtral-mini-latest");
+            match requested {
+                Some(model)
+                    if known_model(model, OPENAI_STT_MODELS)
+                        || known_model(model, GROQ_STT_MODELS) =>
+                {
+                    default
+                }
+                Some(model) => model.to_string(),
+                None => default,
+            }
+        }
+        _ => {
+            let default = env_or_default(&["STT_OPENAI_MODEL"], "whisper-1");
+            match requested {
+                Some(model)
+                    if known_model(model, GROQ_STT_MODELS)
+                        || known_model(model, MISTRAL_STT_MODELS) =>
+                {
+                    default
+                }
+                Some(model) => model.to_string(),
+                None => default,
+            }
+        }
+    }
+}
+
+pub(crate) fn transcription_response_format_for_provider_model(
+    provider: &str,
+    model: &str,
+) -> &'static str {
+    match provider {
+        "groq" => "text",
+        "mistral" => "json",
+        _ => transcription_response_format_for_model(model),
+    }
+}
+
 pub(crate) fn parse_transcription_response(
     body: &str,
     response_format: &str,
@@ -71,30 +192,137 @@ pub(crate) fn parse_transcription_response(
         .to_string())
 }
 
-/// Compose the (endpoint, bearer, transport_label) tuple for a Whisper
-/// request. Pure helper so it can be unit-tested without touching the
-/// network.
+/// Compose the endpoint metadata for a transcription request. Pure helper so
+/// it can be unit-tested without touching the network.
 pub(crate) fn resolve_transcription_endpoint(
     managed: Option<&ManagedToolGatewayConfig>,
-) -> Option<(String, String, &'static str)> {
-    if let Some(cfg) = managed {
-        let base = cfg.gateway_origin.trim_end_matches('/');
-        return Some((
-            format!("{base}/audio/transcriptions"),
-            cfg.nous_user_token.clone(),
-            "managed",
-        ));
+    requested_provider: Option<&str>,
+    requested_model: Option<&str>,
+    requested_response_format: Option<&str>,
+) -> Option<TranscriptionEndpoint> {
+    let raw_provider = requested_provider
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(requested_provider_from_env);
+    let provider = match raw_provider.as_deref() {
+        Some(provider) => Some(normalize_provider_name(provider)?),
+        None => None,
+    };
+
+    if provider.is_none() || provider == Some("openai") {
+        if let Some(cfg) = managed {
+            let base = cfg.gateway_origin.trim_end_matches('/');
+            let model = normalize_stt_model("openai", requested_model);
+            let response_format = requested_response_format
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    transcription_response_format_for_provider_model("openai", &model).to_string()
+                });
+            return Some(TranscriptionEndpoint {
+                endpoint: format!("{base}/audio/transcriptions"),
+                bearer: cfg.nous_user_token.clone(),
+                transport: "managed",
+                provider: "openai",
+                model,
+                response_format,
+                send_response_format: true,
+            });
+        }
     }
 
-    let key = resolve_openai_audio_api_key();
-    if key.is_empty() {
-        return None;
+    let provider = provider.unwrap_or_else(|| {
+        if !resolve_openai_audio_api_key().is_empty() {
+            "openai"
+        } else if env_trimmed("GROQ_API_KEY").is_some() {
+            "groq"
+        } else if env_trimmed("MISTRAL_API_KEY").is_some() {
+            "mistral"
+        } else {
+            "openai"
+        }
+    });
+
+    match provider {
+        "openai" => {
+            let key = resolve_openai_audio_api_key();
+            if key.is_empty() {
+                return None;
+            }
+            let model = normalize_stt_model("openai", requested_model);
+            let response_format = requested_response_format
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    transcription_response_format_for_provider_model("openai", &model).to_string()
+                });
+            let base = env_or_default(
+                &["STT_OPENAI_BASE_URL", "OPENAI_BASE_URL"],
+                "https://api.openai.com/v1",
+            );
+            Some(TranscriptionEndpoint {
+                endpoint: endpoint_from_base(base),
+                bearer: key,
+                transport: "direct",
+                provider: "openai",
+                model,
+                response_format,
+                send_response_format: true,
+            })
+        }
+        "groq" => {
+            let key = env_trimmed("GROQ_API_KEY")?;
+            let model = normalize_stt_model("groq", requested_model);
+            let response_format = requested_response_format
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    transcription_response_format_for_provider_model("groq", &model).to_string()
+                });
+            let base = env_or_default(
+                &["STT_GROQ_BASE_URL", "GROQ_BASE_URL"],
+                "https://api.groq.com/openai/v1",
+            );
+            Some(TranscriptionEndpoint {
+                endpoint: endpoint_from_base(base),
+                bearer: key,
+                transport: "direct",
+                provider: "groq",
+                model,
+                response_format,
+                send_response_format: true,
+            })
+        }
+        "mistral" => {
+            let key = env_trimmed("MISTRAL_API_KEY")?;
+            let model = normalize_stt_model("mistral", requested_model);
+            let response_format = requested_response_format
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    transcription_response_format_for_provider_model("mistral", &model).to_string()
+                });
+            let base = env_or_default(
+                &["STT_MISTRAL_BASE_URL", "MISTRAL_BASE_URL"],
+                "https://api.mistral.ai/v1",
+            );
+            Some(TranscriptionEndpoint {
+                endpoint: endpoint_from_base(base),
+                bearer: key,
+                transport: "direct",
+                provider: "mistral",
+                model,
+                response_format,
+                send_response_format: false,
+            })
+        }
+        _ => None,
     }
-    Some((
-        "https://api.openai.com/v1/audio/transcriptions".into(),
-        key,
-        "direct",
-    ))
 }
 
 #[async_trait]
@@ -108,73 +336,90 @@ impl ToolHandler for TranscriptionHandler {
             return Err(ToolError::InvalidParams("Missing 'audio_path'".into()));
         }
 
+        let provider = params
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let model = params
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let response_format = params
+            .get("response_format")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
         let managed = resolve_managed_tool_gateway("openai-audio", ResolveOptions::default());
-        let (endpoint, bearer, transport) = resolve_transcription_endpoint(managed.as_ref())
-            .ok_or_else(|| {
-                ToolError::ExecutionFailed(
-                    "Whisper transcription requires either VOICE_TOOLS_OPENAI_KEY / \
-                     HERMES_OPENAI_API_KEY (or OPENAI_API_KEY) for direct mode, or a \
-                     Nous-managed openai-audio gateway."
-                        .into(),
-                )
-            })?;
+        let request =
+            resolve_transcription_endpoint(managed.as_ref(), provider, model, response_format)
+                .ok_or_else(|| {
+                    ToolError::ExecutionFailed(
+                        "Transcription requires a configured STT provider: \
+                         VOICE_TOOLS_OPENAI_KEY / HERMES_OPENAI_API_KEY / OPENAI_API_KEY \
+                         for OpenAI, GROQ_API_KEY for Groq, MISTRAL_API_KEY for Mistral, \
+                         or a Nous-managed openai-audio gateway."
+                            .into(),
+                    )
+                })?;
 
         let bytes = tokio::fs::read(path)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Cannot read audio file: {e}")))?;
 
         let fmt = audio_extension_format(path);
-        let model = params
-            .get("model")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .unwrap_or("whisper-1");
-        let response_format = params
-            .get("response_format")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| transcription_response_format_for_model(model));
         let client = reqwest::Client::new();
         let part = reqwest::multipart::Part::bytes(bytes)
             .file_name(format!("audio.{fmt}"))
             .mime_str(&format!("audio/{fmt}"))
             .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
 
-        let form = reqwest::multipart::Form::new()
+        let mut form = reqwest::multipart::Form::new()
             .part("file", part)
-            .text("model", model.to_string())
-            .text("response_format", response_format.to_string());
+            .text("model", request.model.clone());
+        if request.send_response_format {
+            form = form.text("response_format", request.response_format.clone());
+        }
+        if let Some(language) = params
+            .get("language")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            form = form.text("language", language.to_string());
+        }
 
         let resp = client
-            .post(&endpoint)
-            .header("Authorization", format!("Bearer {}", bearer))
+            .post(&request.endpoint)
+            .header("Authorization", format!("Bearer {}", request.bearer))
             .multipart(form)
             .send()
             .await
-            .map_err(|e| ToolError::ExecutionFailed(format!("Whisper API: {e}")))?;
+            .map_err(|e| ToolError::ExecutionFailed(format!("Transcription API: {e}")))?;
 
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
             return Err(ToolError::ExecutionFailed(format!(
-                "Whisper error {status}: {body}"
+                "Transcription error {status}: {body}"
             )));
         }
 
         let body = resp
             .text()
             .await
-            .map_err(|e| ToolError::ExecutionFailed(format!("Whisper read body: {e}")))?;
-        let text = parse_transcription_response(&body, response_format)?;
+            .map_err(|e| ToolError::ExecutionFailed(format!("Transcription read body: {e}")))?;
+        let text = parse_transcription_response(&body, &request.response_format)?;
 
         Ok(json!({
             "audio_path": path,
-            "model": model,
+            "model": request.model,
+            "provider": request.provider,
             "text": text,
-            "response_format": response_format,
-            "transport": transport,
+            "response_format": request.response_format,
+            "transport": request.transport,
             "status": "transcribed",
         })
         .to_string())
@@ -186,11 +431,32 @@ impl ToolHandler for TranscriptionHandler {
             "audio_path".into(),
             json!({"type":"string","description":"Path to audio file"}),
         );
+        props.insert(
+            "provider".into(),
+            json!({
+                "type":"string",
+                "description":"STT provider: openai, groq, or mistral/voxtral. Defaults to managed/OpenAI, then Groq, then Mistral based on available credentials.",
+                "enum":["openai","groq","mistral","voxtral"]
+            }),
+        );
+        props.insert(
+            "model".into(),
+            json!({"type":"string","description":"Provider-specific STT model override"}),
+        );
+        props.insert(
+            "language".into(),
+            json!({"type":"string","description":"Optional ISO language hint"}),
+        );
+        props.insert(
+            "response_format".into(),
+            json!({"type":"string","description":"Optional response format for OpenAI-compatible providers", "enum":["text","json","verbose_json"]}),
+        );
         tool_schema(
             "transcription",
-            "Transcribe audio into text via OpenAI Whisper. Honors VOICE_TOOLS_OPENAI_KEY / \
-             HERMES_OPENAI_API_KEY (or OPENAI_API_KEY) for direct mode and routes through Nous-managed openai-audio \
-             gateway when HERMES_ENABLE_NOUS_MANAGED_TOOLS is enabled.",
+            "Transcribe audio into text via OpenAI, Groq Whisper, or Mistral Voxtral. \
+             Honors VOICE_TOOLS_OPENAI_KEY / HERMES_OPENAI_API_KEY (or OPENAI_API_KEY), \
+             GROQ_API_KEY, MISTRAL_API_KEY, provider/model overrides, and routes OpenAI audio \
+             through the Nous-managed openai-audio gateway when HERMES_ENABLE_NOUS_MANAGED_TOOLS is enabled.",
             JsonSchema::object(props, vec!["audio_path".into()]),
         )
     }
@@ -216,6 +482,19 @@ mod tests {
                 "HERMES_OPENAI_API_KEY",
                 "OPENAI_API_KEY",
                 "VOICE_TOOLS_OPENAI_KEY",
+                "GROQ_API_KEY",
+                "MISTRAL_API_KEY",
+                "HERMES_STT_PROVIDER",
+                "STT_PROVIDER",
+                "STT_OPENAI_MODEL",
+                "STT_GROQ_MODEL",
+                "STT_MISTRAL_MODEL",
+                "STT_OPENAI_BASE_URL",
+                "OPENAI_BASE_URL",
+                "STT_GROQ_BASE_URL",
+                "GROQ_BASE_URL",
+                "STT_MISTRAL_BASE_URL",
+                "MISTRAL_BASE_URL",
                 "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
                 "TOOL_GATEWAY_USER_TOKEN",
                 "TOOL_GATEWAY_DOMAIN",
@@ -270,6 +549,32 @@ mod tests {
             transcription_response_format_for_model("gpt-4o-mini-transcribe"),
             "json"
         );
+        assert_eq!(
+            transcription_response_format_for_provider_model("groq", "whisper-large-v3-turbo"),
+            "text"
+        );
+        assert_eq!(
+            transcription_response_format_for_provider_model("mistral", "voxtral-mini-latest"),
+            "json"
+        );
+    }
+
+    #[test]
+    fn normalize_stt_model_keeps_provider_compatible_defaults() {
+        let _g = EnvScope::new();
+        assert_eq!(normalize_stt_model("openai", None), "whisper-1");
+        assert_eq!(
+            normalize_stt_model("groq", Some("whisper-1")),
+            "whisper-large-v3-turbo"
+        );
+        assert_eq!(
+            normalize_stt_model("mistral", Some("whisper-large-v3")),
+            "voxtral-mini-latest"
+        );
+        assert_eq!(
+            normalize_stt_model("openai", Some("gpt-4o-transcribe")),
+            "gpt-4o-transcribe"
+        );
     }
 
     #[test]
@@ -296,10 +601,15 @@ mod tests {
             nous_user_token: "nous-tok".into(),
             managed_mode: true,
         };
-        let (endpoint, bearer, label) = resolve_transcription_endpoint(Some(&cfg)).unwrap();
-        assert_eq!(endpoint, "https://oa.gw.example.com/audio/transcriptions");
-        assert_eq!(bearer, "nous-tok");
-        assert_eq!(label, "managed");
+        let resolved = resolve_transcription_endpoint(Some(&cfg), None, None, None).unwrap();
+        assert_eq!(
+            resolved.endpoint,
+            "https://oa.gw.example.com/audio/transcriptions"
+        );
+        assert_eq!(resolved.bearer, "nous-tok");
+        assert_eq!(resolved.transport, "managed");
+        assert_eq!(resolved.provider, "openai");
+        assert_eq!(resolved.model, "whisper-1");
     }
 
     #[test]
@@ -307,25 +617,80 @@ mod tests {
         let _g = EnvScope::new();
         std::env::set_var("VOICE_TOOLS_OPENAI_KEY", "voice-key");
         std::env::set_var("OPENAI_API_KEY", "main-key");
-        let (endpoint, bearer, label) = resolve_transcription_endpoint(None).unwrap();
-        assert_eq!(endpoint, "https://api.openai.com/v1/audio/transcriptions");
-        assert_eq!(bearer, "voice-key");
-        assert_eq!(label, "direct");
+        let resolved = resolve_transcription_endpoint(None, Some("openai"), None, None).unwrap();
+        assert_eq!(
+            resolved.endpoint,
+            "https://api.openai.com/v1/audio/transcriptions"
+        );
+        assert_eq!(resolved.bearer, "voice-key");
+        assert_eq!(resolved.transport, "direct");
+        assert_eq!(resolved.provider, "openai");
     }
 
     #[test]
     fn resolve_endpoint_falls_back_to_main_key() {
         let _g = EnvScope::new();
         std::env::set_var("OPENAI_API_KEY", "main-key");
-        let (_endpoint, bearer, label) = resolve_transcription_endpoint(None).unwrap();
-        assert_eq!(bearer, "main-key");
-        assert_eq!(label, "direct");
+        let resolved = resolve_transcription_endpoint(None, None, None, None).unwrap();
+        assert_eq!(resolved.bearer, "main-key");
+        assert_eq!(resolved.provider, "openai");
+        assert_eq!(resolved.transport, "direct");
+    }
+
+    #[test]
+    fn resolve_endpoint_supports_explicit_groq_provider() {
+        let _g = EnvScope::new();
+        std::env::set_var("GROQ_API_KEY", "groq-key");
+        let resolved =
+            resolve_transcription_endpoint(None, Some("groq"), Some("whisper-1"), None).unwrap();
+        assert_eq!(
+            resolved.endpoint,
+            "https://api.groq.com/openai/v1/audio/transcriptions"
+        );
+        assert_eq!(resolved.bearer, "groq-key");
+        assert_eq!(resolved.provider, "groq");
+        assert_eq!(resolved.model, "whisper-large-v3-turbo");
+        assert_eq!(resolved.response_format, "text");
+        assert!(resolved.send_response_format);
+    }
+
+    #[test]
+    fn resolve_endpoint_supports_explicit_mistral_provider() {
+        let _g = EnvScope::new();
+        std::env::set_var("MISTRAL_API_KEY", "mistral-key");
+        let resolved =
+            resolve_transcription_endpoint(None, Some("voxtral"), Some("whisper-1"), None).unwrap();
+        assert_eq!(
+            resolved.endpoint,
+            "https://api.mistral.ai/v1/audio/transcriptions"
+        );
+        assert_eq!(resolved.bearer, "mistral-key");
+        assert_eq!(resolved.provider, "mistral");
+        assert_eq!(resolved.model, "voxtral-mini-latest");
+        assert_eq!(resolved.response_format, "json");
+        assert!(!resolved.send_response_format);
+    }
+
+    #[test]
+    fn resolve_endpoint_auto_falls_back_to_groq_when_openai_unconfigured() {
+        let _g = EnvScope::new();
+        std::env::set_var("GROQ_API_KEY", "groq-key");
+        let resolved = resolve_transcription_endpoint(None, None, None, None).unwrap();
+        assert_eq!(resolved.provider, "groq");
+        assert_eq!(resolved.bearer, "groq-key");
+    }
+
+    #[test]
+    fn resolve_endpoint_rejects_unknown_provider_instead_of_falling_back() {
+        let _g = EnvScope::new();
+        std::env::set_var("VOICE_TOOLS_OPENAI_KEY", "voice-key");
+        assert!(resolve_transcription_endpoint(None, Some("bogus"), None, None).is_none());
     }
 
     #[test]
     fn resolve_endpoint_returns_none_when_unconfigured() {
         let _g = EnvScope::new();
-        assert!(resolve_transcription_endpoint(None).is_none());
+        assert!(resolve_transcription_endpoint(None, None, None, None).is_none());
     }
 
     #[tokio::test]
@@ -339,6 +704,8 @@ mod tests {
         let s = err.to_string();
         assert!(s.contains("VOICE_TOOLS_OPENAI_KEY"));
         assert!(s.contains("HERMES_OPENAI_API_KEY") || s.contains("OPENAI_API_KEY"));
+        assert!(s.contains("GROQ_API_KEY"));
+        assert!(s.contains("MISTRAL_API_KEY"));
         assert!(s.contains("openai-audio gateway"));
     }
 
@@ -358,6 +725,10 @@ mod tests {
         let desc = serde_json::to_string(&s).unwrap();
         assert!(desc.contains("VOICE_TOOLS_OPENAI_KEY"));
         assert!(desc.contains("HERMES_OPENAI_API_KEY"));
+        assert!(desc.contains("GROQ_API_KEY"));
+        assert!(desc.contains("MISTRAL_API_KEY"));
+        assert!(desc.contains("provider"));
+        assert!(desc.contains("model"));
         assert!(desc.contains("HERMES_ENABLE_NOUS_MANAGED_TOOLS"));
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -759,6 +759,34 @@
     "eb49936a60aa": {
       "disposition": "superseded",
       "notes": "upstream docs/install audio-format update is superseded by rust-native TTS providers, media_category/send_file adapter routing, and gateway MEDIA marker delivery tests; no Python install-script runtime remains to port"
+    },
+    "bdac541d1ee2": {
+      "disposition": "ported",
+      "notes": "Rust OpenAI audio key resolution already prefers HERMES_OPENAI_API_KEY over legacy OPENAI_API_KEY and this slice aligns gateway voice STT/TTS error paths with the shared resolver while preserving legacy fallback."
+    },
+    "0858ee2f2701": {
+      "disposition": "ported",
+      "notes": "Rust OpenAI audio key resolution now consistently uses VOICE_TOOLS_OPENAI_KEY first for transcription and gateway voice STT/TTS, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY; focused tests cover precedence and schema/error visibility."
+    },
+    "ec32e9a5406d": {
+      "disposition": "ported",
+      "notes": "Rust transcription now exposes provider-aware Groq STT with GROQ_API_KEY, Groq OpenAI-compatible endpoint/model defaults, model normalization, schema coverage, and gateway SttProvider::GroqWhisper credential/error handling tests."
+    },
+    "b8f8d3ef9e55": {
+      "disposition": "ported",
+      "notes": "Rust transcription now implements the valuable provider fallback portion of the three-provider STT surface: explicit/provider-env OpenAI, Groq, and Mistral/Voxtral with deterministic model normalization and tests. Python faster-whisper local runtime is intentionally not embedded in the Rust runtime."
+    },
+    "5f4b93c20f41": {
+      "disposition": "ported",
+      "notes": "Rust transcription now exposes Mistral/Voxtral STT with MISTRAL_API_KEY, /v1/audio/transcriptions endpoint construction, voxtral model defaults, no unsupported response_format multipart field, schema coverage, and gateway SttProvider::MistralVoxtral tests."
+    },
+    "0f597dd12796": {
+      "disposition": "ported",
+      "notes": "Rust STT provider/model normalization prevents OpenAI whisper-1 from being sent to Groq or Mistral/Voxtral and prevents Groq/Voxtral models from leaking to OpenAI; tool and gateway tests cover mismatch normalization."
+    },
+    "3260413cc7fa": {
+      "disposition": "ported",
+      "notes": "Rust STT override env vars are first-class runtime knobs: HERMES_STT_PROVIDER/STT_PROVIDER, STT_OPENAI_MODEL, STT_GROQ_MODEL, STT_MISTRAL_MODEL, and provider base-url overrides are resolved in the Rust transcription/gateway voice surfaces with tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add provider-aware Rust transcription resolution for OpenAI, Groq Whisper, and Mistral/Voxtral
- align gateway voice STT/TTS OpenAI audio key precedence with VOICE_TOOLS_OPENAI_KEY -> HERMES_OPENAI_API_KEY -> OPENAI_API_KEY
- add GroqWhisper and MistralVoxtral gateway STT providers with provider/model mismatch normalization
- mark 7 upstream STT/key/model parity commits ported

## Queue Delta
- pending: 1958 -> 1951
- ported: 60 -> 67
- superseded: 7601 unchanged

## Verification
- cargo fmt --all --check
- python3 -m json.tool docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-stt-provider-queue.json --out-md /tmp/hermes-stt-provider-queue.md
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-stt-gateway CARGO_INCREMENTAL=0 cargo test -p hermes-tools transcription -- --nocapture -> 16 passed
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-stt-gateway CARGO_INCREMENTAL=0 cargo test -p hermes-gateway voice -- --nocapture -> 10 passed
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-stt-gateway CARGO_INCREMENTAL=0 cargo build -p hermes-tools -p hermes-gateway
- CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-stt-clippy CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-tools -p hermes-gateway -> new=0 stale=5

## Risk
- no live OpenAI/Groq/Mistral transcription API calls were made; coverage is resolver/schema/unit/build/clippy evidence