### PR TITLE
parity(tools): dedup process notifications

### DIFF
--- a/crates/hermes-tools/src/tools/process_registry.rs
+++ b/crates/hermes-tools/src/tools/process_registry.rs
@@ -20,9 +20,26 @@ struct ProcessEntry {
     updated_at: i64,
 }
 
+#[derive(Clone, Debug)]
+struct ProcessNotificationReceipt {
+    dedup_key: String,
+    event_type: String,
+    session_id: String,
+    command: Option<String>,
+    pattern: Option<String>,
+    output: Option<String>,
+    message: Option<String>,
+    suppressed: u64,
+    message_id: Option<String>,
+    first_seen_at: i64,
+    last_seen_at: i64,
+    seen_count: u64,
+}
+
 #[derive(Clone, Default)]
 pub struct ProcessRegistryHandler {
     entries: Arc<Mutex<HashMap<String, ProcessEntry>>>,
+    notification_receipts: Arc<Mutex<HashMap<String, ProcessNotificationReceipt>>>,
 }
 
 fn unix_ts() -> i64 {
@@ -39,6 +56,23 @@ fn normalize_opt_string(input: Option<&Value>) -> Option<String> {
     } else {
         Some(raw.to_string())
     }
+}
+
+fn string_field(params: &Value, key: &str) -> String {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn optional_string_field(params: &Value, key: &str) -> Option<String> {
+    normalize_opt_string(params.get(key))
+}
+
+fn u64_field(params: &Value, key: &str) -> u64 {
+    params.get(key).and_then(Value::as_u64).unwrap_or(0)
 }
 
 fn parse_status(input: Option<&Value>) -> String {
@@ -76,6 +110,55 @@ fn serialize_entry(entry: &ProcessEntry) -> Value {
         "status": entry.status,
         "started_at": entry.started_at,
         "updated_at": entry.updated_at,
+    })
+}
+
+fn notification_event_dedup_key(params: &Value) -> String {
+    let event_type = params
+        .get("type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("completion");
+    let session_id = string_field(params, "session_id");
+    let parts = if event_type == "watch_match" {
+        vec![
+            session_id,
+            event_type.to_string(),
+            string_field(params, "command"),
+            string_field(params, "pattern"),
+            string_field(params, "output"),
+            u64_field(params, "suppressed").to_string(),
+            string_field(params, "message_id"),
+        ]
+    } else if event_type.starts_with("watch_overflow_") || event_type == "watch_disabled" {
+        vec![
+            session_id,
+            event_type.to_string(),
+            string_field(params, "command"),
+            string_field(params, "message"),
+            u64_field(params, "suppressed").to_string(),
+        ]
+    } else {
+        vec![session_id, event_type.to_string()]
+    };
+    serde_json::to_string(&parts).unwrap_or_else(|_| parts.join("\u{1f}"))
+}
+
+fn serialize_notification_receipt(receipt: &ProcessNotificationReceipt) -> Value {
+    json!({
+        "dedup_key": receipt.dedup_key,
+        "type": receipt.event_type,
+        "session_id": receipt.session_id,
+        "command": receipt.command,
+        "pattern": receipt.pattern,
+        "output": receipt.output,
+        "message": receipt.message,
+        "suppressed": receipt.suppressed,
+        "message_id": receipt.message_id,
+        "first_seen_at": receipt.first_seen_at,
+        "last_seen_at": receipt.last_seen_at,
+        "seen_count": receipt.seen_count,
     })
 }
 
@@ -181,6 +264,73 @@ impl ToolHandler for ProcessRegistryHandler {
                     .count();
                 Ok(json!({"status":"cleared","removed": removed}).to_string())
             }
+            "notify" | "record_event" => {
+                let event_type = params
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("completion")
+                    .to_string();
+                let session_id = string_field(&params, "session_id");
+                if session_id.is_empty() {
+                    return Err(ToolError::InvalidParams(
+                        "notify requires non-empty 'session_id'".into(),
+                    ));
+                }
+                let dedup_key = notification_event_dedup_key(&params);
+                let now = unix_ts();
+                let mut receipts = self
+                    .notification_receipts
+                    .lock()
+                    .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+                let emit = !receipts.contains_key(&dedup_key);
+                let receipt = receipts.entry(dedup_key.clone()).or_insert_with(|| {
+                    ProcessNotificationReceipt {
+                        dedup_key: dedup_key.clone(),
+                        event_type,
+                        session_id,
+                        command: optional_string_field(&params, "command"),
+                        pattern: optional_string_field(&params, "pattern"),
+                        output: optional_string_field(&params, "output"),
+                        message: optional_string_field(&params, "message"),
+                        suppressed: u64_field(&params, "suppressed"),
+                        message_id: optional_string_field(&params, "message_id"),
+                        first_seen_at: now,
+                        last_seen_at: now,
+                        seen_count: 0,
+                    }
+                });
+                receipt.last_seen_at = now;
+                receipt.seen_count = receipt.seen_count.saturating_add(1);
+                Ok(json!({
+                    "status": if emit { "recorded" } else { "duplicate" },
+                    "emit": emit,
+                    "dedup_key": dedup_key,
+                    "receipt": serialize_notification_receipt(receipt),
+                })
+                .to_string())
+            }
+            "list_events" => {
+                let receipts = self
+                    .notification_receipts
+                    .lock()
+                    .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+                let ordered: BTreeMap<String, Value> = receipts
+                    .iter()
+                    .map(|(k, v)| (k.clone(), serialize_notification_receipt(v)))
+                    .collect();
+                Ok(json!({"status":"ok","events": ordered, "count": ordered.len()}).to_string())
+            }
+            "clear_events" => {
+                let removed = self
+                    .notification_receipts
+                    .lock()
+                    .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?
+                    .drain()
+                    .count();
+                Ok(json!({"status":"cleared","removed": removed}).to_string())
+            }
             _ => {
                 let entries = self
                     .entries
@@ -199,13 +349,19 @@ impl ToolHandler for ProcessRegistryHandler {
         let mut props = IndexMap::new();
         props.insert(
             "action".into(),
-            json!({"type":"string","enum":["list","register","update","get","poll","deregister","remove","clear"]}),
+            json!({"type":"string","enum":["list","register","update","get","poll","deregister","remove","clear","notify","record_event","list_events","clear_events"]}),
         );
         props.insert("name".into(), json!({"type":"string"}));
         props.insert("pid".into(), json!({"type":"integer"}));
         props.insert("command".into(), json!({"type":"string"}));
         props.insert("task_id".into(), json!({"type":"string"}));
         props.insert("session_key".into(), json!({"type":"string"}));
+        props.insert("type".into(), json!({"type":"string"}));
+        props.insert("pattern".into(), json!({"type":"string"}));
+        props.insert("output".into(), json!({"type":"string"}));
+        props.insert("message".into(), json!({"type":"string"}));
+        props.insert("suppressed".into(), json!({"type":"integer"}));
+        props.insert("message_id".into(), json!({"type":"string"}));
         props.insert(
             "status".into(),
             json!({"type":"string","enum":["running","exited","stopped","failed"]}),
@@ -213,7 +369,7 @@ impl ToolHandler for ProcessRegistryHandler {
         props.insert("started_at".into(), json!({"type":"integer"}));
         tool_schema(
             "process_registry",
-            "Manage lightweight process metadata entries for background tasks.",
+            "Manage lightweight process metadata entries and deduplicated process notification receipts for background tasks.",
             JsonSchema::object(props, vec![]),
         )
     }
@@ -297,6 +453,143 @@ mod tests {
         let parsed = parse_json(&out);
         assert_eq!(parsed["status"], "cleared");
         assert_eq!(parsed["removed"], 2);
+    }
+
+    #[test]
+    fn notification_event_dedup_key_preserves_distinct_watch_matches() {
+        let base = json!({
+            "type": "watch_match",
+            "session_id": "proc_watch",
+            "command": "tail -f app.log",
+            "pattern": "READY",
+            "output": "READY on port 8000",
+            "suppressed": 0,
+        });
+        let identical = base.clone();
+        let distinct_output = json!({
+            "type": "watch_match",
+            "session_id": "proc_watch",
+            "command": "tail -f app.log",
+            "pattern": "READY",
+            "output": "READY on port 9000",
+            "suppressed": 0,
+        });
+        let distinct_pattern = json!({
+            "type": "watch_match",
+            "session_id": "proc_watch",
+            "command": "tail -f app.log",
+            "pattern": "MIGRATION_DONE",
+            "output": "READY on port 8000",
+            "suppressed": 0,
+        });
+
+        let base_key = notification_event_dedup_key(&base);
+        assert_eq!(notification_event_dedup_key(&identical), base_key);
+        assert_ne!(notification_event_dedup_key(&distinct_output), base_key);
+        assert_ne!(notification_event_dedup_key(&distinct_pattern), base_key);
+    }
+
+    #[test]
+    fn notification_event_dedup_key_keeps_completions_one_shot() {
+        let first = json!({
+            "type": "completion",
+            "session_id": "proc_done",
+            "command": "make build",
+            "exit_code": 0,
+            "output": "first output",
+        });
+        let replay = json!({
+            "type": "completion",
+            "session_id": "proc_done",
+            "command": "make build --again",
+            "exit_code": 1,
+            "output": "different output should not change completion key",
+        });
+
+        assert_eq!(
+            notification_event_dedup_key(&first),
+            notification_event_dedup_key(&replay)
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_records_distinct_watch_matches_and_dedups_replay() {
+        let handler = ProcessRegistryHandler::default();
+        let base = json!({
+            "action": "notify",
+            "type": "watch_match",
+            "session_id": "proc_watch_dedup",
+            "command": "tail -f app.log",
+            "pattern": "READY",
+            "output": "READY on port 8000",
+            "suppressed": 0,
+        });
+
+        let first = parse_json(&handler.execute(base.clone()).await.expect("notify first"));
+        let second = parse_json(
+            &handler
+                .execute(json!({
+                    "action": "notify",
+                    "type": "watch_match",
+                    "session_id": "proc_watch_dedup",
+                    "command": "tail -f app.log",
+                    "pattern": "READY",
+                    "output": "READY on port 9000",
+                    "suppressed": 0,
+                }))
+                .await
+                .expect("notify distinct"),
+        );
+        let replay = parse_json(&handler.execute(base).await.expect("notify replay"));
+
+        assert_eq!(first["status"], "recorded");
+        assert_eq!(first["emit"], true);
+        assert_eq!(second["status"], "recorded");
+        assert_eq!(second["emit"], true);
+        assert_eq!(replay["status"], "duplicate");
+        assert_eq!(replay["emit"], false);
+        assert_eq!(replay["receipt"]["seen_count"], 2);
+
+        let events = parse_json(
+            &handler
+                .execute(json!({"action": "list_events"}))
+                .await
+                .expect("list events"),
+        );
+        assert_eq!(events["count"], 2);
+    }
+
+    #[tokio::test]
+    async fn notify_dedups_completion_replays_per_session() {
+        let handler = ProcessRegistryHandler::default();
+        let first = parse_json(
+            &handler
+                .execute(json!({
+                    "action": "notify",
+                    "type": "completion",
+                    "session_id": "proc_done",
+                    "command": "make build",
+                    "output": "first output",
+                }))
+                .await
+                .expect("notify first completion"),
+        );
+        let replay = parse_json(
+            &handler
+                .execute(json!({
+                    "action": "notify",
+                    "type": "completion",
+                    "session_id": "proc_done",
+                    "command": "make build --again",
+                    "output": "different output",
+                }))
+                .await
+                .expect("notify replay completion"),
+        );
+
+        assert_eq!(first["emit"], true);
+        assert_eq!(replay["emit"], false);
+        assert_eq!(replay["receipt"]["seen_count"], 2);
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -815,6 +815,14 @@
     "f75b1d21b4c8cacc2b9b9fb87227ff315365cd90": {
       "disposition": "ported",
       "notes": "Rust agent loop now treats advertised tool schemas as the runtime allowlist, rejects registered-but-disabled fabricated tool calls in non-streaming and streaming loops, and makes delegate_task inherit the parent enabled tool surface when no explicit child toolset is requested; execute_code schema remains Rust-only and does not advertise disabled sandbox helper tools."
+    },
+    "e7a7872a874837ca36105ca3e90db464cf7c125a": {
+      "disposition": "ported",
+      "notes": "Rust process_registry now exposes deduplicated process notification receipts via notify/record_event/list_events/clear_events. Completion events are one-shot per process session, watch_match identities include command/pattern/output/suppressed/message_id so distinct matches are preserved, and focused tests cover replay dedup plus distinct watch-match emission."
+    },
+    "5bcb63e400987e937e696b385e01285339b565c5": {
+      "disposition": "superseded",
+      "notes": "The Python TUI global _sessions/_pending lock fix is structurally superseded by Rust session managers and pending stores that already use Mutex/RwLock for compound mutations (hermes-acp SessionManager/PermissionStore, hermes-gateway SessionManager/BusySessionCoordinator). This slice also adds a Mutex-backed process notification receipt store for the overlapping process-event flood path."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Port upstream `e7a7872a874837ca36105ca3e90db464cf7c125a` (`fix(tui_gateway): dedup re-queued process notifications flooding TUI`) into the Rust process registry surface.
- Add `process_registry` notification receipt actions: `notify`, `record_event`, `list_events`, and `clear_events`.
- Keep completion notifications one-shot per process session while preserving distinct `watch_match` events via command/pattern/output/suppressed/message_id identity.
- Mark upstream `5bcb63e400987e937e696b385e01285339b565c5` as superseded by Rust locked session/pending stores plus this Mutex-backed receipt store.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-process-dedup CARGO_INCREMENTAL=0 cargo test -p hermes-tools notification_event_dedup -- --nocapture` -> 2 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-process-dedup CARGO_INCREMENTAL=0 cargo test -p hermes-tools notify_ -- --nocapture` -> 2 passed
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-process-dedup CARGO_INCREMENTAL=0 cargo test -p hermes-tools process_registry_contract -- --nocapture` -> 2 passed across integration filters
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-process-dedup-build CARGO_INCREMENTAL=0 cargo build -p hermes-tools`
- `CARGO_TARGET_DIR=/tmp/hermes-agent-ultra-target-process-dedup-clippy CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-tools` -> `seen=199 allowlist=204 new=0 stale=5`

## Queue Proof
- `pending=1942`
- `ported=75`
- `mirrored=162`
- `superseded=7602`
- `total_commits=9781`
- `e7a7872a8748=ported`
- `5bcb63e40098=superseded`
