### PR TITLE
parity(acp): emit native todo plan updates

### DIFF
--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -11,7 +11,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::protocol::AvailableCommand;
+use crate::protocol::{AvailableCommand, PlanEntry};
 use crate::tools::{format_tool_result, tool_completion_status, tool_start_metadata};
 
 // ---------------------------------------------------------------------------
@@ -46,6 +46,8 @@ pub enum AcpEventKind {
     AvailableCommandsUpdate,
     /// Session metadata changed.
     SessionInfoUpdate,
+    /// Native plan/task list changed.
+    PlanUpdate,
     /// An error occurred.
     Error,
 }
@@ -89,6 +91,8 @@ pub struct AcpEvent {
         skip_serializing_if = "Option::is_none"
     )]
     pub available_commands: Option<Vec<AvailableCommand>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<Vec<PlanEntry>>,
     #[serde(rename = "updatedAt", default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
 }
@@ -119,6 +123,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -147,6 +152,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -176,6 +182,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -198,6 +205,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -220,6 +228,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -274,6 +283,30 @@ impl AcpEvent {
             api_call_count: None,
             error: None,
             available_commands: None,
+            entries: None,
+            updated_at: None,
+        }
+    }
+
+    pub fn plan_update(session_id: &str, entries: Vec<PlanEntry>) -> Self {
+        Self {
+            kind: AcpEventKind::PlanUpdate,
+            session_id: session_id.to_string(),
+            timestamp: Self::now(),
+            session_update: Some("plan".to_string()),
+            entries: Some(entries),
+            tool_call_id: None,
+            tool_name: None,
+            tool_kind: None,
+            title: None,
+            arguments: None,
+            result: None,
+            status: None,
+            content: None,
+            text: None,
+            api_call_count: None,
+            error: None,
+            available_commands: None,
             updated_at: None,
         }
     }
@@ -296,6 +329,7 @@ impl AcpEvent {
             error: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -318,6 +352,7 @@ impl AcpEvent {
             api_call_count: None,
             session_update: None,
             available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -341,6 +376,7 @@ impl AcpEvent {
             text: None,
             api_call_count: None,
             error: None,
+            entries: None,
         }
     }
 
@@ -366,9 +402,63 @@ impl AcpEvent {
             text: None,
             api_call_count: None,
             error: None,
+            entries: None,
             available_commands: None,
         }
     }
+}
+
+fn json_loads_maybe_prefix(text: &str) -> Option<Value> {
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    serde_json::from_str::<Value>(text).ok().or_else(|| {
+        serde_json::Deserializer::from_str(text)
+            .into_iter::<Value>()
+            .next()
+            .and_then(Result::ok)
+    })
+}
+
+pub fn plan_entries_from_todo_result(result: Option<&str>) -> Option<Vec<PlanEntry>> {
+    let data = json_loads_maybe_prefix(result?)?;
+    let todos = data.get("todos")?.as_array()?;
+
+    let mut entries = Vec::new();
+    for item in todos.iter().filter_map(Value::as_object) {
+        let mut content = item
+            .get("content")
+            .or_else(|| item.get("id"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if content.is_empty() {
+            continue;
+        }
+        let raw_status = item
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("pending")
+            .trim();
+        let status = match raw_status {
+            "completed" => "completed",
+            "in_progress" => "in_progress",
+            "cancelled" => {
+                content = format!("[cancelled] {content}");
+                "completed"
+            }
+            _ => "pending",
+        };
+        entries.push(PlanEntry {
+            content,
+            priority: "medium".to_string(),
+            status: status.to_string(),
+        });
+    }
+
+    Some(entries)
 }
 
 // ---------------------------------------------------------------------------
@@ -542,5 +632,57 @@ mod tests {
             Some("Error: pytest collected 0 items")
         );
         assert_eq!(e3.status.as_deref(), Some("completed"));
+    }
+
+    #[test]
+    fn todo_plan_update_parses_statuses_and_serializes_native_entries() {
+        let entries = plan_entries_from_todo_result(Some(
+            r#"{"todos":[{"id":"inspect","content":"Inspect ACP","status":"completed"},{"id":"patch","content":"Patch renderer","status":"in_progress"},{"id":"old","content":"Drop stale task","status":"cancelled"}]}"#,
+        ))
+        .expect("todo entries");
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.content.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "Inspect ACP",
+                "Patch renderer",
+                "[cancelled] Drop stale task"
+            ]
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.status.as_str())
+                .collect::<Vec<_>>(),
+            vec!["completed", "in_progress", "completed"]
+        );
+
+        let event = AcpEvent::plan_update("s1", entries);
+        let value = serde_json::to_value(event).unwrap();
+        assert_eq!(value["sessionUpdate"], "plan");
+        assert_eq!(value["entries"][0]["priority"], "medium");
+        assert_eq!(
+            value["entries"][2]["content"],
+            "[cancelled] Drop stale task"
+        );
+    }
+
+    #[test]
+    fn todo_plan_update_parses_trailing_hint_and_empty_todos() {
+        let entries = plan_entries_from_todo_result(Some(
+            r#"{"todos":[{"id":"ship","content":"Ship ACP plan","status":"pending"}]}
+
+[Hint: persisted]"#,
+        ))
+        .expect("todo entries with suffix");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].content, "Ship ACP plan");
+        assert_eq!(entries[0].status, "pending");
+
+        let empty = plan_entries_from_todo_result(Some(r#"{"todos":[]}"#)).expect("empty plan");
+        assert!(empty.is_empty());
     }
 }

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -15,7 +15,7 @@ use url::Url;
 use crate::auth::{
     build_auth_methods_for_provider, detect_provider, TERMINAL_SETUP_AUTH_METHOD_ID,
 };
