### PR TITLE
test(file-search): cover diagnostic-free rust search

### DIFF
--- a/crates/hermes-tools/src/backends/file.rs
+++ b/crates/hermes-tools/src/backends/file.rs
@@ -928,6 +928,101 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_content_invalid_regex_surfaces_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(root.join("a.txt"), "needle\n").expect("write a.txt");
+
+        let backend = LocalSearchBackend::new();
+        let err = backend
+            .search_content(
+                "[",
+                root.to_str().expect("path str"),
+                Some("*.txt"),
+                Some(10),
+                Some(0),
+                Some("content"),
+                Some(0),
+            )
+            .await
+            .expect_err("invalid regex should fail before traversal");
+
+        assert!(err.to_string().contains("Invalid regex pattern"));
+    }
+
+    #[tokio::test]
+    async fn search_content_read_errors_keep_matches_and_do_not_pollute_modes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let good = root.join("good.txt");
+        let bad = root.join("bad.txt");
+        std::fs::write(&good, "needle in readable file\n").expect("write good");
+        std::fs::write(&bad, b"\xff\xfe needle in non utf8 file").expect("write bad");
+
+        let backend = LocalSearchBackend::new();
+
+        let content = backend
+            .search_content(
+                "needle",
+                root.to_str().expect("path str"),
+                Some("*.txt"),
+                Some(10),
+                Some(0),
+                Some("content"),
+                Some(0),
+            )
+            .await
+            .expect("content search keeps readable matches");
+        let parsed: Value = serde_json::from_str(&content).expect("json");
+        let matches = parsed["matches"].as_array().expect("matches array");
+        assert_eq!(parsed["total"], 1);
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0]["file"]
+            .as_str()
+            .expect("match file")
+            .ends_with("good.txt"));
+        assert!(!content.contains("bad.txt"));
+
+        let files_only = backend
+            .search_content(
+                "needle",
+                root.to_str().expect("path str"),
+                Some("*.txt"),
+                Some(10),
+                Some(0),
+                Some("files_only"),
+                Some(0),
+            )
+            .await
+            .expect("files_only search keeps readable matches");
+        let parsed: Value = serde_json::from_str(&files_only).expect("json");
+        let files = parsed["files"].as_array().expect("files array");
+        assert_eq!(parsed["total"], 1);
+        assert_eq!(files.len(), 1);
+        assert!(files[0].as_str().expect("file").ends_with("good.txt"));
+        assert!(!files_only.contains("bad.txt"));
+
+        let counts = backend
+            .search_content(
+                "needle",
+                root.to_str().expect("path str"),
+                Some("*.txt"),
+                Some(10),
+                Some(0),
+                Some("count"),
+                Some(0),
+            )
+            .await
+            .expect("count search keeps readable matches");
+        let parsed: Value = serde_json::from_str(&counts).expect("json");
+        let counts = parsed["counts"].as_object().expect("counts object");
+        assert_eq!(parsed["total"], 1);
+        assert_eq!(counts.len(), 1);
+        assert!(counts.keys().any(|path| path.ends_with("good.txt")));
+        assert!(!counts.keys().any(|path| path.ends_with("bad.txt")));
+    }
+
+    #[tokio::test]
     async fn search_content_context_includes_surrounding_lines() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path();

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1035,6 +1035,10 @@
     "338c07433699": {
       "disposition": "ported",
       "notes": "Rust ntfy sends now distinguish explicit tool/router targets from configured publish-topic replies: gateway-backed messaging marks caller recipients explicit, DeliveryTarget routing preserves is_explicit/thread hints for text and file sends, and NtfyAdapter publishes explicit topics directly while retaining configured publish_topic for non-explicit replies."
+    },
+    "ea266f43e9db": {
+      "disposition": "superseded",
+      "notes": "Rust LocalSearchBackend does not shell through rg/grep or parse merged stderr as matches; it compiles regexes with regex::Regex before traversal, skips unreadable/non-UTF8 files without diagnostic payload parsing, and now regression-tests invalid-regex errors plus partial read failures preserving content/files_only/count matches."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Add Rust regression coverage for file-search diagnostic parity around upstream `ea266f43e9db`.
- Prove invalid regexes surface as errors before traversal.
- Prove partial read failures/non-UTF8 files preserve readable matches and do not pollute `content`, `files_only`, or `count` modes.
- Add a precise `superseded` override note explaining why the Rust in-process backend does not need the upstream rg/grep pipefail/diagnostic splitter.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `cargo test -p hermes-tools search_content_invalid_regex_surfaces_error -- --nocapture`
- `cargo test -p hermes-tools search_content_read_errors_keep_matches_and_do_not_pollute_modes -- --nocapture`
- `cargo test -p hermes-tools search_content_ -- --nocapture` (5 passed)
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-tools`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools` (`new=0`, `stale=6`)

Queue proof:
- `ea266f43e9db0abe2d34b9edba94af47cc98d6b1` resolves to `superseded` with the new Rust-specific note.
- Refreshed summary: `mirrored=161`, `pending=1933`, `ported=124`, `superseded=7631`.

Cargo target proof:
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `13G`
