### PR TITLE
parity(acp): emit session info updates

### DIFF
--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -44,6 +44,8 @@ pub enum AcpEventKind {
     Progress,
     /// Available slash commands changed.
     AvailableCommandsUpdate,
+    /// Session metadata changed.
+    SessionInfoUpdate,
     /// An error occurred.
     Error,
 }
@@ -90,6 +92,8 @@ pub struct AcpEvent {
         skip_serializing_if = "Option::is_none"
     )]
     pub available_commands: Option<Vec<AvailableCommand>>,
+    #[serde(rename = "updatedAt", default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
 }
 
 impl AcpEvent {
@@ -119,6 +123,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -147,6 +152,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -176,6 +182,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -198,6 +205,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -220,6 +228,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -278,6 +287,7 @@ impl AcpEvent {
             api_call_count: None,
             error: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -300,6 +310,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -322,6 +333,7 @@ impl AcpEvent {
             api_call_count: None,
             session_update: None,
             available_commands: None,
+            updated_at: None,
         }
     }
 
@@ -332,6 +344,7 @@ impl AcpEvent {
             timestamp: Self::now(),
             session_update: Some("available_commands_update".to_string()),
             available_commands: Some(commands),
+            updated_at: None,
             tool_call_id: None,
             tool_name: None,
             tool_kind: None,
@@ -344,6 +357,33 @@ impl AcpEvent {
             text: None,
             api_call_count: None,
             error: None,
+        }
+    }
+
+    pub fn session_info_update(
+        session_id: &str,
+        title: Option<String>,
+        updated_at: String,
+    ) -> Self {
+        Self {
+            kind: AcpEventKind::SessionInfoUpdate,
+            session_id: session_id.to_string(),
+            timestamp: Self::now(),
+            session_update: Some("session_info_update".to_string()),
+            title,
+            updated_at: Some(updated_at),
+            tool_call_id: None,
+            tool_name: None,
+            tool_kind: None,
+            arguments: None,
+            result: None,
+            status: None,
+            content: None,
+            message_id: None,
+            text: None,
+            api_call_count: None,
+            error: None,
+            available_commands: None,
         }
     }
 }

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine as _;
@@ -694,6 +695,17 @@ impl HermesAcpHandler {
         ));
     }
 
+    fn emit_session_info_update(&self, session_id: &str) {
+        let Some(state) = self.session_manager.get_session(session_id) else {
+            return;
+        };
+        self.event_sink.push(AcpEvent::session_info_update(
+            session_id,
+            session_title_from_history(&state.history),
+            session_info_refresh_timestamp(),
+        ));
+    }
+
     fn replay_session_history(&self, state: &SessionState) {
         let mut active_tool_calls: HashMap<String, String> = HashMap::new();
         for (index, message) in state.history.iter().enumerate() {
@@ -952,6 +964,7 @@ impl HermesAcpHandler {
                 .add_usage(session_id, usage.input_tokens, usage.output_tokens);
         }
         self.session_manager.save_session(session_id);
+        self.emit_session_info_update(session_id);
 
         Ok(usage)
     }
@@ -1199,6 +1212,14 @@ fn history_tool_call_name(tool_call: &Value) -> String {
         .and_then(Value::as_str)
         .filter(|name| !name.trim().is_empty())
         .unwrap_or("tool")
+        .to_string()
+}
+
+fn session_info_refresh_timestamp() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
         .to_string()
 }
 
@@ -3091,6 +3112,23 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("executor:hello")
         );
+
+        let events = handler.event_sink.drain_for_session(&session_id);
+        let info_updates = events
+            .iter()
+            .filter(|event| event.kind == AcpEventKind::SessionInfoUpdate)
+            .collect::<Vec<_>>();
+        assert_eq!(info_updates.len(), 1);
+        assert_eq!(
+            info_updates[0].session_update.as_deref(),
+            Some("session_info_update")
+        );
+        assert_eq!(info_updates[0].title.as_deref(), Some("hello"));
+        assert!(info_updates[0]
+            .updated_at
+            .as_deref()
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some_and(|value| value > 0));
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -879,6 +879,14 @@
     "3034eee38ec516109566c00975be4d0276747c34": {
       "disposition": "ported",
       "notes": "Rust ACP server now flushes session/load and session/resume replay notifications before the JSON-RPC response, with run_on coverage proving clients receive transcript updates within the request lifetime."
+    },
+    "741a34945810a7cb5142804660f9e6108e2d49ec": {
+      "disposition": "ported",
+      "notes": "Rust ACP now emits session_info_update after prompt turns refresh session metadata, using the Rust-derived session title so editor clients can update their session list without waiting for a separate list refresh."
+    },
+    "2057977102da26cbf0fa9e699fa4432dbf017566": {
+      "disposition": "ported",
+      "notes": "Rust ACP session_info_update uses the notification refresh moment for updatedAt instead of relying on stored session updated_at fields; prompt-turn coverage asserts a non-empty fresh numeric timestamp."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- emit ACP `session_info_update` after prompt turns refresh session metadata
- include Rust-derived session title and refresh-moment `updatedAt`
- close upstream ACP session-info update queue items

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-session-info.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-session-info CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` (79 passed)
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-session-info CARGO_INCREMENTAL=0 cargo build -p hermes-acp`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-session-info CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp` (`new=0`, `stale=5`)
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/hermes-next-queue.json --out-md /tmp/hermes-next-queue.md`

Queue after slice: pending=1926, ported=90, mirrored=162, superseded=7603, total=9781.
