### PR TITLE
parity(nous): add direct Portal API provider

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -1089,7 +1089,10 @@ fn is_tool_payload_validation_error(err: &str) -> bool {
 fn preferred_tool_payload_fallback_model(provider_hint: &str, model_name: &str) -> Option<String> {
     let provider = provider_hint.trim().to_ascii_lowercase();
     let model = model_name.trim().to_ascii_lowercase();
-    let nous_openai_route = provider == "nous" && model.starts_with("openai/");
+    let nous_openai_route = matches!(
+        provider.as_str(),
+        "nous" | "nous-api" | "nous_api" | "nousapi" | "nous-portal-api"
+    ) && model.starts_with("openai/");
     if !nous_openai_route {
         return None;
     }
@@ -2885,9 +2888,11 @@ impl AgentLoop {
                 .filter(|v| !v.trim().is_empty())
                 .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
                 .filter(|v| !v.trim().is_empty()),
-            "nous" => std::env::var("NOUS_API_KEY")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
+            "nous" | "nous-api" | "nous_api" | "nousapi" | "nous-portal-api" => {
+                std::env::var("NOUS_API_KEY")
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+            }
             "zai" | "glm" | "z-ai" | "z_ai" | "zhipu" => std::env::var("GLM_API_KEY")
                 .ok()
                 .filter(|v| !v.trim().is_empty())
@@ -2942,6 +2947,15 @@ impl AgentLoop {
                         .map(|s| s.trim().to_string())
                         .filter(|s| !s.is_empty())
                         .or_else(|| Some(bedrock_runtime_base_url(&resolve_bedrock_region())))
+                } else if matches!(
+                    provider,
+                    "nous-api" | "nous_api" | "nousapi" | "nous-portal-api"
+                ) {
+                    std::env::var("NOUS_BASE_URL")
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .or_else(|| Some("https://inference-api.nousresearch.com/v1".to_string()))
                 } else if provider == "stepfun" {
                     Some("https://api.stepfun.ai/step_plan/v1".to_string())
                 } else if provider == "kimi-coding" {
@@ -3560,7 +3574,7 @@ impl AgentLoop {
                         .with_provider_profile(provider),
                 )
             }
-            "nous" => {
+            "nous" | "nous-api" | "nous_api" | "nousapi" | "nous-portal-api" => {
                 let mut p = NousProvider::new(&api_key)
                     .with_model(model_name)
                     .with_optional_request_timeout_seconds(request_timeout_seconds);
@@ -9934,6 +9948,10 @@ mod tests {
             Some("nousresearch/hermes-4-70b".to_string())
         );
         assert_eq!(
+            preferred_tool_payload_fallback_model("nous-api", "openai/gpt-5.5"),
+            Some("nousresearch/hermes-4-70b".to_string())
+        );
+        assert_eq!(
             preferred_tool_payload_fallback_model("openrouter", "openai/gpt-5.5"),
             None
         );
@@ -9942,7 +9960,7 @@ mod tests {
             "nousresearch/hermes-4-405b",
         );
         assert_eq!(
-            preferred_tool_payload_fallback_model("nous", "openai/gpt-5.5"),
+            preferred_tool_payload_fallback_model("nous-portal-api", "openai/gpt-5.5"),
             Some("nousresearch/hermes-4-405b".to_string())
         );
         std::env::remove_var("HERMES_TOOL_PAYLOAD_FALLBACK_MODEL");
@@ -14194,6 +14212,8 @@ mod tests {
         let _arcee = EnvVarGuard::remove("ARCEE_API_KEY");
         let _xiaomi = EnvVarGuard::remove("XIAOMI_API_KEY");
         let _tokenhub = EnvVarGuard::remove("TOKENHUB_API_KEY");
+        let _nous = EnvVarGuard::remove("NOUS_API_KEY");
+        let _nous_base = EnvVarGuard::remove("NOUS_BASE_URL");
 
         let agent = AgentLoop::new(
             AgentConfig::default(),
@@ -14230,6 +14250,29 @@ mod tests {
         assert_eq!(
             agent.resolve_runtime_api_key("tencent", None, None),
             Some("tokenhub-secret".to_string())
+        );
+
+        let _nous_key = EnvVarGuard::set("NOUS_API_KEY", "nous-secret");
+        let _nous_base_override = EnvVarGuard::set("NOUS_BASE_URL", "https://nous.example/v1");
+        assert_eq!(
+            agent.resolve_runtime_api_key("nous-api", None, None),
+            Some("nous-secret".to_string())
+        );
+        assert_eq!(
+            agent
+                .resolve_runtime_api_key("nous-portal-api", None, None)
+                .as_deref(),
+            Some("nous-secret")
+        );
+        assert_eq!(
+            agent.resolve_runtime_base_url("nous-api", None).as_deref(),
+            Some("https://nous.example/v1")
+        );
+        assert!(
+            agent
+                .build_runtime_provider("nous-api", "openai/gpt-5.5", None, None, None, None, None)
+                .is_ok(),
+            "nous-api direct-key runtime provider should build"
         );
 
         assert_eq!(

--- a/crates/hermes-agent/src/model_normalize.rs
+++ b/crates/hermes-agent/src/model_normalize.rs
@@ -14,6 +14,7 @@ fn canonical_provider(provider: &str) -> String {
         "github-copilot-acp" | "copilot-acp-agent" => "copilot-acp".to_string(),
         "opencode" | "zen" => "opencode-zen".to_string(),
         "go" => "opencode-go".to_string(),
+        "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "moonshot" | "kimi-coding" | "kimi-coding-cn" => "kimi".to_string(),
         "glm" | "z-ai" | "z_ai" | "zhipu" => "zai".to_string(),
         "claude" | "claude-code" => "anthropic".to_string(),
@@ -185,7 +186,7 @@ pub fn normalize_model_for_provider(model: &str, provider: &str) -> String {
 
     match provider.as_str() {
         "anthropic" => normalize_anthropic_model_name(trimmed, false),
-        "openrouter" | "nous" => normalize_for_aggregator(trimmed),
+        "openrouter" | "nous" | "nous-api" => normalize_for_aggregator(trimmed),
         "opencode-go" => strip_if_vendor_matches(trimmed, &["opencode-go", "go"]).to_string(),
         "opencode-zen" => normalize_for_opencode_zen(trimmed),
         "copilot" | "copilot-acp" => normalize_for_copilot(trimmed),
@@ -269,6 +270,10 @@ mod tests {
         );
         assert_eq!(
             normalize_model_for_provider("gpt-5.4", "nous"),
+            "openai/gpt-5.4"
+        );
+        assert_eq!(
+            normalize_model_for_provider("gpt-5.4", "nous-api"),
             "openai/gpt-5.4"
         );
         assert_eq!(

--- a/crates/hermes-agent/src/provider_profiles.rs
+++ b/crates/hermes-agent/src/provider_profiles.rs
@@ -19,7 +19,9 @@ pub fn canonical_provider_profile_id(provider: &str) -> Option<&'static str> {
         "kimi" | "moonshot" | "moonshot-ai" | "kimi-coding" => Some("kimi-coding"),
         "kimi-coding-cn" | "kimi-cn" | "moonshot-cn" => Some("kimi-coding-cn"),
         "openrouter" | "or" => Some("openrouter"),
-        "nous" | "nous-portal" => Some("nous"),
+        "nous" | "nous-portal" | "nous-api" | "nous_api" | "nousapi" | "nous-portal-api" => {
+            Some("nous")
+        }
         "qwen" | "qwen-oauth" | "qwen-portal" | "qwen-cli" => Some("qwen-oauth"),
         "xiaomi" | "mimo" | "xiaomi-mimo" => Some("xiaomi"),
         "custom" | "ollama" | "ollama-local" | "llama-cpp" | "vllm" | "mlx" | "apple-ane"
@@ -365,6 +367,8 @@ mod tests {
         );
         assert_eq!(canonical_provider_profile_id("or"), Some("openrouter"));
         assert_eq!(canonical_provider_profile_id("nous-portal"), Some("nous"));
+        assert_eq!(canonical_provider_profile_id("nous-api"), Some("nous"));
+        assert_eq!(canonical_provider_profile_id("nousapi"), Some("nous"));
         assert_eq!(canonical_provider_profile_id("qwen"), Some("qwen-oauth"));
         assert_eq!(canonical_provider_profile_id("mimo"), Some("xiaomi"));
         assert_eq!(canonical_provider_profile_id("xiaomi-mimo"), Some("xiaomi"));

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -47,7 +47,8 @@ use crate::auth::{
     login_nous_device_code, resolve_gemini_oauth_runtime_credentials,
     resolve_nous_runtime_credentials, resolve_qwen_runtime_credentials, save_nous_auth_state,
     NousDeviceCodeOptions, NousRuntimeCredentials, DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
-    NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    DEFAULT_NOUS_INFERENCE_URL, NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 };
 use crate::cli::Cli;
 use crate::commands::recover_queued_background_jobs;
@@ -5192,6 +5193,7 @@ mod tests {
             "Z_AI_API_KEY",
             "GMI_API_KEY",
             "MINIMAX_CN_API_KEY",
+            "NOUS_API_KEY",
             "COPILOT_GITHUB_TOKEN",
             "GH_TOKEN",
             "GITHUB_TOKEN",
@@ -5237,6 +5239,8 @@ mod tests {
             ("TOKENHUB_API_KEY", "tencent"),
             ("TOKENHUB_API_KEY", "tokenhub"),
             ("MINIMAX_CN_API_KEY", "minimax_cn"),
+            ("NOUS_API_KEY", "nous-api"),
+            ("NOUS_API_KEY", "nous-portal-api"),
             ("COPILOT_GITHUB_TOKEN", "github-copilot"),
             ("GH_TOKEN", "github-models"),
             ("GITHUB_TOKEN", "copilot"),
@@ -5263,6 +5267,12 @@ mod tests {
         assert_eq!(
             normalize_runtime_provider_name("gemini-cli"),
             "google-gemini-cli"
+        );
+        assert_eq!(normalize_runtime_provider_name("nous_api"), "nous-api");
+        assert_eq!(normalize_runtime_provider_name("nousapi"), "nous-api");
+        assert_eq!(
+            normalize_runtime_provider_name("nous-portal-api"),
+            "nous-api"
         );
         assert_eq!(normalize_runtime_provider_name("moonshot"), "kimi");
         assert_eq!(normalize_runtime_provider_name("novita-ai"), "novita");
@@ -6317,6 +6327,7 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
     match normalized.as_str() {
         "codex" => "openai-codex".to_string(),
         "claude" | "claude-code" => "anthropic".to_string(),
+        "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
@@ -6352,6 +6363,7 @@ fn normalize_runtime_provider_name(provider: &str) -> String {
 fn provider_default_base_url(provider: &str) -> Option<&'static str> {
     match provider.trim().to_ascii_lowercase().as_str() {
         "openai-codex" | "codex" => Some(OPENAI_CODEX_BASE_URL),
+        "nous-api" | "nous_api" | "nousapi" | "nous-portal-api" => Some(DEFAULT_NOUS_INFERENCE_URL),
         "google-gemini-cli" | "gemini-cli" | "gemini-oauth" => Some(GOOGLE_GEMINI_CLI_BASE_URL),
         "gemini" | "google" | "google-gemini" | "google-ai-studio" => Some(GEMINI_BASE_URL),
         "qwen" | "alibaba" => Some(QWEN_BASE_URL),
@@ -6571,6 +6583,7 @@ fn provider_base_url_from_env(provider: &str) -> Option<String> {
         _ => match normalized_provider.as_str() {
             "openai" => "OPENAI_BASE_URL",
             "openai-codex" | "codex" => "HERMES_OPENAI_CODEX_BASE_URL",
+            "nous-api" => "NOUS_BASE_URL",
             "anthropic" => "ANTHROPIC_BASE_URL",
             "bedrock" => "BEDROCK_BASE_URL",
             "google-gemini-cli" => "HERMES_GEMINI_BASE_URL",
@@ -6731,7 +6744,7 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
         "novita" => std::env::var("NOVITA_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
-        "nous" => std::env::var("NOUS_API_KEY")
+        "nous" | "nous-api" => std::env::var("NOUS_API_KEY")
             .ok()
             .filter(|s| !s.trim().is_empty()),
         "copilot" => std::env::var("COPILOT_GITHUB_TOKEN")
@@ -6965,7 +6978,7 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
                     .with_provider_profile(runtime_provider.as_str()),
             )
         }
-        "nous" => {
+        "nous" | "nous-api" => {
             let mut p = NousProvider::new(&api_key)
                 .with_model(model_name.as_str())
                 .with_optional_request_timeout_seconds(request_timeout_seconds);

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -30,8 +30,8 @@ use hermes_cli::auth::{
     CodexDeviceCodeOptions, GeminiOAuthLoginOptions, NousAuthState, NousDeviceCodeOptions,
     NousRuntimeCredentials, ANTHROPIC_OAUTH_CLIENT_ID, ANTHROPIC_OAUTH_TOKEN_URL,
     CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_TOKEN_URL, DEFAULT_CODEX_BASE_URL,
-    DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS, DEFAULT_NOUS_CLIENT_ID, DEFAULT_NOUS_PORTAL_URL,
-    DEFAULT_OPENAI_BASE_URL, NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS, DEFAULT_NOUS_CLIENT_ID, DEFAULT_NOUS_INFERENCE_URL,
+    DEFAULT_NOUS_PORTAL_URL, DEFAULT_OPENAI_BASE_URL, NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, QWEN_OAUTH_CLIENT_ID, QWEN_OAUTH_TOKEN_URL,
 };
 use hermes_cli::cli::{Cli, CliCommand};
@@ -5813,6 +5813,7 @@ fn normalize_auth_provider(provider: &str) -> String {
         "claude" | "claude-code" => "anthropic".to_string(),
         "codex" => "openai-codex".to_string(),
         "openai-oauth" | "openai-cli" => "openai".to_string(),
+        "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
@@ -5882,6 +5883,7 @@ fn normalize_secret_provider(provider: &str) -> String {
         "claude" | "claude-code" => "anthropic".to_string(),
         "codex" => "openai-codex".to_string(),
         "openai-oauth" | "openai-cli" => "openai".to_string(),
+        "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "moonshot" | "kimi" => "kimi-coding".to_string(),
@@ -5925,6 +5927,12 @@ fn secret_provider_aliases(provider: &str) -> Vec<String> {
         ],
         "kimi-coding-cn" => vec!["kimi-coding-cn".to_string()],
         "stepfun" => vec!["stepfun".to_string(), "step".to_string()],
+        "nous-api" => vec![
+            "nous-api".to_string(),
+            "nous_api".to_string(),
+            "nousapi".to_string(),
+            "nous-portal-api".to_string(),
+        ],
         "copilot" => vec![
             "copilot".to_string(),
             "github-copilot".to_string(),
@@ -6022,7 +6030,7 @@ fn provider_env_var(provider: &str) -> Option<&'static str> {
         "minimax" => Some("MINIMAX_API_KEY"),
         "minimax-cn" => Some("MINIMAX_CN_API_KEY"),
         "stepfun" => Some("STEPFUN_API_KEY"),
-        "nous" => Some("NOUS_API_KEY"),
+        "nous" | "nous-api" => Some("NOUS_API_KEY"),
         "copilot" => Some("COPILOT_GITHUB_TOKEN"),
         "ai-gateway" => Some("AI_GATEWAY_API_KEY"),
         "arcee" => Some("ARCEEAI_API_KEY"),
@@ -10017,6 +10025,11 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
         label: "Nous (recommended, OAuth)",
     },
     SetupModelOption {
+        provider: "nous-api",
+        model: "nous-api:openai/gpt-5.5-pro",
+        label: "Nous Portal API key",
+    },
+    SetupModelOption {
         provider: "openai",
         model: "openai:gpt-4o",
         label: "OpenAI gpt-4o",
@@ -10290,7 +10303,7 @@ fn setup_default_model_pick_index(
         return idx;
     }
 
-    if selected_provider == "nous" {
+    if matches!(selected_provider, "nous" | "nous-api") {
         if let Some(idx) = displayed_suggested_models.iter().position(|candidate| {
             candidate
                 .trim()
@@ -10311,6 +10324,7 @@ fn setup_provider_display(provider: &str) -> &'static str {
         "google-gemini-cli" => "Google Gemini CLI",
         "gemini" => "Google AI Studio",
         "openrouter" => "OpenRouter",
+        "nous-api" => "Nous Portal API",
         "qwen" => "Alibaba DashScope",
         "alibaba" => "Alibaba Cloud DashScope",
         "qwen-oauth" => "Qwen OAuth",
@@ -10367,7 +10381,7 @@ fn setup_provider_env_keys(provider: &str) -> &'static [&'static str] {
         "minimax-cn" => SETUP_MINIMAX_CN_ENV_KEYS,
         "novita" => SETUP_NOVITA_ENV_KEYS,
         "stepfun" => SETUP_STEPFUN_ENV_KEYS,
-        "nous" => SETUP_NOUS_ENV_KEYS,
+        "nous" | "nous-api" => SETUP_NOUS_ENV_KEYS,
         "ai-gateway" => SETUP_AI_GATEWAY_ENV_KEYS,
         "arcee" => SETUP_ARCEE_ENV_KEYS,
         "bedrock" => SETUP_BEDROCK_ENV_KEYS,
@@ -10397,6 +10411,7 @@ fn setup_provider_env_keys(provider: &str) -> &'static [&'static str] {
 fn setup_provider_default_base_url(provider: &str) -> Option<&'static str> {
     match provider {
         "openai-codex" => Some("https://chatgpt.com/backend-api/codex"),
+        "nous-api" => Some(DEFAULT_NOUS_INFERENCE_URL),
         "google-gemini-cli" => Some("cloudcode-pa://google"),
         "gemini" => Some("https://generativelanguage.googleapis.com/v1beta"),
         "qwen" | "alibaba" => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
@@ -10958,7 +10973,7 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
 
     // 6. Prompt for model after provider auth is established.
     let suggested_provider_models = provider_model_ids(&selected_provider).await;
-    let suggested_limit = if selected_provider == "nous" {
+    let suggested_limit = if matches!(selected_provider.as_str(), "nous" | "nous-api") {
         usize::MAX
     } else {
         25
@@ -10993,7 +11008,7 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
             })
             .collect();
         suggested_labels.push("Custom model ID…".to_string());
-        let model_title = if selected_provider == "nous" {
+        let model_title = if matches!(selected_provider.as_str(), "nous" | "nous-api") {
             format!(
                 "Select {} model ({} available)",
                 selected_provider_label,
@@ -15693,6 +15708,7 @@ mod tests {
             );
         }
         assert!(seen.contains("nous"));
+        assert!(seen.contains("nous-api"));
     }
 
     #[test]
@@ -15733,6 +15749,9 @@ mod tests {
         ];
         let idx = setup_default_model_pick_index("nous", "nous:nonexistent/model", &suggested);
         assert_eq!(idx, 1);
+        let idx =
+            setup_default_model_pick_index("nous-api", "nous-api:nonexistent/model", &suggested);
+        assert_eq!(idx, 1);
     }
 
     #[test]
@@ -15750,6 +15769,12 @@ mod tests {
     fn setup_provider_env_keys_include_nous() {
         assert_eq!(setup_provider_display("nous"), "Nous");
         assert_eq!(setup_provider_env_keys("nous"), &["NOUS_API_KEY"]);
+        assert_eq!(setup_provider_display("nous-api"), "Nous Portal API");
+        assert_eq!(setup_provider_env_keys("nous-api"), &["NOUS_API_KEY"]);
+        assert_eq!(
+            setup_provider_default_base_url("nous-api"),
+            Some(DEFAULT_NOUS_INFERENCE_URL)
+        );
         assert_eq!(
             setup_provider_env_keys("ollama-local"),
             &["OLLAMA_LOCAL_API_KEY", "OLLAMA_API_KEY"]

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -535,6 +535,9 @@ pub fn provider_picker_description(provider: &str) -> &'static str {
         "lmstudio" | "lm-studio" => "LM Studio (Local desktop app with built-in model server)",
         "minimax-cn" | "minimax_cn" => "MiniMax China (Domestic direct API)",
         "xai-oauth" => "xAI Grok OAuth (SuperGrok / Premium+ subscription)",
+        "nous-api" | "nous_api" | "nousapi" | "nous-portal-api" => {
+            "Nous Portal API key (direct API key access to Nous inference)"
+        }
         raw => match canonical_provider_id(raw).as_str() {
             "nous" => {
                 "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"
@@ -615,6 +618,11 @@ pub fn merge_with_models_dev(models_dev: &[String], curated: &[&str]) -> Vec<Str
 
 pub fn provider_curated_models(provider: &str) -> &'static [&'static str] {
     let normalized = canonical_provider_id(provider);
+    let normalized = if normalized == "nous-api" {
+        "nous".to_string()
+    } else {
+        normalized
+    };
     for (slug, models) in CURATED_PROVIDER_MODELS {
         if slug.eq_ignore_ascii_case(&normalized) {
             return models;
@@ -954,7 +962,7 @@ pub async fn provider_model_ids_with_client(
             }
         }
         merged
-    } else if normalized == "nous" {
+    } else if matches!(normalized.as_str(), "nous" | "nous-api") {
         // Nous model picker should always include curated compatibility picks
         // (including kimi-k2.6), then append live/models.dev discoveries.
         let mut seen: HashSet<String> = HashSet::new();
@@ -1315,6 +1323,7 @@ mod tests {
     #[test]
     fn provider_picker_descriptions_match_refreshed_upstream_copy() {
         assert!(provider_picker_description("nous").contains("300+ models"));
+        assert!(provider_picker_description("nous-api").contains("direct API key"));
         assert!(provider_picker_description("openrouter").contains("Pay-per-use API aggregator"));
         assert!(provider_picker_description("google-gemini-cli").contains("Code Assist OAuth flow"));
         assert!(provider_picker_description("xai").contains("Grok"));
@@ -1470,6 +1479,11 @@ mod tests {
         assert!(
             out.iter().any(|m| m == "openai/gpt-5.5"),
             "expected openrouter-derived models in nous catalog"
+        );
+        let direct = provider_model_ids_with_client("nous-api", &client).await;
+        assert_eq!(
+            direct, out,
+            "nous-api should reuse the Nous Portal model catalog"
         );
     }
 

--- a/crates/hermes-core/src/providers.rs
+++ b/crates/hermes-core/src/providers.rs
@@ -17,6 +17,7 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "novita",
     "stepfun",
     "nous",
+    "nous-api",
     "copilot",
     "copilot-acp",
     "ai-gateway",
@@ -97,6 +98,7 @@ pub fn canonical_provider_id(provider: &str) -> String {
         "codex" => "openai-codex".to_string(),
         "claude" | "claude-code" => "anthropic".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
+        "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
         "google" | "google-gemini" | "google-ai-studio" => "gemini".to_string(),
         "azure" | "azure-ai-foundry" | "azure_ai_foundry" => "azure-foundry".to_string(),
@@ -238,6 +240,11 @@ mod tests {
         assert!(cap.oauth_supported);
         assert!(cap.managed_tools_supported);
         assert!(!cap.models_dev_merged);
+
+        let direct = provider_capability_for("nous-portal-api").expect("nous-api capability");
+        assert_eq!(direct.id, "nous-api");
+        assert!(!direct.oauth_supported);
+        assert!(!direct.managed_tools_supported);
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -975,6 +975,10 @@
     "486b692ddd80": {
       "disposition": "ported",
       "notes": "Rust Nous provider request shaping now centralizes Portal attribution tags as product=hermes-agent plus client=hermes-client-v<workspace version>, and request-body tests prove the versioned tag is applied to actual Nous chat completion payloads."
+    },
+    "de07aa7c4046": {
+      "disposition": "ported",
+      "notes": "Rust now exposes a first-class `nous-api` direct API-key provider with aliases, non-OAuth provider capability, setup catalog entry, NOUS_API_KEY/NOUS_BASE_URL runtime resolution, Nous provider construction, Nous model normalization/catalog reuse, and targeted core/CLI/agent tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Ports upstream `de07aa7c4046` (`feat: add Nous Portal API key provider (#644)`) into the Rust runtime surface.
- Adds first-class `nous-api` direct API-key provider aliases without making it OAuth-capable or managed-tools-capable.
- Wires `NOUS_API_KEY` / `NOUS_BASE_URL`, setup picker/defaults, provider construction, model normalization, catalog reuse, and parity ledger proof.

## Verification
- `cargo fmt --all`
- `cargo test -p hermes-core provider_capability_registry_marks_nous_as_oauth_and_managed_tools -- --nocapture`
- `cargo test -p hermes-agent preferred_tool_payload_fallback_model_defaults_and_override -- --nocapture`
- `cargo test -p hermes-agent test_runtime_provider_direct_env_keys_and_base_url_defaults -- --nocapture`
- `cargo test -p hermes-agent aggregators_prepend_detected_vendor_for_bare_models -- --nocapture`
- `cargo test -p hermes-agent aliases_match_upstream_provider_profiles -- --nocapture`
- `cargo test -p hermes-cli test_provider_api_key_from_env_supports_extended_registry -- --nocapture`
- `cargo test -p hermes-cli test_normalize_runtime_provider_name_covers_aliases -- --nocapture`
- `cargo test -p hermes-cli setup_provider_env_keys_include_nous -- --nocapture`
- `cargo test -p hermes-cli setup_provider_defaults_are_unique_and_include_nous -- --nocapture`
- `cargo test -p hermes-cli setup_default_model_pick_index_uses_nous_kimi_fallback_when_target_missing -- --nocapture`
- `cargo test -p hermes-cli provider_picker_descriptions_match_refreshed_upstream_copy -- --nocapture`
- `cargo test -p hermes-cli nous_provider_uses_curated_plus_openrouter_agentic_catalog -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-agent -p hermes-cli -p hermes-core`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-cli -p hermes-core` (`new=0`)
- `python3 scripts/generate-upstream-patch-queue.py --no-fetch ...` -> `pending=1938`, `ported=111`, `de07aa7c4046` ported

All Cargo invocations used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` and `CARGO_INCREMENTAL=0`.
