### PR TITLE
parity(acp): preserve provider metadata on model switch

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -1651,6 +1651,7 @@ impl AcpHandler for DefaultAcpHandler {
 mod tests {
     use super::*;
     use crate::events::AcpEventKind;
+    use crate::session::SessionMetaUpdate;
     use serde_json::json;
 
     struct EchoPromptExecutor;
@@ -2023,6 +2024,48 @@ mod tests {
                 .get("approval_mode")
                 .map(String::as_str),
             Some("auto")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_set_session_model_preserves_provider_route_metadata() {
+        let handler = make_handler();
+        let state = handler.session_manager.create_session("/workspace");
+        let session_id = state.session_id;
+        handler
+            .session_manager
+            .update_session_meta(
+                &session_id,
+                SessionMetaUpdate {
+                    model: Some("openrouter:anthropic/claude-sonnet-4".to_string()),
+                    provider: Some("openrouter".to_string()),
+                    api_mode: Some("responses".to_string()),
+                    base_url: Some("https://openrouter.ai/api/v1".to_string()),
+                    ..SessionMetaUpdate::default()
+                },
+            )
+            .expect("session exists");
+
+        let response = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/set_model".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "modelId": "openai/gpt-4.1"
+                })),
+            })
+            .await;
+        assert!(response.error.is_none());
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.model.as_deref(), Some("openai/gpt-4.1"));
+        assert_eq!(state.provider.as_deref(), Some("openrouter"));
+        assert_eq!(state.api_mode.as_deref(), Some("responses"));
+        assert_eq!(
+            state.base_url.as_deref(),
+            Some("https://openrouter.ai/api/v1")
         );
     }
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -843,6 +843,10 @@
     "9cf1140caaefa6f275667ed1b11a61aabb6199dd": {
       "disposition": "ported",
       "notes": "Rust ACP polished tool errors are treated as failed for core tool outputs while generic optional JSON error payloads remain completed; completion-status tests cover both sides of the conservative rule."
+    },
+    "0b9526b4761bbabc98ca48f5c0a3f2dfda765314": {
+      "disposition": "ported",
+      "notes": "Rust ACP session/set_model now has handler-level regression coverage proving model switches preserve existing provider/base_url/api_mode route metadata through the public SessionManager update_session_meta path instead of recreating or clearing provider state."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add ACP handler-level regression coverage for `session/set_model` preserving provider route metadata
- prove model switches keep existing `provider`, `base_url`, and `api_mode` through the public session metadata path
- mark upstream `0b9526b4761b` ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-model CARGO_INCREMENTAL=0 cargo test -p hermes-acp test_set_session_model_preserves_provider_route_metadata -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-model CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 74 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-model CARGO_INCREMENTAL=0 cargo build -p hermes-acp`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-model CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp` -> `new=0`, `stale=5`
- queue proof: `pending=1936`, `ported=81`, `mirrored=162`, `superseded=7602`, `total=9781`; `0b9526b4761b` is `ported`

## ContextLattice
- HTTP checkpoint write degraded locally: `curl: (7) Failed to connect to 127.0.0.1 port 8075`
- fallback checkpoint written to `/tmp/hermes-checkpoints/acp-model-provider-preserve-pre-pr.md`
