### PR TITLE
parity(gateway): persist session titles

### DIFF
--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -40,6 +40,10 @@ pub enum GatewayCommandResult {
     ToggleYolo(String),
     /// Set the home/working directory.
     SetHome { path: String, reply: String },
+    /// Show the current session title.
+    ShowTitle,
+    /// Set or clear the current session title.
+    SetTitle { title: String, reply: String },
     /// Show status information.
     ShowStatus(String),
     /// Show help text.
@@ -551,11 +555,12 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         ),
         "/title" => {
             if args.is_empty() {
-                GatewayCommandResult::Reply(
-                    "🏷 No explicit title set for this gateway session.".to_string(),
-                )
+                GatewayCommandResult::ShowTitle
             } else {
-                GatewayCommandResult::Reply(format!("🏷 Session title set to: {}", args))
+                GatewayCommandResult::SetTitle {
+                    title: args.clone(),
+                    reply: format!("🏷 Session title set to: {}", args),
+                }
             }
         }
         "/resume" => GatewayCommandResult::Reply(
@@ -933,6 +938,21 @@ mod tests {
         match handle_command("/rollback 5") {
             GatewayCommandResult::Rollback { steps } => assert_eq!(steps, 5),
             other => panic!("Expected Rollback, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_title_commands() {
+        match handle_command("/title") {
+            GatewayCommandResult::ShowTitle => {}
+            other => panic!("Expected ShowTitle, got {:?}", other),
+        }
+        match handle_command("/title Release readiness") {
+            GatewayCommandResult::SetTitle { title, reply } => {
+                assert_eq!(title, "Release readiness");
+                assert!(reply.contains("Release readiness"));
+            }
+            other => panic!("Expected SetTitle, got {:?}", other),
         }
     }
 

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -1241,6 +1241,7 @@ impl Gateway {
                     GatewayCommandResult::SwitchModel { reply, .. }
                     | GatewayCommandResult::SwitchFast { reply, .. }
                     | GatewayCommandResult::SwitchPersonality { reply, .. }
+                    | GatewayCommandResult::SetTitle { reply, .. }
                     | GatewayCommandResult::SetHome { reply, .. } => Some(reply),
                     _ => Some(format!("Quick command `{key}` routed to `{rewritten}`.")),
                 })
@@ -1586,6 +1587,37 @@ impl Gateway {
                     .await?;
                 Ok(true)
             }
+            GatewayCommandResult::ShowTitle => {
+                let reply = match self.session_manager.get_title(session_key).await {
+                    Some(title) => format!("🏷 Current session title: {}", title),
+                    None => "🏷 No explicit title set for this gateway session.".to_string(),
+                };
+                self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
+                    .await?;
+                Ok(true)
+            }
+            GatewayCommandResult::SetTitle { title, reply } => {
+                let stored = self.session_manager.set_title(session_key, &title).await;
+                let response = match &stored {
+                    Some(stored_title) if stored_title.as_str() == title => reply,
+                    Some(stored_title) => format!("🏷 Session title set to: {}", stored_title),
+                    None => "🏷 Session title cleared.".to_string(),
+                };
+                self.emit_hook_event(
+                    "session:title",
+                    serde_json::json!({
+                        "platform": incoming.platform,
+                        "chat_id": incoming.chat_id,
+                        "user_id": incoming.user_id,
+                        "session_id": session_key,
+                        "title": stored
+                    }),
+                )
+                .await;
+                self.send_message(&incoming.platform, &incoming.chat_id, &response, None)
+                    .await?;
+                Ok(true)
+            }
             GatewayCommandResult::ShowStatus(_) => {
                 let text = self.build_status_text(session_key).await;
                 self.send_message(&incoming.platform, &incoming.chat_id, &text, None)
@@ -1830,10 +1862,12 @@ impl Gateway {
                             &s.chat_id,
                             &s.user_id,
                         );
+                        let title = s.title.as_deref().unwrap_or("(untitled)");
                         out.push_str(&format!(
-                            "• `{}` — {} messages, platform `{}` (id `{}`)\n",
+                            "• `{}` — {} messages, title `{}`, platform `{}` (id `{}`)\n",
                             key,
                             s.messages.len(),
+                            title,
                             s.platform,
                             s.id
                         ));
@@ -1861,7 +1895,11 @@ impl Gateway {
                 let msg = if let Some(target) = matched {
                     let copied = self
                         .session_manager
-                        .replace_messages(session_key, target.messages.clone())
+                        .replace_messages_and_title(
+                            session_key,
+                            target.messages.clone(),
+                            target.title.clone(),
+                        )
                         .await;
                     if copied {
                         self.clear_session_boundary_security_state(session_key)
@@ -2377,6 +2415,7 @@ impl Gateway {
             .get(session_key)
             .cloned()
             .unwrap_or_default();
+        let title = self.session_manager.get_title(session_key).await;
         let messages = self.session_manager.get_messages(session_key).await;
         let running_tasks = self
             .background_tasks
@@ -2386,7 +2425,8 @@ impl Gateway {
             .count();
 
         format!(
-            "🧭 Gateway status\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- service tier: {}\n- reasoning: {}\n- verbose: {}\n- tool progress: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
+            "🧭 Gateway status\n- title: {}\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- service tier: {}\n- reasoning: {}\n- verbose: {}\n- tool progress: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
+            title.unwrap_or_else(|| "(untitled)".to_string()),
             state.model.unwrap_or_else(|| "default".to_string()),
             state.provider.unwrap_or_else(|| "default".to_string()),
             state.profile.unwrap_or_else(|| "default".to_string()),
@@ -4656,6 +4696,88 @@ mod tests {
         assert!(status_text.contains("provider: openrouter"));
         assert!(status_text.contains("profile: prod"));
         assert!(status_text.contains("mcp generation: 1"));
+    }
+
+    #[tokio::test]
+    async fn gateway_title_command_persists_and_surfaces_session_title() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let hooks = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr.clone(), dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+        let mut registry = HookRegistry::new();
+        registry.register_in_process(
+            "session:title",
+            Arc::new(RecordingHook {
+                seen: hooks.clone(),
+            }),
+        );
+        gw.set_hook_registry(Arc::new(registry)).await;
+
+        let title = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat-title".into(),
+            user_id: "user1".into(),
+            text: "/title Release readiness".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&title).await.is_ok());
+        let session_key = session_mgr.compose_session_key("test", "chat-title", "user1");
+        assert_eq!(
+            session_mgr.get_title(&session_key).await.as_deref(),
+            Some("Release readiness")
+        );
+
+        let show_title = IncomingMessage {
+            text: "/title".into(),
+            ..title.clone()
+        };
+        assert!(gw.route_message(&show_title).await.is_ok());
+
+        let status = IncomingMessage {
+            text: "/status".into(),
+            ..title.clone()
+        };
+        assert!(gw.route_message(&status).await.is_ok());
+
+        let sessions = IncomingMessage {
+            text: "/sessions".into(),
+            ..title
+        };
+        assert!(gw.route_message(&sessions).await.is_ok());
+
+        let msgs = sent.lock().unwrap();
+        assert!(msgs
+            .iter()
+            .any(|(_, text)| text.contains("Session title set to: Release readiness")));
+        assert!(msgs
+            .iter()
+            .any(|(_, text)| text.contains("Current session title: Release readiness")));
+        assert!(msgs
+            .iter()
+            .any(|(_, text)| text.contains("- title: Release readiness")));
+        assert!(msgs
+            .iter()
+            .any(|(_, text)| text.contains("title `Release readiness`")));
+        drop(msgs);
+
+        let hooks = hooks.lock().unwrap();
+        let title_event = hooks
+            .iter()
+            .find(|(name, _)| name == "session:title")
+            .expect("title hook emitted");
+        assert_eq!(title_event.1["session_id"], serde_json::json!(session_key));
+        assert_eq!(
+            title_event.1["title"],
+            serde_json::json!("Release readiness")
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/session.rs
+++ b/crates/hermes-gateway/src/session.rs
@@ -45,6 +45,10 @@ pub struct Session {
     /// All messages in this session.
     pub messages: Vec<Message>,
 
+    /// Optional user-visible title for session lists and status surfaces.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
     /// When this session was created.
     pub created_at: DateTime<Utc>,
 
@@ -74,6 +78,7 @@ impl Session {
             chat_id: chat_id.into(),
             user_id: user_id.into(),
             messages: Vec::new(),
+            title: None,
             created_at: now,
             last_active_at: now,
             reset_policy,
@@ -418,6 +423,40 @@ impl SessionManager {
         false
     }
 
+    /// Replace messages and title metadata when switching the active chat
+    /// context to another known session.
+    pub async fn replace_messages_and_title(
+        &self,
+        session_id: &str,
+        messages: Vec<Message>,
+        title: Option<String>,
+    ) -> bool {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.messages = messages;
+            session.title = normalize_session_title(title.as_deref());
+            session.last_active_at = Utc::now();
+            return true;
+        }
+        false
+    }
+
+    /// Set or clear the user-visible title for a session.
+    pub async fn set_title(&self, session_id: &str, title: impl AsRef<str>) -> Option<String> {
+        let mut sessions = self.sessions.write().await;
+        let normalized = normalize_session_title(Some(title.as_ref()));
+        let session = sessions.get_mut(session_id)?;
+        session.title = normalized.clone();
+        session.last_active_at = Utc::now();
+        normalized
+    }
+
+    /// Return the user-visible title for a session, if one is set.
+    pub async fn get_title(&self, session_id: &str) -> Option<String> {
+        let sessions = self.sessions.read().await;
+        sessions.get(session_id).and_then(|s| s.title.clone())
+    }
+
     /// Pop the latest message from a session.
     pub async fn pop_last_message(&self, session_id: &str) -> Option<Message> {
         let mut sessions = self.sessions.write().await;
@@ -503,6 +542,9 @@ impl SessionManager {
             ctx.set_metadata("session_type", format!("{:?}", session.session_type));
             ctx.set_metadata("message_count", session.messages.len().to_string());
             ctx.set_metadata("created_at", session.created_at.to_rfc3339());
+            if let Some(title) = &session.title {
+                ctx.set_metadata("title", title.clone());
+            }
             ctx
         })
     }
@@ -593,6 +635,12 @@ fn is_slack_shared_channel(platform: &str, chat_id: &str) -> bool {
         return false;
     };
     matches!(first, 'C' | 'c' | 'G' | 'g')
+}
+
+fn normalize_session_title(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 #[cfg(test)]
@@ -770,6 +818,54 @@ mod tests {
         assert_eq!(new_session.chat_id, "chat-reset-id");
         assert!(new_session.messages.is_empty());
         assert!(manager.get_messages(&sid).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_manager_sets_clears_and_copies_title_metadata() {
+        let config = SessionConfig::default();
+        let manager = SessionManager::new(config);
+        let session = manager
+            .get_or_create_session("telegram", "chat-title", "user1")
+            .await;
+        let sid =
+            manager.compose_session_key(&session.platform, &session.chat_id, &session.user_id);
+
+        let title = manager
+            .set_title(&sid, "  Release readiness  ")
+            .await
+            .expect("session exists");
+        assert_eq!(title, "Release readiness");
+        assert_eq!(
+            manager.get_title(&sid).await.as_deref(),
+            Some("Release readiness")
+        );
+
+        let ctx = manager
+            .build_session_context(&sid)
+            .await
+            .expect("session context");
+        assert_eq!(
+            ctx.metadata.get("title").map(String::as_str),
+            Some("Release readiness")
+        );
+
+        assert!(
+            manager
+                .replace_messages_and_title(
+                    &sid,
+                    vec![Message::user("hello")],
+                    Some("Copied title".to_string()),
+                )
+                .await
+        );
+        assert_eq!(manager.get_messages(&sid).await.len(), 1);
+        assert_eq!(
+            manager.get_title(&sid).await.as_deref(),
+            Some("Copied title")
+        );
+
+        assert!(manager.set_title(&sid, "   ").await.is_none());
+        assert!(manager.get_title(&sid).await.is_none());
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1167,6 +1167,10 @@
     "580d9240979c": {
       "disposition": "superseded",
       "notes": "The upstream SQL-bounded desktop SessionDB optimization is superseded for Rust because the relevant runtime surface is file-backed resume snapshots rather than the Python desktop session-search endpoint. The Rust port avoids message-body scans, searches only snapshot stems plus session_info.session_id metadata, and preserves deterministic bounded result selection for resume."
+    },
+    "c54b93587313": {
+      "disposition": "ported",
+      "notes": "Rust gateway /title now persists user-visible Session.title metadata in SessionManager, exposes bare /title, /status and /sessions title surfaces, emits a session:title hook, and copies title metadata when switching sessions; regression tests cover command parsing, session metadata, and gateway routing."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- port gateway session title behavior for upstream `c54b93587313` by making `/title <name>` mutate Rust session metadata instead of returning a static reply
- add `Session.title` storage plus set/get/copy helpers, expose titles in `/title`, `/status`, and `/sessions`, and emit `session:title` hooks
- mark the upstream row ported in `docs/parity/queue-overrides.json`

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway title -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway commands::tests -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway session::tests -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_reload_mcp_and_status_reflect_runtime_state -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_profile_command -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `jq empty docs/parity/queue-overrides.json`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-session-title.json --out-md /tmp/hermes-parity-session-title.md --overrides docs/parity/queue-overrides.json`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-gateway`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-gateway`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway -- --nocapture`

## Parity Queue
- regenerated counts: `mirrored=161`, `pending=1908`, `ported=131`, `superseded=7658`

## Artifact Placement
- `/private/tmp/hermes-agent-ultra-parity-next/target`: `0B`
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `13G`
