### PR TITLE
parity(model): expand provider previews

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -58,6 +58,7 @@ use crate::model_switch::{
     cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
     normalize_provider_model, provider_catalog_entries_for_config, provider_model_ids,
     provider_model_ids_for_config, provider_slug_from_provider_model, provider_slugs_for_config,
+    DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
 };
 use crate::pairing_store::{PairingStatus, PairingStore};
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
@@ -13903,7 +13904,8 @@ async fn handle_provider_command(app: &mut App) -> Result<CommandResult, AgentEr
         emit_command_output(app, "No providers registered.");
         return Ok(CommandResult::Handled);
     }
-    let entries = provider_catalog_entries_for_config(&app.config, 4).await;
+    let entries =
+        provider_catalog_entries_for_config(&app.config, DEFAULT_VISIBLE_MODELS_PER_PROVIDER).await;
     if entries.is_empty() {
         emit_command_output(
             app,

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -40,7 +40,7 @@ use hermes_cli::config_env::hydrate_env_from_config;
 use hermes_cli::model_switch::{
     cached_provider_catalog_status, format_stale_auxiliary_warning, normalize_provider_model,
     provider_catalog_entries_for_config, provider_model_ids, provider_picker_description,
-    provider_slug_from_provider_model,
+    provider_slug_from_provider_model, DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
 };
 use hermes_cli::platform_toolsets::{resolve_platform_tool_schemas, tool_definition_summary};
 use hermes_cli::providers::provider_capability_for;
@@ -1745,7 +1745,9 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
             println!("Current model: {}", current);
 
             // List providers with merged models.dev-aware previews.
-            let entries = provider_catalog_entries_for_config(&config, 3).await;
+            let entries =
+                provider_catalog_entries_for_config(&config, DEFAULT_VISIBLE_MODELS_PER_PROVIDER)
+                    .await;
             println!("\nAvailable providers:");
             if entries.is_empty() {
                 println!("  openai       — OpenAI (gpt-4o, gpt-4o-mini, ...)");

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -19,6 +19,7 @@ use sha2::{Digest, Sha256};
 use crate::providers::{canonical_provider_id, provider_capability_for};
 const NOUS_DEFAULT_INFERENCE_BASE_URL: &str = "https://inference-api.nousresearch.com/v1";
 const PROVIDER_CATALOG_CACHE_VERSION: u32 = 2;
+pub const DEFAULT_VISIBLE_MODELS_PER_PROVIDER: usize = 50;
 const OLLAMA_LOCAL_DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
 const LLAMA_CPP_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080/v1";
 const VLLM_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
@@ -1321,7 +1322,7 @@ mod tests {
         provider_catalog_entries_for_config, provider_curated_models,
         provider_model_ids_for_config, provider_model_ids_with_client, provider_picker_description,
         provider_slug_from_provider_model, provider_slugs_for_config,
-        resolve_huggingface_catalog_endpoint_and_token,
+        resolve_huggingface_catalog_endpoint_and_token, DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
     };
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -1812,6 +1813,34 @@ mod tests {
             .expect("custom provider entry");
         assert_eq!(entry.models, vec!["kimi-k2.5"]);
         assert_eq!(entry.total_models, 2);
+    }
+
+    #[tokio::test]
+    async fn default_visible_models_per_provider_shows_first_fifty() {
+        let mut cfg = hermes_config::GatewayConfig::default();
+        let models = (0..60)
+            .map(|idx| format!("model-{idx:02}"))
+            .collect::<Vec<_>>();
+        cfg.llm_providers.insert(
+            "wide-provider".to_string(),
+            hermes_config::LlmProviderConfig {
+                models,
+                discover_models: false,
+                ..hermes_config::LlmProviderConfig::default()
+            },
+        );
+
+        let entries =
+            provider_catalog_entries_for_config(&cfg, DEFAULT_VISIBLE_MODELS_PER_PROVIDER).await;
+        let entry = entries
+            .iter()
+            .find(|entry| entry.provider == "wide-provider")
+            .expect("wide provider entry");
+
+        assert_eq!(entry.total_models, 60);
+        assert_eq!(entry.models.len(), 50);
+        assert_eq!(entry.models.first().map(String::as_str), Some("model-00"));
+        assert_eq!(entry.models.last().map(String::as_str), Some("model-49"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -4488,7 +4488,11 @@ async fn disconnect_provider_credentials(provider: &str) -> Result<(bool, bool),
 
 async fn open_model_provider_modal(state: &mut TuiState, app: &App) {
     let providers = crate::model_switch::curated_provider_slugs();
-    let entries = crate::model_switch::provider_catalog_entries(&providers, 4).await;
+    let entries = crate::model_switch::provider_catalog_entries(
+        &providers,
+        crate::model_switch::DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
+    )
+    .await;
     let token_store_providers = load_token_store_providers().await;
     let mut items: Vec<PickerItem> = Vec::new();
     for provider in providers {

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1024,6 +1024,10 @@
       "disposition": "ported",
       "notes": "Rust config now detects auxiliary task pins whose provider differs from the selected main provider, top-level and slash-command model switch persistence surfaces warn without auto-clearing legitimate pins, and focused config/model-switch/e2e tests cover stale vs auto/matching slots."
     },
+    "7f016f5f3360": {
+      "disposition": "ported",
+      "notes": "Rust model-provider preview surfaces now share DEFAULT_VISIBLE_MODELS_PER_PROVIDER=50 for CLI model listing, TUI provider picker details, and slash /provider output, with a regression test proving a 60-model configured provider exposes the first 50 while preserving total count."
+    },
     "ffb53767bfff": {
       "disposition": "ported",
       "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."


### PR DESCRIPTION
## Summary
- port upstream `7f016f5f3` model visibility default into Rust provider-preview surfaces
- add `DEFAULT_VISIBLE_MODELS_PER_PROVIDER = 50` and use it for CLI model listing, TUI provider picker details, and slash `/provider` output
- add a Rust regression test proving a 60-model configured provider exposes the first 50 while preserving total count
- mark the upstream SHA as `ported` in the parity queue override ledger

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli default_visible_models_per_provider_shows_first_fifty -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli` (`new=0`, `stale=6`)
- queue regeneration: `pending=1928`, `ported=128`, `7f016f5f3360` => `ported`
- disk proof: local `target` paths `0B`; wd_black cargo target `13G`
