### PR TITLE
parity(config): propagate max token caps

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4914,6 +4914,80 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_config_maps_active_provider_max_tokens() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&["HERMES_MAX_TOKENS"]);
+        std::env::remove_var("HERMES_MAX_TOKENS");
+
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "openrouter".to_string(),
+            LlmProviderConfig {
+                max_tokens: Some(4096),
+                ..LlmProviderConfig::default()
+            },
+        );
+        cfg.llm_providers.insert(
+            "openai".to_string(),
+            LlmProviderConfig {
+                max_tokens: Some(2048),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let agent_cfg = build_agent_config(&cfg, "openrouter:anthropic/claude-sonnet-4.6");
+
+        assert_eq!(agent_cfg.max_tokens, Some(4096));
+    }
+
+    #[test]
+    fn test_build_agent_config_maps_normalized_provider_max_tokens_alias() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&["HERMES_MAX_TOKENS"]);
+        std::env::remove_var("HERMES_MAX_TOKENS");
+
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "openai-codex".to_string(),
+            LlmProviderConfig {
+                max_tokens: Some(1234),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let agent_cfg = build_agent_config(&cfg, "codex:gpt-5");
+
+        assert_eq!(agent_cfg.max_tokens, Some(1234));
+    }
+
+    #[test]
+    fn test_build_agent_config_env_max_tokens_overrides_provider_cap() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&["HERMES_MAX_TOKENS"]);
+
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "openrouter".to_string(),
+            LlmProviderConfig {
+                max_tokens: Some(4096),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        std::env::set_var("HERMES_MAX_TOKENS", "8192");
+        let agent_cfg = build_agent_config(&cfg, "openrouter:anthropic/claude-sonnet-4.6");
+        assert_eq!(agent_cfg.max_tokens, Some(8192));
+
+        std::env::set_var("HERMES_MAX_TOKENS", "not-a-number");
+        let agent_cfg = build_agent_config(&cfg, "openrouter:anthropic/claude-sonnet-4.6");
+        assert_eq!(agent_cfg.max_tokens, Some(4096));
+
+        std::env::set_var("HERMES_MAX_TOKENS", "0");
+        let agent_cfg = build_agent_config(&cfg, "openrouter:anthropic/claude-sonnet-4.6");
+        assert_eq!(agent_cfg.max_tokens, Some(4096));
+    }
+
+    #[test]
     fn test_build_agent_config_forwards_provider_extra_body() {
         let mut cfg = GatewayConfig::default();
         cfg.llm_providers.insert(
@@ -6264,17 +6338,19 @@ fn parse_provider_api_mode(value: &str) -> Option<ApiMode> {
     }
 }
 
-pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
-    let (resolved_provider, _) = resolve_provider_and_model(config, model);
-    let runtime_provider = normalize_runtime_provider_name(resolved_provider.as_str());
-    let provider_extra_body = config
+fn active_llm_provider_config<'a>(
+    config: &'a GatewayConfig,
+    provider_name: &str,
+    runtime_provider: &str,
+) -> Option<&'a hermes_config::LlmProviderConfig> {
+    config
         .llm_providers
-        .get(resolved_provider.as_str())
-        .or_else(|| config.llm_providers.get(runtime_provider.as_str()))
+        .get(provider_name)
+        .or_else(|| config.llm_providers.get(runtime_provider))
         .or_else(|| {
             config.llm_providers.iter().find_map(|(name, cfg)| {
-                if name.eq_ignore_ascii_case(resolved_provider.as_str())
-                    || name.eq_ignore_ascii_case(runtime_provider.as_str())
+                if name.eq_ignore_ascii_case(provider_name)
+                    || name.eq_ignore_ascii_case(runtime_provider)
                 {
                     Some(cfg)
                 } else {
@@ -6282,7 +6358,31 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
                 }
             })
         })
-        .and_then(|cfg| cfg.extra_body.clone());
+}
+
+fn configured_agent_max_tokens(
+    provider_config: Option<&hermes_config::LlmProviderConfig>,
+) -> Option<u32> {
+    if let Ok(raw) = std::env::var("HERMES_MAX_TOKENS") {
+        if let Ok(value) = raw.trim().parse::<u32>() {
+            if value > 0 {
+                return Some(value);
+            }
+        }
+    }
+    provider_config.and_then(|cfg| cfg.max_tokens.filter(|value| *value > 0))
+}
+
+pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
+    let (resolved_provider, _) = resolve_provider_and_model(config, model);
+    let runtime_provider = normalize_runtime_provider_name(resolved_provider.as_str());
+    let provider_config = active_llm_provider_config(
+        config,
+        resolved_provider.as_str(),
+        runtime_provider.as_str(),
+    );
+    let provider_extra_body = provider_config.and_then(|cfg| cfg.extra_body.clone());
+    let max_tokens = configured_agent_max_tokens(provider_config);
     let extra_body =
         merge_service_tier_extra_body(provider_extra_body, config.agent.normalized_service_tier());
     let skip_memory_env = std::env::var("HERMES_SKIP_MEMORY")
