### PR TITLE
parity(acp): polish tool rendering and usage updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,7 @@ dependencies = [
  "base64 0.22.1",
  "hermes-config",
  "hermes-core",
+ "hermes-intelligence",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/hermes-acp/Cargo.toml
+++ b/crates/hermes-acp/Cargo.toml
@@ -9,6 +9,7 @@ description = "Agent Communication Protocol adapter for Hermes Agent"
 [dependencies]
 hermes-core = { workspace = true }
 hermes-config = { workspace = true }
+hermes-intelligence = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -48,6 +48,8 @@ pub enum AcpEventKind {
     SessionInfoUpdate,
     /// Native plan/task list changed.
     PlanUpdate,
+    /// Native context usage changed.
+    UsageUpdate,
     /// An error occurred.
     Error,
 }
@@ -95,6 +97,10 @@ pub struct AcpEvent {
     pub entries: Option<Vec<PlanEntry>>,
     #[serde(rename = "updatedAt", default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub used: Option<u64>,
 }
 
 impl AcpEvent {
@@ -125,6 +131,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -154,6 +162,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -184,6 +194,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -207,6 +219,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -230,6 +244,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -285,6 +301,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -307,6 +325,33 @@ impl AcpEvent {
             api_call_count: None,
             error: None,
             available_commands: None,
+            updated_at: None,
+            size: None,
+            used: None,
+        }
+    }
+
+    pub fn usage_update(session_id: &str, size: u64, used: u64) -> Self {
+        Self {
+            kind: AcpEventKind::UsageUpdate,
+            session_id: session_id.to_string(),
+            timestamp: Self::now(),
+            session_update: Some("usage_update".to_string()),
+            size: Some(size),
+            used: Some(used),
+            tool_call_id: None,
+            tool_name: None,
+            tool_kind: None,
+            title: None,
+            arguments: None,
+            result: None,
+            status: None,
+            content: None,
+            text: None,
+            api_call_count: None,
+            error: None,
+            available_commands: None,
+            entries: None,
             updated_at: None,
         }
     }
@@ -331,6 +376,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -354,6 +401,8 @@ impl AcpEvent {
             available_commands: None,
             entries: None,
             updated_at: None,
+            size: None,
+            used: None,
         }
     }
 
@@ -365,6 +414,8 @@ impl AcpEvent {
             session_update: Some("available_commands_update".to_string()),
             available_commands: Some(commands),
             updated_at: None,
+            size: None,
+            used: None,
             tool_call_id: None,
             tool_name: None,
             tool_kind: None,
@@ -404,6 +455,8 @@ impl AcpEvent {
             error: None,
             entries: None,
             available_commands: None,
+            size: None,
+            used: None,
         }
     }
 }
@@ -632,6 +685,16 @@ mod tests {
             Some("Error: pytest collected 0 items")
         );
         assert_eq!(e3.status.as_deref(), Some("completed"));
+
+        let usage = AcpEvent::usage_update("s1", 100_000, 25_000);
+        assert_eq!(usage.kind, AcpEventKind::UsageUpdate);
+        assert_eq!(usage.session_update.as_deref(), Some("usage_update"));
+        assert_eq!(usage.size, Some(100_000));
+        assert_eq!(usage.used, Some(25_000));
+        let wire = serde_json::to_value(&usage).expect("usage event json");
+        assert_eq!(wire["sessionUpdate"], "usage_update");
+        assert_eq!(wire["size"], 100_000);
+        assert_eq!(wire["used"], 25_000);
     }
 
     #[test]

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -9,6 +9,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine as _;
+use hermes_intelligence::model_metadata::{
+    estimate_request_tokens_rough, get_model_context_length,
+};
 use serde_json::{json, Value};
 use url::Url;
 
@@ -731,6 +734,32 @@ impl HermesAcpHandler {
         ));
     }
 
