### PR TITLE
parity(update): ignore bootstrap marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,10 @@ __pycache__/
 # and provider error details. Keep them off public main.
 artifacts/quorum/
 
+# Desktop/bootstrap install marker written into managed checkout roots. This is
+# Hermes-managed runtime state, not source, and must not be swept into update
+# autostashes by `git stash --include-untracked`.
+.hermes-bootstrap-complete
+
 # Generated PR infographics live in PR bodies, not in-tree.
 infographic/

--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -1059,6 +1059,17 @@ mod tests {
     }
 
     #[test]
+    fn update_autostash_ignores_desktop_bootstrap_marker() {
+        let gitignore = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../.gitignore"));
+        assert!(
+            gitignore
+                .lines()
+                .any(|line| line.trim() == ".hermes-bootstrap-complete"),
+            ".hermes-bootstrap-complete must stay ignored so update autostash paths do not sweep the Desktop bootstrap marker into a stash"
+        );
+    }
+
+    #[test]
     fn cli_parse_verify_provenance() {
         let cli = Cli::try_parse_from(vec![
             "hermes",

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1043,6 +1043,14 @@
     "ec46f5912e30": {
       "disposition": "ported",
       "notes": "Rust Gemini direct-provider setup and runtime defaults now use Google AI Studio's OpenAI-compatible /v1beta/openai endpoint, normalize manually supplied native Gemini base URLs to that endpoint, and defensively strip OpenAI-only extra_body/profile fields from native-Gemini request bodies while preserving thinking_config/thinkingConfig. The upstream native maxOutputTokens default is superseded by Rust's OpenAI-compatible max_tokens path."
+    },
+    "b459bac02c98": {
+      "disposition": "ported",
+      "notes": "Rust repo update/autostash safety now ignores the Desktop bootstrap marker .hermes-bootstrap-complete in the root .gitignore, with a hermes-cli regression test guarding that gitignore contract so bootstrap runtime state is not swept into update stashes."
+    },
+    "72eb42d9ecdf": {
+      "disposition": "superseded",
+      "notes": "The upstream Python source-checkout updater's stash/restore versus discard mode is superseded in Rust because top-level hermes update is non-mutating release-check behavior and does not run git checkout/pull/reset/clean against the source tree. The remaining shared safety contract, ignoring .hermes-bootstrap-complete so autostash paths do not capture Desktop bootstrap state, is ported separately under b459bac02c98."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- ignore the Desktop/bootstrap managed checkout marker `.hermes-bootstrap-complete`
- add a Rust `hermes-cli` regression test guarding the gitignore contract
- mark upstream `b459bac02c98` ported and `72eb42d9ecdf` superseded by Rust's non-mutating release-check updater

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli update_autostash_ignores_desktop_bootstrap_marker -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli`
- queue refresh: `pending=1931`, `ported=126`, `superseded=7631`

## Disk placement
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/tmp/hermes-agent-ultra-parity-next/target`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `13G`
