### PR TITLE
parity(config): align prefill message key handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -516,6 +517,11 @@ pub struct AgentConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ephemeral_system_prompt: Option<String>,
 
+    /// Ephemeral few-shot/prefill messages injected into provider requests.
+    /// These are model-visible but stripped from returned/persisted history.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prefill_messages: Vec<Message>,
+
     /// Session-level hard spend limit in USD. When reached, the loop trips
     /// the cost gate and returns early with a summary system message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -835,6 +841,7 @@ impl Default for AgentConfig {
             pass_session_id: false,
             runtime_providers: HashMap::new(),
             ephemeral_system_prompt: None,
+            prefill_messages: Vec::new(),
             max_cost_usd: None,
             cost_guard_degrade_at_ratio: default_cost_guard_degrade_at_ratio(),
             cost_guard_degrade_model: None,
@@ -1847,6 +1854,7 @@ impl AgentLoop {
         &self,
         ctx: &ContextManager,
         persist_user_idx: Option<usize>,
+        prefill_range: Option<Range<usize>>,
     ) -> Vec<Message> {
         let mut msgs = ctx.get_messages().to_vec();
         if let (Some(idx), Some(override_text)) = (
@@ -1857,6 +1865,11 @@ impl AgentLoop {
                 if msg.role == MessageRole::User {
                     msg.content = Some(override_text.to_string());
                 }
+            }
+        }
+        if let Some(range) = prefill_range {
+            if range.start <= range.end && range.end <= msgs.len() {
+                msgs.drain(range);
             }
         }
         msgs
@@ -1871,10 +1884,11 @@ impl AgentLoop {
         session_cost_usd: f64,
         session_started_hooks_fired: bool,
         persist_user_idx: Option<usize>,
+        prefill_range: Option<Range<usize>>,
     ) -> AgentResult {
         self.memory_on_session_end(ctx.get_messages());
         AgentResult {
-            messages: self.messages_for_persisted_result(ctx, persist_user_idx),
+            messages: self.messages_for_persisted_result(ctx, persist_user_idx, prefill_range),
             finished_naturally: false,
             total_turns,
             tool_errors: tool_errors.to_vec(),
@@ -4966,6 +4980,13 @@ impl AgentLoop {
             session_started_hooks_fired = true;
         }
 
+        let prefill_start = ctx.get_messages().len();
+        for msg in &self.config.prefill_messages {
+            ctx.add_message(msg.clone());
+        }
+        let prefill_end = ctx.get_messages().len();
+        let prefill_range = (prefill_end > prefill_start).then_some(prefill_start..prefill_end);
+
         // Add initial messages
         for msg in messages {
             ctx.add_message(msg);
@@ -5075,6 +5096,7 @@ impl AgentLoop {
                     session_cost_usd,
                     session_started_hooks_fired,
                     persist_user_idx,
+                    prefill_range.clone(),
                 ));
             }
 
@@ -5098,7 +5120,11 @@ impl AgentLoop {
                         }),
                     );
                     return Ok(AgentResult {
-                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        messages: self.messages_for_persisted_result(
+                            &ctx,
+                            persist_user_idx,
+                            prefill_range.clone(),
+                        ),
                         finished_naturally: false,
                         total_turns,
                         tool_errors,
@@ -5237,6 +5263,7 @@ impl AgentLoop {
                         session_cost_usd,
                         session_started_hooks_fired,
                         persist_user_idx,
+                        prefill_range.clone(),
                     ));
                 }
                 let r = match self
