### PR TITLE
parity(providers): propagate request timeouts

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -196,6 +196,9 @@ pub struct RuntimeProviderConfig {
     pub api_key_env: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    /// Per-request timeout in seconds for this provider transport.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_timeout_seconds: Option<f64>,
     /// Optional provider-specific wire protocol override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_mode: Option<ApiMode>,
@@ -2874,6 +2877,28 @@ impl AgentLoop {
             })
     }
 
+    fn resolve_runtime_request_timeout_seconds(&self, provider: &str) -> Option<f64> {
+        self.config
+            .runtime_providers
+            .get(provider)
+            .and_then(|c| c.request_timeout_seconds)
+            .or_else(|| {
+                let alias = match provider {
+                    "codex" => "openai-codex",
+                    "openai-codex" => "codex",
+                    "qwen" => "qwen-oauth",
+                    "qwen-oauth" => "qwen",
+                    "kimi" => "moonshot",
+                    "moonshot" => "kimi",
+                    _ => return None,
+                };
+                self.config
+                    .runtime_providers
+                    .get(alias)
+                    .and_then(|c| c.request_timeout_seconds)
+            })
+    }
+
     fn resolve_oauth_store_api_key(&self, provider: &str) -> Option<String> {
         let provider_key = match provider {
             "openai" => "openai",
@@ -3349,6 +3374,7 @@ impl AgentLoop {
                 ))
             })?;
         let base_url = self.resolve_runtime_base_url(provider, route_base_url);
+        let request_timeout_seconds = self.resolve_runtime_request_timeout_seconds(provider);
         let mode = api_mode.unwrap_or(&self.config.api_mode);
         let normalized_model_name =
             crate::model_normalize::normalize_model_for_provider(model_name, provider);
