### PR TITLE
parity(acp): route streamed reasoning events

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -15,7 +15,7 @@ use url::Url;
 use crate::auth::{
     build_auth_methods_for_provider, detect_provider, TERMINAL_SETUP_AUTH_METHOD_ID,
 };
-use crate::events::{plan_entries_from_todo_result, AcpEvent, EventSink};
+use crate::events::{plan_entries_from_todo_result, AcpEvent, AcpEventKind, EventSink};
 use crate::permissions::PermissionStore;
 use crate::protocol::*;
 use crate::session::{SessionManager, SessionPhase, SessionState};
@@ -971,12 +971,18 @@ impl HermesAcpHandler {
             events,
         } = prompt_result;
 
+        let streamed_message = events.iter().any(|event| {
+            matches!(
+                event.kind,
+                AcpEventKind::MessageDelta | AcpEventKind::MessageComplete
+            ) && event.text.as_deref().is_some_and(|text| !text.is_empty())
+        });
         for event in events {
             self.event_sink.push(event);
         }
 
         let response_text = response_text.trim().to_string();
-        if !response_text.is_empty() {
+        if !response_text.is_empty() && !streamed_message {
             self.event_sink
                 .push(AcpEvent::message_delta(session_id, &response_text));
             self.event_sink
@@ -1948,6 +1954,28 @@ mod tests {
                         Some("contents".to_string()),
                     ),
                 ],
+            })
+        }
+    }
+
+    struct StreamingPromptExecutor;
+
+    #[async_trait::async_trait]
+    impl AcpPromptExecutor for StreamingPromptExecutor {
+        async fn execute_prompt(
+            &self,
+            session: &SessionState,
+            _user_text: &str,
+            _history: &[Value],
+        ) -> Result<PromptExecutionOutput, String> {
+            Ok(PromptExecutionOutput {
+                response_text: "streamed answer".to_string(),
+                usage: None,
+                total_turns: Some(1),
+                events: vec![AcpEvent::message_delta(
+                    &session.session_id,
+                    "streamed answer",
+                )],
             })
         }
     }
@@ -3255,6 +3283,39 @@ mod tests {
             .as_deref()
             .and_then(|value| value.parse::<u64>().ok())
             .is_some_and(|value| value > 0));
