### PR TITLE
parity(mcp): harden runtime coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ hermes-ultra doctor --deep --snapshot --bundle
 
 Optional Sentrux MCP profile:
 
+Full MCP guide: [docs/mcp.md](./docs/mcp.md)
+
 ```bash
 hermes-ultra mcp sentrux
 hermes-ultra mcp sentrux-status

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -59,6 +59,7 @@ use crate::kanban::{
     maybe_checkpoint_to_contextlattice, move_task, remove_attachment_from_task, save_store,
     set_blocked, KanbanActionInput, KanbanBoard, KanbanLane, NewKanbanTaskInput,
 };
+use crate::mcp_config::{load_mcp_config, load_mcp_config_if_exists, McpTransportKind};
 use crate::model_switch::{
     cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
     normalize_provider_model, provider_catalog_entries_for_config, provider_model_ids,
@@ -24952,33 +24953,31 @@ pub async fn handle_cli_mcp(
             );
         }
         "list" => {
-            if !mcp_config_path.exists() {
+            let Some(config) = load_mcp_config_if_exists(&mcp_config_path)? else {
                 println!("No MCP servers configured ({})", mcp_config_path.display());
                 println!("Add one with `hermes mcp add --server <name-or-url>`.");
                 return Ok(());
-            }
-            let content = std::fs::read_to_string(&mcp_config_path)
-                .map_err(|e| hermes_core::AgentError::Io(format!("Read error: {}", e)))?;
-            let servers: serde_json::Value =
-                serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
-            if let Some(obj) = servers.as_object() {
-                if obj.is_empty() {
-                    println!("No MCP servers configured.");
-                } else {
-                    println!("MCP servers ({}):", mcp_config_path.display());
-                    for (name, cfg) in obj {
-                        let url = cfg.get("url").and_then(|v| v.as_str()).unwrap_or("(stdio)");
-                        let parallel = cfg
-                            .get("supports_parallel_tool_calls")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        println!(
-                            "  • {} — {}  [parallel_tool_calls:{}]",
-                            name,
-                            url,
-                            if parallel { "on" } else { "off" }
-                        );
-                    }
+            };
+            if config.servers.is_empty() {
+                println!("No MCP servers configured.");
+            } else {
+                for warning in config.warnings() {
+                    println!("Warning: {warning}");
+                }
+                println!("MCP servers ({}):", mcp_config_path.display());
+                for entry in &config.servers {
+                    println!(
+                        "  • {} — {}  [{}; enabled:{}; parallel_tool_calls:{}]",
+                        entry.name,
+                        entry.transport_display(),
+                        entry.transport_kind().as_str(),
+                        if entry.enabled { "on" } else { "off" },
+                        if entry.supports_parallel_tool_calls {
+                            "on"
+                        } else {
+                            "off"
+                        }
+                    );
                 }
             }
         }
@@ -25142,30 +25141,29 @@ pub async fn handle_cli_mcp(
                 )
             })?;
             println!("Testing MCP server: {}...", srv);
-            if !mcp_config_path.exists() {
+            let Some(config) = load_mcp_config_if_exists(&mcp_config_path)? else {
                 println!("No MCP config found.");
                 return Ok(());
-            }
-            let content = std::fs::read_to_string(&mcp_config_path)
-                .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-            let servers: serde_json::Value =
-                serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
-            match servers.get(&srv) {
-                Some(cfg) => {
-                    let url = cfg.get("url").and_then(|v| v.as_str()).unwrap_or("(stdio)");
-                    let enabled = cfg.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true);
-                    let parallel = cfg
-                        .get("supports_parallel_tool_calls")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
+            };
+            match config.get(&srv) {
+                Some(entry) => {
+                    for warning in &entry.warnings {
+                        println!("Warning: {warning}");
+                    }
                     println!("  Server: {}", srv);
-                    println!("  URL: {}", url);
-                    println!("  Enabled: {}", enabled);
+                    println!("  Transport: {}", entry.transport_kind().as_str());
+                    println!("  Target: {}", entry.transport_display());
+                    println!("  Enabled: {}", entry.enabled);
                     println!(
                         "  Parallel tool calls: {}",
-                        if parallel { "on" } else { "off" }
+                        if entry.supports_parallel_tool_calls {
+                            "on"
+                        } else {
+                            "off"
+                        }
                     );
-                    if url.starts_with("http") {
+                    if entry.transport_kind() == McpTransportKind::Http {
+                        let url = entry.url.as_deref().unwrap_or_default();
                         match reqwest::Client::new()
                             .get(url)
                             .timeout(std::time::Duration::from_secs(5))
@@ -25188,18 +25186,20 @@ pub async fn handle_cli_mcp(
                     "Missing server name. Usage: hermes mcp configure <name>".into(),
                 )
             })?;
-            if !mcp_config_path.exists() {
+            let Some(config) = load_mcp_config_if_exists(&mcp_config_path)? else {
                 println!("No MCP config found. Add a server first with `hermes mcp add`.");
                 return Ok(());
-            }
-            let content = std::fs::read_to_string(&mcp_config_path)
-                .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-            let servers: serde_json::Value =
-                serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
-            match servers.get(&srv) {
-                Some(cfg) => {
+            };
+            match config.get(&srv) {
+                Some(entry) => {
+                    for warning in &entry.warnings {
+                        println!("Warning: {warning}");
+                    }
                     println!("Current config for '{}':", srv);
-                    println!("{}", serde_json::to_string_pretty(cfg).unwrap_or_default());
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(entry).unwrap_or_default()
+                    );
                     println!("\nEdit {} to modify settings.", mcp_config_path.display());
                 }
                 None => println!("Server '{}' not found.", srv),
@@ -25217,11 +25217,7 @@ pub async fn handle_cli_mcp(
                     mcp_config_path.display()
                 )));
             }
-            let configured = std::fs::read_to_string(&mcp_config_path)
-                .ok()
-                .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
-                .and_then(|v| v.get(&srv).cloned())
-                .is_some();
+            let configured = load_mcp_config(&mcp_config_path)?.get(&srv).is_some();
             if !configured {
                 return Err(hermes_core::AgentError::Config(format!(
                     "MCP server '{}' is not configured",

--- a/crates/hermes-cli/src/mcp_config.rs
+++ b/crates/hermes-cli/src/mcp_config.rs
@@ -1,15 +1,272 @@
-use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct McpServerEntry {
-    pub name: String,
-    pub command: Option<String>,
-    pub url: Option<String>,
-    #[serde(default)]
-    pub supports_parallel_tool_calls: bool,
+use hermes_core::AgentError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum McpTransportKind {
+    Http,
+    Stdio,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+impl McpTransportKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Http => "HTTP",
+            Self::Stdio => "stdio",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServerEntry {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub supports_parallel_tool_calls: bool,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+impl McpServerEntry {
+    pub fn transport_kind(&self) -> McpTransportKind {
+        if self.url.is_some() {
+            McpTransportKind::Http
+        } else {
+            McpTransportKind::Stdio
+        }
+    }
+
+    pub fn transport_display(&self) -> String {
+        if let Some(url) = self.url.as_deref() {
+            return url.to_string();
+        }
+        let mut parts = Vec::new();
+        if let Some(command) = self.command.as_deref() {
+            parts.push(command.to_string());
+        }
+        parts.extend(self.args.iter().take(2).cloned());
+        if parts.is_empty() {
+            "(unconfigured)".to_string()
+        } else {
+            parts.join(" ")
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct McpConfig {
     pub servers: Vec<McpServerEntry>,
+}
+
+impl McpConfig {
+    pub fn get(&self, name: &str) -> Option<&McpServerEntry> {
+        self.servers.iter().find(|entry| entry.name == name)
+    }
+
+    pub fn warnings(&self) -> impl Iterator<Item = &str> {
+        self.servers
+            .iter()
+            .flat_map(|entry| entry.warnings.iter().map(String::as_str))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMcpServerEntry {
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    supports_parallel_tool_calls: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn normalized_nonempty(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn parse_entry(name: &str, raw: RawMcpServerEntry) -> Result<McpServerEntry, String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("MCP server name must not be empty".to_string());
+    }
+    let command = normalized_nonempty(raw.command);
+    let url = normalized_nonempty(raw.url);
+    let mut warnings = Vec::new();
+    if command.is_some() && url.is_some() {
+        warnings.push(format!(
+            "MCP server '{name}' has both 'url' and 'command' in config. Using HTTP transport ('url'). Remove 'command' to silence this warning."
+        ));
+    }
+    match (&command, &url) {
+        (None, None) => {
+            return Err(format!(
+                "MCP server '{name}' must configure either 'url' or 'command'"
+            ));
+        }
+        (_, Some(url)) => {
+            let parsed = reqwest::Url::parse(url)
+                .map_err(|err| format!("MCP server '{name}' has invalid url '{url}': {err}"))?;
+            if !matches!(parsed.scheme(), "http" | "https") {
+                return Err(format!(
+                    "MCP server '{name}' url must use http or https, got '{}'",
+                    parsed.scheme()
+                ));
+            }
+        }
+        _ => {}
+    }
+
+    Ok(McpServerEntry {
+        name: name.to_string(),
+        command,
+        args: raw.args,
+        env: raw.env,
+        url,
+        enabled: raw.enabled.unwrap_or(true),
+        supports_parallel_tool_calls: raw.supports_parallel_tool_calls,
+        warnings,
+    })
+}
+
+pub fn parse_mcp_config_json(raw: &str) -> Result<McpConfig, String> {
+    let value: Value =
+        serde_json::from_str(raw).map_err(|err| format!("invalid MCP JSON: {err}"))?;
+    if value.is_null() {
+        return Ok(McpConfig::default());
+    }
+
+    if let Some(servers_value) = value.get("servers") {
+        let array = servers_value
+            .as_array()
+            .ok_or_else(|| "MCP config 'servers' must be an array".to_string())?;
+        let mut servers = Vec::new();
+        for item in array {
+            let name = item
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "MCP server array entries require a string 'name'".to_string())?;
+            let raw_entry: RawMcpServerEntry = serde_json::from_value(item.clone())
+                .map_err(|err| format!("invalid MCP server '{name}': {err}"))?;
+            servers.push(parse_entry(name, raw_entry)?);
+        }
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+        return Ok(McpConfig { servers });
+    }
+
+    let object = value
+        .as_object()
+        .ok_or_else(|| "MCP config must be a JSON object".to_string())?;
+    let mut servers = Vec::new();
+    for (name, entry_value) in object {
+        let raw_entry: RawMcpServerEntry = serde_json::from_value(entry_value.clone())
+            .map_err(|err| format!("invalid MCP server '{name}': {err}"))?;
+        servers.push(parse_entry(name, raw_entry)?);
+    }
+    servers.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(McpConfig { servers })
+}
+
+pub fn load_mcp_config(path: &Path) -> Result<McpConfig, AgentError> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|err| AgentError::Io(format!("failed to read {}: {err}", path.display())))?;
+    parse_mcp_config_json(&raw)
+        .map_err(|err| AgentError::Config(format!("invalid MCP config {}: {err}", path.display())))
+}
+
+pub fn load_mcp_config_if_exists(path: &Path) -> Result<Option<McpConfig>, AgentError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    load_mcp_config(path).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_mcp_config, parse_mcp_config_json, McpTransportKind};
+
+    #[test]
+    fn parses_object_config_and_warns_when_url_and_command_conflict() {
+        let cfg = parse_mcp_config_json(
+            r#"{
+              "remote": {
+                "url": "https://example.com/mcp",
+                "command": "npx",
+                "args": ["-y", "server"],
+                "supports_parallel_tool_calls": true
+              }
+            }"#,
+        )
+        .expect("valid config");
+        let entry = cfg.get("remote").expect("remote entry");
+        assert_eq!(entry.transport_kind(), McpTransportKind::Http);
+        assert_eq!(entry.transport_display(), "https://example.com/mcp");
+        assert!(entry.supports_parallel_tool_calls);
+        assert_eq!(cfg.warnings().count(), 1);
+        assert!(cfg
+            .warnings()
+            .next()
+            .expect("warning")
+            .contains("Using HTTP transport"));
+    }
+
+    #[test]
+    fn rejects_missing_transport() {
+        let err = parse_mcp_config_json(r#"{"broken": {"enabled": true}}"#)
+            .expect_err("missing transport should fail");
+        assert!(err.contains("either 'url' or 'command'"));
+    }
+
+    #[test]
+    fn rejects_non_http_urls() {
+        let err = parse_mcp_config_json(r#"{"bad": {"url": "ftp://example.com/mcp"}}"#)
+            .expect_err("unsupported scheme should fail");
+        assert!(err.contains("http or https"));
+    }
+
+    #[test]
+    fn parses_servers_array_compat_shape() {
+        let cfg = parse_mcp_config_json(
+            r#"{"servers": [{"name": "local", "command": "hermes", "args": ["mcp", "serve"]}]}"#,
+        )
+        .expect("array config");
+        let entry = cfg.get("local").expect("local entry");
+        assert_eq!(entry.transport_kind(), McpTransportKind::Stdio);
+        assert_eq!(entry.transport_display(), "hermes mcp serve");
+        assert!(entry.enabled);
+    }
+
+    #[test]
+    fn load_mcp_config_reports_path_for_invalid_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("mcp_servers.json");
+        std::fs::write(&path, r#"{"bad": {"url": "not a url"}}"#).expect("write");
+        let err = load_mcp_config(&path).expect_err("invalid url");
+        let msg = err.to_string();
+        assert!(msg.contains("mcp_servers.json"));
+        assert!(msg.contains("invalid url"));
+    }
 }

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -155,6 +155,16 @@ pub struct McpProbeResult {
     pub server_info: Option<Value>,
 }
 
+/// Per-server outcome from parallel MCP discovery.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct McpDiscoveryReport {
+    pub name: String,
+    pub connected: bool,
+    pub transport_type: String,
+    pub tool_count: usize,
+    pub error: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // McpServerConfig
 // ---------------------------------------------------------------------------
@@ -266,6 +276,16 @@ impl McpServerConfig {
     /// Returns true if this config is for an HTTP (remote) connection.
     pub fn is_http(&self) -> bool {
         self.url.is_some()
+    }
+}
+
+fn transport_type_for_config(config: &McpServerConfig) -> &'static str {
+    if config.is_http() {
+        "http"
+    } else if config.is_stdio() {
+        "stdio"
+    } else {
+        "unknown"
     }
 }
 
@@ -1045,6 +1065,113 @@ impl McpManager {
         Ok(())
     }
 
+    /// Connect and discover multiple MCP servers concurrently.
+    ///
+    /// Each server gets its own connection future, so one slow MCP server no
+    /// longer consumes the discovery budget for every other configured server.
+    /// The returned reports are intended for user-visible startup summaries.
+    pub async fn connect_all_parallel(
+        &mut self,
+        configs: Vec<(String, McpServerConfig)>,
+    ) -> Vec<McpDiscoveryReport> {
+        let mut reports: Vec<(usize, McpDiscoveryReport)> = Vec::new();
+        let mut tasks = tokio::task::JoinSet::new();
+
+        for (index, (name, config)) in configs.into_iter().enumerate() {
+            if let Some(existing) = self.clients.get(&name) {
+                reports.push((
+                    index,
+                    McpDiscoveryReport {
+                        name,
+                        connected: existing.is_connected(),
+                        transport_type: transport_type_for_config(&existing.config).to_string(),
+                        tool_count: existing.cached_tools().len(),
+                        error: None,
+                    },
+                ));
+                continue;
+            }
+
+            tasks.spawn(async move {
+                let transport_type = transport_type_for_config(&config).to_string();
+                let mut client = McpClient::new(config);
+                let result = client.connect().await;
+                match result {
+                    Ok(()) => {
+                        let tool_count = client.cached_tools().len();
+                        (
+                            index,
+                            McpDiscoveryReport {
+                                name,
+                                connected: true,
+                                transport_type,
+                                tool_count,
+                                error: None,
+                            },
+                            Some(client),
+                        )
+                    }
+                    Err(err) => {
+                        warn!("Failed to connect to MCP server '{}': {}", name, err);
+                        (
+                            index,
+                            McpDiscoveryReport {
+                                name,
+                                connected: false,
+                                transport_type,
+                                tool_count: 0,
+                                error: Some(err.to_string()),
+                            },
+                            None,
+                        )
+                    }
+                }
+            });
+        }
+
+        while let Some(joined) = tasks.join_next().await {
+            match joined {
+                Ok((index, report, client)) => {
+                    if let Some(client) = client {
+                        debug!(
+                            "Discovered {} tools from MCP server '{}'",
+                            report.tool_count, report.name
+                        );
+                        self.clients.insert(report.name.clone(), client);
+                    }
+                    reports.push((index, report));
+                }
+                Err(err) => {
+                    reports.push((
+                        usize::MAX,
+                        McpDiscoveryReport {
+                            name: "mcp-discovery-task".to_string(),
+                            connected: false,
+                            transport_type: "unknown".to_string(),
+                            tool_count: 0,
+                            error: Some(format!("discovery task failed: {err}")),
+                        },
+                    ));
+                }
+            }
+        }
+
+        reports.sort_by_key(|(index, _)| *index);
+        let summary = reports
+            .iter()
+            .fold((0usize, 0usize), |(tools, failed), (_, report)| {
+                (
+                    tools + report.tool_count,
+                    failed + usize::from(!report.connected),
+                )
+            });
+        info!(
+            "MCP discovery complete: {} tool(s), {} failed server(s)",
+            summary.0, summary.1
+        );
+        reports.into_iter().map(|(_, report)| report).collect()
+    }
+
     /// Disconnect from an MCP server and remove it from the active list.
     pub async fn disconnect(&mut self, name: &str) -> Result<(), McpError> {
         if let Some(mut client) = self.clients.remove(name) {
@@ -1282,7 +1409,9 @@ impl McpManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{cache_mcp_image_block, is_stale_transport_error, McpClient, McpServerConfig};
+    use super::{
+        cache_mcp_image_block, is_stale_transport_error, McpClient, McpManager, McpServerConfig,
+    };
     use crate::transport::McpTransport;
     use crate::McpError;
     use async_trait::async_trait;
@@ -1401,6 +1530,34 @@ mod tests {
         assert!(!client.is_connected());
         assert!(client.cached_tools().is_empty());
         assert!(client.cached_resources().is_empty());
+    }
+
+    #[tokio::test]
+    async fn connect_all_parallel_reports_failed_servers_without_aborting_batch() {
+        let registry = Arc::new(hermes_tools::ToolRegistry::new());
+        let mut manager = McpManager::new(registry);
+
+        let reports = manager
+            .connect_all_parallel(vec![
+                (
+                    "missing-a".to_string(),
+                    McpServerConfig::stdio("__hermes_missing_mcp_a__", Vec::new()),
+                ),
+                (
+                    "missing-b".to_string(),
+                    McpServerConfig::stdio("__hermes_missing_mcp_b__", Vec::new()),
+                ),
+            ])
+            .await;
+
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].name, "missing-a");
+        assert_eq!(reports[1].name, "missing-b");
+        assert!(reports.iter().all(|report| !report.connected));
+        assert!(reports.iter().all(|report| report.tool_count == 0));
+        assert!(reports.iter().all(|report| report.error.is_some()));
+        assert!(!manager.is_connected("missing-a"));
+        assert!(!manager.is_connected("missing-b"));
     }
 
     #[test]

--- a/crates/hermes-mcp/src/lib.rs
+++ b/crates/hermes-mcp/src/lib.rs
@@ -99,8 +99,8 @@ impl From<serde_json::Error> for McpError {
 // Re-export primary types
 pub use auth::{BearerTokenAuth, McpAuthProvider, OAuthConfig};
 pub use client::{
-    McpClient, McpManager, McpProbeResult, McpServerConfig, McpServerStatus, PromptArgument,
-    PromptInfo, PromptMessage, PromptResult, ResourceInfo, SamplingConfig,
+    McpClient, McpDiscoveryReport, McpManager, McpProbeResult, McpServerConfig, McpServerStatus,
+    PromptArgument, PromptInfo, PromptMessage, PromptResult, ResourceInfo, SamplingConfig,
 };
 pub use serve::{
     ApprovalStore as McpApprovalStore, BridgeEvent, EventBridge, HermesMcpServe,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,93 @@
+# MCP Runtime
+
+Hermes Agent Ultra supports MCP in both directions:
+
+- MCP client mode: connect Hermes Ultra to external MCP servers and expose their tools to the runtime.
+- MCP server mode: run `hermes-ultra mcp serve` so another MCP client can call Hermes Ultra tools over stdio.
+
+The implementation is Rust-native in `crates/hermes-mcp` and is surfaced through `hermes-ultra mcp ...` commands.
+
+## Client Configuration
+
+Add MCP servers with the CLI:
+
+```bash
+hermes-ultra mcp add filesystem --command npx --parallel-tools
+hermes-ultra mcp add remote-api --url https://example.com/mcp
+hermes-ultra mcp list
+hermes-ultra mcp test remote-api
+```
+
+The CLI keeps `mcp_servers.json` and `config.yaml` synchronized under the Hermes home directory.
+
+Equivalent JSON shape:
+
+```json
+{
+  "filesystem": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    "enabled": true,
+    "supports_parallel_tool_calls": true
+  },
+  "remote-api": {
+    "url": "https://example.com/mcp",
+    "enabled": true
+  }
+}
+```
+
+Validation rules:
+
+- Every server must have either `url` or `command`.
+- `url` must use `http` or `https`.
+- If both `url` and `command` are present, HTTP wins and the CLI prints a warning.
+- `supports_parallel_tool_calls` is preserved and displayed by `mcp list` and `mcp test`.
+
+## Runtime Behavior
+
+`crates/hermes-mcp` provides:
+
+- stdio and HTTP/SSE transports.
+- `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, and `prompts/get` client methods.
+- Parallel connection/discovery reporting through `McpManager::connect_all_parallel`.
+- Stale transport detection with one reconnect attempt on tool calls.
+- Bearer/OAuth authentication providers for remote servers.
+- Media block caching for image tool responses.
+
+Parallel discovery gives each configured server an independent connection future, so one slow or broken server does not consume the entire startup budget for other servers.
+
+## Server Mode
+
+Run Hermes Ultra as an MCP stdio server:
+
+```bash
+hermes-ultra mcp serve
+```
+
+Example MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "hermes-ultra": {
+      "command": "hermes-ultra",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+The server exposes Hermes Ultra tool definitions through MCP `tools/list` and runs tool calls through the same Rust tool registry used by the agent runtime.
+
+## Sentrux Profile
+
+Hermes Ultra includes a convenience profile for the Sentrux MCP backend:
+
+```bash
+hermes-ultra mcp sentrux
+hermes-ultra mcp sentrux-status
+hermes-ultra mcp sentrux-remove
+```
+
+This configures the Sentrux MCP command in both JSON and YAML config surfaces and marks it as safe for parallel tool calls.

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1240,6 +1240,22 @@
       "disposition": "ported",
       "notes": "Rust /reload-skills follows the final upstream behavior: it queues a one-shot system note for the next agent turn, confirms dynamic SKILL.md slash commands are scanned live, and does not delete prompt caches or expose a skills_reload agent tool. CLI and gateway tests cover command routing, snapshot rendering, and one-shot gateway note injection."
     },
