### PR TITLE
parity(acp): map top-level usage in cli executor

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -26765,6 +26765,16 @@ fn acp_events_from_agent_messages(
     events
 }
 
+fn acp_usage_from_agent_usage(usage: &hermes_core::UsageStats) -> hermes_acp::Usage {
+    hermes_acp::Usage {
+        input_tokens: usage.prompt_tokens,
+        output_tokens: usage.completion_tokens,
+        total_tokens: usage.total_tokens,
+        thought_tokens: None,
+        cached_read_tokens: None,
+    }
+}
+
 struct CliAcpPromptExecutor {
     config: Arc<hermes_config::GatewayConfig>,
     tool_registry: Arc<hermes_tools::ToolRegistry>,
@@ -26813,13 +26823,7 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
             .and_then(|m| m.content.clone())
             .unwrap_or_default();
 
-        let usage = result.usage.map(|u| hermes_acp::Usage {
-            input_tokens: u.prompt_tokens,
-            output_tokens: u.completion_tokens,
-            total_tokens: u.total_tokens,
-            thought_tokens: None,
-            cached_read_tokens: None,
-        });
+        let usage = result.usage.as_ref().map(acp_usage_from_agent_usage);
 
         Ok(hermes_acp::PromptExecutionOutput {
             response_text,
@@ -27841,6 +27845,24 @@ mod tests {
         assert_eq!(events[0].tool_call_id.as_deref(), Some("tc-untracked"));
         assert_eq!(events[0].tool_name.as_deref(), Some("terminal"));
         assert_eq!(events[0].result.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn test_acp_usage_from_agent_usage_maps_top_level_agent_fields() {
+        let usage = hermes_core::UsageStats {
+            prompt_tokens: 123,
+            completion_tokens: 45,
+            total_tokens: 168,
+            estimated_cost: Some(0.0123),
+        };
+
+        let acp_usage = acp_usage_from_agent_usage(&usage);
+
+        assert_eq!(acp_usage.input_tokens, 123);
+        assert_eq!(acp_usage.output_tokens, 45);
+        assert_eq!(acp_usage.total_tokens, 168);
+        assert_eq!(acp_usage.thought_tokens, None);
+        assert_eq!(acp_usage.cached_read_tokens, None);
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -847,6 +847,14 @@
     "0b9526b4761bbabc98ca48f5c0a3f2dfda765314": {
       "disposition": "ported",
       "notes": "Rust ACP session/set_model now has handler-level regression coverage proving model switches preserve existing provider/base_url/api_mode route metadata through the public SessionManager update_session_meta path instead of recreating or clearing provider state."
+    },
+    "f92298fe955fe2ddbea27f4c504ce310ec46545b": {
+      "disposition": "ported",
+      "notes": "Rust ACP maps typed top-level AgentResult usage into PromptResponse.usage through the CLI ACP executor boundary; regression coverage proves prompt/completion/total fields populate ACP input/output/total tokens without relying on a nested result usage dict."
+    },
+    "4e78963fe86a5f2758bf754a7979dc31aaf1a3db": {
+      "disposition": "superseded",
+      "notes": "The dead Python nested usage dict path is structurally superseded by Rust's typed AgentResult.usage and PromptExecutionOutput.usage flow; the CLI ACP usage test proves only the top-level typed fields are converted."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- map Rust agent `UsageStats` into ACP `PromptResponse.usage` through an explicit CLI executor helper
- add regression coverage for prompt/completion/total top-level usage conversion
- close upstream ACP usage queue items for top-level usage and dead nested usage dict path

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-usage.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-cli-acp-usage CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_acp_usage_from_agent_usage_maps_top_level_agent_fields -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-cli-acp-usage CARGO_INCREMENTAL=0 cargo build -p hermes-cli`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-cli-acp-usage CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli` (`new=0`, `stale=5`)
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-next-queue.json --out-md /tmp/hermes-next-queue.md`

Queue after slice: pending=1934, ported=82, mirrored=162, superseded=7603, total=9781.