-use crate::events::{AcpEvent, EventSink};
+use crate::events::{plan_entries_from_todo_result, AcpEvent, EventSink};
 use crate::permissions::PermissionStore;
 use crate::protocol::*;
 use crate::session::{SessionManager, SessionPhase, SessionState};
@@ -807,12 +807,19 @@ impl HermesAcpHandler {
                         })
                         .unwrap_or_else(|| "tool".to_string());
                     let text = history_message_text(message);
+                    let result = (!text.is_empty()).then_some(text.as_str());
                     self.event_sink.push(AcpEvent::tool_call_complete(
                         &state.session_id,
                         tool_call_id,
                         &tool_name,
-                        (!text.is_empty()).then_some(text),
+                        result.map(str::to_string),
                     ));
+                    if tool_name == "todo" {
+                        if let Some(entries) = plan_entries_from_todo_result(result) {
+                            self.event_sink
+                                .push(AcpEvent::plan_update(&state.session_id, entries));
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -2493,6 +2500,64 @@ mod tests {
             events.last().unwrap().kind,
             AcpEventKind::AvailableCommandsUpdate
         );
+    }
+
+    #[tokio::test]
+    async fn test_load_session_replays_native_plan_for_persisted_todo_tool() {
+        let handler = make_handler();
+        let created = handler.session_manager.create_session("/tmp");
+        let session_id = created.session_id;
+        let todo_result = r#"{"todos":[{"id":"ship","content":"Ship it","status":"in_progress"}]}"#;
+        handler.session_manager.set_history(
+            &session_id,
+            vec![
+                json!({
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_todo_1",
+                        "function": {
+                            "name": "todo",
+                            "arguments": "{\"todos\":[{\"id\":\"ship\",\"content\":\"Ship it\",\"status\":\"in_progress\"}]}"
+                        }
+                    }]
+                }),
+                json!({
+                    "role": "tool",
+                    "tool_call_id": "call_todo_1",
+                    "content": todo_result,
+                }),
+            ],
+        );
+
+        let loaded = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/load".into(),
+                params: Some(json!({"sessionId": session_id, "cwd": "/tmp"})),
+            })
+            .await;
+        assert!(loaded.error.is_none());
+
+        let events = handler.event_sink.drain_for_session(&session_id);
+        let kinds = events
+            .iter()
+            .map(|event| event.kind.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            kinds,
+            vec![
+                AcpEventKind::ToolCallStart,
+                AcpEventKind::ToolCallComplete,
+                AcpEventKind::PlanUpdate,
+                AcpEventKind::AvailableCommandsUpdate,
+            ]
+        );
+        assert_eq!(events[2].session_update.as_deref(), Some("plan"));
+        let entries = events[2].entries.as_ref().expect("plan entries");
+        assert_eq!(entries[0].content, "Ship it");
+        assert_eq!(entries[0].status, "in_progress");
     }
 
     #[tokio::test]

--- a/crates/hermes-acp/src/lib.rs
+++ b/crates/hermes-acp/src/lib.rs
@@ -20,7 +20,9 @@ pub mod session;
 pub mod tools;
 
 pub use auth::{build_auth_methods, detect_provider, has_provider, TERMINAL_SETUP_AUTH_METHOD_ID};
-pub use events::{AcpEvent, AcpEventKind, EventSink, ToolCallIdTracker};
+pub use events::{
+    plan_entries_from_todo_result, AcpEvent, AcpEventKind, EventSink, ToolCallIdTracker,
+};
 pub use handler::{
     AcpHandler, AcpPromptExecutor, DefaultAcpHandler, HermesAcpHandler, PromptExecutionOutput,
 };