@@ -6318,6 +6418,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         hermes_home: config.home_dir.clone(),
         provider: Some(resolved_provider),
         stream: config.streaming.enabled,
+        max_tokens,
         max_delegate_depth,
         delegation_model: config
             .delegation
@@ -7044,21 +7145,8 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         runtime_provider.as_str(),
     );
 
-    let provider_config = config
-        .llm_providers
-        .get(provider_name.as_str())
-        .or_else(|| config.llm_providers.get(runtime_provider.as_str()));
-    let provider_config = provider_config.or_else(|| {
-        config.llm_providers.iter().find_map(|(name, cfg)| {
-            if name.eq_ignore_ascii_case(provider_name.as_str())
-                || name.eq_ignore_ascii_case(runtime_provider.as_str())
-            {
-                Some(cfg)
-            } else {
-                None
-            }
-        })
-    });
+    let provider_config =
+        active_llm_provider_config(config, provider_name.as_str(), runtime_provider.as_str());
     let request_timeout_seconds = provider_config.and_then(|c| c.request_timeout_seconds);
 
     let default_base_url = provider_default_base_url(provider_name.as_str())

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -989,7 +989,11 @@ pub struct LlmProviderConfig {
     pub api_mode: Option<String>,
 
     /// Maximum tokens in the completion response.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "max_output_tokens",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub max_tokens: Option<u32>,
 
     /// Sampling temperature.

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -849,6 +849,21 @@ fn apply_user_config_patch_dotted(
                 "base_url" => entry.base_url = Some(value.to_string()),
                 "model" => entry.model = Some(value.to_string()),
                 "api_mode" => entry.api_mode = Some(normalize_provider_api_mode(value)?),
+                "max_tokens" | "max_output_tokens" => {
+                    let parsed = value.parse::<u32>().map_err(|_| {
+                        ConfigError::ValidationError(format!(
+                            "llm.{}.{} must be a positive integer: {}",
+                            provider, field, value
+                        ))
+                    })?;
+                    if parsed == 0 {
+                        return Err(ConfigError::ValidationError(format!(
+                            "llm.{}.{} must be a positive integer: {}",
+                            provider, field, value
+                        )));
+                    }
+                    entry.max_tokens = Some(parsed);
+                }
                 "command" => entry.command = Some(value.to_string()),
                 "args" => {
                     entry.args = value
@@ -865,7 +880,7 @@ fn apply_user_config_patch_dotted(
                 "oauth_client_id" => entry.oauth_client_id = Some(value.to_string()),
                 other => {
                     return Err(ConfigError::NotFound(format!(
-                        "unknown llm field: llm.{}.{} (supported: api_key, api_key_env, base_url, model, api_mode, command, args, request_timeout_seconds, oauth_token_url, oauth_client_id)",
+                        "unknown llm field: llm.{}.{} (supported: api_key, api_key_env, base_url, model, api_mode, max_tokens, max_output_tokens, command, args, request_timeout_seconds, oauth_token_url, oauth_client_id)",
                         provider, other
                     )));
                 }
@@ -1075,6 +1090,12 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .and_then(|c| c.api_mode.as_deref())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["llm", provider, "max_tokens"] | ["llm", provider, "max_output_tokens"] => Ok(config
+            .llm_providers
+            .get(*provider)
+            .and_then(|c| c.max_tokens)
+            .map(|value| value.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
         ["llm", provider, "command"] => Ok(config
             .llm_providers
@@ -2197,6 +2218,11 @@ pub fn validate_config(config: &GatewayConfig) -> Result<(), ConfigError> {
                 )));
             }
         }
+        if matches!(provider.max_tokens, Some(0)) {
+            return Err(ConfigError::ValidationError(format!(
+                "llm_providers.{name}.max_tokens must be a positive integer"
+            )));
+        }
     }
 
     if let Some(api_key) = &config.delegation.api_key {
@@ -3035,6 +3061,28 @@ llm_providers:
     }
 
     #[test]
+    fn load_user_config_file_parses_llm_provider_max_output_tokens_alias() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+llm_providers:
+  custom:
+    base_url: https://gateway.example.com/v1
+    max_output_tokens: 4096
+"#,
+        )
+        .unwrap();
+
+        let loaded = load_user_config_file(&path).unwrap();
+        let provider = loaded.llm_providers.get("custom").expect("custom provider");
+        assert_eq!(provider.max_tokens, Some(4096));
+    }
+
+    #[test]
     fn load_user_config_file_rejects_unknown_llm_provider_api_mode() {
         use tempfile::tempdir;
 
@@ -3062,6 +3110,7 @@ llm_providers:
         apply_user_config_patch(&mut c, "llm.openai.base_url", "https://api.openai.com/v1")
             .unwrap();
         apply_user_config_patch(&mut c, "llm.openai.api_mode", "codex-responses").unwrap();
+        apply_user_config_patch(&mut c, "llm.openai.max_output_tokens", "8192").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.command", "copilot-language-server").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.args", "--stdio,--model,gpt-4o-mini").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.request_timeout_seconds", "45.5").unwrap();
@@ -3082,6 +3131,10 @@ llm_providers:
         assert_eq!(
             c.llm_providers.get("openai").unwrap().api_mode.as_deref(),
             Some("codex_responses")
+        );
+        assert_eq!(
+            c.llm_providers.get("openai").unwrap().max_tokens,
+            Some(8192)
         );
         assert_eq!(
             c.llm_providers.get("openai").unwrap().command.as_deref(),
@@ -3123,6 +3176,14 @@ llm_providers:
             "codex_responses"
         );
         assert_eq!(
+            user_config_field_display(&c, "llm.openai.max_tokens").unwrap(),
+            "8192"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "llm.openai.max_output_tokens").unwrap(),
+            "8192"
+        );
+        assert_eq!(
             user_config_field_display(&c, "llm.openai.args").unwrap(),
             "--stdio,--model,gpt-4o-mini"
         );