@@ -5258,6 +5285,7 @@ impl AgentLoop {
                             session_cost_usd,
                             session_started_hooks_fired,
                             persist_user_idx,
+                            prefill_range.clone(),
                         ));
                     }
                     Err(e) => {
@@ -5427,7 +5455,11 @@ impl AgentLoop {
                     )));
                     self.memory_on_session_end(ctx.get_messages());
                     return Ok(AgentResult {
-                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        messages: self.messages_for_persisted_result(
+                            &ctx,
+                            persist_user_idx,
+                            prefill_range.clone(),
+                        ),
                         finished_naturally: false,
                         total_turns,
                         tool_errors,
@@ -5614,7 +5646,11 @@ impl AgentLoop {
                     }),
                 );
                 return Ok(AgentResult {
-                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                    messages: self.messages_for_persisted_result(
+                        &ctx,
+                        persist_user_idx,
+                        prefill_range.clone(),
+                    ),
                     finished_naturally: true,
                     total_turns,
                     tool_errors,
@@ -5681,7 +5717,11 @@ impl AgentLoop {
                     )));
                     self.memory_on_session_end(ctx.get_messages());
                     return Ok(AgentResult {
-                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        messages: self.messages_for_persisted_result(
+                            &ctx,
+                            persist_user_idx,
+                            prefill_range.clone(),
+                        ),
                         finished_naturally: false,
                         total_turns,
                         tool_errors,
@@ -5797,6 +5837,7 @@ impl AgentLoop {
                     session_cost_usd,
                     session_started_hooks_fired,
                     persist_user_idx,
+                    prefill_range.clone(),
                 ));
             }
             let tool_span = tracing::info_span!(
@@ -5958,6 +5999,7 @@ impl AgentLoop {
                     session_cost_usd,
                     session_started_hooks_fired,
                     persist_user_idx,
+                    prefill_range.clone(),
                 ));
             }
             if should_trip_tool_loop_guard(
@@ -5994,7 +6036,11 @@ impl AgentLoop {
                 }
                 self.memory_on_session_end(ctx.get_messages());
                 return Ok(AgentResult {
-                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                    messages: self.messages_for_persisted_result(
+                        &ctx,
+                        persist_user_idx,
+                        prefill_range.clone(),
+                    ),
                     finished_naturally: false,
                     total_turns,
                     tool_errors,
@@ -6169,6 +6215,13 @@ impl AgentLoop {
             session_started_hooks_fired = true;
         }
 
+        let prefill_start = ctx.get_messages().len();
+        for msg in &self.config.prefill_messages {
+            ctx.add_message(msg.clone());
+        }
+        let prefill_end = ctx.get_messages().len();
+        let prefill_range = (prefill_end > prefill_start).then_some(prefill_start..prefill_end);
+
         for msg in messages {
             ctx.add_message(msg);
         }
@@ -6276,6 +6329,7 @@ impl AgentLoop {
                     session_cost_usd,
                     session_started_hooks_fired,
                     persist_user_idx,
+                    prefill_range.clone(),
                 ));
             }
 
@@ -6299,7 +6353,11 @@ impl AgentLoop {
                         }),
                     );
                     return Ok(AgentResult {
-                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        messages: self.messages_for_persisted_result(
+                            &ctx,
+                            persist_user_idx,
+                            prefill_range.clone(),
+                        ),
                         finished_naturally: false,
                         total_turns,
                         tool_errors,
@@ -6435,6 +6493,7 @@ impl AgentLoop {
                         session_cost_usd,
                         session_started_hooks_fired,
                         persist_user_idx,
+                        prefill_range.clone(),
                     ));
                 }
                 let r = if inner_attempt == 0 {
@@ -6468,6 +6527,7 @@ impl AgentLoop {
                                 session_cost_usd,
                                 session_started_hooks_fired,
                                 persist_user_idx,
+                                prefill_range.clone(),
                             ));
                         }
                         Err(e) => {
@@ -6501,6 +6561,7 @@ impl AgentLoop {
                                 session_cost_usd,
                                 session_started_hooks_fired,
                                 persist_user_idx,
+                                prefill_range.clone(),
                             ));
                         }
                         Err(e) => {
@@ -6680,7 +6741,11 @@ impl AgentLoop {
                         }),
                     );
                     return Ok(AgentResult {
-                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        messages: self.messages_for_persisted_result(
+                            &ctx,
+                            persist_user_idx,
+                            prefill_range.clone(),
+                        ),
                         finished_naturally: false,
                         total_turns,
                         tool_errors,
@@ -6899,7 +6964,11 @@ impl AgentLoop {
                     });
                 }
                 return Ok(AgentResult {
-                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                    messages: self.messages_for_persisted_result(
+                        &ctx,
+                        persist_user_idx,
+                        prefill_range.clone(),
+                    ),
                     finished_naturally: true,
                     total_turns,
                     tool_errors,
@@ -6989,7 +7058,11 @@ impl AgentLoop {
                     )));
                     self.memory_on_session_end(ctx.get_messages());
                     return Ok(AgentResult {
-                        messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                        messages: self.messages_for_persisted_result(
+                            &ctx,
+                            persist_user_idx,
+                            prefill_range.clone(),
+                        ),
                         finished_naturally: false,
                         total_turns,
                         tool_errors,
@@ -7097,6 +7170,7 @@ impl AgentLoop {
                     session_cost_usd,
                     session_started_hooks_fired,
                     persist_user_idx,
+                    prefill_range.clone(),
                 ));
             }
 
