### PR TITLE
parity(mcp): resolve live toolset aliases

### DIFF
--- a/crates/hermes-cli/src/platform_toolsets.rs
+++ b/crates/hermes-cli/src/platform_toolsets.rs
@@ -450,4 +450,33 @@ mod tests {
         let names = resolve_platform_tool_names(&cfg, "cli", &reg);
         assert!(names.contains(&"CustomTool".to_string()));
     }
+
+    #[test]
+    fn platform_toolsets_resolve_live_mcp_server_aliases() {
+        let mut cfg = GatewayConfig::default();
+        cfg.platform_toolsets
+            .insert("cli".to_string(), vec!["dynserver".to_string()]);
+        let reg = registry_with_minimal_tools();
+        let schema = tool_schema(
+            "mcp_dynserver_ping",
+            "MCP server ping",
+            JsonSchema::new("object"),
+        );
+        reg.register(
+            "mcp_dynserver_ping",
+            "mcp-dynserver",
+            schema.clone(),
+            Arc::new(NoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "MCP server ping",
+            "x",
+            None,
+        );
+        reg.register_toolset_alias("dynserver", "mcp-dynserver");
+
+        let names = resolve_platform_tool_names(&cfg, "cli", &reg);
+        assert_eq!(names, vec!["mcp_dynserver_ping".to_string()]);
+    }
 }