+    fn context_usage_for_state(state: &SessionState) -> Option<(u64, u64)> {
+        let model = match (state.provider.as_deref(), state.model.as_deref()) {
+            (Some(provider), Some(model)) if !model.contains(':') => {
+                format!("{provider}:{model}")
+            }
+            (_, Some(model)) => model.to_string(),
+            _ => "unknown-model".to_string(),
+        };
+        let size = get_model_context_length(&model);
+        if size == 0 {
+            return None;
+        }
+        let used = estimate_request_tokens_rough(&state.history, "", None);
+        Some((size, used))
+    }
+
+    fn emit_usage_update(&self, session_id: &str) {
+        let Some(state) = self.session_manager.get_session(session_id) else {
+            return;
+        };
+        if let Some((size, used)) = Self::context_usage_for_state(&state) {
+            self.event_sink
+                .push(AcpEvent::usage_update(session_id, size, used));
+        }
+    }
+
     fn emit_session_info_update(&self, session_id: &str) {
         let Some(state) = self.session_manager.get_session(session_id) else {
             return;
@@ -1033,9 +1062,6 @@ impl HermesAcpHandler {
             "context" => {
                 let state = self.session_manager.get_session(session_id)?;
                 let n = state.history.len();
-                if n == 0 {
-                    return Some("Conversation is empty (no messages yet).".to_string());
-                }
                 let mut roles: HashMap<String, usize> = HashMap::new();
                 for msg in &state.history {
                     let role = msg
@@ -1044,14 +1070,44 @@ impl HermesAcpHandler {
                         .unwrap_or("unknown");
                     *roles.entry(role.to_string()).or_default() += 1;
                 }
-                Some(format!(
-                    "Conversation: {} messages\n  user: {}, assistant: {}, tool: {}, system: {}",
-                    n,
-                    roles.get("user").unwrap_or(&0),
-                    roles.get("assistant").unwrap_or(&0),
-                    roles.get("tool").unwrap_or(&0),
-                    roles.get("system").unwrap_or(&0),
-                ))
+                let mut lines = if n == 0 {
+                    vec!["Conversation is empty (no messages yet).".to_string()]
+                } else {
+                    vec![format!(
+                        "Conversation: {} messages\n  user: {}, assistant: {}, tool: {}, system: {}",
+                        n,
+                        roles.get("user").unwrap_or(&0),
+                        roles.get("assistant").unwrap_or(&0),
+                        roles.get("tool").unwrap_or(&0),
+                        roles.get("system").unwrap_or(&0),
+                    )]
+                };
+                if let Some((size, used)) = Self::context_usage_for_state(&state) {
+                    let percent = if size == 0 {
+                        0.0
+                    } else {
+                        (used as f64 / size as f64) * 100.0
+                    };
+                    let threshold = ((size as f64) * 0.80).round() as u64;
+                    lines.push(format!(
+                        "Context usage: ~{} / {} tokens ({percent:.1}%)",
+                        format_token_count_plain(used),
+                        format_token_count_plain(size)
+                    ));
+                    if used >= threshold {
+                        lines.push(format!(
+                            "Compression: due now (threshold ~{}, 80%). Run /compact.",
+                            format_token_count_plain(threshold)
+                        ));
+                    } else {
+                        lines.push(format!(
+                            "Compression: ~{} tokens until threshold (~{}, 80%).",
+                            format_token_count_plain(threshold.saturating_sub(used)),
+                            format_token_count_plain(threshold)
+                        ));
+                    }
+                }
+                Some(lines.join("\n"))
             }
             "reset" => {
                 self.session_manager.set_history(session_id, Vec::new());
@@ -1292,6 +1348,18 @@ fn session_id_response(session_id: &str) -> Value {
     json!({"sessionId": session_id})
 }
 
+fn format_token_count_plain(value: u64) -> String {
+    let raw = value.to_string();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    for (idx, ch) in raw.chars().rev().enumerate() {
+        if idx > 0 && idx % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
 fn session_title_from_history(history: &[Value]) -> Option<String> {
     history.iter().find_map(|message| {
         let role = message.get("role").and_then(Value::as_str)?;
@@ -1392,6 +1460,7 @@ impl AcpHandler for HermesAcpHandler {
                     .unwrap_or(".");
                 let state = self.session_manager.create_session(cwd);
                 self.advertise_available_commands(&state.session_id);
+                self.emit_usage_update(&state.session_id);
                 AcpResponse::success(request.id, session_id_response(&state.session_id))
             }
 
@@ -1406,6 +1475,7 @@ impl AcpHandler for HermesAcpHandler {
                     Some(state) => {
                         self.replay_session_history(&state);
                         self.advertise_available_commands(session_id);
+                        self.emit_usage_update(session_id);
                         AcpResponse::success(request.id, json!({}))
                     }
                     None => AcpResponse::error(
@@ -1426,10 +1496,12 @@ impl AcpHandler for HermesAcpHandler {
                 if let Some(state) = self.session_manager.update_cwd(session_id, cwd) {
                     self.replay_session_history(&state);
                     self.advertise_available_commands(&state.session_id);
+                    self.emit_usage_update(&state.session_id);
                     AcpResponse::success(request.id, json!({}))
                 } else {
                     let state = self.session_manager.create_session(cwd);
                     self.advertise_available_commands(&state.session_id);
+                    self.emit_usage_update(&state.session_id);
                     AcpResponse::success(request.id, session_id_response(&state.session_id))
                 }
             }
@@ -1444,6 +1516,7 @@ impl AcpHandler for HermesAcpHandler {
                 match self.session_manager.fork_session(session_id, cwd) {
                     Some(new_state) => {
                         self.advertise_available_commands(&new_state.session_id);
+                        self.emit_usage_update(&new_state.session_id);
                         AcpResponse::success(request.id, session_id_response(&new_state.session_id))
                     }
                     None => AcpResponse::error(
@@ -1580,6 +1653,7 @@ impl AcpHandler for HermesAcpHandler {
                     if let Some(response_text) = self.handle_slash_command(&user_text, session_id) {
                         self.event_sink
                             .push(AcpEvent::message_complete(session_id, &response_text));
+                        self.emit_usage_update(session_id);
                         return AcpResponse::success(
                             request.id,
                             prompt_response_value(StopReason::EndTurn, None),
@@ -1648,6 +1722,7 @@ impl AcpHandler for HermesAcpHandler {
 
                 self.session_manager
                     .set_phase(session_id, SessionPhase::Idle);
+                self.emit_usage_update(session_id);
 
                 AcpResponse::success(
                     request.id,
@@ -1676,6 +1751,7 @@ impl AcpHandler for HermesAcpHandler {
                 match self.session_manager.update_model(session_id, model_id) {
                     Some(_) => {
                         tracing::info!("Session {}: model switched to {}", session_id, model_id);
+                        self.emit_usage_update(session_id);
                         AcpResponse::success(request.id, json!({}))
                     }
                     None => AcpResponse::error(
@@ -2325,7 +2401,7 @@ mod tests {
     }
 
     fn assert_available_commands_update(events: Vec<AcpEvent>, expected_session_id: &str) {
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
         let event = &events[0];
         assert_eq!(event.kind, AcpEventKind::AvailableCommandsUpdate);
         assert_eq!(event.session_id, expected_session_id);
@@ -2345,6 +2421,13 @@ mod tests {
         assert_eq!(model.input_hint.as_deref(), Some("model name to switch to"));
         assert!(commands.iter().any(|command| command.name == "queue"));
         assert!(commands.iter().any(|command| command.name == "steer"));
+
+        let usage = &events[1];
+        assert_eq!(usage.kind, AcpEventKind::UsageUpdate);
+        assert_eq!(usage.session_id, expected_session_id);
+        assert_eq!(usage.session_update.as_deref(), Some("usage_update"));
+        assert!(usage.size.unwrap_or_default() > 0);
+        assert!(usage.used.is_some());
     }
 
     #[tokio::test]
@@ -2462,6 +2545,7 @@ mod tests {
                 AcpEventKind::ToolCallStart,
                 AcpEventKind::ToolCallComplete,
                 AcpEventKind::AvailableCommandsUpdate,
+                AcpEventKind::UsageUpdate,
             ]
         );
         assert_eq!(
@@ -2525,9 +2609,10 @@ mod tests {
             "Reasoning persisted without assistant text."
         );
         assert_eq!(
-            events.last().unwrap().kind,
+            events[events.len() - 2].kind,
             AcpEventKind::AvailableCommandsUpdate
         );
+        assert_eq!(events.last().unwrap().kind, AcpEventKind::UsageUpdate);
     }
 
     #[tokio::test]
@@ -2580,6 +2665,7 @@ mod tests {
                 AcpEventKind::ToolCallComplete,
                 AcpEventKind::PlanUpdate,
                 AcpEventKind::AvailableCommandsUpdate,
+                AcpEventKind::UsageUpdate,
             ]
         );
         assert_eq!(events[2].session_update.as_deref(), Some("plan"));
@@ -2628,6 +2714,35 @@ mod tests {
             state.base_url.as_deref(),
             Some("https://openrouter.ai/api/v1")
         );
+    }
+
+    #[tokio::test]
+    async fn test_context_slash_command_includes_usage_and_threshold() {
+        let handler = make_handler();
+        let state = handler.session_manager.create_session("/workspace");
+        let session_id = state.session_id;
+        handler
+            .session_manager
+            .update_model(&session_id, "gpt-4o")
+            .expect("session exists");
+        handler.session_manager.set_history(
+            &session_id,
+            vec![
+                json!({"role": "user", "content": "hello"}),
+                json!({"role": "assistant", "content": "hi"}),
+            ],
+        );
+
+        let response = handler
+            .handle_slash_command("/context", &session_id)
+            .expect("context response");
+
+        assert!(response.contains("Conversation: 2 messages"));
+        assert!(response.contains("user: 1, assistant: 1"));
+        assert!(response.contains("Context usage: ~"));
+        assert!(response.contains("/ 128,000 tokens"));
+        assert!(response.contains("Compression: ~"));
+        assert!(response.contains("tokens until threshold (~102,400, 80%)."));
     }
 
     #[tokio::test]

--- a/crates/hermes-acp/src/server.rs
+++ b/crates/hermes-acp/src/server.rs
@@ -279,7 +279,7 @@ mod tests {
             .map(|line| serde_json::from_str(line).unwrap())
             .collect();
 
-        assert_eq!(lines.len(), 2);
+        assert_eq!(lines.len(), 3);
         let session_id = lines[0]["result"]["sessionId"].as_str().unwrap();
         assert_eq!(lines[1]["method"], "session/update");
         assert_eq!(lines[1]["params"]["kind"], "available_commands_update");
@@ -297,6 +297,12 @@ mod tests {
             .find(|command| command["name"] == "model")
             .expect("model command");
         assert_eq!(model["inputHint"], "model name to switch to");
+        assert_eq!(lines[2]["method"], "session/update");
+        assert_eq!(lines[2]["params"]["kind"], "usage_update");
+        assert_eq!(lines[2]["params"]["sessionUpdate"], "usage_update");
+        assert_eq!(lines[2]["params"]["session_id"], session_id);
+        assert!(lines[2]["params"]["size"].as_u64().unwrap() > 0);
+        assert!(lines[2]["params"]["used"].as_u64().is_some());
     }
 
     #[tokio::test]
@@ -333,7 +339,7 @@ mod tests {
             .map(|line| serde_json::from_str(line).unwrap())
             .collect();
 
-        assert_eq!(lines.len(), 4);
+        assert_eq!(lines.len(), 5);
         assert_eq!(lines[0]["method"], "session/update");
         assert_eq!(lines[0]["params"]["kind"], "user_message_chunk");
         assert_eq!(lines[0]["params"]["sessionUpdate"], "user_message_chunk");
@@ -342,8 +348,13 @@ mod tests {
         assert_eq!(lines[1]["params"]["kind"], "agent_message_chunk");
         assert_eq!(lines[2]["method"], "session/update");
         assert_eq!(lines[2]["params"]["kind"], "available_commands_update");
-        assert_eq!(lines[3]["id"], 1);
-        assert_eq!(lines[3]["result"], serde_json::json!({}));
+        assert_eq!(lines[3]["method"], "session/update");
+        assert_eq!(lines[3]["params"]["kind"], "usage_update");
+        assert_eq!(lines[3]["params"]["sessionUpdate"], "usage_update");
+        assert!(lines[3]["params"]["size"].as_u64().unwrap() > 0);
+        assert!(lines[3]["params"]["used"].as_u64().unwrap() > 0);
+        assert_eq!(lines[4]["id"], 1);
+        assert_eq!(lines[4]["result"], serde_json::json!({}));
     }
 
     #[test]

--- a/crates/hermes-acp/src/tools.rs
+++ b/crates/hermes-acp/src/tools.rs
@@ -15,16 +15,31 @@ const TOOL_KIND_MAP: &[(&str, &str)] = &[
     ("execute_code", "execute"),
     ("patch", "edit"),
     ("write_file", "edit"),
+    ("skills_list", "read"),
     ("web_search", "fetch"),
     ("web_extract", "fetch"),
     ("browser_navigate", "fetch"),
-    ("browser_click", "fetch"),
+    ("browser_click", "execute"),
+    ("browser_type", "execute"),
+    ("browser_snapshot", "read"),
+    ("browser_vision", "read"),
+    ("browser_scroll", "execute"),
+    ("browser_press", "execute"),
+    ("browser_back", "execute"),
+    ("browser_console", "read"),
+    ("browser_get_images", "read"),
     ("skill_view", "read"),
     ("skill_manage", "edit"),
     ("todo", "other"),
     ("memory", "other"),
     ("session_search", "read"),
-    ("delegate_task", "other"),
+    ("delegate_task", "execute"),
+    ("vision_analyze", "read"),
+    ("image_generate", "execute"),
+    ("text_to_speech", "execute"),
+    ("cronjob", "other"),
+    ("send_message", "other"),
+    ("clarify", "other"),
 ];
 
 static TOOL_CALL_IDS: AtomicU64 = AtomicU64::new(1);
@@ -74,11 +89,68 @@ pub fn tool_title(tool_name: &str, arguments: Option<&Value>) -> String {
             .unwrap_or_else(|| "web_search".to_string()),
         "web_extract" => value_urls(value, "urls")
             .first()
-            .map(|url| format!("extract: {url}"))
+            .map(|url| {
+                let extra = value_urls(value, "urls").len().saturating_sub(1);
+                if extra > 0 {
+                    format!("extract: {url} (+{extra})")
+                } else {
+                    format!("extract: {url}")
+                }
+            })
             .unwrap_or_else(|| "web_extract".to_string()),
         "browser_navigate" => value_string(value, "url")
             .map(|url| format!("navigate: {url}"))
             .unwrap_or_else(|| "browser_navigate".to_string()),
+        "process" => {
+            let action = value_string(value, "action").unwrap_or_else(|| "manage".to_string());
+            value_string(value, "session_id")
+                .map(|sid| format!("process {action}: {sid}"))
+                .unwrap_or_else(|| format!("process {action}"))
+        }
+        "delegate_task" => {
+            if let Some(tasks) = value.get("tasks").and_then(Value::as_array) {
+                if !tasks.is_empty() {
+                    return format!(
+                        "delegate batch ({} task{})",
+                        tasks.len(),
+                        if tasks.len() == 1 { "" } else { "s" }
+                    );
+                }
+            }
+            value_string(value, "goal")
+                .map(|goal| format!("delegate: {}", truncate_chars(&goal, 60)))
+                .unwrap_or_else(|| "delegate task".to_string())
+        }
+        "session_search" => value_string(value, "query")
+            .map(|query| format!("session search: {query}"))
+            .unwrap_or_else(|| "recent sessions".to_string()),
+        "memory" => {
+            let action = value_string(value, "action").unwrap_or_else(|| "manage".to_string());
+            let target = value_string(value, "target").unwrap_or_else(|| "memory".to_string());
+            format!("memory {action}: {target}")
+        }
+        "skills_list" => value_string(value, "category")
+            .map(|category| format!("skills list ({category})"))
+            .unwrap_or_else(|| "skills list".to_string()),
+        "browser_snapshot" => "browser snapshot".to_string(),
+        "browser_vision" => value_string(value, "question")
+            .map(|question| format!("browser vision: {}", truncate_chars(&question, 50)))
+            .unwrap_or_else(|| "browser vision".to_string()),
+        "browser_get_images" => "browser images".to_string(),
+        "vision_analyze" => value_string(value, "question")
+            .map(|question| format!("analyze image: {}", truncate_chars(&question, 50)))
+            .unwrap_or_else(|| "analyze image".to_string()),
+        "image_generate" => value_string(value, "prompt")
+            .or_else(|| value_string(value, "description"))
+            .map(|prompt| format!("generate image: {}", truncate_chars(&prompt, 50)))
+            .unwrap_or_else(|| "generate image".to_string()),
+        "cronjob" => {
+            let action = value_string(value, "action").unwrap_or_else(|| "manage".to_string());
+            value_string(value, "job_id")
+                .or_else(|| value_string(value, "id"))
+                .map(|job_id| format!("cron {action}: {job_id}"))
+                .unwrap_or_else(|| format!("cron {action}"))
+        }
         "skill_view" => {
             let name = value_string(value, "name").unwrap_or_else(|| "unknown".to_string());
             match value_string(value, "file_path") {
@@ -122,6 +194,10 @@ pub fn tool_completion_status(tool_name: &str, result: Option<&str>) -> &'static
 }
 
 pub fn format_tool_result(tool_name: &str, result: Option<&str>) -> Option<String> {
+    if tool_name == "web_extract" {
+        return format_web_extract_result(result);
+    }
+
     let formatted = match tool_name {
         "todo" => format_todo_result(result),
         "read_file" => format_read_file_result(result),
@@ -129,12 +205,16 @@ pub fn format_tool_result(tool_name: &str, result: Option<&str>) -> Option<Strin
         "execute_code" => format_execute_code_result(result),
         "skill_view" => format_skill_view_result(result),
         "skill_manage" | "write_file" | "patch" => format_edit_result(tool_name, result),
+        "web_search" => format_web_search_result(result),
+        "process" => format_process_result(result),
+        "delegate_task" => format_delegate_result(result),
+        "session_search" => format_session_search_result(result),
+        "memory" => format_memory_result(result),
         "browser_navigate" | "browser_snapshot" | "browser_vision" | "browser_get_images" => {
             format_browser_result(tool_name, result)
         }
-        "memory" | "process" | "delegate_task" | "session_search" | "web_search"
-        | "web_extract" | "vision_analyze" | "image_generate" | "cronjob" => {
-            format_generic_structured_result(tool_name, result, true)
+        "vision_analyze" | "image_generate" | "text_to_speech" | "cronjob" => {
+            format_media_or_cron_result(tool_name, result)
         }
         _ => format_generic_structured_result(tool_name, result, false),
     };
@@ -624,6 +704,485 @@ fn format_browser_result(tool_name: &str, result: Option<&str>) -> Option<String
     Some(truncate_text(&lines.join("\n"), 7000))
 }
 
+fn format_web_search_result(result: Option<&str>) -> Option<String> {
+    let data = json_loads_maybe(result)?;
+    let obj = data.as_object()?;
+    let web = obj
+        .get("data")
+        .and_then(|data| data.get("web"))
+        .or_else(|| obj.get("web"))?
+        .as_array()?;
+    let mut lines = vec![format!("Web results: {}", web.len())];
+    for item in web.iter().take(10).filter_map(Value::as_object) {
+        let title = item
+            .get("title")
+            .or_else(|| item.get("url"))
+            .and_then(value_summary)
+            .unwrap_or_else(|| "result".to_string());
+        let url = item
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|url| !url.is_empty());
+        lines.push(match url {
+            Some(url) if url != title => format!("- {title} - {url}"),
+            _ => format!("- {title}"),
+        });
+        if let Some(desc) = item
+            .get("description")
+            .or_else(|| item.get("snippet"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|desc| !desc.is_empty())
+        {
+            lines.push(format!("  {}", truncate_text(desc, 500)));
+        }
+    }
+    Some(truncate_text(&lines.join("\n"), 5000))
+}
+
+fn format_web_extract_result(result: Option<&str>) -> Option<String> {
+    let data = json_loads_maybe(result)?;
+    let obj = data.as_object()?;
+    if obj.get("success").and_then(Value::as_bool) == Some(false) {
+        return Some(format!(
+            "Web extract failed: {}",
+            obj.get("error")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+
+    let results = obj.get("results")?.as_array()?;
+    let mut failures = Vec::new();
+    for item in results.iter().take(10).filter_map(Value::as_object) {
+        let Some(error) = item
+            .get("error")
+            .and_then(value_summary)
+            .map(|error| error.trim().to_string())
+            .filter(|error| !error.is_empty() && error != "None" && error != "null")
+        else {
+            continue;
+        };
+        let url = item
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|url| !url.is_empty());
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+            .or(url)
+            .unwrap_or("Untitled");
+        failures.push(match url {
+            Some(url) if url != title => {
+                format!("- {title} - {url}\n  Error: {}", truncate_text(&error, 500))
+            }
+            _ => format!("- {title}\n  Error: {}", truncate_text(&error, 500)),
+        });
+    }
+
+    if failures.is_empty() {
+        return None;
+    }
+    let mut lines = vec![format!(
+        "Web extract failed for {} URL{}",
+        failures.len(),
+        if failures.len() == 1 { "" } else { "s" }
+    )];
+    lines.extend(failures);
+    Some(lines.join("\n"))
+}
+
+fn format_process_result(result: Option<&str>) -> Option<String> {
+    let Some(data) = json_loads_maybe(result) else {
+        return result
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(|text| truncate_text(text, 5000));
+    };
+    let obj = data.as_object()?;
+    if obj.get("success").and_then(Value::as_bool) == Some(false) || obj.contains_key("error") {
+        return Some(format!(
+            "Process error: {}",
+            obj.get("error")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+
+    if let Some(processes) = obj.get("processes").and_then(Value::as_array) {
+        let mut lines = vec![format!("Processes: {}", processes.len())];
+        for proc in processes.iter().take(20) {
+            let Some(proc_obj) = proc.as_object() else {
+                if let Some(summary) = value_summary(proc) {
+                    lines.push(format!("- {summary}"));
+                }
+                continue;
+            };
+            let sid = proc_obj
+                .get("session_id")
+                .or_else(|| proc_obj.get("id"))
+                .and_then(value_summary)
+                .unwrap_or_else(|| "?".to_string());
+            let status = proc_obj
+                .get("status")
+                .and_then(value_summary)
+                .or_else(|| {
+                    proc_obj
+                        .get("exited")
+                        .and_then(Value::as_bool)
+                        .map(|exited| if exited { "exited" } else { "running" }.to_string())
+                })
+                .unwrap_or_else(|| "running".to_string());
+            let mut bits = vec![status];
+            if let Some(pid) = proc_obj.get("pid").and_then(value_summary) {
+                bits.push(format!("pid {pid}"));
+            }
+            if let Some(code) = proc_obj
+                .get("exit_code")
+                .or_else(|| proc_obj.get("returncode"))
+                .and_then(value_summary)
+            {
+                bits.push(format!("exit {code}"));
+            }
+            let command = proc_obj
+                .get("command")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|cmd| !cmd.is_empty())
+                .map(|cmd| truncate_text(cmd, 120));
+            let suffix = command.map(|cmd| format!(" - {cmd}")).unwrap_or_default();
+            lines.push(format!("- `{sid}` - {}{suffix}", bits.join(", ")));
+        }
+        if processes.len() > 20 {
+            lines.push(format!("... {} more process(es)", processes.len() - 20));
+        }
+        return Some(lines.join("\n"));
+    }
+
+    let action = obj
+        .get("action")
+        .and_then(value_summary)
+        .unwrap_or_else(|| "process".to_string());
+    let status = obj
+        .get("status")
+        .or_else(|| obj.get("state"))
+        .and_then(value_summary)
+        .unwrap_or_else(|| action.clone());
+    let sid = obj
+        .get("session_id")
+        .and_then(value_summary)
+        .filter(|sid| !sid.trim().is_empty());
+    let mut lines = vec![match sid {
+        Some(sid) => format!("Process {action}: {status} (`{sid}`)"),
+        None => format!("Process {action}: {status}"),
+    }];
+    for (key, label) in [
+        ("command", "Command"),
+        ("pid", "PID"),
+        ("exit_code", "Exit code"),
+        ("returncode", "Exit code"),
+        ("lines", "Lines"),
+    ] {
+        if let Some(value) = obj.get(key).and_then(value_summary) {
+            lines.push(format!("- **{label}:** {value}"));
+        }
+    }
+    if let Some(output) = obj
+        .get("output")
+        .or_else(|| obj.get("new_output"))
+        .or_else(|| obj.get("log"))
+        .or_else(|| obj.get("stdout"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        lines.extend([
+            "".to_string(),
+            "Output:".to_string(),
+            truncate_text(output, 5000),
+        ]);
+    }
+    if let Some(error) = obj
+        .get("stderr")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        lines.extend([
+            "".to_string(),
+            "Error:".to_string(),
+            truncate_text(error, 2000),
+        ]);
+    }
+    if let Some(message) = obj
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        lines.push(message.to_string());
+    }
+    Some(truncate_text(&lines.join("\n"), 7000))
+}
+
+fn format_delegate_result(result: Option<&str>) -> Option<String> {
+    let data = json_loads_maybe(result)?;
+    let obj = data.as_object()?;
+    if obj.get("error").is_some() && !obj.get("results").is_some_and(Value::is_array) {
+        return Some(format!(
+            "Delegation failed: {}",
+            obj.get("error")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+    let results = obj.get("results")?.as_array()?;
+    let total = obj.get("total_duration_seconds").and_then(value_summary);
+    let mut lines = vec![match total {
+        Some(total) => format!(
+            "Delegation results: {} task{} in {total}s",
+            results.len(),
+            if results.len() == 1 { "" } else { "s" }
+        ),
+        None => format!(
+            "Delegation results: {} task{}",
+            results.len(),
+            if results.len() == 1 { "" } else { "s" }
+        ),
+    }];
+    for item in results {
+        let Some(item) = item.as_object() else {
+            if let Some(summary) = value_summary(item) {
+                lines.push(format!("- {summary}"));
+            }
+            continue;
+        };
+        let idx = item
+            .get("task_index")
+            .and_then(Value::as_i64)
+            .map(|idx| idx + 1)
+            .map(|idx| idx.to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let status = item
+            .get("status")
+            .and_then(value_summary)
+            .unwrap_or_else(|| "unknown".to_string());
+        let mut header = format!("Task {idx}: {status}");
+        let mut bits = Vec::new();
+        if let Some(model) = item.get("model").and_then(value_summary) {
+            bits.push(model);
+        }
+        if let Some(role) = item.get("_child_role").and_then(value_summary) {
+            bits.push(format!("role={role}"));
+        }
+        if let Some(duration) = item.get("duration_seconds").and_then(value_summary) {
+            bits.push(format!("{duration}s"));
+        }
+        if !bits.is_empty() {
+            header.push_str(&format!(" ({})", bits.join(", ")));
+        }
+        lines.extend(["".to_string(), header]);
+        if let Some(summary) = item
+            .get("summary")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+        {
+            lines.push(truncate_text(summary, 1200));
+        }
+        if let Some(error) = item
+            .get("error")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+        {
+            lines.push(format!("Error: {}", truncate_text(error, 800)));
+        }
+        if let Some(trace) = item.get("tool_trace").and_then(Value::as_array) {
+            let names: Vec<String> = trace
+                .iter()
+                .filter_map(Value::as_object)
+                .filter_map(|tool| tool.get("tool").and_then(value_summary))
+                .collect();
+            if !names.is_empty() {
+                let mut line = format!(
+                    "Tools: {}",
+                    names
+                        .iter()
+                        .take(12)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                if names.len() > 12 {
+                    line.push_str(&format!(" (+{})", names.len() - 12));
+                }
+                lines.push(line);
+            }
+        }
+    }
+    Some(truncate_text(&lines.join("\n"), 8000))
+}
+
+fn format_session_search_result(result: Option<&str>) -> Option<String> {
+    let data = json_loads_maybe(result)?;
+    let obj = data.as_object()?;
+    if obj.get("success").and_then(Value::as_bool) == Some(false) {
+        return Some(format!(
+            "Session search failed: {}",
+            obj.get("error")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+    let results = obj.get("results")?.as_array()?;
+    let mode = obj.get("mode").and_then(Value::as_str).unwrap_or("search");
+    let query = obj
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|query| !query.is_empty());
+    let mut lines = vec![if mode == "recent" {
+        "Recent sessions".to_string()
+    } else if let Some(query) = query {
+        format!("Session search results for `{query}`")
+    } else {
+        "Session search results".to_string()
+    }];
+    if results.is_empty() {
+        lines.push(
+            obj.get("message")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "No matching sessions found.".to_string()),
+        );
+        return Some(lines.join("\n"));
+    }
+    for item in results.iter().filter_map(Value::as_object) {
+        let sid = item
+            .get("session_id")
+            .and_then(value_summary)
+            .unwrap_or_else(|| "?".to_string());
+        let title = item
+            .get("title")
+            .or_else(|| item.get("when"))
+            .and_then(value_summary)
+            .unwrap_or_else(|| "Untitled session".to_string());
+        let mut meta = Vec::new();
+        for key in ["last_active", "started_at", "when", "source"] {
+            if let Some(value) = item.get(key).and_then(value_summary) {
+                meta.push(value);
+            }
+        }
+        if let Some(count) = item.get("message_count").and_then(value_summary) {
+            meta.push(format!("{count} msgs"));
+        }
+        let suffix = if meta.is_empty() {
+            String::new()
+        } else {
+            format!(" - {}", meta.join(", "))
+        };
+        lines.push(format!("- **{title}** (`{sid}`){suffix}"));
+        if let Some(summary) = item
+            .get("summary")
+            .or_else(|| item.get("preview"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+        {
+            lines.push(format!(
+                "  {}",
+                truncate_text(
+                    &summary.split_whitespace().collect::<Vec<_>>().join(" "),
+                    500
+                )
+            ));
+        }
+    }
+    Some(truncate_text(&lines.join("\n"), 7000))
+}
+
+fn format_memory_result(result: Option<&str>) -> Option<String> {
+    let data = json_loads_maybe(result)?;
+    let obj = data.as_object()?;
+    let action = obj
+        .get("action")
+        .and_then(value_summary)
+        .unwrap_or_else(|| "memory".to_string());
+    let target = obj
+        .get("target")
+        .and_then(value_summary)
+        .unwrap_or_else(|| "memory".to_string());
+    if obj.get("success").and_then(Value::as_bool) == Some(false) {
+        let mut lines = vec![
+            format!("Memory {action} failed ({target})"),
+            obj.get("error")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "unknown error".to_string()),
+        ];
+        if let Some(matches) = obj.get("matches").and_then(Value::as_array) {
+            lines.push("Matches:".to_string());
+            lines.extend(
+                matches
+                    .iter()
+                    .take(5)
+                    .filter_map(value_summary)
+                    .map(|summary| format!("- {}", truncate_text(&summary, 160))),
+            );
+        }
+        return Some(lines.join("\n"));
+    }
+    let mut lines = vec![format!("Memory {action} saved ({target})")];
+    if let Some(message) = obj.get("message").and_then(value_summary) {
+        lines.push(message);
+    }
+    if let Some(entry_count) = obj.get("entry_count").and_then(value_summary) {
+        lines.push(format!("Entries: {entry_count}"));
+    }
+    if let Some(usage) = obj.get("usage").and_then(value_summary) {
+        lines.push(format!("Usage: {usage}"));
+    }
+    Some(lines.join("\n"))
+}
+
+fn format_media_or_cron_result(tool_name: &str, result: Option<&str>) -> Option<String> {
+    let Some(data) = json_loads_maybe(result) else {
+        return result
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(|text| truncate_text(text, 5000));
+    };
+    let obj = data.as_object()?;
+    if obj.get("success").and_then(Value::as_bool) == Some(false) || obj.contains_key("error") {
+        return Some(format!(
+            "{tool_name} failed: {}",
+            obj.get("error")
+                .and_then(value_summary)
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+    let mut lines = vec![format!("{tool_name} completed")];
+    for key in [
+        "file_path",
+        "path",
+        "url",
+        "image_url",
+        "job_id",
+        "id",
+        "status",
+        "message",
+        "next_run",
+    ] {
+        if let Some(value) = obj.get(key).and_then(value_summary) {
+            lines.push(format!("- **{key}:** {value}"));
+        }
+    }
+    Some(lines.join("\n"))
+}
+
 fn format_structured_value(
     key: &str,
     value: &Value,
@@ -931,10 +1490,15 @@ mod tests {
             ("write_file", "edit"),
             ("process", "execute"),
             ("web_search", "fetch"),
+            ("web_extract", "fetch"),
+            ("skills_list", "read"),
             ("execute_code", "execute"),
             ("todo", "other"),
             ("skill_view", "read"),
             ("browser_navigate", "fetch"),
+            ("browser_click", "execute"),
+            ("browser_snapshot", "read"),
+            ("delegate_task", "execute"),
             ("unknown_tool", "other"),
         ] {
             assert_eq!(tool_kind(tool), expected);
@@ -969,6 +1533,13 @@ mod tests {
             "search: rust acp"
         );
         assert_eq!(
+            tool_title(
+                "web_extract",
+                Some(&json!({"urls": ["https://a.test", "https://b.test"]}))
+            ),
+            "extract: https://a.test (+1)"
+        );
+        assert_eq!(
             tool_title("browser_navigate", Some(&json!({"url": "https://x.com"}))),
             "navigate: https://x.com"
         );
@@ -999,6 +1570,36 @@ mod tests {
                 Some(&json!({"todos": [{"id": "one", "content": "Fix ACP"}]}))
             ),
             "todo (1 item)"
+        );
+        assert_eq!(
+            tool_title("process", Some(&json!({"action": "list"}))),
+            "process list"
+        );
+        assert_eq!(
+            tool_title(
+                "delegate_task",
+                Some(&json!({"tasks": [{"goal": "one"}, {"goal": "two"}]}))
+            ),
+            "delegate batch (2 tasks)"
+        );
+        assert_eq!(
+            tool_title("session_search", Some(&json!({"query": "ACP"}))),
+            "session search: ACP"
+        );
+        assert_eq!(
+            tool_title("memory", Some(&json!({"action": "add", "target": "user"}))),
+            "memory add: user"
+        );
+        assert_eq!(
+            tool_title("skills_list", Some(&json!({"category": "rust"}))),
+            "skills list (rust)"
+        );
+        assert_eq!(
+            tool_title(
+                "cronjob",
+                Some(&json!({"action": "run", "job_id": "nightly"}))
+            ),
+            "cron run: nightly"
         );
     }
 
@@ -1072,6 +1673,121 @@ mod tests {
         assert!(result.contains("- **status:** done"));
         assert!(result.contains("hidden body"));
         assert!(!result.contains(r#""success""#));
+    }
+
+    #[test]
+    fn format_tool_result_renders_web_search_results() {
+        let result = format_tool_result(
+            "web_search",
+            Some(
+                r#"{"data":{"web":[{"title":"ACP docs","url":"https://example.com/acp","description":"Agent protocol docs."},{"url":"https://example.com/zed"}]}}"#,
+            ),
+        )
+        .expect("formatted");
+        assert!(result.contains("Web results: 2"));
+        assert!(result.contains("ACP docs - https://example.com/acp"));
+        assert!(result.contains("Agent protocol docs."));
+        assert!(!result.contains(r#""data""#));
+    }
+
+    #[test]
+    fn format_tool_result_keeps_successful_web_extract_compact() {
+        let result = format_tool_result(
+            "web_extract",
+            Some(
+                r##"{"results":[{"url":"https://example.com","title":"Example","content":"# Intro\nThis is extracted content."}]}"##,
+            ),
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn format_tool_result_shows_web_extract_failures() {
+        let result = format_tool_result(
+            "web_extract",
+            Some(
+                r#"{"results":[{"url":"https://example.com","title":"Example","error":"timeout"}]}"#,
+            ),
+        )
+        .expect("formatted");
+        assert!(result.contains("Web extract failed for 1 URL"));
+        assert!(result.contains("Example - https://example.com"));
+        assert!(result.contains("timeout"));
+        assert!(!result.contains(r#""results""#));
+    }
+
+    #[test]
+    fn format_tool_result_renders_process_list() {
+        let result = format_tool_result(
+            "process",
+            Some(
+                r#"{"processes":[{"session_id":"p1","status":"running","pid":123,"command":"npm run dev"}]}"#,
+            ),
+        )
+        .expect("formatted");
+        assert!(result.contains("Processes: 1"));
+        assert!(result.contains("`p1`"));
+        assert!(result.contains("pid 123"));
+        assert!(result.contains("npm run dev"));
+        assert!(!result.contains(r#""processes""#));
+    }
+
+    #[test]
+    fn format_tool_result_summarizes_delegate_children() {
+        let result = format_tool_result(
+            "delegate_task",
+            Some(
+                r#"{"results":[{"task_index":0,"status":"completed","summary":"Reviewed ACP rendering.","model":"gpt-5.5","duration_seconds":3.2,"tool_trace":[{"tool":"read_file"}]}],"total_duration_seconds":3.4}"#,
+            ),
+        )
+        .expect("formatted");
+        assert!(result.contains("Delegation results: 1 task in 3.4s"));
+        assert!(result.contains("Task 1: completed"));
+        assert!(result.contains("Reviewed ACP rendering."));
+        assert!(result.contains("gpt-5.5"));
+        assert!(result.contains("Tools: read_file"));
+    }
+
+    #[test]
+    fn format_tool_result_renders_session_search_recent() {
+        let result = format_tool_result(
+            "session_search",
+            Some(
+                r#"{"success":true,"mode":"recent","results":[{"session_id":"s1","title":"ACP work","last_active":"2026-05-02","message_count":12,"preview":"Polished tool rendering."}],"count":1}"#,
+            ),
+        )
+        .expect("formatted");
+        assert!(result.contains("Recent sessions"));
+        assert!(result.contains("ACP work"));
+        assert!(result.contains("s1"));
+        assert!(result.contains("Polished tool rendering."));
+    }
+
+    #[test]
+    fn format_tool_result_memory_avoids_dumping_entries() {
+        let result = format_tool_result(
+            "memory",
+            Some(
+                r#"{"success":true,"action":"add","target":"user","entries":["private long memory"],"usage":"19/2000 chars","entry_count":1,"message":"Entry added."}"#,
+            ),
+        )
+        .expect("formatted");
+        assert!(result.contains("Memory add saved (user)"));
+        assert!(result.contains("Entry added."));
+        assert!(result.contains("Entries: 1"));
+        assert!(!result.contains("private long memory"));
+    }
+
+    #[test]
+    fn format_tool_result_renders_media_and_cron_keys() {
+        let result = format_tool_result(
+            "cronjob",
+            Some(r#"{"success":true,"job_id":"nightly","status":"scheduled","next_run":"2026-06-07T00:00:00Z"}"#),
+        )
+        .expect("formatted");
+        assert!(result.contains("cronjob completed"));
+        assert!(result.contains("- **job_id:** nightly"));
+        assert!(result.contains("- **next_run:** 2026-06-07T00:00:00Z"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -907,6 +907,34 @@
     "e26f9b207041c03d1aa9a982d29dbfda66df3a82": {
       "disposition": "ported",
       "notes": "Rust ACP routes provider reasoning callbacks to agent_thought_chunk updates, routes stream deltas to message_delta updates, and suppresses fallback final-response emission when executor streaming already delivered message content."
+    },
+    "72c8037a24b58b7b1a38a99903cc0bf8a3d7595c": {
+      "disposition": "ported",
+      "notes": "Rust ACP now has dedicated compact completion renderers for web_search, process, delegate_task, session_search, memory, media/cron, plus expanded tool kind/title mappings; tests assert raw JSON/private entry dumps are avoided."
+    },
+    "b294d1d0229ff6026838a04c4cb59c3b13e4827f": {
+      "disposition": "superseded",
+      "notes": "Rust ACP start events already carry compact title/kind/arguments only and do not synthesize read_file output content; existing title tests cover read_file start compactness."
+    },
+    "19854c7cd2f00e3d591e72ccbe2e456ad10c4886": {
+      "disposition": "superseded",
+      "notes": "Rust ACP already fences read_file completion content and intentionally flushes load/resume replay before the RPC response for deterministic local clients; server tests cover replay flushing and read_file formatting."
+    },
+    "9987f3d82486b04151dee2d27d640b3ae01b7b16": {
+      "disposition": "ported",
+      "notes": "Rust ACP now keeps successful web_extract completions silent while rendering compact per-URL failures; read_file fenced completion and compact replay rendering are covered by hermes-acp tools tests."
+    },
+    "6622277f11ca1dee03e868b064fb1851e5598b77": {
+      "disposition": "ported",
+      "notes": "Rust ACP browser_navigate starts already expose polished navigate titles without raw content, and this slice adds regression coverage plus corrected tool kind mappings for polished browser and delegate tools."
+    },
+    "eb612f55748d8f0888f09f055abd86afef925150": {
+      "disposition": "ported",
+      "notes": "Rust ACP web_extract rendering now matches the compact contract: success omits extracted content, structured failures show URL/title/error summaries, and tests prevent raw result dumps."
+    },
+    "ef9a08a872d1ed87eb4c91cf8ad8e8f4ef5a6e2b": {
+      "disposition": "ported",
+      "notes": "Rust ACP now emits native usage_update events with size/used on session lifecycle, model switch, slash-command, and prompt completion paths, enriches /context with usage and compaction threshold text, and ports polished common tool rendering/kind/title behavior with hermes-acp tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add native ACP `usage_update` events with `size`/`used` context pressure on session lifecycle, model switch, slash-command, and prompt completion paths
- enrich ACP `/context` output with Rust-native token usage and compaction threshold information
- port compact ACP tool completion renderers for web/search/extract, process, delegate, session search, memory, media/cron, and expanded tool kind/title mappings
- classify the covered upstream ACP rendering/context commits in the parity queue overrides

## Verification
- `cargo fmt --all --check`
- `cargo test -p hermes-acp -- --nocapture` -> 93 passed
- `git diff --check`
- `python3 -m json.tool docs/parity/queue-overrides.json >/tmp/queue-overrides-check.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-render CARGO_INCREMENTAL=0 cargo build -p hermes-acp -p hermes-cli`
- `CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-acp-render CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp -p hermes-cli` -> new=0, stale=5
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /tmp/acp-render-queue.json --out-md /tmp/acp-render-queue.md`

## Queue Delta
- marked ported: `ef9a08a872d1`, `72c8037a24b5`, `9987f3d82486`, `6622277f11ca`, `eb612f55748d`
- marked superseded: `b294d1d0229f`, `19854c7cd2f0`
