### PR TITLE
parity(discord): add voice mixer runtime

### DIFF
--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -33,6 +33,7 @@ pub mod sticker_cache;
 pub mod stream;
 pub mod tool_backends;
 pub mod voice;
+pub mod voice_mixer;
 
 // Re-export core types from hermes-core
 pub use hermes_core::errors::GatewayError;

--- a/crates/hermes-gateway/src/voice.rs
+++ b/crates/hermes-gateway/src/voice.rs
@@ -7,6 +7,8 @@ use hermes_core::AgentError;
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
+use crate::voice_mixer::{synth_ambient_pcm, VoiceMixer};
+
 /// Voice mode state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VoiceState {
@@ -29,6 +31,7 @@ pub struct VoiceConfig {
     pub tts_provider: TtsProvider,
     pub auto_detect_voice: bool,
     pub language: Option<String>,
+    pub voice_fx: VoiceFxConfig,
 }
 
 impl Default for VoiceConfig {
@@ -39,6 +42,39 @@ impl Default for VoiceConfig {
             tts_provider: TtsProvider::OpenAi,
             auto_detect_voice: false,
             language: None,
+            voice_fx: VoiceFxConfig::default(),
+        }
+    }
+}
+
+/// Outgoing voice-channel effects: ambient bed plus ducked speech overlays.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VoiceFxConfig {
+    pub enabled: bool,
+    pub ambient_enabled: bool,
+    pub ambient_gain: f32,
+    pub duck_gain: f32,
+    pub speech_gain: f32,
+    pub ack_enabled: bool,
+    pub ack_phrases: Vec<String>,
+}
+
+impl Default for VoiceFxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ambient_enabled: true,
+            ambient_gain: 0.18,
+            duck_gain: 0.06,
+            speech_gain: 1.0,
+            ack_enabled: true,
+            ack_phrases: vec![
+                "Let me look into that.".to_string(),
+                "One moment.".to_string(),
+                "Checking on that now.".to_string(),
+                "Give me a sec.".to_string(),
+                "On it.".to_string(),
+            ],
         }
     }
 }
@@ -167,6 +203,8 @@ fn gateway_transcription_response_format(provider: &str, model: &str) -> &'stati
 pub struct VoiceManager {
     config: VoiceConfig,
     joined_channels: Mutex<HashMap<String, HashSet<String>>>,
+    voice_mixers: Mutex<HashMap<String, VoiceMixer>>,
+    ack_phrase_cursor: Mutex<usize>,
 }
 
 impl VoiceManager {
@@ -174,6 +212,8 @@ impl VoiceManager {
         Self {
             config,
             joined_channels: Mutex::new(HashMap::new()),
+            voice_mixers: Mutex::new(HashMap::new()),
+            ack_phrase_cursor: Mutex::new(0),
         }
     }
 
@@ -280,6 +320,8 @@ impl VoiceManager {
             );
             return Ok(());
         }
