### PR TITLE
parity(cli): display profile aliases

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -14137,6 +14137,39 @@ fn resolve_profile_name(
         .unwrap_or_else(|| requested.trim().to_string())
 }
 
+fn profile_alias_label(
+    aliases: &std::collections::BTreeMap<String, String>,
+    target: &str,
+) -> Option<String> {
+    let target = target.trim();
+    if target.is_empty() {
+        return None;
+    }
+    let mut custom = Vec::new();
+    let mut profile_named = Vec::new();
+    for (alias, resolved_target) in aliases {
+        let alias = alias.trim();
+        if alias.is_empty() || resolved_target.trim() != target {
+            continue;
+        }
+        if alias == target {
+            profile_named.push(alias.to_string());
+        } else {
+            custom.push(alias.to_string());
+        }
+    }
+    let selected = if custom.is_empty() {
+        profile_named
+    } else {
+        custom
+    };
+    match selected.as_slice() {
+        [] => None,
+        [one] => Some(format!("alias: {one}")),
+        many => Some(format!("aliases: {}", many.join(", "))),
+    }
+}
+
 fn resolve_profile_yaml_path(profiles_dir: &Path, name: &str) -> Option<PathBuf> {
     let yaml = profiles_dir.join(format!("{}.yaml", name));
     if yaml.exists() {
@@ -14247,6 +14280,13 @@ async fn run_profile(
                 read_active_profile_name(&profiles_dir).unwrap_or_else(|| "(none)".to_string());
             println!("Current profile:");
             println!("  Active:      {}", active);
+            if let Some(label) = profile_alias_label(&aliases, &active) {
+                if let Some(alias) = label.strip_prefix("alias: ") {
+                    println!("  Alias:       {alias}");
+                } else if let Some(alias) = label.strip_prefix("aliases: ") {
+                    println!("  Aliases:     {alias}");
+                }
+            }
             println!(
                 "  Model:       {}",
                 config.model.as_deref().unwrap_or("gpt-4o")
@@ -14293,7 +14333,10 @@ async fn run_profile(
                     } else {
                         " "
                     };
-                    println!("{} {}", marker, name);
+                    let alias = profile_alias_label(&aliases, name)
+                        .map(|label| format!(" ({label})"))
+                        .unwrap_or_default();
+                    println!("{} {}{}", marker, name, alias);
                 }
                 if !aliases.is_empty() {
                     println!("\nAliases:");
@@ -16234,6 +16277,25 @@ skills:
             validate_profile_name("prod-profile_1.2").expect("valid"),
             "prod-profile_1.2"
         );
+    }
+
+    #[test]
+    fn profile_alias_label_prefers_custom_aliases() {
+        let mut aliases = std::collections::BTreeMap::new();
+        aliases.insert("steve".to_string(), "steve".to_string());
+        aliases.insert("qiaobusi".to_string(), "steve".to_string());
+        aliases.insert("jobs".to_string(), "steve".to_string());
+        aliases.insert("other".to_string(), "research".to_string());
+
+        assert_eq!(
+            profile_alias_label(&aliases, "steve").as_deref(),
+            Some("aliases: jobs, qiaobusi")
+        );
+        assert_eq!(
+            profile_alias_label(&aliases, "research").as_deref(),
+            Some("alias: other")
+        );
+        assert_eq!(profile_alias_label(&aliases, "missing"), None);
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/tests/e2e_cli.rs
+++ b/crates/hermes-cli/tests/e2e_cli.rs
@@ -69,6 +69,51 @@ fn e2e_cli_config_set_dotted_llm_and_get_masks_key() {
 }
 
 #[test]
+fn e2e_cli_profile_list_and_current_show_custom_alias() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = dir.path();
+
+    let mut create = Command::cargo_bin("hermes").expect("binary exists");
+    create.env("HERMES_HOME", home);
+    create.args(["profile", "create", "steve", "--no-alias"]);
+    create.assert().success();
+
+    let mut alias = Command::cargo_bin("hermes").expect("binary exists");
+    alias.env("HERMES_HOME", home);
+    alias.args(["profile", "alias", "steve", "--name", "qiaobusi"]);
+    alias.assert().success();
+
+    let mut list = Command::cargo_bin("hermes").expect("binary exists");
+    list.env("HERMES_HOME", home);
+    list.args(["profile", "list"]);
+    let list_out = list.assert().success().get_output().stdout.clone();
+    let list_text = std::str::from_utf8(&list_out).expect("utf8");
+    assert!(
+        list_text.contains("  steve (alias: qiaobusi)"),
+        "expected custom alias in profile list, got: {list_text:?}"
+    );
+
+    let mut use_alias = Command::cargo_bin("hermes").expect("binary exists");
+    use_alias.env("HERMES_HOME", home);
+    use_alias.args(["profile", "use", "qiaobusi"]);
+    use_alias.assert().success();
+
+    let mut current = Command::cargo_bin("hermes").expect("binary exists");
+    current.env("HERMES_HOME", home);
+    current.arg("profile");
+    let current_out = current.assert().success().get_output().stdout.clone();
+    let current_text = std::str::from_utf8(&current_out).expect("utf8");
+    assert!(
+        current_text.contains("Active:      steve"),
+        "expected resolved active profile, got: {current_text:?}"
+    );
+    assert!(
+        current_text.contains("Alias:       qiaobusi"),
+        "expected custom alias in current profile output, got: {current_text:?}"
+    );
+}
+
+#[test]
 fn e2e_cli_sessions_optimize_runs_against_isolated_home() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut cmd = Command::cargo_bin("hermes").expect("binary exists");

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -992,6 +992,10 @@
       "disposition": "ported",
       "notes": "Rust credits notices now classify usage-band, grant-spent, and depleted states, suppress flash-style usage/grant-spent notices when a new TUI processing cycle starts, keep depleted sticky, and regression-test that yielded notices stay quiet until the band or grant-spent condition changes."
     },
+    "5af899c7ca75": {
+      "disposition": "ported",
+      "notes": "Rust profile management now reverse-displays custom aliases from aliases.json in profile list rows and current-profile output, prefers custom aliases over profile-named self aliases, keeps raw profile show output parse-safe, and covers the real CLI create/alias/list/use/current flow."
+    },
     "ffb53767bfff": {
       "disposition": "ported",
       "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."


### PR DESCRIPTION
## Summary
- Port upstream parity item `5af899c7ca75` as the Rust-native `aliases.json` equivalent.
- Reverse-display custom profile aliases in `hermes profile list` rows and no-arg current-profile output.
- Prefer custom aliases over profile-named self aliases while keeping raw `profile show <name>` YAML output parse-safe.
- Add unit coverage for deterministic alias preference and e2e coverage for create/alias/list/use/current output.
- Mark `5af899c7ca75` as `ported` in `docs/parity/queue-overrides.json`.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli profile_alias_label_prefers_custom_aliases -- --nocapture` (`1 passed`)
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli e2e_cli_profile_list_and_current_show_custom_alias -- --nocapture` (`1 passed`)
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli` (`new=0`, `stale=6`)

## Disk placement proof
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
