### PR TITLE
parity(nous): add versioned portal client tag

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -3132,7 +3132,10 @@ mod tests {
         });
         assert_eq!(
             nous_body["tags"],
-            serde_json::json!(["product=hermes-agent"])
+            serde_json::json!([
+                provider_profiles::NOUS_PRODUCT_TAG,
+                provider_profiles::hermes_client_tag()
+            ])
         );
         assert!(nous_body.get("reasoning").is_none());
 

--- a/crates/hermes-agent/src/provider_profiles.rs
+++ b/crates/hermes-agent/src/provider_profiles.rs
@@ -7,6 +7,7 @@
 use serde_json::{Map, Value};
 
 pub const NOUS_PRODUCT_TAG: &str = "product=hermes-agent";
+pub const NOUS_CLIENT_TAG_PREFIX: &str = "client=hermes-client-v";
 
 pub fn canonical_provider_profile_id(provider: &str) -> Option<&'static str> {
     let normalized = provider.trim().to_ascii_lowercase();
@@ -74,8 +75,15 @@ pub fn profile_base_url(profile: &str) -> Option<&'static str> {
     }
 }
 
+pub fn hermes_client_tag() -> String {
+    format!("{NOUS_CLIENT_TAG_PREFIX}{}", env!("CARGO_PKG_VERSION"))
+}
+
 pub fn nous_portal_tags() -> Value {
-    Value::Array(vec![Value::String(NOUS_PRODUCT_TAG.to_string())])
+    Value::Array(vec![
+        Value::String(NOUS_PRODUCT_TAG.to_string()),
+        Value::String(hermes_client_tag()),
+    ])
 }
 
 pub fn local_control_key_for_profile(profile: Option<&str>, key: &str) -> bool {
@@ -382,6 +390,27 @@ mod tests {
         assert!(profile_base_url("mimo").unwrap().contains("xiaomimimo.com"));
         assert!(supports_vision("xiaomi"));
         assert!(!supports_vision("kimi"));
+    }
+
+    #[test]
+    fn nous_portal_tags_include_product_and_versioned_client() {
+        assert_eq!(
+            hermes_client_tag(),
+            format!("{NOUS_CLIENT_TAG_PREFIX}{}", env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(
+            nous_portal_tags(),
+            serde_json::json!([NOUS_PRODUCT_TAG, hermes_client_tag()])
+        );
+        let mut mutated = nous_portal_tags();
+        mutated
+            .as_array_mut()
+            .expect("portal tags array")
+            .push(Value::String("caller=mutated".to_string()));
+        assert_eq!(
+            nous_portal_tags(),
+            serde_json::json!([NOUS_PRODUCT_TAG, hermes_client_tag()])
+        );
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -971,6 +971,10 @@
     "da4f407e5173": {
       "disposition": "ported",
       "notes": "Rust `hermes portal` now defaults to Nous Portal onboarding/setup, `portal info/status/check` report status, CLI help/README/auth recovery guidance use the human-readable portal alias, and focused CLI tests cover the dispatch without OAuth side effects."
+    },
+    "486b692ddd80": {
+      "disposition": "ported",
+      "notes": "Rust Nous provider request shaping now centralizes Portal attribution tags as product=hermes-agent plus client=hermes-client-v<workspace version>, and request-body tests prove the versioned tag is applied to actual Nous chat completion payloads."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add a centralized `client=hermes-client-v<version>` tag beside the existing Nous Portal product tag
- apply the canonical tag list through the existing Rust Nous provider request-profile path
- update request-body/helper tests and mark upstream 486b692ddd80 as ported

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent nous_portal_tags_include_product_and_versioned_client -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent test_provider_profile_request_body_openrouter_nous_and_custom_contracts -- --nocapture
- cargo fmt --all --check
- git diff --check
- jq empty docs/parity/queue-overrides.json
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-agent
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --out-json /Volumes/wd_black/hermes-agent-ultra/nous-portal-client-tags-queue.json --out-md /Volumes/wd_black/hermes-agent-ultra/nous-portal-client-tags-queue.md

Queue proof: pending=1939, ported=110; 486b692ddd80 is ported.
Disk proof: /private/tmp/hermes-agent-ultra-target-delegation stayed 0B; Cargo target is on /Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation.