### PR TITLE
parity(acp): add public session meta update

### DIFF
--- a/crates/hermes-acp/src/session.rs
+++ b/crates/hermes-acp/src/session.rs
@@ -66,6 +66,21 @@ pub struct SessionState {
     pub total_completion_tokens: u64,
 }
 
+/// Public metadata update for ACP sessions.
+///
+/// Optional fields intentionally preserve existing values when omitted. This
+/// mirrors upstream's `update_session_meta(..., model=None)` COALESCE behavior
+/// without exposing storage internals to callers.
+#[derive(Debug, Clone, Default)]
+pub struct SessionMetaUpdate {
+    pub cwd: Option<String>,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub api_mode: Option<String>,
+    pub base_url: Option<String>,
+    pub config_options: HashMap<String, String>,
+}
+
 impl SessionState {
     pub fn new(session_id: String, cwd: String) -> Self {
         let now = SystemTime::now()
@@ -181,24 +196,55 @@ impl SessionManager {
 
     /// Update a session's working directory.
     pub fn update_cwd(&self, session_id: &str, cwd: &str) -> Option<SessionState> {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(state) = sessions.get_mut(session_id) {
-            state.cwd = cwd.to_string();
-            state.touch();
-            let cloned = state.clone();
-            drop(sessions);
-            self.persist(&cloned);
-            Some(cloned)
-        } else {
-            None
-        }
+        self.update_session_meta(
+            session_id,
+            SessionMetaUpdate {
+                cwd: Some(cwd.to_string()),
+                ..SessionMetaUpdate::default()
+            },
+        )
     }
 
     /// Update a session's model identifier.
     pub fn update_model(&self, session_id: &str, model: &str) -> Option<SessionState> {
+        self.update_session_meta(
+            session_id,
+            SessionMetaUpdate {
+                model: Some(model.to_string()),
+                ..SessionMetaUpdate::default()
+            },
+        )
+    }
+
+    /// Update session metadata through the public, lock-protected manager path.
+    pub fn update_session_meta(
+        &self,
+        session_id: &str,
+        update: SessionMetaUpdate,
+    ) -> Option<SessionState> {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(state) = sessions.get_mut(session_id) {
-            state.model = Some(model.to_string());
+            if let Some(cwd) = update.cwd {
+                state.cwd = cwd;
+            }
+            if let Some(model) = update.model.filter(|value| !value.trim().is_empty()) {
+                state.model = Some(model);
+            }
+            if let Some(provider) = update.provider.filter(|value| !value.trim().is_empty()) {
+                state.provider = Some(provider);
+            }
+            if let Some(api_mode) = update.api_mode.filter(|value| !value.trim().is_empty()) {
+                state.api_mode = Some(api_mode);
+            }
+            if let Some(base_url) = update.base_url.filter(|value| !value.trim().is_empty()) {
+                state.base_url = Some(base_url);
+            }
+            for (key, value) in update.config_options {
+                let key = key.trim();
+                if !key.is_empty() {
+                    state.config_options.insert(key.to_string(), value);
+                }
+            }
             state.touch();
             let cloned = state.clone();
             drop(sessions);
@@ -453,5 +499,109 @@ mod tests {
                 .map(String::as_str),
             Some("0.2")
         );
+    }
+
+    #[test]
+    fn update_session_meta_preserves_model_when_omitted() {
+        let mgr = SessionManager::new();
+        let state = mgr.create_session("/tmp");
+        let sid = state.session_id;
+
+        mgr.update_model(&sid, "nous:gpt-5.4");
+        let updated = mgr
+            .update_session_meta(
+                &sid,
+                SessionMetaUpdate {
+                    cwd: Some("/workspace".to_string()),
+                    ..SessionMetaUpdate::default()
+                },
+            )
+            .expect("session exists");
+
+        assert_eq!(updated.cwd, "/workspace");
+        assert_eq!(updated.model.as_deref(), Some("nous:gpt-5.4"));
+        let stored = mgr.get_session(&sid).expect("session exists");
+        assert_eq!(stored.model.as_deref(), Some("nous:gpt-5.4"));
+    }
+
+    #[test]
+    fn update_session_meta_merges_fields_and_persists_once() {
+        use std::sync::{Arc, Mutex};
+
+        let persisted = Arc::new(Mutex::new(Vec::<SessionState>::new()));
+        let persisted_for_cb = persisted.clone();
+        let mgr = SessionManager::new().with_persist_callback(move |state| {
+            persisted_for_cb
+                .lock()
+                .expect("persisted lock")
+                .push(state.clone());
+        });
+        let state = mgr.create_session("/tmp");
+        let sid = state.session_id;
+        persisted.lock().expect("persisted lock").clear();
+
+        let mut config_options = HashMap::new();
+        config_options.insert("temperature".to_string(), "0.2".to_string());
+        config_options.insert("".to_string(), "ignored".to_string());
+        let updated = mgr
+            .update_session_meta(
+                &sid,
+                SessionMetaUpdate {
+                    cwd: Some("/repo".to_string()),
+                    model: Some("openai:gpt-4o".to_string()),
+                    provider: Some("openai".to_string()),
+                    api_mode: Some("responses".to_string()),
+                    base_url: Some("https://api.openai.com/v1".to_string()),
+                    config_options,
+                },
+            )
+            .expect("session exists");
+
+        assert_eq!(updated.cwd, "/repo");
+        assert_eq!(updated.model.as_deref(), Some("openai:gpt-4o"));
+        assert_eq!(updated.provider.as_deref(), Some("openai"));
+        assert_eq!(updated.api_mode.as_deref(), Some("responses"));
+        assert_eq!(
+            updated.base_url.as_deref(),
+            Some("https://api.openai.com/v1")
+        );
+        assert_eq!(
+            updated
+                .config_options
+                .get("temperature")
+                .map(String::as_str),
+            Some("0.2")
+        );
+        assert!(!updated.config_options.contains_key(""));
+
+        let persisted = persisted.lock().expect("persisted lock");
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].session_id, sid);
+        assert_eq!(persisted[0].cwd, "/repo");
+    }
+
+    #[test]
+    fn update_session_meta_missing_session_is_noop() {
+        use std::sync::{Arc, Mutex};
+
+        let persisted = Arc::new(Mutex::new(Vec::<SessionState>::new()));
+        let persisted_for_cb = persisted.clone();
+        let mgr = SessionManager::new().with_persist_callback(move |state| {
+            persisted_for_cb
+                .lock()
+                .expect("persisted lock")
+                .push(state.clone());
+        });
+        assert!(mgr
+            .update_session_meta(
+                "missing",
+                SessionMetaUpdate {
+                    cwd: Some("/repo".to_string()),
+                    model: Some("openai:gpt-4o".to_string()),
+                    ..SessionMetaUpdate::default()
+                },
+            )
+            .is_none());
+        assert!(persisted.lock().expect("persisted lock").is_empty());
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -823,6 +823,10 @@
     "5bcb63e400987e937e696b385e01285339b565c5": {
       "disposition": "superseded",
       "notes": "The Python TUI global _sessions/_pending lock fix is structurally superseded by Rust session managers and pending stores that already use Mutex/RwLock for compound mutations (hermes-acp SessionManager/PermissionStore, hermes-gateway SessionManager/BusySessionCoordinator). This slice also adds a Mutex-backed process notification receipt store for the overlapping process-event flood path."
+    },
+    "19db9cd0760e05dafcd1ae637db946cdd65322ce": {
+      "disposition": "ported",
+      "notes": "Rust ACP SessionManager now exposes a public lock-protected update_session_meta API with COALESCE-style optional model preservation, merges cwd/provider/api_mode/base_url/config options, routes existing update_cwd/update_model through it, and tests missing-session no-op plus single persist callback behavior."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add a public `SessionManager::update_session_meta` API for ACP session metadata updates
- preserve existing model when the update omits or passes an empty model, matching upstream COALESCE-style behavior without exposing storage internals
- route existing cwd/model update helpers through the public locked path and mark upstream commit `19db9cd0760e05dafcd1ae637db946cdd65322ce` ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-meta CARGO_INCREMENTAL=0 cargo test -p hermes-acp update_session_meta -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-meta CARGO_INCREMENTAL=0 cargo test -p hermes-acp test_update_model_mode_and_config_option -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-meta CARGO_INCREMENTAL=0 cargo test -p hermes-acp test_set_session_fields_persist -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-meta CARGO_INCREMENTAL=0 cargo build -p hermes-acp`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-meta CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp` -> `new=0`, `stale=5`
- queue proof: `pending=1941`, `ported=76`, `mirrored=162`, `superseded=7602`, `total=9781`; `19db9cd0760e` is `ported`

## ContextLattice
- HTTP checkpoint write degraded locally: `curl: (7) Failed to connect to 127.0.0.1 port 8075`
- fallback checkpoint written to `/tmp/hermes-checkpoints/acp-session-meta-update-pre-pr.md`