@@ -3144,6 +3205,7 @@ llm_providers:
         assert!(
             apply_user_config_patch(&mut c, "llm.openai.request_timeout_seconds", "fast").is_err()
         );
+        assert!(apply_user_config_patch(&mut c, "llm.openai.max_tokens", "0").is_err());
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -960,6 +960,22 @@
       "disposition": "ported",
       "notes": "Rust provider config now accepts llm.<provider>.request_timeout_seconds, validates and exposes it through config set/get, propagates it into AgentConfig RuntimeProviderConfig, and applies it to OpenAI-compatible, Codex Responses, Anthropic, OpenRouter, extra provider, fallback/runtime-routing, and client rebuild paths with targeted tests."
     },
+    "cf786593cd83": {
+      "disposition": "ported",
+      "notes": "Rust now propagates active provider output caps into AgentConfig.max_tokens so gateway/CLI/cron agent paths pass configured max_tokens into provider requests through the existing AgentLoop max_tokens chain."
+    },
+    "1c909e75e1a0": {
+      "disposition": "ported",
+      "notes": "Rust build_agent_config now honors HERMES_MAX_TOKENS as the highest-precedence output-token override and falls back to active provider config caps for CLI and gateway-created agents, with focused precedence tests."
+    },
+    "14275d7baa1a": {
+      "disposition": "ported",
+      "notes": "Rust llm provider config accepts max_output_tokens as an alias for max_tokens, exposes both dotted config set/get spellings, validates positive values, and uses the active provider cap only when HERMES_MAX_TOKENS is unset."
+    },
+    "2dda393f99cb": {
+      "disposition": "ported",
+      "notes": "Rust regression tests cover the max_tokens propagation chain from config parsing/set-get through build_agent_config into AgentConfig.max_tokens precedence, superseding the upstream Python gateway test-only follow-up."
+    },
     "38695254f851": {
       "disposition": "ported",
       "notes": "Rust session persistence now exposes FTS index counting and optimize_fts maintenance, VACUUM runs FTS optimization before reclaiming pages, and top-level `hermes sessions optimize` reports FTS index count plus before/after sessions.db size with Rust unit/e2e coverage."


### PR DESCRIPTION
## Summary
- accept provider `max_output_tokens` as an alias for `max_tokens`
- expose dotted config set/get for provider output-token caps
- propagate `HERMES_MAX_TOKENS` and active provider caps into `AgentConfig.max_tokens`
- mark upstream max-token propagation commits as Rust-ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `cargo test -p hermes-config load_user_config_file_parses_llm_provider_max_output_tokens_alias -- --nocapture`
- `cargo test -p hermes-config apply_patch_dotted_llm_proxy_budget -- --nocapture`
- `cargo test -p hermes-cli test_build_agent_config_maps_active_provider_max_tokens -- --nocapture`
- `cargo test -p hermes-cli test_build_agent_config_maps_normalized_provider_max_tokens_alias -- --nocapture`
- `cargo test -p hermes-cli test_build_agent_config_env_max_tokens_overrides_provider_cap -- --nocapture`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-config -p hermes-cli`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-cli`

## Disk placement
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
