### PR TITLE
parity(acp): advertise available commands

### DIFF
--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -11,6 +11,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::protocol::AvailableCommand;
 use crate::tools::{format_tool_result, tool_completion_status, tool_start_metadata};
 
 // ---------------------------------------------------------------------------
@@ -35,6 +36,8 @@ pub enum AcpEventKind {
     StepComplete,
     /// Session-level progress update.
     Progress,
+    /// Available slash commands changed.
+    AvailableCommandsUpdate,
     /// An error occurred.
     Error,
 }
@@ -65,6 +68,18 @@ pub struct AcpEvent {
     pub api_call_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(
+        rename = "sessionUpdate",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub session_update: Option<String>,
+    #[serde(
+        rename = "availableCommands",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub available_commands: Option<Vec<AvailableCommand>>,
 }
 
 impl AcpEvent {
@@ -90,6 +105,8 @@ impl AcpEvent {
             status: None,
             api_call_count: None,
             error: None,
+            session_update: None,
+            available_commands: None,
         }
     }
 
@@ -114,6 +131,8 @@ impl AcpEvent {
             status: None,
             api_call_count: None,
             error: None,
+            session_update: None,
+            available_commands: None,
         }
     }
 
@@ -139,6 +158,8 @@ impl AcpEvent {
             status: Some(status.to_string()),
             api_call_count: None,
             error: None,
+            session_update: None,
+            available_commands: None,
         }
     }
 
@@ -157,6 +178,8 @@ impl AcpEvent {
             status: None,
             api_call_count: None,
             error: None,
+            session_update: None,
+            available_commands: None,
         }
     }
 
@@ -175,6 +198,8 @@ impl AcpEvent {
             status: None,
             api_call_count: None,
             error: None,
+            session_update: None,
+            available_commands: None,
         }
     }
 
@@ -193,6 +218,8 @@ impl AcpEvent {
             status: None,
             text: None,
             error: None,
+            session_update: None,
+            available_commands: None,
         }
     }
 
@@ -211,6 +238,28 @@ impl AcpEvent {
             status: None,
             text: None,
             api_call_count: None,
+            session_update: None,
+            available_commands: None,
+        }
+    }
+
+    pub fn available_commands_update(session_id: &str, commands: Vec<AvailableCommand>) -> Self {
+        Self {
+            kind: AcpEventKind::AvailableCommandsUpdate,
+            session_id: session_id.to_string(),
+            timestamp: Self::now(),
+            session_update: Some("available_commands_update".to_string()),
+            available_commands: Some(commands),
+            tool_call_id: None,
+            tool_name: None,
+            tool_kind: None,
+            title: None,
+            arguments: None,
+            result: None,
+            status: None,
+            text: None,
+            api_call_count: None,
+            error: None,
         }
     }
 }

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -562,44 +562,54 @@ fn extract_prompt_payload(p: &serde_json::Map<String, Value>) -> PromptExtractio
 struct SlashCommand {
     name: &'static str,
     description: &'static str,
+    input_hint: Option<&'static str>,
 }
 
 const SLASH_COMMANDS: &[SlashCommand] = &[
     SlashCommand {
         name: "help",
         description: "Show available commands",
+        input_hint: None,
     },
     SlashCommand {
         name: "model",
         description: "Show or change current model",
+        input_hint: Some("model name to switch to"),
     },
     SlashCommand {
         name: "tools",
         description: "List available tools",
+        input_hint: None,
     },
     SlashCommand {
         name: "context",
         description: "Show conversation context info",
+        input_hint: None,
     },
     SlashCommand {
         name: "reset",
         description: "Clear conversation history",
+        input_hint: None,
     },
     SlashCommand {
         name: "compact",
         description: "Compress conversation context",
+        input_hint: None,
     },
     SlashCommand {
         name: "steer",
         description: "Inject guidance into the currently running agent turn",
+        input_hint: Some("guidance for the active turn"),
     },
     SlashCommand {
         name: "queue",
         description: "Queue a prompt to run after the current turn finishes",
+        input_hint: Some("prompt to run next"),
     },
     SlashCommand {
         name: "version",
         description: "Show Hermes version",
+        input_hint: None,
     },
 ];
 
