### PR TITLE
parity(acp): advertise and forward image prompts

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -237,6 +237,52 @@ fn json_image_part(url: impl Into<String>) -> Value {
     })
 }
 
+fn image_block_to_parts(block: &serde_json::Map<String, Value>) -> Vec<Value> {
+    let mime = block
+        .get("mimeType")
+        .or_else(|| block.get("mime_type"))
+        .and_then(|v| v.as_str());
+    let image_mime = canonical_mime(mime).unwrap_or_else(|| "image/png".to_string());
+
+    let data = block
+        .get("data")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+    if !data.is_empty() {
+        let url = if data.starts_with("data:") {
+            data.to_string()
+        } else {
+            format!("data:{image_mime};base64,{data}")
+        };
+        return vec![
+            json_text_part(format!("[Attached image: {image_mime}]")),
+            json_image_part(url),
+        ];
+    }
+
+    let url = block
+        .get("url")
+        .and_then(|v| v.as_str())
+        .or_else(|| block.get("image_url").and_then(|v| v.as_str()))
+        .or_else(|| {
+            block
+                .get("image_url")
+                .and_then(|v| v.get("url"))
+                .and_then(|v| v.as_str())
+        })
+        .unwrap_or("")
+        .trim();
+    if url.is_empty() {
+        Vec::new()
+    } else {
+        vec![
+            json_text_part(format!("[Attached image]\nURL: {url}")),
+            json_image_part(url),
+        ]
+    }
+}
+
 fn resource_link_to_parts(block: &serde_json::Map<String, Value>) -> Vec<Value> {
     let uri = block
         .get("uri")
@@ -477,22 +523,12 @@ fn extract_prompt_payload(p: &serde_json::Map<String, Value>) -> PromptExtractio
                     }
                     "image" => {
                         text_only_prompt = false;
-                        let url = obj
-                            .get("url")
-                            .and_then(|v| v.as_str())
-                            .or_else(|| {
-                                obj.get("image_url")
-                                    .and_then(|v| v.get("url"))
-                                    .and_then(|v| v.as_str())
-                            })
-                            .unwrap_or("")
-                            .trim()
-                            .to_string();
-                        if !url.is_empty() {
-                            let header = format!("[Attached image]\nURL: {url}");
-                            text_parts.push(header.clone());
-                            parts.push(json_text_part(header));
-                            parts.push(json_image_part(url));
+                        let image_parts = image_block_to_parts(obj);
+                        for part in image_parts {
+                            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                                text_parts.push(text.to_string());
+                            }
+                            parts.push(part);
                         }
                     }
                     "resource_link" => {
@@ -1301,6 +1337,7 @@ impl AcpHandler for HermesAcpHandler {
                     },
                     agent_capabilities: AgentCapabilities {
                         load_session: true,
+                        prompt_capabilities: Some(PromptCapabilities { image: true }),
                         session_capabilities: Some(SessionCapabilities {
                             fork: true,
                             list: true,
@@ -1995,6 +2032,10 @@ mod tests {
         assert_eq!(result["protocolVersion"], 1);
         assert_eq!(result["agentInfo"]["name"], "hermes-agent");
         assert_eq!(result["agentCapabilities"]["loadSession"], true);
+        assert_eq!(
+            result["agentCapabilities"]["promptCapabilities"]["image"],
+            true
+        );
         assert_eq!(
             result["agentCapabilities"]["sessionCapabilities"]["fork"],
             true
@@ -2737,6 +2778,40 @@ mod tests {
             .and_then(|v| v.as_str())
             .unwrap_or("");
         assert!(assistant_text.contains("ACP session"));
+    }
+
+    #[tokio::test]
+    async fn test_prompt_forwards_acp_image_data_blocks_as_multimodal_content() {
+        let handler = make_handler();
+        let session_id = create_session(&handler).await;
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "sessionId": session_id.clone(),
+                    "prompt": [
+                        {"type": "text", "text": "What is in this image?"},
+                        {"type": "image", "data": "aGVsbG8=", "mimeType": "image/png"}
+                    ]
+                })),
+            })
+            .await;
+        assert!(resp.error.is_none());
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        let parts = state.history[0]["content"].as_array().unwrap();
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "What is in this image?");
+        assert_eq!(parts[1]["type"], "text");
+        assert_eq!(parts[1]["text"], "[Attached image: image/png]");
+        assert_eq!(parts[2]["type"], "image_url");
+        assert_eq!(
+            parts[2]["image_url"]["url"],
+            "data:image/png;base64,aGVsbG8="
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-acp/src/lib.rs
+++ b/crates/hermes-acp/src/lib.rs
@@ -31,7 +31,7 @@ pub use permissions::{
 pub use protocol::{
     AcpError, AcpMethod, AcpRequest, AcpResponse, AgentCapabilities, AuthMethod, AvailableCommand,
     ClientCapabilities, ContentBlock, Implementation, InitializeResponse, McpServerConfig,
-    PromptResponse, SessionCapabilities, SessionUpdate, StopReason, Usage,
+    PromptCapabilities, PromptResponse, SessionCapabilities, SessionUpdate, StopReason, Usage,
 };
 pub use server::AcpServer;
 pub use session::{SessionInfo, SessionManager, SessionPhase, SessionState};

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -143,6 +143,13 @@ impl From<&str> for AcpMethod {
 pub struct AgentCapabilities {
     #[serde(rename = "loadSession", alias = "load_session", default)]
     pub load_session: bool,
+    #[serde(
+        rename = "promptCapabilities",
+        alias = "prompt_capabilities",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub prompt_capabilities: Option<PromptCapabilities>,
     #[serde(default)]
     #[serde(
         rename = "sessionCapabilities",
@@ -156,6 +163,13 @@ pub struct AgentCapabilities {
     pub streaming: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub models: Option<Vec<String>>,
+}
+
+/// Prompt-level capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PromptCapabilities {
+    #[serde(default)]
+    pub image: bool,
 }
 
 /// Session-level capabilities.
@@ -229,7 +243,12 @@ pub enum ContentBlock {
         text: String,
     },
     Image {
+        #[serde(default)]
         url: String,
+        #[serde(default)]
+        data: Option<String>,
+        #[serde(rename = "mimeType", alias = "mime_type", default)]
+        mime_type: Option<String>,
         #[serde(default)]
         alt: Option<String>,
     },
@@ -456,11 +475,33 @@ mod tests {
             ContentBlock::text("hello"),
             ContentBlock::Image {
                 url: "http://img.png".into(),
+                data: None,
+                mime_type: None,
                 alt: None,
             },
             ContentBlock::text("world"),
         ];
         assert_eq!(extract_text(&blocks), "hello\nworld");
+
+        let image: ContentBlock = serde_json::from_value(serde_json::json!({
+            "type": "image",
+            "data": "aGVsbG8=",
+            "mimeType": "image/png"
+        }))
+        .unwrap();
+        match image {
+            ContentBlock::Image {
+                url,
+                data,
+                mime_type,
+                ..
+            } => {
+                assert_eq!(url, "");
+                assert_eq!(data.as_deref(), Some("aGVsbG8="));
+                assert_eq!(mime_type.as_deref(), Some("image/png"));
+            }
+            _ => panic!("expected image block"),
+        }
     }
 
     #[test]
@@ -480,6 +521,7 @@ mod tests {
     fn test_capabilities_serde() {
         let caps = AgentCapabilities {
             load_session: true,
+            prompt_capabilities: Some(PromptCapabilities { image: true }),
             session_capabilities: Some(SessionCapabilities {
                 fork: true,
                 list: true,
@@ -490,6 +532,7 @@ mod tests {
         };
         let json = serde_json::to_value(&caps).unwrap();
         assert_eq!(json["loadSession"], true);
+        assert_eq!(json["promptCapabilities"]["image"], true);
         assert_eq!(json["sessionCapabilities"]["fork"], true);
         assert_eq!(json["streaming"], true);
     }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -891,6 +891,10 @@
     "658947480a01dc59a2aa7a6a06a6434d7214edff": {
       "disposition": "ported",
       "notes": "Rust ACP replay chunk events no longer carry the invalid messageId field; the typed event model omits the field and load replay tests assert serialized user/agent chunks match the ACP schema."
+    },
+    "cdf9793d6d6b97aa99e1b2f27629e52d89eac41d": {
+      "disposition": "ported",
+      "notes": "Rust ACP forwards image prompt blocks as OpenAI-style image_url multimodal content, preserves text-only slash command interception, treats image-bearing slash text as a model prompt, and now advertises promptCapabilities.image during initialize with protocol and handler tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- advertise `agentCapabilities.promptCapabilities.image` during ACP initialize
- accept ACP `image` blocks with `data`/`mimeType` and convert them to OpenAI-style `image_url` data URLs
- preserve text-only slash command interception while forwarding image-bearing slash text to the agent
- mark upstream `cdf9793d6d6b97aa99e1b2f27629e52d89eac41d` as ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-image-check.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-image-capability CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 80 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-image-capability CARGO_INCREMENTAL=0 cargo test -p hermes-cli acp_history_to_messages -- --nocapture` -> 2 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-image-capability CARGO_INCREMENTAL=0 cargo build -p hermes-acp -p hermes-cli`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-image-capability CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp -p hermes-cli` -> new=0, stale=5
- queue proof: pending=1924, ported=92, mirrored=162, superseded=7603; `cdf979` disposition=ported
