### PR TITLE
parity(cli): make portal onboarding the default alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ hermes-ultra setup --portal
 That starts Nous OAuth setup, sets Nous as the provider, and enables Tool Gateway routing. Inspect the current state with:
 
 ```bash
-hermes-ultra portal status
+hermes-ultra portal info
 ```
 
 You can still bring your own keys for individual tools; gateway routing is per backend, not all-or-nothing.

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -819,6 +819,7 @@ impl App {
     fn auth_error_requires_nous_login(err: &AgentError) -> bool {
         let text = err.to_string().to_ascii_lowercase();
         text.contains("not logged into nous portal")
+            || text.contains("run `hermes portal`")
             || text.contains("re-run `hermes auth nous`")
             || text.contains("stored nous auth state is invalid")
             || text.contains("missing refresh token")
@@ -5818,9 +5819,13 @@ mod tests {
     #[test]
     fn test_auth_error_requires_nous_login_detects_missing_login_shape() {
         let err = AgentError::AuthFailed(
-            "Hermes is not logged into Nous Portal. Run `hermes auth nous`.".to_string(),
+            "Hermes is not logged into Nous Portal. Run `hermes portal`.".to_string(),
         );
         assert!(App::auth_error_requires_nous_login(&err));
+        let legacy = AgentError::AuthFailed(
+            "Stored Nous auth state is invalid; re-run `hermes auth nous`.".to_string(),
+        );
+        assert!(App::auth_error_requires_nous_login(&legacy));
         let unrelated = AgentError::AuthFailed("rate limited".to_string());
         assert!(!App::auth_error_requires_nous_login(&unrelated));
     }

--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -1261,14 +1261,14 @@ pub async fn resolve_nous_runtime_credentials(
     let mut state = if let Some(raw_state) = read_provider_auth_state("nous")? {
         parse_nous_oauth_state(raw_state).ok_or_else(|| {
             AgentError::AuthFailed(
-                "Stored Nous auth state is invalid; re-run `hermes auth nous`.".into(),
+                "Stored Nous auth state is invalid; re-run `hermes portal`.".into(),
             )
         })?
     } else if let Some(imported) = discover_existing_nous_oauth()? {
         imported.state
     } else {
         return Err(AgentError::AuthFailed(
-            "Hermes is not logged into Nous Portal. Run `hermes auth nous`.".into(),
+            "Hermes is not logged into Nous Portal. Run `hermes portal`.".into(),
         ));
     };
 
@@ -1340,7 +1340,7 @@ pub async fn resolve_nous_runtime_credentials(
 
     let api_key = state.runtime_api_key().ok_or_else(|| {
         AgentError::AuthFailed(
-            "Failed to resolve a Nous runtime API key. Re-run `hermes auth nous`.".into(),
+            "Failed to resolve a Nous runtime API key. Re-run `hermes portal`.".into(),
         )
     })?;
     let expires_at = state

--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -103,11 +103,11 @@ pub enum CliCommand {
     /// Nous Portal OAuth setup and status.
     ///
     /// Examples:
-    ///   hermes portal          — show Nous Portal auth status
+    ///   hermes portal          — run Nous Portal device-code login
     ///   hermes portal setup    — run Nous Portal device-code login
-    ///   hermes portal status   — show Nous Portal auth status
+    ///   hermes portal info     — show Nous Portal auth status
     Portal {
-        /// Action: "setup", "login", or "status".
+        /// Action: "setup", "login", "info", or "status".
         action: Option<String>,
     },
 

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -7751,9 +7751,26 @@ async fn run_auth_verify(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PortalActionKind {
+    Setup,
+    Info,
+}
+
+fn portal_action_kind(action: Option<&str>) -> Result<PortalActionKind, AgentError> {
+    match action.map(str::trim).filter(|value| !value.is_empty()) {
+        None | Some("setup" | "login" | "auth") => Ok(PortalActionKind::Setup),
+        Some("info" | "status" | "check") => Ok(PortalActionKind::Info),
+        Some(other) => Err(AgentError::Config(format!(
+            "Unknown portal action '{}'. Use `hermes-ultra portal` for setup or `hermes-ultra portal info` for status.",
+            other
+        ))),
+    }
+}
+
 async fn run_portal(cli: Cli, action: Option<String>) -> Result<(), AgentError> {
-    match action.as_deref().unwrap_or("status") {
-        "setup" | "login" | "auth" => {
+    match portal_action_kind(action.as_deref())? {
+        PortalActionKind::Setup => {
             println!("Nous Portal setup ({DEFAULT_NOUS_PORTAL_URL})");
             run_auth(
                 cli,
@@ -7767,8 +7784,8 @@ async fn run_portal(cli: Cli, action: Option<String>) -> Result<(), AgentError> 
             )
             .await
         }
-        "status" | "check" => {
-            println!("Nous Portal status ({DEFAULT_NOUS_PORTAL_URL})");
+        PortalActionKind::Info => {
+            println!("Nous Portal info ({DEFAULT_NOUS_PORTAL_URL})");
             run_auth(
                 cli,
                 Some("status".to_string()),
@@ -7781,10 +7798,6 @@ async fn run_portal(cli: Cli, action: Option<String>) -> Result<(), AgentError> 
             )
             .await
         }
-        other => Err(AgentError::Config(format!(
-            "Unknown portal action '{}'. Use `hermes-ultra portal status` or `hermes-ultra portal setup`.",
-            other
-        ))),
     }
 }
 
@@ -14746,6 +14759,34 @@ mod tests {
             .await
             .expect_err("unknown portal actions must fail before auth side effects");
         assert!(err.to_string().contains("Unknown portal action 'bogus'"));
+        assert!(err.to_string().contains("hermes-ultra portal info"));
+    }
+
+    #[test]
+    fn portal_default_runs_setup_alias() {
+        for action in [
+            None,
+            Some(""),
+            Some("  "),
+            Some("setup"),
+            Some("login"),
+            Some("auth"),
+        ] {
+            assert_eq!(
+                portal_action_kind(action).expect("setup portal action"),
+                PortalActionKind::Setup
+            );
+        }
+    }
+
+    #[test]
+    fn portal_info_and_status_are_status_aliases() {
+        for action in [Some("info"), Some("status"), Some("check")] {
+            assert_eq!(
+                portal_action_kind(action).expect("info portal action"),
+                PortalActionKind::Info
+            );
+        }
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -967,6 +967,10 @@
     "3d1d0a49fe90": {
       "disposition": "ported",
       "notes": "Rust MiniMax direct auxiliary defaults now use MiniMax-M3 for minimax and minimax-cn, MiniMax CN registers as a first-class auxiliary direct-key provider, setup defaults and curated picker fallbacks expose MiniMax-M3 first, and regression tests guard against stale/highspeed defaults."
+    },
+    "da4f407e5173": {
+      "disposition": "ported",
+      "notes": "Rust `hermes portal` now defaults to Nous Portal onboarding/setup, `portal info/status/check` report status, CLI help/README/auth recovery guidance use the human-readable portal alias, and focused CLI tests cover the dispatch without OAuth side effects."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- make bare `hermes portal` run Nous Portal onboarding/setup instead of status
- add `portal info` as the human-readable status path while preserving `status`/`check` compatibility
- update CLI help, README, auth recovery copy, and parity queue override for upstream da4f407e5173

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli portal -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli auth_error_requires_nous_login -- --nocapture
- cargo fmt --all --check
- git diff --check
- jq empty docs/parity/queue-overrides.json
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-cli
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --out-json /Volumes/wd_black/hermes-agent-ultra/portal-onboarding-alias-queue.json --out-md /Volumes/wd_black/hermes-agent-ultra/portal-onboarding-alias-queue.md

Queue proof: pending=1940, ported=109.
Disk proof: /private/tmp/hermes-agent-ultra-target-delegation stayed 0B; Cargo target is on /Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation.