### PR TITLE
parity(agent): enforce disabled toolsets at runtime

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -1103,6 +1103,17 @@ fn rand_u64_range(min: u64, max: u64) -> u64 {
     }
 }
 
+fn advertised_tool_name_index(tool_schemas: &[ToolSchema]) -> (HashSet<&str>, String) {
+    let mut names: Vec<&str> = tool_schemas
+        .iter()
+        .map(|schema| schema.name.as_str())
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    let display = names.join(", ");
+    (names.into_iter().collect(), display)
+}
+
 /// Result of collecting one streaming completion (may end with user interrupt).
 enum StreamCollectOutcome {
     Complete(LlmResponse),
@@ -4622,6 +4633,8 @@ impl AgentLoop {
 
         // Determine which tools to expose
         let tool_schemas: Vec<ToolSchema> = tools.unwrap_or_else(|| self.tool_registry.schemas());
+        let (advertised_tool_names, advertised_tool_names_display) =
+            advertised_tool_name_index(&tool_schemas);
 
         // Build and inject system prompt (or reuse SQLite-cached prompt for session continuity)
         let (system_content, restored_system) =
@@ -5328,7 +5341,7 @@ impl AgentLoop {
             }
             let invalid_tool_calls: Vec<String> = tool_calls
                 .iter()
-                .filter(|tc| self.tool_registry.get(&tc.function.name).is_none())
+                .filter(|tc| !advertised_tool_names.contains(tc.function.name.as_str()))
                 .map(|tc| tc.function.name.clone())
                 .collect();
             if !invalid_tool_calls.is_empty() {
@@ -5340,7 +5353,6 @@ impl AgentLoop {
                         invalid_tool_retries, self.config.invalid_tool_call_max_retries
                     ),
                 );
-                let available = self.tool_registry.names().join(", ");
                 if invalid_tool_retries >= self.config.invalid_tool_call_max_retries {
                     self.emit_status(
                         "lifecycle",
@@ -5369,7 +5381,12 @@ impl AgentLoop {
                     let content = if self.tool_registry.get(&tc.function.name).is_none() {
                         format!(
                             "Tool '{}' does not exist. Available tools: {}",
-                            tc.function.name, available
+                            tc.function.name, advertised_tool_names_display
+                        )
+                    } else if !advertised_tool_names.contains(tc.function.name.as_str()) {
+                        format!(
+                            "Tool '{}' is not enabled in this session. Available tools: {}",
+                            tc.function.name, advertised_tool_names_display
                         )
                     } else {
                         "Skipped: another tool call in this turn used an invalid name. Please retry this tool call.".to_string()
@@ -5488,6 +5505,7 @@ impl AgentLoop {
                     &tool_calls,
                     total_turns,
                     tool_governor.tool_concurrency,
+                    &tool_schemas,
                     contextlattice_connect_intent,
                     self.config
                         .max_cost_usd
@@ -5806,6 +5824,8 @@ impl AgentLoop {
             .unwrap_or_default();
 
         let tool_schemas: Vec<ToolSchema> = tools.unwrap_or_else(|| self.tool_registry.schemas());
+        let (advertised_tool_names, advertised_tool_names_display) =
+            advertised_tool_name_index(&tool_schemas);
         let (system_content, restored_system) =
             self.resolve_initial_system_prompt(&task_hint, &tool_schemas);
         ctx.add_message(Message::system(&system_content));
@@ -6615,7 +6635,7 @@ impl AgentLoop {
 
             let invalid_tool_calls: Vec<String> = tool_calls
                 .iter()
-                .filter(|tc| self.tool_registry.get(&tc.function.name).is_none())
+                .filter(|tc| !advertised_tool_names.contains(tc.function.name.as_str()))
                 .map(|tc| tc.function.name.clone())
                 .collect();
             if !invalid_tool_calls.is_empty() {
@@ -6627,7 +6647,6 @@ impl AgentLoop {
                         invalid_tool_retries, self.config.invalid_tool_call_max_retries
                     ),
                 );
-                let available = self.tool_registry.names().join(", ");
                 if invalid_tool_retries >= self.config.invalid_tool_call_max_retries {
                     self.emit_status(
                         "lifecycle",
@@ -6656,7 +6675,12 @@ impl AgentLoop {
                     let content = if self.tool_registry.get(&tc.function.name).is_none() {
                         format!(
                             "Tool '{}' does not exist. Available tools: {}",
-                            tc.function.name, available
+                            tc.function.name, advertised_tool_names_display
+                        )
+                    } else if !advertised_tool_names.contains(tc.function.name.as_str()) {
+                        format!(
+                            "Tool '{}' is not enabled in this session. Available tools: {}",
+                            tc.function.name, advertised_tool_names_display
                         )
                     } else {
                         "Skipped: another tool call in this turn used an invalid name. Please retry this tool call.".to_string()
@@ -6770,6 +6794,7 @@ impl AgentLoop {
                     &tool_calls,
                     total_turns,
                     tool_concurrency,
+                    &tool_schemas,
                     contextlattice_connect_intent,
                     self.config
                         .max_cost_usd
@@ -7603,6 +7628,7 @@ impl AgentLoop {
         tool_calls: &[ToolCall],
         turn: u32,
         tool_concurrency: usize,
+        tool_schemas: &[ToolSchema],
         contextlattice_connect_intent: bool,
         parent_budget_remaining_usd: Option<f64>,
         tool_errors: &mut Vec<hermes_core::ToolErrorRecord>,
@@ -7660,16 +7686,24 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                let requested_toolset = parsed
+                    .get("toolset")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
                 let req = crate::sub_agent_orchestrator::SubAgentRequest {
                     task,
                     context: parsed
                         .get("context")
                         .and_then(|v| v.as_str())
                         .map(str::to_string),
-                    toolset: parsed
-                        .get("toolset")
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string),
+                    inherited_tool_schemas: if requested_toolset.is_none() {
+                        tool_schemas.to_vec()
+                    } else {
+                        Vec::new()
+                    },
+                    toolset: requested_toolset,
                     model: parsed
                         .get("model")
                         .and_then(|v| v.as_str())
@@ -12456,6 +12490,111 @@ mod tests {
         // Python follows the same cadence because `_iters_since_skill += 1`
         // happens at each loop iteration before the tool/reset branch.
         assert_eq!(counters.iters_since_skill, 1);
+    }
+
+    #[test]
+    fn hidden_registered_tool_call_is_rejected_when_not_advertised() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        struct HiddenToolProvider {
+            calls: Arc<AtomicU32>,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for HiddenToolProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                let n = self.calls.fetch_add(1, Ordering::SeqCst);
+                let message = if n == 0 {
+                    Message::assistant_with_tool_calls(
+                        None,
+                        vec![ToolCall {
+                            id: "tc_hidden".to_string(),
+                            function: hermes_core::FunctionCall {
+                                name: "web_search".to_string(),
+                                arguments: "{}".to_string(),
+                            },
+                            extra_content: None,
+                        }],
+                    )
+                } else {
+                    Message::assistant("done")
+                };
+                Ok(hermes_core::LlmResponse {
+                    message,
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let terminal_schema =
+            ToolSchema::new("terminal", "Terminal tool", JsonSchema::new("object"));
+        let hidden_executions = Arc::new(AtomicU32::new(0));
+        let hidden_executions_for_tool = hidden_executions.clone();
+        let mut registry = ToolRegistry::new();
+        registry.register(
+            "terminal",
+            terminal_schema.clone(),
+            Arc::new(|_args| Ok("terminal ran".to_string())),
+        );
+        registry.register(
+            "web_search",
+            ToolSchema::new("web_search", "Web search", JsonSchema::new("object")),
+            Arc::new(move |_args| {
+                hidden_executions_for_tool.fetch_add(1, Ordering::SeqCst);
+                Ok("web ran".to_string())
+            }),
+        );
+
+        let config = AgentConfig {
+            max_turns: 4,
+            invalid_tool_call_max_retries: 2,
+            ..AgentConfig::default()
+        };
+        let provider = Arc::new(HiddenToolProvider {
+            calls: Arc::new(AtomicU32::new(0)),
+        });
+        let agent = AgentLoop::new(config, Arc::new(registry), provider);
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let result = rt
+            .block_on(agent.run(
+                vec![Message::user("search the web")],
+                Some(vec![terminal_schema]),
+            ))
+            .expect("agent run should succeed");
+
+        assert!(result.finished_naturally);
+        assert_eq!(hidden_executions.load(Ordering::SeqCst), 0);
+        let transcript = result
+            .messages
+            .iter()
+            .filter_map(|msg| msg.content.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(transcript.contains("Tool 'web_search' is not enabled in this session"));
+        assert!(transcript.contains("Available tools: terminal"));
+        assert!(!transcript.contains("web ran"));
     }
 
     #[test]

--- a/crates/hermes-agent/src/sub_agent_orchestrator.rs
+++ b/crates/hermes-agent/src/sub_agent_orchestrator.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use hermes_core::{AgentError, LlmProvider, Message};
+use hermes_core::{AgentError, LlmProvider, Message, ToolSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::time::timeout;
@@ -99,6 +99,8 @@ pub struct SubAgentRequest {
     pub task: String,
     pub context: Option<String>,
     pub toolset: Option<String>,
+    /// Parent-advertised tools to inherit when no explicit child toolset is requested.
+    pub inherited_tool_schemas: Vec<ToolSchema>,
     pub model: Option<String>,
     /// Child depth injected by parent agent loop (parent_depth + 1).
     pub child_depth: u32,
@@ -284,6 +286,11 @@ impl SubAgentOrchestrator {
         let tool_registry = self.cfg.tool_registry.clone();
         let llm_provider = self.cfg.llm_provider.clone();
         let child_depth = req.child_depth;
+        let inherited_tools = if req.toolset.is_none() && !req.inherited_tool_schemas.is_empty() {
+            Some(req.inherited_tool_schemas.clone())
+        } else {
+            None
+        };
         let initial = initial_messages(&req.task, req.context.as_deref());
 
         // Run the child on its own tokio task so that its `impl Future` type is
@@ -300,7 +307,7 @@ impl SubAgentOrchestrator {
                 child_interrupt_for_spawn,
             )
             .with_delegate_depth(child_depth);
-            child_agent.run(initial, None).await
+            child_agent.run(initial, inherited_tools).await
         });
 
         let result = match timeout(self.cfg.timeout, join).await {
@@ -430,8 +437,8 @@ fn extract_final_assistant_text(messages: &[Message]) -> String {
 mod tests {
     use super::*;
     use futures::stream::{BoxStream, StreamExt};
-    use hermes_core::{LlmResponse, StreamChunk, ToolSchema};
-    use std::sync::Arc;
+    use hermes_core::{JsonSchema, LlmResponse, StreamChunk, ToolSchema};
+    use std::sync::{Arc, Mutex};
 
     // Minimal test provider that returns a deterministic assistant response
     // so the child loop finishes in a single turn. Behavioural tests live
@@ -466,6 +473,85 @@ mod tests {
         ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
             futures::stream::empty().boxed()
         }
+    }
+
+    #[tokio::test]
+    async fn omitted_toolset_inherits_parent_advertised_tools() {
+        struct RecordingProvider {
+            seen_tools: Arc<Mutex<Vec<Vec<String>>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for RecordingProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<LlmResponse, AgentError> {
+                self.seen_tools
+                    .lock()
+                    .expect("seen tools lock")
+                    .push(tools.iter().map(|tool| tool.name.clone()).collect());
+                Ok(LlmResponse {
+                    message: Message::assistant("done"),
+                    usage: None,
+                    model: "recording".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let seen_tools = Arc::new(Mutex::new(Vec::<Vec<String>>::new()));
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = Arc::new(SubAgentOrchestrator::new(SubAgentOrchestratorConfig {
+            parent_config: AgentConfig {
+                max_turns: 2,
+                ..AgentConfig::default()
+            },
+            tool_registry: Arc::new(ToolRegistry::new()),
+            llm_provider: Arc::new(RecordingProvider {
+                seen_tools: seen_tools.clone(),
+            }),
+            parent_interrupt: InterruptController::new(),
+            hermes_home: tmp.path().to_path_buf(),
+            parent_session_id: Some("parent".into()),
+            timeout: Duration::from_secs(2),
+        }));
+
+        let out = orch
+            .execute(SubAgentRequest {
+                task: "child task".into(),
+                child_depth: 1,
+                max_depth: 4,
+                inherited_tool_schemas: vec![ToolSchema::new(
+                    "terminal",
+                    "Terminal tool",
+                    JsonSchema::new("object"),
+                )],
+                ..Default::default()
+            })
+            .await;
+
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["status"], "completed");
+        let seen = seen_tools.lock().expect("seen tools lock");
+        assert_eq!(seen.as_slice(), &[vec!["terminal".to_string()]]);
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/tools/code_execution.rs
+++ b/crates/hermes-tools/src/tools/code_execution.rs
@@ -119,6 +119,9 @@ mod tests {
         assert_eq!(schema.name, "execute_code");
         let rendered = serde_json::to_string(&schema.parameters).expect("schema json");
         assert!(!rendered.contains("\"python\""));
+        assert!(!rendered.contains("web_search"));
+        assert!(!rendered.contains("web_extract"));
+        assert!(!rendered.contains("read_file"));
         assert!(rendered.contains("\"language\""));
     }
 

--- a/crates/hermes-tools/src/tools/delegation.rs
+++ b/crates/hermes-tools/src/tools/delegation.rs
@@ -99,7 +99,7 @@ impl ToolHandler for DelegateTaskHandler {
             "toolset".into(),
             json!({
                 "type": "string",
-                "description": "Toolset name to assign to the sub-agent (e.g. 'web', 'terminal')"
+                "description": "Optional toolset name for the sub-agent. Omit to inherit the currently enabled parent tools."
             }),
         );
         props.insert(
@@ -133,7 +133,7 @@ impl ToolHandler for DelegateTaskHandler {
 
         tool_schema(
             "delegate_task",
-            "Delegate a task to a sub-agent with an isolated context. The sub-agent will work independently and return results.",
+            "Delegate a task to a sub-agent with an isolated context. Omitted toolset inherits the current session's enabled tools.",
             JsonSchema::object(props, vec!["task".into()]),
         )
     }
@@ -164,6 +164,9 @@ mod tests {
     async fn test_delegate_task_schema() {
         let handler = DelegateTaskHandler::new(Arc::new(MockDelegationBackend));
         assert_eq!(handler.schema().name, "delegate_task");
+        let rendered = serde_json::to_string(&handler.schema()).expect("schema json");
+        assert!(rendered.contains("inherit"));
+        assert!(rendered.contains("currently enabled parent tools"));
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -811,6 +811,10 @@
     "ef5eaf8d8757a5e75fa571042abc287430192f53": {
       "disposition": "ported",
       "notes": "Rust cron now honors the cron platform_toolsets config path, adds the hermes-cron default platform/toolset surface, hard-denies recursive and interactive cron tools, preserves direct custom-tool fallback, and covers default/configured cron filtering with targeted tests."
+    },
+    "f75b1d21b4c8cacc2b9b9fb87227ff315365cd90": {
+      "disposition": "ported",
+      "notes": "Rust agent loop now treats advertised tool schemas as the runtime allowlist, rejects registered-but-disabled fabricated tool calls in non-streaming and streaming loops, and makes delegate_task inherit the parent enabled tool surface when no explicit child toolset is requested; execute_code schema remains Rust-only and does not advertise disabled sandbox helper tools."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Port upstream `f75b1d21b4c8cacc2b9b9fb87227ff315365cd90` (`fix: execute_code and delegate_task now respect disabled toolsets`) into the Rust runtime.
- Treat advertised tool schemas as the runtime allowlist in both non-streaming and streaming `AgentLoop` paths, rejecting registered-but-disabled fabricated tool calls before execution.
- Make `delegate_task` inherit the parent enabled tool surface when no explicit child `toolset` is requested.
- Add schema guards for `delegate_task` inheritance wording and Rust-only `execute_code` surface.
- Mark the upstream SHA as `ported` in `docs/parity/queue-overrides.json`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-disabled-tools CARGO_INCREMENTAL=0 cargo test -p hermes-agent hidden_registered_tool_call -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-disabled-tools CARGO_INCREMENTAL=0 cargo test -p hermes-agent omitted_toolset_inherits_parent_advertised_tools -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-disabled-tools CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_delegate_task_schema -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-disabled-tools CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_execute_code_schema -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-disabled-tools-build CARGO_INCREMENTAL=0 cargo build -p hermes-agent -p hermes-tools`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-disabled-tools-clippy CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-tools` -> `seen=199 allowlist=204 new=0 stale=5`

## Queue Proof
- `pending=1944`
- `ported=74`
- `mirrored=162`
- `superseded=7601`
- `total_commits=9781`
- `f75b1d21b4c8=ported`