+    "3c252ae44b52": {
+      "disposition": "ported",
+      "notes": "Rust hermes-mcp provides MCP client support through McpClient and McpManager, stdio and HTTP/SSE transports, OAuth/bearer auth, tools/list, tools/call, resources, prompts, stale transport reconnect, and media caching. CLI mcp add/list/remove/test/configure/login/serve wiring and focused hermes-mcp/hermes-cli tests cover the core client surface."
+    },
+    "60effcfc4427": {
+      "disposition": "ported",
+      "notes": "Rust now mirrors the upstream MCP discovery hardening with McpManager::connect_all_parallel for concurrent per-server discovery reports, user-visible CLI config warnings when url and command conflict, URL/transport validation for mcp list/test/configure/login, and regression tests for conflict detection, invalid configs, and failed-server parallel discovery."
+    },
+    "63f5e14c6993": {
+      "disposition": "mirrored",
+      "notes": "Rust repo now includes docs/mcp.md with client configuration, config validation rules, parallel discovery behavior, mcp serve setup, and Sentrux MCP profile examples, plus a README link near the MCP quick commands."
+    },
+    "6716e66e89fc": {
+      "disposition": "ported",
+      "notes": "Rust hermes mcp serve is implemented in crates/hermes-mcp/src/serve.rs and exposed by hermes-cli handle_cli_mcp serve. Tests cover serve tool definitions, session/resource/event/approval tools, numeric coercion, stringified object arguments, and systems MCP conformance; docs/mcp.md documents the server mode."
+    },
     "3824b0323793": {
       "disposition": "superseded",
       "notes": "Python TUI session.title DB/RPC edge cases are superseded by Rust gateway in-memory Session.title storage and command tests; there is no pending DB row queue or Python RPC failure mode in this runtime path."


### PR DESCRIPTION
## Summary

- Add Rust MCP config parsing/validation for `mcp_servers.json` with user-visible warnings when both `url` and `command` are configured; HTTP wins like upstream.
- Add `McpManager::connect_all_parallel` with per-server discovery reports so slow/broken servers do not block the whole batch.
- Wire `hermes-ultra mcp list/test/configure/login` through the validated config view.
- Add `docs/mcp.md` and README link for the implemented Rust MCP client/server runtime.
- Clear only the proven MCP parity rows: client support, parallel discovery/config validation, docs, and `mcp serve`; leave sampling/ACP/dynamic/nullable MCP rows pending.

## Verification

- `cargo test -p hermes-cli mcp_config -- --nocapture` -> 5 passed
- `cargo test -p hermes-mcp connect_all_parallel -- --nocapture` -> 1 passed
- `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-mcp-runtime.json --out-md /tmp/hermes-parity-mcp-runtime.md --overrides docs/parity/queue-overrides.json` -> `mirrored=162 pending=1883 ported=142 superseded=7671`
- `cargo test -p hermes-mcp -- --nocapture` -> 44 passed
- `cargo fmt --all --check` -> passed
- `jq empty docs/parity/queue-overrides.json` -> passed
- `git diff --check` -> passed
- `scripts/check-rust-runtime-no-python.sh` -> passed
- `scripts/check-runtime-placeholders.sh` -> passed
- `cargo test -p hermes-cli mcp -- --nocapture` -> 10 passed
- `cargo build -p hermes-mcp -p hermes-cli` -> passed
- `scripts/clippy-warning-gate.sh --check -- -p hermes-mcp -p hermes-cli` -> `seen=197 allowlist=204 new=0 stale=7`, passed

## Disk Target Proof

- `/tmp/hermes-agent-ultra-parity-next/target`: `0B`
- `/private/tmp/hermes-agent-ultra-target-delegation`: `0B`
- `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`: `15G`