+        drop(lock);
+        self.install_voice_mixer_if_enabled(&platform, &channel_id)?;
         tracing::info!(
             platform = platform,
             channel_id = channel_id,
@@ -316,12 +358,146 @@ impl VoiceManager {
         if channels.is_empty() {
             lock.remove(&platform);
         }
+        drop(lock);
+        self.remove_voice_mixer(&platform, &channel_id);
         tracing::info!(
             platform = platform,
             channel_id = channel_id,
             "Left voice channel"
         );
         Ok(())
+    }
+
+    fn install_voice_mixer_if_enabled(
+        &self,
+        platform: &str,
+        channel_id: &str,
+    ) -> Result<(), AgentError> {
+        if !self.config.voice_fx.enabled {
+            return Ok(());
+        }
+        let mixer = VoiceMixer::new(
+            self.config.voice_fx.ambient_gain,
+            self.config.voice_fx.duck_gain,
+            self.config.voice_fx.speech_gain,
+            400,
+        );
+        if self.config.voice_fx.ambient_enabled {
+            let ambient = synth_ambient_pcm(4.0);
+            mixer.set_ambient(Some(&ambient), None);
+        }
+        let mut mixers = self
+            .voice_mixers
+            .lock()
+            .map_err(|_| AgentError::Io("voice mixer lock poisoned".into()))?;
+        mixers.insert(Self::voice_mixer_key(platform, channel_id), mixer);
+        Ok(())
+    }
+
+    fn remove_voice_mixer(&self, platform: &str, channel_id: &str) {
+        let Ok(mut mixers) = self.voice_mixers.lock() else {
+            return;
+        };
+        if let Some(mixer) = mixers.remove(&Self::voice_mixer_key(platform, channel_id)) {
+            mixer.cleanup();
+        }
+    }
+
+    pub fn voice_mixer_active(&self, platform: &str, channel_id: &str) -> bool {
+        let Ok(mixers) = self.voice_mixers.lock() else {
+            return false;
+        };
+        mixers.contains_key(&Self::voice_mixer_key(platform, channel_id))
+    }
+
+    pub fn play_voice_speech_pcm(
+        &self,
+        platform: &str,
+        channel_id: &str,
+        pcm: &[u8],
+    ) -> Result<(), AgentError> {
+        let platform = Self::normalize_identifier(platform, "platform")?;
+        let channel_id = Self::normalize_identifier(channel_id, "channel_id")?;
+        let mixers = self
+            .voice_mixers
+            .lock()
+            .map_err(|_| AgentError::Io("voice mixer lock poisoned".into()))?;
+        let mixer = mixers
+            .get(&Self::voice_mixer_key(&platform, &channel_id))
+            .ok_or_else(|| {
+                AgentError::Config(format!(
+                    "Voice mixer is not active for '{}' channel '{}'",
+                    platform, channel_id
+                ))
+            })?;
+        mixer.play_speech(pcm, Some(self.config.voice_fx.speech_gain), 40);
+        Ok(())
+    }
+
+    pub fn read_voice_mixer_frame(
+        &self,
+        platform: &str,
+        channel_id: &str,
+    ) -> Result<Vec<u8>, AgentError> {
+        let platform = Self::normalize_identifier(platform, "platform")?;
+        let channel_id = Self::normalize_identifier(channel_id, "channel_id")?;
+        let mixers = self
+            .voice_mixers
+            .lock()
+            .map_err(|_| AgentError::Io("voice mixer lock poisoned".into()))?;
+        let mixer = mixers
+            .get(&Self::voice_mixer_key(&platform, &channel_id))
+            .ok_or_else(|| {
+                AgentError::Config(format!(
+                    "Voice mixer is not active for '{}' channel '{}'",
+                    platform, channel_id
+                ))
+            })?;
+        Ok(mixer.read())
+    }
+
+    pub fn voice_speech_active(&self, platform: &str, channel_id: &str) -> bool {
+        let Ok(mixers) = self.voice_mixers.lock() else {
+            return false;
+        };
+        mixers
+            .get(&Self::voice_mixer_key(platform, channel_id))
+            .map(VoiceMixer::speech_active)
+            .unwrap_or(false)
+    }
+
+    pub fn stop_voice_speech(&self, platform: &str, channel_id: &str) -> bool {
+        let Ok(mixers) = self.voice_mixers.lock() else {
+            return false;
+        };
+        let Some(mixer) = mixers.get(&Self::voice_mixer_key(platform, channel_id)) else {
+            return false;
+        };
+        mixer.stop_speech();
+        true
+    }
+
+    pub fn voice_ack_phrase(&self, platform: &str, channel_id: &str) -> Option<String> {
+        if !self.config.voice_fx.ack_enabled || !self.voice_mixer_active(platform, channel_id) {
+            return None;
+        }
+        let phrases: Vec<_> = self
+            .config
+            .voice_fx
+            .ack_phrases
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if phrases.is_empty() {
+            return None;
+        }
+        let Ok(mut cursor) = self.ack_phrase_cursor.lock() else {
+            return Some(phrases[0].to_string());
+        };
+        let phrase = phrases[*cursor % phrases.len()].to_string();
+        *cursor = cursor.saturating_add(1);
+        Some(phrase)
     }
 
     /// Lightweight voice activity detection (VAD) using RMS energy.
@@ -381,6 +557,14 @@ impl VoiceManager {
         Ok(trimmed.to_string())
     }
 
+    fn voice_mixer_key(platform: &str, channel_id: &str) -> String {
+        format!(
+            "{}:{}",
+            platform.trim().to_ascii_lowercase(),
+            channel_id.trim()
+        )
+    }
+
     pub fn is_joined(&self, platform: &str, channel_id: &str) -> bool {
         let lock = match self.joined_channels.lock() {
             Ok(l) => l,
@@ -406,6 +590,12 @@ impl VoiceManager {
         };
         let count: usize = lock.values().map(|channels| channels.len()).sum();
         lock.clear();
+        drop(lock);
+        if let Ok(mut mixers) = self.voice_mixers.lock() {
+            for (_, mixer) in mixers.drain() {
+                mixer.cleanup();
+            }
+        }
         count
     }
 
@@ -787,6 +977,7 @@ impl VoiceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::voice_mixer::{FRAME_SIZE, SILENCE_FRAME};
     use std::f32::consts::PI;
     use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
 
@@ -849,6 +1040,8 @@ mod tests {
         let config = VoiceConfig::default();
         assert_eq!(config.state, VoiceState::Disabled);
         assert_eq!(config.stt_provider, SttProvider::Whisper);
+        assert!(!config.voice_fx.enabled);
+        assert_eq!(config.voice_fx.ack_phrases[0], "Let me look into that.");
     }
 
     #[test]
@@ -888,6 +1081,114 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn voice_fx_installs_mixer_on_join_and_removes_on_leave() {
+        let mut config = VoiceConfig::default();
+        config.state = VoiceState::FullDuplex;
+        config.voice_fx.enabled = true;
+        config.voice_fx.ack_phrases = vec!["One moment.".to_string()];
+        let mgr = VoiceManager::new(config);
+
+        mgr.join_voice_channel("discord", "voice-1")
+            .await
+            .expect("join should install mixer");
+        assert!(mgr.voice_mixer_active("DISCORD", "voice-1"));
+        assert_eq!(
+            mgr.voice_ack_phrase("discord", "voice-1").as_deref(),
+            Some("One moment.")
+        );
+
+        let ambient_frame = mgr
+            .read_voice_mixer_frame("discord", "voice-1")
+            .expect("mixer frame");
+        assert_eq!(ambient_frame.len(), FRAME_SIZE);
+        assert_ne!(ambient_frame, SILENCE_FRAME.to_vec());
+
+        mgr.leave_voice_channel("discord", "voice-1")
+            .await
+            .expect("leave should remove mixer");
+        assert!(!mgr.voice_mixer_active("discord", "voice-1"));
+        assert!(mgr.voice_ack_phrase("discord", "voice-1").is_none());
+    }
+
+    #[tokio::test]
+    async fn voice_fx_ack_phrases_rotate_and_skip_empty_values() {
+        let mut config = VoiceConfig::default();
+        config.state = VoiceState::FullDuplex;
+        config.voice_fx.enabled = true;
+        config.voice_fx.ack_phrases = vec![
+            " ".to_string(),
+            "One moment.".to_string(),
+            "Checking now.".to_string(),
+        ];
+        let mgr = VoiceManager::new(config);
+        mgr.join_voice_channel("discord", "voice-ack")
+            .await
+            .expect("join should install mixer");
+
+        assert_eq!(
+            mgr.voice_ack_phrase("discord", "voice-ack").as_deref(),
+            Some("One moment.")
+        );
+        assert_eq!(
+            mgr.voice_ack_phrase("discord", "voice-ack").as_deref(),
+            Some("Checking now.")
+        );
+        assert_eq!(
+            mgr.voice_ack_phrase("discord", "voice-ack").as_deref(),
+            Some("One moment.")
+        );
+    }
+
+    #[tokio::test]
+    async fn voice_fx_speech_layers_and_can_stop() {
+        let mut config = VoiceConfig::default();
+        config.state = VoiceState::FullDuplex;
+        config.voice_fx.enabled = true;
+        config.voice_fx.ambient_enabled = false;
+        let mgr = VoiceManager::new(config);
+        mgr.join_voice_channel("discord", "voice-2")
+            .await
+            .expect("join should install mixer");
+
+        assert_eq!(
+            mgr.read_voice_mixer_frame("discord", "voice-2").unwrap(),
+            SILENCE_FRAME.to_vec()
+        );
+        let speech = constant_pcm(16_000, 10);
+        mgr.play_voice_speech_pcm("discord", "voice-2", &speech)
+            .expect("speech should enqueue");
+        assert!(mgr.voice_speech_active("discord", "voice-2"));
+        let frame = mgr.read_voice_mixer_frame("discord", "voice-2").unwrap();
+        assert_eq!(frame.len(), FRAME_SIZE);
+        assert_ne!(frame, SILENCE_FRAME.to_vec());
+        assert!(mgr.stop_voice_speech("discord", "voice-2"));
+        assert!(!mgr.voice_speech_active("discord", "voice-2"));
+    }
+
+    #[tokio::test]
+    async fn leave_all_channels_cleans_voice_mixers() {
+        let mut config = VoiceConfig::default();
+        config.state = VoiceState::FullDuplex;
+        config.voice_fx.enabled = true;
+        let mgr = VoiceManager::new(config);
+        mgr.join_voice_channel("discord", "voice-a").await.unwrap();
+        mgr.join_voice_channel("discord", "voice-b").await.unwrap();
+        assert!(mgr.voice_mixer_active("discord", "voice-a"));
+        assert_eq!(mgr.leave_all_channels(), 2);
+        assert!(!mgr.voice_mixer_active("discord", "voice-a"));
+        assert!(!mgr.voice_mixer_active("discord", "voice-b"));
+    }
+
+    #[test]
+    fn voice_fx_play_requires_active_mixer() {
+        let mgr = VoiceManager::new(VoiceConfig::default());
+        let err = mgr
+            .play_voice_speech_pcm("discord", "missing", &[1, 2, 3])
+            .unwrap_err();
+        assert!(err.to_string().contains("Voice mixer is not active"));
+    }
+
+    #[tokio::test]
     async fn test_join_requires_voice_enabled() {
         let mgr = VoiceManager::new(VoiceConfig::default());
         let err = mgr
@@ -913,6 +1214,15 @@ mod tests {
             pcm.extend_from_slice(&sample.to_le_bytes());
         }
         assert!(mgr.detect_voice_activity(&pcm));
+    }
+
+    fn constant_pcm(sample: i16, frames: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        for _ in 0..(crate::voice_mixer::SAMPLES_PER_FRAME * crate::voice_mixer::CHANNELS * frames)
+        {
+            out.extend_from_slice(&sample.to_le_bytes());
+        }
+        out
     }
 
     #[test]

--- a/crates/hermes-gateway/src/voice_mixer.rs
+++ b/crates/hermes-gateway/src/voice_mixer.rs
@@ -1,0 +1,437 @@
+//! Dependency-free PCM voice mixer for gateway voice channels.
+//!
+//! The mixer produces Discord-native 48 kHz stereo s16le 20 ms frames. It is
+//! intentionally independent of Discord client crates: platform adapters can
+//! drain `read` into whatever voice transport they own.
+
+use std::f32::consts::PI;
+use std::sync::{Arc, Mutex};
+
+pub const SAMPLE_RATE: usize = 48_000;
+pub const CHANNELS: usize = 2;
+pub const SAMPLE_WIDTH: usize = 2;
+pub const FRAME_LENGTH_MS: usize = 20;
+pub const SAMPLES_PER_FRAME: usize = SAMPLE_RATE * FRAME_LENGTH_MS / 1000;
+pub const FRAME_SIZE: usize = SAMPLES_PER_FRAME * CHANNELS * SAMPLE_WIDTH;
+pub const SILENCE_FRAME: [u8; FRAME_SIZE] = [0; FRAME_SIZE];
+
+#[derive(Debug, Clone)]
+struct MixerChild {
+    pcm: Vec<u8>,
+    pos: usize,
+    looped: bool,
+    gain: f32,
+    fade_frames: usize,
+    fade_done: usize,
+    finished: bool,
+}
+
+impl MixerChild {
+    fn new(pcm: &[u8], looped: bool, gain: f32, fade_in_ms: usize) -> Self {
+        let mut padded = pcm.to_vec();
+        let remainder = padded.len() % FRAME_SIZE;
+        if remainder != 0 {
+            padded.resize(padded.len() + (FRAME_SIZE - remainder), 0);
+        }
+        Self {
+            pcm: padded,
+            pos: 0,
+            looped,
+            gain: sanitize_gain(gain),
+            fade_frames: fade_in_ms / FRAME_LENGTH_MS,
+            fade_done: 0,
+            finished: false,
+        }
+    }
+
+    fn read_frame(&mut self) -> Option<Vec<f32>> {
+        if self.finished {
+            return None;
+        }
+        if self.pos >= self.pcm.len() {
+            if self.looped && !self.pcm.is_empty() {
+                self.pos = 0;
+            } else {
+                self.finished = true;
+                return None;
+            }
+        }
+
+        let end = (self.pos + FRAME_SIZE).min(self.pcm.len());
+        let mut chunk = self.pcm[self.pos..end].to_vec();
+        self.pos += FRAME_SIZE;
+        if chunk.len() < FRAME_SIZE {
+            chunk.resize(FRAME_SIZE, 0);
+        }
+
+        let mut effective_gain = self.gain;
+        if self.fade_frames > 0 && self.fade_done < self.fade_frames {
+            self.fade_done += 1;
+            effective_gain *= self.fade_done as f32 / self.fade_frames as f32;
+        }
+
+        Some(
+            chunk
+                .chunks_exact(2)
+                .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]) as f32 * effective_gain)
+                .collect(),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct VoiceMixerState {
+    ambient: Option<MixerChild>,
+    speech: Vec<MixerChild>,
+    ambient_gain: f32,
+    duck_gain: f32,
+    speech_gain: f32,
+    duck_release_frames: usize,
+    duck_release_left: usize,
+    speech_active: bool,
+    closed: bool,
+}
+
+/// Continuous PCM mixer with optional ambient bed and ducked speech overlays.
+#[derive(Debug, Clone)]
+pub struct VoiceMixer {
+    state: Arc<Mutex<VoiceMixerState>>,
+}
+
+impl VoiceMixer {
+    pub fn new(
+        ambient_gain: f32,
+        duck_gain: f32,
+        speech_gain: f32,
+        duck_release_ms: usize,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(VoiceMixerState {
+                ambient: None,
+                speech: Vec::new(),
+                ambient_gain: sanitize_gain(ambient_gain),
+                duck_gain: sanitize_gain(duck_gain),
+                speech_gain: sanitize_gain(speech_gain),
+                duck_release_frames: (duck_release_ms / FRAME_LENGTH_MS).max(1),
+                duck_release_left: 0,
+                speech_active: false,
+                closed: false,
+            })),
+        }
+    }
+
+    /// Mirrors Discord AudioSource semantics: adapters should send raw PCM.
+    pub fn is_opus(&self) -> bool {
+        false
+    }
+
+    pub fn set_ambient(&self, pcm: Option<&[u8]>, gain: Option<f32>) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if let Some(gain) = gain {
+            state.ambient_gain = sanitize_gain(gain);
+        }
+        let Some(pcm) = pcm.filter(|p| !p.is_empty()) else {
+            state.ambient = None;
+            return;
+        };
+        let effective_gain = if state.speech_active {
+            state.duck_gain
+        } else {
+            state.ambient_gain
+        };
+        state.ambient = Some(MixerChild::new(pcm, true, effective_gain, 200));
+    }
+
+    pub fn play_speech(&self, pcm: &[u8], gain: Option<f32>, fade_in_ms: usize) {
+        if pcm.is_empty() {
+            return;
+        }
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        let child = MixerChild::new(
+            pcm,
+            false,
+            gain.map(sanitize_gain).unwrap_or(state.speech_gain),
+            fade_in_ms,
+        );
+        state.speech.push(child);
+        state.speech_active = true;
+        state.duck_release_left = 0;
+        let duck_gain = state.duck_gain;
+        if let Some(ambient) = state.ambient.as_mut() {
+            ambient.gain = duck_gain;
+        }
+    }
+
+    pub fn speech_active(&self) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.speech_active)
+            .unwrap_or(false)
+    }
+
+    pub fn stop_speech(&self) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        state.speech.clear();
+        begin_duck_release(&mut state);
+    }
+
+    pub fn cleanup(&self) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        state.closed = true;
+        state.ambient = None;
+        state.speech.clear();
+        state.speech_active = false;
+    }
+
+    /// Read one mixed 20 ms PCM frame.
+    pub fn read(&self) -> Vec<u8> {
+        let Ok(mut state) = self.state.lock() else {
+            return SILENCE_FRAME.to_vec();
+        };
+        if state.closed {
+            return SILENCE_FRAME.to_vec();
+        }
+
+        let mut acc: Option<Vec<f32>> = None;
+        if !state.speech.is_empty() {
+            let mut live = Vec::new();
+            let mut speech = std::mem::take(&mut state.speech);
+            for mut child in speech.drain(..) {
+                if let Some(frame) = child.read_frame() {
+                    add_frame(&mut acc, &frame);
+                    live.push(child);
+                }
+            }
+            state.speech = live;
+            if state.speech.is_empty() && state.speech_active {
+                begin_duck_release(&mut state);
+            }
+        }
+
+        let speech_active = state.speech_active;
+        let duck_release_left = state.duck_release_left;
+        let duck_release_frames = state.duck_release_frames;
+        let duck_gain = state.duck_gain;
+        let ambient_gain = state.ambient_gain;
+        let mut release_left_after = state.duck_release_left;
+        if let Some(ambient) = state.ambient.as_mut() {
+            if duck_release_left > 0 && !speech_active {
+                release_left_after = duck_release_left - 1;
+                let frac = 1.0 - (release_left_after as f32 / duck_release_frames as f32);
+                ambient.gain = duck_gain + (ambient_gain - duck_gain) * frac;
+            } else if !speech_active && duck_release_left == 0 {
+                ambient.gain = ambient_gain;
+            }
+            if let Some(frame) = ambient.read_frame() {
+                add_frame(&mut acc, &frame);
+            }
+        }
+        state.duck_release_left = release_left_after;
+
+        let Some(samples) = acc else {
+            return SILENCE_FRAME.to_vec();
+        };
+        samples_to_bytes(&samples)
+    }
+}
+
+impl Default for VoiceMixer {
+    fn default() -> Self {
+        Self::new(0.18, 0.06, 1.0, 400)
+    }
+}
+
+fn begin_duck_release(state: &mut VoiceMixerState) {
+    state.speech_active = false;
+    state.duck_release_left = state.duck_release_frames;
+}
+
+fn add_frame(acc: &mut Option<Vec<f32>>, frame: &[f32]) {
+    match acc {
+        Some(existing) => {
+            for (dst, src) in existing.iter_mut().zip(frame.iter()) {
+                *dst += *src;
+            }
+        }
+        None => *acc = Some(frame.to_vec()),
+    }
+}
+
+fn samples_to_bytes(samples: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(FRAME_SIZE);
+    for sample in samples.iter().take(SAMPLES_PER_FRAME * CHANNELS) {
+        let clamped = sample.round().clamp(i16::MIN as f32, i16::MAX as f32) as i16;
+        out.extend_from_slice(&clamped.to_le_bytes());
+    }
+    out.resize(FRAME_SIZE, 0);
+    out
+}
+
+fn sanitize_gain(gain: f32) -> f32 {
+    if gain.is_finite() {
+        gain.clamp(0.0, 4.0)
+    } else {
+        1.0
+    }
+}
+
+pub fn synth_ambient_pcm(seconds: f32) -> Vec<u8> {
+    let seconds = seconds.clamp(0.1, 30.0);
+    let raw_samples = (SAMPLE_RATE as f32 * seconds).round() as usize;
+    let frame_count = (raw_samples / SAMPLES_PER_FRAME).max(1);
+    let samples = frame_count * SAMPLES_PER_FRAME;
+    let seconds = samples as f32 / SAMPLE_RATE as f32;
+
+    let whole_cycle_freq = |target: f32| -> f32 { (target * seconds).round().max(1.0) / seconds };
+    let f1 = whole_cycle_freq(110.0);
+    let f2 = whole_cycle_freq(110.5);
+    let trem = whole_cycle_freq(0.5);
+
+    let mut mono = Vec::with_capacity(samples);
+    let mut peak = 0.0_f32;
+    for i in 0..samples {
+        let t = i as f32 / SAMPLE_RATE as f32;
+        let pad = 0.55 * (2.0 * PI * f1 * t).sin() + 0.45 * (2.0 * PI * f2 * t).sin();
+        let tremolo = 0.6 + 0.4 * (0.5 * (1.0 + (2.0 * PI * trem * t).sin()));
+        let air = 0.03 * (2.0 * PI * 880.0 * t).sin();
+        let sample = pad * tremolo + air;
+        peak = peak.max(sample.abs());
+        mono.push(sample);
+    }
+    let scale = if peak > f32::EPSILON { 0.5 / peak } else { 0.0 };
+
+    let mut out = Vec::with_capacity(samples * CHANNELS * SAMPLE_WIDTH);
+    for sample in mono {
+        let s = (sample * scale * i16::MAX as f32).round() as i16;
+        for _ in 0..CHANNELS {
+            out.extend_from_slice(&s.to_le_bytes());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn max_abs_i16(frame: &[u8]) -> i16 {
+        frame
+            .chunks_exact(2)
+            .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]).unsigned_abs())
+            .max()
+            .unwrap_or(0)
+            .min(i16::MAX as u16) as i16
+    }
+
+    fn constant_frame(sample: i16, frames: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(FRAME_SIZE * frames);
+        for _ in 0..(SAMPLES_PER_FRAME * CHANNELS * frames) {
+            out.extend_from_slice(&sample.to_le_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn frame_geometry_matches_discord_pcm() {
+        assert_eq!(SAMPLES_PER_FRAME, 960);
+        assert_eq!(FRAME_SIZE, 3840);
+        assert_eq!(SILENCE_FRAME.len(), FRAME_SIZE);
+        assert!(!VoiceMixer::default().is_opus());
+    }
+
+    #[test]
+    fn empty_mixer_returns_silence_frames() {
+        let mixer = VoiceMixer::default();
+        for _ in 0..5 {
+            assert_eq!(mixer.read(), SILENCE_FRAME.to_vec());
+        }
+    }
+
+    #[test]
+    fn ambient_loops_and_stays_quiet() {
+        let mixer = VoiceMixer::new(0.2, 0.05, 1.0, 200);
+        let ambient = synth_ambient_pcm(0.5);
+        assert_eq!(ambient.len() % FRAME_SIZE, 0);
+        mixer.set_ambient(Some(&ambient), None);
+        let peaks: Vec<_> = (0..100).map(|_| max_abs_i16(&mixer.read())).collect();
+        assert!(peaks.iter().skip(10).any(|p| *p > 0));
+        assert!(peaks.into_iter().max().unwrap_or(0) < (i16::MAX as f32 * 0.5) as i16);
+    }
+
+    #[test]
+    fn speech_layers_over_ambient_then_releases() {
+        let mixer = VoiceMixer::new(0.2, 0.05, 1.0, 200);
+        let ambient = synth_ambient_pcm(0.5);
+        mixer.set_ambient(Some(&ambient), None);
+        let base = (0..10).map(|_| max_abs_i16(&mixer.read())).max().unwrap();
+        mixer.play_speech(&constant_frame(20_000, 20), None, 0);
+        assert!(mixer.speech_active());
+        let speech_peak = (0..15).map(|_| max_abs_i16(&mixer.read())).max().unwrap();
+        assert!(speech_peak > base);
+        for _ in 0..40 {
+            mixer.read();
+        }
+        assert!(!mixer.speech_active());
+    }
+
+    #[test]
+    fn clipping_prevents_i16_wraparound() {
+        let mixer = VoiceMixer::default();
+        let loud = constant_frame(30_000, 1);
+        mixer.play_speech(&loud, None, 0);
+        mixer.play_speech(&loud, None, 0);
+        let out = mixer.read();
+        let samples: Vec<i16> = out
+            .chunks_exact(2)
+            .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]))
+            .collect();
+        assert_eq!(samples.iter().copied().max(), Some(i16::MAX));
+        assert!(samples.iter().all(|s| *s >= 0));
+    }
+
+    #[test]
+    fn stop_speech_clears_in_flight() {
+        let mixer = VoiceMixer::default();
+        mixer.play_speech(&constant_frame(10_000, 20), None, 40);
+        assert!(mixer.speech_active());
+        mixer.stop_speech();
+        mixer.read();
+        assert!(!mixer.speech_active());
+    }
+
+    #[test]
+    fn set_ambient_none_clears_and_cleanup_silences() {
+        let mixer = VoiceMixer::default();
+        let ambient = synth_ambient_pcm(0.5);
+        mixer.set_ambient(Some(&ambient), None);
+        mixer.set_ambient(None, None);
+        assert_eq!(mixer.read(), SILENCE_FRAME.to_vec());
+
+        mixer.set_ambient(Some(&ambient), None);
+        mixer.cleanup();
+        assert_eq!(mixer.read(), SILENCE_FRAME.to_vec());
+    }
+
+    #[test]
+    fn non_frame_aligned_pcm_is_padded() {
+        let mixer = VoiceMixer::default();
+        mixer.play_speech(&[1, 2, 3], None, 0);
+        assert_eq!(mixer.read().len(), FRAME_SIZE);
+    }
+
+    #[test]
+    fn synthesized_ambient_is_stereo_and_frame_aligned() {
+        let pcm = synth_ambient_pcm(1.0);
+        assert_eq!(pcm.len() % (CHANNELS * SAMPLE_WIDTH), 0);
+        assert_eq!(pcm.len() % FRAME_SIZE, 0);
+        assert!(max_abs_i16(&pcm[..FRAME_SIZE]) > 0);
+    }
+}

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1048,6 +1048,10 @@
       "disposition": "superseded",
       "notes": "Desktop Cmd/Ctrl+Enter steer keybinding policy is not a Rust runtime surface. Rust TUI has its own terminal key contract: Enter submits, Shift+Enter and Ctrl+J insert newlines, Ctrl+Enter/Ctrl+M are submit fallbacks, and focused tests guard those shortcuts."
     },