@@ -664,6 +674,24 @@ impl HermesAcpHandler {
             ("todo", "Track task progress"),
             ("cronjob", "Schedule recurring jobs"),
         ]
+    }
+
+    fn available_commands() -> Vec<AvailableCommand> {
+        SLASH_COMMANDS
+            .iter()
+            .map(|command| AvailableCommand {
+                name: command.name.to_string(),
+                description: command.description.to_string(),
+                input_hint: command.input_hint.map(str::to_string),
+            })
+            .collect()
+    }
+
+    fn advertise_available_commands(&self, session_id: &str) {
+        self.event_sink.push(AcpEvent::available_commands_update(
+            session_id,
+            Self::available_commands(),
+        ));
     }
 
     fn compact_session_history(&self, session_id: &str) -> Option<String> {
@@ -1152,6 +1180,7 @@ impl AcpHandler for HermesAcpHandler {
                     .and_then(|p| param_str(p, "cwd"))
                     .unwrap_or(".");
                 let state = self.session_manager.create_session(cwd);
+                self.advertise_available_commands(&state.session_id);
                 AcpResponse::success(request.id, session_id_response(&state.session_id))
             }
 
@@ -1163,7 +1192,10 @@ impl AcpHandler for HermesAcpHandler {
                 let cwd = param_str(p, "cwd").unwrap_or(".");
 
                 match self.session_manager.update_cwd(session_id, cwd) {
-                    Some(_) => AcpResponse::success(request.id, json!({})),
+                    Some(_) => {
+                        self.advertise_available_commands(session_id);
+                        AcpResponse::success(request.id, json!({}))
+                    }
                     None => AcpResponse::error(
                         request.id,
                         -32602,
@@ -1181,9 +1213,11 @@ impl AcpHandler for HermesAcpHandler {
 
                 if self.session_manager.get_session(session_id).is_some() {
                     self.session_manager.update_cwd(session_id, cwd);
+                    self.advertise_available_commands(session_id);
                     AcpResponse::success(request.id, json!({}))
                 } else {
                     let state = self.session_manager.create_session(cwd);
+                    self.advertise_available_commands(&state.session_id);
                     AcpResponse::success(request.id, session_id_response(&state.session_id))
                 }
             }
@@ -1197,6 +1231,7 @@ impl AcpHandler for HermesAcpHandler {
 
                 match self.session_manager.fork_session(session_id, cwd) {
                     Some(new_state) => {
+                        self.advertise_available_commands(&new_state.session_id);
                         AcpResponse::success(request.id, session_id_response(&new_state.session_id))
                     }
                     None => AcpResponse::error(
@@ -1802,6 +1837,10 @@ mod tests {
             result["agentCapabilities"]["sessionCapabilities"]["fork"],
             true
         );
+        assert_eq!(
+            result["agentCapabilities"]["sessionCapabilities"]["resume"],
+            true
+        );
         assert!(result.get("protocol_version").is_none());
         assert!(result.get("agent_info").is_none());
         assert!(result["agentCapabilities"].get("load_session").is_none());
@@ -2014,6 +2053,22 @@ mod tests {
             .unwrap();
         assert_eq!(config["configOptions"][0]["configId"], "approval_mode");
 
+        let stable_config = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(6)),
+                method: "session/set_config_option".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "configId": "sandbox",
+                    "value": "workspace-write"
+                })),
+            })
+            .await
+            .result
+            .unwrap();
+        assert_eq!(stable_config["configOptions"][0]["configId"], "sandbox");
+
         let state = handler.session_manager.get_session(&session_id).unwrap();
         assert_eq!(state.cwd, "/work");
         assert_eq!(state.model.as_deref(), Some("nous:gpt-5.4"));
@@ -2024,6 +2079,98 @@ mod tests {
                 .get("approval_mode")
                 .map(String::as_str),
             Some("auto")
+        );
+        assert_eq!(
+            state.config_options.get("sandbox").map(String::as_str),
+            Some("workspace-write")
+        );
+    }
+
+    fn assert_available_commands_update(events: Vec<AcpEvent>, expected_session_id: &str) {
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.kind, AcpEventKind::AvailableCommandsUpdate);
+        assert_eq!(event.session_id, expected_session_id);
+        assert_eq!(
+            event.session_update.as_deref(),
+            Some("available_commands_update")
+        );
+        let commands = event
+            .available_commands
+            .as_ref()
+            .expect("available commands");
+        assert!(commands.iter().any(|command| command.name == "help"));
+        let model = commands
+            .iter()
+            .find(|command| command.name == "model")
+            .expect("model command");
+        assert_eq!(model.input_hint.as_deref(), Some("model name to switch to"));
+        assert!(commands.iter().any(|command| command.name == "queue"));
+        assert!(commands.iter().any(|command| command.name == "steer"));
+    }
+
+    #[tokio::test]
+    async fn test_session_lifecycle_advertises_available_commands() {
+        let handler = make_handler();
+
+        let created = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/new".into(),
+                params: Some(json!({"cwd": "/tmp"})),
+            })
+            .await
+            .result
+            .unwrap();
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+        assert_available_commands_update(
+            handler.event_sink.drain_for_session(&session_id),
+            &session_id,
+        );
+
+        let loaded = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session/load".into(),
+                params: Some(json!({"sessionId": session_id, "cwd": "/work"})),
+            })
+            .await;
+        assert!(loaded.error.is_none());
+        assert_available_commands_update(
+            handler.event_sink.drain_for_session(&session_id),
+            &session_id,
+        );
+
+        let resumed = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(3)),
+                method: "session/resume".into(),
+                params: Some(json!({"sessionId": session_id, "cwd": "/work"})),
+            })
+            .await;
+        assert!(resumed.error.is_none());
+        assert_available_commands_update(
+            handler.event_sink.drain_for_session(&session_id),
+            &session_id,
+        );
+
+        let forked = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(4)),
+                method: "session/fork".into(),
+                params: Some(json!({"sessionId": session_id, "cwd": "/fork"})),
+            })
+            .await
+            .result
+            .unwrap();
+        let forked_session_id = forked["sessionId"].as_str().unwrap().to_string();
+        assert_available_commands_update(
+            handler.event_sink.drain_for_session(&forked_session_id),
+            &forked_session_id,
         );
     }
 

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -117,7 +117,9 @@ impl From<&str> for AcpMethod {
             "prompt" => Self::Prompt,
             "session/set_model" | "set_session_model" => Self::SetSessionModel,
             "session/set_mode" | "set_session_mode" => Self::SetSessionMode,
-            "session/set_config" | "set_config_option" => Self::SetConfigOption,
+            "session/set_config" | "session/set_config_option" | "set_config_option" => {
+                Self::SetConfigOption
+            }
 
             // Legacy methods
             "conversation.create" => Self::CreateConversation,
@@ -418,6 +420,10 @@ mod tests {
         assert_eq!(AcpMethod::from("new_session"), AcpMethod::NewSession);
         assert_eq!(AcpMethod::from("prompt"), AcpMethod::Prompt);
         assert_eq!(AcpMethod::from("cancel"), AcpMethod::Cancel);
+        assert_eq!(
+            AcpMethod::from("session/set_config_option"),
+            AcpMethod::SetConfigOption
+        );
         assert_eq!(
             AcpMethod::from("conversation.create"),
             AcpMethod::CreateConversation

--- a/crates/hermes-acp/src/server.rs
+++ b/crates/hermes-acp/src/server.rs
@@ -238,6 +238,49 @@ mod tests {
         assert_eq!(lines[1]["params"]["arguments"]["path"], "/tmp/a.txt");
     }
 
+    #[tokio::test]
+    async fn run_on_advertises_available_commands_after_new_session() {
+        let session_manager = Arc::new(SessionManager::new());
+        let event_sink = Arc::new(EventSink::default());
+        let permission_store = Arc::new(PermissionStore::new());
+        let handler = Arc::new(HermesAcpHandler::new(
+            session_manager.clone(),
+            event_sink.clone(),
+            permission_store.clone(),
+        ));
+        let server =
+            AcpServer::with_components(handler, session_manager, event_sink, permission_store);
+
+        let input = br#"{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp"}}"#;
+        let mut output = Vec::new();
+        server.run_on(&input[..], &mut output).await.unwrap();
+
+        let text = String::from_utf8(output).unwrap();
+        let lines: Vec<serde_json::Value> = text
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+
+        assert_eq!(lines.len(), 2);
+        let session_id = lines[0]["result"]["sessionId"].as_str().unwrap();
+        assert_eq!(lines[1]["method"], "session/update");
+        assert_eq!(lines[1]["params"]["kind"], "available_commands_update");
+        assert_eq!(
+            lines[1]["params"]["sessionUpdate"],
+            "available_commands_update"
+        );
+        assert_eq!(lines[1]["params"]["session_id"], session_id);
+        let commands = lines[1]["params"]["availableCommands"]
+            .as_array()
+            .expect("available commands");
+        assert!(commands.iter().any(|command| command["name"] == "help"));
+        let model = commands
+            .iter()
+            .find(|command| command["name"] == "model")
+            .expect("model command");
+        assert_eq!(model["inputHint"], "model name to switch to");
+    }
+
     #[test]
     fn server_permission_stores_are_instance_scoped() {
         let handler_a = Arc::new(HermesAcpHandler::new(

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -855,6 +855,18 @@
     "4e78963fe86a5f2758bf754a7979dc31aaf1a3db": {
       "disposition": "superseded",
       "notes": "The dead Python nested usage dict path is structurally superseded by Rust's typed AgentResult.usage and PromptExecutionOutput.usage flow; the CLI ACP usage test proves only the top-level typed fields are converted."
+    },
+    "1bcc87a1535cd4c17dc2bfe45fd198863404e892": {
+      "disposition": "ported",
+      "notes": "Rust ACP initialize advertises loadSession and sessionCapabilities.resume in the wire-format agentCapabilities object; handler tests assert the ACP aliases so editor clients can discover load/resume support."
+    },
+    "c71b1d197f446e264a94f962fd55f285c9dc231f": {
+      "disposition": "ported",
+      "notes": "Rust ACP now converts its slash command table into availableCommands updates with input hints and emits available_commands_update after session new/load/resume/fork; handler and server run_on tests prove the lifecycle and JSON-RPC notification path."
+    },
+    "4764e06fdefa65cb75961da64da1ed63c99a0a2a": {
+      "disposition": "ported",
+      "notes": "Rust ACP exposes the editor session-management surface with load/resume/fork/list plus model/mode/config updates, now including the stable session/set_config_option method alias; handler tests cover camelCase routing and persisted session config."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- advertise ACP slash commands as `available_commands_update` session/update notifications after session new/load/resume/fork
- add command input hints for model/queue/steer and prove JSON-RPC wire output includes `availableCommands`
- accept stable `session/set_config_option` as a session config method alias
- close upstream ACP initialize/session-management/command-advertisement queue items

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-commands.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-commands CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` (76 passed)
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-commands CARGO_INCREMENTAL=0 cargo build -p hermes-acp`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-commands CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp` (`new=0`, `stale=5`)
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-next-queue.json --out-md /tmp/hermes-next-queue.md`

Queue after slice: pending=1931, ported=85, mirrored=162, superseded=7603, total=9781.