@@ -31,7 +33,8 @@ pub use permissions::{
 pub use protocol::{
     AcpError, AcpMethod, AcpRequest, AcpResponse, AgentCapabilities, AuthMethod, AvailableCommand,
     ClientCapabilities, ContentBlock, Implementation, InitializeResponse, McpServerConfig,
-    PromptCapabilities, PromptResponse, SessionCapabilities, SessionUpdate, StopReason, Usage,
+    PlanEntry, PromptCapabilities, PromptResponse, SessionCapabilities, SessionUpdate, StopReason,
+    Usage,
 };
 pub use server::AcpServer;
 pub use session::{SessionInfo, SessionManager, SessionPhase, SessionState};

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -327,6 +327,14 @@ pub struct AvailableCommand {
     pub input_hint: Option<String>,
 }
 
+/// Entry in a native ACP plan update.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanEntry {
+    pub content: String,
+    pub priority: String,
+    pub status: String,
+}
+
 // ---------------------------------------------------------------------------
 // Usage stats
 // ---------------------------------------------------------------------------

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -26757,6 +26757,13 @@ fn acp_events_from_agent_messages(
                     &tool_name,
                     message.content.clone(),
                 ));
+                if tool_name == "todo" {
+                    if let Some(entries) =
+                        hermes_acp::plan_entries_from_todo_result(message.content.as_deref())
+                    {
+                        events.push(hermes_acp::AcpEvent::plan_update(session_id, entries));
+                    }
+                }
             }
             _ => {}
         }
@@ -27832,6 +27839,38 @@ mod tests {
         assert_eq!(events[2].result.as_deref(), Some("127.0.0.1 localhost"));
         assert_eq!(events[3].tool_call_id.as_deref(), Some("tc-web"));
         assert_eq!(events[3].tool_name.as_deref(), Some("web_search"));
+    }
+
+    #[test]
+    fn test_acp_events_from_agent_messages_emits_native_todo_plan() {
+        let todo_result = r#"{"todos":[{"id":"inspect","content":"Inspect ACP","status":"completed"},{"id":"patch","content":"Patch renderer","status":"in_progress"}]}"#;
+        let messages = vec![
+            hermes_core::Message::assistant_with_tool_calls(
+                None,
+                vec![hermes_core::ToolCall {
+                    id: "tc-todo".to_string(),
+                    function: hermes_core::FunctionCall {
+                        name: "todo".to_string(),
+                        arguments: r#"{"todos":[]}"#.to_string(),
+                    },
+                    extra_content: None,
+                }],
+            ),
+            hermes_core::Message::tool_result("tc-todo", todo_result),
+        ];
+
+        let events = acp_events_from_agent_messages("session-1", &messages);
+
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].kind, hermes_acp::AcpEventKind::ToolCallStart);
+        assert_eq!(events[1].kind, hermes_acp::AcpEventKind::ToolCallComplete);
+        assert_eq!(events[2].kind, hermes_acp::AcpEventKind::PlanUpdate);
+        assert_eq!(events[2].session_update.as_deref(), Some("plan"));
+        let entries = events[2].entries.as_ref().expect("plan entries");
+        assert_eq!(entries[0].content, "Inspect ACP");
+        assert_eq!(entries[0].status, "completed");
+        assert_eq!(entries[1].content, "Patch renderer");
+        assert_eq!(entries[1].status, "in_progress");
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -895,6 +895,14 @@
     "cdf9793d6d6b97aa99e1b2f27629e52d89eac41d": {
       "disposition": "ported",
       "notes": "Rust ACP forwards image prompt blocks as OpenAI-style image_url multimodal content, preserves text-only slash command interception, treats image-bearing slash text as a model prompt, and now advertises promptCapabilities.image during initialize with protocol and handler tests."
+    },
+    "4444d5fe4f65dcbca939a1f39ae58438205e7dad": {
+      "disposition": "ported",
+      "notes": "Rust ACP emits native sessionUpdate=plan events after live todo tool completions, using typed PlanEntry values and shared parser tests for status mapping, cancelled preservation, and wire serialization."
+    },
+    "bd3a5873e11f084d74be876a505a406224a6ef3e": {
+      "disposition": "ported",
+      "notes": "Rust ACP replays native todo plan updates from persisted tool results after tool_call_complete, supports trailing human hints and empty todo lists for plan clearing, and covers replay ordering plus CLI live converter behavior."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add typed ACP `PlanEntry` and `sessionUpdate=plan` event support
- emit native plan updates after live `todo` tool completions in the CLI ACP converter
- replay native plan updates after persisted `todo` tool completions on session load/resume
- mark upstream `4444d5fe4f65dcbca939a1f39ae58438205e7dad` and `bd3a5873e11f084d74be876a505a406224a6ef3e` as ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-todo-plan-check.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-todo-plans CARGO_INCREMENTAL=0 cargo test -p hermes-acp todo -- --nocapture` -> 4 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-todo-plans CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_acp_events_from_agent_messages_emits_native_todo_plan -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-todo-plans CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 83 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-todo-plans CARGO_INCREMENTAL=0 cargo build -p hermes-acp -p hermes-cli`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-todo-plans CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp -p hermes-cli` -> new=0, stale=5
- queue proof: pending=1922, ported=94, mirrored=162, superseded=7603; `4444d5fe` and `bd3a5873` disposition=ported
