### PR TITLE
parity(acp): carry session profile scope

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -21,7 +21,7 @@ use crate::auth::{
 use crate::events::{plan_entries_from_todo_result, AcpEvent, AcpEventKind, EventSink};
 use crate::permissions::PermissionStore;
 use crate::protocol::*;
-use crate::session::{SessionManager, SessionPhase, SessionState};
+use crate::session::{SessionManager, SessionMetaUpdate, SessionPhase, SessionState};
 
 /// Trait for handling ACP requests.
 #[async_trait::async_trait]
@@ -1197,6 +1197,42 @@ fn param_str_any<'a>(p: &'a serde_json::Map<String, Value>, keys: &[&str]) -> Op
     keys.iter().find_map(|key| param_str(p, key))
 }
 
+fn session_meta_from_params(
+    p: &serde_json::Map<String, Value>,
+) -> Result<SessionMetaUpdate, String> {
+    let profile = match param_str(p, "profile").map(str::trim) {
+        Some("") | None => None,
+        Some(profile) if valid_session_profile(profile) => Some(profile.to_string()),
+        Some(profile) => {
+            return Err(format!(
+                "invalid profile '{}': use letters, numbers, '-', '_' or '.'",
+                profile
+            ))
+        }
+    };
+    let home = param_str_any(
+        p,
+        &["home", "homeDir", "home_dir", "profileHome", "profile_home"],
+    )
+    .map(str::trim)
+    .filter(|home| !home.is_empty())
+    .map(ToOwned::to_owned);
+    Ok(SessionMetaUpdate {
+        profile,
+        home,
+        ..SessionMetaUpdate::default()
+    })
+}
+
+fn valid_session_profile(profile: &str) -> bool {
+    !profile.is_empty()
+        && !profile.contains('/')
+        && !profile.contains('\\')
+        && profile
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+}
+
 fn param_value_as_string(p: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
     let value = p.get(key)?;
     if let Some(s) = value.as_str() {
@@ -1394,6 +1430,8 @@ fn session_info_value(session: &SessionState) -> Value {
         "sessionId": session.session_id,
         "cwd": session.cwd,
         "model": session.model,
+        "profile": session.profile,
+        "home": session.home,
         "phase": session.phase,
         "historyLen": session.history.len(),
         "createdAt": session.created_at.to_string(),
@@ -1455,10 +1493,13 @@ impl AcpHandler for HermesAcpHandler {
 
             // -- Session management -----------------------------------------
             AcpMethod::NewSession => {
-                let cwd = params_obj(&request.params)
-                    .and_then(|p| param_str(p, "cwd"))
-                    .unwrap_or(".");
-                let state = self.session_manager.create_session(cwd);
+                let p = params_obj(&request.params);
+                let cwd = p.and_then(|p| param_str(p, "cwd")).unwrap_or(".");
+                let meta = match p.map(session_meta_from_params).transpose() {
+                    Ok(meta) => meta.unwrap_or_default(),
+                    Err(err) => return AcpResponse::error(request.id, -32602, err),
+                };
+                let state = self.session_manager.create_session_with_meta(cwd, meta);
                 self.advertise_available_commands(&state.session_id);
                 self.emit_usage_update(&state.session_id);
                 AcpResponse::success(request.id, session_id_response(&state.session_id))
@@ -1470,8 +1511,13 @@ impl AcpHandler for HermesAcpHandler {
                 };
                 let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
+                let mut meta = match session_meta_from_params(p) {
+                    Ok(meta) => meta,
+                    Err(err) => return AcpResponse::error(request.id, -32602, err),
+                };
+                meta.cwd = Some(cwd.to_string());
 
-                match self.session_manager.update_cwd(session_id, cwd) {
+                match self.session_manager.update_session_meta(session_id, meta) {
                     Some(state) => {
                         self.replay_session_history(&state);
                         self.advertise_available_commands(session_id);
@@ -1492,14 +1538,23 @@ impl AcpHandler for HermesAcpHandler {
                 };
                 let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
+                let mut meta = match session_meta_from_params(p) {
+                    Ok(meta) => meta,
+                    Err(err) => return AcpResponse::error(request.id, -32602, err),
+                };
+                meta.cwd = Some(cwd.to_string());
 
-                if let Some(state) = self.session_manager.update_cwd(session_id, cwd) {
+                if let Some(state) = self.session_manager.update_session_meta(session_id, meta) {
                     self.replay_session_history(&state);
                     self.advertise_available_commands(&state.session_id);
                     self.emit_usage_update(&state.session_id);
                     AcpResponse::success(request.id, json!({}))
                 } else {
-                    let state = self.session_manager.create_session(cwd);
+                    let meta = match session_meta_from_params(p) {
+                        Ok(meta) => meta,
+                        Err(err) => return AcpResponse::error(request.id, -32602, err),
+                    };
+                    let state = self.session_manager.create_session_with_meta(cwd, meta);
                     self.advertise_available_commands(&state.session_id);
                     self.emit_usage_update(&state.session_id);
                     AcpResponse::success(request.id, session_id_response(&state.session_id))
@@ -1512,8 +1567,15 @@ impl AcpHandler for HermesAcpHandler {
                 };
                 let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
+                let meta = match session_meta_from_params(p) {
+                    Ok(meta) => meta,
+                    Err(err) => return AcpResponse::error(request.id, -32602, err),
+                };
 
-                match self.session_manager.fork_session(session_id, cwd) {
+                match self
+                    .session_manager
+                    .fork_session_with_meta(session_id, cwd, meta)
+                {
                     Some(new_state) => {
                         self.advertise_available_commands(&new_state.session_id);
                         self.emit_usage_update(&new_state.session_id);
@@ -1534,9 +1596,16 @@ impl AcpHandler for HermesAcpHandler {
                 let cursor = params_obj(&request.params)
                     .and_then(|p| param_str(p, "cursor"))
                     .filter(|cursor| !cursor.trim().is_empty());
+                let profile_filter = params_obj(&request.params)
+                    .and_then(|p| param_str(p, "profile"))
+                    .map(str::trim)
+                    .filter(|profile| !profile.is_empty());
                 let mut sessions = self.session_manager.list_session_states();
                 if let Some(cwd) = cwd_filter {
                     sessions.retain(|s| s.cwd == cwd);
+                }
+                if let Some(profile) = profile_filter {
+                    sessions.retain(|s| s.profile.as_deref() == Some(profile));
                 }
                 sessions.sort_by(|a, b| {
                     b.updated_at
@@ -2002,6 +2071,33 @@ mod tests {
         }
     }
 
+    type SeenProfiles = Vec<(Option<String>, Option<String>)>;
+
+    struct ProfileRecordingPromptExecutor {
+        seen: Arc<std::sync::Mutex<SeenProfiles>>,
+    }
+
+    #[async_trait::async_trait]
+    impl AcpPromptExecutor for ProfileRecordingPromptExecutor {
+        async fn execute_prompt(
+            &self,
+            session: &SessionState,
+            user_text: &str,
+            _history: &[Value],
+        ) -> Result<PromptExecutionOutput, String> {
+            self.seen
+                .lock()
+                .expect("profile recorder lock")
+                .push((session.profile.clone(), session.home.clone()));
+            Ok(PromptExecutionOutput {
+                response_text: format!("profiled:{user_text}"),
+                usage: None,
+                total_turns: Some(1),
+                events: Vec::new(),
+            })
+        }
+    }
+
     struct ToolEventPromptExecutor;
 
     #[async_trait::async_trait]
@@ -2398,6 +2494,121 @@ mod tests {
             state.config_options.get("sandbox").map(String::as_str),
             Some("workspace-write")
         );
+    }
+
+    #[tokio::test]
+    async fn test_session_profile_home_metadata_flows_through_acp_lifecycle() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let handler =
+            make_handler().with_prompt_executor(Arc::new(ProfileRecordingPromptExecutor {
+                seen: seen.clone(),
+            }));
+
+        let created = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/new".into(),
+                params: Some(json!({
+                    "cwd": "/tmp",
+                    "profile": "work",
+                    "profileHome": "/profiles/work"
+                })),
+            })
+            .await
+            .result
+            .unwrap();
+        let session_id = created["sessionId"].as_str().unwrap().to_string();
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.profile.as_deref(), Some("work"));
+        assert_eq!(state.home.as_deref(), Some("/profiles/work"));
+
+        let listed = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session/list".into(),
+                params: Some(json!({"profile": "work"})),
+            })
+            .await
+            .result
+            .unwrap();
+        let sessions = listed["sessions"].as_array().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["profile"], "work");
+        assert_eq!(sessions[0]["home"], "/profiles/work");
+
+        let loaded = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(3)),
+                method: "session/load".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "cwd": "/repo",
+                    "profile": "research",
+                    "homeDir": "/profiles/research"
+                })),
+            })
+            .await;
+        assert!(loaded.error.is_none());
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.cwd, "/repo");
+        assert_eq!(state.profile.as_deref(), Some("research"));
+        assert_eq!(state.home.as_deref(), Some("/profiles/research"));
+
+        let prompt = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(4)),
+                method: "prompt".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "prompt": "who owns this profile?"
+                })),
+            })
+            .await;
+        assert!(prompt.error.is_none());
+        assert_eq!(
+            seen.lock().expect("profile recorder lock").as_slice(),
+            &[(
+                Some("research".to_string()),
+                Some("/profiles/research".to_string())
+            )]
+        );
+
+        let forked = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(5)),
+                method: "session/fork".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "cwd": "/fork",
+                    "profile": "scratch",
+                    "home": "/profiles/scratch"
+                })),
+            })
+            .await
+            .result
+            .unwrap();
+        let forked_id = forked["sessionId"].as_str().unwrap().to_string();
+        let forked_state = handler.session_manager.get_session(&forked_id).unwrap();
+        assert_eq!(forked_state.profile.as_deref(), Some("scratch"));
+        assert_eq!(forked_state.home.as_deref(), Some("/profiles/scratch"));
+
+        let invalid = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(6)),
+                method: "session/resume".into(),
+                params: Some(json!({
+                    "sessionId": "missing",
+                    "profile": "../bad"
+                })),
+            })
+            .await;
+        assert!(invalid.error.is_some());
     }
 
     fn assert_available_commands_update(events: Vec<AcpEvent>, expected_session_id: &str) {

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -434,6 +434,10 @@ pub struct AcpSessionInfo {
     #[serde(rename = "sessionId", alias = "session_id")]
     pub session_id: String,
     pub cwd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/hermes-acp/src/session.rs
+++ b/crates/hermes-acp/src/session.rs
@@ -50,6 +50,8 @@ pub struct SessionState {
     pub provider: Option<String>,
     pub api_mode: Option<String>,
     pub base_url: Option<String>,
+    pub profile: Option<String>,
+    pub home: Option<String>,
     pub phase: SessionPhase,
     pub history: Vec<Value>,
     pub mode: Option<String>,
@@ -78,6 +80,8 @@ pub struct SessionMetaUpdate {
     pub provider: Option<String>,
     pub api_mode: Option<String>,
     pub base_url: Option<String>,
+    pub profile: Option<String>,
+    pub home: Option<String>,
     pub config_options: HashMap<String, String>,
 }
 
@@ -94,6 +98,8 @@ impl SessionState {
             provider: None,
             api_mode: None,
             base_url: None,
+            profile: None,
+            home: None,
             phase: SessionPhase::Created,
             history: Vec::new(),
             mode: None,
@@ -125,6 +131,10 @@ pub struct SessionInfo {
     pub session_id: String,
     pub cwd: String,
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<String>,
     pub phase: SessionPhase,
     pub history_len: usize,
     pub created_at: u64,
@@ -137,6 +147,8 @@ impl From<&SessionState> for SessionInfo {
             session_id: s.session_id.clone(),
             cwd: s.cwd.clone(),
             model: s.model.clone(),
+            profile: s.profile.clone(),
+            home: s.home.clone(),
             phase: s.phase,
             history_len: s.history.len(),
             created_at: s.created_at,
@@ -177,8 +189,14 @@ impl SessionManager {
 
     /// Create a new session with a unique ID.
     pub fn create_session(&self, cwd: &str) -> SessionState {
+        self.create_session_with_meta(cwd, SessionMetaUpdate::default())
+    }
+
+    /// Create a new session with initial metadata.
+    pub fn create_session_with_meta(&self, cwd: &str, update: SessionMetaUpdate) -> SessionState {
         let session_id = uuid::Uuid::new_v4().to_string();
-        let state = SessionState::new(session_id.clone(), cwd.to_string());
+        let mut state = SessionState::new(session_id.clone(), cwd.to_string());
+        apply_session_meta(&mut state, update);
         {
             let mut sessions = self.sessions.lock().unwrap();
             sessions.insert(session_id.clone(), state.clone());
@@ -224,27 +242,7 @@ impl SessionManager {
     ) -> Option<SessionState> {
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(state) = sessions.get_mut(session_id) {
-            if let Some(cwd) = update.cwd {
-                state.cwd = cwd;
-            }
-            if let Some(model) = update.model.filter(|value| !value.trim().is_empty()) {
-                state.model = Some(model);
-            }
-            if let Some(provider) = update.provider.filter(|value| !value.trim().is_empty()) {
-                state.provider = Some(provider);
-            }
-            if let Some(api_mode) = update.api_mode.filter(|value| !value.trim().is_empty()) {
-                state.api_mode = Some(api_mode);
-            }
-            if let Some(base_url) = update.base_url.filter(|value| !value.trim().is_empty()) {
-                state.base_url = Some(base_url);
-            }
-            for (key, value) in update.config_options {
-                let key = key.trim();
-                if !key.is_empty() {
-                    state.config_options.insert(key.to_string(), value);
-                }
-            }
+            apply_session_meta(state, update);
             state.touch();
             let cloned = state.clone();
             drop(sessions);
@@ -371,11 +369,29 @@ impl SessionManager {
 
     /// Fork a session — deep-copy history into a new session.
     pub fn fork_session(&self, session_id: &str, cwd: &str) -> Option<SessionState> {
+        self.fork_session_with_meta(session_id, cwd, SessionMetaUpdate::default())
+    }
+
+    /// Fork a session with optional metadata overrides.
+    pub fn fork_session_with_meta(
+        &self,
+        session_id: &str,
+        cwd: &str,
+        update: SessionMetaUpdate,
+    ) -> Option<SessionState> {
         let original = self.get_session(session_id)?;
         let new_id = uuid::Uuid::new_v4().to_string();
         let mut new_state = SessionState::new(new_id.clone(), cwd.to_string());
         new_state.model = original.model.clone();
+        new_state.provider = original.provider.clone();
+        new_state.api_mode = original.api_mode.clone();
+        new_state.base_url = original.base_url.clone();
+        new_state.profile = original.profile.clone();
+        new_state.home = original.home.clone();
+        new_state.mode = original.mode.clone();
+        new_state.config_options = original.config_options.clone();
         new_state.history = original.history.clone();
+        apply_session_meta(&mut new_state, update);
         {
             let mut sessions = self.sessions.lock().unwrap();
             sessions.insert(new_id.clone(), new_state.clone());
@@ -423,6 +439,41 @@ impl SessionManager {
     fn persist(&self, state: &SessionState) {
         if let Some(ref cb) = self.on_persist {
             cb(state);
+        }
+    }
+}
+
+fn normalize_meta_string(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn apply_session_meta(state: &mut SessionState, update: SessionMetaUpdate) {
+    if let Some(cwd) = update.cwd.and_then(normalize_meta_string) {
+        state.cwd = cwd;
+    }
+    if let Some(model) = update.model.and_then(normalize_meta_string) {
+        state.model = Some(model);
+    }
+    if let Some(provider) = update.provider.and_then(normalize_meta_string) {
+        state.provider = Some(provider);
+    }
+    if let Some(api_mode) = update.api_mode.and_then(normalize_meta_string) {
+        state.api_mode = Some(api_mode);
+    }
+    if let Some(base_url) = update.base_url.and_then(normalize_meta_string) {
+        state.base_url = Some(base_url);
+    }
+    if let Some(profile) = update.profile.and_then(normalize_meta_string) {
+        state.profile = Some(profile);
+    }
+    if let Some(home) = update.home.and_then(normalize_meta_string) {
+        state.home = Some(home);
+    }
+    for (key, value) in update.config_options {
+        let key = key.trim();
+        if !key.is_empty() {
+            state.config_options.insert(key.to_string(), value);
         }
     }
 }
@@ -553,6 +604,7 @@ mod tests {
                     api_mode: Some("responses".to_string()),
                     base_url: Some("https://api.openai.com/v1".to_string()),
                     config_options,
+                    ..SessionMetaUpdate::default()
                 },
             )
             .expect("session exists");
@@ -578,6 +630,54 @@ mod tests {
         assert_eq!(persisted.len(), 1);
         assert_eq!(persisted[0].session_id, sid);
         assert_eq!(persisted[0].cwd, "/repo");
+    }
+
+    #[test]
+    fn profile_home_metadata_flows_through_create_update_and_fork() {
+        let mgr = SessionManager::new();
+        let state = mgr.create_session_with_meta(
+            "/workspace",
+            SessionMetaUpdate {
+                profile: Some("work".to_string()),
+                home: Some("/profiles/work".to_string()),
+                provider: Some("openrouter".to_string()),
+                ..SessionMetaUpdate::default()
+            },
+        );
+        assert_eq!(state.profile.as_deref(), Some("work"));
+        assert_eq!(state.home.as_deref(), Some("/profiles/work"));
+
+        let updated = mgr
+            .update_session_meta(
+                &state.session_id,
+                SessionMetaUpdate {
+                    cwd: Some("/workspace/repo".to_string()),
+                    profile: Some("research".to_string()),
+                    home: Some("/profiles/research".to_string()),
+                    ..SessionMetaUpdate::default()
+                },
+            )
+            .expect("session exists");
+        assert_eq!(updated.cwd, "/workspace/repo");
+        assert_eq!(updated.profile.as_deref(), Some("research"));
+        assert_eq!(updated.home.as_deref(), Some("/profiles/research"));
+        assert_eq!(updated.provider.as_deref(), Some("openrouter"));
+
+        let forked = mgr
+            .fork_session_with_meta(
+                &state.session_id,
+                "/fork",
+                SessionMetaUpdate {
+                    profile: Some("scratch".to_string()),
+                    home: Some("/profiles/scratch".to_string()),
+                    ..SessionMetaUpdate::default()
+                },
+            )
+            .expect("forked");
+        assert_eq!(forked.cwd, "/fork");
+        assert_eq!(forked.profile.as_deref(), Some("scratch"));
+        assert_eq!(forked.home.as_deref(), Some("/profiles/scratch"));
+        assert_eq!(forked.provider.as_deref(), Some("openrouter"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1171,6 +1171,70 @@
     "c54b93587313": {
       "disposition": "ported",
       "notes": "Rust gateway /title now persists user-visible Session.title metadata in SessionManager, exposes bare /title, /status and /sessions title surfaces, emits a session:title hook, and copies title metadata when switching sessions; regression tests cover command parsing, session metadata, and gateway routing."
+    },
+    "02d6bf1c39df": {
+      "disposition": "ported",
+      "notes": "Rust ACP sessions now carry profile/home ownership through session/new, session/load, session/resume, session/fork, session/list, and prompt executor snapshots. The upstream desktop Electron routing pieces are not present in this Rust-only repo; the runtime-equivalent profile-scoped session lifecycle is covered by hermes-acp tests."
+    },
+    "6f6eb871d834": {
+      "disposition": "ported",
+      "notes": "Rust ACP session/new now accepts profile/home metadata and preserves it on the SessionState handed to prompt executors, so new chats can remain attached to their owning profile in the Rust runtime surface. Regression coverage asserts create, prompt, list, and fork profile ownership."
+    },
+    "83c13862f107": {
+      "disposition": "superseded",
+      "notes": "Upstream change is Electron desktop remote-profile read routing only (apps/desktop/electron/main.cjs). This Rust repo has no desktop Electron backend-routing layer; profile ownership is represented in Rust ACP/gateway session metadata instead."
+    },
+    "3e4fa8ca9ca3": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-rail drag-axis polish touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "9915665e4c51": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-rail cell drag/clamp behavior touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "fb18bde89740": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-rail haptic reordering touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "76b98f43ca0a": {
+      "disposition": "superseded",
+      "notes": "Desktop ALL-profiles grouping gate touches only apps/desktop sidebar UI, which is absent from this Rust-only runtime repo."
+    },
+    "0c7def31aa86": {
+      "disposition": "superseded",
+      "notes": "Desktop single-profile rail plus-button behavior touches only apps/desktop sidebar UI, which is absent from this Rust-only runtime repo."
+    },
+    "cf9dc366dd0b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop cross-profile read-only icon/action cleanup is tied to apps/desktop and Python web_server/session DB surfaces. Rust runtime profile ownership is handled through ACP/gateway session metadata, not desktop per-session icon routing."
+    },
+    "86371e6cd8d5": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-swap overlay border/radius styling touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "1b01fa3acf15": {
+      "disposition": "superseded",
+      "notes": "Desktop long-press profile color picker touches only apps/desktop React UI/storage, which is absent from this Rust-only runtime repo."
+    },
+    "cdfbd89ea539": {
+      "disposition": "ported",
+      "notes": "Rust gateway /title now persists Session.title metadata directly, bare /title reads current title, /status and /sessions expose it, and gateway tests cover the title command lifecycle. No Python TUI session.title RPC is used in the Rust runtime."
+    },
+    "3824b0323793": {
+      "disposition": "superseded",
+      "notes": "Python TUI session.title DB/RPC edge cases are superseded by Rust gateway in-memory Session.title storage and command tests; there is no pending DB row queue or Python RPC failure mode in this runtime path."
+    },
+    "492c4c6573b4": {
+      "disposition": "superseded",
+      "notes": "Python TUI pending-title flush/no-op DB lookup edge cases are superseded by Rust gateway Session.title mutation on the active in-memory session, with hook/status/session-list regression coverage."
+    },
+    "3aa86717b60c": {
+      "disposition": "superseded",
+      "notes": "Python TUI pending-title retry and title validation error mapping are superseded by Rust gateway title parsing/storage; invalid empty titles fall through to bare /title read and no DB retry path exists."
+    },
+    "27936ee02dfc": {
+      "disposition": "superseded",
+      "notes": "Python TUI queued-title retry over auto-title DB state is superseded by Rust gateway user title storage on Session.title, which is not delayed behind DB materialization."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add Rust ACP session profile/home metadata to `SessionState`, `SessionInfo`, and ACP wire session info
- carry profile/home through `session/new`, `session/load`, `session/resume`, `session/fork`, `session/list`, and prompt executor snapshots
- update parity queue overrides for ACP remote-profile lifecycle rows and desktop-only profile rail/title rows

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-acp profile -- --nocapture` -> 2 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-acp session::tests -- --nocapture` -> 9 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-acp handler::tests::test_session_profile_home_metadata_flows_through_acp_lifecycle -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-acp handler::tests::test_session_methods_accept_camel_case_wire_fields -- --nocapture` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture` -> 96 passed, doc-tests 0
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-acp` -> passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check` -> passed
- `jq empty docs/parity/queue-overrides.json` -> passed
- `git diff --check` -> passed
- `scripts/check-rust-runtime-no-python.sh` -> passed
- `scripts/check-runtime-placeholders.sh` -> passed
- `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-acp-profile-scope.json --out-md /tmp/hermes-parity-acp-profile-scope.md --overrides docs/parity/queue-overrides.json` -> passed
- parity queue counts: `mirrored=161`, `pending=1892`, `ported=134`, `superseded=7671`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-acp` -> `seen=198 allowlist=204 new=0 stale=6`
- disk proof: repo `target` 0B, `/private/tmp/hermes-agent-ultra-target-delegation` 0B, `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` 13G