@@ -7254,6 +7328,7 @@ impl AgentLoop {
                     session_cost_usd,
                     session_started_hooks_fired,
                     persist_user_idx,
+                    prefill_range.clone(),
                 ));
             }
             if should_trip_tool_loop_guard(
@@ -7304,7 +7379,11 @@ impl AgentLoop {
                 }
                 self.memory_on_session_end(ctx.get_messages());
                 return Ok(AgentResult {
-                    messages: self.messages_for_persisted_result(&ctx, persist_user_idx),
+                    messages: self.messages_for_persisted_result(
+                        &ctx,
+                        persist_user_idx,
+                        prefill_range.clone(),
+                    ),
                     finished_naturally: false,
                     total_turns,
                     tool_errors,
@@ -9811,6 +9890,98 @@ mod tests {
         assert!(!config.smart_model_routing.enabled);
         assert!(config.background_review_metrics_enabled);
         assert_eq!(config.stream_read_max_retries, 2);
+        assert!(config.prefill_messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prefill_messages_are_model_visible_but_not_returned_for_persistence() {
+        #[derive(Default)]
+        struct CapturingProvider {
+            seen_messages: Mutex<Vec<Message>>,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for CapturingProvider {
+            async fn chat_completion(
+                &self,
+                messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<LlmResponse, AgentError> {
+                *self.seen_messages.lock().expect("seen messages lock") = messages.to_vec();
+                Ok(LlmResponse {
+                    message: Message::assistant("done"),
+                    usage: None,
+                    model: "test".to_string(),
+                    finish_reason: Some("stop".to_string()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let provider = std::sync::Arc::new(CapturingProvider::default());
+        let mut config = AgentConfig {
+            skip_memory: true,
+            skip_context_files: true,
+            prefill_messages: vec![
+                Message::system("prefill system"),
+                Message::user("prefill user example"),
+            ],
+            ..AgentConfig::default()
+        };
+        let _home = isolate_route_learning_home(&mut config);
+        let agent = AgentLoop::new(
+            config,
+            std::sync::Arc::new(ToolRegistry::new()),
+            provider.clone(),
+        );
+
+        let result = agent
+            .run(vec![Message::user("real question")], Some(Vec::new()))
+            .await
+            .expect("agent run");
+
+        let seen = provider.seen_messages.lock().expect("seen messages lock");
+        assert!(seen
+            .iter()
+            .any(|m| m.content.as_deref() == Some("prefill system")));
+        assert!(seen
+            .iter()
+            .any(|m| m.content.as_deref() == Some("prefill user example")));
+        assert!(seen
+            .iter()
+            .any(|m| m.content.as_deref() == Some("real question")));
+
+        assert!(!result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("prefill system")));
+        assert!(!result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("prefill user example")));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("real question")));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("done")));
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4647,6 +4647,36 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_loads_prefill_messages_from_config() {
+        let _lock = env_test_lock();
+        let _env = EnvSnapshot::capture(&["HERMES_PREFILL_MESSAGES_FILE"]);
+        std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE");
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("prefill.json"),
+            r#"[{"role":"system","content":"cli prefill"},{"role":"user","content":"cli example"}]"#,
+        )
+        .unwrap();
+        let cfg = GatewayConfig {
+            home_dir: Some(dir.path().to_string_lossy().to_string()),
+            prefill_messages_file: Some("prefill.json".to_string()),
+            ..GatewayConfig::default()
+        };
+
+        let agent_cfg = build_agent_config(&cfg, "openai:gpt-4o");
+        assert_eq!(agent_cfg.prefill_messages.len(), 2);
+        assert_eq!(
+            agent_cfg.prefill_messages[0].content.as_deref(),
+            Some("cli prefill")
+        );
+        assert_eq!(
+            agent_cfg.prefill_messages[1].content.as_deref(),
+            Some("cli example")
+        );
+    }
+
+    #[test]
     fn test_build_agent_config_maps_runtime_provider_request_timeout_seconds() {
         let mut cfg = GatewayConfig::default();
         cfg.llm_providers.insert(
@@ -6343,6 +6373,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
                 )
             })
             .collect(),
+        prefill_messages: hermes_config::load_prefill_messages(config),
         retry: retry_cfg,
         smart_model_routing: hermes_agent::agent_loop::SmartModelRoutingConfig {
             enabled: config.smart_model_routing.enabled,

--- a/crates/hermes-cli/src/config_env.rs
+++ b/crates/hermes-cli/src/config_env.rs
@@ -7,11 +7,16 @@ use serde_json::Value;
 /// Returns number of variables set from configuration.
 pub fn hydrate_env_from_config(config: &GatewayConfig) -> usize {
     let mut applied = 0usize;
+    let prefill_messages_file = hermes_config::resolve_prefill_messages_file(config);
 
     applied += set_if_absent("HERMES_MODEL", config.model.as_deref());
     applied += set_if_absent("HERMES_PERSONALITY", config.personality.as_deref());
     applied += set_if_absent_owned("HERMES_MAX_TURNS", config.max_turns.to_string());
     applied += set_if_absent("HERMES_SYSTEM_PROMPT", config.system_prompt.as_deref());
+    applied += set_if_absent(
+        "HERMES_PREFILL_MESSAGES_FILE",
+        prefill_messages_file.as_deref(),
+    );
     applied += set_if_absent_owned(
         "HERMES_ALLOW_PRIVATE_URLS",
         if config.security.allow_private_urls {
@@ -220,6 +225,7 @@ mod tests {
         let _guard = EnvGuard::capture(&[
             "HERMES_MODEL",
             "HERMES_MAX_TURNS",
+            "HERMES_PREFILL_MESSAGES_FILE",
             "DISCORD_ALLOWED_USERS",
             "HERMES_PLATFORM_DISCORD_ALLOWED_USERS",
             "DISCORD_CUSTOM_FLAG",
@@ -230,6 +236,7 @@ mod tests {
         ]);
         std::env::remove_var("HERMES_MODEL");
         std::env::remove_var("HERMES_MAX_TURNS");
+        std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE");
         std::env::remove_var("DISCORD_ALLOWED_USERS");
         std::env::remove_var("HERMES_PLATFORM_DISCORD_ALLOWED_USERS");
         std::env::remove_var("DISCORD_CUSTOM_FLAG");
@@ -241,6 +248,7 @@ mod tests {
         let mut cfg = GatewayConfig {
             model: Some("openai:gpt-4o".to_string()),
             max_turns: 77,
+            prefill_messages_file: Some("prefill.json".to_string()),
             ..GatewayConfig::default()
         };
         let mut discord = PlatformConfig {
@@ -279,6 +287,10 @@ mod tests {
         );
         assert_eq!(std::env::var("HERMES_MAX_TURNS").unwrap(), "77".to_string());
         assert_eq!(
+            std::env::var("HERMES_PREFILL_MESSAGES_FILE").unwrap(),
+            "prefill.json".to_string()
+        );
+        assert_eq!(
             std::env::var("DISCORD_ALLOWED_USERS").unwrap(),
             "123,456".to_string()
         );
@@ -309,21 +321,41 @@ mod tests {
     }
 
     #[test]
+    fn hydrate_env_sets_prefill_from_legacy_agent_key() {
+        let _lock = test_env_lock::lock();
+        let _guard = EnvGuard::capture(&["HERMES_PREFILL_MESSAGES_FILE"]);
+        std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE");
+
+        let mut cfg = GatewayConfig::default();
+        cfg.agent.prefill_messages_file = Some("legacy-prefill.json".to_string());
+
+        let applied = hydrate_env_from_config(&cfg);
+        assert!(applied > 0);
+        assert_eq!(
+            std::env::var("HERMES_PREFILL_MESSAGES_FILE").unwrap(),
+            "legacy-prefill.json"
+        );
+    }
+
+    #[test]
     fn hydrate_env_never_overwrites_existing_values() {
         let _lock = test_env_lock::lock();
         let _guard = EnvGuard::capture(&[
             "HERMES_MODEL",
+            "HERMES_PREFILL_MESSAGES_FILE",
             "DISCORD_ALLOWED_USERS",
             "DISCORD_IGNORED_CHANNELS",
             "DISCORD_REPLY_TO_MODE",
         ]);
         std::env::set_var("HERMES_MODEL", "existing:model");
+        std::env::set_var("HERMES_PREFILL_MESSAGES_FILE", "existing-prefill.json");
         std::env::set_var("DISCORD_ALLOWED_USERS", "from-env");
         std::env::set_var("DISCORD_IGNORED_CHANNELS", "999");
         std::env::set_var("DISCORD_REPLY_TO_MODE", "first");
 
         let mut cfg = GatewayConfig {
             model: Some("openai:gpt-4o".to_string()),
+            prefill_messages_file: Some("config-prefill.json".to_string()),
             ..GatewayConfig::default()
         };
         let mut discord = PlatformConfig {
@@ -345,6 +377,10 @@ mod tests {
         let _ = hydrate_env_from_config(&cfg);
 
         assert_eq!(std::env::var("HERMES_MODEL").unwrap(), "existing:model");
+        assert_eq!(
+            std::env::var("HERMES_PREFILL_MESSAGES_FILE").unwrap(),
+            "existing-prefill.json"
+        );
         assert_eq!(std::env::var("DISCORD_ALLOWED_USERS").unwrap(), "from-env");
         assert_eq!(std::env::var("DISCORD_IGNORED_CHANNELS").unwrap(), "999");
         assert_eq!(std::env::var("DISCORD_REPLY_TO_MODE").unwrap(), "first");

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -34,6 +34,13 @@ pub struct GatewayConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
 
+    /// Optional JSON few-shot/prefill message file.
+    ///
+    /// This is the canonical upstream-compatible key. Messages are injected at
+    /// runtime only and must not be persisted into session history.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefill_messages_file: Option<String>,
+
     /// List of enabled tool names. Defaults to all core tools.
     #[serde(default = "default_tools")]
     pub tools: Vec<String>,
@@ -167,6 +174,7 @@ impl Default for GatewayConfig {
             personality: None,
             max_turns: default_max_turns(),
             system_prompt: None,
+            prefill_messages_file: None,
             tools: default_tools(),
             budget: BudgetConfig::default(),
             tool_output: ToolOutputConfig::default(),
@@ -706,6 +714,12 @@ pub struct AgentLoopBehaviorConfig {
         alias = "apiMaxRetries"
     )]
     pub api_max_retries: Option<u32>,
+    /// Legacy location for `prefill_messages_file`.
+    ///
+    /// The top-level key is canonical; this field is retained so older CLI and
+    /// godmode-generated configs continue to work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefill_messages_file: Option<String>,
 }
 
 fn default_agent_memory_nudge_interval() -> u32 {
@@ -758,6 +772,7 @@ impl Default for AgentLoopBehaviorConfig {
             lsp_context_max_chars: default_agent_lsp_context_max_chars(),
             service_tier: None,
             api_max_retries: None,
+            prefill_messages_file: None,
         }
     }
 }

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -30,8 +30,10 @@ pub use config::{
 };
 pub use loader::{
     apply_user_config_patch, atomic_json_write, atomic_json_write_pretty, atomic_write_bytes,
-    atomic_yaml_write, load_config, load_user_config_file, save_config_yaml, set_user_config_value,
-    user_config_field_display, validate_config, ConfigError, ConfigSetResult,
+    atomic_yaml_write, load_config, load_prefill_messages, load_prefill_messages_file,
+    load_user_config_file, resolve_prefill_messages_file, resolve_prefill_messages_path,
+    save_config_yaml, set_user_config_value, user_config_field_display, validate_config,
+    ConfigError, ConfigSetResult,
 };
 pub use managed_gateway::{
     build_vendor_gateway_url, coerce_modal_mode, env_var_enabled, get_tool_gateway_scheme,

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -569,7 +569,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -659,6 +659,9 @@ fn apply_user_config_patch_flat(
         }
         "system_prompt" => {
             config.system_prompt = Some(value.to_string());
+        }
+        "prefill_messages_file" => {
+            config.prefill_messages_file = Some(value.to_string());
         }
         other => {
             return Err(ConfigError::NotFound(format!(
@@ -941,6 +944,12 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             "max_turns" => config.max_turns.to_string(),
             "system_prompt" => config
                 .system_prompt
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "(not set)".to_string()),
+            "prefill_messages_file" => config
+                .prefill_messages_file
                 .as_deref()
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string())
@@ -1529,6 +1538,113 @@ pub fn load_from_json(path: &Path) -> Result<GatewayConfig, ConfigError> {
     Ok(config)
 }
 
+/// Resolve the prefill JSON file using upstream-compatible precedence.
+///
+/// `prefill_messages_file` at the top level is canonical. The nested
+/// `agent.prefill_messages_file` key remains a legacy fallback for older
+/// generated configs.
+pub fn resolve_prefill_messages_file(config: &GatewayConfig) -> Option<String> {
+    env_var_nonempty("HERMES_PREFILL_MESSAGES_FILE")
+        .or_else(|| trimmed_optional(config.prefill_messages_file.as_deref()))
+        .or_else(|| trimmed_optional(config.agent.prefill_messages_file.as_deref()))
+}
+
+/// Resolve a configured prefill JSON path, mapping relative paths under HERMES_HOME.
+pub fn resolve_prefill_messages_path(config: &GatewayConfig) -> Option<PathBuf> {
+    let path = expand_home_path(&resolve_prefill_messages_file(config)?);
+    if path.is_absolute() {
+        return Some(path);
+    }
+    let home = config
+        .home_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(paths::hermes_home);
+    Some(home.join(path))
+}
+
+/// Load configured ephemeral prefill messages.
+///
+/// Invalid or missing files match Python behavior: warn and continue without
+/// prefill rather than blocking startup.
+pub fn load_prefill_messages(config: &GatewayConfig) -> Vec<hermes_core::Message> {
+    let Some(path) = resolve_prefill_messages_path(config) else {
+        return Vec::new();
+    };
+    load_prefill_messages_file(&path)
+}
+
+pub fn load_prefill_messages_file(path: &Path) -> Vec<hermes_core::Message> {
+    if !path.exists() {
+        tracing::warn!("Prefill messages file not found: {}", path.display());
+        return Vec::new();
+    }
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            tracing::warn!(
+                "Failed to load prefill messages from {}: {}",
+                path.display(),
+                err
+            );
+            return Vec::new();
+        }
+    };
+    let value = match serde_json::from_str::<serde_json::Value>(&contents) {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!(
+                "Failed to parse prefill messages from {}: {}",
+                path.display(),
+                err
+            );
+            return Vec::new();
+        }
+    };
+    if !value.is_array() {
+        tracing::warn!(
+            "Prefill messages file must contain a JSON array: {}",
+            path.display()
+        );
+        return Vec::new();
+    }
+    match serde_json::from_value::<Vec<hermes_core::Message>>(value) {
+        Ok(messages) => messages,
+        Err(err) => {
+            tracing::warn!(
+                "Failed to parse prefill messages from {}: {}",
+                path.display(),
+                err
+            );
+            Vec::new()
+        }
+    }
+}
+
+fn trimmed_optional(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn expand_home_path(raw: &str) -> PathBuf {
+    let trimmed = raw.trim();
+    if trimmed == "~" {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(trimmed)
+}
+
 fn env_var_nonempty(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
@@ -1879,6 +1995,9 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
     }
     if let Ok(v) = std::env::var("HERMES_SYSTEM_PROMPT") {
         config.system_prompt = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("HERMES_PREFILL_MESSAGES_FILE") {
+        config.prefill_messages_file = Some(v);
     }
     if let Ok(v) = std::env::var("HERMES_KANBAN_DISPATCH_IN_GATEWAY") {
         if let Some(parsed) = parse_bool_env("HERMES_KANBAN_DISPATCH_IN_GATEWAY", &v) {
@@ -2758,6 +2877,98 @@ agent:
         .unwrap();
         let camel = load_user_config_file(&camel_path).unwrap();
         assert_eq!(camel.agent.api_max_retries, Some(8));
+    }
+
+    #[test]
+    fn prefill_messages_file_resolution_prefers_env_then_top_level_then_legacy_agent_key() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE") };
+        let mut cfg = GatewayConfig::default();
+        cfg.agent.prefill_messages_file = Some("legacy.json".to_string());
+        assert_eq!(
+            resolve_prefill_messages_file(&cfg).as_deref(),
+            Some("legacy.json")
+        );
+
+        cfg.prefill_messages_file = Some("top.json".to_string());
+        assert_eq!(
+            resolve_prefill_messages_file(&cfg).as_deref(),
+            Some("top.json")
+        );
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::set_var("HERMES_PREFILL_MESSAGES_FILE", "env.json") };
+        assert_eq!(
+            resolve_prefill_messages_file(&cfg).as_deref(),
+            Some("env.json")
+        );
+
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE") };
+    }
+
+    #[test]
+    fn load_config_accepts_canonical_and_legacy_prefill_messages_file_keys() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE") };
+
+        let dir = tempdir().unwrap();
+        let top_path = dir.path().join("top.yaml");
+        std::fs::write(&top_path, "prefill_messages_file: prefill-top.json\n").unwrap();
+        let top = load_user_config_file(&top_path).unwrap();
+        assert_eq!(
+            top.prefill_messages_file.as_deref(),
+            Some("prefill-top.json")
+        );
+
+        let legacy_path = dir.path().join("legacy.yaml");
+        std::fs::write(
+            &legacy_path,
+            "agent:\n  prefill_messages_file: prefill-legacy.json\n",
+        )
+        .unwrap();
+        let legacy = load_user_config_file(&legacy_path).unwrap();
+        assert_eq!(
+            legacy.agent.prefill_messages_file.as_deref(),
+            Some("prefill-legacy.json")
+        );
+        assert_eq!(
+            resolve_prefill_messages_file(&legacy).as_deref(),
+            Some("prefill-legacy.json")
+        );
+    }
+
+    #[test]
+    fn load_prefill_messages_resolves_relative_json_under_config_home() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: test process serializes env mutation via ENV_LOCK.
+        unsafe { std::env::remove_var("HERMES_PREFILL_MESSAGES_FILE") };
+
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("prefill.json"),
+            r#"[{"role":"system","content":"few-shot system"},{"role":"user","content":"example"}]"#,
+        )
+        .unwrap();
+        let cfg = GatewayConfig {
+            home_dir: Some(dir.path().to_string_lossy().to_string()),
+            prefill_messages_file: Some("prefill.json".to_string()),
+            ..GatewayConfig::default()
+        };
+
+        let messages = load_prefill_messages(&cfg);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, hermes_core::MessageRole::System);
+        assert_eq!(messages[0].content.as_deref(), Some("few-shot system"));
+        assert_eq!(messages[1].role, hermes_core::MessageRole::User);
+        assert_eq!(messages[1].content.as_deref(), Some("example"));
     }
 
     #[test]

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -113,6 +113,7 @@ fn arb_gateway_config() -> impl Strategy<Value = GatewayConfig> {
                 personality,
                 max_turns,
                 system_prompt: None,
+                prefill_messages_file: None,
                 tools: vec!["bash".into(), "read".into()],
                 budget: BudgetConfig::default(),
                 tool_output: ToolOutputConfig::default(),

--- a/crates/hermes-cron/src/runner.rs
+++ b/crates/hermes-cron/src/runner.rs
@@ -18,7 +18,7 @@ use std::time::Duration as StdDuration;
 use hermes_agent::agent_loop::ToolRegistry;
 use hermes_agent::skill_orchestrator::parse_frontmatter;
 use hermes_agent::{AgentConfig, AgentLoop};
-use hermes_config::{load_config, GatewayConfig};
+use hermes_config::{load_config, load_prefill_messages, GatewayConfig};
 use hermes_core::{AgentResult, LlmProvider, Message, Skill, ToolSchema};
 use hermes_skills::SkillGuard;
 use hermes_tools::{ToolRegistry as ToolsetRegistry, ToolsetManager};
@@ -528,6 +528,18 @@ impl CronRunner {
 
         // Build agent config from job settings
         let mut config = AgentConfig::default();
+        let runtime_config = match load_config(None) {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::warn!(
+                    "Cron runtime config load failed for job '{}'; prefill disabled: {}",
+                    job.id,
+                    err
+                );
+                GatewayConfig::default()
+            }
+        };
+        config.prefill_messages = load_prefill_messages(&runtime_config);
         // Scheduled/background runs should avoid user/workspace context injection
         // so job trajectories stay deterministic and non-user-specific. Per-job
         // workdir intentionally re-enables workspace context for that directory.
@@ -1103,6 +1115,98 @@ tools_config:
 
         let messages = runner.build_messages(&job).expect("messages");
         assert_eq!(messages[0].content.as_deref(), Some("Say hello"));
+    }
+
+    #[test]
+    fn test_run_job_loads_legacy_prefill_messages_without_persisting_them() {
+        #[derive(Clone)]
+        struct CapturingLlmProvider {
+            seen: Arc<Mutex<Vec<Message>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for CapturingLlmProvider {
+            async fn chat_completion(
+                &self,
+                messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, hermes_core::AgentError> {
+                *self.seen.lock().expect("seen messages lock") = messages.to_vec();
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("cron done"),
+                    usage: None,
+                    model: "mock".to_string(),
+                    finish_reason: Some("stop".to_string()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> futures::stream::BoxStream<
+                'static,
+                Result<hermes_core::StreamChunk, hermes_core::AgentError>,
+            > {
+                Box::pin(futures::stream::empty())
+            }
+        }
+
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        fs::write(
+            home.path().join("config.yaml"),
+            "agent:\n  prefill_messages_file: prefill.json\n",
+        )
+        .unwrap();
+        fs::write(
+            home.path().join("prefill.json"),
+            r#"[{"role":"system","content":"cron prefill system"},{"role":"user","content":"cron prefill user"}]"#,
+        )
+        .unwrap();
+        let _home = EnvGuard::set("HERMES_HOME", home.path().to_string_lossy().as_ref());
+        let _ignore = EnvGuard::remove("HERMES_IGNORE_USER_CONFIG");
+        let _prefill_env = EnvGuard::remove("HERMES_PREFILL_MESSAGES_FILE");
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let runner = CronRunner {
+            llm_provider: Arc::new(CapturingLlmProvider { seen: seen.clone() }),
+            tool_registry: Arc::new(ToolRegistry::new()),
+        };
+        let job = CronJob::new("0 9 * * *", "cron prompt");
+
+        let result = block_on(runner.run_job(&job)).expect("cron run");
+        let seen_messages = seen.lock().expect("seen messages lock");
+        assert!(seen_messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("cron prefill system")));
+        assert!(seen_messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("cron prefill user")));
+        assert!(seen_messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("cron prompt")));
+
+        assert!(!result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("cron prefill system")));
+        assert!(!result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("cron prefill user")));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("cron prompt")));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -2725,14 +2725,7 @@ impl Gateway {
 
     /// Load optional prefill messages.
     pub fn load_prefill_messages(&self, path: &std::path::Path) -> Vec<Message> {
-        let Ok(content) = std::fs::read_to_string(path) else {
-            return vec![];
-        };
-        content
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(Message::user)
-            .collect()
+        hermes_config::load_prefill_messages_file(path)
     }
 
     /// Load optional ephemeral system prompt.
@@ -3044,6 +3037,28 @@ mod tests {
         fn platform_name(&self) -> &str {
             "media-marker-test"
         }
+    }
+
+    #[test]
+    fn gateway_prefill_loader_parses_json_message_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prefill.json");
+        std::fs::write(
+            &path,
+            r#"[{"role":"system","content":"gateway system"},{"role":"assistant","content":"gateway assistant"}]"#,
+        )
+        .unwrap();
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let dm_manager = DmManager::with_ignore_behavior();
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        let messages = gw.load_prefill_messages(&path);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, MessageRole::System);
+        assert_eq!(messages[0].content.as_deref(), Some("gateway system"));
+        assert_eq!(messages[1].role, MessageRole::Assistant);
+        assert_eq!(messages[1].content.as_deref(), Some("gateway assistant"));
     }
 
     #[tokio::test]

--- a/crates/hermes-http/Cargo.toml
+++ b/crates/hermes-http/Cargo.toml
@@ -36,3 +36,4 @@ reqwest = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tracing-subscriber = { workspace = true }
+tempfile = "3"

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -760,6 +760,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
                 )
             })
             .collect(),
+        prefill_messages: hermes_config::load_prefill_messages(config),
         smart_model_routing: hermes_agent::agent_loop::SmartModelRoutingConfig {
             enabled: config.smart_model_routing.enabled,
             max_simple_chars: config.smart_model_routing.max_simple_chars,
@@ -1003,6 +1004,33 @@ mod tests {
                 .get("openai")
                 .and_then(|cfg| cfg.request_timeout_seconds),
             Some(45.5)
+        );
+    }
+
+    #[test]
+    fn build_agent_config_loads_prefill_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("prefill.json"),
+            r#"[{"role":"system","content":"http prefill"},{"role":"user","content":"http example"}]"#,
+        )
+        .unwrap();
+        let config = GatewayConfig {
+            home_dir: Some(dir.path().to_string_lossy().to_string()),
+            prefill_messages_file: Some("prefill.json".to_string()),
+            ..GatewayConfig::default()
+        };
+
+        let agent_config = build_agent_config(&config, "openai:gpt-4o");
+
+        assert_eq!(agent_config.prefill_messages.len(), 2);
+        assert_eq!(
+            agent_config.prefill_messages[0].content.as_deref(),
+            Some("http prefill")
+        );
+        assert_eq!(
+            agent_config.prefill_messages[1].content.as_deref(),
+            Some("http example")
         );
     }
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -987,6 +987,10 @@
     "fcb1944b4f76": {
       "disposition": "ported",
       "notes": "Rust now captures Nous credits headers at the provider HTTP boundary, parses the v1 x-nous-credits and x-nous-tool-pool contracts with strict money/bool validation, stores a last-known credits snapshot, appends the credits block to CLI and gateway /usage output, and surfaces depleted/50/75/90 percent usage notices in the TUI status bar with focused Rust tests. Python dev fixtures and desktop-only scaffolding are superseded by the Rust runtime surface."
+    },
+    "ffb53767bfff": {
+      "disposition": "ported",
+      "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Port upstream `ffb53767bfff` prefill config-key behavior into Rust.
- Add canonical top-level `prefill_messages_file` with legacy `agent.prefill_messages_file` fallback and `HERMES_PREFILL_MESSAGES_FILE` env precedence.
- Load JSON message arrays relative to `HERMES_HOME`/config home and inject them ephemerally into CLI, HTTP/API, cron, and gateway helper paths.
- Strip prefill messages from returned/persisted agent history while keeping them model-visible.
- Mark the upstream commit as `ported` in `docs/parity/queue-overrides.json`.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-config -p hermes-agent -p hermes-cli -p hermes-cron -p hermes-gateway -p hermes-http`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-config prefill -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli prefill -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli hydrate_env_ -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent prefill_messages_are_model_visible_but_not_returned_for_persistence -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cron test_run_job_loads_legacy_prefill_messages_without_persisting_them -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_prefill_loader_parses_json_message_array -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-http build_agent_config_loads_prefill_messages -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-agent -p hermes-cli -p hermes-cron -p hermes-gateway -p hermes-http` (`new=0`)

## Disk Target Proof
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
