### PR TITLE
parity(model): honor custom provider discovery flags

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -56,7 +56,8 @@ use crate::kanban::{
 };
 use crate::model_switch::{
     cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
-    normalize_provider_model, provider_model_ids, provider_slug_from_provider_model,
+    normalize_provider_model, provider_catalog_entries_for_config, provider_model_ids,
+    provider_model_ids_for_config, provider_slug_from_provider_model, provider_slugs_for_config,
 };
 use crate::pairing_store::{PairingStatus, PairingStore};
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
@@ -4020,7 +4021,8 @@ async fn handle_model_explain_command(
     } else {
         normalize_model_target(&app.current_model, &positional[0])?
     };
-    let (guarded, remap_note) = guard_provider_model_selection(&target).await?;
+    let (guarded, remap_note) =
+        guard_provider_model_selection_for_config(&target, &app.config).await?;
     let (provider, model_id) = split_provider_model(&guarded);
     let client = default_client();
     client.fetch(false).await;
@@ -4055,7 +4057,7 @@ async fn handle_model_explain_command(
         } else {
             let _ = writeln!(out, "requirements: FAILED ({})", requirements.summary());
             let _ = writeln!(out, "missing: {}", unmet.join(", "));
-            let catalog = provider_model_ids(provider).await;
+            let catalog = provider_model_ids_for_config(provider, &app.config).await;
             let alternatives: Vec<String> = catalog
                 .into_iter()
                 .filter(|candidate| {
@@ -4094,7 +4096,10 @@ async fn handle_model_explain_command(
     Ok(CommandResult::Handled)
 }
 
-fn parse_model_switch_request(args: &[&str], known_providers: &[&str]) -> ModelSwitchRequest {
+fn parse_model_switch_request<S: AsRef<str>>(
+    args: &[&str],
+    known_providers: &[S],
+) -> ModelSwitchRequest {
     if args.is_empty() {
         return ModelSwitchRequest::PickProviderThenModel;
     }
@@ -4108,7 +4113,7 @@ fn parse_model_switch_request(args: &[&str], known_providers: &[&str]) -> ModelS
     }
     if known_providers
         .iter()
-        .any(|p| p.eq_ignore_ascii_case(trimmed))
+        .any(|p| p.as_ref().eq_ignore_ascii_case(trimmed))
     {
         return ModelSwitchRequest::PickModelFromProvider(trimmed.to_ascii_lowercase());
     }
@@ -4232,8 +4237,9 @@ fn rank_catalog_model_candidates(
         .collect()
 }
 
-async fn guard_provider_model_selection(
+async fn guard_provider_model_selection_for_config(
     provider_model: &str,
+    config: &GatewayConfig,
 ) -> Result<(String, Option<String>), AgentError> {
     if !model_catalog_guard_enabled() {
         return Ok((provider_model.to_string(), None));
@@ -4255,14 +4261,14 @@ async fn guard_provider_model_selection(
             )),
         ));
     }
-    if !curated_provider_slugs()
+    if !provider_slugs_for_config(config)
         .iter()
         .any(|slug| slug.eq_ignore_ascii_case(&provider))
     {
         return Ok((provider_model.to_string(), None));
     }
 
-    let catalog = provider_model_ids(&provider).await;
+    let catalog = provider_model_ids_for_config(&provider, config).await;
     if catalog.is_empty() {
         return Ok((provider_model.to_string(), None));
     }
@@ -4353,7 +4359,7 @@ async fn pick_model_for_provider(
     current_model: &str,
     requirements: ModelCapabilityRequirements,
 ) -> Result<bool, AgentError> {
-    let models = provider_model_ids(provider).await;
+    let models = provider_model_ids_for_config(provider, &app.config).await;
     if models.is_empty() {
         emit_command_output(
             app,
@@ -4404,7 +4410,8 @@ async fn pick_model_for_provider(
         return Ok(false);
     }
     let provider_model = format!("{}:{}", provider, filtered_models[pick.index].trim());
-    let (guarded, note) = guard_provider_model_selection(&provider_model).await?;
+    let (guarded, note) =
+        guard_provider_model_selection_for_config(&provider_model, &app.config).await?;
     app.switch_model(&guarded);
     let mut msg = format!("Model switched to: {}", guarded);
     if let Some(n) = note {
@@ -4955,11 +4962,12 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
         }
     }
     let positional_refs: Vec<&str> = positional.iter().map(String::as_str).collect();
-    let known_providers = curated_provider_slugs();
+    let known_providers = provider_slugs_for_config(&app.config);
     match parse_model_switch_request(&positional_refs, &known_providers) {
         ModelSwitchRequest::SetDirect(raw) => {
             let provider_model = normalize_model_target(&app.current_model, &raw)?;
-            let (guarded, note) = guard_provider_model_selection(&provider_model).await?;
+            let (guarded, note) =
+                guard_provider_model_selection_for_config(&provider_model, &app.config).await?;
             if !requirements.is_empty() {
                 let (provider, model_id) = split_provider_model(&guarded);
                 let client = default_client();
@@ -4996,7 +5004,7 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
         }
         ModelSwitchRequest::PickProviderThenModel => {
             emit_command_output(app, format!("Current model: {}", app.current_model));
-            let providers: Vec<String> = known_providers.iter().map(|p| (*p).to_string()).collect();
+            let providers: Vec<String> = known_providers.clone();
             if providers.is_empty() {
                 emit_command_output(app, "No providers are registered for selection.");
                 return Ok(CommandResult::Handled);
@@ -13890,12 +13898,12 @@ fn handle_context_command(app: &mut App, args: &[&str]) -> Result<CommandResult,
 }
 
 async fn handle_provider_command(app: &mut App) -> Result<CommandResult, AgentError> {
-    let providers = curated_provider_slugs();
+    let providers = provider_slugs_for_config(&app.config);
     if providers.is_empty() {
         emit_command_output(app, "No providers registered.");
         return Ok(CommandResult::Handled);
     }
-    let entries = crate::model_switch::provider_catalog_entries(&providers, 4).await;
+    let entries = provider_catalog_entries_for_config(&app.config, 4).await;
     if entries.is_empty() {
         emit_command_output(
             app,
@@ -29037,9 +29045,12 @@ mod tests {
     async fn guard_provider_model_selection_soft_accepts_unlisted_codex_models() {
         let _guard = env_test_lock();
         std::env::set_var("HERMES_MODEL_CATALOG_GUARD", "1");
-        let (guarded, note) = guard_provider_model_selection("openai-codex:gpt-9-codex-preview")
-            .await
-            .expect("codex soft-accept");
+        let (guarded, note) = guard_provider_model_selection_for_config(
+            "openai-codex:gpt-9-codex-preview",
+            &GatewayConfig::default(),
+        )
+        .await
+        .expect("codex soft-accept");
         assert_eq!(guarded, "openai-codex:gpt-9-codex-preview");
         assert!(note
             .as_deref()
@@ -30112,6 +30123,43 @@ install_command: "uv pip install -r requirements.txt"
             req,
             ModelSwitchRequest::PickModelFromProvider("nous".to_string())
         );
+    }
+
+    #[test]
+    fn parse_model_switch_request_accepts_configured_provider_strings() {
+        let providers = vec![
+            "openai".to_string(),
+            "qianfan-coding".to_string(),
+            "my-gateway".to_string(),
+        ];
+        let req = parse_model_switch_request(&["QIANFAN-CODING"], &providers);
+        assert_eq!(
+            req,
+            ModelSwitchRequest::PickModelFromProvider("qianfan-coding".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_provider_model_selection_uses_configured_provider_models() {
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "qianfan-coding".to_string(),
+            LlmProviderConfig {
+                models: vec!["kimi-k2.5".to_string(), "glm-5".to_string()],
+                discover_models: false,
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let (guarded, note) =
+            guard_provider_model_selection_for_config("qianfan-coding:kimi", &cfg)
+                .await
+                .expect("guard");
+
+        assert_eq!(guarded, "qianfan-coding:kimi-k2.5");
+        assert!(note
+            .as_deref()
+            .is_some_and(|text| text.contains("Model catalog guard remapped")));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -38,9 +38,9 @@ use hermes_cli::auth::{
 use hermes_cli::cli::{Cli, CliCommand};
 use hermes_cli::config_env::hydrate_env_from_config;
 use hermes_cli::model_switch::{
-    cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
-    normalize_provider_model, provider_catalog_entries, provider_model_ids,
-    provider_picker_description, provider_slug_from_provider_model,
+    cached_provider_catalog_status, format_stale_auxiliary_warning, normalize_provider_model,
+    provider_catalog_entries_for_config, provider_model_ids, provider_picker_description,
+    provider_slug_from_provider_model,
 };
 use hermes_cli::platform_toolsets::{resolve_platform_tool_schemas, tool_definition_summary};
 use hermes_cli::providers::provider_capability_for;
@@ -1655,8 +1655,7 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
             println!("Current model: {}", current);
 
             // List providers with merged models.dev-aware previews.
-            let providers = curated_provider_slugs();
-            let entries = provider_catalog_entries(&providers, 3).await;
+            let entries = provider_catalog_entries_for_config(&config, 3).await;
             println!("\nAvailable providers:");
             if entries.is_empty() {
                 println!("  openai       — OpenAI (gpt-4o, gpt-4o-mini, ...)");

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -7,7 +7,7 @@ use hermes_agent::bedrock::{
     curated_bedrock_models_for_region, discover_bedrock_model_ids, has_aws_credentials,
     resolve_bedrock_region,
 };
-use hermes_config::StaleAuxiliaryAssignment;
+use hermes_config::{GatewayConfig, LlmProviderConfig, StaleAuxiliaryAssignment};
 use hermes_core::AgentError;
 use hermes_intelligence::models_dev::{default_client, ModelsDevClient};
 use hmac::{Hmac, Mac};
@@ -671,6 +671,151 @@ pub fn provider_curated_models(provider: &str) -> &'static [&'static str] {
     &[]
 }
 
+fn configured_llm_provider<'a>(
+    config: &'a GatewayConfig,
+    provider: &str,
+) -> Option<(&'a String, &'a LlmProviderConfig)> {
+    let trimmed = provider.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    config.llm_providers.get_key_value(trimmed).or_else(|| {
+        config
+            .llm_providers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(trimmed))
+    })
+}
+
+fn dedup_model_ids(models: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for model in models {
+        let trimmed = model.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let key = trimmed.to_ascii_lowercase();
+        if seen.insert(key) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+fn resolve_configured_api_key(provider: &LlmProviderConfig) -> Option<String> {
+    if let Some(env_name) = provider
+        .api_key_env
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if let Ok(value) = std::env::var(env_name) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+
+    let raw = provider.api_key.as_deref()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some(env_name) = raw.strip_prefix("${").and_then(|v| v.strip_suffix('}')) {
+        return std::env::var(env_name.trim())
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+    Some(raw.to_string())
+}
+
+pub fn provider_slugs_for_config(config: &GatewayConfig) -> Vec<String> {
+    let mut providers = Vec::new();
+    let mut seen = HashSet::new();
+
+    for provider in curated_provider_slugs() {
+        let key = provider.to_ascii_lowercase();
+        if seen.insert(key) {
+            providers.push(provider.to_string());
+        }
+    }
+
+    let mut configured: Vec<String> = config
+        .llm_providers
+        .keys()
+        .map(|provider| provider.trim().to_string())
+        .filter(|provider| !provider.is_empty())
+        .collect();
+    configured.sort_by_key(|provider| provider.to_ascii_lowercase());
+    for provider in configured {
+        let key = provider.to_ascii_lowercase();
+        if seen.insert(key) {
+            providers.push(provider);
+        }
+    }
+
+    providers
+}
+
+pub async fn provider_model_ids_for_config(provider: &str, config: &GatewayConfig) -> Vec<String> {
+    let configured = configured_llm_provider(config, provider).map(|(_, cfg)| cfg);
+    if let Some(provider_cfg) = configured {
+        let configured_models = dedup_model_ids(provider_cfg.models.clone());
+        if !provider_cfg.discover_models && !configured_models.is_empty() {
+            return configured_models;
+        }
+
+        if let Some(base_url) = provider_cfg
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let api_key = resolve_configured_api_key(provider_cfg);
+            let should_probe =
+                provider_cfg.discover_models && (api_key.is_some() || configured_models.is_empty());
+            if should_probe {
+                let live = fetch_openai_compatible_live_models(base_url, api_key.as_deref()).await;
+                if !live.is_empty() {
+                    return live;
+                }
+            }
+        }
+
+        if !configured_models.is_empty() {
+            return configured_models;
+        }
+    }
+
+    provider_model_ids(provider).await
+}
+
+pub async fn provider_catalog_entries_for_config(
+    config: &GatewayConfig,
+    max_models: usize,
+) -> Vec<ProviderCatalogEntry> {
+    let providers = provider_slugs_for_config(config);
+    let mut entries = Vec::new();
+
+    for provider in providers {
+        let models = provider_model_ids_for_config(&provider, config).await;
+        if models.is_empty() {
+            continue;
+        }
+        let total_models = models.len();
+        let models = models.into_iter().take(max_models).collect();
+        entries.push(ProviderCatalogEntry {
+            provider,
+            models,
+            total_models,
+        });
+    }
+
+    entries
+}
+
 fn is_local_openai_compatible_provider(provider: &str) -> bool {
     matches!(
         provider.trim().to_ascii_lowercase().as_str(),
@@ -1173,8 +1318,10 @@ mod tests {
         cached_provider_catalog_status, is_models_dev_preferred_provider,
         load_provider_catalog_cache, merge_with_models_dev, normalize_provider_model,
         persist_provider_catalog_cache, provider_catalog_cache_path, provider_catalog_entries,
-        provider_curated_models, provider_model_ids_with_client, provider_picker_description,
-        provider_slug_from_provider_model, resolve_huggingface_catalog_endpoint_and_token,
+        provider_catalog_entries_for_config, provider_curated_models,
+        provider_model_ids_for_config, provider_model_ids_with_client, provider_picker_description,
+        provider_slug_from_provider_model, provider_slugs_for_config,
+        resolve_huggingface_catalog_endpoint_and_token,
     };
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -1600,6 +1747,71 @@ mod tests {
         // Smoke-test the function shape with unknown providers only, avoiding network use.
         let entries = provider_catalog_entries(&["unknown-provider"], 2).await;
         assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn configured_provider_discover_false_keeps_explicit_models() {
+        let mut cfg = hermes_config::GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "qianfan-coding".to_string(),
+            hermes_config::LlmProviderConfig {
+                base_url: Some("https://qianfan.baidubce.com/v2/coding".to_string()),
+                api_key: Some("sk-test".to_string()),
+                models: vec![
+                    " kimi-k2.5 ".to_string(),
+                    "glm-5".to_string(),
+                    "KIMI-K2.5".to_string(),
+                ],
+                discover_models: false,
+                ..hermes_config::LlmProviderConfig::default()
+            },
+        );
+
+        let out = provider_model_ids_for_config("QIANFAN-CODING", &cfg).await;
+
+        assert_eq!(out, vec!["kimi-k2.5", "glm-5"]);
+    }
+
+    #[tokio::test]
+    async fn configured_provider_falls_back_to_explicit_models_when_probe_empty() {
+        let mut cfg = hermes_config::GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "my-gateway".to_string(),
+            hermes_config::LlmProviderConfig {
+                base_url: Some("https://gateway.example.com/v1".to_string()),
+                api_key: Some("sk-test".to_string()),
+                models: vec!["fallback-a".to_string(), "fallback-b".to_string()],
+                ..hermes_config::LlmProviderConfig::default()
+            },
+        );
+
+        let out = provider_model_ids_for_config("my-gateway", &cfg).await;
+
+        assert_eq!(out, vec!["fallback-a", "fallback-b"]);
+    }
+
+    #[tokio::test]
+    async fn config_catalog_entries_include_custom_provider_models() {
+        let mut cfg = hermes_config::GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "baidu-coding".to_string(),
+            hermes_config::LlmProviderConfig {
+                models: vec!["kimi-k2.5".to_string(), "glm-5".to_string()],
+                discover_models: false,
+                ..hermes_config::LlmProviderConfig::default()
+            },
+        );
+
+        let providers = provider_slugs_for_config(&cfg);
+        assert!(providers.iter().any(|provider| provider == "baidu-coding"));
+
+        let entries = provider_catalog_entries_for_config(&cfg, 1).await;
+        let entry = entries
+            .iter()
+            .find(|entry| entry.provider == "baidu-coding")
+            .expect("custom provider entry");
+        assert_eq!(entry.models, vec!["kimi-k2.5"]);
+        assert_eq!(entry.total_models, 2);
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/tests/e2e_cli.rs
+++ b/crates/hermes-cli/tests/e2e_cli.rs
@@ -9,6 +9,39 @@ fn e2e_cli_model_command_prints_current_model() {
 }
 
 #[test]
+fn e2e_cli_model_command_lists_configured_custom_provider_models() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("config.yaml"),
+        r#"
+model: qianfan-coding:kimi-k2.5
+llm_providers:
+  qianfan-coding:
+    base_url: https://qianfan.baidubce.com/v2/coding
+    discover_models: false
+    models:
+      kimi-k2.5: {}
+      glm-5: {}
+"#,
+    )
+    .expect("write config");
+
+    let mut cmd = Command::cargo_bin("hermes").expect("binary exists");
+    cmd.env("HERMES_HOME", dir.path());
+    cmd.arg("model");
+    let out = cmd.assert().success().get_output().stdout.clone();
+    let text = std::str::from_utf8(&out).expect("utf8");
+    assert!(
+        text.contains("qianfan-coding"),
+        "expected custom provider in model list: {text:?}"
+    );
+    assert!(
+        text.contains("kimi-k2.5") && text.contains("glm-5"),
+        "expected configured model subset in model list: {text:?}"
+    );
+}
+
+#[test]
 fn e2e_cli_gateway_status_command_runs() {
     let mut cmd = Command::cargo_bin("hermes").expect("binary exists");
     cmd.args(["gateway", "status"]);

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -936,6 +936,71 @@ where
     deserializer.deserialize_any(StringListVisitor)
 }
 
+fn deserialize_provider_model_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ProviderModelListVisitor;
+
+    impl<'de> Visitor<'de> for ProviderModelListVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .write_str("a string, comma-separated string, list of strings, or map of model ids")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            Ok(value
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToString::to_string)
+                .collect())
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            self.visit_str(&value)
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut values = Vec::new();
+            while let Some(value) = seq.next_element::<String>()? {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    values.push(trimmed.to_string());
+                }
+            }
+            Ok(values)
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut values = Vec::new();
+            while let Some((key, _ignored)) = map.next_entry::<String, serde::de::IgnoredAny>()? {
+                let trimmed = key.trim();
+                if !trimmed.is_empty() {
+                    values.push(trimmed.to_string());
+                }
+            }
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_any(ProviderModelListVisitor)
+}
+
 fn default_tools() -> Vec<String> {
     vec![
         "bash".into(),
@@ -983,6 +1048,22 @@ pub struct LlmProviderConfig {
     /// Default model to use for this provider.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+
+    /// Explicit model allowlist for custom/named providers.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_provider_model_list",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub models: Vec<String>,
+
+    /// Whether model pickers should live-probe `/models` for this provider.
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_boolish",
+        skip_serializing_if = "is_true"
+    )]
+    pub discover_models: bool,
 
     /// Explicit provider wire protocol, e.g. `chat_completions` or `codex_responses`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1033,6 +1114,8 @@ impl Default for LlmProviderConfig {
             command: None,
             args: Vec::new(),
             model: None,
+            models: Vec::new(),
+            discover_models: true,
             api_mode: None,
             max_tokens: None,
             temperature: None,

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -557,6 +557,8 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
             || provider.command.is_some()
             || !provider.args.is_empty()
             || provider.model.is_some()
+            || !provider.models.is_empty()
+            || !provider.discover_models
             || provider.api_mode.is_some()
             || provider.max_tokens.is_some()
             || provider.temperature.is_some()
@@ -569,7 +571,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -848,6 +850,17 @@ fn apply_user_config_patch_dotted(
                 "api_key_env" => entry.api_key_env = Some(value.to_string()),
                 "base_url" => entry.base_url = Some(value.to_string()),
                 "model" => entry.model = Some(value.to_string()),
+                "models" => {
+                    entry.models = value
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                }
+                "discover_models" => {
+                    entry.discover_models =
+                        parse_config_bool(&format!("llm.{}.discover_models", provider), value)?;
+                }
                 "api_mode" => entry.api_mode = Some(normalize_provider_api_mode(value)?),
                 "max_tokens" | "max_output_tokens" => {
                     let parsed = value.parse::<u32>().map_err(|_| {
@@ -880,7 +893,7 @@ fn apply_user_config_patch_dotted(
                 "oauth_client_id" => entry.oauth_client_id = Some(value.to_string()),
                 other => {
                     return Err(ConfigError::NotFound(format!(
-                        "unknown llm field: llm.{}.{} (supported: api_key, api_key_env, base_url, model, api_mode, max_tokens, max_output_tokens, command, args, request_timeout_seconds, oauth_token_url, oauth_client_id)",
+                        "unknown llm field: llm.{}.{} (supported: api_key, api_key_env, base_url, model, models, discover_models, api_mode, max_tokens, max_output_tokens, command, args, request_timeout_seconds, oauth_token_url, oauth_client_id)",
                         provider, other
                     )));
                 }
@@ -1083,6 +1096,17 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .and_then(|c| c.model.as_deref())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["llm", provider, "models"] => Ok(config
+            .llm_providers
+            .get(*provider)
+            .map(|c| c.models.join(","))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "(not set)".to_string())),
+        ["llm", provider, "discover_models"] => Ok(config
+            .llm_providers
+            .get(*provider)
+            .map(|c| c.discover_models.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
         ["llm", provider, "api_mode"] => Ok(config
             .llm_providers
@@ -2223,6 +2247,11 @@ pub fn validate_config(config: &GatewayConfig) -> Result<(), ConfigError> {
                 "llm_providers.{name}.max_tokens must be a positive integer"
             )));
         }
+        if provider.models.iter().any(|model| model.trim().is_empty()) {
+            return Err(ConfigError::ValidationError(format!(
+                "llm_providers.{name}.models must not contain empty model ids"
+            )));
+        }
     }
 
     if let Some(api_key) = &config.delegation.api_key {
@@ -2370,6 +2399,28 @@ mod tests {
                 .and_then(|cfg| cfg.request_timeout_seconds),
             Some(45.0)
         );
+    }
+
+    #[test]
+    fn normalize_provider_secrets_keeps_models_only_provider_entries() {
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "qianfan-coding".into(),
+            crate::config::LlmProviderConfig {
+                models: vec!["kimi-k2.5".into(), "glm-5".into()],
+                discover_models: false,
+                ..Default::default()
+            },
+        );
+
+        normalize_provider_secrets(&mut config);
+
+        let provider = config
+            .llm_providers
+            .get("qianfan-coding")
+            .expect("models-only provider should remain");
+        assert_eq!(provider.models, vec!["kimi-k2.5", "glm-5"]);
+        assert!(!provider.discover_models);
     }
 
     #[test]
@@ -3083,6 +3134,37 @@ llm_providers:
     }
 
     #[test]
+    fn load_user_config_file_parses_provider_models_and_discovery_flag() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+llm_providers:
+  qianfan-coding:
+    base_url: https://qianfan.baidubce.com/v2/coding
+    discover_models: "false"
+    models:
+      kimi-k2.5:
+        context_length: 128000
+      glm-5:
+        context_length: 128000
+"#,
+        )
+        .unwrap();
+
+        let loaded = load_user_config_file(&path).unwrap();
+        let provider = loaded
+            .llm_providers
+            .get("qianfan-coding")
+            .expect("provider");
+        assert!(!provider.discover_models);
+        assert_eq!(provider.models, vec!["kimi-k2.5", "glm-5"]);
+    }
+
+    #[test]
     fn load_user_config_file_rejects_unknown_llm_provider_api_mode() {
         use tempfile::tempdir;
 
@@ -3110,6 +3192,8 @@ llm_providers:
         apply_user_config_patch(&mut c, "llm.openai.base_url", "https://api.openai.com/v1")
             .unwrap();
         apply_user_config_patch(&mut c, "llm.openai.api_mode", "codex-responses").unwrap();
+        apply_user_config_patch(&mut c, "llm.openai.models", "gpt-4o,gpt-4o-mini").unwrap();
+        apply_user_config_patch(&mut c, "llm.openai.discover_models", "false").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.max_output_tokens", "8192").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.command", "copilot-language-server").unwrap();
         apply_user_config_patch(&mut c, "llm.openai.args", "--stdio,--model,gpt-4o-mini").unwrap();
@@ -3136,6 +3220,11 @@ llm_providers:
             c.llm_providers.get("openai").unwrap().max_tokens,
             Some(8192)
         );
+        assert_eq!(
+            c.llm_providers.get("openai").unwrap().models,
+            vec!["gpt-4o", "gpt-4o-mini"]
+        );
+        assert!(!c.llm_providers.get("openai").unwrap().discover_models);
         assert_eq!(
             c.llm_providers.get("openai").unwrap().command.as_deref(),
             Some("copilot-language-server")
@@ -3184,6 +3273,14 @@ llm_providers:
             "8192"
         );
         assert_eq!(
+            user_config_field_display(&c, "llm.openai.models").unwrap(),
+            "gpt-4o,gpt-4o-mini"
+        );
+        assert_eq!(
+            user_config_field_display(&c, "llm.openai.discover_models").unwrap(),
+            "false"
+        );
+        assert_eq!(
             user_config_field_display(&c, "llm.openai.args").unwrap(),
             "--stdio,--model,gpt-4o-mini"
         );
@@ -3206,6 +3303,7 @@ llm_providers:
             apply_user_config_patch(&mut c, "llm.openai.request_timeout_seconds", "fast").is_err()
         );
         assert!(apply_user_config_patch(&mut c, "llm.openai.max_tokens", "0").is_err());
+        assert!(apply_user_config_patch(&mut c, "llm.openai.discover_models", "maybe").is_err());
     }
 
     #[test]

--- a/crates/hermes-config/src/python_yaml_compat.rs
+++ b/crates/hermes-config/src/python_yaml_compat.rs
@@ -200,6 +200,8 @@ fn merge_custom_providers_into_llm(map: &mut Mapping) {
                 "command",
                 "args",
                 "model",
+                "models",
+                "discover_models",
                 "api_mode",
                 "max_tokens",
                 "temperature",
@@ -614,6 +616,10 @@ custom_providers:
     api_key: sk-beans
     api_key_env: BEANS_API_KEY
     model: fallback-beans-model
+    discover_models: "false"
+    models:
+      kimi-k2.5: {}
+      glm-5: {}
     api_mode: codex_responses
   - name: local
     base_url: http://localhost:8080/v1/
@@ -631,6 +637,8 @@ custom_providers:
         assert_eq!(beans.api_key.as_deref(), Some("sk-beans"));
         assert_eq!(beans.api_key_env.as_deref(), Some("BEANS_API_KEY"));
         assert_eq!(beans.model.as_deref(), Some("fallback-beans-model"));
+        assert!(!beans.discover_models);
+        assert_eq!(beans.models, vec!["kimi-k2.5", "glm-5"]);
         assert_eq!(beans.api_mode.as_deref(), Some("codex_responses"));
 
         let local = cfg.llm_providers.get("local").expect("local provider");

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -976,6 +976,14 @@
       "disposition": "ported",
       "notes": "Rust regression tests cover the max_tokens propagation chain from config parsing/set-get through build_agent_config into AgentConfig.max_tokens precedence, superseding the upstream Python gateway test-only follow-up."
     },
+    "4b2d00f845eb": {
+      "disposition": "ported",
+      "notes": "Rust custom provider catalogs now preserve `discover_models: false` from both canonical llm_providers and legacy custom_providers, keep explicit `models` subsets without probing live `/models`, and expose config-aware provider lists with Rust model-switch tests."
+    },
+    "7ae8aac3b9b2": {
+      "disposition": "ported",
+      "notes": "Rust terminal and slash/TUI model flows now include configured custom providers, use explicit provider model lists when discovery is disabled, fall back to configured models after empty probes, and guard direct switches against those configured catalogs with CLI/config tests."
+    },
     "38695254f851": {
       "disposition": "ported",
       "notes": "Rust session persistence now exposes FTS index counting and optimize_fts maintenance, VACUUM runs FTS optimization before reclaiming pages, and top-level `hermes sessions optimize` reports FTS index count plus before/after sessions.db size with Rust unit/e2e coverage."


### PR DESCRIPTION
## Summary
- add Rust config support for provider `models` and boolish `discover_models`
- preserve `models`/`discover_models` from legacy `custom_providers` into `llm_providers`
- make terminal and slash/TUI model catalogs config-aware so configured custom providers are selectable
- honor `discover_models: false` by keeping explicit configured model subsets and skipping live `/models` probing
- fall back to configured models when live probing returns empty
- mark upstream custom-provider discovery commits as Rust-ported

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-config -p hermes-cli`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-cli` -> `new=0`, `stale=6`
- `cargo test -p hermes-config load_user_config_file_parses_provider_models_and_discovery_flag -- --nocapture`
- `cargo test -p hermes-config normalize_provider_secrets_keeps_models_only_provider_entries -- --nocapture`
- `cargo test -p hermes-config apply_patch_dotted_llm_proxy_budget -- --nocapture`
- `cargo test -p hermes-config python_custom_providers_merge_into_llm_provider_config -- --nocapture`
- `cargo test -p hermes-cli configured_provider_discover_false_keeps_explicit_models -- --nocapture`
- `cargo test -p hermes-cli configured_provider_falls_back_to_explicit_models_when_probe_empty -- --nocapture`
- `cargo test -p hermes-cli config_catalog_entries_include_custom_provider_models -- --nocapture`
- `cargo test -p hermes-cli parse_model_switch_request_accepts_configured_provider_strings -- --nocapture`
- `cargo test -p hermes-cli guard_provider_model_selection_uses_configured_provider_models -- --nocapture`
- `cargo test -p hermes-cli guard_provider_model_selection_soft_accepts_unlisted_codex_models -- --nocapture`
- `cargo test -p hermes-cli e2e_cli_model_command_lists_configured_custom_provider_models -- --nocapture`

## Disk placement
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `12G`
