### PR TITLE
parity(delegation): route subagents by provider model

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -446,6 +446,22 @@ pub struct AgentConfig {
     #[serde(default = "default_max_delegate_depth")]
     pub max_delegate_depth: u32,
 
+    /// Optional config-level model override for delegated child agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_model: Option<String>,
+
+    /// Optional config-level provider override for delegated child agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_provider: Option<String>,
+
+    /// Optional config-level base URL override for delegated child agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_base_url: Option<String>,
+
+    /// Optional config-level API key override for delegated child agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_api_key: Option<String>,
+
     /// Flush memories every N turns.
     #[serde(default = "default_memory_flush_interval")]
     pub memory_flush_interval: u32,
@@ -802,6 +818,10 @@ impl Default for AgentConfig {
             max_tokens: None,
             max_concurrent_delegates: default_max_concurrent_delegates(),
             max_delegate_depth: default_max_delegate_depth(),
+            delegation_model: None,
+            delegation_provider: None,
+            delegation_base_url: None,
+            delegation_api_key: None,
             memory_flush_interval: default_memory_flush_interval(),
             session_id: None,
             hermes_home: None,
@@ -2679,6 +2699,56 @@ impl AgentLoop {
         (fallback_provider, model)
     }
 
+    fn runtime_provider_config(&self, provider: &str) -> Option<&RuntimeProviderConfig> {
+        let provider = provider.trim();
+        if provider.is_empty() {
+            return None;
+        }
+        if let Some(cfg) = self.config.runtime_providers.get(provider) {
+            return Some(cfg);
+        }
+
+        let lower = provider.to_ascii_lowercase();
+        if let Some(cfg) = self.config.runtime_providers.get(lower.as_str()) {
+            return Some(cfg);
+        }
+
+        let canonical = hermes_core::providers::canonical_provider_id(provider);
+        if let Some(cfg) = self.config.runtime_providers.get(canonical.as_str()) {
+            return Some(cfg);
+        }
+
+        let profile = crate::provider_profiles::canonical_provider_profile_id(provider);
+        if let Some(profile) = profile {
+            if let Some(cfg) = self.config.runtime_providers.get(profile) {
+                return Some(cfg);
+            }
+        }
+
+        if let Some((_, cfg)) = self
+            .config
+            .runtime_providers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(provider))
+        {
+            return Some(cfg);
+        }
+
+        if let Some(profile) = profile {
+            if let Some((_, cfg)) = self.config.runtime_providers.iter().find(|(name, _)| {
+                crate::provider_profiles::canonical_provider_profile_id(name) == Some(profile)
+            }) {
+                return Some(cfg);
+            }
+        }
+
+        self.config
+            .runtime_providers
+            .iter()
+            .find(|(name, _)| hermes_core::providers::canonical_provider_id(name) == canonical)
+            .map(|(_, cfg)| cfg)
+    }
+
     fn resolve_runtime_api_key(
         &self,
         provider: &str,
@@ -2710,7 +2780,7 @@ impl AgentLoop {
                 }
             }
         }