+    }
+
+    #[tokio::test]
+    async fn test_prompt_does_not_duplicate_streamed_final_message() {
+        let handler = make_handler().with_prompt_executor(Arc::new(StreamingPromptExecutor));
+        let session_id = create_session(&handler).await;
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "sessionId": session_id.clone(),
+                    "text": "hello"
+                })),
+            })
+            .await;
+        assert!(resp.error.is_none());
+
+        let events = handler.event_sink.drain_for_session(&session_id);
+        let message_events = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.kind,
+                    AcpEventKind::MessageDelta | AcpEventKind::MessageComplete
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(message_events.len(), 1);
+        assert_eq!(message_events[0].kind, AcpEventKind::MessageDelta);
+        assert_eq!(message_events[0].text.as_deref(), Some("streamed answer"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -26789,6 +26789,41 @@ struct CliAcpPromptExecutor {
     interrupts: Arc<Mutex<HashMap<String, hermes_agent::InterruptController>>>,
 }
 
+fn acp_stream_callbacks(
+    session_id: &str,
+    callback_events: Arc<Mutex<Vec<hermes_acp::AcpEvent>>>,
+) -> hermes_agent::AgentCallbacks {
+    let thought_events = callback_events.clone();
+    let thought_session_id = session_id.to_string();
+    let stream_events = callback_events;
+    let stream_session_id = session_id.to_string();
+    hermes_agent::AgentCallbacks {
+        on_thinking: Some(Box::new(move |thinking: &str| {
+            if thinking.trim().is_empty() {
+                return;
+            }
+            if let Ok(mut events) = thought_events.lock() {
+                events.push(hermes_acp::AcpEvent::agent_thought_chunk(
+                    &thought_session_id,
+                    thinking,
+                ));
+            }
+        })),
+        on_stream_delta: Some(Box::new(move |delta: &str| {
+            if delta.is_empty() {
+                return;
+            }
+            if let Ok(mut events) = stream_events.lock() {
+                events.push(hermes_acp::AcpEvent::message_delta(
+                    &stream_session_id,
+                    delta,
+                ));
+            }
+        })),
+        ..hermes_agent::AgentCallbacks::default()
+    }
+}
+
 #[async_trait::async_trait]
 impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
     async fn execute_prompt(
@@ -26812,8 +26847,12 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
         if let Ok(mut active) = self.interrupts.lock() {
             active.insert(session.session_id.clone(), interrupt.clone());
         }
+        let callback_events: Arc<Mutex<Vec<hermes_acp::AcpEvent>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let callbacks = acp_stream_callbacks(&session.session_id, callback_events.clone());
         let agent = hermes_agent::attach_discovered_memory(
-            hermes_agent::AgentLoop::with_interrupt(agent_config, agent_tools, provider, interrupt),
+            hermes_agent::AgentLoop::with_interrupt(agent_config, agent_tools, provider, interrupt)
+                .with_callbacks(callbacks),
         );
         let messages = acp_history_to_messages(history, user_text);
 
@@ -26831,12 +26870,20 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
             .unwrap_or_default();
 
         let usage = result.usage.as_ref().map(acp_usage_from_agent_usage);
+        let mut events = callback_events
+            .lock()
+            .map(|mut events| std::mem::take(&mut *events))
+            .unwrap_or_default();
+        events.extend(acp_events_from_agent_messages(
+            &session.session_id,
+            &result.messages,
+        ));
 
         Ok(hermes_acp::PromptExecutionOutput {
             response_text,
             usage,
             total_turns: Some(result.total_turns),
-            events: acp_events_from_agent_messages(&session.session_id, &result.messages),
+            events,
         })
     }
 
@@ -27871,6 +27918,28 @@ mod tests {
         assert_eq!(entries[0].status, "completed");
         assert_eq!(entries[1].content, "Patch renderer");
         assert_eq!(entries[1].status, "in_progress");
+    }
+
+    #[test]
+    fn test_acp_stream_callbacks_route_reasoning_and_message_deltas() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let callbacks = acp_stream_callbacks("session-1", events.clone());
+
+        callbacks.on_thinking.as_ref().unwrap()("actual reasoning");
+        callbacks.on_stream_delta.as_ref().unwrap()("streamed answer");
+        callbacks.on_thinking.as_ref().unwrap()("   ");
+        callbacks.on_stream_delta.as_ref().unwrap()("");
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, hermes_acp::AcpEventKind::AgentThoughtChunk);
+        assert_eq!(
+            events[0].session_update.as_deref(),
+            Some("agent_thought_chunk")
+        );
+        assert_eq!(events[0].text.as_deref(), Some("actual reasoning"));
+        assert_eq!(events[1].kind, hermes_acp::AcpEventKind::MessageDelta);
+        assert_eq!(events[1].text.as_deref(), Some("streamed answer"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -903,6 +903,10 @@
     "bd3a5873e11f084d74be876a505a406224a6ef3e": {
       "disposition": "ported",
       "notes": "Rust ACP replays native todo plan updates from persisted tool results after tool_call_complete, supports trailing human hints and empty todo lists for plan clearing, and covers replay ordering plus CLI live converter behavior."
+    },
+    "e26f9b207041c03d1aa9a982d29dbfda66df3a82": {
+      "disposition": "ported",
+      "notes": "Rust ACP routes provider reasoning callbacks to agent_thought_chunk updates, routes stream deltas to message_delta updates, and suppresses fallback final-response emission when executor streaming already delivered message content."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- route Rust agent reasoning callbacks to ACP `agent_thought_chunk` updates
- route Rust stream deltas to ACP `message_delta` updates
- suppress fallback final response emission when executor streaming already delivered message content
- mark upstream `e26f9b207041c03d1aa9a982d29dbfda66df3a82` as ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/hermes-overrides-streaming-check.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-streaming CARGO_INCREMENTAL=0 cargo test -p hermes-acp test_prompt_does_not_duplicate_streamed_final_message -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-streaming CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_acp_stream_callbacks_route_reasoning_and_message_deltas -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-streaming CARGO_INCREMENTAL=0 cargo build -p hermes-acp -p hermes-cli`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-streaming CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp -p hermes-cli` -> new=0, stale=5
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-streaming CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 84 passed
- queue proof: pending=1921, ported=95, mirrored=162, superseded=7603; `e26f9` disposition=ported
