### PR TITLE
parity(ntfy): honor explicit topic targets

### DIFF
--- a/crates/hermes-cli/src/runtime_tool_wiring.rs
+++ b/crates/hermes-cli/src/runtime_tool_wiring.rs
@@ -215,12 +215,12 @@ mod tests {
     use serde_json::json;
     use std::sync::Mutex;
 
-    use hermes_core::{GatewayError, ParseMode, PlatformAdapter};
+    use hermes_core::{GatewayError, ParseMode, PlatformAdapter, SendMessageOptions};
     use hermes_cron::{CronRunner, FileJobPersistence, MinimalCronLlm};
     use hermes_gateway::{gateway::GatewayConfig, DmManager, SessionManager};
     use tempfile::TempDir;
 
-    type SentRecord = (String, String, Option<String>);
+    type SentRecord = (String, String, Option<String>, bool);
 
     struct RecordingAdapter {
         sent: Arc<Mutex<Vec<SentRecord>>>,
@@ -257,16 +257,16 @@ mod tests {
             self.sent
                 .lock()
                 .expect("recording adapter lock poisoned")
-                .push((chat_id.to_string(), text.to_string(), None));
+                .push((chat_id.to_string(), text.to_string(), None, false));
             Ok(())
         }
 
-        async fn send_message_threaded(
+        async fn send_message_with_options(
             &self,
             chat_id: &str,
             text: &str,
             _parse_mode: Option<ParseMode>,
-            thread_id: Option<&str>,
+            options: SendMessageOptions,
         ) -> Result<(), GatewayError> {
             self.sent
                 .lock()
@@ -274,7 +274,8 @@ mod tests {
                 .push((
                     chat_id.to_string(),
                     text.to_string(),
-                    thread_id.map(ToOwned::to_owned),
+                    options.thread_id,
+                    options.explicit_chat_id,
                 ));
             Ok(())
         }
@@ -339,6 +340,7 @@ mod tests {
         assert_eq!(sent[0].0, "12345");
         assert_eq!(sent[0].1, "hello");
         assert_eq!(sent[0].2, None);
+        assert!(sent[0].3);
     }
 
     #[tokio::test]
@@ -377,7 +379,8 @@ mod tests {
             [(
                 "C123".to_string(),
                 "reply".to_string(),
-                Some("171234.5".to_string())
+                Some("171234.5".to_string()),
+                true,
             )]
         );
     }

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -38,7 +38,8 @@ pub use schema_sanitizer::{
 
 // Re-export trait definitions
 pub use traits::{
-    LlmProvider, MemoryProvider, PlatformAdapter, SkillProvider, TerminalBackend, ToolHandler,
+    LlmProvider, MemoryProvider, PlatformAdapter, SendMessageOptions, SkillProvider,
+    TerminalBackend, ToolHandler,
 };
 
 // Re-export tool call parser public API

--- a/crates/hermes-core/src/traits.rs
+++ b/crates/hermes-core/src/traits.rs
@@ -62,6 +62,32 @@ pub enum ParseMode {
     Html,
 }
 
+/// Optional routing hints for platform sends.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SendMessageOptions {
+    /// Platform-native thread/topic id for adapters that support threaded replies.
+    pub thread_id: Option<String>,
+    /// True when the caller supplied the chat/topic id explicitly rather than
+    /// letting the gateway choose a configured home/publish target.
+    pub explicit_chat_id: bool,
+}
+
+impl SendMessageOptions {
+    pub fn threaded(thread_id: Option<&str>) -> Self {
+        Self {
+            thread_id: thread_id.map(ToOwned::to_owned),
+            explicit_chat_id: false,
+        }
+    }
+
+    pub fn explicit_threaded(thread_id: Option<&str>) -> Self {
+        Self {
+            thread_id: thread_id.map(ToOwned::to_owned),
+            explicit_chat_id: true,
+        }
+    }
+}
+
 /// Trait for platform communication adapters (Telegram, Discord, etc.).
 #[async_trait]
 pub trait PlatformAdapter: Send + Sync {
@@ -91,6 +117,22 @@ pub trait PlatformAdapter: Send + Sync {
     ) -> Result<(), GatewayError> {
         let _ = thread_id;
         self.send_message(chat_id, text, parse_mode).await
+    }
+
+    /// Send a text message with routing hints.
+    ///
+    /// The default preserves existing adapter behavior while allowing adapters
+    /// such as ntfy to distinguish explicit tool targets from configured home
+    /// reply targets.
+    async fn send_message_with_options(
+        &self,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        options: SendMessageOptions,
+    ) -> Result<(), GatewayError> {
+        self.send_message_threaded(chat_id, text, parse_mode, options.thread_id.as_deref())
+            .await
     }
 
     /// Send or update a status message keyed by stable status type.
@@ -123,6 +165,20 @@ pub trait PlatformAdapter: Send + Sync {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError>;
+
+    /// Send a file with routing hints.
+    ///
+    /// Adapters without explicit-target behavior inherit the plain file send.
+    async fn send_file_with_options(
+        &self,
+        chat_id: &str,
+        file_path: &str,
+        caption: Option<&str>,
+        options: SendMessageOptions,
+    ) -> Result<(), GatewayError> {
+        let _ = options;
+        self.send_file(chat_id, file_path, caption).await
+    }
 
     /// Send an image by URL using native platform capabilities when possible.
     ///

--- a/crates/hermes-gateway/src/delivery.rs
+++ b/crates/hermes-gateway/src/delivery.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, warn};
 
 use crate::media::validate_media_delivery_path;
 use hermes_core::errors::GatewayError;
-use hermes_core::traits::PlatformAdapter;
+use hermes_core::traits::{PlatformAdapter, SendMessageOptions};
 
 // ---------------------------------------------------------------------------
 // DeliveryItem
@@ -348,7 +348,16 @@ impl DeliveryRouter {
         }
 
         if let Some(chat_id) = chat_id {
-            self.send_to_platform(platform_name, chat_id, message).await
+            self.send_to_platform(
+                platform_name,
+                chat_id,
+                message,
+                SendMessageOptions {
+                    thread_id: target.thread_id.clone(),
+                    explicit_chat_id: target.is_explicit,
+                },
+            )
+            .await
         } else {
             Err(GatewayError::SendFailed(format!(
                 "Delivery target '{}' has no chat_id/home channel configured",
@@ -372,6 +381,7 @@ impl DeliveryRouter {
         platform_name: &str,
         chat_id: &str,
         message: &str,
+        options: SendMessageOptions,
     ) -> Result<(), GatewayError> {
         let adapters = self.adapters.read().await;
         match adapters.get(platform_name) {
@@ -382,7 +392,9 @@ impl DeliveryRouter {
                         "Adapter is not running, attempting delivery anyway"
                     );
                 }
-                adapter.send_message(chat_id, message, None).await
+                adapter
+                    .send_message_with_options(chat_id, message, None, options)
+                    .await
             }
             None => {
                 error!(
@@ -445,7 +457,19 @@ impl DeliveryRouter {
 
         let adapters = self.adapters.read().await;
         match adapters.get(platform_name) {
-            Some(adapter) => adapter.send_file(chat_id, validated_path, caption).await,
+            Some(adapter) => {
+                adapter
+                    .send_file_with_options(
+                        chat_id,
+                        validated_path,
+                        caption,
+                        SendMessageOptions {
+                            thread_id: target.thread_id.clone(),
+                            explicit_chat_id: target.is_explicit,
+                        },
+                    )
+                    .await
+            }
             None => Err(GatewayError::SendFailed(format!(
                 "No adapter registered for platform '{}'",
                 platform_name
@@ -474,6 +498,12 @@ mod tests {
 
     struct FileRecordingAdapter {
         files: Arc<Mutex<Vec<String>>>,
+    }
+
+    type RecordedMessage = (String, String, Option<String>, bool);
+
+    struct MessageRecordingAdapter {
+        messages: Arc<Mutex<Vec<RecordedMessage>>>,
     }
 
     #[async_trait]
@@ -523,6 +553,74 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl PlatformAdapter for MessageRecordingAdapter {
+        async fn start(&self) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn send_message(
+            &self,
+            chat_id: &str,
+            text: &str,
+            _parse_mode: Option<ParseMode>,
+        ) -> Result<(), GatewayError> {
+            self.messages.lock().unwrap().push((
+                chat_id.to_string(),
+                text.to_string(),
+                None,
+                false,
+            ));
+            Ok(())
+        }
+
+        async fn send_message_with_options(
+            &self,
+            chat_id: &str,
+            text: &str,
+            _parse_mode: Option<ParseMode>,
+            options: SendMessageOptions,
+        ) -> Result<(), GatewayError> {
+            self.messages.lock().unwrap().push((
+                chat_id.to_string(),
+                text.to_string(),
+                options.thread_id,
+                options.explicit_chat_id,
+            ));
+            Ok(())
+        }
+
+        async fn edit_message(
+            &self,
+            _chat_id: &str,
+            _message_id: &str,
+            _text: &str,
+        ) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn send_file(
+            &self,
+            _chat_id: &str,
+            _file_path: &str,
+            _caption: Option<&str>,
+        ) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        fn is_running(&self) -> bool {
+            true
+        }
+
+        fn platform_name(&self) -> &str {
+            "ntfy"
+        }
+    }
+
     #[test]
     fn test_parse_target_origin() {
         let target = parse_target("origin");
@@ -557,6 +655,16 @@ mod tests {
         assert_eq!(discord.platform, "discord");
         assert_eq!(discord.chat_id, None);
         assert!(!discord.is_explicit);
+    }
+
+    #[test]
+    fn test_parse_target_ntfy_topic_is_explicit() {
+        let target = parse_target("ntfy:alerts-channel");
+
+        assert_eq!(target.platform, "ntfy");
+        assert_eq!(target.chat_id.as_deref(), Some("alerts-channel"));
+        assert_eq!(target.thread_id, None);
+        assert!(target.is_explicit);
     }
 
     #[test]
@@ -600,6 +708,30 @@ mod tests {
         let item = q.dequeue().unwrap();
         assert_eq!(item.text, "hello");
         assert!(q.is_empty());
+    }
+
+    #[tokio::test]
+    async fn route_delivery_preserves_explicit_ntfy_topic() {
+        let router = DeliveryRouter::new();
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        router
+            .register_adapter(
+                "ntfy",
+                Arc::new(MessageRecordingAdapter {
+                    messages: messages.clone(),
+                }),
+            )
+            .await;
+
+        router
+            .route_delivery(&parse_target("ntfy:alerts-channel"), "done", None, None)
+            .await
+            .expect("explicit ntfy target should route");
+
+        assert_eq!(
+            messages.lock().unwrap().as_slice(),
+            &[("alerts-channel".to_string(), "done".to_string(), None, true,)]
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, warn};
 
 use hermes_config::{normalize_service_tier, DisplayConfig, QuickCommandConfig};
 use hermes_core::errors::GatewayError;
-use hermes_core::traits::{ParseMode, PlatformAdapter};
+use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 use hermes_core::types::{Message, MessageRole};
 
 use crate::background::{BackgroundTaskManager, TaskStatus};
@@ -2477,6 +2477,46 @@ impl Gateway {
         parse_mode: Option<ParseMode>,
         thread_id: Option<&str>,
     ) -> Result<(), GatewayError> {
+        self.send_message_with_options(
+            platform,
+            chat_id,
+            text,
+            parse_mode,
+            SendMessageOptions::threaded(thread_id),
+        )
+        .await
+    }
+
+    /// Send a message to a caller-supplied platform chat/topic.
+    ///
+    /// This keeps explicit tool targets distinct from gateway-origin replies
+    /// that may intentionally use platform-level home/publish overrides.
+    pub async fn send_message_explicit(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        thread_id: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        self.send_message_with_options(
+            platform,
+            chat_id,
+            text,
+            parse_mode,
+            SendMessageOptions::explicit_threaded(thread_id),
+        )
+        .await
+    }
+
+    async fn send_message_with_options(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        options: SendMessageOptions,
+    ) -> Result<(), GatewayError> {
         let adapter = self.get_adapter(platform).await.ok_or_else(|| {
             GatewayError::Platform(format!("No adapter registered for platform: {}", platform))
         })?;
@@ -2485,17 +2525,17 @@ impl Gateway {
         if images.is_empty() && media_files.is_empty() {
             if without_media == text {
                 return adapter
-                    .send_message_threaded(chat_id, text, parse_mode, thread_id)
+                    .send_message_with_options(chat_id, text, parse_mode, options)
                     .await;
             }
             return adapter
-                .send_message_threaded(chat_id, &cleaned, parse_mode, thread_id)
+                .send_message_with_options(chat_id, &cleaned, parse_mode, options)
                 .await;
         }
 
         if !cleaned.is_empty() {
             adapter
-                .send_message_threaded(chat_id, &cleaned, parse_mode.clone(), thread_id)
+                .send_message_with_options(chat_id, &cleaned, parse_mode.clone(), options.clone())
                 .await?;
         }
 
@@ -2517,7 +2557,12 @@ impl Gateway {
                     _ => image.url.clone(),
                 };
                 adapter
-                    .send_message_threaded(chat_id, &fallback, Some(ParseMode::Plain), thread_id)
+                    .send_message_with_options(
+                        chat_id,
+                        &fallback,
+                        Some(ParseMode::Plain),
+                        options.clone(),
+                    )
                     .await?;
             }
         }
@@ -2532,11 +2577,11 @@ impl Gateway {
                     "refusing to deliver unsafe MEDIA marker path"
                 );
                 adapter
-                    .send_message_threaded(
+                    .send_message_with_options(
                         chat_id,
                         "[media attachment blocked: unsafe local file path]",
                         Some(ParseMode::Plain),
-                        thread_id,
+                        options.clone(),
                     )
                     .await?;
                 continue;
@@ -2550,17 +2595,20 @@ impl Gateway {
                     "refusing to deliver non-UTF-8 MEDIA marker path"
                 );
                 adapter
-                    .send_message_threaded(
+                    .send_message_with_options(
                         chat_id,
                         "[media attachment blocked: non-UTF-8 local file path]",
                         Some(ParseMode::Plain),
-                        thread_id,
+                        options.clone(),
                     )
                     .await?;
                 continue;
             };
 
-            if let Err(err) = adapter.send_file(chat_id, validated_path, None).await {
+            if let Err(err) = adapter
+                .send_file_with_options(chat_id, validated_path, None, options.clone())
+                .await
+            {
                 warn!(
                     platform = platform,
                     chat_id = chat_id,
@@ -2570,11 +2618,11 @@ impl Gateway {
                     "native media file send failed; falling back to plain file marker"
                 );
                 adapter
-                    .send_message_threaded(
+                    .send_message_with_options(
                         chat_id,
                         &format!("[media attachment] {validated_path}"),
                         Some(ParseMode::Plain),
-                        thread_id,
+                        options.clone(),
                     )
                     .await?;
             }

--- a/crates/hermes-gateway/src/platforms/ntfy.rs
+++ b/crates/hermes-gateway/src/platforms/ntfy.rs
@@ -18,7 +18,7 @@ use tokio::sync::{mpsc, Notify, RwLock};
 use tracing::{debug, info, warn};
 
 use hermes_core::errors::GatewayError;
-use hermes_core::traits::{ParseMode, PlatformAdapter};
+use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
 use crate::gateway::IncomingMessage;
@@ -211,6 +211,20 @@ impl NtfyAdapter {
             include_echo_tag,
             markdown,
         )
+    }
+
+    fn publish_topic_for(&self, chat_id: &str, explicit_chat_id: bool) -> String {
+        if explicit_chat_id {
+            return chat_id.trim().to_string();
+        }
+        self.inner
+            .config
+            .publish_topic
+            .as_deref()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or(chat_id)
+            .trim()
+            .to_string()
     }
 
     async fn is_duplicate(inner: &NtfyInner, message_id: &str) -> bool {
@@ -420,14 +434,18 @@ impl PlatformAdapter for NtfyAdapter {
         text: &str,
         parse_mode: Option<ParseMode>,
     ) -> Result<(), GatewayError> {
-        let publish_topic = self
-            .inner
-            .config
-            .publish_topic
-            .as_deref()
-            .filter(|v| !v.trim().is_empty())
-            .unwrap_or(chat_id)
-            .trim();
+        self.send_message_with_options(chat_id, text, parse_mode, SendMessageOptions::default())
+            .await
+    }
+
+    async fn send_message_with_options(
+        &self,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        options: SendMessageOptions,
+    ) -> Result<(), GatewayError> {
+        let publish_topic = self.publish_topic_for(chat_id, options.explicit_chat_id);
         if publish_topic.is_empty() {
             return Err(GatewayError::SendFailed(
                 "ntfy publish topic is empty".into(),
@@ -477,11 +495,23 @@ impl PlatformAdapter for NtfyAdapter {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
+        self.send_file_with_options(chat_id, file_path, caption, SendMessageOptions::default())
+            .await
+    }
+
+    async fn send_file_with_options(
+        &self,
+        chat_id: &str,
+        file_path: &str,
+        caption: Option<&str>,
+        options: SendMessageOptions,
+    ) -> Result<(), GatewayError> {
         let text = match caption.map(str::trim).filter(|v| !v.is_empty()) {
             Some(caption) => format!("{caption}\n[Attachment: {file_path}]"),
             None => format!("[Attachment: {file_path}]"),
         };
-        self.send_message(chat_id, &text, None).await
+        self.send_message_with_options(chat_id, &text, None, options)
+            .await
     }
 
     fn is_running(&self) -> bool {
@@ -578,6 +608,85 @@ mod tests {
         let adapter = NtfyAdapter::new(test_config(server.uri())).unwrap();
         adapter
             .send_message("hermes-in", "Hello!", None)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_message_uses_configured_publish_topic_for_non_explicit_reply() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/configured-topic"))
+            .and(header("X-Tags", ECHO_TAG))
+            .and(body_string("done"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config(server.uri());
+        config.publish_topic = Some("configured-topic".into());
+        let adapter = NtfyAdapter::new(config).unwrap();
+        adapter
+            .send_message("hermes-in", "done", None)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn explicit_send_overrides_configured_publish_topic() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/alerts-channel"))
+            .and(header("X-Tags", ECHO_TAG))
+            .and(body_string("done"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config(server.uri());
+        config.publish_topic = Some("configured-topic".into());
+        let adapter = NtfyAdapter::new(config).unwrap();
+        adapter
+            .send_message_with_options(
+                "alerts-channel",
+                "done",
+                None,
+                SendMessageOptions {
+                    explicit_chat_id: true,
+                    ..SendMessageOptions::default()
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn explicit_file_send_overrides_configured_publish_topic() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/alerts-channel"))
+            .and(header("X-Tags", ECHO_TAG))
+            .and(body_string("[Attachment: /tmp/report.pdf]"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config(server.uri());
+        config.publish_topic = Some("configured-topic".into());
+        let adapter = NtfyAdapter::new(config).unwrap();
+        adapter
+            .send_file_with_options(
+                "alerts-channel",
+                "/tmp/report.pdf",
+                None,
+                SendMessageOptions {
+                    explicit_chat_id: true,
+                    ..SendMessageOptions::default()
+                },
+            )
             .await
             .unwrap();
     }

--- a/crates/hermes-gateway/src/tool_backends.rs
+++ b/crates/hermes-gateway/src/tool_backends.rs
@@ -50,7 +50,7 @@ impl MessagingBackend for GatewayMessagingBackend {
         thread_id: Option<&str>,
     ) -> Result<String, ToolError> {
         self.gateway
-            .send_message_threaded(platform, recipient, message, None, thread_id)
+            .send_message_explicit(platform, recipient, message, None, thread_id)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("gateway send failed: {}", e)))?;
         let mut response = json!({

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1031,6 +1031,10 @@
     "a61420952e29": {
       "disposition": "ported",
       "notes": "Rust now constructs tool-result messages with the originating tool name in Message.name when the ToolCall is known, including invalid-tool and invalid-JSON result paths, persists messages.name through the SQLite session store with legacy DB migration, and regression-tests model-visible plus persisted tool-result name round trips."
+    },
+    "338c07433699": {
+      "disposition": "ported",
+      "notes": "Rust ntfy sends now distinguish explicit tool/router targets from configured publish-topic replies: gateway-backed messaging marks caller recipients explicit, DeliveryTarget routing preserves is_explicit/thread hints for text and file sends, and NtfyAdapter publishes explicit topics directly while retaining configured publish_topic for non-explicit replies."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Add `SendMessageOptions` / `send_file_with_options` to the Rust platform adapter contract so caller-supplied targets can be distinguished from configured home/publish targets.
- Route gateway-backed `send_message` tool calls as explicit sends while preserving Slack thread IDs.
- Make `DeliveryRouter` preserve explicit/thread hints for text and file sends.
- Make `NtfyAdapter` publish explicit text/file targets directly while retaining configured `publish_topic` for non-explicit gateway replies.
- Mark upstream `338c07433699` as ported in `docs/parity/queue-overrides.json`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-gateway --features ntfy explicit -- --nocapture`
- `cargo test -p hermes-gateway route_file_delivery_validates_and_canonicalizes_path_before_adapter_send -- --nocapture`
- `cargo test -p hermes-gateway route_delivery_preserves_explicit_ntfy_topic -- --nocapture`
- `cargo test -p hermes-cli gateway_messaging_backend -- --nocapture`
- `cargo build -p hermes-core -p hermes-gateway -p hermes-cli`
- `cargo build -p hermes-gateway --features ntfy`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-gateway -p hermes-cli` (`new=0`, `stale=6`)
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features ntfy` (`new=0`, `stale=6`)

Cargo target proof:
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `13G`

Queue proof:
- Refreshed upstream queue reports `338c07433699569c24c32df4a2d1a8b9472400a8` as `ported`.
- Summary after override: `ported: 124`, `pending: 1933`, `superseded: 7631`, `mirrored: 161`.