--- a/crates/hermes-tools/src/registry.rs
+++ b/crates/hermes-tools/src/registry.rs
@@ -6,7 +6,7 @@
 //! - Per-tool result size limits and global default
 //! - Dispatch with error catching that always returns JSON
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -57,6 +57,9 @@ pub struct ToolEntry {
 pub struct ToolRegistryInner {
     /// Registered tools keyed by name.
     tools: HashMap<String, ToolEntry>,
+    /// Explicit aliases for dynamic toolset names, for example an MCP server
+    /// name (`dynserver`) pointing at its canonical toolset (`mcp-dynserver`).
+    toolset_aliases: HashMap<String, String>,
     /// Global default max result size in characters.
     pub global_max_result_size_chars: usize,
     /// Centralized policy engine for tool-call governance.
@@ -84,6 +87,7 @@ impl ToolRegistry {
         Self {
             inner: Arc::new(Mutex::new(ToolRegistryInner {
                 tools: HashMap::new(),
+                toolset_aliases: HashMap::new(),
                 global_max_result_size_chars: 50_000,
                 policy: ToolPolicyEngine::from_env(),
                 policy_counters: ToolPolicyCounters::default(),
@@ -100,6 +104,7 @@ impl ToolRegistry {
         Self {
             inner: Arc::new(Mutex::new(ToolRegistryInner {
                 tools: HashMap::new(),
+                toolset_aliases: HashMap::new(),
                 global_max_result_size_chars: max,
                 policy: ToolPolicyEngine::from_env(),
                 policy_counters: ToolPolicyCounters::default(),
@@ -206,7 +211,20 @@ impl ToolRegistry {
     /// Returns `true` if the tool was present and removed.
     pub fn deregister(&self, name: &str) -> bool {
         let mut inner = self.inner.lock().unwrap();
-        inner.tools.remove(name).is_some()
+        let Some(removed) = inner.tools.remove(name) else {
+            return false;
+        };
+        let target_toolset = removed.toolset;
+        if !inner
+            .tools
+            .values()
+            .any(|entry| entry.toolset == target_toolset)
+        {
+            inner
+                .toolset_aliases
+                .retain(|_, target| target != &target_toolset);
+        }
+        true
     }
 
     /// Get tool definitions for all tools whose `check_fn` returns true.
@@ -406,9 +424,51 @@ impl ToolRegistry {
     pub fn list_toolsets(&self) -> Vec<String> {
         let inner = self.inner.lock().unwrap();
         let mut sets: Vec<String> = inner.tools.values().map(|e| e.toolset.clone()).collect();
+        sets.extend(inner.toolset_aliases.keys().cloned());
         sets.sort();
         sets.dedup();
         sets
+    }
+
+    /// Register an explicit alias from a user-facing toolset token to its
+    /// canonical live-registry toolset.
+    pub fn register_toolset_alias(&self, alias: impl Into<String>, target: impl Into<String>) {
+        let alias = alias.into().trim().to_string();
+        let target = target.into().trim().to_string();
+        if alias.is_empty() || target.is_empty() {
+            return;
+        }
+        let mut inner = self.inner.lock().unwrap();
+        inner.toolset_aliases.insert(alias, target);
+    }
+
+    /// Return the canonical target for a registered toolset alias.
+    pub fn get_toolset_alias_target(&self, alias: &str) -> Option<String> {
+        let inner = self.inner.lock().unwrap();
+        inner.toolset_aliases.get(alias).cloned()
+    }
+
+    /// Check whether the registry owns this live toolset or alias.
+    pub fn has_toolset(&self, toolset: &str) -> bool {
+        let inner = self.inner.lock().unwrap();
+        let resolved = resolve_toolset_alias_locked(&inner, toolset);
+        inner.tools.values().any(|entry| entry.toolset == resolved)
+            || inner.toolset_aliases.contains_key(toolset)
+    }
+
+    /// Return tool names belonging to a live registry-owned toolset or alias.
+    pub fn tool_names_for_toolset(&self, toolset: &str, available_only: bool) -> Vec<String> {
+        let inner = self.inner.lock().unwrap();
+        let resolved = resolve_toolset_alias_locked(&inner, toolset);
+        let mut names: Vec<String> = inner
+            .tools
+            .values()
+            .filter(|entry| entry.toolset == resolved)
+            .filter(|entry| !available_only || (entry.check_fn)())
+            .map(|entry| entry.name.clone())
+            .collect();
+        names.sort();
+        names
     }
 
     /// Check whether a tool is available (exists and check_fn passes).
@@ -534,6 +594,20 @@ fn maybe_annotate_audit(output: String, decision: &ToolPolicyDecision) -> String
     } else {
         output
     }
+}
+
+fn resolve_toolset_alias_locked(inner: &ToolRegistryInner, name: &str) -> String {
+    let mut current = name.to_string();
+    let mut seen = HashSet::new();
+    while seen.insert(current.clone()) {
+        let Some(next) = inner.toolset_aliases.get(&current) else {
+            return current;
+        };
+        current = next.clone();
+    }
+    // Alias cycles are invalid configuration; fall back to the last distinct
+    // name so resolution stays deterministic instead of looping forever.
+    current
 }
 
 fn looks_like_json(data: &str) -> bool {
@@ -679,6 +753,73 @@ mod tests {
         assert!(registry.deregister("echo"));
         assert!(!registry.deregister("echo"));
         assert!(registry.get_definitions().is_empty());
+    }
+
+    #[test]
+    fn toolset_alias_resolves_live_registry_tools() {
+        let registry = ToolRegistry::new();
+        let schema = tool_schema("mcp_dynserver_ping", "MCP ping", JsonSchema::new("object"));
+        registry.register(
+            "mcp_dynserver_ping",
+            "mcp-dynserver",
+            schema,
+            Arc::new(EchoHandler),
+            Arc::new(|| true),
+            vec![],
+            false,
+            "MCP ping",
+            "x",
+            None,
+        );
+        registry.register_toolset_alias("dynserver", "mcp-dynserver");
+
+        assert_eq!(
+            registry.get_toolset_alias_target("dynserver").as_deref(),
+            Some("mcp-dynserver")
+        );
+        assert!(registry.has_toolset("dynserver"));
+        assert_eq!(
+            registry.tool_names_for_toolset("dynserver", true),
+            vec!["mcp_dynserver_ping".to_string()]
+        );
+        let toolsets = registry.list_toolsets();
+        assert!(toolsets.contains(&"dynserver".to_string()));
+        assert!(toolsets.contains(&"mcp-dynserver".to_string()));
+    }
+
+    #[test]
+    fn toolset_alias_cleanup_waits_for_last_target_tool() {
+        let registry = ToolRegistry::new();
+        for tool_name in ["mcp_dynserver_ping", "mcp_dynserver_status"] {
+            let schema = tool_schema(tool_name, "MCP tool", JsonSchema::new("object"));
+            registry.register(
+                tool_name,
+                "mcp-dynserver",
+                schema,
+                Arc::new(EchoHandler),
+                Arc::new(|| true),
+                vec![],
+                false,
+                "MCP tool",
+                "x",
+                None,
+            );
+        }
+        registry.register_toolset_alias("dynserver", "mcp-dynserver");
+
+        assert!(registry.deregister("mcp_dynserver_ping"));
+        assert_eq!(
+            registry.get_toolset_alias_target("dynserver").as_deref(),
+            Some("mcp-dynserver")
+        );
+        assert_eq!(
+            registry.tool_names_for_toolset("dynserver", true),
+            vec!["mcp_dynserver_status".to_string()]
+        );
+
+        assert!(registry.deregister("mcp_dynserver_status"));
+        assert_eq!(registry.get_toolset_alias_target("dynserver"), None);
+        assert!(!registry.has_toolset("dynserver"));
     }
 
     #[test]

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -406,11 +406,11 @@ impl ToolsetManager {
         // Handle "all" or "*" wildcard
         if name == "all" || name == "*" {
             let mut all_tools = HashSet::new();
-            for ts_name in self.toolsets.keys() {
+            for ts_name in self.list_toolsets() {
                 // Each sub-toolset gets its own visited set to avoid
                 // false cycle detection across independent branches.
                 let mut sub_visited = HashSet::new();
-                let tools = self.resolve_inner(ts_name, &mut sub_visited)?;
+                let tools = self.resolve_inner(&ts_name, &mut sub_visited)?;
                 all_tools.extend(tools);
             }
             let mut result: Vec<String> = all_tools.into_iter().collect();
@@ -424,10 +424,12 @@ impl ToolsetManager {
         }
         visited.insert(name.to_string());
 
-        let toolset = self
-            .toolsets
-            .get(name)
-            .ok_or_else(|| ToolsetError::NotFound(name.to_string()))?;
+        let Some(toolset) = self.toolsets.get(name) else {
+            if self.registry.has_toolset(name) {
+                return Ok(self.registry.tool_names_for_toolset(name, true));
+            }
+            return Err(ToolsetError::NotFound(name.to_string()));
+        };
 
         let mut resolved = HashSet::new();
 
@@ -468,11 +470,11 @@ impl ToolsetManager {
     ) -> Result<Vec<String>, ToolsetError> {
         if name == "all" || name == "*" {
             let mut all_tools = HashSet::new();
-            for ts_name in self.toolsets.keys() {
+            for ts_name in self.list_toolsets() {
                 // Each sub-toolset gets its own visited set to avoid
                 // false cycle detection across independent branches.
                 let mut sub_visited = HashSet::new();
-                let tools = self.resolve_inner_unfiltered(ts_name, &mut sub_visited)?;
+                let tools = self.resolve_inner_unfiltered(&ts_name, &mut sub_visited)?;
                 all_tools.extend(tools);
             }
             let mut result: Vec<String> = all_tools.into_iter().collect();
@@ -485,10 +487,12 @@ impl ToolsetManager {
         }
         visited.insert(name.to_string());
 
-        let toolset = self
-            .toolsets
-            .get(name)
-            .ok_or_else(|| ToolsetError::NotFound(name.to_string()))?;
+        let Some(toolset) = self.toolsets.get(name) else {
+            if self.registry.has_toolset(name) {
+                return Ok(self.registry.tool_names_for_toolset(name, false));
+            }
+            return Err(ToolsetError::NotFound(name.to_string()));
+        };
 
         let mut resolved = HashSet::new();
         for tool in &toolset.tools {
@@ -514,7 +518,9 @@ impl ToolsetManager {
     /// Get the list of all registered toolset names.
     pub fn list_toolsets(&self) -> Vec<String> {
         let mut names: Vec<String> = self.toolsets.keys().cloned().collect();
+        names.extend(self.registry.list_toolsets());
         names.sort();
+        names.dedup();
         names
     }
 
@@ -540,10 +546,49 @@ pub enum ToolsetError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+    use serde_json::Value;
     use std::sync::Arc;
+
+    struct NoopHandler {
+        schema: ToolSchema,
+    }
+
+    #[async_trait]
+    impl ToolHandler for NoopHandler {
+        async fn execute(&self, _params: Value) -> Result<String, ToolError> {
+            Ok("ok".to_string())
+        }
+
+        fn schema(&self) -> ToolSchema {
+            self.schema.clone()
+        }
+    }
 
     fn empty_registry() -> Arc<ToolRegistry> {
         Arc::new(ToolRegistry::new())
+    }
+
+    fn register_live_tool(
+        registry: &Arc<ToolRegistry>,
+        name: &str,
+        toolset: &str,
+        available: bool,
+    ) {
+        let schema = tool_schema(name, "live tool", JsonSchema::new("object"));
+        registry.register(
+            name,
+            toolset,
+            schema.clone(),
+            Arc::new(NoopHandler { schema }),
+            Arc::new(move || available),
+            vec![],
+            false,
+            "live tool",
+            "x",
+            None,
+        );
     }
 
     #[test]
@@ -607,6 +652,51 @@ mod tests {
         );
         let tools = manager.resolve_toolset_unfiltered("my_custom").unwrap();
         assert_eq!(tools.len(), 2);
+    }
+
+    #[test]
+    fn resolves_live_registry_owned_toolset_without_static_registration() {
+        let registry = empty_registry();
+        register_live_tool(&registry, "mcp_dynserver_ping", "mcp-dynserver", true);
+        let manager = ToolsetManager::new(Arc::clone(&registry));
+
+        assert_eq!(
+            manager.resolve_toolset("mcp-dynserver").unwrap(),
+            vec!["mcp_dynserver_ping".to_string()]
+        );
+        assert_eq!(
+            manager.resolve_toolset_unfiltered("mcp-dynserver").unwrap(),
+            vec!["mcp_dynserver_ping".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolves_live_registry_toolset_aliases() {
+        let registry = empty_registry();
+        register_live_tool(&registry, "mcp_dynserver_ping", "mcp-dynserver", true);
+        registry.register_toolset_alias("dynserver", "mcp-dynserver");
+        let manager = ToolsetManager::new(Arc::clone(&registry));
+
+        assert_eq!(
+            manager.resolve_toolset("dynserver").unwrap(),
+            vec!["mcp_dynserver_ping".to_string()]
+        );
+        let names = manager.list_toolsets();
+        assert!(names.contains(&"dynserver".to_string()));
+        assert!(names.contains(&"mcp-dynserver".to_string()));
+    }
+
+    #[test]
+    fn live_registry_toolset_availability_filter_returns_empty_not_missing() {
+        let registry = empty_registry();
+        register_live_tool(&registry, "mcp_dynserver_ping", "mcp-dynserver", false);
+        let manager = ToolsetManager::new(Arc::clone(&registry));
+
+        assert_eq!(manager.resolve_toolset("mcp-dynserver").unwrap().len(), 0);
+        assert_eq!(
+            manager.resolve_toolset_unfiltered("mcp-dynserver").unwrap(),
+            vec!["mcp_dynserver_ping".to_string()]
+        );
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1279,6 +1279,14 @@
     "aa948832886a": {
       "disposition": "ported",
       "notes": "Rust MCP tools/call now applies schema-aware string argument coercion before dispatch: nullable object/array/type-union fields convert literal \"null\" to JSON null only when the inputSchema permits null, while integer, boolean, object, and array string values are coerced according to the exposed schema. Both generic McpServer and hermes mcp serve paths have focused runtime regression coverage."
+    },
+    "cda64a59612f": {
+      "disposition": "ported",
+      "notes": "Rust ToolsetManager now resolves otherwise-unknown live registry-owned toolsets, including MCP-style dynamic toolsets, through ToolRegistry instead of requiring static toolset registration. Wildcard/list discovery includes live registry toolsets and focused hermes-tools tests cover filtered and unfiltered resolution."
+    },
+    "c10fea8d264e": {
+      "disposition": "ported",
+      "notes": "Rust ToolRegistry now supports explicit live toolset aliases such as server-name to mcp-server-name mappings, exposes alias targets for inspection, removes aliases only when the target toolset loses its last tool, and platform toolset filtering resolves configured MCP server aliases with hermes-tools and hermes-cli regression coverage."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add ToolRegistry-owned live toolset alias support with target lookup and stale-alias cleanup
- make ToolsetManager resolve live registry-owned toolsets and aliases without static toolset registration
- cover platform toolset config resolving an explicit MCP server alias
- mark upstream rows cda64a59612f and c10fea8d264e as ported

## Verification
- `cargo test -p hermes-tools toolset -- --nocapture`
- `cargo test -p hermes-cli platform_toolsets -- --nocapture`
- `cargo test -p hermes-cli platform_toolsets_resolve_live_mcp_server_aliases -- --nocapture`
- `jq empty docs/parity/queue-overrides.json`
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-mcp-live-toolsets.json --out-md /tmp/hermes-parity-mcp-live-toolsets.md --overrides docs/parity/queue-overrides.json` -> `pending=1879`, `ported=146`
- `cargo build -p hermes-tools -p hermes-cli`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools -p hermes-cli` -> `new=0`

## Disk routing
- all cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
- local `target` remained `0B`
