### PR TITLE
parity(model): warn on stale auxiliary pins

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -55,8 +55,8 @@ use crate::kanban::{
     set_blocked, KanbanActionInput, KanbanBoard, KanbanLane, NewKanbanTaskInput,
 };
 use crate::model_switch::{
-    cached_provider_catalog_status, curated_provider_slugs, normalize_provider_model,
-    provider_model_ids,
+    cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
+    normalize_provider_model, provider_model_ids, provider_slug_from_provider_model,
 };
 use crate::pairing_store::{PairingStatus, PairingStore};
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
@@ -4329,13 +4329,22 @@ fn persist_current_model_selection(app: &App) -> Result<PathBuf, AgentError> {
 }
 
 fn format_model_persistence_note(app: &App) -> String {
-    match persist_current_model_selection(app) {
+    let mut note = match persist_current_model_selection(app) {
         Ok(path) => format!("Persisted default model in {}.", path.display()),
         Err(err) => format!(
             "Warning: switched for this session, but failed to persist default model: {}",
             err
         ),
+    };
+    let main_provider = provider_slug_from_provider_model(&app.current_model);
+    let stale_aux = app
+        .config
+        .stale_auxiliary_assignments_for_main_provider(main_provider);
+    if let Some(warning) = format_stale_auxiliary_warning(main_provider, &stale_aux) {
+        note.push('\n');
+        note.push_str(&warning);
     }
+    note
 }
 
 async fn pick_model_for_provider(

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -38,8 +38,9 @@ use hermes_cli::auth::{
 use hermes_cli::cli::{Cli, CliCommand};
 use hermes_cli::config_env::hydrate_env_from_config;
 use hermes_cli::model_switch::{
-    cached_provider_catalog_status, curated_provider_slugs, normalize_provider_model,
-    provider_catalog_entries, provider_model_ids, provider_picker_description,
+    cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
+    normalize_provider_model, provider_catalog_entries, provider_model_ids,
+    provider_picker_description, provider_slug_from_provider_model,
 };
 use hermes_cli::platform_toolsets::{resolve_platform_tool_schemas, tool_definition_summary};
 use hermes_cli::providers::provider_capability_for;
@@ -1639,10 +1640,15 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
             let cfg_path = hermes_state_root(&cli).join("config.yaml");
             let mut disk =
                 load_user_config_file(&cfg_path).map_err(|e| AgentError::Config(e.to_string()))?;
+            let main_provider = provider_slug_from_provider_model(&normalized).to_string();
+            let stale_aux = disk.stale_auxiliary_assignments_for_main_provider(&main_provider);
             disk.model = Some(normalized.clone());
             save_config_yaml(&cfg_path, &disk).map_err(|e| AgentError::Config(e.to_string()))?;
             println!("Model switched to: {}", normalized);
             println!("Persisted default model in {}.", cfg_path.display());
+            if let Some(warning) = format_stale_auxiliary_warning(&main_provider, &stale_aux) {
+                println!("{warning}");
+            }
         }
         None => {
             let current = config.model.as_deref().unwrap_or("gpt-4o");

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -7,6 +7,7 @@ use hermes_agent::bedrock::{
     curated_bedrock_models_for_region, discover_bedrock_model_ids, has_aws_credentials,
     resolve_bedrock_region,
 };
+use hermes_config::StaleAuxiliaryAssignment;
 use hermes_core::AgentError;
 use hermes_intelligence::models_dev::{default_client, ModelsDevClient};
 use hmac::{Hmac, Mac};
@@ -513,6 +514,45 @@ pub fn normalize_provider_model(input: &str) -> Result<String, AgentError> {
     } else {
         Ok(format!("openai:{trimmed}"))
     }
+}
+
+pub fn provider_slug_from_provider_model(provider_model: &str) -> &str {
+    provider_model
+        .split_once(':')
+        .map(|(provider, _)| provider.trim())
+        .filter(|provider| !provider.is_empty())
+        .unwrap_or("openai")
+}
+
+pub fn format_stale_auxiliary_warning(
+    main_provider: &str,
+    stale: &[StaleAuxiliaryAssignment],
+) -> Option<String> {
+    if stale.is_empty() {
+        return None;
+    }
+
+    let slots = stale
+        .iter()
+        .map(|entry| {
+            let model = entry.model.trim();
+            if model.is_empty() {
+                format!("{}={}", entry.task, entry.provider)
+            } else {
+                format!("{}={}/{}", entry.task, entry.provider, model)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let plural = if stale.len() == 1 { "" } else { "s" };
+
+    Some(format!(
+        "Warning: {} auxiliary task{} ({}) still run on providers other than main '{}'. They will not follow this model switch. Reset with `hermes config set auxiliary.<task>.provider auto`.",
+        stale.len(),
+        plural,
+        slots,
+        main_provider
+    ))
 }
 
 pub fn curated_provider_slugs() -> Vec<&'static str> {
@@ -1134,7 +1174,7 @@ mod tests {
         load_provider_catalog_cache, merge_with_models_dev, normalize_provider_model,
         persist_provider_catalog_cache, provider_catalog_cache_path, provider_catalog_entries,
         provider_curated_models, provider_model_ids_with_client, provider_picker_description,
-        resolve_huggingface_catalog_endpoint_and_token,
+        provider_slug_from_provider_model, resolve_huggingface_catalog_endpoint_and_token,
     };
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -1203,6 +1243,40 @@ mod tests {
             normalize_provider_model("gpt-4o").expect("bare OpenAI model"),
             "openai:gpt-4o"
         );
+    }
+
+    #[test]
+    fn provider_slug_from_provider_model_defaults_bare_to_openai() {
+        assert_eq!(
+            provider_slug_from_provider_model("openrouter:anthropic/claude-opus-4.8"),
+            "openrouter"
+        );
+        assert_eq!(provider_slug_from_provider_model("gpt-4o"), "openai");
+        assert_eq!(provider_slug_from_provider_model(":gpt-4o"), "openai");
+    }
+
+    #[test]
+    fn format_stale_auxiliary_warning_lists_pinned_slots() {
+        let stale = vec![
+            hermes_config::StaleAuxiliaryAssignment {
+                task: "compression".to_string(),
+                provider: "nous".to_string(),
+                model: "hermes-4".to_string(),
+            },
+            hermes_config::StaleAuxiliaryAssignment {
+                task: "curator".to_string(),
+                provider: "openai".to_string(),
+                model: String::new(),
+            },
+        ];
+        let warning =
+            super::format_stale_auxiliary_warning("openrouter", &stale).expect("stale warning");
+        assert!(warning.contains("Warning: 2 auxiliary tasks"));
+        assert!(warning.contains("compression=nous/hermes-4"));
+        assert!(warning.contains("curator=openai"));
+        assert!(warning.contains("main 'openrouter'"));
+        assert!(warning.contains("auxiliary.<task>.provider auto"));
+        assert!(super::format_stale_auxiliary_warning("openrouter", &[]).is_none());
     }
 
     #[test]

--- a/crates/hermes-cli/tests/e2e_cli.rs
+++ b/crates/hermes-cli/tests/e2e_cli.rs
@@ -69,6 +69,47 @@ fn e2e_cli_config_set_dotted_llm_and_get_masks_key() {
 }
 
 #[test]
+fn e2e_cli_model_switch_warns_on_stale_auxiliary_provider() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = dir.path();
+
+    let mut set_compression_provider = Command::cargo_bin("hermes").expect("binary exists");
+    set_compression_provider.env("HERMES_HOME", home);
+    set_compression_provider.args(["config", "set", "auxiliary.compression.provider", "nous"]);
+    set_compression_provider.assert().success();
+
+    let mut set_compression_model = Command::cargo_bin("hermes").expect("binary exists");
+    set_compression_model.env("HERMES_HOME", home);
+    set_compression_model.args(["config", "set", "auxiliary.compression.model", "hermes-4"]);
+    set_compression_model.assert().success();
+
+    let mut set_vision_auto = Command::cargo_bin("hermes").expect("binary exists");
+    set_vision_auto.env("HERMES_HOME", home);
+    set_vision_auto.args(["config", "set", "auxiliary.vision.provider", "auto"]);
+    set_vision_auto.assert().success();
+
+    let mut switch = Command::cargo_bin("hermes").expect("binary exists");
+    switch.env("HERMES_HOME", home);
+    switch.args(["model", "openrouter:anthropic/claude-opus-4.8"]);
+    let out = switch.assert().success().get_output().stdout.clone();
+    let text = std::str::from_utf8(&out).expect("utf8");
+    assert!(
+        text.contains("Model switched to: openrouter:anthropic/claude-opus-4.8"),
+        "expected model switch output, got: {text:?}"
+    );
+    assert!(
+        text.contains(
+            "Warning: 1 auxiliary task (compression=nous/hermes-4) still run on providers other than main 'openrouter'"
+        ),
+        "expected stale auxiliary warning, got: {text:?}"
+    );
+    assert!(
+        !text.contains("vision"),
+        "auto auxiliary provider should not be reported stale: {text:?}"
+    );
+}
+
+#[test]
 fn e2e_cli_profile_list_and_current_show_custom_alias() {
     let dir = tempfile::tempdir().expect("tempdir");
     let home = dir.path();

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -466,6 +466,14 @@ fn default_auxiliary_provider() -> String {
     "auto".to_string()
 }
 
+/// Auxiliary slot pinned to a provider that differs from the selected main provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StaleAuxiliaryAssignment {
+    pub task: String,
+    pub provider: String,
+    pub model: String,
+}
+
 fn deserialize_string_or_empty<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
@@ -551,6 +559,38 @@ pub fn default_auxiliary_task_configs() -> BTreeMap<String, AuxiliaryTaskConfig>
 const BUILTIN_AUXILIARY_ENV_BRIDGE_TASKS: &[&str] = &["approval", "vision", "web_extract"];
 
 impl GatewayConfig {
+    /// Return auxiliary tasks pinned to a provider other than `main_provider`.
+    ///
+    /// Switching the main model does not clear auxiliary overrides. This helper
+    /// surfaces the silent mismatch so callers can warn and offer reset guidance
+    /// without destroying legitimate dedicated auxiliary model choices.
+    pub fn stale_auxiliary_assignments_for_main_provider(
+        &self,
+        main_provider: &str,
+    ) -> Vec<StaleAuxiliaryAssignment> {
+        let main_provider = main_provider.trim().to_ascii_lowercase();
+        if main_provider.is_empty() {
+            return Vec::new();
+        }
+        self.auxiliary
+            .iter()
+            .filter_map(|(task, cfg)| {
+                let provider = cfg.provider.trim();
+                if provider.is_empty()
+                    || provider.eq_ignore_ascii_case("auto")
+                    || provider.eq_ignore_ascii_case(&main_provider)
+                {
+                    return None;
+                }
+                Some(StaleAuxiliaryAssignment {
+                    task: task.clone(),
+                    provider: provider.to_string(),
+                    model: cfg.model.trim().to_string(),
+                })
+            })
+            .collect()
+    }
+
     /// Return config-derived environment overrides for the built-in auxiliary
     /// bridge set (`vision`, `web_extract`, `approval`).
     pub fn builtin_auxiliary_env_overrides(&self) -> Vec<(String, String)> {
@@ -1684,6 +1724,49 @@ llm_providers:
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn stale_auxiliary_assignments_report_provider_mismatches() {
+        let mut cfg = GatewayConfig::default();
+        cfg.auxiliary.insert(
+            "compression".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "nous".to_string(),
+                model: "hermes-4".to_string(),
+                ..Default::default()
+            },
+        );
+        cfg.auxiliary.insert(
+            "vision".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "auto".to_string(),
+                model: "ignored".to_string(),
+                ..Default::default()
+            },
+        );
+        cfg.auxiliary.insert(
+            "curator".to_string(),
+            AuxiliaryTaskConfig {
+                provider: "openrouter".to_string(),
+                model: "anthropic/claude-opus-4.7".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let stale = cfg.stale_auxiliary_assignments_for_main_provider("openrouter");
+        assert_eq!(
+            stale,
+            vec![StaleAuxiliaryAssignment {
+                task: "compression".to_string(),
+                provider: "nous".to_string(),
+                model: "hermes-4".to_string(),
+            }]
+        );
+        assert!(cfg
+            .stale_auxiliary_assignments_for_main_provider("nous")
+            .iter()
+            .any(|entry| entry.task == "curator"));
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -24,9 +24,10 @@ pub use config::{
     ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DelegationConfig, DisplayConfig,
     GatewayConfig, LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig,
     ProxyConfig, QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
-    SmartModelRoutingConfig, TerminalBackendType, TerminalConfig, ToolOutputConfig, ToolsSettings,
-    WebConfig, WebsiteBlocklistConfig, DEFAULT_TOOL_OUTPUT_MAX_BYTES,
-    DEFAULT_TOOL_OUTPUT_MAX_LINES, DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH,
+    SmartModelRoutingConfig, StaleAuxiliaryAssignment, TerminalBackendType, TerminalConfig,
+    ToolOutputConfig, ToolsSettings, WebConfig, WebsiteBlocklistConfig,
+    DEFAULT_TOOL_OUTPUT_MAX_BYTES, DEFAULT_TOOL_OUTPUT_MAX_LINES,
+    DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH,
 };
 pub use loader::{
     apply_user_config_patch, atomic_json_write, atomic_json_write_pretty, atomic_write_bytes,

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -996,6 +996,10 @@
       "disposition": "ported",
       "notes": "Rust profile management now reverse-displays custom aliases from aliases.json in profile list rows and current-profile output, prefers custom aliases over profile-named self aliases, keeps raw profile show output parse-safe, and covers the real CLI create/alias/list/use/current flow."
     },
+    "b91aade17683": {
+      "disposition": "ported",
+      "notes": "Rust config now detects auxiliary task pins whose provider differs from the selected main provider, top-level and slash-command model switch persistence surfaces warn without auto-clearing legitimate pins, and focused config/model-switch/e2e tests cover stale vs auto/matching slots."
+    },
     "ffb53767bfff": {
       "disposition": "ported",
       "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."


### PR DESCRIPTION
## Summary
- add Rust config detection for auxiliary task providers that stay pinned away from the selected main provider
- warn from both top-level `hermes model provider:model` and interactive `/model` persistence notes without auto-clearing legitimate auxiliary pins
- mark upstream `b91aade17683` as ported in the parity queue

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `cargo test -p hermes-config stale_auxiliary_assignments_report_provider_mismatches -- --nocapture`
- `cargo test -p hermes-cli provider_slug_from_provider_model_defaults_bare_to_openai -- --nocapture`
- `cargo test -p hermes-cli format_stale_auxiliary_warning_lists_pinned_slots -- --nocapture`
- `cargo test -p hermes-cli e2e_cli_model_switch_warns_on_stale_auxiliary_provider -- --nocapture`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-config -p hermes-cli`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-cli` (`new=0`)

## Disk placement
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
