### PR TITLE
parity(credits): surface Nous usage telemetry

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -772,6 +772,17 @@ impl GenericProvider {
         req
     }
 
+    fn capture_nous_credits_headers(&self, headers: &reqwest::header::HeaderMap) {
+        let _ = hermes_core::credits::capture_nous_credits_from_pairs(headers.iter().filter_map(
+            |(key, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (key.as_str().to_string(), value.to_string()))
+            },
+        ));
+    }
+
     async fn send_with_dead_connection_recovery(
         &self,
         url: &str,
@@ -1050,6 +1061,7 @@ impl LlmProvider for GenericProvider {
             .await?;
 
         self.update_rate_limit(resp.headers());
+        self.capture_nous_credits_headers(resp.headers());
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -1116,6 +1128,7 @@ impl LlmProvider for GenericProvider {
             };
 
             provider.update_rate_limit(resp.headers());
+            provider.capture_nous_credits_headers(resp.headers());
 
             if !resp.status().is_success() {
                 let status = resp.status();
@@ -2896,6 +2909,42 @@ mod tests {
             .expect("request");
 
         assert!(request.headers().get("User-Agent").is_none());
+    }
+
+    #[test]
+    fn generic_provider_captures_nous_credits_headers() {
+        hermes_core::credits::clear_last_nous_credits_state();
+        let provider = GenericProvider::new(
+            "https://inference-api.nousresearch.com/v1",
+            "nous-key",
+            "openai/gpt-5.5-pro",
+        );
+        let mut headers = reqwest::header::HeaderMap::new();
+        for (key, value) in [
+            ("x-nous-credits-version", "1"),
+            ("x-nous-credits-remaining-micros", "12000000"),
+            ("x-nous-credits-remaining-usd", "12.00"),
+            ("x-nous-credits-subscription-micros", "5000000"),
+            ("x-nous-credits-subscription-usd", "5.00"),
+            ("x-nous-credits-subscription-limit-micros", "10000000"),
+            ("x-nous-credits-subscription-limit-usd", "10.00"),
+            ("x-nous-credits-rollover-micros", "0"),
+            ("x-nous-credits-purchased-micros", "7000000"),
+            ("x-nous-credits-purchased-usd", "7.00"),
+            ("x-nous-credits-denominator-kind", "subscription_cap"),
+            ("x-nous-credits-paid-access", "true"),
+        ] {
+            headers.insert(
+                reqwest::header::HeaderName::from_static(key),
+                reqwest::header::HeaderValue::from_static(value),
+            );
+        }
+
+        provider.capture_nous_credits_headers(&headers);
+        let state = hermes_core::credits::last_nous_credits_state().expect("captured state");
+        assert_eq!(state.remaining_usd, "12.00");
+        assert_eq!(state.used_fraction(), Some(0.5));
+        hermes_core::credits::clear_last_nous_credits_state();
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -6365,6 +6365,12 @@ fn handle_usage_command(app: &mut App) -> Result<CommandResult, AgentError> {
         ));
     }
 
+    let nous_credits = hermes_core::credits::render_last_nous_credits_lines();
+    if !nous_credits.is_empty() {
+        output.push_str("\n\n");
+        output.push_str(&nous_credits.join("\n"));
+    }
+
     emit_command_output(app, output);
     Ok(CommandResult::Handled)
 }
@@ -28095,6 +28101,7 @@ mod tests {
     #[tokio::test]
     async fn usage_command_reports_actual_session_usage_and_cost() {
         let _guard = env_test_lock();
+        hermes_core::credits::clear_last_nous_credits_state();
         let tmp = tempdir().expect("tempdir");
         let _home_guard = TempHomeGuard::new(tmp.path());
         let mut app = build_test_app_with_stream(tmp.path()).await;
@@ -28126,6 +28133,41 @@ mod tests {
         assert!(output.contains("Last response: 12 prompt / 3 completion / 15 total tokens"));
         assert!(output.contains("Actual session: 12 prompt / 3 completion / 15 total tokens"));
         assert!(output.contains("Actual cost:   $0.0123"));
+        hermes_core::credits::clear_last_nous_credits_state();
+    }
+
+    #[tokio::test]
+    async fn usage_command_includes_last_nous_credits_state() {
+        let _guard = env_test_lock();
+        hermes_core::credits::clear_last_nous_credits_state();
+        hermes_core::credits::capture_nous_credits_from_pairs([
+            ("x-nous-credits-version", "1"),
+            ("x-nous-credits-remaining-micros", "12000000"),
+            ("x-nous-credits-remaining-usd", "12.00"),
+            ("x-nous-credits-subscription-micros", "5000000"),
+            ("x-nous-credits-subscription-usd", "5.00"),
+            ("x-nous-credits-subscription-limit-micros", "10000000"),
+            ("x-nous-credits-subscription-limit-usd", "10.00"),
+            ("x-nous-credits-rollover-micros", "1000000"),
+            ("x-nous-credits-purchased-micros", "7000000"),
+            ("x-nous-credits-purchased-usd", "7.00"),
+            ("x-nous-credits-denominator-kind", "subscription_cap"),
+            ("x-nous-credits-paid-access", "true"),
+        ])
+        .expect("capture credits");
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        let result = handle_slash_command(&mut app, "/usage", &[])
+            .await
+            .expect("usage command");
+        assert_eq!(result, CommandResult::Handled);
+        let output = latest_ui_assistant_text(&app);
+        assert!(output.contains("Nous credits"));
+        assert!(output.contains("Subscription: 50% remaining (50% used)"));
+        assert!(output.contains("Total usable: 12.00"));
+        hermes_core::credits::clear_last_nous_credits_state();
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -3979,6 +3979,10 @@ fn render_status(
     if state.background_jobs_running > 0 {
         status_text.push_str(&format!(" | bg:{}", state.background_jobs_running));
     }
+    if let Some(credits_notice) = hermes_core::credits::last_nous_credits_notice_line() {
+        status_text.push_str(" | ");
+        status_text.push_str(&credits_notice);
+    }
     status_text.push_str(if app.mouse_enabled() {
         " | mouse:on"
     } else {

--- a/crates/hermes-core/src/credits.rs
+++ b/crates/hermes-core/src/credits.rs
@@ -1,0 +1,390 @@
+//! Nous credits telemetry captured from inference response headers.
+//!
+//! This module is intentionally shared from `hermes-core` so providers can
+//! capture headers at the HTTP boundary while CLI and gateway surfaces can render
+//! the last-known state without depending on `hermes-agent`.
+
+use chrono::Utc;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, OnceLock};
+
+static LAST_NOUS_CREDITS: OnceLock<Mutex<Option<NousCreditsState>>> = OnceLock::new();
+static USD_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^-?\d+\.\d{2}$").unwrap());
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NousCreditsState {
+    pub version: i64,
+    pub remaining_micros: i64,
+    pub remaining_usd: String,
+    pub subscription_micros: i64,
+    pub subscription_usd: String,
+    pub subscription_limit_micros: Option<i64>,
+    pub subscription_limit_usd: Option<String>,
+    pub rollover_micros: i64,
+    pub purchased_micros: i64,
+    pub purchased_usd: String,
+    pub tool_pool_micros: i64,
+    pub tool_pool_gated_off: bool,
+    pub denominator_kind: String,
+    pub paid_access: bool,
+    pub disabled_reason: Option<String>,
+    pub as_of_ms: Option<i64>,
+    pub captured_at_ms: i64,
+}
+
+impl NousCreditsState {
+    pub fn depleted(&self) -> bool {
+        !self.paid_access
+    }
+
+    pub fn used_fraction(&self) -> Option<f64> {
+        let limit = self.subscription_limit_micros?;
+        if limit <= 0 {
+            return None;
+        }
+        let used = limit.saturating_sub(self.subscription_micros);
+        Some(((used as f64) / (limit as f64)).clamp(0.0, 1.0))
+    }
+}
+
+pub fn capture_nous_credits_from_pairs<I, K, V>(headers: I) -> Option<NousCreditsState>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let state = parse_nous_credits_headers(headers)?;
+    let store = LAST_NOUS_CREDITS.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = store.lock() {
+        *guard = Some(state.clone());
+    }
+    Some(state)
+}
+
+pub fn last_nous_credits_state() -> Option<NousCreditsState> {
+    LAST_NOUS_CREDITS
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
+
+pub fn clear_last_nous_credits_state() {
+    if let Ok(mut guard) = LAST_NOUS_CREDITS.get_or_init(|| Mutex::new(None)).lock() {
+        *guard = None;
+    }
+}
+
+pub fn render_last_nous_credits_lines() -> Vec<String> {
+    let Some(state) = last_nous_credits_state() else {
+        return Vec::new();
+    };
+    render_nous_credits_lines(&state)
+}
+
+pub fn last_nous_credits_notice_line() -> Option<String> {
+    last_nous_credits_state().and_then(|state| nous_credits_notice_line(&state))
+}
+
+pub fn nous_credits_notice_line(state: &NousCreditsState) -> Option<String> {
+    if state.depleted() {
+        return Some("credits: depleted - run /usage".to_string());
+    }
+    let used_fraction = state.used_fraction()?;
+    let band = if used_fraction >= 0.90 {
+        90
+    } else if used_fraction >= 0.75 {
+        75
+    } else if used_fraction >= 0.50 {
+        50
+    } else {
+        return None;
+    };
+    Some(format!("credits: {band}% used - run /usage"))
+}
+
+pub fn render_nous_credits_lines(state: &NousCreditsState) -> Vec<String> {
+    let mut lines = vec!["Nous credits".to_string(), "Provider: nous".to_string()];
+
+    if let Some(used_fraction) = state.used_fraction() {
+        let used_pct = (used_fraction * 100.0).round().clamp(0.0, 100.0) as u64;
+        let remaining_pct = 100u64.saturating_sub(used_pct);
+        let detail = match (
+            &state.subscription_limit_usd,
+            state.subscription_usd.as_str(),
+        ) {
+            (Some(limit), subscription) if !subscription.is_empty() => {
+                format!(" - {subscription} of {limit} left")
+            }
+            _ => String::new(),
+        };
+        lines.push(format!(
+            "Subscription: {remaining_pct}% remaining ({used_pct}% used){detail}"
+        ));
+    }
+
+    if !state.remaining_usd.is_empty() {
+        lines.push(format!("Total usable: {}", state.remaining_usd));
+    } else {
+        lines.push(format!("Total usable: {} micros", state.remaining_micros));
+    }
+    if !state.subscription_usd.is_empty() {
+        lines.push(format!("Subscription credits: {}", state.subscription_usd));
+    }
+    if !state.purchased_usd.is_empty() {
+        lines.push(format!("Top-up credits: {}", state.purchased_usd));
+    }
+    if state.rollover_micros > 0 {
+        lines.push(format!("Rollover: {} micros", state.rollover_micros));
+    }
+    if state.tool_pool_micros > 0 || state.tool_pool_gated_off {
+        lines.push(format!(
+            "Tool pool: {} micros{}",
+            state.tool_pool_micros,
+            if state.tool_pool_gated_off {
+                " (gated off)"
+            } else {
+                ""
+            }
+        ));
+    }
+    if state.depleted() {
+        let reason = state
+            .disabled_reason
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("paid access paused");
+        lines.push(format!("Status: access depleted - {reason}"));
+    }
+    if let Some(as_of_ms) = state.as_of_ms {
+        lines.push(format!("As of: {as_of_ms} ms"));
+    }
+    lines
+}
+
+pub fn parse_nous_credits_headers<I, K, V>(headers: I) -> Option<NousCreditsState>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let map = headers
+        .into_iter()
+        .map(|(key, value)| {
+            (
+                key.as_ref().trim().to_ascii_lowercase(),
+                value.as_ref().trim().to_string(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let version = parse_i64(required(&map, "x-nous-credits-version")?)?;
+    if version != 1 {
+        tracing::warn!(version, "unsupported Nous credits header schema version");
+        return None;
+    }
+
+    let remaining_micros =
+        parse_nonnegative_i64(required(&map, "x-nous-credits-remaining-micros")?)?;
+    let subscription_micros = parse_i64(required(&map, "x-nous-credits-subscription-micros")?)?;
+    let rollover_micros = parse_nonnegative_i64(required(&map, "x-nous-credits-rollover-micros")?)?;
+    let purchased_micros =
+        parse_nonnegative_i64(required(&map, "x-nous-credits-purchased-micros")?)?;
+    let denominator_kind = required(&map, "x-nous-credits-denominator-kind")?.to_string();
+    if !matches!(denominator_kind.as_str(), "subscription_cap" | "none") {
+        return None;
+    }
+    let paid_access = parse_bool_string(required(&map, "x-nous-credits-paid-access")?)?;
+
+    let remaining_usd = optional_usd(&map, "x-nous-credits-remaining-usd")?.unwrap_or_default();
+    let subscription_usd =
+        optional_usd(&map, "x-nous-credits-subscription-usd")?.unwrap_or_default();
+    let purchased_usd = optional_usd(&map, "x-nous-credits-purchased-usd")?.unwrap_or_default();
+
+    let limit_micros_raw = map.get("x-nous-credits-subscription-limit-micros");
+    let limit_usd_raw = map.get("x-nous-credits-subscription-limit-usd");
+    let (subscription_limit_micros, subscription_limit_usd) =
+        match (limit_micros_raw, limit_usd_raw) {
+            (Some(micros), Some(usd)) => {
+                let parsed = parse_nonnegative_i64(micros)?;
+                if !valid_usd(usd) {
+                    return None;
+                }
+                (Some(parsed), Some(usd.clone()))
+            }
+            _ => (None, None),
+        };
+
+    let tool_pool_micros = match map.get("x-nous-tool-pool-micros") {
+        Some(value) => parse_nonnegative_i64(value)?,
+        None => 0,
+    };
+    let tool_pool_gated_off = match map.get("x-nous-tool-pool-gated-off") {
+        Some(value) => parse_bool_string(value)?,
+        None => false,
+    };
+    let disabled_reason = map
+        .get("x-nous-credits-disabled-reason")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let as_of_ms = match map.get("x-nous-credits-as-of-ms") {
+        Some(value) => Some(parse_nonnegative_i64(value)?),
+        None => None,
+    };
+
+    Some(NousCreditsState {
+        version,
+        remaining_micros,
+        remaining_usd,
+        subscription_micros,
+        subscription_usd,
+        subscription_limit_micros,
+        subscription_limit_usd,
+        rollover_micros,
+        purchased_micros,
+        purchased_usd,
+        tool_pool_micros,
+        tool_pool_gated_off,
+        denominator_kind,
+        paid_access,
+        disabled_reason,
+        as_of_ms,
+        captured_at_ms: Utc::now().timestamp_millis(),
+    })
+}
+
+fn required<'a>(map: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    map.get(key).map(String::as_str).filter(|v| !v.is_empty())
+}
+
+fn parse_i64(raw: &str) -> Option<i64> {
+    if raw.contains('.') {
+        return None;
+    }
+    raw.parse::<i64>().ok()
+}
+
+fn parse_nonnegative_i64(raw: &str) -> Option<i64> {
+    let value = parse_i64(raw)?;
+    (value >= 0).then_some(value)
+}
+
+fn parse_bool_string(raw: &str) -> Option<bool> {
+    match raw.trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn optional_usd(map: &HashMap<String, String>, key: &str) -> Option<Option<String>> {
+    let Some(value) = map
+        .get(key)
+        .map(|value| value.trim())
+        .filter(|v| !v.is_empty())
+    else {
+        return Some(None);
+    };
+    valid_usd(value).then_some(Some(value.to_string()))
+}
+
+fn valid_usd(value: &str) -> bool {
+    USD_RE.is_match(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_headers() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("x-nous-credits-version", "1"),
+            ("x-nous-credits-remaining-micros", "12000000"),
+            ("x-nous-credits-remaining-usd", "12.00"),
+            ("x-nous-credits-subscription-micros", "5000000"),
+            ("x-nous-credits-subscription-usd", "5.00"),
+            ("x-nous-credits-subscription-limit-micros", "10000000"),
+            ("x-nous-credits-subscription-limit-usd", "10.00"),
+            ("x-nous-credits-rollover-micros", "1000000"),
+            ("x-nous-credits-purchased-micros", "6000000"),
+            ("x-nous-credits-purchased-usd", "6.00"),
+            ("x-nous-credits-denominator-kind", "subscription_cap"),
+            ("x-nous-credits-paid-access", "true"),
+            ("x-nous-credits-as-of-ms", "1710000000000"),
+            ("x-nous-tool-pool-micros", "250000"),
+            ("x-nous-tool-pool-gated-off", "false"),
+        ]
+    }
+
+    #[test]
+    fn parse_valid_nous_credits_headers() {
+        let state = parse_nous_credits_headers(valid_headers()).expect("credits state");
+        assert_eq!(state.remaining_micros, 12_000_000);
+        assert_eq!(state.subscription_micros, 5_000_000);
+        assert_eq!(state.subscription_limit_micros, Some(10_000_000));
+        assert_eq!(state.used_fraction(), Some(0.5));
+        assert_eq!(state.tool_pool_micros, 250_000);
+        assert!(!state.tool_pool_gated_off);
+    }
+
+    #[test]
+    fn parse_rejects_bool_traps_and_bad_money() {
+        let mut headers = valid_headers();
+        headers.retain(|(key, _)| *key != "x-nous-credits-paid-access");
+        headers.push(("x-nous-credits-paid-access", "1"));
+        assert!(parse_nous_credits_headers(headers).is_none());
+
+        let mut headers = valid_headers();
+        headers.retain(|(key, _)| *key != "x-nous-credits-remaining-usd");
+        headers.push(("x-nous-credits-remaining-usd", "12"));
+        assert!(parse_nous_credits_headers(headers).is_none());
+    }
+
+    #[test]
+    fn parse_allows_subscription_debt_only() {
+        let mut headers = valid_headers();
+        headers.retain(|(key, _)| *key != "x-nous-credits-subscription-micros");
+        headers.push(("x-nous-credits-subscription-micros", "-1000000"));
+        assert!(parse_nous_credits_headers(headers).is_some());
+
+        let mut headers = valid_headers();
+        headers.retain(|(key, _)| *key != "x-nous-credits-remaining-micros");
+        headers.push(("x-nous-credits-remaining-micros", "-1"));
+        assert!(parse_nous_credits_headers(headers).is_none());
+    }
+
+    #[test]
+    fn half_subscription_limit_pair_is_ignored() {
+        let mut headers = valid_headers();
+        headers.retain(|(key, _)| *key != "x-nous-credits-subscription-limit-usd");
+        let state = parse_nous_credits_headers(headers).expect("credits state");
+        assert_eq!(state.subscription_limit_micros, None);
+        assert_eq!(state.used_fraction(), None);
+    }
+
+    #[test]
+    fn capture_and_render_last_state() {
+        clear_last_nous_credits_state();
+        capture_nous_credits_from_pairs(valid_headers()).expect("captured");
+        let lines = render_last_nous_credits_lines();
+        assert!(lines.iter().any(|line| line == "Nous credits"));
+        assert!(lines.iter().any(|line| line.contains("50% remaining")));
+        assert_eq!(
+            last_nous_credits_notice_line().as_deref(),
+            Some("credits: 50% used - run /usage")
+        );
+        clear_last_nous_credits_state();
+    }
+
+    #[test]
+    fn notice_line_prefers_depleted_over_usage_band() {
+        let mut state = parse_nous_credits_headers(valid_headers()).expect("credits state");
+        state.paid_access = false;
+        assert_eq!(
+            nous_credits_notice_line(&state).as_deref(),
+            Some("credits: depleted - run /usage")
+        );
+    }
+}

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! used across the hermes-agent-rust workspace.
 
 pub mod auth_gate;
+pub mod credits;
 pub mod errors;
 pub mod providers;
 pub mod schema_sanitizer;

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -2097,7 +2097,7 @@ impl Gateway {
         let stat = usage.get(session_key).cloned().unwrap_or_default();
         let approx_input_tokens = stat.input_chars / 4;
         let approx_output_tokens = stat.output_chars / 4;
-        format!(
+        let mut text = format!(
             "📊 Usage\n- user messages: {}\n- assistant messages: {}\n- input chars: {} (~{} tokens)\n- output chars: {} (~{} tokens)",
             stat.user_messages,
             stat.assistant_messages,
@@ -2105,7 +2105,13 @@ impl Gateway {
             approx_input_tokens,
             stat.output_chars,
             approx_output_tokens
-        )
+        );
+        let nous_credits = hermes_core::credits::render_last_nous_credits_lines();
+        if !nous_credits.is_empty() {
+            text.push_str("\n\n");
+            text.push_str(&nous_credits.join("\n"));
+        }
+        text
     }
 
     fn summarize_removed_messages(messages: &[Message]) -> Result<String, String> {
@@ -4164,6 +4170,36 @@ mod tests {
             }),
             "summary marker should be persisted into compressed transcript"
         );
+    }
+
+    #[tokio::test]
+    async fn gateway_usage_text_includes_last_nous_credits_state() {
+        hermes_core::credits::clear_last_nous_credits_state();
+        hermes_core::credits::capture_nous_credits_from_pairs([
+            ("x-nous-credits-version", "1"),
+            ("x-nous-credits-remaining-micros", "12000000"),
+            ("x-nous-credits-remaining-usd", "12.00"),
+            ("x-nous-credits-subscription-micros", "5000000"),
+            ("x-nous-credits-subscription-usd", "5.00"),
+            ("x-nous-credits-subscription-limit-micros", "10000000"),
+            ("x-nous-credits-subscription-limit-usd", "10.00"),
+            ("x-nous-credits-rollover-micros", "0"),
+            ("x-nous-credits-purchased-micros", "7000000"),
+            ("x-nous-credits-purchased-usd", "7.00"),
+            ("x-nous-credits-denominator-kind", "subscription_cap"),
+            ("x-nous-credits-paid-access", "true"),
+        ])
+        .expect("capture credits");
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_pair_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let text = gw.build_usage_text("test:chat:user").await;
+
+        assert!(text.contains("Usage"));
+        assert!(text.contains("Nous credits"));
+        assert!(text.contains("Subscription: 50% remaining (50% used)"));
+        hermes_core::credits::clear_last_nous_credits_state();
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -983,6 +983,10 @@
     "4447e7d71afa": {
       "disposition": "ported",
       "notes": "Rust runtime now supports Kimi Code sk-kimi-* routing to https://api.kimi.com/coding/v1 with KimiCLI user-agent while preserving KIMI_BASE_URL override and legacy Moonshot fallback."
+    },
+    "fcb1944b4f76": {
+      "disposition": "ported",
+      "notes": "Rust now captures Nous credits headers at the provider HTTP boundary, parses the v1 x-nous-credits and x-nous-tool-pool contracts with strict money/bool validation, stores a last-known credits snapshot, appends the credits block to CLI and gateway /usage output, and surfaces depleted/50/75/90 percent usage notices in the TUI status bar with focused Rust tests. Python dev fixtures and desktop-only scaffolding are superseded by the Rust runtime surface."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary

Ports the durable Rust runtime surface for upstream commit `fcb1944b4f76cc74d5092c2b8605d972c095bd3c` (`feat(credits): usage-aware credits — in-session notices, /usage view, dev readout (#40011)`).

## What changed

- Adds `hermes_core::credits`:
  - strict v1 `x-nous-credits-*` parser
  - `x-nous-tool-pool-*` support
  - exact integer micros parsing; rejects float-shaped micros
  - string boolean parsing only (`true` / `false`)
  - only subscription micros may be negative
  - subscription-limit half-pairs are ignored instead of producing a bogus gauge
  - last-known process-local Nous credits snapshot
  - `/usage` render lines and in-session notice-line derivation for depleted / 50 / 75 / 90 percent bands
- Captures Nous credits headers at the Rust provider HTTP boundary for non-streaming and streaming OpenAI-compatible responses.
- Appends the last-known Nous credits block to Rust CLI `/usage`.
- Appends the same block to Rust gateway `/usage`.
- Surfaces a TUI status-bar notice when the last-known Nous credits state is depleted or crosses 50/75/90 percent usage.
- Marks upstream `fcb1944b4f76` as ported in the parity queue override.

## Verification

All Cargo commands used:

`CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0`

Passed:

- `cargo test -p hermes-core credits -- --nocapture` -> `6 passed`
- `cargo test -p hermes-agent generic_provider_captures_nous_credits_headers -- --nocapture`
- `cargo test -p hermes-cli usage_command_includes_last_nous_credits_state -- --nocapture`
- `cargo test -p hermes-cli usage_command_reports_actual_session_usage_and_cost -- --nocapture`
- `cargo test -p hermes-gateway gateway_usage_text_includes_last_nous_credits_state -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-core -p hermes-agent -p hermes-cli -p hermes-gateway` -> finished in `51.15s`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-agent -p hermes-cli -p hermes-gateway` -> `new=0`

Parity proof:

- `python3 scripts/generate-upstream-patch-queue.py --no-fetch --out-json /Volumes/wd_black/hermes-agent-ultra/parity-proofs/nous-credits-usage-queue.json --out-md /Volumes/wd_black/hermes-agent-ultra/parity-proofs/nous-credits-usage-queue.md`
- `fcb1944b4f76cc74d5092c2b8605d972c095bd3c` classified as `ported`.

Disk placement proof:

- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