-        if let Some(cfg) = self.config.runtime_providers.get(provider) {
+        if let Some(cfg) = self.runtime_provider_config(provider) {
             if let Some(ref key) = cfg.api_key {
                 let trimmed = key.trim();
                 if let Some(env_ref) = trimmed.strip_prefix("${").and_then(|s| s.strip_suffix('}'))
@@ -2793,14 +2863,37 @@ impl AgentLoop {
             "qwen" | "qwen-oauth" => std::env::var("DASHSCOPE_API_KEY")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
-            "kimi" | "moonshot" => std::env::var("MOONSHOT_API_KEY")
+            "kimi" | "moonshot" | "kimi-coding" => std::env::var("KIMI_CODING_API_KEY")
                 .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("KIMI_API_KEY").ok())
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("MOONSHOT_API_KEY").ok())
+                .filter(|v| !v.trim().is_empty()),
+            "kimi-coding-cn" => std::env::var("KIMI_CN_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("KIMI_API_KEY").ok())
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("MOONSHOT_API_KEY").ok())
                 .filter(|v| !v.trim().is_empty()),
             "minimax" => std::env::var("MINIMAX_API_KEY")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            "minimax-cn" | "minimax_cn" => std::env::var("MINIMAX_CN_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+                .filter(|v| !v.trim().is_empty()),
             "nous" => std::env::var("NOUS_API_KEY")
                 .ok()
+                .filter(|v| !v.trim().is_empty()),
+            "zai" | "glm" | "z-ai" | "z_ai" | "zhipu" => std::env::var("GLM_API_KEY")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("ZAI_API_KEY").ok())
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| std::env::var("Z_AI_API_KEY").ok())
                 .filter(|v| !v.trim().is_empty()),
             "copilot" | "copilot-acp" => std::env::var("COPILOT_GITHUB_TOKEN")
                 .ok()
@@ -2823,9 +2916,7 @@ impl AgentLoop {
         if let Some(b) = route_base_url.map(str::trim).filter(|s| !s.is_empty()) {
             return Some(b.to_string());
         }
-        self.config
-            .runtime_providers
-            .get(provider)
+        self.runtime_provider_config(provider)
             .and_then(|c| c.base_url.as_ref())
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
@@ -2853,6 +2944,12 @@ impl AgentLoop {
                         .or_else(|| Some(bedrock_runtime_base_url(&resolve_bedrock_region())))
                 } else if provider == "stepfun" {
                     Some("https://api.stepfun.ai/step_plan/v1".to_string())
+                } else if provider == "kimi-coding" {
+                    Some("https://api.moonshot.ai/v1".to_string())
+                } else if provider == "kimi-coding-cn" {
+                    Some("https://api.moonshot.cn/v1".to_string())
+                } else if provider == "minimax-cn" || provider == "minimax_cn" {
+                    Some("https://api.minimaxi.com/anthropic".to_string())
                 } else if provider == "copilot" {
                     Some("https://api.githubcopilot.com".to_string())
                 } else if matches!(
@@ -2871,6 +2968,8 @@ impl AgentLoop {
                     "tencent-tokenhub" | "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas"
                 ) {
                     Some("https://tokenhub.tencentmaas.com/v1".to_string())
+                } else if matches!(provider, "zai" | "glm" | "z-ai" | "z_ai" | "zhipu") {
+                    Some("https://api.z.ai/api/paas/v4".to_string())
                 } else {
                     None
                 }
@@ -2878,9 +2977,7 @@ impl AgentLoop {
     }
 
     fn resolve_runtime_request_timeout_seconds(&self, provider: &str) -> Option<f64> {
-        self.config
-            .runtime_providers
-            .get(provider)
+        self.runtime_provider_config(provider)
             .and_then(|c| c.request_timeout_seconds)
             .or_else(|| {
                 let alias = match provider {
@@ -3311,7 +3408,7 @@ impl AgentLoop {
             .collect();
 
         if let Some(provider) = provider {
-            if let Some(cfg) = self.config.runtime_providers.get(provider) {
+            if let Some(cfg) = self.runtime_provider_config(provider) {
                 if let Some(cmd) = cfg
                     .command
                     .as_deref()
@@ -3355,7 +3452,7 @@ impl AgentLoop {
         (command, args)
     }
 
-    fn build_runtime_provider(
+    pub(crate) fn build_runtime_provider(
         &self,
         provider: &str,
         model_name: &str,
@@ -3502,6 +3599,28 @@ impl AgentLoop {
             }
         };
         Ok(provider_obj)
+    }
+
+    pub(crate) fn build_delegation_runtime_provider(
+        &self,
+        provider: &str,
+        model_name: &str,
+        route_base_url: Option<&str>,
+        explicit_api_key: Option<&str>,
+    ) -> Result<Arc<dyn LlmProvider>, AgentError> {
+        let api_mode = self
+            .runtime_provider_config(provider)
+            .and_then(|cfg| cfg.api_mode.clone())
+            .or_else(|| route_base_url.and_then(detect_api_mode_for_url));
+        self.build_runtime_provider(
+            provider,
+            model_name,
+            route_base_url,
+            None,
+            explicit_api_key,
+            api_mode.as_ref(),
+            self.primary_credential_pool.as_ref(),
+        )
     }
 
     fn credential_pool_for_route<'a>(
@@ -14138,6 +14257,89 @@ mod tests {
                 .resolve_runtime_base_url("tencentmaas", None)
                 .as_deref(),
             Some("https://tokenhub.tencentmaas.com/v1")
+        );
+    }
+
+    #[test]
+    fn runtime_provider_config_lookup_supports_delegation_aliases() {
+        use futures::stream::BoxStream;
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let mut runtime_providers = HashMap::new();
+        runtime_providers.insert(
+            "kimi-coding".to_string(),
+            RuntimeProviderConfig {
+                api_key: Some("kimi-config-key".to_string()),
+                base_url: Some("https://api.moonshot.ai/v1".to_string()),
+                request_timeout_seconds: Some(41.0),
+                ..RuntimeProviderConfig::default()
+            },
+        );
+        runtime_providers.insert(
+            "zai".to_string(),
+            RuntimeProviderConfig {
+                api_key_env: Some("ZAI_CONFIG_KEY".to_string()),
+                base_url: Some("https://api.z.ai/api/paas/v4".to_string()),
+                ..RuntimeProviderConfig::default()
+            },
+        );
+
+        let agent = AgentLoop::new(
+            AgentConfig {
+                runtime_providers,
+                ..AgentConfig::default()
+            },
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+
+        assert_eq!(
+            agent.resolve_runtime_api_key("kimi", None, None).as_deref(),
+            Some("kimi-config-key")
+        );
+        assert_eq!(
+            agent.resolve_runtime_base_url("moonshot", None).as_deref(),
+            Some("https://api.moonshot.ai/v1")
+        );
+        assert_eq!(
+            agent.resolve_runtime_request_timeout_seconds("kimi"),
+            Some(41.0)
+        );
+        assert_eq!(
+            agent.resolve_runtime_base_url("z-ai", None).as_deref(),
+            Some("https://api.z.ai/api/paas/v4")
         );
     }
 

--- a/crates/hermes-agent/src/sub_agent_orchestrator.rs
+++ b/crates/hermes-agent/src/sub_agent_orchestrator.rs
@@ -32,6 +32,7 @@ use serde_json::json;
 use tokio::time::timeout;
 
 use crate::agent_loop::{AgentConfig, AgentLoop, ToolRegistry};
+use crate::credential_pool::CredentialPool;
 use crate::interrupt::InterruptController;
 
 /// Boxed `Send` future type alias used to short-circuit async-recursion
@@ -62,6 +63,8 @@ pub struct SubAgentLineage {
     pub toolset: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     pub depth: u32,
     pub max_depth: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -116,6 +119,7 @@ pub struct SubAgentOrchestratorConfig {
     pub parent_config: AgentConfig,
     pub tool_registry: Arc<ToolRegistry>,
     pub llm_provider: Arc<dyn LlmProvider>,
+    pub parent_credential_pool: Option<Arc<CredentialPool>>,
     pub parent_interrupt: InterruptController,
     pub hermes_home: PathBuf,
     pub parent_session_id: Option<String>,
@@ -143,6 +147,7 @@ impl SubAgentOrchestrator {
                 parent_config: parent.config.clone(),
                 tool_registry: parent.tool_registry.clone(),
                 llm_provider: parent.llm_provider.clone(),
+                parent_credential_pool: parent.primary_credential_pool.clone(),
                 parent_interrupt: parent.interrupt.clone(),
                 hermes_home,
                 parent_session_id: parent.config.session_id.clone(),
@@ -179,7 +184,10 @@ impl SubAgentOrchestrator {
             task: req.task.clone(),
             context: req.context.clone(),
             toolset: req.toolset.clone(),
-            model: req.model.clone(),
+            model: clean_config_string(req.model.as_deref())
+                .or_else(|| clean_config_string(self.cfg.parent_config.delegation_model.as_deref()))
+                .map(str::to_string),
+            provider: self.effective_delegation_provider(),
             depth: req.child_depth,
             max_depth: req.max_depth,
             parent_budget_remaining_usd: req.parent_budget_remaining_usd,
@@ -282,9 +290,9 @@ impl SubAgentOrchestrator {
         });
 
         let child_config = self.build_child_config(req, sub_agent_id);
+        let child_provider = self.child_llm_provider(&child_config)?;
         let child_interrupt_for_spawn = child_interrupt.clone();
         let tool_registry = self.cfg.tool_registry.clone();
-        let llm_provider = self.cfg.llm_provider.clone();
         let child_depth = req.child_depth;
         let inherited_tools = if req.toolset.is_none() && !req.inherited_tool_schemas.is_empty() {
             Some(req.inherited_tool_schemas.clone())
@@ -303,7 +311,7 @@ impl SubAgentOrchestrator {
             let child_agent = AgentLoop::with_interrupt(
                 child_config,
                 tool_registry,
-                llm_provider,
+                child_provider,
                 child_interrupt_for_spawn,
             )
             .with_delegate_depth(child_depth);
@@ -360,12 +368,23 @@ impl SubAgentOrchestrator {
         // Children should not re-spawn grandchildren beyond the contract;
         // depth checks inside AgentLoop::execute_tool_calls still apply.
         child.skip_memory = true;
-        // Apply explicit model override if the caller requested one.
-        if let Some(model) = req.model.as_ref() {
-            if !model.is_empty() {
-                child.model = model.clone();
-            }
+
+        let requested_model = clean_config_string(req.model.as_deref())
+            .map(str::to_string)
+            .or_else(|| {
+                clean_config_string(parent.delegation_model.as_deref()).map(str::to_string)
+            });
+        let runtime_provider = self.effective_delegation_provider();
+
+        if let Some(provider) = runtime_provider {
+            let model = requested_model.unwrap_or_else(|| model_part(parent.model.as_str()));
+            child.provider = Some(provider.clone());
+            child.model = format!("{provider}:{}", strip_provider_prefix(model.as_str()));
+        } else if let Some(model) = requested_model {
+            // Model-only override inherits the parent provider and credentials.
+            child.model = model;
         }
+
         // Budget: hard-cap child by parent remaining budget when known.
         if let Some(remaining) = req.parent_budget_remaining_usd {
             let cap = remaining.max(0.0);
@@ -375,6 +394,47 @@ impl SubAgentOrchestrator {
             });
         }
         child
+    }
+
+    fn effective_delegation_provider(&self) -> Option<String> {
+        let parent = &self.cfg.parent_config;
+        clean_config_string(parent.delegation_provider.as_deref())
+            .map(str::to_string)
+            .or_else(|| {
+                let has_direct_endpoint =
+                    clean_config_string(parent.delegation_base_url.as_deref()).is_some()
+                        || clean_config_string(parent.delegation_api_key.as_deref()).is_some();
+                has_direct_endpoint.then(|| "custom".to_string())
+            })
+    }
+
+    fn child_llm_provider(
+        &self,
+        child_config: &AgentConfig,
+    ) -> Result<Arc<dyn LlmProvider>, SubAgentError> {
+        let Some(provider) = self.effective_delegation_provider() else {
+            return Ok(self.cfg.llm_provider.clone());
+        };
+
+        let model_name = strip_provider_prefix(child_config.model.as_str()).to_string();
+        let mut resolver = AgentLoop::with_interrupt(
+            child_config.clone(),
+            self.cfg.tool_registry.clone(),
+            self.cfg.llm_provider.clone(),
+            InterruptController::new(),
+        );
+        if let Some(pool) = self.cfg.parent_credential_pool.as_ref() {
+            resolver = resolver.with_primary_credential_pool(pool.clone());
+        }
+
+        resolver
+            .build_delegation_runtime_provider(
+                provider.as_str(),
+                model_name.as_str(),
+                clean_config_string(child_config.delegation_base_url.as_deref()),
+                clean_config_string(child_config.delegation_api_key.as_deref()),
+            )
+            .map_err(SubAgentError::Agent)
     }
 
     async fn persist_lineage(&self, lineage: &SubAgentLineage) {
@@ -412,6 +472,22 @@ impl std::fmt::Display for SubAgentError {
             SubAgentError::Agent(e) => write!(f, "sub-agent error: {}", e),
         }
     }
+}
+
+fn clean_config_string(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+fn strip_provider_prefix(model: &str) -> &str {
+    model
+        .split_once(':')
+        .map(|(_, model)| model.trim())
+        .filter(|model| !model.is_empty())
+        .unwrap_or_else(|| model.trim())
+}
+
+fn model_part(model: &str) -> String {
+    strip_provider_prefix(model).to_string()
 }
 
 fn initial_messages(task: &str, context: Option<&str>) -> Vec<Message> {
@@ -528,6 +604,7 @@ mod tests {
             llm_provider: Arc::new(RecordingProvider {
                 seen_tools: seen_tools.clone(),
             }),
+            parent_credential_pool: None,
             parent_interrupt: InterruptController::new(),
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("parent".into()),
@@ -599,6 +676,7 @@ mod tests {
             parent_config: parent_cfg,
             tool_registry: Arc::new(ToolRegistry::new()),
             llm_provider: Arc::new(SlowProvider),
+            parent_credential_pool: None,
             parent_interrupt: InterruptController::new(),
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("parent".into()),
@@ -639,6 +717,7 @@ mod tests {
             parent_config: AgentConfig::default(),
             tool_registry: Arc::new(ToolRegistry::new()),
             llm_provider: Arc::new(NoopProvider),
+            parent_credential_pool: None,
             parent_interrupt: parent_ctrl,
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: None,
@@ -673,6 +752,7 @@ mod tests {
             parent_config: parent,
             tool_registry: Arc::new(ToolRegistry::new()),
             llm_provider: Arc::new(NoopProvider),
+            parent_credential_pool: None,
             parent_interrupt: InterruptController::new(),
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("root".into()),
@@ -698,5 +778,162 @@ mod tests {
         assert_eq!(child.memory_nudge_interval, 0);
         assert_eq!(child.skill_creation_nudge_interval, 0);
         assert!(child.quiet_mode);
+    }
+
+    #[test]
+    fn build_child_config_model_only_override_inherits_parent_provider() {
+        let inherited_provider: Arc<dyn LlmProvider> = Arc::new(NoopProvider);
+        let parent = AgentConfig {
+            max_turns: 20,
+            model: "nous:hermes-3".into(),
+            provider: Some("nous".into()),
+            delegation_model: Some("google/gemini-3-flash-preview".into()),
+            ..AgentConfig::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = SubAgentOrchestrator::new(SubAgentOrchestratorConfig {
+            parent_config: parent,
+            tool_registry: Arc::new(ToolRegistry::new()),
+            llm_provider: inherited_provider.clone(),
+            parent_credential_pool: None,
+            parent_interrupt: InterruptController::new(),
+            hermes_home: tmp.path().to_path_buf(),
+            parent_session_id: Some("root".into()),
+            timeout: Duration::from_secs(1),
+        });
+
+        let child = orch.build_child_config(
+            &SubAgentRequest {
+                task: "t".into(),
+                child_depth: 1,
+                max_depth: 4,
+                ..Default::default()
+            },
+            "subagent-model-only",
+        );
+        let child_provider = orch
+            .child_llm_provider(&child)
+            .expect("model-only delegation inherits provider");
+
+        assert_eq!(child.model, "google/gemini-3-flash-preview");
+        assert_eq!(child.provider.as_deref(), Some("nous"));
+        assert!(Arc::ptr_eq(&child_provider, &inherited_provider));
+    }
+
+    #[test]
+    fn build_child_config_provider_override_prefixes_child_model() {
+        let parent = AgentConfig {
+            max_turns: 20,
+            model: "nous:hermes-3".into(),
+            provider: Some("nous".into()),
+            delegation_model: Some("google/gemini-3-flash-preview".into()),
+            delegation_provider: Some("openrouter".into()),
+            ..AgentConfig::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = SubAgentOrchestrator::new(SubAgentOrchestratorConfig {
+            parent_config: parent,
+            tool_registry: Arc::new(ToolRegistry::new()),
+            llm_provider: Arc::new(NoopProvider),
+            parent_credential_pool: None,
+            parent_interrupt: InterruptController::new(),
+            hermes_home: tmp.path().to_path_buf(),
+            parent_session_id: Some("root".into()),
+            timeout: Duration::from_secs(1),
+        });
+
+        let child = orch.build_child_config(
+            &SubAgentRequest {
+                task: "t".into(),
+                child_depth: 1,
+                max_depth: 4,
+                ..Default::default()
+            },
+            "subagent-provider",
+        );
+
+        assert_eq!(child.provider.as_deref(), Some("openrouter"));
+        assert_eq!(child.model, "openrouter:google/gemini-3-flash-preview");
+    }
+
+    #[test]
+    fn direct_endpoint_override_builds_distinct_child_provider() {
+        let inherited_provider: Arc<dyn LlmProvider> = Arc::new(NoopProvider);
+        let parent = AgentConfig {
+            max_turns: 20,
+            model: "nous:hermes-3".into(),
+            provider: Some("nous".into()),
+            delegation_model: Some("qwen2.5-coder".into()),
+            delegation_base_url: Some("http://127.0.0.1:1234/v1".into()),
+            delegation_api_key: Some("local-key".into()),
+            ..AgentConfig::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = SubAgentOrchestrator::new(SubAgentOrchestratorConfig {
+            parent_config: parent,
+            tool_registry: Arc::new(ToolRegistry::new()),
+            llm_provider: inherited_provider.clone(),
+            parent_credential_pool: None,
+            parent_interrupt: InterruptController::new(),
+            hermes_home: tmp.path().to_path_buf(),
+            parent_session_id: Some("root".into()),
+            timeout: Duration::from_secs(1),
+        });
+
+        let child = orch.build_child_config(
+            &SubAgentRequest {
+                task: "t".into(),
+                child_depth: 1,
+                max_depth: 4,
+                ..Default::default()
+            },
+            "subagent-direct",
+        );
+        let child_provider = orch
+            .child_llm_provider(&child)
+            .expect("direct endpoint delegation builds provider");
+
+        assert_eq!(child.provider.as_deref(), Some("custom"));
+        assert_eq!(child.model, "custom:qwen2.5-coder");
+        assert!(!Arc::ptr_eq(&child_provider, &inherited_provider));
+    }
+
+    #[tokio::test]
+    async fn unresolved_delegation_provider_returns_structured_error() {
+        let parent = AgentConfig {
+            max_turns: 2,
+            model: "nous:hermes-3".into(),
+            provider: Some("nous".into()),
+            delegation_model: Some("some-model".into()),
+            delegation_provider: Some("definitely-missing-provider".into()),
+            ..AgentConfig::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = Arc::new(SubAgentOrchestrator::new(SubAgentOrchestratorConfig {
+            parent_config: parent,
+            tool_registry: Arc::new(ToolRegistry::new()),
+            llm_provider: Arc::new(NoopProvider),
+            parent_credential_pool: None,
+            parent_interrupt: InterruptController::new(),
+            hermes_home: tmp.path().to_path_buf(),
+            parent_session_id: Some("root".into()),
+            timeout: Duration::from_secs(1),
+        }));
+
+        let out = orch
+            .execute(SubAgentRequest {
+                task: "t".into(),
+                child_depth: 1,
+                max_depth: 4,
+                ..Default::default()
+            })
+            .await;
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(parsed["status"], "failed");
+        assert!(parsed["error"]
+            .as_str()
+            .unwrap()
+            .contains("definitely-missing-provider"));
     }
 }

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4569,6 +4569,28 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_maps_delegation_provider_model_runtime_overrides() {
+        let mut cfg = GatewayConfig::default();
+        cfg.delegation.model = Some(" google/gemini-3-flash-preview ".to_string());
+        cfg.delegation.provider = Some(" openrouter ".to_string());
+        cfg.delegation.base_url = Some(" http://localhost:1234/v1 ".to_string());
+        cfg.delegation.api_key = Some(" local-key ".to_string());
+
+        let agent_cfg = build_agent_config(&cfg, "nous:hermes-3");
+
+        assert_eq!(
+            agent_cfg.delegation_model.as_deref(),
+            Some("google/gemini-3-flash-preview")
+        );
+        assert_eq!(agent_cfg.delegation_provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            agent_cfg.delegation_base_url.as_deref(),
+            Some("http://localhost:1234/v1")
+        );
+        assert_eq!(agent_cfg.delegation_api_key.as_deref(), Some("local-key"));
+    }
+
+    #[test]
     fn explore_first_defaults_do_not_shadow_configured_delegation_depth() {
         let _guard = env_test_lock();
         let keys = [
@@ -6101,6 +6123,34 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         provider: Some(resolved_provider),
         stream: config.streaming.enabled,
         max_delegate_depth,
+        delegation_model: config
+            .delegation
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        delegation_provider: config
+            .delegation
+            .provider
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        delegation_base_url: config
+            .delegation
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        delegation_api_key: config
+            .delegation
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
         skip_memory,
         skip_context_files,
         platform: Some("cli".to_string()),

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -205,6 +205,20 @@ pub struct DelegationConfig {
     /// Maximum sub-agent spawn depth. Values below 1 are floored by runtime consumers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_spawn_depth: Option<u32>,
+    /// Optional model override for child agents. When set without a provider,
+    /// children keep the parent's provider/credentials and only switch model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Optional provider override for child agents. Runtime consumers resolve
+    /// the provider's full credential bundle before spawning the child.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Optional direct endpoint override for delegated child agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Optional direct API key override for delegated child agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1504,6 +1518,35 @@ delegation:
         let json = serde_json::to_string(&cfg).unwrap();
         let back: GatewayConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.delegation.max_spawn_depth, Some(99));
+    }
+
+    #[test]
+    fn delegation_config_accepts_provider_model_and_direct_endpoint() {
+        let cfg: GatewayConfig = serde_yaml::from_str(
+            r#"
+delegation:
+  model: google/gemini-3-flash-preview
+  provider: openrouter
+  base_url: http://localhost:1234/v1
+  api_key: local-key
+"#,
+        )
+        .expect("delegation provider/model config should deserialize");
+
+        assert_eq!(
+            cfg.delegation.model.as_deref(),
+            Some("google/gemini-3-flash-preview")
+        );
+        assert_eq!(cfg.delegation.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            cfg.delegation.base_url.as_deref(),
+            Some("http://localhost:1234/v1")
+        );
+        assert_eq!(cfg.delegation.api_key.as_deref(), Some("local-key"));
+
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: GatewayConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.delegation, cfg.delegation);
     }
 
     #[test]

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -569,7 +569,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -782,6 +782,25 @@ fn apply_user_config_patch_dotted(
                 ))
             })?);
         }
+        ["delegation", "model"] => {
+            config.delegation.model = Some(value.to_string());
+        }
+        ["delegation", "provider"] => {
+            config.delegation.provider = Some(value.to_string());
+        }
+        ["delegation", "base_url"] => {
+            config.delegation.base_url = Some(value.to_string());
+        }
+        ["delegation", "api_key"] => {
+            config.delegation.api_key = Some(value.to_string());
+        }
+        ["delegation", "max_spawn_depth"] => {
+            config.delegation.max_spawn_depth = Some(value.parse().map_err(|_| {
+                ConfigError::ValidationError(format!(
+                    "delegation.max_spawn_depth must be a non-negative integer: {value}"
+                ))
+            })?);
+        }
         ["auxiliary", task, field] => {
             let entry = config
                 .auxiliary
@@ -981,6 +1000,39 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
         ["agent", "api_max_retries"] | ["agent", "apiMaxRetries"] => Ok(config
             .agent
             .api_max_retries
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["delegation", "model"] => Ok(config
+            .delegation
+            .model
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["delegation", "provider"] => Ok(config
+            .delegation
+            .provider
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["delegation", "base_url"] => Ok(config
+            .delegation
+            .base_url
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["delegation", "api_key"] => Ok(config
+            .delegation
+            .api_key
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(mask_secret)
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["delegation", "max_spawn_depth"] => Ok(config
+            .delegation
+            .max_spawn_depth
             .map(|value| value.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
         ["llm", provider, "api_key"] => Ok(
@@ -2028,6 +2080,14 @@ pub fn validate_config(config: &GatewayConfig) -> Result<(), ConfigError> {
         }
     }
 
+    if let Some(api_key) = &config.delegation.api_key {
+        if api_key.trim().is_empty() {
+            return Err(ConfigError::ValidationError(
+                "delegation.api_key must not be empty".into(),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -2903,6 +2963,50 @@ llm_providers:
             "7"
         );
         assert!(apply_user_config_patch(&mut c, "agent.api_max_retries", "nope").is_err());
+    }
+
+    #[test]
+    fn apply_patch_dotted_delegation_provider_model_runtime_values() {
+        let mut c = GatewayConfig::default();
+
+        apply_user_config_patch(&mut c, "delegation.model", "google/gemini-3-flash-preview")
+            .unwrap();
+        apply_user_config_patch(&mut c, "delegation.provider", "openrouter").unwrap();
+        apply_user_config_patch(&mut c, "delegation.base_url", "http://localhost:1234/v1").unwrap();
+        apply_user_config_patch(&mut c, "delegation.api_key", "local-key").unwrap();
+        apply_user_config_patch(&mut c, "delegation.max_spawn_depth", "9").unwrap();
+
+        assert_eq!(
+            c.delegation.model.as_deref(),
+            Some("google/gemini-3-flash-preview")
+        );
+        assert_eq!(c.delegation.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            c.delegation.base_url.as_deref(),
+            Some("http://localhost:1234/v1")
+        );
+        assert_eq!(c.delegation.api_key.as_deref(), Some("local-key"));
+        assert_eq!(c.delegation.max_spawn_depth, Some(9));
+        assert_eq!(
+            user_config_field_display(&c, "delegation.model").unwrap(),
+            "google/gemini-3-flash-preview"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "delegation.provider").unwrap(),
+            "openrouter"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "delegation.base_url").unwrap(),
+            "http://localhost:1234/v1"
+        );
+        assert!(user_config_field_display(&c, "delegation.api_key")
+            .unwrap()
+            .starts_with("***"));
+        assert_eq!(
+            user_config_field_display(&c, "delegation.max_spawn_depth").unwrap(),
+            "9"
+        );
+        assert!(apply_user_config_patch(&mut c, "delegation.max_spawn_depth", "deep").is_err());
     }
 
     #[test]

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -709,6 +709,34 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         hermes_home: config.home_dir.clone(),
         provider: provider_from_model,
         stream: config.streaming.enabled,
+        delegation_model: config
+            .delegation
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        delegation_provider: config
+            .delegation
+            .provider
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        delegation_base_url: config
+            .delegation
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        delegation_api_key: config
+            .delegation
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
         skip_context_files: config.agent.skip_context_files || skip_context_files_env,
         platform: Some("http".to_string()),
         pass_session_id: true,
@@ -975,6 +1003,34 @@ mod tests {
                 .get("openai")
                 .and_then(|cfg| cfg.request_timeout_seconds),
             Some(45.5)
+        );
+    }
+
+    #[test]
+    fn build_agent_config_maps_delegation_provider_model_runtime_overrides() {
+        let mut config = GatewayConfig::default();
+        config.delegation.model = Some(" meta-llama/llama-4-scout ".to_string());
+        config.delegation.provider = Some(" openrouter ".to_string());
+        config.delegation.base_url = Some(" https://openrouter.ai/api/v1 ".to_string());
+        config.delegation.api_key = Some(" sk-or-test ".to_string());
+
+        let agent_config = build_agent_config(&config, "nous:hermes-3");
+
+        assert_eq!(
+            agent_config.delegation_model.as_deref(),
+            Some("meta-llama/llama-4-scout")
+        );
+        assert_eq!(
+            agent_config.delegation_provider.as_deref(),
+            Some("openrouter")
+        );
+        assert_eq!(
+            agent_config.delegation_base_url.as_deref(),
+            Some("https://openrouter.ai/api/v1")
+        );
+        assert_eq!(
+            agent_config.delegation_api_key.as_deref(),
+            Some("sk-or-test")
         );
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -952,6 +952,10 @@
       "disposition": "ported",
       "notes": "Rust delegation depth now has a first-class AgentConfig max_delegate_depth plus delegation.max_spawn_depth config bridge with floor 1 and no legacy ceiling; env/config values above the old cap pass through with agent, CLI, config, and backend tests."
     },
+    "9423fda5cb57": {
+      "disposition": "ported",
+      "notes": "Rust delegation config now accepts delegation.model/provider plus documented direct endpoint fields, exposes them through config set/get, propagates them through CLI/HTTP AgentConfig construction, and makes subagents either inherit the parent provider for model-only overrides or build an independent provider for provider/base_url/api_key overrides with structured credential errors."
+    },
     "f1fe29d1c368": {
       "disposition": "ported",
       "notes": "Rust provider config now accepts llm.<provider>.request_timeout_seconds, validates and exposes it through config set/get, propagates it into AgentConfig RuntimeProviderConfig, and applies it to OpenAI-compatible, Codex Responses, Anthropic, OpenRouter, extra provider, fallback/runtime-routing, and client rebuild paths with targeted tests."


### PR DESCRIPTION
## Summary
- add first-class Rust config for `delegation.model`, `delegation.provider`, and documented direct endpoint overrides
- propagate delegation runtime overrides through CLI and HTTP `AgentConfig` construction
- make subagents inherit parent credentials for model-only overrides and build independent providers for provider/base_url/api_key overrides, with structured credential errors

## Verification
- `cargo fmt --all --check`
- `cargo test -p hermes-config delegation -- --nocapture`
- `cargo test -p hermes-config apply_patch_dotted_delegation -- --nocapture`
- `cargo test -p hermes-agent runtime_provider_config_lookup_supports_delegation_aliases -- --nocapture`
- `cargo test -p hermes-agent delegation -- --nocapture`
- `cargo test -p hermes-agent build_child_config -- --nocapture`
- `cargo test -p hermes-agent direct_endpoint_override -- --nocapture`
- `cargo test -p hermes-cli delegation_provider_model -- --nocapture`
- `cargo test -p hermes-http delegation_provider_model -- --nocapture`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-agent -p hermes-config -p hermes-cli -p hermes-http`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-config -p hermes-cli -p hermes-http` (`seen=199 allowlist=204 new=0 stale=5`)
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --out-json /Volumes/wd_black/hermes-agent-ultra/delegation-provider-model-queue.json --out-md /Volumes/wd_black/hermes-agent-ultra/delegation-provider-model-queue.md`
