### PR TITLE
parity(minimax): default auxiliary models to M3

### DIFF
--- a/crates/hermes-agent/src/auxiliary_builder.rs
+++ b/crates/hermes-agent/src/auxiliary_builder.rs
@@ -28,7 +28,7 @@ mod default_models {
     pub const OPENAI: &str = "gpt-4o-mini";
     pub const ZAI: &str = "glm-4.5-flash";
     pub const KIMI: &str = "kimi-k2-turbo-preview";
-    pub const MINIMAX: &str = "MiniMax-M2.7";
+    pub const MINIMAX: &str = "MiniMax-M3";
     pub const GEMINI: &str = "gemini-3.5-flash";
     pub const GMI: &str = "google/gemini-3.1-flash-lite-preview";
     pub const TENCENT_TOKENHUB: &str = "hy3-preview";
@@ -44,6 +44,8 @@ mod default_base_urls {
     pub const GMI: &str = "https://api.gmi-serving.com/v1";
     pub const HUGGINGFACE: &str = "https://router.huggingface.co/v1";
     pub const ZAI: &str = "https://api.z.ai/api/paas/v4";
+    pub const MINIMAX: &str = "https://api.minimax.io/v1";
+    pub const MINIMAX_CN: &str = "https://api.minimaxi.com/v1";
     pub const NOVITA: &str = "https://api.novita.ai/openai/v1";
     pub const NVIDIA: &str = "https://integrate.api.nvidia.com/v1";
     pub const ARCEE: &str = "https://api.arcee.ai/api/v1";
@@ -252,7 +254,16 @@ pub fn build_auxiliary_client_with_main_runtime(
         &mut summary,
         "MINIMAX_API_KEY",
         "minimax",
-        "https://api.minimax.io/v1",
+        default_base_urls::MINIMAX,
+        default_models::MINIMAX,
+        main_label.as_deref(),
+    );
+    register_direct_key(
+        &mut builder,
+        &mut summary,
+        "MINIMAX_CN_API_KEY",
+        "minimax-cn",
+        default_base_urls::MINIMAX_CN,
         default_models::MINIMAX,
         main_label.as_deref(),
     );
@@ -470,7 +481,8 @@ fn provider_api_key_from_env(label: &str) -> Option<String> {
             "MOONSHOT_API_KEY",
             "KIMI_CN_API_KEY",
         ],
-        "minimax" => &["MINIMAX_API_KEY", "MINIMAX_CN_API_KEY"],
+        "minimax" => &["MINIMAX_API_KEY"],
+        "minimax-cn" => &["MINIMAX_CN_API_KEY", "MINIMAX_API_KEY"],
         "copilot" | "copilot-acp" => &["GITHUB_COPILOT_TOKEN", "COPILOT_GITHUB_TOKEN"],
         "deepseek" => &["DEEPSEEK_API_KEY"],
         "gemini" | "google" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
@@ -513,6 +525,8 @@ fn default_base_url(label: &str) -> Option<&'static str> {
         "tencent-tokenhub" => Some(default_base_urls::TENCENT_TOKENHUB),
         "huggingface" => Some(default_base_urls::HUGGINGFACE),
         "zai" => Some(default_base_urls::ZAI),
+        "minimax" => Some(default_base_urls::MINIMAX),
+        "minimax-cn" => Some(default_base_urls::MINIMAX_CN),
         "novita" => Some(default_base_urls::NOVITA),
         "nvidia" => Some(default_base_urls::NVIDIA),
         "arcee" => Some(default_base_urls::ARCEE),
@@ -742,7 +756,41 @@ mod tests {
         }
         std::env::remove_var("GEMINI_API_KEY");
 
-        // Scenario 7: full chain, deterministic order.
+        // Scenario 7: MiniMax direct API defaults to M3 and avoids highspeed.
+        std::env::set_var("MINIMAX_API_KEY", "sk-minimax");
+        {
+            let (client, summary) = build_default_auxiliary_client(AuxiliaryConfig::default());
+            assert_eq!(client.chain_labels(), vec!["minimax"]);
+            assert_eq!(
+                client.chain_entries(),
+                vec![("minimax".to_string(), "MiniMax-M3".to_string(), true,)]
+            );
+            assert_eq!(summary.registered, vec!["minimax"]);
+            assert!(!client.chain_entries()[0]
+                .1
+                .to_ascii_lowercase()
+                .contains("highspeed"));
+        }
+        std::env::remove_var("MINIMAX_API_KEY");
+
+        // Scenario 8: MiniMax CN is a first-class direct-key auxiliary provider.
+        std::env::set_var("MINIMAX_CN_API_KEY", "sk-minimax-cn");
+        {
+            let (client, summary) = build_default_auxiliary_client(AuxiliaryConfig::default());
+            assert_eq!(client.chain_labels(), vec!["minimax-cn"]);
+            assert_eq!(
+                client.chain_entries(),
+                vec![("minimax-cn".to_string(), "MiniMax-M3".to_string(), true,)]
+            );
+            assert_eq!(summary.registered, vec!["minimax-cn"]);
+            assert!(!client.chain_entries()[0]
+                .1
+                .to_ascii_lowercase()
+                .contains("highspeed"));
+        }
+        std::env::remove_var("MINIMAX_CN_API_KEY");
+
+        // Scenario 9: full chain, deterministic order.
         std::env::set_var("OPENROUTER_API_KEY", "sk-or");
         std::env::set_var("HERMES_OPENAI_API_KEY", "sk-hermes-oa");
         std::env::set_var("OPENAI_API_KEY", "sk-oa-legacy");

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -10090,12 +10090,12 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
     },
     SetupModelOption {
         provider: "minimax",
-        model: "minimax:MiniMax-M2.7",
+        model: "minimax:MiniMax-M3",
         label: "MiniMax",
     },
     SetupModelOption {
         provider: "minimax-cn",
-        model: "minimax-cn:MiniMax-M2.7",
+        model: "minimax-cn:MiniMax-M3",
         label: "MiniMax China",
     },
     SetupModelOption {
@@ -15652,6 +15652,24 @@ mod tests {
             );
         }
         assert!(seen.contains("nous"));
+    }
+
+    #[test]
+    fn setup_minimax_defaults_use_m3_frontier_model() {
+        let providers = setup_provider_defaults();
+        let minimax = providers
+            .iter()
+            .find(|option| option.provider == "minimax")
+            .expect("minimax setup option");
+        let minimax_cn = providers
+            .iter()
+            .find(|option| option.provider == "minimax-cn")
+            .expect("minimax-cn setup option");
+
+        assert_eq!(minimax.model, "minimax:MiniMax-M3");
+        assert_eq!(minimax_cn.model, "minimax-cn:MiniMax-M3");
+        assert!(!minimax.model.to_ascii_lowercase().contains("highspeed"));
+        assert!(!minimax_cn.model.to_ascii_lowercase().contains("highspeed"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -254,6 +254,8 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
     ),
     ("tencent-tokenhub", &["hy3-preview"]),
     ("zai", &["glm-5.1", "glm-5.0", "glm-4.5-flash"]),
+    ("minimax", &["MiniMax-M3", "MiniMax-M2.7"]),
+    ("minimax-cn", &["MiniMax-M3", "MiniMax-M2.7"]),
     (
         "gemini",
         &[
@@ -1277,6 +1279,22 @@ mod tests {
         assert!(provider_curated_models("arcee-ai").contains(&"trinity-mini"));
         assert!(provider_curated_models("mimo").contains(&"mimo-v2.5-pro"));
         assert!(provider_curated_models("tokenhub").contains(&"hy3-preview"));
+        assert_eq!(provider_curated_models("minimax")[0], "MiniMax-M3");
+        assert_eq!(provider_curated_models("minimax-cn")[0], "MiniMax-M3");
+    }
+
+    #[test]
+    fn minimax_picker_defaults_merge_models_dev_with_m3_fallback() {
+        assert!(is_models_dev_preferred_provider("minimax"));
+        assert!(is_models_dev_preferred_provider("minimax-cn"));
+        for provider in ["minimax", "minimax-cn"] {
+            let models = provider_curated_models(provider);
+            assert!(models.contains(&"MiniMax-M3"));
+            assert!(models.contains(&"MiniMax-M2.7"));
+            assert!(!models
+                .iter()
+                .any(|model| model.to_ascii_lowercase().contains("highspeed")));
+        }
     }
 
     #[test]

--- a/crates/hermes-core/src/providers.rs
+++ b/crates/hermes-core/src/providers.rs
@@ -69,6 +69,8 @@ pub const MODELS_DEV_MERGED_PROVIDERS: &[&str] = &[
     "nvidia",
     "huggingface",
     "zai",
+    "minimax",
+    "minimax-cn",
     "gemini",
     "google",
 ];

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -963,6 +963,10 @@
     "38695254f851": {
       "disposition": "ported",
       "notes": "Rust session persistence now exposes FTS index counting and optimize_fts maintenance, VACUUM runs FTS optimization before reclaiming pages, and top-level `hermes sessions optimize` reports FTS index count plus before/after sessions.db size with Rust unit/e2e coverage."
+    },
+    "3d1d0a49fe90": {
+      "disposition": "ported",
+      "notes": "Rust MiniMax direct auxiliary defaults now use MiniMax-M3 for minimax and minimax-cn, MiniMax CN registers as a first-class auxiliary direct-key provider, setup defaults and curated picker fallbacks expose MiniMax-M3 first, and regression tests guard against stale/highspeed defaults."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- default Rust MiniMax auxiliary direct-key routing to `MiniMax-M3` for `minimax` and `minimax-cn`
- register `MINIMAX_CN_API_KEY` as a first-class `minimax-cn` auxiliary provider instead of leaving CN only as incidental env plumbing
- update setup defaults and model picker fallbacks to expose `MiniMax-M3` first while keeping `MiniMax-M2.7` as non-highspeed fallback
- mark upstream `3d1d0a49fe90` as ported in the parity queue override

## Verification
- `cargo test -p hermes-agent build_default_auxiliary_client_scenarios -- --nocapture` (1 passed)
- `cargo test -p hermes-cli setup_minimax_defaults_use_m3_frontier_model -- --nocapture` (1 passed)
- `cargo test -p hermes-cli minimax_picker_defaults_merge_models_dev_with_m3_fallback -- --nocapture` (1 passed)
- `cargo test -p hermes-core provider_capability_registry_marks_models_dev_merged_providers -- --nocapture` (1 passed)
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-agent -p hermes-cli -p hermes-core`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-cli -p hermes-core` (`seen=199 allowlist=204 new=0 stale=5`)
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --out-json /Volumes/wd_black/hermes-agent-ultra/minimax-m3-aux-default-queue.json --out-md /Volumes/wd_black/hermes-agent-ultra/minimax-m3-aux-default-queue.md` (`pending=1941`, `ported=108`; `3d1d0a49fe90...` => `sha_override`/`ported`)

## Build Artifact Routing
- Cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0`
- `/private/tmp/hermes-agent-ultra-target-delegation` remained `0B`
