### PR TITLE
parity(acp): drop replay chunk message ids

### DIFF
--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -72,9 +72,6 @@ pub struct AcpEvent {
     pub status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<Value>,
-    #[serde(rename = "messageId", default, skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_call_count: Option<u32>,
@@ -118,7 +115,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             api_call_count: None,
             error: None,
             session_update: None,
@@ -147,7 +143,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             api_call_count: None,
             error: None,
             session_update: None,
@@ -177,7 +172,6 @@ impl AcpEvent {
             arguments: None,
             status: Some(status.to_string()),
             content: None,
-            message_id: None,
             api_call_count: None,
             error: None,
             session_update: None,
@@ -200,7 +194,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             api_call_count: None,
             error: None,
             session_update: None,
@@ -223,7 +216,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             api_call_count: None,
             error: None,
             session_update: None,
@@ -232,32 +224,29 @@ impl AcpEvent {
         }
     }
 
-    pub fn user_message_chunk(session_id: &str, message_id: &str, text: &str) -> Self {
+    pub fn user_message_chunk(session_id: &str, text: &str) -> Self {
         Self::history_text_chunk(
             AcpEventKind::UserMessageChunk,
             "user_message_chunk",
             session_id,
-            message_id,
             text,
         )
     }
 
-    pub fn agent_message_chunk(session_id: &str, message_id: &str, text: &str) -> Self {
+    pub fn agent_message_chunk(session_id: &str, text: &str) -> Self {
         Self::history_text_chunk(
             AcpEventKind::AgentMessageChunk,
             "agent_message_chunk",
             session_id,
-            message_id,
             text,
         )
     }
 
-    pub fn agent_thought_chunk(session_id: &str, message_id: &str, text: &str) -> Self {
+    pub fn agent_thought_chunk(session_id: &str, text: &str) -> Self {
         Self::history_text_chunk(
             AcpEventKind::AgentThoughtChunk,
             "agent_thought_chunk",
             session_id,
-            message_id,
             text,
         )
     }
@@ -266,7 +255,6 @@ impl AcpEvent {
         kind: AcpEventKind,
         session_update: &str,
         session_id: &str,
-        message_id: &str,
         text: &str,
     ) -> Self {
         Self {
@@ -274,7 +262,6 @@ impl AcpEvent {
             session_id: session_id.to_string(),
             timestamp: Self::now(),
             session_update: Some(session_update.to_string()),
-            message_id: Some(message_id.to_string()),
             content: Some(json!({"type": "text", "text": text})),
             text: Some(text.to_string()),
             tool_call_id: None,
@@ -305,7 +292,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             text: None,
             error: None,
             session_update: None,
@@ -328,7 +314,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             text: None,
             api_call_count: None,
             session_update: None,
@@ -353,7 +338,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             text: None,
             api_call_count: None,
             error: None,
@@ -379,7 +363,6 @@ impl AcpEvent {
             result: None,
             status: None,
             content: None,
-            message_id: None,
             text: None,
             api_call_count: None,
             error: None,

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -708,36 +708,27 @@ impl HermesAcpHandler {
 
     fn replay_session_history(&self, state: &SessionState) {
         let mut active_tool_calls: HashMap<String, String> = HashMap::new();
-        for (index, message) in state.history.iter().enumerate() {
+        for message in &state.history {
             let role = message.get("role").and_then(Value::as_str).unwrap_or("");
             match role {
                 "user" => {
                     let text = history_message_text(message);
                     if !text.is_empty() {
-                        self.event_sink.push(AcpEvent::user_message_chunk(
-                            &state.session_id,
-                            &history_message_id(&state.session_id, index, role, "message"),
-                            &text,
-                        ));
+                        self.event_sink
+                            .push(AcpEvent::user_message_chunk(&state.session_id, &text));
                     }
                 }
                 "assistant" => {
                     let thought = history_reasoning_text(message);
                     if !thought.is_empty() {
-                        self.event_sink.push(AcpEvent::agent_thought_chunk(
-                            &state.session_id,
-                            &history_message_id(&state.session_id, index, role, "thought"),
-                            &thought,
-                        ));
+                        self.event_sink
+                            .push(AcpEvent::agent_thought_chunk(&state.session_id, &thought));
                     }
 
                     let text = history_message_text(message);
                     if !text.is_empty() {
-                        self.event_sink.push(AcpEvent::agent_message_chunk(
-                            &state.session_id,
-                            &history_message_id(&state.session_id, index, role, "message"),
-                            &text,
-                        ));
+                        self.event_sink
+                            .push(AcpEvent::agent_message_chunk(&state.session_id, &text));
                     }
 
                     if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
@@ -1184,10 +1175,6 @@ fn history_reasoning_text(message: &Value) -> String {
         .map(|key| flatten_history_text(message.get(*key)))
         .find(|text| !text.is_empty())
         .unwrap_or_default()
-}
-
-fn history_message_id(session_id: &str, index: usize, role: &str, suffix: &str) -> String {
-    format!("history:{session_id}:{index}:{role}:{suffix}")
 }
 
 fn history_tool_call_arguments(tool_call: &Value) -> Option<Value> {
@@ -2425,11 +2412,10 @@ mod tests {
         assert_eq!(events[3].tool_name.as_deref(), Some("read_file"));
         assert_eq!(events[3].arguments.as_ref().unwrap()["path"], "/tmp/a.txt");
         assert_eq!(events[4].result.as_deref(), Some("file contents"));
-        assert!(events[0]
-            .message_id
-            .as_deref()
-            .unwrap()
-            .starts_with(&format!("history:{session_id}:1:user:")));
+        let replay_user_json = serde_json::to_value(&events[0]).unwrap();
+        let replay_agent_json = serde_json::to_value(&events[2]).unwrap();
+        assert!(replay_user_json.get("messageId").is_none());
+        assert!(replay_agent_json.get("messageId").is_none());
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -887,6 +887,10 @@
     "2057977102da26cbf0fa9e699fa4432dbf017566": {
       "disposition": "ported",
       "notes": "Rust ACP session_info_update uses the notification refresh moment for updatedAt instead of relying on stored session updated_at fields; prompt-turn coverage asserts a non-empty fresh numeric timestamp."
+    },
+    "658947480a01dc59a2aa7a6a06a6434d7214edff": {
+      "disposition": "ported",
+      "notes": "Rust ACP replay chunk events no longer carry the invalid messageId field; the typed event model omits the field and load replay tests assert serialized user/agent chunks match the ACP schema."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- remove the invalid `messageId` field from Rust ACP replay chunk events
- stop generating synthetic history replay message IDs for load/resume transcript chunks
- mark upstream `658947480a01dc59a2aa7a6a06a6434d7214edff` as ported in the parity queue

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-check.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-drop-message-id CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 79 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-drop-message-id CARGO_INCREMENTAL=0 cargo build -p hermes-acp`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-drop-message-id CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp` -> new=0, stale=5
- queue proof: pending=1925, ported=91, mirrored=162, superseded=7603; `658947` disposition=ported
