### PR TITLE
parity(delegation): uncap Rust spawn depth

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -439,6 +439,10 @@ pub struct AgentConfig {
     #[serde(default = "default_max_concurrent_delegates")]
     pub max_concurrent_delegates: u32,
 
+    /// Maximum sub-agent spawn depth. Values below 1 are normalized to 1.
+    #[serde(default = "default_max_delegate_depth")]
+    pub max_delegate_depth: u32,
+
     /// Flush memories every N turns.
     #[serde(default = "default_memory_flush_interval")]
     pub memory_flush_interval: u32,
@@ -654,6 +658,26 @@ fn default_max_concurrent_delegates() -> u32 {
     1
 }
 
+fn default_max_delegate_depth() -> u32 {
+    4
+}
+
+fn normalize_delegate_depth(value: u32) -> u32 {
+    value.max(1)
+}
+
+fn parse_delegate_depth(value: &str) -> Option<u32> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match trimmed.parse::<i128>() {
+        Ok(parsed) if parsed < 1 => Some(1),
+        Ok(parsed) => Some(parsed.min(i128::from(u32::MAX)) as u32),
+        Err(_) => None,
+    }
+}
+
 fn delegation_spawning_paused() -> bool {
     std::env::var("HERMES_DELEGATION_PAUSED")
         .ok()
@@ -774,6 +798,7 @@ impl Default for AgentConfig {
             temperature: None,
             max_tokens: None,
             max_concurrent_delegates: default_max_concurrent_delegates(),
+            max_delegate_depth: default_max_delegate_depth(),
             memory_flush_interval: default_memory_flush_interval(),
             session_id: None,
             hermes_home: None,
@@ -7958,9 +7983,8 @@ impl AgentLoop {
     fn resolve_max_delegate_depth(&self) -> u32 {
         std::env::var("HERMES_MAX_DELEGATE_DEPTH")
             .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .filter(|v| *v > 0)
-            .unwrap_or(4)
+            .and_then(|v| parse_delegate_depth(&v))
+            .unwrap_or_else(|| normalize_delegate_depth(self.config.max_delegate_depth))
     }
 
     /// Cap concurrent delegate_task calls based on config.
@@ -9528,6 +9552,7 @@ mod tests {
         assert_eq!(config.model, "gpt-4o");
         assert!(!config.stream);
         assert_eq!(config.max_concurrent_delegates, 1);
+        assert_eq!(config.max_delegate_depth, 4);
         assert_eq!(config.memory_flush_interval, 5);
         assert_eq!(config.api_mode, ApiMode::ChatCompletions);
         assert_eq!(config.retry.max_retries, 3);
@@ -9544,6 +9569,83 @@ mod tests {
         assert!(!config.smart_model_routing.enabled);
         assert!(config.background_review_metrics_enabled);
         assert_eq!(config.stream_read_max_retries, 2);
+    }
+
+    #[test]
+    fn delegate_depth_parser_floors_without_legacy_ceiling() {
+        assert_eq!(parse_delegate_depth("99"), Some(99));
+        assert_eq!(parse_delegate_depth(" 12 "), Some(12));
+        assert_eq!(parse_delegate_depth("1"), Some(1));
+        assert_eq!(parse_delegate_depth("0"), Some(1));
+        assert_eq!(parse_delegate_depth("-7"), Some(1));
+        assert_eq!(parse_delegate_depth(""), None);
+        assert_eq!(parse_delegate_depth("not-a-number"), None);
+    }
+
+    #[test]
+    fn max_delegate_depth_resolves_env_then_config_with_floor() {
+        let _guard = env_test_lock();
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let _env = EnvVarGuard::set("HERMES_MAX_DELEGATE_DEPTH", "99");
+        let config = AgentConfig {
+            max_delegate_depth: 2,
+            ..AgentConfig::default()
+        };
+        let agent = AgentLoop::new(
+            config.clone(),
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+        assert_eq!(agent.resolve_max_delegate_depth(), 99);
+        drop(_env);
+
+        let _env = EnvVarGuard::set("HERMES_MAX_DELEGATE_DEPTH", "0");
+        assert_eq!(agent.resolve_max_delegate_depth(), 1);
+        drop(_env);
+
+        let _env = EnvVarGuard::remove("HERMES_MAX_DELEGATE_DEPTH");
+        let config = AgentConfig {
+            max_delegate_depth: 0,
+            ..AgentConfig::default()
+        };
+        let agent = AgentLoop::new(
+            config,
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+        assert_eq!(agent.resolve_max_delegate_depth(), 1);
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -1939,7 +1939,7 @@ impl App {
         })
     }
 
-    fn apply_explore_first_runtime_defaults() {
+    fn apply_explore_first_runtime_defaults(config: &GatewayConfig) {
         if std::env::var("HERMES_SKILL_GUARD_MODE")
             .ok()
             .map(|v| v.trim().is_empty())
@@ -1989,10 +1989,11 @@ impl App {
         {
             std::env::set_var("HERMES_TOOL_CALL_MAX_CONCURRENCY", "12");
         }
-        if std::env::var("HERMES_MAX_DELEGATE_DEPTH")
-            .ok()
-            .map(|v| v.trim().is_empty())
-            .unwrap_or(true)
+        if config.delegation.max_spawn_depth.is_none()
+            && std::env::var("HERMES_MAX_DELEGATE_DEPTH")
+                .ok()
+                .map(|v| v.trim().is_empty())
+                .unwrap_or(true)
         {
             std::env::set_var("HERMES_MAX_DELEGATE_DEPTH", "4");
         }
@@ -2010,7 +2011,7 @@ impl App {
 
         let mut config = config;
         apply_cli_runtime_overrides(&mut config, &cli);
-        Self::apply_explore_first_runtime_defaults();
+        Self::apply_explore_first_runtime_defaults(&config);
 
         if config.sessions.auto_prune {
             let resolved_home = config
@@ -3766,6 +3767,32 @@ mod tests {
         test_env_lock::lock()
     }
 
+    struct EnvSnapshot {
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                vars: keys
+                    .iter()
+                    .map(|key| (*key, std::env::var(key).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in &self.vars {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
     struct TestToolHandler {
         name: &'static str,
     }
@@ -4506,6 +4533,50 @@ mod tests {
             .get("custom")
             .expect("runtime provider should exist");
         assert_eq!(runtime.api_key_env.as_deref(), Some("MY_FALLBACK_KEY"));
+    }
+
+    #[test]
+    fn test_build_agent_config_maps_delegation_max_spawn_depth_without_legacy_ceiling() {
+        let mut cfg = GatewayConfig::default();
+        cfg.delegation.max_spawn_depth = Some(99);
+        let agent_cfg = build_agent_config(&cfg, "openai:gpt-4o");
+        assert_eq!(agent_cfg.max_delegate_depth, 99);
+
+        cfg.delegation.max_spawn_depth = Some(0);
+        let agent_cfg = build_agent_config(&cfg, "openai:gpt-4o");
+        assert_eq!(agent_cfg.max_delegate_depth, 1);
+    }
+
+    #[test]
+    fn explore_first_defaults_do_not_shadow_configured_delegation_depth() {
+        let _guard = env_test_lock();
+        let keys = [
+            "HERMES_SKILL_GUARD_MODE",
+            "HERMES_GUARD_MODE",
+            "HERMES_TOOL_POLICY_PRESET",
+            "HERMES_TOOL_POLICY_MODE",
+            "HERMES_REPO_REVIEW_BUDGET_PROFILE",
+            "HERMES_MAX_ITERATIONS",
+            "HERMES_TOOL_CALL_MAX_CONCURRENCY",
+            "HERMES_MAX_DELEGATE_DEPTH",
+        ];
+        let _snapshot = EnvSnapshot::capture(&keys);
+        for key in keys {
+            std::env::remove_var(key);
+        }
+
+        let mut cfg = GatewayConfig::default();
+        cfg.delegation.max_spawn_depth = Some(99);
+        App::apply_explore_first_runtime_defaults(&cfg);
+
+        assert!(std::env::var("HERMES_MAX_DELEGATE_DEPTH").is_err());
+
+        cfg.delegation.max_spawn_depth = None;
+        App::apply_explore_first_runtime_defaults(&cfg);
+        assert_eq!(
+            std::env::var("HERMES_MAX_DELEGATE_DEPTH").ok().as_deref(),
+            Some("4")
+        );
     }
 
     #[tokio::test]
@@ -5992,6 +6063,11 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
     let skip_context_files = config.agent.skip_context_files || skip_context_files_env;
 
     let retry_cfg = build_retry_config(config);
+    let max_delegate_depth = config
+        .delegation
+        .max_spawn_depth
+        .map(|depth| depth.max(1))
+        .unwrap_or_else(|| AgentConfig::default().max_delegate_depth);
 
     AgentConfig {
         max_turns: config.max_turns,
@@ -6003,6 +6079,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         hermes_home: config.home_dir.clone(),
         provider: Some(resolved_provider),
         stream: config.streaming.enabled,
+        max_delegate_depth,
         skip_memory,
         skip_context_files,
         platform: Some("cli".to_string()),

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -54,6 +54,10 @@ pub struct GatewayConfig {
     #[serde(default = "default_platform_toolsets")]
     pub platform_toolsets: HashMap<String, Vec<String>>,
 
+    /// Sub-agent delegation controls.
+    #[serde(default)]
+    pub delegation: DelegationConfig,
+
     /// Session management settings.
     #[serde(default)]
     pub session: SessionConfig,
@@ -168,6 +172,7 @@ impl Default for GatewayConfig {
             tool_output: ToolOutputConfig::default(),
             platforms: HashMap::new(),
             platform_toolsets: default_platform_toolsets(),
+            delegation: DelegationConfig::default(),
             session: SessionConfig::default(),
             sessions: SessionsMaintenanceConfig::default(),
             streaming: StreamingConfig::default(),
@@ -193,6 +198,13 @@ impl Default for GatewayConfig {
             home_dir: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DelegationConfig {
+    /// Maximum sub-agent spawn depth. Values below 1 are floored by runtime consumers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_spawn_depth: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1423,6 +1435,7 @@ mod tests {
         assert!(cfg.model.is_none());
         assert_eq!(cfg.tool_output, ToolOutputConfig::default());
         assert!(cfg.auxiliary.is_empty());
+        assert!(cfg.delegation.max_spawn_depth.is_none());
         assert!(cfg.tts.is_null());
         assert!(cfg.proxy.is_none());
         assert_eq!(
@@ -1469,6 +1482,23 @@ mod tests {
         assert_eq!(back.tools, cfg.tools);
         assert_eq!(back.auxiliary["vision"].model, "google/gemini-2.5-flash");
         assert_eq!(back.tts["provider"], "piper");
+    }
+
+    #[test]
+    fn delegation_config_accepts_uncapped_max_spawn_depth() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+delegation:
+  max_spawn_depth: 99
+"#,
+        )
+        .expect("delegation config should deserialize");
+
+        assert_eq!(cfg.delegation.max_spawn_depth, Some(99));
+
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: GatewayConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.delegation.max_spawn_depth, Some(99));
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -21,9 +21,9 @@ pub mod streaming;
 // Re-export key types for convenience
 pub use config::{
     default_auxiliary_task_configs, normalize_service_tier, AgentLoopBehaviorConfig,
-    ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DisplayConfig, GatewayConfig,
-    LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig, ProxyConfig,
-    QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
+    ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DelegationConfig, DisplayConfig,
+    GatewayConfig, LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig,
+    ProxyConfig, QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
     SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolOutputConfig, ToolsSettings,
     WebConfig, WebsiteBlocklistConfig, DEFAULT_TOOL_OUTPUT_MAX_BYTES,
     DEFAULT_TOOL_OUTPUT_MAX_LINES, DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH,

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -118,6 +118,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 tool_output: ToolOutputConfig::default(),
                 platforms: HashMap::new(),
                 platform_toolsets: hermes_config::config::default_platform_toolsets(),
+                delegation: Default::default(),
                 session,
                 sessions: SessionsMaintenanceConfig::default(),
                 streaming,

--- a/crates/hermes-tools/src/backends/delegation.rs
+++ b/crates/hermes-tools/src/backends/delegation.rs
@@ -132,3 +132,44 @@ impl DelegationBackend for RpcDelegationBackend {
         Ok(text)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[tokio::test]
+    async fn signal_delegation_backend_allows_depths_above_legacy_cap() {
+        let backend = SignalDelegationBackend::new().with_depth(98, 99);
+        let out = backend
+            .delegate(
+                "prove uncapped depth",
+                None,
+                None,
+                None,
+                Some(99),
+                Some(99),
+                None,
+            )
+            .await
+            .expect("depth at configured max should be allowed");
+        let value: Value = serde_json::from_str(&out).expect("delegation envelope json");
+
+        assert_eq!(value["child_depth"], 99);
+        assert_eq!(value["max_depth"], 99);
+        assert_eq!(value["status"], "pending");
+    }
+
+    #[tokio::test]
+    async fn signal_delegation_backend_rejects_only_above_configured_max_depth() {
+        let backend = SignalDelegationBackend::new().with_depth(99, 99);
+        let err = backend
+            .delegate("too deep", None, None, None, Some(100), Some(99), None)
+            .await
+            .expect_err("child depth above configured max should be rejected");
+
+        assert!(err
+            .to_string()
+            .contains("Delegation depth limit reached (100/99)"));
+    }
+}

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -947,6 +947,10 @@
     "0f45509daf72": {
       "disposition": "ported",
       "notes": "Rust agent loop now treats formatted /steer redirects as trusted mid-turn out-of-band user messages appended to the last tool result, adds the shared steer channel system-prompt note when tools are available, and wires ACP active-session steer through the shared marker with regression tests preventing the old User guidance label."
+    },
+    "d41427504ef04": {
+      "disposition": "ported",
+      "notes": "Rust delegation depth now has a first-class AgentConfig max_delegate_depth plus delegation.max_spawn_depth config bridge with floor 1 and no legacy ceiling; env/config values above the old cap pass through with agent, CLI, config, and backend tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Adds first-class Rust delegation depth config via `AgentConfig.max_delegate_depth` and `GatewayConfig.delegation.max_spawn_depth`.
- Preserves the current Rust default depth of 4 while applying upstream parity semantics: floor values below 1 to 1, no legacy ceiling for high values.
- Prevents explore-first startup defaults from shadowing a configured delegation depth through `HERMES_MAX_DELEGATE_DEPTH=4`.
- Adds agent, CLI, config, and backend tests proving uncapped depth above the old cap and bounded rejection only above the configured max.
- Marks upstream `d41427504ef04` as ported in the parity queue ledger.

## Verification
All Cargo work used external target output on `/Volumes/wd_black`:

- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent delegate_depth -- --nocapture` -> 2 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-config delegation_config_accepts_uncapped_max_spawn_depth -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli delegation_depth -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_build_agent_config_maps_delegation_max_spawn_depth_without_legacy_ceiling -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-tools signal_delegation_backend -- --nocapture` -> 2 passed
- `cargo fmt --all --check` passed
- `python3 -m json.tool docs/parity/queue-overrides.json >/Volumes/wd_black/hermes-agent-ultra/delegation-depth-queue-overrides-check.json && git diff --check` passed
- `scripts/check-rust-runtime-no-python.sh` passed
- `scripts/check-runtime-placeholders.sh` passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-agent -p hermes-config -p hermes-cli -p hermes-tools` passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-config -p hermes-cli -p hermes-tools` passed with `new=0`, `stale=5`
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --overrides docs/parity/queue-overrides.json --out-json /Volumes/wd_black/hermes-agent-ultra/hermes-delegation-depth-queue.json --out-md /Volumes/wd_black/hermes-agent-ultra/hermes-delegation-depth-queue.md` passed
- Queue proof: `pending=1942`, `ported=104`, `mirrored=161`, `superseded=7634`; `d41427504ef04` is `ported`