@@ -3357,7 +3383,9 @@ impl AgentLoop {
         let provider_obj: Arc<dyn LlmProvider> = match provider {
             "openai" | "codex" | "openai-codex" => {
                 if matches!(mode, ApiMode::CodexResponses) {
-                    let mut p = CodexProvider::new(&api_key).with_model(model_name);
+                    let mut p = CodexProvider::new(&api_key)
+                        .with_model(model_name)
+                        .with_optional_request_timeout_seconds(request_timeout_seconds);
                     if let Some(ref url) = base_url {
                         p = p.with_base_url(url.clone());
                     }
@@ -3366,7 +3394,9 @@ impl AgentLoop {
                     }
                     Arc::new(p)
                 } else {
-                    let mut p = OpenAiProvider::new(&api_key).with_model(model_name);
+                    let mut p = OpenAiProvider::new(&api_key)
+                        .with_model(model_name)
+                        .with_optional_request_timeout_seconds(request_timeout_seconds);
                     if let Some(url) = base_url {
                         p = p.with_base_url(url);
                     }
@@ -3377,7 +3407,9 @@ impl AgentLoop {
                 }
             }
             "anthropic" => {
-                let mut p = AnthropicProvider::new(&api_key).with_model(model_name);
+                let mut p = AnthropicProvider::new(&api_key)
+                    .with_model(model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                 if let Some(url) = base_url {
                     p = p.with_base_url(url);
                 }
@@ -3387,28 +3419,36 @@ impl AgentLoop {
                 Arc::new(p)
             }
             "openrouter" => {
-                let mut p = OpenRouterProvider::new(&api_key).with_model(model_name);
+                let mut p = OpenRouterProvider::new(&api_key)
+                    .with_model(model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                 if let Some(pool) = credential_pool {
                     p = p.with_credential_pool(pool.clone());
                 }
                 Arc::new(p)
             }
             "qwen" | "qwen-oauth" => {
-                let mut p = QwenProvider::new(&api_key).with_model(model_name);
+                let mut p = QwenProvider::new(&api_key)
+                    .with_model(model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                 if let Some(url) = base_url {
                     p = p.with_base_url(url);
                 }
                 Arc::new(p)
             }
             "kimi" | "moonshot" => {
-                let mut p = KimiProvider::new(&api_key).with_model(model_name);
+                let mut p = KimiProvider::new(&api_key)
+                    .with_model(model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                 if let Some(url) = base_url {
                     p = p.with_base_url(url);
                 }
                 Arc::new(p)
             }
             "minimax" => {
-                let mut p = MiniMaxProvider::new(&api_key).with_model(model_name);
+                let mut p = MiniMaxProvider::new(&api_key)
+                    .with_model(model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                 if let Some(url) = base_url {
                     p = p.with_base_url(url);
                 }
@@ -3418,11 +3458,15 @@ impl AgentLoop {
                 let url =
                     base_url.unwrap_or_else(|| "https://api.stepfun.ai/step_plan/v1".to_string());
                 Arc::new(
-                    GenericProvider::new(url, &api_key, model_name).with_provider_profile(provider),
+                    GenericProvider::new(url, &api_key, model_name)
+                        .with_optional_request_timeout_seconds(request_timeout_seconds)
+                        .with_provider_profile(provider),
                 )
             }
             "nous" => {
-                let mut p = NousProvider::new(&api_key).with_model(model_name);
+                let mut p = NousProvider::new(&api_key)
+                    .with_model(model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                 if let Some(url) = base_url {
                     p = p.with_base_url(url);
                 }
@@ -3442,13 +3486,15 @@ impl AgentLoop {
                     base_url.unwrap_or_else(|| "https://api.githubcopilot.com".to_string()),
                     &api_key,
                 )
-                .with_model(model_name);
+                .with_model(model_name)
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
                 Arc::new(p)
             }
             _ => {
                 let url = base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string());
-                let mut g =
-                    GenericProvider::new(url, &api_key, model_name).with_provider_profile(provider);
+                let mut g = GenericProvider::new(url, &api_key, model_name)
+                    .with_optional_request_timeout_seconds(request_timeout_seconds)
+                    .with_provider_profile(provider);
                 if let Some(pool) = credential_pool {
                     g = g.with_credential_pool(pool.clone());
                 }
@@ -10347,6 +10393,7 @@ mod tests {
                 provider.to_string(),
                 RuntimeProviderConfig {
                     base_url: Some(base_url.to_string()),
+                    request_timeout_seconds: None,
                     api_mode: None,
                     ..RuntimeProviderConfig::default()
                 },
@@ -11747,6 +11794,7 @@ mod tests {
                 api_key: Some("sk-test-key".to_string()),
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -11829,6 +11877,7 @@ mod tests {
                 api_key: Some("sk-test-key".to_string()),
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -12133,6 +12182,7 @@ mod tests {
                 api_key: Some("sk-test-key".to_string()),
                 api_key_env: None,
                 base_url: Some("https://api.openai.com/v1".to_string()),
+                request_timeout_seconds: Some(45.0),
                 api_mode: None,
                 command: Some("copilot-language-server".to_string()),
                 args: vec![
@@ -12142,6 +12192,13 @@ mod tests {
                 ],
                 oauth_token_url: None,
                 oauth_client_id: None,
+            },
+        );
+        runtime_providers.insert(
+            "openai-codex".to_string(),
+            RuntimeProviderConfig {
+                request_timeout_seconds: Some(75.0),
+                ..RuntimeProviderConfig::default()
             },
         );
 
@@ -12159,6 +12216,14 @@ mod tests {
             Arc::new(DummyProvider),
         );
         let primary = agent.primary_runtime_snapshot();
+        assert_eq!(
+            agent.resolve_runtime_request_timeout_seconds("openai"),
+            Some(45.0)
+        );
+        assert_eq!(
+            agent.resolve_runtime_request_timeout_seconds("codex"),
+            Some(75.0)
+        );
         assert_eq!(primary.command.as_deref(), Some("copilot-language-server"));
         assert_eq!(
             primary.args,
@@ -12214,6 +12279,7 @@ mod tests {
                 api_key: Some("sk-test-key".to_string()),
                 api_key_env: None,
                 base_url: Some("https://api.openai.com/v1".to_string()),
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -12304,6 +12370,7 @@ mod tests {
                 api_key: Some("sk-qwen-oauth".to_string()),
                 api_key_env: None,
                 base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string()),
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -12385,6 +12452,7 @@ mod tests {
                 api_key: Some("stepfun-test-key".to_string()),
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -12476,6 +12544,7 @@ mod tests {
                 api_key: None,
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -12582,6 +12651,7 @@ mod tests {
                 api_key: None,
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -12984,6 +13054,7 @@ mod tests {
                 api_key: None,
                 api_key_env: None,
                 base_url: Some("acp://copilot".to_string()),
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: Some("definitely-not-installed-copilot-cli".to_string()),
                 args: vec!["--acp".to_string(), "--stdio".to_string()],
@@ -13065,6 +13136,7 @@ mod tests {
                 api_key: None,
                 api_key_env: None,
                 base_url: Some("acp+tcp://127.0.0.1:8765".to_string()),
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: Some("definitely-not-installed-copilot-cli".to_string()),
                 args: vec!["--acp".to_string(), "--stdio".to_string()],
@@ -13518,6 +13590,7 @@ mod tests {
                 api_key: None,
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -13533,6 +13606,7 @@ mod tests {
                 api_key: None,
                 api_key_env: None,
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),
@@ -13611,6 +13685,7 @@ mod tests {
                 api_key: None,
                 api_key_env: Some("MY_FALLBACK_KEY".to_string()),
                 base_url: None,
+                request_timeout_seconds: None,
                 api_mode: None,
                 command: None,
                 args: Vec::new(),

--- a/crates/hermes-agent/src/api_bridge.rs
+++ b/crates/hermes-agent/src/api_bridge.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 use reqwest::Client;
 use serde_json::Value;
 use std::sync::Arc;
+use std::time::Duration;
 
 use hermes_core::{
     AgentError, FunctionCall, FunctionCallDelta, LlmProvider, LlmResponse, Message, MessageRole,
@@ -18,6 +19,27 @@ use hermes_core::{
 use crate::credential_pool::CredentialPool;
 use crate::rate_limit::RateLimitTracker;
 
+fn request_timeout_duration(seconds: Option<f64>) -> Option<Duration> {
+    seconds.and_then(|value| {
+        if value.is_finite() && value > 0.0 {
+            Duration::try_from_secs_f64(value).ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn build_codex_http_client(request_timeout: Option<Duration>) -> Client {
+    let mut builder = Client::builder();
+    if let Some(timeout) = request_timeout {
+        builder = builder.timeout(timeout);
+    }
+    builder.build().unwrap_or_else(|err| {
+        tracing::warn!("failed to build Codex HTTP client: {}", err);
+        Client::new()
+    })
+}
+
 /// OpenAI Responses API provider for Codex models.
 #[derive(Debug, Clone)]
 pub struct CodexProvider {
@@ -25,17 +47,20 @@ pub struct CodexProvider {
     pub api_key: String,
     pub model: String,
     client: Client,
+    request_timeout: Option<Duration>,
     pub rate_limiter: Option<Arc<RateLimitTracker>>,
     pub credential_pool: Option<Arc<CredentialPool>>,
 }
 
 impl CodexProvider {
     pub fn new(api_key: impl Into<String>) -> Self {
+        let request_timeout = None;
         Self {
             base_url: "https://api.openai.com/v1".to_string(),
             api_key: api_key.into(),
             model: "codex-mini-latest".to_string(),
-            client: Client::new(),
+            client: build_codex_http_client(request_timeout),
+            request_timeout,
             rate_limiter: None,
             credential_pool: None,
         }
@@ -49,6 +74,21 @@ impl CodexProvider {
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
         self
+    }
+
+    pub fn with_optional_request_timeout_seconds(mut self, seconds: Option<f64>) -> Self {
+        self.request_timeout = request_timeout_duration(seconds);
+        self.client = build_codex_http_client(self.request_timeout);
+        self
+    }
+
+    pub fn with_request_timeout_seconds(self, seconds: f64) -> Self {
+        self.with_optional_request_timeout_seconds(Some(seconds))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn configured_request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
     }
 
     pub fn with_rate_limiter(mut self, tracker: Arc<RateLimitTracker>) -> Self {
@@ -501,6 +541,31 @@ impl LlmProvider for CodexProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codex_provider_request_timeout_seconds_configures_client() {
+        let provider = CodexProvider::new("sk-test").with_request_timeout_seconds(45.0);
+
+        assert_eq!(
+            provider.configured_request_timeout(),
+            Some(Duration::from_secs(45))
+        );
+    }
+
+    #[test]
+    fn codex_provider_ignores_invalid_request_timeout_seconds() {
+        for value in [
+            None,
+            Some(0.0),
+            Some(-1.0),
+            Some(f64::INFINITY),
+            Some(f64::NAN),
+        ] {
+            let provider =
+                CodexProvider::new("sk-test").with_optional_request_timeout_seconds(value);
+            assert_eq!(provider.configured_request_timeout(), None);
+        }
+    }
 
     #[test]
     fn test_convert_input_basic() {

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -48,6 +48,27 @@ const ACP_MULTIMODAL_PREFIX: &str = "__hermes_acp_parts_json__:";
 pub const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const CODEX_CLOUDFLARE_ORIGINATOR: &str = "codex_cli_rs";
 
+fn request_timeout_duration(seconds: Option<f64>) -> Option<Duration> {
+    seconds.and_then(|value| {
+        if value.is_finite() && value > 0.0 {
+            Duration::try_from_secs_f64(value).ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn build_provider_http_client(request_timeout: Option<Duration>) -> Client {
+    let mut builder = Client::builder();
+    if let Some(timeout) = request_timeout {
+        builder = builder.timeout(timeout);
+    }
+    builder.build().unwrap_or_else(|err| {
+        tracing::warn!("failed to build provider HTTP client: {}", err);
+        Client::new()
+    })
+}
+
 pub fn codex_cloudflare_headers(access_token: Option<&str>) -> Vec<(String, String)> {
     let mut headers = vec![
         (
@@ -75,6 +96,15 @@ pub fn openai_codex_provider(
     model: impl Into<String>,
     base_url: Option<&str>,
 ) -> OpenAiProvider {
+    openai_codex_provider_with_timeout(api_key, model, base_url, None)
+}
+
+pub fn openai_codex_provider_with_timeout(
+    api_key: impl Into<String>,
+    model: impl Into<String>,
+    base_url: Option<&str>,
+    request_timeout_seconds: Option<f64>,
+) -> OpenAiProvider {
     let api_key = api_key.into();
     let base_url = base_url
         .map(str::trim)
@@ -83,7 +113,8 @@ pub fn openai_codex_provider(
         .to_string();
     let mut provider = OpenAiProvider::new(api_key.as_str())
         .with_model(model)
-        .with_base_url(base_url.as_str());
+        .with_base_url(base_url.as_str())
+        .with_optional_request_timeout_seconds(request_timeout_seconds);
     if is_codex_cloudflare_base_url(base_url.as_str()) {
         provider = provider.with_headers(codex_cloudflare_headers(Some(api_key.as_str())));
     }
@@ -237,6 +268,8 @@ pub struct GenericProvider {
     pub model: String,
     /// HTTP client.
     client: Arc<Mutex<Client>>,
+    /// Optional total request timeout applied to newly-built clients.
+    request_timeout: Option<Duration>,
     /// Last time we rebuilt the client transport.
     client_refreshed_at: Arc<Mutex<Instant>>,
     /// Optional custom headers to send with every request.
@@ -256,11 +289,13 @@ impl GenericProvider {
         api_key: impl Into<String>,
         model: impl Into<String>,
     ) -> Self {
+        let request_timeout = None;
         Self {
             base_url: base_url.into(),
             api_key: api_key.into(),
             model: model.into(),
-            client: Arc::new(Mutex::new(Client::new())),
+            client: Arc::new(Mutex::new(build_provider_http_client(request_timeout))),
+            request_timeout,
             client_refreshed_at: Arc::new(Mutex::new(Instant::now())),
             extra_headers: Vec::new(),
             rate_limiter: None,
@@ -285,6 +320,25 @@ impl GenericProvider {
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = model.into();
         self
+    }
+
+    /// Set an optional total request timeout used by this provider and rebuilds.
+    pub fn with_optional_request_timeout_seconds(mut self, seconds: Option<f64>) -> Self {
+        self.request_timeout = request_timeout_duration(seconds);
+        if let Ok(mut client) = self.client.lock() {
+            *client = build_provider_http_client(self.request_timeout);
+        }
+        self
+    }
+
+    /// Set a total request timeout in seconds.
+    pub fn with_request_timeout_seconds(self, seconds: f64) -> Self {
+        self.with_optional_request_timeout_seconds(Some(seconds))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn configured_request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
     }
 
     /// Attach a Rust-native provider profile for request shaping.
@@ -446,13 +500,13 @@ impl GenericProvider {
         self.client
             .lock()
             .map(|c| c.clone())
-            .unwrap_or_else(|_| Client::new())
+            .unwrap_or_else(|_| build_provider_http_client(self.request_timeout))
     }
 
     fn refresh_client(&self, reason: &str) {
         tracing::warn!("rebuilding primary HTTP client: {}", reason);
         if let Ok(mut c) = self.client.lock() {
-            *c = Client::new();
+            *c = build_provider_http_client(self.request_timeout);
         }
         if let Ok(mut t) = self.client_refreshed_at.lock() {
             *t = Instant::now();
@@ -1167,6 +1221,13 @@ impl OpenAiProvider {
         }
     }
 
+    /// Set an optional total request timeout used by this provider and rebuilds.
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
+        }
+    }
+
     /// Add a custom header to every OpenAI-compatible request.
     pub fn with_header(self, key: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
@@ -1252,6 +1313,8 @@ pub struct AnthropicProvider {
     pub model: String,
     /// HTTP client.
     client: Arc<Mutex<Client>>,
+    /// Optional total request timeout applied to newly-built clients.
+    request_timeout: Option<Duration>,
     /// Last time we rebuilt the client transport.
     client_refreshed_at: Arc<Mutex<Instant>>,
     /// Anthropic API version header.
@@ -1265,11 +1328,13 @@ pub struct AnthropicProvider {
 impl AnthropicProvider {
     /// Create a new Anthropic provider with the given API key.
     pub fn new(api_key: impl Into<String>) -> Self {
+        let request_timeout = None;
         Self {
             base_url: "https://api.anthropic.com".to_string(),
             api_key: api_key.into(),
             model: "claude-3-5-sonnet-20241022".to_string(),
-            client: Arc::new(Mutex::new(Client::new())),
+            client: Arc::new(Mutex::new(build_provider_http_client(request_timeout))),
+            request_timeout,
             client_refreshed_at: Arc::new(Mutex::new(Instant::now())),
             api_version: "2023-06-01".to_string(),
             rate_limiter: None,
@@ -1287,6 +1352,25 @@ impl AnthropicProvider {
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
         self
+    }
+
+    /// Set an optional total request timeout used by this provider and rebuilds.
+    pub fn with_optional_request_timeout_seconds(mut self, seconds: Option<f64>) -> Self {
+        self.request_timeout = request_timeout_duration(seconds);
+        if let Ok(mut client) = self.client.lock() {
+            *client = build_provider_http_client(self.request_timeout);
+        }
+        self
+    }
+
+    /// Set a total request timeout in seconds.
+    pub fn with_request_timeout_seconds(self, seconds: f64) -> Self {
+        self.with_optional_request_timeout_seconds(Some(seconds))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn configured_request_timeout(&self) -> Option<Duration> {
+        self.request_timeout
     }
 
     /// Attach a rate limit tracker.
@@ -1328,13 +1412,13 @@ impl AnthropicProvider {
         self.client
             .lock()
             .map(|c| c.clone())
-            .unwrap_or_else(|_| Client::new())
+            .unwrap_or_else(|_| build_provider_http_client(self.request_timeout))
     }
 
     fn refresh_client(&self, reason: &str) {
         tracing::warn!("rebuilding anthropic HTTP client: {}", reason);
         if let Ok(mut c) = self.client.lock() {
-            *c = Client::new();
+            *c = build_provider_http_client(self.request_timeout);
         }
         if let Ok(mut t) = self.client_refreshed_at.lock() {
             *t = Instant::now();
@@ -2094,6 +2178,14 @@ impl OpenRouterProvider {
         }
     }
 
+    /// Set an optional total request timeout used by this provider and rebuilds.
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
+            ..self
+        }
+    }
+
     /// Set the HTTP-Referer header (required by OpenRouter).
     pub fn with_http_referer(mut self, referer: impl Into<String>) -> Self {
         self.http_referer = Some(referer.into());
@@ -2752,6 +2844,48 @@ mod tests {
 
         assert!(request.headers().get("originator").is_none());
         assert!(request.headers().get("ChatGPT-Account-ID").is_none());
+    }
+
+    #[test]
+    fn generic_provider_request_timeout_survives_client_rebuilds() {
+        let provider = GenericProvider::new("https://api.example.com/v1", "sk-test", "model")
+            .with_optional_request_timeout_seconds(Some(45.5));
+
+        assert_eq!(
+            provider.configured_request_timeout(),
+            Some(Duration::from_secs_f64(45.5))
+        );
+
+        provider.refresh_client("unit test");
+        assert_eq!(
+            provider.configured_request_timeout(),
+            Some(Duration::from_secs_f64(45.5))
+        );
+    }
+
+    #[test]
+    fn generic_provider_ignores_invalid_request_timeout_seconds() {
+        for value in [
+            None,
+            Some(0.0),
+            Some(-1.0),
+            Some(f64::INFINITY),
+            Some(f64::NAN),
+        ] {
+            let provider = GenericProvider::new("https://api.example.com/v1", "sk-test", "model")
+                .with_optional_request_timeout_seconds(value);
+            assert_eq!(provider.configured_request_timeout(), None);
+        }
+    }
+
+    #[test]
+    fn openai_codex_provider_applies_request_timeout_seconds() {
+        let provider = openai_codex_provider_with_timeout("sk-test", "gpt-5.4", None, Some(60.0));
+
+        assert_eq!(
+            provider.inner.configured_request_timeout(),
+            Some(Duration::from_secs(60))
+        );
     }
 
     #[test]
@@ -3667,6 +3801,23 @@ mod tests {
             .expect("anthropic-beta");
         assert!(betas.contains("oauth-2025-04-20"));
         assert!(betas.contains("claude-code-20250219"));
+    }
+
+    #[test]
+    fn anthropic_provider_request_timeout_survives_client_rebuilds() {
+        let provider =
+            AnthropicProvider::new("sk-ant-api03-secret").with_request_timeout_seconds(90.0);
+
+        assert_eq!(
+            provider.configured_request_timeout(),
+            Some(Duration::from_secs(90))
+        );
+
+        provider.refresh_client("unit test");
+        assert_eq!(
+            provider.configured_request_timeout(),
+            Some(Duration::from_secs(90))
+        );
     }
 
     #[test]

--- a/crates/hermes-agent/src/providers_extra.rs
+++ b/crates/hermes-agent/src/providers_extra.rs
@@ -77,6 +77,12 @@ impl QwenProvider {
             inner: self.inner.with_base_url(url),
         }
     }
+
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
+        }
+    }
 }
 
 #[async_trait]
@@ -147,6 +153,12 @@ impl KimiProvider {
             inner: self.inner.with_base_url(url),
         }
     }
+
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
+        }
+    }
 }
 
 #[async_trait]
@@ -214,6 +226,12 @@ impl MiniMaxProvider {
     pub fn with_base_url(self, url: impl Into<String>) -> Self {
         Self {
             inner: self.inner.with_base_url(url),
+        }
+    }
+
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
         }
     }
 }
@@ -288,6 +306,12 @@ impl NousProvider {
     pub fn with_base_url(self, url: impl Into<String>) -> Self {
         Self {
             inner: self.inner.with_base_url(url),
+        }
+    }
+
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
         }
     }
 }
@@ -367,6 +391,12 @@ impl CopilotProvider {
             inner: self.inner.with_base_url(url),
         }
     }
+
+    pub fn with_optional_request_timeout_seconds(self, seconds: Option<f64>) -> Self {
+        Self {
+            inner: self.inner.with_optional_request_timeout_seconds(seconds),
+        }
+    }
 }
 
 #[async_trait]
@@ -412,6 +442,7 @@ impl LlmProvider for CopilotProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn qwen_provider_defaults() {
@@ -487,5 +518,46 @@ mod tests {
         let p = CopilotProvider::new("https://copilot.example.com/v1", "token")
             .with_model("gpt-4o-mini");
         assert_eq!(p.inner.model, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn openai_compatible_extra_providers_apply_request_timeout_seconds() {
+        let timeout = Some(Duration::from_secs(45));
+
+        assert_eq!(
+            QwenProvider::new("test-key")
+                .with_optional_request_timeout_seconds(Some(45.0))
+                .inner
+                .configured_request_timeout(),
+            timeout
+        );
+        assert_eq!(
+            KimiProvider::new("test-key")
+                .with_optional_request_timeout_seconds(Some(45.0))
+                .inner
+                .configured_request_timeout(),
+            timeout
+        );
+        assert_eq!(
+            MiniMaxProvider::new("test-key")
+                .with_optional_request_timeout_seconds(Some(45.0))
+                .inner
+                .configured_request_timeout(),
+            timeout
+        );
+        assert_eq!(
+            NousProvider::new("test-key")
+                .with_optional_request_timeout_seconds(Some(45.0))
+                .inner
+                .configured_request_timeout(),
+            timeout
+        );
+        assert_eq!(
+            CopilotProvider::new("https://copilot.example.com/v1", "token")
+                .with_optional_request_timeout_seconds(Some(45.0))
+                .inner
+                .configured_request_timeout(),
+            timeout
+        );
     }
 }

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -19,8 +19,8 @@ use hermes_agent::bedrock::{
 };
 use hermes_agent::plugins::HookType;
 use hermes_agent::provider::{
-    openai_codex_provider, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
-    OPENAI_CODEX_BASE_URL,
+    openai_codex_provider_with_timeout, AnthropicProvider, GenericProvider, OpenAiProvider,
+    OpenRouterProvider, OPENAI_CODEX_BASE_URL,
 };
 use hermes_agent::providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,
@@ -4536,6 +4536,27 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_maps_runtime_provider_request_timeout_seconds() {
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "anthropic".to_string(),
+            LlmProviderConfig {
+                api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+                request_timeout_seconds: Some(45.5),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let agent_cfg = build_agent_config(&cfg, "anthropic:claude-sonnet-4.5");
+        let runtime = agent_cfg
+            .runtime_providers
+            .get("anthropic")
+            .expect("runtime provider should exist");
+
+        assert_eq!(runtime.request_timeout_seconds, Some(45.5));
+    }
+
+    #[test]
     fn test_build_agent_config_maps_delegation_max_spawn_depth_without_legacy_ceiling() {
         let mut cfg = GatewayConfig::default();
         cfg.delegation.max_spawn_depth = Some(99);
@@ -6096,6 +6117,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
                         api_key: cfg.api_key.clone(),
                         api_key_env: cfg.api_key_env.clone(),
                         base_url: cfg.base_url.clone(),
+                        request_timeout_seconds: cfg.request_timeout_seconds,
                         api_mode: cfg.api_mode.as_deref().and_then(parse_provider_api_mode),
                         command: cfg.command.clone(),
                         args: cfg.args.clone(),
@@ -6766,6 +6788,7 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             }
         })
     });
+    let request_timeout_seconds = provider_config.and_then(|c| c.request_timeout_seconds);
 
     let default_base_url = provider_default_base_url(provider_name.as_str())
         .or_else(|| provider_default_base_url(runtime_provider.as_str()));
@@ -6812,19 +6835,24 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
 
     match runtime_provider.as_str() {
         "openai" => {
-            let mut p = OpenAiProvider::new(&api_key).with_model(model_name.as_str());
+            let mut p = OpenAiProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
             Arc::new(p)
         }
-        "openai-codex" | "codex" => Arc::new(openai_codex_provider(
+        "openai-codex" | "codex" => Arc::new(openai_codex_provider_with_timeout(
             &api_key,
             model_name.as_str(),
             base_url.as_deref(),
+            request_timeout_seconds,
         )),
         "anthropic" => {
-            let mut p = AnthropicProvider::new(&api_key).with_model(model_name.as_str());
+            let mut p = AnthropicProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
@@ -6842,25 +6870,33 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             Arc::new(p)
         }
         "openrouter" => {
-            let p = OpenRouterProvider::new(&api_key).with_model(model_name.as_str());
+            let p = OpenRouterProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             Arc::new(p)
         }
         "qwen" | "qwen-oauth" => {
-            let mut p = QwenProvider::new(&api_key).with_model(model_name.as_str());
+            let mut p = QwenProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
             Arc::new(p)
         }
         "kimi" | "moonshot" => {
-            let mut p = KimiProvider::new(&api_key).with_model(model_name.as_str());
+            let mut p = KimiProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
             Arc::new(p)
         }
         "minimax" => {
-            let mut p = MiniMaxProvider::new(&api_key).with_model(model_name.as_str());
+            let mut p = MiniMaxProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
@@ -6870,11 +6906,14 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             let url = base_url.unwrap_or_else(|| STEPFUN_BASE_URL.to_string());
             Arc::new(
                 GenericProvider::new(url, &api_key, model_name.as_str())
+                    .with_optional_request_timeout_seconds(request_timeout_seconds)
                     .with_provider_profile(runtime_provider.as_str()),
             )
         }
         "nous" => {
-            let mut p = NousProvider::new(&api_key).with_model(model_name.as_str());
+            let mut p = NousProvider::new(&api_key)
+                .with_model(model_name.as_str())
+                .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
@@ -6885,13 +6924,15 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
                 base_url.unwrap_or_else(|| COPILOT_BASE_URL.to_string()),
                 &api_key,
             )
-            .with_model(model_name.as_str());
+            .with_model(model_name.as_str())
+            .with_optional_request_timeout_seconds(request_timeout_seconds);
             Arc::new(p)
         }
         "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane" | "sglang" | "tgi" => {
             let url = base_url.unwrap_or_else(|| "http://127.0.0.1:11434/v1".to_string());
             Arc::new(
                 GenericProvider::new(url, &api_key, model_name.as_str())
+                    .with_optional_request_timeout_seconds(request_timeout_seconds)
                     .with_provider_profile(runtime_provider.as_str()),
             )
         }
@@ -6899,6 +6940,7 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
             let url = base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string());
             Arc::new(
                 GenericProvider::new(url, &api_key, model_name.as_str())
+                    .with_optional_request_timeout_seconds(request_timeout_seconds)
                     .with_provider_profile(runtime_provider.as_str()),
             )
         }

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -899,6 +899,10 @@ pub struct LlmProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
 
+    /// Per-request timeout in seconds for this provider transport.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_timeout_seconds: Option<f64>,
+
     /// Optional external-process command used by runtime-provider resolvers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
@@ -952,6 +956,7 @@ impl Default for LlmProviderConfig {
             api_key: None,
             api_key_env: None,
             base_url: None,
+            request_timeout_seconds: None,
             command: None,
             args: Vec::new(),
             model: None,
@@ -1499,6 +1504,29 @@ delegation:
         let json = serde_json::to_string(&cfg).unwrap();
         let back: GatewayConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.delegation.max_spawn_depth, Some(99));
+    }
+
+    #[test]
+    fn llm_provider_config_accepts_request_timeout_seconds() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+llm_providers:
+  anthropic:
+    api_key_env: ANTHROPIC_API_KEY
+    request_timeout_seconds: 45.5
+"#,
+        )
+        .expect("provider config should deserialize");
+
+        assert_eq!(
+            cfg.llm_providers
+                .get("anthropic")
+                .and_then(|provider| provider.request_timeout_seconds),
+            Some(45.5)
+        );
+
+        let yaml = serde_yaml::to_string(&cfg).expect("serialize config");
+        assert!(yaml.contains("request_timeout_seconds: 45.5"));
     }
 
     #[test]

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -563,12 +563,13 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
             || provider.extra_body.is_some()
             || provider.rate_limit.is_some()
             || !provider.credential_pool.is_empty()
+            || provider.request_timeout_seconds.is_some()
             || provider.oauth_token_url.is_some()
             || provider.oauth_client_id.is_some()
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -588,6 +589,19 @@ fn parse_config_bool(key: &str, value: &str) -> Result<bool, ConfigError> {
         _ => Err(ConfigError::ValidationError(format!(
             "{key} must be a boolean: {value}"
         ))),
+    }
+}
+
+fn parse_positive_timeout_seconds(key: &str, value: &str) -> Result<f64, ConfigError> {
+    let parsed: f64 = value.parse().map_err(|_| {
+        ConfigError::ValidationError(format!("{key} must be a positive finite number: {value}"))
+    })?;
+    if parsed.is_finite() && parsed > 0.0 {
+        Ok(parsed)
+    } else {
+        Err(ConfigError::ValidationError(format!(
+            "{key} must be a positive finite number: {value}"
+        )))
     }
 }
 
@@ -821,11 +835,15 @@ fn apply_user_config_patch_dotted(
                         .filter(|s| !s.is_empty())
                         .collect();
                 }
+                "request_timeout_seconds" => {
+                    entry.request_timeout_seconds =
+                        Some(parse_positive_timeout_seconds(key, value)?);
+                }
                 "oauth_token_url" => entry.oauth_token_url = Some(value.to_string()),
                 "oauth_client_id" => entry.oauth_client_id = Some(value.to_string()),
                 other => {
                     return Err(ConfigError::NotFound(format!(
-                        "unknown llm field: llm.{}.{} (supported: api_key, api_key_env, base_url, model, api_mode, command, args, oauth_token_url, oauth_client_id)",
+                        "unknown llm field: llm.{}.{} (supported: api_key, api_key_env, base_url, model, api_mode, command, args, request_timeout_seconds, oauth_token_url, oauth_client_id)",
                         provider, other
                     )));
                 }
@@ -1009,6 +1027,12 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .get(*provider)
             .map(|c| c.args.join(","))
             .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["llm", provider, "request_timeout_seconds"] => Ok(config
+            .llm_providers
+            .get(*provider)
+            .and_then(|c| c.request_timeout_seconds)
+            .map(|value| value.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
         ["llm", provider, "oauth_token_url"] => Ok(config
             .llm_providers
@@ -1995,6 +2019,13 @@ pub fn validate_config(config: &GatewayConfig) -> Result<(), ConfigError> {
                 ))
             })?;
         }
+        if let Some(timeout) = provider.request_timeout_seconds {
+            if !timeout.is_finite() || timeout <= 0.0 {
+                return Err(ConfigError::ValidationError(format!(
+                    "llm_providers.{name}.request_timeout_seconds must be a positive finite number"
+                )));
+            }
+        }
     }
 
     Ok(())
@@ -2112,6 +2143,49 @@ mod tests {
                 .and_then(|cfg| cfg.api_key.as_deref()),
             Some("tok-abc")
         );
+    }
+
+    #[test]
+    fn normalize_provider_secrets_keeps_timeout_only_provider_entries() {
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "anthropic".into(),
+            crate::config::LlmProviderConfig {
+                request_timeout_seconds: Some(45.0),
+                ..Default::default()
+            },
+        );
+
+        normalize_provider_secrets(&mut config);
+
+        assert_eq!(
+            config
+                .llm_providers
+                .get("anthropic")
+                .and_then(|cfg| cfg.request_timeout_seconds),
+            Some(45.0)
+        );
+    }
+
+    #[test]
+    fn validate_llm_provider_request_timeout_seconds() {
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "anthropic".into(),
+            crate::config::LlmProviderConfig {
+                request_timeout_seconds: Some(45.0),
+                ..Default::default()
+            },
+        );
+        assert!(validate_config(&config).is_ok());
+
+        config
+            .llm_providers
+            .get_mut("anthropic")
+            .expect("provider")
+            .request_timeout_seconds = Some(0.0);
+        let err = validate_config(&config).unwrap_err().to_string();
+        assert!(err.contains("request_timeout_seconds"));
     }
 
     #[test]
@@ -2719,6 +2793,7 @@ llm_providers:
         apply_user_config_patch(&mut c, "llm.openai.api_mode", "codex-responses").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.command", "copilot-language-server").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.args", "--stdio,--model,gpt-4o-mini").unwrap();
+        apply_user_config_patch(&mut c, "llm.openai.request_timeout_seconds", "45.5").unwrap();
         apply_user_config_patch(&mut c, "proxy.http", "http://127.0.0.1:8080").unwrap();
         apply_user_config_patch(&mut c, "budget.max_result_size_chars", "500").unwrap();
         apply_user_config_patch(&mut c, "sessions.auto_prune", "true").unwrap();
@@ -2750,6 +2825,13 @@ llm_providers:
             ]
         );
         assert_eq!(
+            c.llm_providers
+                .get("openai")
+                .unwrap()
+                .request_timeout_seconds,
+            Some(45.5)
+        );
+        assert_eq!(
             c.proxy.as_ref().unwrap().http_proxy.as_deref(),
             Some("http://127.0.0.1:8080")
         );
@@ -2774,12 +2856,22 @@ llm_providers:
             "--stdio,--model,gpt-4o-mini"
         );
         assert_eq!(
+            user_config_field_display(&c, "llm.openai.request_timeout_seconds").unwrap(),
+            "45.5"
+        );
+        assert_eq!(
             user_config_field_display(&c, "sessions.auto_prune").unwrap(),
             "true"
         );
         assert_eq!(
             user_config_field_display(&c, "sessions.retention_days").unwrap(),
             "30"
+        );
+        assert!(
+            apply_user_config_patch(&mut c, "llm.openai.request_timeout_seconds", "0").is_err()
+        );
+        assert!(
+            apply_user_config_patch(&mut c, "llm.openai.request_timeout_seconds", "fast").is_err()
         );
     }
 

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -722,6 +722,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
                         api_key: cfg.api_key.clone(),
                         api_key_env: cfg.api_key_env.clone(),
                         base_url: cfg.base_url.clone(),
+                        request_timeout_seconds: cfg.request_timeout_seconds,
                         api_mode: cfg.api_mode.as_deref().and_then(parse_provider_api_mode),
                         command: cfg.command.clone(),
                         args: cfg.args.clone(),
@@ -937,6 +938,7 @@ fn resolve_model(default_model: &str, provider: Option<&str>, model: Option<&str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hermes_config::LlmProviderConfig;
 
     #[test]
     fn gateway_provider_aliases_resolve_to_direct_provider_defaults() {
@@ -952,5 +954,27 @@ mod tests {
             assert_eq!(canonical_gateway_provider_name(alias), canonical);
             assert_eq!(default_gateway_base_url(canonical), Some(base_url));
         }
+    }
+
+    #[test]
+    fn build_agent_config_maps_provider_request_timeout_seconds() {
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "openai".to_string(),
+            LlmProviderConfig {
+                request_timeout_seconds: Some(45.5),
+                ..Default::default()
+            },
+        );
+
+        let agent_config = build_agent_config(&config, "openai:gpt-4o");
+
+        assert_eq!(
+            agent_config
+                .runtime_providers
+                .get("openai")
+                .and_then(|cfg| cfg.request_timeout_seconds),
+            Some(45.5)
+        );
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -951,6 +951,10 @@
     "d41427504ef04": {
       "disposition": "ported",
       "notes": "Rust delegation depth now has a first-class AgentConfig max_delegate_depth plus delegation.max_spawn_depth config bridge with floor 1 and no legacy ceiling; env/config values above the old cap pass through with agent, CLI, config, and backend tests."
+    },
+    "f1fe29d1c368": {
+      "disposition": "ported",
+      "notes": "Rust provider config now accepts llm.<provider>.request_timeout_seconds, validates and exposes it through config set/get, propagates it into AgentConfig RuntimeProviderConfig, and applies it to OpenAI-compatible, Codex Responses, Anthropic, OpenRouter, extra provider, fallback/runtime-routing, and client rebuild paths with targeted tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add `llm.<provider>.request_timeout_seconds` to Rust config schema, config set/get, validation, and provider normalization
- propagate provider request timeouts through CLI, HTTP, and agent-loop runtime provider config
- apply configured timeouts to OpenAI-compatible providers, Codex Responses, Anthropic, OpenRouter, extra providers, fallback/runtime routing, and client rebuild paths
- mark upstream `f1fe29d1c368` as ported in the parity queue overrides

## Verification
- `cargo test -p hermes-config request_timeout -- --nocapture`
- `cargo test -p hermes-config timeout -- --nocapture`
- `cargo test -p hermes-config apply_patch_dotted_llm_proxy_budget -- --nocapture`
- `cargo test -p hermes-agent request_timeout -- --nocapture`
- `cargo test -p hermes-agent test_runtime_provider_command_args_override_primary_acp_metadata -- --nocapture`
- `cargo test -p hermes-cli request_timeout -- --nocapture`
- `cargo test -p hermes-http request_timeout -- --nocapture`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo build -p hermes-agent -p hermes-config -p hermes-cli -p hermes-http`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-config -p hermes-cli -p hermes-http` (`new=0`)

## Queue Proof
- external proof: `/Volumes/wd_black/hermes-agent-ultra/provider-timeouts-queue.json`
- `f1fe29d1c368f7930430a6a6c2c262764e3ae486`: `ported`, target ticket `20`
- queue summary: `pending=1941`, `ported=105`, `superseded=7634`, `mirrored=161`
