### PR TITLE
parity(mcp): preserve nullable argument coercion

### DIFF
--- a/crates/hermes-mcp/src/lib.rs
+++ b/crates/hermes-mcp/src/lib.rs
@@ -14,14 +14,158 @@ pub mod serve;
 pub mod server;
 pub mod transport;
 
-pub(crate) fn coerce_mcp_tool_arguments(arguments: serde_json::Value) -> serde_json::Value {
-    let serde_json::Value::String(raw) = arguments else {
+use serde_json::{Number, Value};
+
+pub(crate) fn coerce_mcp_tool_arguments_for_schema(
+    arguments: Value,
+    schema: Option<&Value>,
+) -> Value {
+    let mut arguments = coerce_whole_mcp_arguments(arguments);
+    let Some(schema) = schema else {
         return arguments;
     };
-    match serde_json::from_str::<serde_json::Value>(raw.trim()) {
-        Ok(parsed @ (serde_json::Value::Object(_) | serde_json::Value::Array(_))) => parsed,
-        _ => serde_json::Value::String(raw),
+    let Some(args) = arguments.as_object_mut() else {
+        return arguments;
+    };
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return arguments;
+    };
+
+    for (key, value) in args {
+        let Some(raw) = value.as_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(property_schema) = properties.get(key) else {
+            continue;
+        };
+        if let Some(coerced) = coerce_string_for_schema(&raw, property_schema) {
+            *value = coerced;
+        }
     }
+
+    arguments
+}
+
+fn coerce_whole_mcp_arguments(arguments: Value) -> Value {
+    let Value::String(raw) = arguments else {
+        return arguments;
+    };
+    match serde_json::from_str::<Value>(raw.trim()) {
+        Ok(parsed @ (Value::Object(_) | Value::Array(_))) => parsed,
+        _ => Value::String(raw),
+    }
+}
+
+fn coerce_string_for_schema(raw: &str, schema: &Value) -> Option<Value> {
+    let trimmed = raw.trim();
+    if schema_allows_null(schema) && trimmed.eq_ignore_ascii_case("null") {
+        return Some(Value::Null);
+    }
+
+    for expected in schema_types(schema) {
+        if expected == "null" && trimmed.eq_ignore_ascii_case("null") {
+            return Some(Value::Null);
+        }
+        if let Some(coerced) = coerce_string_for_type(trimmed, expected) {
+            return Some(coerced);
+        }
+    }
+
+    None
+}
+
+fn coerce_string_for_type(raw: &str, expected: &str) -> Option<Value> {
+    match expected {
+        "integer" => coerce_number(raw, true),
+        "number" => coerce_number(raw, false),
+        "boolean" => coerce_boolean(raw),
+        "array" => coerce_json_shape(raw, Value::is_array),
+        "object" => coerce_json_shape(raw, Value::is_object),
+        _ => None,
+    }
+}
+
+fn coerce_number(raw: &str, integer_only: bool) -> Option<Value> {
+    let parsed = raw.parse::<f64>().ok()?;
+    if !parsed.is_finite() {
+        return None;
+    }
+    if parsed.fract() == 0.0 {
+        if parsed < i64::MIN as f64 || parsed > i64::MAX as f64 {
+            return None;
+        }
+        return Some(Value::Number(Number::from(parsed as i64)));
+    }
+    if integer_only {
+        return None;
+    }
+    Number::from_f64(parsed).map(Value::Number)
+}
+
+fn coerce_boolean(raw: &str) -> Option<Value> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" => Some(Value::Bool(true)),
+        "false" => Some(Value::Bool(false)),
+        _ => None,
+    }
+}
+
+fn coerce_json_shape(raw: &str, predicate: fn(&Value) -> bool) -> Option<Value> {
+    let parsed = serde_json::from_str::<Value>(raw).ok()?;
+    predicate(&parsed).then_some(parsed)
+}
+
+fn schema_types(schema: &Value) -> Vec<&str> {
+    let mut out = Vec::new();
+    collect_schema_types(schema, &mut out);
+    out
+}
+
+fn collect_schema_types<'a>(schema: &'a Value, out: &mut Vec<&'a str>) {
+    match schema.get("type") {
+        Some(Value::String(kind)) => out.push(kind),
+        Some(Value::Array(kinds)) => {
+            for kind in kinds {
+                if let Some(kind) = kind.as_str() {
+                    out.push(kind);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    for key in ["anyOf", "oneOf"] {
+        if let Some(variants) = schema.get(key).and_then(Value::as_array) {
+            for variant in variants {
+                collect_schema_types(variant, out);
+            }
+        }
+    }
+}
+
+fn schema_allows_null(schema: &Value) -> bool {
+    if schema.get("nullable").and_then(Value::as_bool) == Some(true) {
+        return true;
+    }
+    match schema.get("type") {
+        Some(Value::String(kind)) if kind == "null" => return true,
+        Some(Value::Array(kinds)) if kinds.iter().any(|kind| kind.as_str() == Some("null")) => {
+            return true;
+        }
+        _ => {}
+    }
+
+    for key in ["anyOf", "oneOf"] {
+        if schema
+            .get(key)
+            .and_then(Value::as_array)
+            .is_some_and(|variants| variants.iter().any(schema_allows_null))
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hermes-mcp/src/serve.rs
+++ b/crates/hermes-mcp/src/serve.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::{coerce_mcp_tool_arguments, McpError};
+use crate::{coerce_mcp_tool_arguments_for_schema, McpError};
 
 // ---------------------------------------------------------------------------
 // EventBridge — in-memory event queue with cursor-based polling
@@ -392,7 +392,7 @@ impl HermesMcpServe {
                     "type": "object",
                     "properties": {
                         "after_cursor": {"type": "integer", "description": "Cursor position (0 for all)."},
-                        "session_key": {"type": "string", "description": "Filter to one session."},
+                        "session_key": {"type": "string", "nullable": true, "description": "Filter to one session."},
                         "limit": {"type": "integer", "description": "Max events (default 20)."}
                     }
                 }
@@ -404,7 +404,7 @@ impl HermesMcpServe {
                     "type": "object",
                     "properties": {
                         "after_cursor": {"type": "integer", "description": "Cursor position."},
-                        "session_key": {"type": "string", "description": "Filter to one session."},
+                        "session_key": {"type": "string", "nullable": true, "description": "Filter to one session."},
                         "timeout_ms": {"type": "integer", "description": "Max wait in ms (default 30000)."}
                     }
                 }
@@ -591,8 +591,10 @@ impl HermesMcpServe {
                     .get("name")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| McpError::InvalidParams("missing tool name".into()))?;
-                let arguments = coerce_mcp_tool_arguments(
+                let schema = self.input_schema_for_tool(tool_name);
+                let arguments = coerce_mcp_tool_arguments_for_schema(
                     params.get("arguments").cloned().unwrap_or(json!({})),
+                    schema.as_ref(),
                 );
                 let result = self.handle_tool_call(tool_name, arguments).await?;
                 Ok(json!({
@@ -603,6 +605,13 @@ impl HermesMcpServe {
             "ping" => Ok(json!({})),
             _ => Err(McpError::MethodNotFound(method.to_string())),
         }
+    }
+
+    fn input_schema_for_tool(&self, tool_name: &str) -> Option<Value> {
+        self.tool_definitions()
+            .into_iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some(tool_name))
+            .and_then(|tool| tool.get("inputSchema").cloned())
     }
 }
 
@@ -767,5 +776,32 @@ mod tests {
         let (events, _) = serve.event_bridge.poll(0, Some("s1"), 10);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data["content"], "hello");
+    }
+
+    #[tokio::test]
+    async fn test_tools_call_coerces_nullable_session_filter() {
+        let store = Arc::new(InMemorySessionStore::new());
+        let serve = HermesMcpServe::new(store);
+        serve.event_bridge.push("message", "s1", HashMap::new());
+
+        let result = serve
+            .handle_request(
+                "tools/call",
+                json!({
+                    "name": "events_poll",
+                    "arguments": {
+                        "after_cursor": "0",
+                        "limit": "1",
+                        "session_key": "null"
+                    }
+                }),
+            )
+            .await
+            .expect("events_poll with nullable session_key");
+
+        assert!(!result["isError"].as_bool().unwrap_or(true));
+        let text = result["content"][0]["text"].as_str().unwrap_or("");
+        let payload: Value = serde_json::from_str(text).expect("tool result json");
+        assert_eq!(payload["events"].as_array().unwrap().len(), 1);
     }
 }

--- a/crates/hermes-mcp/src/server.rs
+++ b/crates/hermes-mcp/src/server.rs
@@ -18,7 +18,7 @@ use hermes_tools::ToolRegistry;
 
 use crate::client::ResourceInfo;
 use crate::transport::McpTransport;
-use crate::{coerce_mcp_tool_arguments, McpError};
+use crate::{coerce_mcp_tool_arguments_for_schema, McpError};
 
 // ---------------------------------------------------------------------------
 // MCP tool format (for exposing to clients)
@@ -233,7 +233,8 @@ impl McpServer {
             .get("arguments")
             .cloned()
             .unwrap_or(Value::Object(serde_json::Map::new()));
-        let arguments = coerce_mcp_tool_arguments(arguments);
+        let schema = self.tool_schema_for_name(tool_name);
+        let arguments = coerce_mcp_tool_arguments_for_schema(arguments, schema.as_ref());
 
         debug!("MCP tools/call: {} with args: {}", tool_name, arguments);
 
@@ -255,6 +256,14 @@ impl McpServer {
             "content": content,
             "isError": is_error,
         }))
+    }
+
+    fn tool_schema_for_name(&self, tool_name: &str) -> Option<Value> {
+        self.tool_registry
+            .get_definitions()
+            .into_iter()
+            .find(|schema| schema.name == tool_name)
+            .and_then(|schema| serde_json::to_value(schema.parameters).ok())
     }
 
     /// Handle resources/list request.
@@ -474,9 +483,9 @@ impl McpServer {
 mod tests {
     use super::{McpCapabilityPolicy, McpPromptInfo, McpServer};
     use crate::client::ResourceInfo;
-    use crate::coerce_mcp_tool_arguments;
+    use crate::coerce_mcp_tool_arguments_for_schema;
     use async_trait::async_trait;
-    use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+    use hermes_core::{tool_schema, ToolError, ToolHandler, ToolSchema};
     use hermes_tools::ToolRegistry;
     use serde_json::{json, Value};
     use std::sync::Arc;
@@ -500,7 +509,37 @@ mod tests {
         }
 
         fn schema(&self) -> ToolSchema {
-            tool_schema("echo_args", "Echo args", JsonSchema::new("object"))
+            tool_schema(
+                "echo_args",
+                "Echo args",
+                serde_json::from_value(json!({
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "ids": {"type": "array", "items": {"type": "string"}},
+                        "label": {"type": "string"},
+                        "limit": {"type": "integer"},
+                        "payload": {"type": "object", "additionalProperties": true},
+                        "setting": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "nullable": true,
+                            "default": null
+                        },
+                        "stages": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "nullable": true,
+                            "default": null
+                        },
+                        "workdir": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "default": null
+                        }
+                    }
+                }))
+                .expect("test schema"),
+            )
         }
     }
 
