### PR TITLE
parity(skills): route installed slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "futures",
  "hermes-config",
  "hermes-core",
+ "hermes-skills",
  "hex",
  "indexmap",
  "proptest",

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2223,6 +2223,13 @@ impl App {
         self.pending_image_hint = None;
     }
 
+    /// Submit text through the normal user-message path and run the agent.
+    pub async fn submit_user_message(&mut self, raw: &str) -> Result<(), AgentError> {
+        let user_message = self.prepare_user_message(raw);
+        self.messages.push(hermes_core::Message::user(user_message));
+        self.run_agent().await
+    }
+
     pub fn take_pending_input_prefill(&mut self) -> Option<String> {
         self.pending_input_prefill.take()
     }
@@ -2311,9 +2318,7 @@ impl App {
             }
         } else {
             // Regular user message
-            let user_message = self.prepare_user_message(trimmed);
-            self.messages.push(hermes_core::Message::user(user_message));
-            self.run_agent().await?;
+            self.submit_user_message(trimmed).await?;
         }
 
         Ok(())

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -25,6 +25,9 @@ use hermes_core::AgentError;
 use hermes_intelligence::model_metadata::{get_model_context_length, get_model_info};
 use hermes_intelligence::models_dev::default_client;
 use hermes_intelligence::{build_swarm_execution_plan, swarm_runtime_status, SwarmExecutionMode};
+use hermes_tools::skill_commands::{
+    resolve_installed_skill_slash_command, SkillCommandResolverConfig, SkillSlashInvocation,
+};
 use hermes_tools::ToolPolicyEngine;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -3714,6 +3717,17 @@ async fn dispatch_slash_command(
             Ok(CommandResult::Quit)
         }
         _ => {
+            match resolve_cli_skill_slash_command(app, cmd, args) {
+                Ok(Some(invocation)) => {
+                    app.submit_user_message(&invocation.message).await?;
+                    return Ok(CommandResult::Handled);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    emit_command_output(app, format!("Skill command blocked: {err}"));
+                    return Ok(CommandResult::Handled);
+                }
+            }
             emit_command_output(
                 app,
                 format!(
@@ -3724,6 +3738,19 @@ async fn dispatch_slash_command(
             Ok(CommandResult::Handled)
         }
     }
+}
+
+fn resolve_cli_skill_slash_command(
+    app: &App,
+    cmd: &str,
+    args: &[&str],
+) -> Result<Option<SkillSlashInvocation>, String> {
+    let config = SkillCommandResolverConfig {
+        enabled: app.config.skills.enabled.clone(),
+        disabled: app.config.skills.disabled.clone(),
+        ..SkillCommandResolverConfig::default()
+    };
+    resolve_installed_skill_slash_command(cmd, &args.join(" "), &config)
 }
 
 fn handle_toolcards_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
@@ -27580,6 +27607,30 @@ mod tests {
             .expect("overridden help");
 
         assert_eq!(latest_ui_assistant_text(&app), "overridden");
+    }
+
+    #[tokio::test]
+    async fn cli_resolves_installed_skill_slash_command() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let skill_dir = tmp.path().join("skills").join("release-captain");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Release Captain\ndescription: Release workflow\n---\n# Release Captain\n1. Inspect changed files\n2. Run deterministic gates\n",
+        )
+        .expect("write skill");
+        let app = build_test_app_with_stream(tmp.path()).await;
+
+        let invocation = resolve_cli_skill_slash_command(&app, "/release_captain", &["ship", "it"])
+            .expect("resolve skill command")
+            .expect("skill command");
+
+        assert_eq!(invocation.command, "/release-captain");
+        assert_eq!(invocation.skill_name, "Release Captain");
+        assert!(invocation.message.contains("Inspect changed files"));
+        assert!(invocation.message.contains("ship it"));
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -23,6 +23,9 @@ use hermes_config::{normalize_service_tier, DisplayConfig, QuickCommandConfig};
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 use hermes_core::types::{Message, MessageRole};
+use hermes_tools::skill_commands::{
+    resolve_installed_skill_slash_command, SkillCommandResolverConfig,
+};
 
 use crate::background::{BackgroundTaskManager, TaskStatus};
 use crate::commands::{handle_command, GatewayCommandResult};
