### PR TITLE
parity(runtime): add shared version slash surface

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -1152,7 +1152,7 @@ impl HermesAcpHandler {
                     None
                 }
             }
-            "version" => Some(format!("Hermes Agent v{}", self.version)),
+            "version" => Some(hermes_core::version::version_label()),
             "tools" => {
                 let tools = self.available_tools();
                 if tools.is_empty() {
@@ -2414,6 +2414,7 @@ mod tests {
             .as_ref()
             .expect("available commands");
         assert!(commands.iter().any(|command| command.name == "help"));
+        assert!(commands.iter().any(|command| command.name == "version"));
         let model = commands
             .iter()
             .find(|command| command.name == "model")
@@ -2743,6 +2744,18 @@ mod tests {
         assert!(response.contains("/ 128,000 tokens"));
         assert!(response.contains("Compression: ~"));
         assert!(response.contains("tokens until threshold (~102,400, 80%)."));
+    }
+
+    #[tokio::test]
+    async fn test_version_slash_command_uses_shared_version_label() {
+        let handler = make_handler();
+        let state = handler.session_manager.create_session("/workspace");
+
+        let response = handler
+            .handle_slash_command("/version", &state.session_id)
+            .expect("version response");
+
+        assert_eq!(response, hermes_core::version::version_label());
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -162,6 +162,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ),
     ("/profile", "Show active profile and Hermes home path"),
     ("/whoami", "Alias for /profile"),
+    ("/version", "Show Hermes Agent Ultra version and build label"),
     ("/fast", "Toggle fast-mode hints"),
     ("/skin", "Show available skin/theme options"),
     ("/skins", "Alias for /skin"),
@@ -3627,6 +3628,10 @@ async fn dispatch_slash_command(
         "/provider" => handle_provider_command(app).await,
         "/personality" => handle_personality_command(app, args),
         "/profile" | "/whoami" => handle_profile_command(app),
+        "/version" => {
+            emit_command_output(app, hermes_core::version::version_label());
+            Ok(CommandResult::Handled)
+        }
         "/fast" | "/skin" | "/voice" => {
             handle_runtime_ui_mode_command(app, canonical_command(cmd), args)
         }
@@ -20207,6 +20212,7 @@ const COMMAND_CATALOG_SECTIONS: &[CommandCatalogSection] = &[
             "/qos",
             "/boot",
             "/walkthrough",
+            "/version",
         ],
     },
     CommandCatalogSection {
@@ -27146,7 +27152,7 @@ pub async fn handle_cli_import(path: String) -> Result<(), hermes_core::AgentErr
 
 /// Handle `hermes version`.
 pub fn handle_cli_version() -> Result<(), hermes_core::AgentError> {
-    println!("hermes {}", env!("CARGO_PKG_VERSION"));
+    println!("{}", hermes_core::version::version_label());
     Ok(())
 }
 
@@ -27362,6 +27368,24 @@ mod tests {
         let results = autocomplete_contextual("/objective behavior ");
         assert!(results.contains(&"/objective behavior strict ".to_string()));
         assert!(results.contains(&"/objective behavior sigma ".to_string()));
+    }
+
+    #[tokio::test]
+    async fn version_slash_command_renders_shared_version_label() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        let result = handle_slash_command(&mut app, "/version", &[])
+            .await
+            .expect("version command");
+
+        assert_eq!(result, CommandResult::Handled);
+        assert_eq!(
+            latest_ui_assistant_text(&app),
+            hermes_core::version::version_label()
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-core/build.rs
+++ b/crates/hermes-core/build.rs
@@ -1,0 +1,71 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=HERMES_BUILD_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let repo_root = manifest_dir.join("../..");
+    emit_git_rerun_triggers(&repo_root);
+
+    if let Ok(build_sha) = std::env::var("HERMES_BUILD_GIT_SHA") {
+        let trimmed = build_sha.trim();
+        if !trimmed.is_empty() {
+            println!(
+                "cargo:rustc-env=HERMES_BUILD_GIT_SHA={}",
+                short_sha(trimmed)
+            );
+        }
+        return;
+    }
+
+    if let Ok(github_sha) = std::env::var("GITHUB_SHA") {
+        let trimmed = github_sha.trim();
+        if !trimmed.is_empty() {
+            println!(
+                "cargo:rustc-env=HERMES_BUILD_GIT_SHA={}",
+                short_sha(trimmed)
+            );
+            return;
+        }
+    }
+
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .current_dir(repo_root)
+        .output();
+
+    if let Ok(output) = output {
+        if output.status.success() {
+            let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !sha.is_empty() {
+                println!("cargo:rustc-env=HERMES_BUILD_GIT_SHA={sha}");
+            }
+        }
+    }
+}
+
+fn short_sha(raw: &str) -> String {
+    raw.chars().take(12).collect()
+}
+
+fn emit_git_rerun_triggers(repo_root: &std::path::Path) {
+    let git_dir = repo_root.join(".git");
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("packed-refs").display()
+    );
+
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).unwrap_or_default();
+    let Some(ref_path) = head.trim().strip_prefix("ref: ") else {
+        return;
+    };
+    if !ref_path.contains("..") {
+        println!(
+            "cargo:rerun-if-changed={}",
+            git_dir.join(ref_path).display()
+        );
+    }
+}

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod tool_call_parser;
 pub mod tool_schema;
 pub mod traits;
 pub mod types;
+pub mod version;
 
 #[cfg(test)]
 pub mod test_generators;

--- a/crates/hermes-core/src/version.rs
+++ b/crates/hermes-core/src/version.rs
@@ -1,0 +1,47 @@
+//! Shared runtime version labeling.
+
+/// Workspace package version embedded at compile time.
+pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Optional git SHA captured by the build script or release environment.
+pub const BUILD_GIT_SHA: Option<&str> = option_env!("HERMES_BUILD_GIT_SHA");
+
+/// Return the optional build git SHA after trimming empty values.
+pub fn build_git_sha() -> Option<&'static str> {
+    BUILD_GIT_SHA.and_then(|sha| {
+        let trimmed = sha.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
+}
+
+/// Human-readable version line for chat and CLI slash surfaces.
+pub fn version_label() -> String {
+    match build_git_sha() {
+        Some(sha) => format!("Hermes Agent Ultra v{PACKAGE_VERSION} ({sha})"),
+        None => format!("Hermes Agent Ultra v{PACKAGE_VERSION}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_label_contains_product_and_version() {
+        let label = version_label();
+        assert!(label.starts_with("Hermes Agent Ultra v"));
+        assert!(label.contains(PACKAGE_VERSION));
+    }
+
+    #[test]
+    fn build_git_sha_is_empty_or_trimmed() {
+        if let Some(sha) = build_git_sha() {
+            assert_eq!(sha, sha.trim());
+            assert!(!sha.is_empty());
+        }
+    }
+}

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -80,6 +80,8 @@ pub enum GatewayCommandResult {
     Rollback { steps: usize },
     /// Check for updates.
     CheckUpdate,
+    /// Show runtime version.
+    ShowVersion(String),
     /// Unknown command.
     Unknown(String),
     /// No-op (command handled internally).
@@ -216,6 +218,12 @@ pub fn all_commands() -> Vec<CommandInfo> {
             aliases: &[],
             description: "Show current status",
             usage: "/status",
+        },
+        CommandInfo {
+            name: "/version",
+            aliases: &[],
+            description: "Show Hermes Agent Ultra version and build label",
+            usage: "/version",
         },
         CommandInfo {
             name: "/agents",
@@ -533,6 +541,7 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         "/status" => {
             GatewayCommandResult::ShowStatus("Status information will be shown.".to_string())
         }
+        "/version" => GatewayCommandResult::ShowVersion(hermes_core::version::version_label()),
         "/agents" | "/tasks" => GatewayCommandResult::Reply(
             "🧵 Active task state is shown by /background list in this Rust gateway.".to_string(),
         ),
@@ -727,9 +736,21 @@ mod tests {
             GatewayCommandResult::ShowHelp(text) => {
                 assert!(text.contains("Available Commands"));
                 assert!(text.contains("`/start`"));
+                assert!(text.contains("`/version`"));
             }
             other => panic!("Expected ShowHelp for /commands, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_version_command_returns_shared_version_label() {
+        match handle_command("/version") {
+            GatewayCommandResult::ShowVersion(text) => {
+                assert_eq!(text, hermes_core::version::version_label());
+            }
+            other => panic!("Expected ShowVersion, got {:?}", other),
+        }
+        assert!(should_bypass_active_session(Some("/version")));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -1080,6 +1080,7 @@ impl Gateway {
                     | GatewayCommandResult::ToggleReasoning(text)
                     | GatewayCommandResult::ShowUsage(text)
                     | GatewayCommandResult::ShowStatus(text)
+                    | GatewayCommandResult::ShowVersion(text)
                     | GatewayCommandResult::CompressContext(text)
                     | GatewayCommandResult::StopAgent(text) => Some(text),
                     GatewayCommandResult::SwitchModel { reply, .. }
@@ -1432,6 +1433,11 @@ impl Gateway {
             }
             GatewayCommandResult::ShowStatus(_) => {
                 let text = self.build_status_text(session_key).await;
+                self.send_message(&incoming.platform, &incoming.chat_id, &text, None)
+                    .await?;
+                Ok(true)
+            }
+            GatewayCommandResult::ShowVersion(text) => {
                 self.send_message(&incoming.platform, &incoming.chat_id, &text, None)
                     .await?;
                 Ok(true)

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -935,6 +935,14 @@
     "ef9a08a872d1ed87eb4c91cf8ad8e8f4ef5a6e2b": {
       "disposition": "ported",
       "notes": "Rust ACP now emits native usage_update events with size/used on session lifecycle, model switch, slash-command, and prompt completion paths, enriches /context with usage and compaction threshold text, and ports polished common tool rendering/kind/title behavior with hermes-acp tests."
+    },
+    "9c1bb8d2c729": {
+      "disposition": "ported",
+      "notes": "Rust now exposes /version through CLI/TUI slash dispatch, gateway slash dispatch, and ACP slash handling via a shared hermes-core version_label helper with targeted Rust tests."
+    },
+    "30340eae2f6e": {
+      "disposition": "ported",
+      "notes": "Rust shared version_label includes the workspace package version and optional build git SHA captured by hermes-core build.rs, so CLI/gateway/ACP version surfaces share the same label helper."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add shared Rust version label helper in hermes-core with optional build git SHA capture
- wire /version into CLI/TUI slash dispatch, gateway slash dispatch/application, and ACP slash handling
- mark upstream /version and shared version-label commits as ported in the parity queue overrides

## Verification
- cargo fmt --all --check
- git diff --check
- python3 -m json.tool docs/parity/queue-overrides.json >/tmp/version-queue-overrides-check.json
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 cargo test -p hermes-core version -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 cargo test -p hermes-gateway version_command -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 cargo test -p hermes-acp version_slash_command -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 cargo test -p hermes-cli version_slash_command_renders_shared_version_label -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 cargo build -p hermes-core -p hermes-acp -p hermes-gateway -p hermes-cli
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-acp -p hermes-gateway -p hermes-cli
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-core
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /private/tmp/hermes-version-queue.json --out-md /private/tmp/hermes-version-queue.md
- CARGO_TARGET_DIR=/private/tmp/hermes-agent-ultra-target-version-seq CARGO_INCREMENTAL=0 cargo run -p hermes-cli --bin hermes-ultra -- version

Queue proof: pending=1944, ported=102, superseded=7634, mirrored=161.
Smoke output: Hermes Agent Ultra v0.16.0 (da282eba8ced).
Clippy gate: new=0, stale=5 existing allowlist entries.