### PR TITLE
parity(skills): refresh installed command inventory

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -314,6 +314,8 @@ pub struct App {
     pub session_objective: Option<String>,
     /// User text staged back into the composer by commands such as `/undo`.
     pending_input_prefill: Option<String>,
+    /// System notes injected once before the next submitted user message.
+    pending_system_notes: Vec<String>,
     /// One-shot quorum arm state set by `/quorum run`.
     pub quorum_armed_once: bool,
     /// Animated companion pet settings.
@@ -337,6 +339,7 @@ impl std::fmt::Debug for App {
             .field("pending_image_hint", &self.pending_image_hint)
             .field("session_objective", &self.session_objective)
             .field("pending_input_prefill", &self.pending_input_prefill)
+            .field("pending_system_notes", &self.pending_system_notes)
             .field("quorum_armed_once", &self.quorum_armed_once)
             .field("pet_settings", &self.pet_settings)
             .finish_non_exhaustive()
@@ -370,6 +373,7 @@ impl Clone for App {
             pending_image_hint: self.pending_image_hint.clone(),
             session_objective: self.session_objective.clone(),
             pending_input_prefill: self.pending_input_prefill.clone(),
+            pending_system_notes: self.pending_system_notes.clone(),
             quorum_armed_once: self.quorum_armed_once,
             pet_settings: self.pet_settings.clone(),
         }
@@ -2169,6 +2173,7 @@ impl App {
             pending_image_hint: None,
             session_objective: None,
             pending_input_prefill: None,
+            pending_system_notes: Vec::new(),
             quorum_armed_once: false,
             pet_settings: load_pet_settings(),
         };
@@ -2225,9 +2230,24 @@ impl App {
 
     /// Submit text through the normal user-message path and run the agent.
     pub async fn submit_user_message(&mut self, raw: &str) -> Result<(), AgentError> {
+        for note in std::mem::take(&mut self.pending_system_notes) {
+            self.messages.push(hermes_core::Message::system(note));
+        }
         let user_message = self.prepare_user_message(raw);
         self.messages.push(hermes_core::Message::user(user_message));
         self.run_agent().await
+    }
+
+    pub fn queue_next_turn_system_note(&mut self, note: String) {
+        let trimmed = note.trim();
+        if !trimmed.is_empty() {
+            self.pending_system_notes.push(trimmed.to_string());
+        }
+    }
+
+    #[cfg(test)]
+    pub fn pending_system_note_count(&self) -> usize {
+        self.pending_system_notes.len()
     }
 
     pub fn take_pending_input_prefill(&mut self) -> Option<String> {
@@ -3939,6 +3959,7 @@ mod tests {
             pending_image_hint: None,
             session_objective: None,
             pending_input_prefill: None,
+            pending_system_notes: Vec::new(),
             quorum_armed_once: false,
             pet_settings: PetSettings::default(),
         }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -26,7 +26,9 @@ use hermes_intelligence::model_metadata::{get_model_context_length, get_model_in
 use hermes_intelligence::models_dev::default_client;
 use hermes_intelligence::{build_swarm_execution_plan, swarm_runtime_status, SwarmExecutionMode};
 use hermes_tools::skill_commands::{
-    resolve_installed_skill_slash_command, SkillCommandResolverConfig, SkillSlashInvocation,
+    build_skill_reload_system_note, installed_skill_slash_command_snapshot,
+    render_skill_slash_command_snapshot, resolve_installed_skill_slash_command,
+    SkillCommandResolverConfig, SkillSlashInvocation,
 };
 use hermes_tools::ToolPolicyEngine;
 use regex::Regex;
@@ -3380,8 +3382,7 @@ fn canonical_command(cmd: &str) -> &str {
         "/scheduler" => "/background",
         "/gateway" => "/platforms",
         "/onboard" => "/walkthrough",
-        "/reload-skills" => "/reload",
-        "/reload_skills" => "/reload",
+        "/reload-skills" | "/reload_skills" => "/reload-skills",
         "/reload_mcp" => "/reload-mcp",
         "/fork" => "/branch",
         "/tt" => "/timetravel",
@@ -3649,7 +3650,9 @@ async fn dispatch_slash_command(
         "/plugins" => handle_plugins_command(app),
         "/disk-cleanup" => handle_disk_cleanup_command(app, args),
         "/mcp" => handle_mcp_command(app),
-        "/reload" | "/reload-mcp" => handle_reload_command(app, canonical_command(cmd)),
+        "/reload" | "/reload-skills" | "/reload-mcp" => {
+            handle_reload_command(app, canonical_command(cmd))
+        }
         "/cron" => handle_cron_command(app),
         "/agents" => handle_agents_command(app, args),
         "/kanban" => handle_kanban_command(app, args),
@@ -14576,6 +14579,15 @@ fn handle_reload_command(app: &mut App, cmd: &str) -> Result<CommandResult, Agen
             app,
             "MCP reload requested. Restart session/gateway for full connector renegotiation.",
         );
+    } else if cmd == "/reload-skills" {
+        let config = SkillCommandResolverConfig {
+            enabled: app.config.skills.enabled.clone(),
+            disabled: app.config.skills.disabled.clone(),
+            ..SkillCommandResolverConfig::default()
+        };
+        let snapshot = installed_skill_slash_command_snapshot(&config);
+        app.queue_next_turn_system_note(build_skill_reload_system_note(&snapshot));
+        emit_command_output(app, render_skill_slash_command_snapshot(&snapshot));
     } else {
         hermes_config::loader::load_dotenv();
         match hermes_config::load_config(app.state_root.to_str()) {
@@ -27634,6 +27646,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cli_reload_skills_reports_snapshot_and_queues_note() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let skill_dir = tmp.path().join("skills").join("release-captain");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Release Captain\ndescription: Release workflow\n---\n# Release Captain\n1. Inspect changed files\n",
+        )
+        .expect("write skill");
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        handle_slash_command(&mut app, "/reload-skills", &[])
+            .await
+            .expect("reload skills");
+
+        let out = latest_ui_assistant_text(&app);
+        assert!(out.contains("Reloaded installed skill commands"));
+        assert!(out.contains("/release-captain"));
+        assert!(out.contains("no prompt cache was invalidated"));
+        assert_eq!(app.pending_system_note_count(), 1);
+    }
+
+    #[tokio::test]
     async fn promoted_snapshot_command_lists_snapshots() {
         let _guard = env_test_lock();
         let tmp = tempdir().expect("tempdir");
@@ -28966,8 +29003,8 @@ mod tests {
     #[test]
     fn test_upstream_compat_aliases_are_mapped() {
         assert_eq!(canonical_command("/topic"), "/title");
-        assert_eq!(canonical_command("/reload-skills"), "/reload");
-        assert_eq!(canonical_command("/reload_skills"), "/reload");
+        assert_eq!(canonical_command("/reload-skills"), "/reload-skills");
+        assert_eq!(canonical_command("/reload_skills"), "/reload-skills");
         assert_eq!(canonical_command("/swarms"), "/swarm");
         assert_eq!(canonical_command("/summary"), "/recap");
         assert_eq!(canonical_command("/whoami"), "/profile");

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -74,6 +74,8 @@ pub enum GatewayCommandResult {
     },
     /// Reload MCP server registry/state.
     ReloadMcp,
+    /// Refresh installed skill slash command inventory.
+    ReloadSkills,
     /// Switch active provider.
     SwitchProvider { provider: String, reply: String },
     /// Switch active profile.
@@ -270,6 +272,12 @@ pub fn all_commands() -> Vec<CommandInfo> {
             aliases: &["/mcp_reload"],
             description: "Reload MCP tool/server registrations",
             usage: "/reload_mcp",
+        },
+        CommandInfo {
+            name: "/reload-skills",
+            aliases: &["/reload_skills"],
+            description: "Refresh installed skill slash command inventory",
+            usage: "/reload-skills",
         },
         CommandInfo {
             name: "/provider",
@@ -568,6 +576,7 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
                 .to_string(),
         ),
         "/reload_mcp" | "/mcp_reload" => GatewayCommandResult::ReloadMcp,
+        "/reload_skills" => GatewayCommandResult::ReloadSkills,
         "/provider" => {
             if args.is_empty() {
                 GatewayCommandResult::Reply(
@@ -790,6 +799,18 @@ mod tests {
         match handle_command("/xyz123") {
             GatewayCommandResult::Unknown(_) => {}
             other => panic!("Expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_reload_skills_command() {
+        match handle_command("/reload-skills") {
+            GatewayCommandResult::ReloadSkills => {}
+            other => panic!("Expected ReloadSkills for /reload-skills, got {:?}", other),
+        }
+        match handle_command("/reload_skills") {
+            GatewayCommandResult::ReloadSkills => {}
+            other => panic!("Expected ReloadSkills for /reload_skills, got {:?}", other),
         }
     }
 

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -24,7 +24,9 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 use hermes_core::types::{Message, MessageRole};
 use hermes_tools::skill_commands::{
-    resolve_installed_skill_slash_command, SkillCommandResolverConfig,
+    build_skill_reload_system_note, installed_skill_slash_command_snapshot,
+    render_skill_slash_command_snapshot, resolve_installed_skill_slash_command,
+    SkillCommandResolverConfig,
 };
 
 use crate::background::{BackgroundTaskManager, TaskStatus};
@@ -259,6 +261,7 @@ struct SessionRuntimeState {
     verbose: bool,
     yolo: bool,
     reasoning: bool,
+    pending_system_notes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -322,6 +325,7 @@ impl Default for SessionRuntimeState {
             verbose: false,
             yolo: false,
             reasoning: false,
+            pending_system_notes: Vec::new(),
         }
     }
 }
@@ -1420,6 +1424,30 @@ impl Gateway {
             .map(|maybe| maybe.map(|invocation| invocation.message))
     }
 
+    async fn apply_reload_skills_command(
+        &self,
+        incoming: &IncomingMessage,
+        session_key: &str,
+    ) -> Result<(), GatewayError> {
+        let config = SkillCommandResolverConfig::default();
+        let snapshot = installed_skill_slash_command_snapshot(&config);
+        {
+            let mut states = self.runtime_state.write().await;
+            states
+                .entry(session_key.to_string())
+                .or_default()
+                .pending_system_notes
+                .push(build_skill_reload_system_note(&snapshot));
+        }
+        self.send_message(
+            &incoming.platform,
+            &incoming.chat_id,
+            &render_skill_slash_command_snapshot(&snapshot),
+            None,
+        )
+        .await
+    }
+
     async fn apply_command_result(
         &self,
         incoming: &IncomingMessage,
@@ -1703,6 +1731,11 @@ impl Gateway {
                     None,
                 )
                 .await?;
+                Ok(true)
+            }
+            GatewayCommandResult::ReloadSkills => {
+                self.apply_reload_skills_command(incoming, session_key)
+                    .await?;
                 Ok(true)
             }
             GatewayCommandResult::SwitchProvider { provider, reply } => {
@@ -2239,13 +2272,12 @@ impl Gateway {
         session_key: &str,
         messages: Vec<Message>,
     ) -> Vec<Message> {
-        let state = self
-            .runtime_state
-            .read()
-            .await
-            .get(session_key)
-            .cloned()
-            .unwrap_or_default();
+        let (state, pending_system_notes) = {
+            let mut states = self.runtime_state.write().await;
+            let state = states.entry(session_key.to_string()).or_default();
+            let pending = std::mem::take(&mut state.pending_system_notes);
+            (state.clone(), pending)
+        };
 
         let mut hints = Vec::new();
         if let Some(model) = state.model {
@@ -2266,15 +2298,20 @@ impl Gateway {
         {
             hints.push(format!("service_tier={service_tier}"));
         }
-        if hints.is_empty() {
+        if hints.is_empty() && pending_system_notes.is_empty() {
             return messages;
         }
 
-        let mut out = Vec::with_capacity(messages.len() + 1);
-        out.push(Message::system(format!(
-            "[gateway_runtime]\n{}",
-            hints.join("\n")
-        )));
+        let mut out = Vec::with_capacity(messages.len() + 1 + pending_system_notes.len());
+        if !hints.is_empty() {
+            out.push(Message::system(format!(
+                "[gateway_runtime]\n{}",
+                hints.join("\n")
+            )));
+        }
+        for note in pending_system_notes {
+            out.push(Message::system(note));
+        }
         out.extend(messages);
         out
     }
@@ -3559,6 +3596,102 @@ mod tests {
         assert!(seen[0].contains("Release Captain"));
         assert!(seen[0].contains("Inspect changed files"));
         assert!(seen[0].contains("ship it"));
+    }
+
+    #[tokio::test]
+    async fn gateway_reload_skills_replies_and_injects_one_shot_note() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home_guard = HermesHomeEnvGuard::set(tmp.path());
+        let skill_dir = tmp.path().join("skills").join("release-captain");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Release Captain\ndescription: Release workflow\n---\n# Release Captain\n1. Inspect changed files\n",
+        )
+        .expect("write skill");
+
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let seen_messages = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+        let seen_for_handler = seen_messages.clone();
+        gw.set_message_handler(Arc::new(move |messages| {
+            let seen = seen_for_handler.clone();
+            Box::pin(async move {
+                seen.lock().expect("seen lock").push(messages);
+                Ok("agent-ok".to_string())
+            })
+        }))
+        .await;
+
+        gw.route_message(&IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/reload-skills".into(),
+            message_id: None,
+            is_dm: true,
+        })
+        .await
+        .expect("reload skills");
+        gw.route_message(&IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "next turn".into(),
+            message_id: None,
+            is_dm: true,
+        })
+        .await
+        .expect("next turn");
+        gw.route_message(&IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "later turn".into(),
+            message_id: None,
+            is_dm: true,
+        })
+        .await
+        .expect("later turn");
+
+        let sent = sent.lock().expect("sent lock");
+        assert!(sent[0].1.contains("Reloaded installed skill commands"));
+        assert!(sent[0].1.contains("/release-captain"));
+        assert_eq!(sent[1].1, "agent-ok");
+        assert_eq!(sent[2].1, "agent-ok");
+        drop(sent);
+
+        let seen = seen_messages.lock().expect("seen lock");
+        assert_eq!(seen.len(), 2);
+        let first_note_count = seen[0]
+            .iter()
+            .filter(|message| {
+                message.role == MessageRole::System
+                    && message
+                        .content
+                        .as_deref()
+                        .is_some_and(|text| text.contains("/reload-skills"))
+            })
+            .count();
+        let second_note_count = seen[1]
+            .iter()
+            .filter(|message| {
+                message.role == MessageRole::System
+                    && message
+                        .content
+                        .as_deref()
+                        .is_some_and(|text| text.contains("/reload-skills"))
+            })
+            .count();
+        assert_eq!(first_note_count, 1);
+        assert_eq!(second_note_count, 0);
     }
 
     #[async_trait]

--- a/crates/hermes-tools/src/tools/skill_commands.rs
+++ b/crates/hermes-tools/src/tools/skill_commands.rs
@@ -78,6 +78,34 @@ pub struct SkillSlashInvocation {
     pub message: String,
 }
 
+/// One installed skill command discovered during a refresh/snapshot pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillSlashCommandEntry {
+    /// Canonical command key, including leading slash.
+    pub command: String,
+    /// Skill name from frontmatter or the skill directory.
+    pub skill_name: String,
+    /// Short description from frontmatter, if present.
+    pub description: String,
+    /// Path to the resolved `SKILL.md`.
+    pub skill_md_path: PathBuf,
+    /// Security rejection text when the skill was blocked.
+    pub blocked_reason: Option<String>,
+}
+
+/// Snapshot of installed skill slash commands visible to the current runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillSlashCommandSnapshot {
+    /// Skill roots scanned for nested `SKILL.md` files.
+    pub roots: Vec<PathBuf>,
+    /// Safe commands available for slash invocation.
+    pub available: Vec<SkillSlashCommandEntry>,
+    /// Matching skills blocked by the security gate.
+    pub blocked: Vec<SkillSlashCommandEntry>,
+    /// Skills skipped by platform, enable/disable filters, empty slugs, or duplicate commands.
+    pub skipped: usize,
+}
+
 impl SkillCommandRegistry {
     pub fn new() -> Self {
         Self {
@@ -226,6 +254,134 @@ fn security_gate_skill_content(name: &str, body: &str) -> Result<(), String> {
         .map_err(|err| err.to_string())
 }
 
+fn skill_description(skill: &SkillInfo) -> String {
+    skill
+        .frontmatter
+        .get("description")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn skill_command_entry(
+    skill: &SkillInfo,
+    slug: &str,
+    blocked_reason: Option<String>,
+) -> SkillSlashCommandEntry {
+    SkillSlashCommandEntry {
+        command: format!("/{slug}"),
+        skill_name: skill.name.clone(),
+        description: skill_description(skill),
+        skill_md_path: skill.path.join("SKILL.md"),
+        blocked_reason,
+    }
+}
+
+/// Scan installed skills and report the slash commands currently visible.
+///
+/// This is intentionally a snapshot, not a cache invalidation hook. Dynamic
+/// installed-skill slash commands are resolved from disk each time they are
+/// invoked; `/reload-skills` uses this to provide user-visible confirmation and
+/// to queue an agent-visible note for the next turn.
+pub fn installed_skill_slash_command_snapshot(
+    config: &SkillCommandResolverConfig,
+) -> SkillSlashCommandSnapshot {
+    let mut available = Vec::new();
+    let mut blocked = Vec::new();
+    let mut skipped = 0usize;
+    let mut seen_slugs = HashSet::new();
+
+    for skill in discover_skills(&config.roots) {
+        if !skill_matches_platform(&skill, config.platform.as_deref()) {
+            skipped = skipped.saturating_add(1);
+            continue;
+        }
+        let slug = slugify_skill_command_name(&skill.name);
+        if slug.is_empty() || !skill_allowed(&skill.name, &slug, &config.enabled, &config.disabled)
+        {
+            skipped = skipped.saturating_add(1);
+            continue;
+        }
+        if !seen_slugs.insert(slug.clone()) {
+            skipped = skipped.saturating_add(1);
+            continue;
+        }
+        match security_gate_skill_content(&skill.name, &skill.body) {
+            Ok(()) => available.push(skill_command_entry(&skill, &slug, None)),
+            Err(err) => blocked.push(skill_command_entry(&skill, &slug, Some(err))),
+        }
+    }
+
+    available.sort_by(|a, b| a.command.cmp(&b.command));
+    blocked.sort_by(|a, b| a.command.cmp(&b.command));
+
+    SkillSlashCommandSnapshot {
+        roots: config.roots.clone(),
+        available,
+        blocked,
+        skipped,
+    }
+}
+
+/// Render a concise `/reload-skills` reply for CLI/gateway users.
+pub fn render_skill_slash_command_snapshot(snapshot: &SkillSlashCommandSnapshot) -> String {
+    let mut out = format!(
+        "Reloaded installed skill commands: available={} blocked={} skipped={}.\nDynamic SKILL.md slash commands are scanned live; no prompt cache was invalidated.",
+        snapshot.available.len(),
+        snapshot.blocked.len(),
+        snapshot.skipped
+    );
+    if !snapshot.available.is_empty() {
+        let commands = snapshot
+            .available
+            .iter()
+            .map(|entry| format!("{} ({})", entry.command, entry.skill_name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        out.push_str("\nAvailable: ");
+        out.push_str(&commands);
+    }
+    if !snapshot.blocked.is_empty() {
+        let blocked = snapshot
+            .blocked
+            .iter()
+            .map(|entry| format!("{} ({})", entry.command, entry.skill_name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        out.push_str("\nBlocked by security policy: ");
+        out.push_str(&blocked);
+    }
+    out
+}
+
+/// Build the one-shot system note queued after `/reload-skills`.
+pub fn build_skill_reload_system_note(snapshot: &SkillSlashCommandSnapshot) -> String {
+    let available = if snapshot.available.is_empty() {
+        "none".to_string()
+    } else {
+        snapshot
+            .available
+            .iter()
+            .map(|entry| format!("{} ({})", entry.command, entry.skill_name))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let blocked = if snapshot.blocked.is_empty() {
+        "none".to_string()
+    } else {
+        snapshot
+            .blocked
+            .iter()
+            .map(|entry| format!("{} ({})", entry.command, entry.skill_name))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    format!(
+        "[SYSTEM: The user refreshed installed skill slash commands with /reload-skills. Dynamic SKILL.md commands are scanned from disk on invocation; no prompt cache was invalidated. Current available commands: {available}. Blocked commands: {blocked}.]"
+    )
+}
+
 /// Build the agent-facing message for a skill slash command invocation.
 pub fn build_skill_slash_invocation_message(
     skill_name: &str,
@@ -281,12 +437,7 @@ pub fn resolve_installed_skill_slash_command(
         }
         security_gate_skill_content(&skill.name, &skill.body)?;
         let skill_md_path = skill.path.join("SKILL.md");
-        let description = skill
-            .frontmatter
-            .get("description")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default()
-            .to_string();
+        let description = skill_description(&skill);
         let message = build_skill_slash_invocation_message(&skill.name, &skill.body, args);
         return Ok(Some(SkillSlashInvocation {
             command: format!("/{slug}"),
@@ -616,5 +767,53 @@ mod tests {
             .expect_err("dangerous skill should be blocked");
         assert!(err.contains("Guard violation:"));
         assert!(err.contains("Blocked content:"));
+    }
+
+    #[test]
+    fn snapshot_reports_available_blocked_and_skipped_skill_commands() {
+        let tmp = tempdir().unwrap();
+        write_skill(
+            tmp.path(),
+            "release-captain",
+            "name: Release Captain\ndescription: Ship releases safely",
+            "# Release Captain\n1. Inspect changes",
+        );
+        write_skill(
+            tmp.path(),
+            "danger",
+            "name: Danger",
+            "# Danger\n1. Run rm -rf /",
+        );
+        write_skill(
+            tmp.path(),
+            "mac-only",
+            "name: Mac Only\nplatform: darwin",
+            "# Mac Only\n1. Use macOS",
+        );
+        let config = SkillCommandResolverConfig {
+            roots: vec![tmp.path().to_path_buf()],
+            platform: Some("linux".to_string()),
+            ..SkillCommandResolverConfig::default()
+        };
+
+        let snapshot = installed_skill_slash_command_snapshot(&config);
+
+        assert_eq!(snapshot.available.len(), 1);
+        assert_eq!(snapshot.available[0].command, "/release-captain");
+        assert_eq!(snapshot.available[0].description, "Ship releases safely");
+        assert_eq!(snapshot.blocked.len(), 1);
+        assert_eq!(snapshot.blocked[0].command, "/danger");
+        assert!(snapshot.blocked[0].blocked_reason.is_some());
+        assert_eq!(snapshot.skipped, 1);
+
+        let rendered = render_skill_slash_command_snapshot(&snapshot);
+        assert!(rendered.contains("available=1 blocked=1 skipped=1"));
+        assert!(rendered.contains("/release-captain"));
+        assert!(rendered.contains("no prompt cache was invalidated"));
+
+        let note = build_skill_reload_system_note(&snapshot);
+        assert!(note.contains("/reload-skills"));
+        assert!(note.contains("/release-captain"));
+        assert!(note.contains("/danger"));
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1232,6 +1232,14 @@
       "disposition": "ported",
       "notes": "Rust CLI and gateway now resolve otherwise-unknown installed SKILL.md slash commands from configured skill roots, apply enabled/disabled/platform/security filtering, inject full skill content plus invocation args into the normal agent turn, and cover the shared resolver plus CLI and gateway routing with focused tests."
     },
+    "7966560fb50f": {
+      "disposition": "ported",
+      "notes": "Rust now exposes first-class /reload-skills and /reload_skills in CLI and gateway. The command snapshots installed SKILL.md slash commands through the shared Rust resolver, reports available/blocked/skipped commands, queues an agent-visible next-turn note, and deliberately avoids prompt-cache invalidation. The upstream skills_reload agent tool portion is superseded by the later upstream refactor and not mirrored."
+    },
+    "dd2d1ba5e61c": {
+      "disposition": "ported",
+      "notes": "Rust /reload-skills follows the final upstream behavior: it queues a one-shot system note for the next agent turn, confirms dynamic SKILL.md slash commands are scanned live, and does not delete prompt caches or expose a skills_reload agent tool. CLI and gateway tests cover command routing, snapshot rendering, and one-shot gateway note injection."
+    },
     "3824b0323793": {
       "disposition": "superseded",
       "notes": "Python TUI session.title DB/RPC edge cases are superseded by Rust gateway in-memory Session.title storage and command tests; there is no pending DB row queue or Python RPC failure mode in this runtime path."


### PR DESCRIPTION
## Summary
- make `/reload-skills` and `/reload_skills` first-class Rust CLI and gateway commands
- add a shared installed-skill slash-command snapshot helper that reuses the dynamic SKILL.md resolver semantics
- report available/blocked/skipped skill commands without deleting prompt caches
- queue a one-shot system note for the next CLI/gateway agent turn
- preserve final upstream behavior by not adding a `skills_reload` agent tool

## Queue Delta
Generated with `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-reload-skills.json --out-md /tmp/hermes-parity-reload-skills.md --overrides docs/parity/queue-overrides.json`:

- `pending`: 1889 -> 1887
- `ported`: 137 -> 139
- `mirrored`: 161
- `superseded`: 7671

Rows cleared:
- `7966560fb50f` feat(skills): /reload-skills slash command + skills_reload agent tool
- `dd2d1ba5e61c` refactor(reload-skills): queue note for next turn, drop cache invalidation + agent tool

## Verification
All Cargo commands used:

`CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0`

Passed:
- `cargo test -p hermes-tools skill_commands -- --nocapture` -> 10 passed
- `cargo test -p hermes-cli cli_reload_skills_reports_snapshot_and_queues_note -- --nocapture` -> 1 passed
- `cargo test -p hermes-gateway test_reload_skills_command -- --nocapture` -> 1 passed
- `cargo test -p hermes-gateway gateway_reload_skills_replies_and_injects_one_shot_note -- --nocapture` -> 1 passed
- `cargo test -p hermes-cli test_upstream_compat_aliases_are_mapped -- --nocapture` -> 1 passed
- `cargo build -p hermes-tools -p hermes-cli -p hermes-gateway`
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools -p hermes-cli -p hermes-gateway` -> `new=0`

Disk placement proof before PR:
- `/tmp/hermes-agent-ultra-parity-next/target`: `0B`
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `15G`
