### PR TITLE
parity(acp): add queue and steer runtime

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -43,6 +43,10 @@ pub trait AcpPromptExecutor: Send + Sync {
         user_text: &str,
         history: &[Value],
     ) -> Result<PromptExecutionOutput, String>;
+
+    fn steer_prompt(&self, _session: &SessionState, _guidance: &str) -> Result<bool, String> {
+        Ok(false)
+    }
 }
 
 const MAX_ACP_RESOURCE_BYTES: usize = 512 * 1024;
@@ -586,6 +590,14 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         description: "Compress conversation context",
     },
     SlashCommand {
+        name: "steer",
+        description: "Inject guidance into the currently running agent turn",
+    },
+    SlashCommand {
+        name: "queue",
+        description: "Queue a prompt to run after the current turn finishes",
+    },
+    SlashCommand {
         name: "version",
         description: "Show Hermes version",
     },
@@ -741,10 +753,97 @@ impl HermesAcpHandler {
         ))
     }
 
+    async fn execute_prompt_turn(
+        &self,
+        session_id: &str,
+        user_text: String,
+        user_content: Value,
+    ) -> Result<Option<Usage>, String> {
+        let mut history = self
+            .session_manager
+            .get_session(session_id)
+            .map(|s| s.history)
+            .unwrap_or_default();
+        history.push(json!({
+            "role": "user",
+            "content": user_content,
+        }));
+        self.session_manager
+            .set_history(session_id, history.clone());
+
+        self.event_sink
+            .push(AcpEvent::thinking(session_id, "Processing prompt..."));
+        let session_snapshot = self
+            .session_manager
+            .get_session(session_id)
+            .ok_or_else(|| format!("Session not found: {session_id}"))?;
+
+        let prompt_result = if let Some(executor) = &self.prompt_executor {
+            executor
+                .execute_prompt(&session_snapshot, &user_text, &history)
+                .await
+        } else {
+            let turn = history
+                .iter()
+                .filter(|m| {
+                    m.get("role")
+                        .and_then(|v| v.as_str())
+                        .map(|r| r == "user")
+                        .unwrap_or(false)
+                })
+                .count();
+            let snippet = user_text.chars().take(200).collect::<String>();
+            Ok(PromptExecutionOutput {
+                response_text: format!(
+                    "ACP session {} processed turn {}.\n\n{}",
+                    session_id, turn, snippet
+                ),
+                usage: None,
+                total_turns: Some(1),
+                events: Vec::new(),
+            })
+        }?;
+
+        let PromptExecutionOutput {
+            response_text,
+            usage,
+            total_turns,
+            events,
+        } = prompt_result;
+
+        for event in events {
+            self.event_sink.push(event);
+        }
+
+        let response_text = response_text.trim().to_string();
+        if !response_text.is_empty() {
+            self.event_sink
+                .push(AcpEvent::message_delta(session_id, &response_text));
+            self.event_sink
+                .push(AcpEvent::message_complete(session_id, &response_text));
+        }
+        self.event_sink.push(AcpEvent::step_complete(
+            session_id,
+            total_turns.unwrap_or(1),
+        ));
+
+        history.push(json!({
+            "role": "assistant",
+            "content": response_text,
+        }));
+        self.session_manager.set_history(session_id, history);
+
+        if let Some(usage) = usage.as_ref() {
+            self.session_manager
+                .add_usage(session_id, usage.input_tokens, usage.output_tokens);
+        }
+        self.session_manager.save_session(session_id);
+
+        Ok(usage)
+    }
+
     fn handle_slash_command(&self, text: &str, session_id: &str) -> Option<String> {
-        let parts: Vec<&str> = text.splitn(2, ' ').collect();
-        let cmd = parts[0].trim_start_matches('/').to_lowercase();
-        let args = if parts.len() > 1 { parts[1].trim() } else { "" };
+        let (cmd, args) = slash_command_parts(text)?;
 
         match cmd.as_str() {
             "help" => {
@@ -793,6 +892,43 @@ impl HermesAcpHandler {
                 Some("Conversation history cleared.".to_string())
             }
             "compact" => self.compact_session_history(session_id),
+            "queue" => {
+                if args.is_empty() {
+                    return Some("Usage: /queue <prompt>".to_string());
+                }
+                if self.session_manager.push_queued_prompt(session_id, args) {
+                    Some("Queued prompt for the next turn.".to_string())
+                } else {
+                    Some(format!("Session not found: {session_id}"))
+                }
+            }
+            "steer" => {
+                if args.is_empty() {
+                    return Some("Usage: /steer <guidance>".to_string());
+                }
+                let state = self.session_manager.get_session(session_id)?;
+                if state.phase == SessionPhase::Active {
+                    self.session_manager.push_queued_prompt(session_id, args);
+                    let steered = match self.prompt_executor.as_ref() {
+                        Some(executor) => match executor.steer_prompt(&state, args) {
+                            Ok(steered) => steered,
+                            Err(err) => {
+                                return Some(format!(
+                                    "Steer failed; queued prompt for the next turn: {err}"
+                                ));
+                            }
+                        },
+                        None => false,
+                    };
+                    if steered {
+                        Some("Steered the active ACP session.".to_string())
+                    } else {
+                        Some("Queued prompt for the next turn.".to_string())
+                    }
+                } else {
+                    None
+                }
+            }
             "version" => Some(format!("Hermes Agent v{}", self.version)),
             "tools" => {
                 let tools = self.available_tools();
@@ -849,6 +985,65 @@ fn param_value_as_string(p: &serde_json::Map<String, Value>, key: &str) -> Optio
 
 fn param_value_as_string_any(p: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
     keys.iter().find_map(|key| param_value_as_string(p, key))
+}
+
+fn slash_command_parts(text: &str) -> Option<(String, &str)> {
+    let trimmed = text.trim_start();
+    let rest = trimmed.strip_prefix('/')?;
+    let (cmd, args) = rest
+        .split_once(char::is_whitespace)
+        .map(|(cmd, args)| (cmd, args.trim()))
+        .unwrap_or((rest, ""));
+    let cmd = cmd.split('@').next().unwrap_or(cmd).trim();
+    (!cmd.is_empty()).then(|| (cmd.to_ascii_lowercase().replace('-', "_"), args))
+}
+
+fn content_value_to_text(value: &Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    if let Some(parts) = value.as_array() {
+        let text = parts
+            .iter()
+            .filter_map(|part| part.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return (!text.trim().is_empty()).then_some(text);
+    }
+    None
+}
+
+fn latest_user_prompt_text(history: &[Value]) -> Option<String> {
+    history.iter().rev().find_map(|message| {
+        (message.get("role").and_then(Value::as_str) == Some("user"))
+            .then(|| message.get("content").and_then(content_value_to_text))
+            .flatten()
+    })
+}
+
+fn merge_usage(left: Option<Usage>, right: Option<Usage>) -> Option<Usage> {
+    match (left, right) {
+        (None, None) => None,
+        (Some(usage), None) | (None, Some(usage)) => Some(usage),
+        (Some(mut left), Some(right)) => {
+            left.input_tokens += right.input_tokens;
+            left.output_tokens += right.output_tokens;
+            left.total_tokens += right.total_tokens;
+            left.thought_tokens = match (left.thought_tokens, right.thought_tokens) {
+                (Some(a), Some(b)) => Some(a + b),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            };
+            left.cached_read_tokens = match (left.cached_read_tokens, right.cached_read_tokens) {
+                (Some(a), Some(b)) => Some(a + b),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            };
+            Some(left)
+        }
+    }
 }
 
 fn prompt_response_value(stop_reason: StopReason, usage: Option<Usage>) -> Value {
@@ -1056,6 +1251,14 @@ impl AcpHandler for HermesAcpHandler {
                 let session_id = params_obj(&request.params)
                     .and_then(|p| param_str_any(p, &["sessionId", "session_id"]))
                     .unwrap_or("");
+                if let Some(state) = self.session_manager.get_session(session_id) {
+                    if state.phase == SessionPhase::Active {
+                        self.session_manager.set_interrupted_prompt_text(
+                            session_id,
+                            latest_user_prompt_text(&state.history),
+                        );
+                    }
+                }
                 self.session_manager
                     .set_phase(session_id, SessionPhase::Cancelled);
                 tracing::info!("Cancelled session {}", session_id);
@@ -1077,8 +1280,8 @@ impl AcpHandler for HermesAcpHandler {
                 }
 
                 let extraction = extract_prompt_payload(p);
-                let user_text = extraction.user_text;
-                let user_content = extraction.user_content;
+                let mut user_text = extraction.user_text;
+                let mut user_content = extraction.user_content;
                 let text_only_prompt = extraction.text_only_prompt;
                 let has_content = extraction.has_content;
 
@@ -1087,6 +1290,42 @@ impl AcpHandler for HermesAcpHandler {
                         request.id,
                         prompt_response_value(StopReason::EndTurn, None),
                     );
+                }
+
+                if text_only_prompt {
+                    if let Some((cmd, args)) = slash_command_parts(&user_text) {
+                        if cmd == "steer" {
+                            if args.is_empty() {
+                                self.event_sink.push(AcpEvent::message_complete(
+                                    session_id,
+                                    "Usage: /steer <guidance>",
+                                ));
+                                return AcpResponse::success(
+                                    request.id,
+                                    prompt_response_value(StopReason::EndTurn, None),
+                                );
+                            }
+
+                            let active = self
+                                .session_manager
+                                .get_session(session_id)
+                                .map(|s| s.phase == SessionPhase::Active)
+                                .unwrap_or(false);
+                            if !active {
+                                if let Some(interrupted) = self
+                                    .session_manager
+                                    .take_interrupted_prompt_text(session_id)
+                                {
+                                    user_text = format!(
+                                        "{interrupted}\n\nUser correction/guidance after interrupt: {args}"
+                                    );
+                                } else {
+                                    user_text = args.to_string();
+                                }
+                                user_content = Value::String(user_text.clone());
+                            }
+                        }
+                    }
                 }
 
                 // Intercept slash commands
@@ -1101,64 +1340,37 @@ impl AcpHandler for HermesAcpHandler {
                     }
                 }
 
+                if self
+                    .session_manager
+                    .get_session(session_id)
+                    .map(|s| s.phase == SessionPhase::Active)
+                    .unwrap_or(false)
+                {
+                    let queued_text = if user_text.trim().is_empty() {
+                        "[Image attachment]"
+                    } else {
+                        user_text.trim()
+                    };
+                    self.session_manager
+                        .push_queued_prompt(session_id, queued_text);
+                    self.event_sink.push(AcpEvent::message_complete(
+                        session_id,
+                        "Queued prompt for the next turn.",
+                    ));
+                    return AcpResponse::success(
+                        request.id,
+                        prompt_response_value(StopReason::EndTurn, None),
+                    );
+                }
+
                 self.session_manager
                     .set_phase(session_id, SessionPhase::Active);
 
-                let mut history = self
-                    .session_manager
-                    .get_session(session_id)
-                    .map(|s| s.history)
-                    .unwrap_or_default();
-                history.push(json!({
-                    "role": "user",
-                    "content": user_content,
-                }));
-                self.session_manager
-                    .set_history(session_id, history.clone());
-
-                self.event_sink
-                    .push(AcpEvent::thinking(session_id, "Processing prompt..."));
-                let session_snapshot = self
-                    .session_manager
-                    .get_session(session_id)
-                    .ok_or_else(|| format!("Session not found: {session_id}"));
-                let session_snapshot = match session_snapshot {
-                    Ok(s) => s,
-                    Err(e) => {
-                        self.event_sink.push(AcpEvent::error(session_id, &e));
-                        self.session_manager
-                            .set_phase(session_id, SessionPhase::Failed);
-                        return AcpResponse::error(request.id, -32602, e);
-                    }
-                };
-
-                let prompt_result = if let Some(executor) = &self.prompt_executor {
-                    executor
-                        .execute_prompt(&session_snapshot, &user_text, &history)
-                        .await
-                } else {
-                    let turn = history
-                        .iter()
-                        .filter(|m| {
-                            m.get("role")
-                                .and_then(|v| v.as_str())
-                                .map(|r| r == "user")
-                                .unwrap_or(false)
-                        })
-                        .count();
-                    let snippet = user_text.chars().take(200).collect::<String>();
-                    Ok(PromptExecutionOutput {
-                        response_text: format!(
-                            "ACP session {} processed turn {}.\n\n{}",
-                            session_id, turn, snippet
-                        ),
-                        usage: None,
-                        total_turns: Some(1),
-                        events: Vec::new(),
-                    })
-                };
-                let prompt_result = match prompt_result {
-                    Ok(r) => r,
+                let mut usage = match self
+                    .execute_prompt_turn(session_id, user_text, user_content)
+                    .await
+                {
+                    Ok(usage) => usage,
                     Err(err) => {
                         self.event_sink.push(AcpEvent::error(session_id, &err));
                         self.session_manager
@@ -1167,43 +1379,25 @@ impl AcpHandler for HermesAcpHandler {
                     }
                 };
 
-                let PromptExecutionOutput {
-                    response_text,
-                    usage,
-                    total_turns,
-                    events,
-                } = prompt_result;
-
-                for event in events {
-                    self.event_sink.push(event);
+                while let Some(queued_prompt) = self.session_manager.pop_queued_prompt(session_id) {
+                    let queued_usage = match self
+                        .execute_prompt_turn(
+                            session_id,
+                            queued_prompt.clone(),
+                            Value::String(queued_prompt),
+                        )
+                        .await
+                    {
+                        Ok(usage) => usage,
+                        Err(err) => {
+                            self.event_sink.push(AcpEvent::error(session_id, &err));
+                            self.session_manager
+                                .set_phase(session_id, SessionPhase::Failed);
+                            return AcpResponse::error(request.id, -32000, err);
+                        }
+                    };
+                    usage = merge_usage(usage, queued_usage);
                 }
-
-                let response_text = response_text.trim().to_string();
-                if !response_text.is_empty() {
-                    self.event_sink
-                        .push(AcpEvent::message_delta(session_id, &response_text));
-                    self.event_sink
-                        .push(AcpEvent::message_complete(session_id, &response_text));
-                }
-                self.event_sink.push(AcpEvent::step_complete(
-                    session_id,
-                    total_turns.unwrap_or(1),
-                ));
-
-                history.push(json!({
-                    "role": "assistant",
-                    "content": response_text,
-                }));
-                self.session_manager.set_history(session_id, history);
-
-                if let Some(usage) = usage.as_ref() {
-                    self.session_manager.add_usage(
-                        session_id,
-                        usage.input_tokens,
-                        usage.output_tokens,
-                    );
-                }
-                self.session_manager.save_session(session_id);
 
                 self.session_manager
                     .set_phase(session_id, SessionPhase::Idle);
@@ -1516,12 +1710,56 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct SteeringPromptExecutor {
+        steers: std::sync::Mutex<Vec<String>>,
+        runs: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl AcpPromptExecutor for SteeringPromptExecutor {
+        async fn execute_prompt(
+            &self,
+            _session: &SessionState,
+            user_text: &str,
+            _history: &[Value],
+        ) -> Result<PromptExecutionOutput, String> {
+            self.runs.lock().unwrap().push(user_text.to_string());
+            Ok(PromptExecutionOutput {
+                response_text: format!("ran:{user_text}"),
+                usage: None,
+                total_turns: Some(1),
+                events: Vec::new(),
+            })
+        }
+
+        fn steer_prompt(&self, _session: &SessionState, guidance: &str) -> Result<bool, String> {
+            self.steers.lock().unwrap().push(guidance.to_string());
+            Ok(true)
+        }
+    }
+
     fn make_handler() -> HermesAcpHandler {
         HermesAcpHandler::new(
             Arc::new(SessionManager::new()),
             Arc::new(EventSink::default()),
             Arc::new(PermissionStore::new()),
         )
+    }
+
+    async fn create_session(handler: &HermesAcpHandler) -> String {
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/new".into(),
+                params: Some(json!({"cwd": "."})),
+            })
+            .await;
+        resp.result.unwrap()["sessionId"]
+            .as_str()
+            .unwrap()
+            .to_string()
     }
 
     fn make_handler_with_auth_provider(provider: Option<&'static str>) -> HermesAcpHandler {
@@ -2096,6 +2334,232 @@ mod tests {
 
         let state = handler.session_manager.get_session(&session_id).unwrap();
         assert!(state.history.len() < 14);
+    }
+
+    #[tokio::test]
+    async fn test_help_lists_queue_and_steer_slash_commands() {
+        let handler = make_handler();
+        let session_id = create_session(&handler).await;
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "/help",
+                })),
+            })
+            .await;
+        assert_eq!(resp.result.unwrap()["stopReason"], "end_turn");
+
+        let events = handler.event_sink.drain_for_session(&session_id);
+        let help_text = events
+            .iter()
+            .filter(|event| matches!(event.kind, AcpEventKind::MessageComplete))
+            .filter_map(|event| event.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(help_text.contains("/queue"));
+        assert!(help_text.contains("/steer"));
+    }
+
+    #[tokio::test]
+    async fn test_acp_queue_slash_command_adds_next_turn_without_running_now() {
+        let executor = Arc::new(SteeringPromptExecutor::default());
+        let handler = make_handler().with_prompt_executor(executor.clone());
+        let session_id = create_session(&handler).await;
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "/queue run the tests after this",
+                })),
+            })
+            .await;
+
+        assert_eq!(resp.result.unwrap()["stopReason"], "end_turn");
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.queued_prompts, vec!["run the tests after this"]);
+        assert!(state.history.is_empty());
+        assert!(executor.runs.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_acp_prompt_drains_queued_turns_after_current_run() {
+        let handler = HermesAcpHandler::new(
+            Arc::new(SessionManager::new()),
+            Arc::new(EventSink::default()),
+            Arc::new(PermissionStore::new()),
+        )
+        .with_prompt_executor(Arc::new(EchoPromptExecutor));
+        let session_id = create_session(&handler).await;
+        handler
+            .session_manager
+            .push_queued_prompt(&session_id, "then run tests");
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "make the change",
+                })),
+            })
+            .await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["stopReason"], "end_turn");
+        assert_eq!(result["usage"]["inputTokens"], 6);
+        assert_eq!(result["usage"]["outputTokens"], 10);
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        let user_turns = state
+            .history
+            .iter()
+            .filter(|message| message.get("role").and_then(Value::as_str) == Some("user"))
+            .filter_map(|message| message.get("content").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(user_turns, vec!["make the change", "then run tests"]);
+        assert!(state.queued_prompts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_acp_regular_prompt_queues_while_session_is_active() {
+        let executor = Arc::new(SteeringPromptExecutor::default());
+        let handler = make_handler().with_prompt_executor(executor.clone());
+        let session_id = create_session(&handler).await;
+        handler
+            .session_manager
+            .set_phase(&session_id, SessionPhase::Active);
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "follow up after current work",
+                })),
+            })
+            .await;
+
+        assert_eq!(resp.result.unwrap()["stopReason"], "end_turn");
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.queued_prompts, vec!["follow up after current work"]);
+        assert!(state.history.is_empty());
+        assert!(executor.runs.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_acp_steer_slash_command_signals_active_executor_and_queues_guidance() {
+        let executor = Arc::new(SteeringPromptExecutor::default());
+        let handler = make_handler().with_prompt_executor(executor.clone());
+        let session_id = create_session(&handler).await;
+        handler
+            .session_manager
+            .set_phase(&session_id, SessionPhase::Active);
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "/steer prefer the simpler fix",
+                })),
+            })
+            .await;
+
+        assert_eq!(resp.result.unwrap()["stopReason"], "end_turn");
+        assert_eq!(
+            executor.steers.lock().unwrap().as_slice(),
+            ["prefer the simpler fix"]
+        );
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.queued_prompts, vec!["prefer the simpler fix"]);
+        assert!(executor.runs.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_acp_steer_on_idle_session_runs_as_regular_prompt() {
+        let executor = Arc::new(SteeringPromptExecutor::default());
+        let handler = make_handler().with_prompt_executor(executor.clone());
+        let session_id = create_session(&handler).await;
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "/steer summarize the README",
+                })),
+            })
+            .await;
+
+        assert_eq!(resp.result.unwrap()["stopReason"], "end_turn");
+        assert_eq!(
+            executor.runs.lock().unwrap().as_slice(),
+            ["summarize the README"]
+        );
+        assert!(executor.steers.lock().unwrap().is_empty());
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert!(state.queued_prompts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_acp_steer_after_cancel_replays_interrupted_prompt_with_guidance() {
+        let executor = Arc::new(SteeringPromptExecutor::default());
+        let handler = make_handler().with_prompt_executor(executor.clone());
+        let session_id = create_session(&handler).await;
+        handler.session_manager.set_history(
+            &session_id,
+            vec![json!({"role": "user", "content": "write hi to a text file"})],
+        );
+        handler
+            .session_manager
+            .set_phase(&session_id, SessionPhase::Active);
+
+        let cancel = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session/cancel".into(),
+                params: Some(json!({"session_id": session_id.clone()})),
+            })
+            .await;
+        assert_eq!(cancel.result.unwrap()["cancelled"], true);
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(3)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "session_id": session_id.clone(),
+                    "text": "/steer write HELLO instead",
+                })),
+            })
+            .await;
+
+        assert_eq!(resp.result.unwrap()["stopReason"], "end_turn");
+        assert_eq!(
+            executor.runs.lock().unwrap().as_slice(),
+            ["write hi to a text file\n\nUser correction/guidance after interrupt: write HELLO instead"]
+        );
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert!(state.interrupted_prompt_text.is_none());
+        assert!(state.queued_prompts.is_empty());
     }
 
     #[tokio::test]

