### PR TITLE
parity(agent): persist tool result names

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -1875,6 +1875,28 @@ impl AgentLoop {
         msgs
     }
 
+    fn named_tool_result_message(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Message {
+        Message::tool_result_with_name(tool_call_id, tool_name, content)
+    }
+
+    fn tool_result_message_from_execution(result: &ToolResult, tool_calls: &[ToolCall]) -> Message {
+        tool_calls
+            .iter()
+            .find(|tc| tc.id == result.tool_call_id)
+            .map(|tc| {
+                Self::named_tool_result_message(
+                    &result.tool_call_id,
+                    &tc.function.name,
+                    &result.content,
+                )
+            })
+            .unwrap_or_else(|| Message::tool_result(&result.tool_call_id, &result.content))
+    }
+
     fn graceful_interrupt_result(
         &self,
         ctx: &ContextManager,
@@ -5745,7 +5767,11 @@ impl AgentLoop {
                     } else {
                         "Skipped: another tool call in this turn used an invalid name. Please retry this tool call.".to_string()
                     };
-                    ctx.add_message(Message::tool_result(tc.id.clone(), content));
+                    ctx.add_message(Self::named_tool_result_message(
+                        tc.id.clone(),
+                        tc.function.name.clone(),
+                        content,
+                    ));
                 }
                 continue;
             }
@@ -5790,7 +5816,11 @@ impl AgentLoop {
                     } else {
                         "Skipped: other tool call in this response had invalid JSON.".to_string()
                     };
-                    ctx.add_message(Message::tool_result(tc.id.clone(), content));
+                    ctx.add_message(Self::named_tool_result_message(
+                        tc.id.clone(),
+                        tc.function.name.clone(),
+                        content,
+                    ));
                 }
                 continue;
             }
@@ -5985,7 +6015,10 @@ impl AgentLoop {
                         "content_preview": result.content.chars().take(240).collect::<String>(),
                     }),
                 );
-                ctx.add_message(Message::tool_result(&result.tool_call_id, &result.content));
+                ctx.add_message(Self::tool_result_message_from_execution(
+                    &result,
+                    &tool_calls,
+                ));
             }
             if let Some(note) = lsp_note {
                 ctx.add_message(Message::system(note));
@@ -7086,7 +7119,11 @@ impl AgentLoop {
                     } else {
                         "Skipped: another tool call in this turn used an invalid name. Please retry this tool call.".to_string()
                     };
-                    ctx.add_message(Message::tool_result(tc.id.clone(), content));
+                    ctx.add_message(Self::named_tool_result_message(
+                        tc.id.clone(),
+                        tc.function.name.clone(),
+                        content,
+                    ));
                 }
                 continue;
             }
@@ -7131,7 +7168,11 @@ impl AgentLoop {
                     } else {
                         "Skipped: other tool call in this response had invalid JSON.".to_string()
                     };
-                    ctx.add_message(Message::tool_result(tc.id.clone(), content));
+                    ctx.add_message(Self::named_tool_result_message(
+                        tc.id.clone(),
+                        tc.function.name.clone(),
+                        content,
+                    ));
                 }
                 continue;
             }
@@ -7314,7 +7355,10 @@ impl AgentLoop {
                         "content_preview": result.content.chars().take(240).collect::<String>(),
                     }),
                 );