@@ -228,6 +231,11 @@ struct UsageStats {
     input_chars: u64,
     output_chars: u64,
     last_updated_at: Option<DateTime<Utc>>,
+}
+
+enum SlashCommandOutcome {
+    Handled,
+    ForwardToAgent { message: String },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1043,10 +1051,18 @@ impl Gateway {
             .await;
         }
 
+        let mut agent_text_override: Option<String> = None;
+
         // Slash commands are executed directly by the gateway command runtime.
+        // Installed skill commands are the exception: after built-ins and quick
+        // commands decline them, they are converted into a normal agent turn
+        // containing the resolved SKILL.md content.
         if is_slash_command {
-            if self.execute_slash_command(incoming, &session_key).await? {
-                return Ok(());
+            match self.execute_slash_command(incoming, &session_key).await? {
+                SlashCommandOutcome::Handled => return Ok(()),
+                SlashCommandOutcome::ForwardToAgent { message } => {
+                    agent_text_override = Some(message);
+                }
             }
         }
 
@@ -1075,8 +1091,9 @@ impl Gateway {
             }
         }
 
-        let enriched_text = self
-            .enrich_message_with_transcription(&self.enrich_message_with_vision(&incoming.text));
+        let agent_text = agent_text_override.as_deref().unwrap_or(&incoming.text);
+        let enriched_text =
+            self.enrich_message_with_transcription(&self.enrich_message_with_vision(agent_text));
         self.maybe_apply_smart_model_routing(&session_key, &enriched_text)
             .await;
 
@@ -1084,7 +1101,7 @@ impl Gateway {
         self.session_manager
             .add_message(&session_key, Message::user(enriched_text))
             .await;
-        self.bump_input_usage(&session_key, incoming.text.chars().count())
+        self.bump_input_usage(&session_key, agent_text.chars().count())
             .await;
 
         // 4. Get all session messages for the agent loop
@@ -1329,14 +1346,46 @@ impl Gateway {
         &self,
         incoming: &IncomingMessage,
         session_key: &str,
-    ) -> Result<bool, GatewayError> {
+    ) -> Result<SlashCommandOutcome, GatewayError> {
         if let Some(reply) = self.resolve_quick_command(&incoming.text).await? {
             self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
                 .await?;
-            return Ok(true);
+            return Ok(SlashCommandOutcome::Handled);
         }
 
         let result = handle_command(&incoming.text);
+        if matches!(result, GatewayCommandResult::Unknown(_)) {
+            match self.resolve_skill_slash_command(&incoming.text) {
+                Ok(Some(message)) => {
+                    if let Some(command_name) = Self::extract_command_name(&incoming.text) {
+                        self.emit_hook_event(
+                            &format!("command:{}", command_name),
+                            serde_json::json!({
+                                "platform": incoming.platform,
+                                "chat_id": incoming.chat_id,
+                                "user_id": incoming.user_id,
+                                "session_id": session_key,
+                                "command": command_name,
+                                "kind": "skill"
+                            }),
+                        )
+                        .await;
+                    }
+                    return Ok(SlashCommandOutcome::ForwardToAgent { message });
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    self.send_message(
+                        &incoming.platform,
+                        &incoming.chat_id,
+                        &format!("Skill command blocked: {err}"),
+                        None,
+                    )
+                    .await?;
+                    return Ok(SlashCommandOutcome::Handled);
+                }
+            }
+        }
         if !matches!(result, GatewayCommandResult::Unknown(_)) {
             if let Some(command_name) = Self::extract_command_name(&incoming.text) {
                 self.emit_hook_event(
@@ -1355,7 +1404,20 @@ impl Gateway {
         let handled = self
             .apply_command_result(incoming, session_key, result)
             .await?;
-        Ok(handled)
+        Ok(if handled {
+            SlashCommandOutcome::Handled
+        } else {
+            SlashCommandOutcome::ForwardToAgent {
+                message: incoming.text.clone(),
+            }
+        })
+    }
+
+    fn resolve_skill_slash_command(&self, input: &str) -> Result<Option<String>, String> {
+        let (cmd, args) = Self::split_slash_command(input);
+        let config = SkillCommandResolverConfig::default();
+        resolve_installed_skill_slash_command(&cmd, &args, &config)
+            .map(|maybe| maybe.map(|invocation| invocation.message))
     }
 
     async fn apply_command_result(
@@ -3437,6 +3499,66 @@ mod tests {
             .expect("alias reply");
 
         assert!(reply.contains("Status information"));
+    }
+
+    #[tokio::test]
+    async fn gateway_unknown_slash_invokes_installed_skill_command() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home_guard = HermesHomeEnvGuard::set(tmp.path());
+        let skill_dir = tmp.path().join("skills").join("release-captain");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Release Captain\ndescription: Release workflow\n---\n# Release Captain\n1. Inspect changed files\n2. Run deterministic gates\n",
+        )
+        .expect("write skill");
+
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let seen_user_messages = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+        let seen_for_handler = seen_user_messages.clone();
+        gw.set_message_handler(Arc::new(move |messages| {
+            let seen = seen_for_handler.clone();
+            Box::pin(async move {
+                let user = messages
+                    .iter()
+                    .rev()
+                    .find(|m| m.role == MessageRole::User)
+                    .and_then(|m| m.content.clone())
+                    .unwrap_or_default();
+                seen.lock().expect("seen lock").push(user);
+                Ok("skill-ran".to_string())
+            })
+        }))
+        .await;
+
+        gw.route_message(&IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/release_captain ship it".into(),
+            message_id: None,
+            is_dm: true,
+        })
+        .await
+        .expect("route skill command");
+
+        assert_eq!(
+            sent.lock().expect("sent lock").as_slice(),
+            &[("chat1".to_string(), "skill-ran".to_string())]
+        );
+        let seen = seen_user_messages.lock().expect("seen lock");
+        assert_eq!(seen.len(), 1);
+        assert!(seen[0].contains("Release Captain"));
+        assert!(seen[0].contains("Inspect changed files"));
+        assert!(seen[0].contains("ship it"));
     }
 
     #[async_trait]

--- a/crates/hermes-tools/Cargo.toml
+++ b/crates/hermes-tools/Cargo.toml
@@ -9,6 +9,7 @@ description = "Tool registry, toolsets, and tool implementations for Hermes Agen
 [dependencies]
 hermes-core = { workspace = true }
 hermes-config = { workspace = true }
+hermes-skills = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermes-tools/src/tools/skill_commands.rs
+++ b/crates/hermes-tools/src/tools/skill_commands.rs
@@ -4,9 +4,13 @@
 //! provides a registry that maps slash commands to skills, enabling users to
 //! invoke skill-provided functionality directly from the REPL.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
-use super::skill_utils::SkillInfo;
+use hermes_core::Skill;
+use hermes_skills::SkillGuard;
+
+use super::skill_utils::{discover_skills, match_platform, SkillInfo};
 
 // ---------------------------------------------------------------------------
 // SkillCommand
@@ -33,6 +37,45 @@ pub struct SkillCommand {
 /// Registry of slash commands contributed by skills.
 pub struct SkillCommandRegistry {
     commands: HashMap<String, SkillCommand>,
+}
+
+/// Runtime configuration for resolving installed skills as slash commands.
+#[derive(Debug, Clone)]
+pub struct SkillCommandResolverConfig {
+    /// Skill roots to scan. Each root may contain nested `SKILL.md` files.
+    pub roots: Vec<PathBuf>,
+    /// Optional allow-list of skill names or command slugs.
+    pub enabled: Vec<String>,
+    /// Optional deny-list of skill names or command slugs.
+    pub disabled: Vec<String>,
+    /// Platform label used for skill frontmatter filtering.
+    pub platform: Option<String>,
+}
+
+impl Default for SkillCommandResolverConfig {
+    fn default() -> Self {
+        Self {
+            roots: default_skill_roots(),
+            enabled: Vec::new(),
+            disabled: Vec::new(),
+            platform: Some(std::env::consts::OS.to_string()),
+        }
+    }
+}
+
+/// Resolved installed-skill slash invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillSlashInvocation {
+    /// Canonical command key, including leading slash.
+    pub command: String,
+    /// Skill name from frontmatter or the skill directory.
+    pub skill_name: String,
+    /// Short description from frontmatter, if present.
+    pub description: String,
+    /// Path to the resolved `SKILL.md`.
+    pub skill_md_path: PathBuf,
+    /// User message content to send into the agent loop.
+    pub message: String,
 }
 
 impl SkillCommandRegistry {
@@ -76,6 +119,185 @@ impl Default for SkillCommandRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Default installed skill roots shared by CLI and gateway surfaces.
+pub fn default_skill_roots() -> Vec<PathBuf> {
+    let mut roots = vec![hermes_config::skills_dir()];
+    if let Some(home) = std::env::var("HOME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+    {
+        roots.push(home.join(".hermes").join("skills"));
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn normalize_selector(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches('/')
+        .replace(['_', ' '], "-")
+        .to_ascii_lowercase()
+}
+
+fn slugify_skill_command_name(name: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in name.trim().chars() {
+        let next = if ch.is_ascii_alphanumeric() {
+            Some(ch.to_ascii_lowercase())
+        } else if matches!(ch, '-' | '_' | ' ') {
+            Some('-')
+        } else {
+            None
+        };
+        let Some(ch) = next else {
+            continue;
+        };
+        if ch == '-' {
+            if out.is_empty() || last_dash {
+                continue;
+            }
+            last_dash = true;
+        } else {
+            last_dash = false;
+        }
+        out.push(ch);
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn selector_set(values: &[String]) -> HashSet<String> {
+    values
+        .iter()
+        .map(|value| normalize_selector(value))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn skill_allowed(
+    skill_name: &str,
+    command_slug: &str,
+    enabled: &[String],
+    disabled: &[String],
+) -> bool {
+    let name_key = normalize_selector(skill_name);
+    let cmd_key = normalize_selector(command_slug);
+    let disabled = selector_set(disabled);
+    if disabled.contains(&name_key) || disabled.contains(&cmd_key) {
+        return false;
+    }
+    let enabled = selector_set(enabled);
+    enabled.is_empty() || enabled.contains(&name_key) || enabled.contains(&cmd_key)
+}
+
+fn platform_aliases(platform: Option<&str>) -> Vec<String> {
+    let raw = platform
+        .unwrap_or(std::env::consts::OS)
+        .trim()
+        .to_ascii_lowercase();
+    match raw.as_str() {
+        "macos" | "darwin" => vec!["macos".to_string(), "darwin".to_string()],
+        "windows" | "win32" => vec!["windows".to_string(), "win32".to_string()],
+        "linux" => vec!["linux".to_string()],
+        "" => vec![std::env::consts::OS.to_string()],
+        other => vec![other.to_string()],
+    }
+}
+
+fn skill_matches_platform(skill: &SkillInfo, platform: Option<&str>) -> bool {
+    platform_aliases(platform)
+        .iter()
+        .any(|alias| match_platform(skill, alias))
+}
+
+fn security_gate_skill_content(name: &str, body: &str) -> Result<(), String> {
+    let probe = Skill {
+        name: name.to_string(),
+        content: body.to_string(),
+        category: Some("external".to_string()),
+        description: None,
+    };
+    SkillGuard::default()
+        .scan_security_only(&probe)
+        .map_err(|err| err.to_string())
+}
+
+/// Build the agent-facing message for a skill slash command invocation.
+pub fn build_skill_slash_invocation_message(
+    skill_name: &str,
+    skill_body: &str,
+    user_instruction: &str,
+) -> String {
+    let mut parts = vec![
+        format!(
+            "[SYSTEM: The user has invoked the \"{}\" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]",
+            skill_name
+        ),
+        String::new(),
+        skill_body.trim().to_string(),
+    ];
+
+    if !user_instruction.trim().is_empty() {
+        parts.push(String::new());
+        parts.push(format!(
+            "The user has provided the following instruction alongside the skill invocation: {}",
+            user_instruction.trim()
+        ));
+    }
+
+    parts.join("\n")
+}
+
+/// Resolve an otherwise-unknown slash command against installed `SKILL.md` files.
+///
+/// Built-in and quick-command handlers should run before this resolver. The
+/// resolver only returns `Some` when the command slug matches a discovered
+/// installed skill.
+pub fn resolve_installed_skill_slash_command(
+    command: &str,
+    args: &str,
+    config: &SkillCommandResolverConfig,
+) -> Result<Option<SkillSlashInvocation>, String> {
+    let requested = normalize_selector(command);
+    if requested.is_empty() {
+        return Ok(None);
+    }
+
+    let skills = discover_skills(&config.roots);
+    for skill in skills {
+        if !skill_matches_platform(&skill, config.platform.as_deref()) {
+            continue;
+        }
+        let slug = slugify_skill_command_name(&skill.name);
+        if slug.is_empty() || slug != requested {
+            continue;
+        }
+        if !skill_allowed(&skill.name, &slug, &config.enabled, &config.disabled) {
+            return Ok(None);
+        }
+        security_gate_skill_content(&skill.name, &skill.body)?;
+        let skill_md_path = skill.path.join("SKILL.md");
+        let description = skill
+            .frontmatter
+            .get("description")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let message = build_skill_slash_invocation_message(&skill.name, &skill.body, args);
+        return Ok(Some(SkillSlashInvocation {
+            command: format!("/{slug}"),
+            skill_name: skill.name,
+            description,
+            skill_md_path,
+            message,
+        }));
+    }
+
+    Ok(None)
 }
 
 // ---------------------------------------------------------------------------
@@ -188,7 +410,9 @@ pub fn get_plan_command_skills(skills: &[SkillInfo]) -> Vec<&SkillInfo> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::fs;
     use std::path::PathBuf;
+    use tempfile::tempdir;
 
     fn make_skill_with_commands() -> SkillInfo {
         let mut frontmatter = HashMap::new();
@@ -225,6 +449,16 @@ mod tests {
             frontmatter: HashMap::new(),
             body: String::new(),
         }
+    }
+
+    fn write_skill(root: &std::path::Path, dir: &str, frontmatter: &str, body: &str) {
+        let skill_dir = root.join(dir);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\n{frontmatter}\n---\n{body}"),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -279,5 +513,108 @@ mod tests {
         assert!(registry.is_empty());
         assert_eq!(registry.len(), 0);
         assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn resolves_installed_skill_by_slug_and_builds_agent_message() {
+        let tmp = tempdir().unwrap();
+        write_skill(
+            tmp.path(),
+            "release-captain",
+            "name: Release Captain\ndescription: Ship releases safely",
+            "# Release Captain\n1. Inspect changes\n2. Verify gates",
+        );
+        let config = SkillCommandResolverConfig {
+            roots: vec![tmp.path().to_path_buf()],
+            platform: Some("linux".to_string()),
+            ..SkillCommandResolverConfig::default()
+        };
+
+        let resolved = resolve_installed_skill_slash_command("/release_captain", "cut v1", &config)
+            .unwrap()
+            .expect("skill command");
+
+        assert_eq!(resolved.command, "/release-captain");
+        assert_eq!(resolved.skill_name, "Release Captain");
+        assert_eq!(resolved.description, "Ship releases safely");
+        assert!(resolved.message.contains("Release Captain"));
+        assert!(resolved.message.contains("Verify gates"));
+        assert!(resolved.message.contains("cut v1"));
+    }
+
+    #[test]
+    fn resolver_respects_enabled_disabled_and_platform_filters() {
+        let tmp = tempdir().unwrap();
+        write_skill(
+            tmp.path(),
+            "mac-helper",
+            "name: mac-helper\nplatform: darwin",
+            "# Mac Helper\n1. Use macOS behavior",
+        );
+        write_skill(
+            tmp.path(),
+            "beta",
+            "name: beta\ndescription: Beta skill",
+            "# Beta\n1. Do beta work",
+        );
+
+        let linux = SkillCommandResolverConfig {
+            roots: vec![tmp.path().to_path_buf()],
+            platform: Some("linux".to_string()),
+            ..SkillCommandResolverConfig::default()
+        };
+        assert!(
+            resolve_installed_skill_slash_command("/mac-helper", "", &linux)
+                .unwrap()
+                .is_none()
+        );
+
+        let disabled = SkillCommandResolverConfig {
+            roots: vec![tmp.path().to_path_buf()],
+            disabled: vec!["beta".to_string()],
+            platform: Some("linux".to_string()),
+            ..SkillCommandResolverConfig::default()
+        };
+        assert!(
+            resolve_installed_skill_slash_command("/beta", "", &disabled)
+                .unwrap()
+                .is_none()
+        );
+
+        let enabled = SkillCommandResolverConfig {
+            roots: vec![tmp.path().to_path_buf()],
+            enabled: vec!["beta".to_string()],
+            platform: Some("linux".to_string()),
+            ..SkillCommandResolverConfig::default()
+        };
+        assert!(resolve_installed_skill_slash_command("/beta", "", &enabled)
+            .unwrap()
+            .is_some());
+        assert!(
+            resolve_installed_skill_slash_command("/mac-helper", "", &enabled)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolver_blocks_dangerous_skill_content() {
+        let tmp = tempdir().unwrap();
+        write_skill(
+            tmp.path(),
+            "danger",
+            "name: danger",
+            "# Danger\n1. Run rm -rf /",
+        );
+        let config = SkillCommandResolverConfig {
+            roots: vec![tmp.path().to_path_buf()],
+            platform: Some("linux".to_string()),
+            ..SkillCommandResolverConfig::default()
+        };
+
+        let err = resolve_installed_skill_slash_command("/danger", "", &config)
+            .expect_err("dangerous skill should be blocked");
+        assert!(err.contains("Guard violation:"));
+        assert!(err.contains("Blocked content:"));
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1220,6 +1220,18 @@
       "disposition": "ported",
       "notes": "Rust gateway /title now persists Session.title metadata directly, bare /title reads current title, /status and /sessions expose it, and gateway tests cover the title command lifecycle. No Python TUI session.title RPC is used in the Rust runtime."
     },
+    "9350e26e681e": {
+      "disposition": "ported",
+      "notes": "Rust exposes the clarify tool as a typed ClarifyHandler with signal, stdio, and gateway channel backends, registers it in built-in/toolset/runtime wiring, and covers schema, trimming, choice normalization, empty-question rejection, stdio auto-answer, and gateway dispatcher roundtrip/timeout behavior."
+    },
+    "c36b256de56a": {
+      "disposition": "ported",
+      "notes": "Rust provides Home Assistant REST tools and backend handlers for entity listing, state lookup, service listing, and service calls, registers the homeassistant toolset and platform aliases, and includes a Home Assistant gateway adapter. Focused tests cover schemas, handler contracts, backend validation, and platform contract startup/routing."
+    },
+    "8e0c48e6d25b": {
+      "disposition": "ported",
+      "notes": "Rust CLI and gateway now resolve otherwise-unknown installed SKILL.md slash commands from configured skill roots, apply enabled/disabled/platform/security filtering, inject full skill content plus invocation args into the normal agent turn, and cover the shared resolver plus CLI and gateway routing with focused tests."
+    },
     "3824b0323793": {
       "disposition": "superseded",
       "notes": "Python TUI session.title DB/RPC edge cases are superseded by Rust gateway in-memory Session.title storage and command tests; there is no pending DB row queue or Python RPC failure mode in this runtime path."


### PR DESCRIPTION
## Summary
- add a shared Rust resolver that maps otherwise-unknown installed `SKILL.md` files to slash commands
- wire the resolver into CLI and gateway paths after built-in/quick slash commands decline the input
- preserve safety filters: enabled/disabled selectors in CLI, platform frontmatter, and `SkillGuard` security scanning
- update parity queue overrides for dynamic skill slash commands, clarify tool runtime parity, and core Home Assistant REST/tool parity

## Queue Delta
Generated with `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-dynamic-skill-slash.json --out-md /tmp/hermes-parity-dynamic-skill-slash.md --overrides docs/parity/queue-overrides.json`:

- `pending`: 1892 -> 1889
- `ported`: 134 -> 137
- `mirrored`: 161
- `superseded`: 7671

Rows cleared:
- `8e0c48e6d25b` dynamic skill slash commands
- `9350e26e681e` clarify questions tool
- `c36b256de56a` Home Assistant REST tools + WebSocket gateway

Rows deliberately left pending:
- `ffec21236d21` enhanced Home Assistant service discovery/setup
- `7966560fb50f` / `dd2d1ba5e61c` reload-skills behavior

## Verification
All Cargo commands used:

`CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0`

Passed:
- `cargo test -p hermes-tools skill_commands -- --nocapture` -> 9 passed
- `cargo test -p hermes-cli cli_resolves_installed_skill_slash_command -- --nocapture` -> 1 passed
- `cargo test -p hermes-gateway gateway_unknown_slash_invokes_installed_skill_command -- --nocapture` -> 1 passed
- `cargo test -p hermes-tools clarify -- --nocapture` -> 8 matched tests passed across unit/contract binaries
- `cargo test -p hermes-tools homeassistant -- --nocapture` -> 10 matched tests passed across unit/contract binaries
- `cargo test -p hermes-gateway tool_backends -- --nocapture` -> 2 passed
- `cargo test -p hermes-gateway --test contract_primary_platforms -- --nocapture` -> 11 passed
- `cargo test -p hermes-cli stdio_clarify_backend_uses_auto_answer_in_non_interactive_mode -- --nocapture` -> 1 passed
- `cargo test -p hermes-gateway slash -- --nocapture` -> 2 passed
- `cargo build -p hermes-tools -p hermes-cli -p hermes-gateway`
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools -p hermes-cli -p hermes-gateway` -> `new=0`

Disk placement proof before PR:
- `/tmp/hermes-agent-ultra-parity-next/target`: `0B`
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `15G`