--- a/crates/hermes-acp/src/session.rs
+++ b/crates/hermes-acp/src/session.rs
@@ -54,6 +54,10 @@ pub struct SessionState {
     pub history: Vec<Value>,
     pub mode: Option<String>,
     pub config_options: HashMap<String, String>,
+    /// Prompts queued by `/queue` to run after the current prompt completes.
+    pub queued_prompts: Vec<String>,
+    /// Last interrupted prompt text that `/steer` can replay with guidance.
+    pub interrupted_prompt_text: Option<String>,
     pub created_at: u64,
     pub updated_at: u64,
     /// Total prompt tokens across all turns.
@@ -79,6 +83,8 @@ impl SessionState {
             history: Vec::new(),
             mode: None,
             config_options: HashMap::new(),
+            queued_prompts: Vec::new(),
+            interrupted_prompt_text: None,
             created_at: now,
             updated_at: now,
             total_prompt_tokens: 0,
@@ -256,6 +262,65 @@ impl SessionManager {
             state.history = history;
             state.touch();
         }
+    }
+
+    /// Queue a prompt to execute after the current turn.
+    pub fn push_queued_prompt(&self, session_id: &str, prompt: &str) -> bool {
+        let mut sessions = self.sessions.lock().unwrap();
+        if let Some(state) = sessions.get_mut(session_id) {
+            let prompt = prompt.trim();
+            if !prompt.is_empty() {
+                state.queued_prompts.push(prompt.to_string());
+                state.touch();
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Drain queued prompts in FIFO order.
+    pub fn take_queued_prompts(&self, session_id: &str) -> Vec<String> {
+        let mut sessions = self.sessions.lock().unwrap();
+        if let Some(state) = sessions.get_mut(session_id) {
+            state.touch();
+            return std::mem::take(&mut state.queued_prompts);
+        }
+        Vec::new()
+    }
+
+    /// Pop one queued prompt in FIFO order.
+    pub fn pop_queued_prompt(&self, session_id: &str) -> Option<String> {
+        let mut sessions = self.sessions.lock().unwrap();
+        if let Some(state) = sessions.get_mut(session_id) {
+            if !state.queued_prompts.is_empty() {
+                state.touch();
+                return Some(state.queued_prompts.remove(0));
+            }
+        }
+        None
+    }
+
+    /// Store an interrupted prompt for subsequent `/steer` replay.
+    pub fn set_interrupted_prompt_text(&self, session_id: &str, prompt: Option<String>) -> bool {
+        let mut sessions = self.sessions.lock().unwrap();
+        if let Some(state) = sessions.get_mut(session_id) {
+            state.interrupted_prompt_text = prompt
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            state.touch();
+            return true;
+        }
+        false
+    }
+
+    /// Take and clear the interrupted prompt text.
+    pub fn take_interrupted_prompt_text(&self, session_id: &str) -> Option<String> {
+        let mut sessions = self.sessions.lock().unwrap();
+        if let Some(state) = sessions.get_mut(session_id) {
+            state.touch();
+            return state.interrupted_prompt_text.take();
+        }
+        None
     }
 
     /// Fork a session — deep-copy history into a new session.

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -4,7 +4,7 @@
 //! REPL, and provides auto-completion suggestions.
 
 use std::process::{Command, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::{
     collections::{HashMap, HashSet},
     fmt::Write as _,
@@ -26769,6 +26769,7 @@ struct CliAcpPromptExecutor {
     config: Arc<hermes_config::GatewayConfig>,
     tool_registry: Arc<hermes_tools::ToolRegistry>,
     tool_schemas: Vec<hermes_core::ToolSchema>,
+    interrupts: Arc<Mutex<HashMap<String, hermes_agent::InterruptController>>>,
 }
 
 #[async_trait::async_trait]
@@ -26790,17 +26791,20 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
         agent_config.session_id = Some(session.session_id.clone());
 
         let agent_tools = Arc::new(crate::app::bridge_tool_registry(&self.tool_registry));
-        let agent = hermes_agent::attach_discovered_memory(hermes_agent::AgentLoop::new(
-            agent_config,
-            agent_tools,
-            provider,
-        ));
+        let interrupt = hermes_agent::InterruptController::new();
+        if let Ok(mut active) = self.interrupts.lock() {
+            active.insert(session.session_id.clone(), interrupt.clone());
+        }
+        let agent = hermes_agent::attach_discovered_memory(
+            hermes_agent::AgentLoop::with_interrupt(agent_config, agent_tools, provider, interrupt),
+        );
         let messages = acp_history_to_messages(history, user_text);
 
-        let result = agent
-            .run(messages, Some(self.tool_schemas.clone()))
-            .await
-            .map_err(|e| e.to_string())?;
+        let result = agent.run(messages, Some(self.tool_schemas.clone())).await;
+        if let Ok(mut active) = self.interrupts.lock() {
+            active.remove(&session.session_id);
+        }
+        let result = result.map_err(|e| e.to_string())?;
         let response_text = result
             .messages
             .iter()
@@ -26823,6 +26827,25 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
             total_turns: Some(result.total_turns),
             events: acp_events_from_agent_messages(&session.session_id, &result.messages),
         })
+    }
+
+    fn steer_prompt(
+        &self,
+        session: &hermes_acp::SessionState,
+        guidance: &str,
+    ) -> Result<bool, String> {
+        let controller = self
+            .interrupts
+            .lock()
+            .map_err(|_| "ACP interrupt registry poisoned".to_string())?
+            .get(&session.session_id)
+            .cloned();
+        if let Some(controller) = controller {
+            controller.interrupt(Some(format!("User guidance: {guidance}")));
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -26925,6 +26948,7 @@ pub async fn handle_cli_acp(
                 config: Arc::new(config.clone()),
                 tool_registry,
                 tool_schemas,
+                interrupts: Arc::new(Mutex::new(HashMap::new())),
             });
 
             let session_manager = Arc::new(hermes_acp::SessionManager::new());

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -787,6 +787,18 @@
     "3260413cc7fa": {
       "disposition": "ported",
       "notes": "Rust STT override env vars are first-class runtime knobs: HERMES_STT_PROVIDER/STT_PROVIDER, STT_OPENAI_MODEL, STT_GROQ_MODEL, STT_MISTRAL_MODEL, and provider base-url overrides are resolved in the Rust transcription/gateway voice surfaces with tests."
+    },
+    "e27b0b76517c903541af20d0bd606fa7b3c83005": {
+      "disposition": "ported",
+      "notes": "Rust ACP now advertises /steer and /queue, queues prompts without racing active sessions, drains queued turns FIFO after current completion, and exposes an AcpPromptExecutor steer hook; hermes-acp queue/steer tests cover slash discovery, no-run queueing, active queueing, active steer signaling, and queued drain."
+    },
+    "78886365c2a04f3367028190b71c5b4a96433279": {
+      "disposition": "ported",
+      "notes": "Rust ACP cancel now captures the interrupted user prompt and idle /steer replays it with explicit correction/guidance; hermes-acp tests cover cancel replay and clearing interrupted_prompt_text."
+    },
+    "41fa1f1b5cf560c22a7e9adb06eb463d7122f9e0": {
+      "disposition": "ported",
+      "notes": "Rust ACP rewrites idle /steer into a regular user prompt instead of silently queueing it, matching upstream editor-client behavior; hermes-acp idle steer test proves the prompt runs immediately and leaves the queue empty."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Add Rust ACP `/queue` and `/steer` slash command discovery and handling.
- Queue regular prompts that arrive while a session is active, then drain queued turns FIFO after the current turn.
- Add idle `/steer` rewrite, cancelled-prompt replay with guidance, and an `AcpPromptExecutor::steer_prompt` hook backed by the CLI ACP `InterruptController`.
- Promote the three upstream ACP queue/steer SHAs to `ported` in `docs/parity/queue-overrides.json`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json`
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-acp-queue-steer-queue.json --out-md /tmp/hermes-acp-queue-steer-queue.md`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-acp-queue CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 66 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-acp-cli CARGO_INCREMENTAL=0 cargo test -p hermes-cli acp -- --nocapture` -> filtered ACP tests passed
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-acp-build CARGO_INCREMENTAL=0 cargo build -p hermes-acp -p hermes-cli`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-acp-clippy CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp -p hermes-cli` -> `new=0`

## Parity Proof
- Queue proof after overrides: `pending=1948`, `ported=70`, `mirrored=162`, `superseded=7601`.
- Ported SHAs: `e27b0b76517c`, `78886365c2a0`, `41fa1f1b5cf5`.

## Risk
- Active `/steer` signals the current Rust ACP agent through the existing interrupt controller and queues the guidance for follow-up execution. It does not claim token-level mid-generation mutation beyond the agent loop's cooperative interrupt points.