+    "8a9ded5b21b1": {
+      "disposition": "ported",
+      "notes": "Rust gateway now has a dependency-free 48 kHz stereo s16le continuous VoiceMixer with ambient loops, ducked speech overlays, clipping, stop/cleanup, and synthesized ambient PCM, plus VoiceManager voice_fx lifecycle integration for join/remove, active checks, ack phrase selection, speech enqueue/read/stop, and focused mixer/manager unit tests."
+    },
     "ffb53767bfff": {
       "disposition": "ported",
       "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."


### PR DESCRIPTION
## Summary
- add a Rust-native continuous PCM `VoiceMixer` for 48 kHz stereo s16le 20 ms frames
- support ambient loops, ducked speech overlays, clipping, speech stop, cleanup, and synthesized ambient PCM without adding runtime dependencies
- integrate `voice_fx` lifecycle into `VoiceManager`: join installs mixers when enabled, leave/leave-all cleans them, and public methods expose active checks, ack phrase rotation, speech enqueue/read/stop
- mark upstream Discord voice-channel mixer row `8a9ded5b21b1` as ported

## Upstream Row
- `8a9ded5b21b1 feat(discord): voice-channel mixer — ambient idle bed + verbal acks that overlap TTS (#39659)`

## Verification
- `cargo test -p hermes-gateway voice_mixer -- --nocapture` passed: `10 passed; 0 failed`
- `cargo test -p hermes-gateway voice_fx -- --nocapture` passed: `4 passed; 0 failed`
- `cargo test -p hermes-gateway leave_all_channels_cleans_voice_mixers -- --nocapture` passed: `1 passed; 0 failed`
- `cargo test -p hermes-gateway voice::tests -- --nocapture` passed: `14 passed; 0 failed`
- `cargo fmt --all --check` passed
- `git diff --check` passed
- `jq empty docs/parity/queue-overrides.json` passed
- `scripts/check-rust-runtime-no-python.sh` passed
- `scripts/check-runtime-placeholders.sh` passed
- `cargo build -p hermes-gateway` passed
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway` passed: `seen=198 allowlist=204 new=0 stale=6`
- queue regeneration: `{'mirrored': 161, 'pending': 1929, 'ported': 129, 'superseded': 7639}` and `8a9ded5b21b1` resolves to `ported`
- disk proof: local `target` paths `0B`; delegated target `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` `13G`