@@ -525,19 +564,22 @@ mod tests {
     #[test]
     fn stringified_mcp_arguments_coerce_only_objects_and_arrays() {
         assert_eq!(
-            coerce_mcp_tool_arguments(Value::String(r#"{"path":"Cargo.toml"}"#.to_string())),
+            coerce_mcp_tool_arguments_for_schema(
+                Value::String(r#"{"path":"Cargo.toml"}"#.to_string()),
+                None
+            ),
             json!({"path":"Cargo.toml"})
         );
         assert_eq!(
-            coerce_mcp_tool_arguments(Value::String(r#"[{"x":1}]"#.to_string())),
+            coerce_mcp_tool_arguments_for_schema(Value::String(r#"[{"x":1}]"#.to_string()), None),
             json!([{"x":1}])
         );
         assert_eq!(
-            coerce_mcp_tool_arguments(Value::String(r#""plain""#.to_string())),
+            coerce_mcp_tool_arguments_for_schema(Value::String(r#""plain""#.to_string()), None),
             Value::String(r#""plain""#.to_string())
         );
         assert_eq!(
-            coerce_mcp_tool_arguments(Value::String("not json".to_string())),
+            coerce_mcp_tool_arguments_for_schema(Value::String("not json".to_string()), None),
             Value::String("not json".to_string())
         );
     }
@@ -560,6 +602,46 @@ mod tests {
         let payload: Value = serde_json::from_str(text).expect("tool json");
         assert_eq!(payload["kind"], "object");
         assert_eq!(payload["params"], json!({"path":"Cargo.toml"}));
+    }
+
+    #[tokio::test]
+    async fn tools_call_coerces_schema_typed_string_arguments_before_dispatch() {
+        let server = McpServer::new(registry_with_echo_args());
+        let result = server
+            .handle_request(
+                "tools/call",
+                json!({
+                    "name": "echo_args",
+                    "arguments": {
+                        "enabled": "false",
+                        "ids": "[\"a\", \"b\"]",
+                        "label": "null",
+                        "limit": "1e2",
+                        "payload": "{\"max\":50}",
+                        "setting": "null",
+                        "stages": "null",
+                        "workdir": "null"
+                    }
+                }),
+            )
+            .await
+            .expect("tools/call");
+
+        let text = result["content"][0]["text"].as_str().expect("text");
+        let payload: Value = serde_json::from_str(text).expect("tool json");
+        assert_eq!(
+            payload["params"],
+            json!({
+                "enabled": false,
+                "ids": ["a", "b"],
+                "label": "null",
+                "limit": 100,
+                "payload": {"max": 50},
+                "setting": null,
+                "stages": null,
+                "workdir": null
+            })
+        );
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1275,6 +1275,10 @@
     "27936ee02dfc": {
       "disposition": "superseded",
       "notes": "Python TUI queued-title retry over auto-title DB state is superseded by Rust gateway user title storage on Session.title, which is not delayed behind DB materialization."
+    },
+    "aa948832886a": {
+      "disposition": "ported",
+      "notes": "Rust MCP tools/call now applies schema-aware string argument coercion before dispatch: nullable object/array/type-union fields convert literal \"null\" to JSON null only when the inputSchema permits null, while integer, boolean, object, and array string values are coerced according to the exposed schema. Both generic McpServer and hermes mcp serve paths have focused runtime regression coverage."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add schema-aware MCP tools/call argument coercion before dispatch
- convert literal "null" to JSON null only when the inputSchema permits null via nullable/type/anyOf/oneOf
- preserve existing whole-argument stringified object/array coercion and extend typed string coercion for integer, boolean, object, and array values
- apply the path to both generic McpServer and hermes mcp serve, with focused runtime regressions
- mark upstream aa948832886a as ported in the parity queue overrides

## Verification
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-mcp -- --nocapture
- scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-mcp-nullable.json --out-md /tmp/hermes-parity-mcp-nullable.md --overrides docs/parity/queue-overrides.json
- jq empty docs/parity/queue-overrides.json
- git diff --check
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build -p hermes-mcp
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-mcp

## Queue Delta
- before: pending=1882, ported=143, mirrored=162, superseded=7671
- after: pending=1881, ported=144, mirrored=162, superseded=7671

## Disk Routing
- /tmp/hermes-agent-ultra-parity-next/target: 0B
- /private/tmp/hermes-agent-ultra-target-delegation: 0B
- /Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation: 15G