-                ctx.add_message(Message::tool_result(&result.tool_call_id, &result.content));
+                ctx.add_message(Self::tool_result_message_from_execution(
+                    &result,
+                    &tool_calls,
+                ));
             }
             if let Some(note) = lsp_note {
                 ctx.add_message(Message::system(note));
@@ -12113,12 +12157,20 @@ mod tests {
             .iter()
             .find(|message| message.role == MessageRole::Tool)
             .expect("tool result in second call");
+        assert_eq!(tool_message.name.as_deref(), Some("steer_test"));
         let content = tool_message.content.as_deref().expect("tool content");
         assert!(content.contains("tool output"));
         assert!(content.contains(crate::steer::STEER_MARKER_OPEN));
         assert!(content.contains("prefer the simpler fix"));
         assert!(content.contains(crate::steer::STEER_MARKER_CLOSE));
         assert!(!content.contains("User guidance:"));
+
+        let persisted_tool_message = result
+            .messages
+            .iter()
+            .find(|message| message.role == MessageRole::Tool)
+            .expect("persisted tool result");
+        assert_eq!(persisted_tool_message.name.as_deref(), Some("steer_test"));
     }
 
     #[test]

--- a/crates/hermes-agent/src/session_persistence.rs
+++ b/crates/hermes-agent/src/session_persistence.rs
@@ -323,6 +323,7 @@ impl SessionPersistence {
                 role TEXT NOT NULL,
                 content TEXT,
                 tool_call_id TEXT,
+                name TEXT,
                 tool_calls TEXT,
                 reasoning_content TEXT,
                 created_at TEXT NOT NULL,
@@ -349,14 +350,8 @@ impl SessionPersistence {
         ] {
             Self::ensure_text_column(&conn, "sessions", column)?;
         }
-        if let Err(e) = conn.execute("ALTER TABLE messages ADD COLUMN reasoning_content TEXT", []) {
-            let msg = e.to_string();
-            if !msg.contains("duplicate column") {
-                return Err(AgentError::Io(format!(
-                    "Failed to migrate messages.reasoning_content: {e}"
-                )));
-            }
-        }
+        Self::ensure_text_column(&conn, "messages", "reasoning_content")?;
+        Self::ensure_text_column(&conn, "messages", "name")?;
         Self::ensure_integer_column(&conn, "sessions", "rewind_count", 0, true)?;
         Self::ensure_integer_column(&conn, "messages", "active", 1, true)?;
         conn.execute(
@@ -867,8 +862,8 @@ impl SessionPersistence {
 
         let mut stmt = conn
             .prepare(
-                "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls, reasoning_content, created_at, active)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1)",
+                "INSERT INTO messages (session_id, role, content, tool_call_id, name, tool_calls, reasoning_content, created_at, active)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)",
             )
             .map_err(|e| AgentError::Io(format!("Failed to prepare insert: {e}")))?;
 
@@ -890,6 +885,7 @@ impl SessionPersistence {
                 role,
                 msg.content.as_deref(),
                 msg.tool_call_id.as_deref(),
+                msg.name.as_deref(),
                 tool_calls_json.as_deref(),
                 msg.reasoning_content.as_deref(),
                 now,
@@ -1013,7 +1009,7 @@ impl SessionPersistence {
 
         let mut stmt = conn
             .prepare(
-                "SELECT role, content, tool_call_id, tool_calls, reasoning_content
+                "SELECT role, content, tool_call_id, name, tool_calls, reasoning_content
                  FROM messages
                  WHERE session_id = ?1 AND active = 1
                  ORDER BY id ASC",
@@ -1025,8 +1021,9 @@ impl SessionPersistence {
                 let role_str: String = row.get(0)?;
                 let content: Option<String> = row.get(1)?;
                 let tool_call_id: Option<String> = row.get(2)?;
-                let tool_calls_json: Option<String> = row.get(3)?;
-                let reasoning_content: Option<String> = row.get(4)?;
+                let name: Option<String> = row.get(3)?;
+                let tool_calls_json: Option<String> = row.get(4)?;
+                let reasoning_content: Option<String> = row.get(5)?;
 
                 let role = match role_str.as_str() {
                     "system" => MessageRole::System,
@@ -1043,7 +1040,7 @@ impl SessionPersistence {
                     content,
                     tool_calls,
                     tool_call_id,
-                    name: None,
+                    name,
                     reasoning_content,
                     cache_control: None,
                 })
@@ -1176,6 +1173,27 @@ mod tests {
     }
 
     #[test]
+    fn test_persist_and_load_tool_result_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        let messages = vec![Message::tool_result_with_name(
+            "call_terminal",
+            "terminal",
+            "stdout",
+        )];
+
+        sp.persist_session("tool-name-session", &messages, None, None, None, None)
+            .unwrap();
+
+        let loaded = sp.load_session("tool-name-session").unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].role, MessageRole::Tool);
+        assert_eq!(loaded[0].tool_call_id.as_deref(), Some("call_terminal"));
+        assert_eq!(loaded[0].name.as_deref(), Some("terminal"));
+        assert_eq!(loaded[0].content.as_deref(), Some("stdout"));
+    }
+
+    #[test]
     fn test_migrates_reasoning_content_column_for_legacy_db() {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("sessions.db");
@@ -1233,14 +1251,13 @@ mod tests {
         let mut stmt = conn
             .prepare("PRAGMA table_info(messages)")
             .expect("pragma prepare");
-        let has_reasoning_col = stmt
+        let message_cols = stmt
             .query_map([], |row| row.get::<_, String>(1))
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
-            .unwrap()
-            .iter()
-            .any(|name| name == "reasoning_content");
-        assert!(has_reasoning_col);
+            .unwrap();
+        assert!(message_cols.iter().any(|name| name == "reasoning_content"));
+        assert!(message_cols.iter().any(|name| name == "name"));
 
         let loaded = sp.load_session("legacy-migrate").unwrap();
         assert_eq!(loaded.len(), 1);

--- a/crates/hermes-core/src/types.rs
+++ b/crates/hermes-core/src/types.rs
@@ -206,6 +206,24 @@ impl Message {
             cache_control: None,
         }
     }
+
+    /// Create a tool result message with the originating tool name.
+    pub fn tool_result_with_name(
+        tool_call_id: impl Into<String>,
+        name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        let name = name.into();
+        Self {
+            role: MessageRole::Tool,
+            content: Some(content.into()),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            name: (!name.trim().is_empty()).then_some(name),
+            reasoning_content: None,
+            cache_control: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -422,6 +440,12 @@ mod tests {
 
         let err = ToolResult::err("call_2", "failed");
         assert!(err.is_error);
+
+        let msg = Message::tool_result_with_name("call_3", "terminal", "stdout");
+        assert_eq!(msg.role, MessageRole::Tool);
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_3"));
+        assert_eq!(msg.name.as_deref(), Some("terminal"));
+        assert_eq!(msg.content.as_deref(), Some("stdout"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -991,6 +991,10 @@
     "ffb53767bfff": {
       "disposition": "ported",
       "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."
+    },
+    "a61420952e29": {
+      "disposition": "ported",
+      "notes": "Rust now constructs tool-result messages with the originating tool name in Message.name when the ToolCall is known, including invalid-tool and invalid-JSON result paths, persists messages.name through the SQLite session store with legacy DB migration, and regression-tests model-visible plus persisted tool-result name round trips."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Port upstream parity item `a61420952e29` by preserving originating tool names on tool-result messages.
- Add `Message::tool_result_with_name` and route known `ToolCall` metadata into normal, invalid-tool-name, and invalid-JSON tool-result paths.
- Persist and restore `Message.name` through SQLite sessions with legacy DB migration coverage.
- Mark the upstream item as `ported` in `docs/parity/queue-overrides.json`.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-core -p hermes-agent`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-core test_tool_result -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent mid_turn_steer_interrupt_is_appended_to_last_tool_result -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent test_persist_and_load_tool_result_name -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent test_migrates_reasoning_content_column_for_legacy_db -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-agent` (`new=0`, `stale=6`)

## Disk placement proof
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
