### PR TITLE
parity(acp): register client MCP tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,8 @@ dependencies = [
  "hermes-config",
  "hermes-core",
  "hermes-intelligence",
+ "hermes-mcp",
+ "hermes-tools",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/hermes-acp/Cargo.toml
+++ b/crates/hermes-acp/Cargo.toml
@@ -10,6 +10,8 @@ description = "Agent Communication Protocol adapter for Hermes Agent"
 hermes-core = { workspace = true }
 hermes-config = { workspace = true }
 hermes-intelligence = { workspace = true }
+hermes-mcp = { workspace = true }
+hermes-tools = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -12,7 +12,13 @@ use base64::Engine as _;
 use hermes_intelligence::model_metadata::{
     estimate_request_tokens_rough, get_model_context_length,
 };
+use hermes_mcp::{
+    sanitize_mcp_name_component, BearerTokenAuth, McpManager,
+    McpServerConfig as HermesMcpServerConfig,
+};
+use hermes_tools::ToolRegistry;
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 use url::Url;
 
 use crate::auth::{
@@ -653,6 +659,109 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
     },
 ];
 
+fn acp_mcp_servers_from_params(p: Option<&serde_json::Map<String, Value>>) -> Vec<McpServerConfig> {
+    let Some(value) = p.and_then(|p| p.get("mcpServers").or_else(|| p.get("mcp_servers"))) else {
+        return Vec::new();
+    };
+    let Some(items) = value.as_array() else {
+        tracing::warn!("ACP mcp_servers parameter was not an array; ignoring");
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(
+            |item| match serde_json::from_value::<McpServerConfig>(item.clone()) {
+                Ok(server) => Some(server),
+                Err(err) => {
+                    tracing::warn!("Ignoring invalid ACP MCP server entry: {}", err);
+                    None
+                }
+            },
+        )
+        .collect()
+}
+
+fn bearer_token_from_headers(headers: &[EnvVar]) -> Option<String> {
+    headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case("authorization"))
+        .map(|header| header.value.trim())
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .strip_prefix("Bearer ")
+                .or_else(|| value.strip_prefix("bearer "))
+                .unwrap_or(value)
+                .trim()
+                .to_string()
+        })
+        .filter(|value| !value.is_empty())
+}
+
+fn acp_mcp_server_to_hermes_config(
+    server: &McpServerConfig,
+) -> Option<(String, HermesMcpServerConfig)> {
+    match server {
+        McpServerConfig::Stdio {
+            name,
+            command,
+            args,
+            env,
+        } => {
+            let name = sanitize_mcp_name_component(name.trim());
+            if name.is_empty() || command.trim().is_empty() {
+                return None;
+            }
+            let mut config = HermesMcpServerConfig::stdio(command.trim(), args.clone());
+            for item in env {
+                if !item.name.trim().is_empty() {
+                    config = config.with_env(item.name.trim(), item.value.clone());
+                }
+            }
+            Some((name, config))
+        }
+        McpServerConfig::Http { name, url, headers }
+        | McpServerConfig::Sse { name, url, headers } => {
+            let name = sanitize_mcp_name_component(name.trim());
+            if name.is_empty() || url.trim().is_empty() {
+                return None;
+            }
+            let mut config = HermesMcpServerConfig::http(url.trim());
+            if let Some(token) = bearer_token_from_headers(headers) {
+                config = config.with_auth(Arc::new(BearerTokenAuth::new(token)));
+            }
+            Some((name, config))
+        }
+    }
+}
+
+fn expand_acp_enabled_toolsets(
+    toolsets: impl IntoIterator<Item = String>,
+    mcp_server_names: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    let mut expanded = Vec::new();
+    for name in toolsets {
+        let name = name.trim();
+        if !name.is_empty() && !expanded.iter().any(|existing| existing == name) {
+            expanded.push(name.to_string());
+        }
+    }
+    if expanded.is_empty() {
+        expanded.push("hermes-acp".to_string());
+    }
+    for server_name in mcp_server_names {
+        let safe = sanitize_mcp_name_component(server_name.trim());
+        if safe.is_empty() {
+            continue;
+        }
+        let toolset_name = format!("mcp-{safe}");
+        if !expanded.iter().any(|existing| existing == &toolset_name) {
+            expanded.push(toolset_name);
+        }
+    }
+    expanded
+}
+
 // ---------------------------------------------------------------------------
 // HermesAcpHandler
 // ---------------------------------------------------------------------------
@@ -662,6 +771,8 @@ pub struct HermesAcpHandler {
     pub session_manager: Arc<SessionManager>,
     pub event_sink: Arc<EventSink>,
     pub permission_store: Arc<PermissionStore>,
+    tool_registry: Arc<ToolRegistry>,
+    mcp_manager: Arc<AsyncMutex<McpManager>>,
     version: String,
     prompt_executor: Option<Arc<dyn AcpPromptExecutor>>,
     auth_provider_resolver: Arc<dyn Fn() -> Option<String> + Send + Sync>,
@@ -673,10 +784,14 @@ impl HermesAcpHandler {
         event_sink: Arc<EventSink>,
         permission_store: Arc<PermissionStore>,
     ) -> Self {
+        let tool_registry = Arc::new(ToolRegistry::new());
+        let mcp_manager = Arc::new(AsyncMutex::new(McpManager::new(Arc::clone(&tool_registry))));
         Self {
             session_manager,
             event_sink,
             permission_store,
+            tool_registry,
+            mcp_manager,
             version: env!("CARGO_PKG_VERSION").to_string(),
             prompt_executor: None,
             auth_provider_resolver: Arc::new(detect_provider),
@@ -696,24 +811,73 @@ impl HermesAcpHandler {
         self
     }
 
-    fn available_tools(&self) -> Vec<(&'static str, &'static str)> {
-        vec![
-            ("bash", "Execute shell commands with approval controls"),
-            ("read", "Read files from the local workspace"),
-            ("write", "Write or create files in the local workspace"),
-            ("edit", "Patch files in-place"),
-            ("grep", "Search file contents"),
-            ("glob", "Find files by pattern"),
-            ("web_search", "Search the web"),
-            ("web_fetch", "Fetch and parse URLs"),
-            ("memory", "Read/write persistent memory notes"),
-            ("session_search", "Search prior session content"),
-            ("skills_list", "List installed skills"),
-            ("skill_view", "Inspect a specific skill"),
-            ("skill_manage", "Install/update/remove skills"),
-            ("todo", "Track task progress"),
-            ("cronjob", "Schedule recurring jobs"),
-        ]
+    pub fn with_mcp_components(
+        mut self,
+        tool_registry: Arc<ToolRegistry>,
+        mcp_manager: Arc<AsyncMutex<McpManager>>,
+    ) -> Self {
+        self.tool_registry = tool_registry;
+        self.mcp_manager = mcp_manager;
+        self
+    }
+
+    pub fn tool_registry(&self) -> &Arc<ToolRegistry> {
+        &self.tool_registry
+    }
+
+    fn available_tools(&self) -> Vec<(String, String)> {
+        let mut tools = vec![
+            (
+                "bash".to_string(),
+                "Execute shell commands with approval controls".to_string(),
+            ),
+            (
+                "read".to_string(),
+                "Read files from the local workspace".to_string(),
+            ),
+            (
+                "write".to_string(),
+                "Write or create files in the local workspace".to_string(),
+            ),
+            ("edit".to_string(), "Patch files in-place".to_string()),
+            ("grep".to_string(), "Search file contents".to_string()),
+            ("glob".to_string(), "Find files by pattern".to_string()),
+            ("web_search".to_string(), "Search the web".to_string()),
+            ("web_fetch".to_string(), "Fetch and parse URLs".to_string()),
+            (
+                "memory".to_string(),
+                "Read/write persistent memory notes".to_string(),
+            ),
+            (
+                "session_search".to_string(),
+                "Search prior session content".to_string(),
+            ),
+            (
+                "skills_list".to_string(),
+                "List installed skills".to_string(),
+            ),
+            (
+                "skill_view".to_string(),
+                "Inspect a specific skill".to_string(),
+            ),
+            (
+                "skill_manage".to_string(),
+                "Install/update/remove skills".to_string(),
+            ),
+            ("todo".to_string(), "Track task progress".to_string()),
+            ("cronjob".to_string(), "Schedule recurring jobs".to_string()),
+        ];
+        for entry in self
+            .tool_registry
+            .list_tools()
+            .into_iter()
+            .filter(|entry| entry.toolset.starts_with("mcp-"))
+        {
+            tools.push((entry.name, entry.description));
+        }
+        tools.sort_by(|a, b| a.0.cmp(&b.0));
+        tools.dedup_by(|a, b| a.0 == b.0);
+        tools
     }
 
     fn available_commands() -> Vec<AvailableCommand> {
@@ -732,6 +896,52 @@ impl HermesAcpHandler {
             session_id,
             Self::available_commands(),
         ));
+    }
+
+    async fn register_session_mcp_servers(
+        &self,
+        state: &SessionState,
+        servers: Vec<McpServerConfig>,
+    ) {
+        if servers.is_empty() {
+            return;
+        }
+        let configs: Vec<(String, HermesMcpServerConfig)> = servers
+            .iter()
+            .filter_map(acp_mcp_server_to_hermes_config)
+            .collect();
+        if configs.is_empty() {
+            return;
+        }
+        let enabled_toolsets = expand_acp_enabled_toolsets(
+            vec!["hermes-acp".to_string()],
+            configs.iter().map(|(name, _)| name.clone()),
+        );
+        tracing::debug!(
+            "ACP session {} enabling toolsets after MCP registration: {:?}",
+            state.session_id,
+            enabled_toolsets
+        );
+        let reports = {
+            let mut manager = self.mcp_manager.lock().await;
+            manager.connect_all_parallel(configs).await
+        };
+        let connected = reports.iter().filter(|report| report.connected).count();
+        let failed = reports.len().saturating_sub(connected);
+        if failed > 0 {
+            tracing::warn!(
+                "ACP session {} registered {} MCP server(s), {} failed",
+                state.session_id,
+                connected,
+                failed
+            );
+        } else {
+            tracing::info!(
+                "ACP session {} registered {} MCP server(s)",
+                state.session_id,
+                connected
+            );
+        }
     }
 
     fn context_usage_for_state(state: &SessionState) -> Option<(u64, u64)> {
@@ -1462,6 +1672,12 @@ impl AcpHandler for HermesAcpHandler {
                             list: true,
                             resume: true,
                         }),
+                        tools: Some(
+                            self.available_tools()
+                                .into_iter()
+                                .map(|(name, _)| name)
+                                .collect(),
+                        ),
                         streaming: true,
                         ..Default::default()
                     },
@@ -1495,11 +1711,13 @@ impl AcpHandler for HermesAcpHandler {
             AcpMethod::NewSession => {
                 let p = params_obj(&request.params);
                 let cwd = p.and_then(|p| param_str(p, "cwd")).unwrap_or(".");
+                let mcp_servers = acp_mcp_servers_from_params(p);
                 let meta = match p.map(session_meta_from_params).transpose() {
                     Ok(meta) => meta.unwrap_or_default(),
                     Err(err) => return AcpResponse::error(request.id, -32602, err),
                 };
                 let state = self.session_manager.create_session_with_meta(cwd, meta);
+                self.register_session_mcp_servers(&state, mcp_servers).await;
                 self.advertise_available_commands(&state.session_id);
                 self.emit_usage_update(&state.session_id);
                 AcpResponse::success(request.id, session_id_response(&state.session_id))
@@ -1511,6 +1729,7 @@ impl AcpHandler for HermesAcpHandler {
                 };
                 let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
+                let mcp_servers = acp_mcp_servers_from_params(Some(p));
                 let mut meta = match session_meta_from_params(p) {
                     Ok(meta) => meta,
                     Err(err) => return AcpResponse::error(request.id, -32602, err),
@@ -1519,6 +1738,7 @@ impl AcpHandler for HermesAcpHandler {
 
                 match self.session_manager.update_session_meta(session_id, meta) {
                     Some(state) => {
+                        self.register_session_mcp_servers(&state, mcp_servers).await;
                         self.replay_session_history(&state);
                         self.advertise_available_commands(session_id);
                         self.emit_usage_update(session_id);
@@ -1538,6 +1758,7 @@ impl AcpHandler for HermesAcpHandler {
                 };
                 let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
+                let mcp_servers = acp_mcp_servers_from_params(Some(p));
                 let mut meta = match session_meta_from_params(p) {
                     Ok(meta) => meta,
                     Err(err) => return AcpResponse::error(request.id, -32602, err),
@@ -1545,6 +1766,7 @@ impl AcpHandler for HermesAcpHandler {
                 meta.cwd = Some(cwd.to_string());
 
                 if let Some(state) = self.session_manager.update_session_meta(session_id, meta) {
+                    self.register_session_mcp_servers(&state, mcp_servers).await;
                     self.replay_session_history(&state);
                     self.advertise_available_commands(&state.session_id);
                     self.emit_usage_update(&state.session_id);
@@ -1555,6 +1777,7 @@ impl AcpHandler for HermesAcpHandler {
                         Err(err) => return AcpResponse::error(request.id, -32602, err),
                     };
                     let state = self.session_manager.create_session_with_meta(cwd, meta);
+                    self.register_session_mcp_servers(&state, mcp_servers).await;
                     self.advertise_available_commands(&state.session_id);
                     self.emit_usage_update(&state.session_id);
                     AcpResponse::success(request.id, session_id_response(&state.session_id))
@@ -1567,6 +1790,7 @@ impl AcpHandler for HermesAcpHandler {
                 };
                 let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
                 let cwd = param_str(p, "cwd").unwrap_or(".");
+                let mcp_servers = acp_mcp_servers_from_params(Some(p));
                 let meta = match session_meta_from_params(p) {
                     Ok(meta) => meta,
                     Err(err) => return AcpResponse::error(request.id, -32602, err),
@@ -1577,6 +1801,8 @@ impl AcpHandler for HermesAcpHandler {
                     .fork_session_with_meta(session_id, cwd, meta)
                 {
                     Some(new_state) => {
+                        self.register_session_mcp_servers(&new_state, mcp_servers)
+                            .await;
                         self.advertise_available_commands(&new_state.session_id);
                         self.emit_usage_update(&new_state.session_id);
                         AcpResponse::success(request.id, session_id_response(&new_state.session_id))
@@ -2044,6 +2270,7 @@ mod tests {
     use super::*;
     use crate::events::AcpEventKind;
     use crate::session::SessionMetaUpdate;
+    use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
     use serde_json::json;
 
     struct EchoPromptExecutor;
@@ -2068,6 +2295,21 @@ mod tests {
                 total_turns: Some(2),
                 events: Vec::new(),
             })
+        }
+    }
+
+    struct NoopTool {
+        schema: ToolSchema,
+    }
+
+    #[async_trait::async_trait]
+    impl ToolHandler for NoopTool {
+        async fn execute(&self, _params: Value) -> Result<String, ToolError> {
+            Ok("ok".to_string())
+        }
+
+        fn schema(&self) -> ToolSchema {
+            self.schema.clone()
         }
     }
 
@@ -2206,6 +2448,105 @@ mod tests {
 
     fn make_handler_with_auth_provider(provider: Option<&'static str>) -> HermesAcpHandler {
         make_handler().with_auth_provider_resolver(Arc::new(move || provider.map(str::to_string)))
+    }
+
+    #[tokio::test]
+    async fn acp_mcp_server_params_convert_to_hermes_configs() {
+        let params = json!({
+            "mcpServers": [
+                {
+                    "type": "stdio",
+                    "name": "bad/name",
+                    "command": "/bin/mcp",
+                    "args": ["--serve"],
+                    "env": [{"name": "MCP_KEY", "value": "v"}]
+                },
+                {
+                    "type": "http",
+                    "name": "remote.server",
+                    "url": "https://example.test/mcp",
+                    "headers": [{"name": "Authorization", "value": "Bearer test-token"}]
+                }
+            ]
+        });
+        let servers = acp_mcp_servers_from_params(params.as_object());
+        assert_eq!(servers.len(), 2);
+
+        let (stdio_name, stdio_config) =
+            acp_mcp_server_to_hermes_config(&servers[0]).expect("stdio config");
+        assert_eq!(stdio_name, "bad_name");
+        assert_eq!(stdio_config.command.as_deref(), Some("/bin/mcp"));
+        assert_eq!(stdio_config.args, vec!["--serve".to_string()]);
+        assert_eq!(
+            stdio_config.env.get("MCP_KEY").map(String::as_str),
+            Some("v")
+        );
+
+        let (http_name, http_config) =
+            acp_mcp_server_to_hermes_config(&servers[1]).expect("http config");
+        assert_eq!(http_name, "remote_server");
+        assert_eq!(http_config.url.as_deref(), Some("https://example.test/mcp"));
+        let token = http_config
+            .auth_provider
+            .as_ref()
+            .expect("bearer auth")
+            .get_token()
+            .await
+            .expect("token");
+        assert_eq!(token, "test-token");
+    }
+
+    #[test]
+    fn acp_enabled_toolsets_include_explicit_mcp_toolsets() {
+        let expanded = expand_acp_enabled_toolsets(
+            vec!["hermes-acp".to_string(), "hermes-acp".to_string()],
+            vec!["srv".to_string(), "remote.server".to_string()],
+        );
+        assert_eq!(
+            expanded,
+            vec![
+                "hermes-acp".to_string(),
+                "mcp-srv".to_string(),
+                "mcp-remote_server".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn tools_list_and_slash_tools_include_registered_mcp_tools() {
+        let handler = make_handler();
+        let schema = tool_schema("mcp_srv_ping", "MCP ping", JsonSchema::new("object"));
+        handler.tool_registry().register(
+            "mcp_srv_ping",
+            "mcp-srv",
+            schema.clone(),
+            Arc::new(NoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "MCP ping",
+            "mcp",
+            None,
+        );
+
+        let resp = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "tools.list".into(),
+                params: None,
+            })
+            .await;
+        let tools = resp.result.unwrap()["tools"].as_array().unwrap().clone();
+        assert!(tools
+            .iter()
+            .any(|tool| { tool["name"] == "mcp_srv_ping" && tool["description"] == "MCP ping" }));
+
+        let slash = handler
+            .handle_slash_command("/tools json", "session-id")
+            .expect("tools slash response");
+        assert!(slash.contains("mcp_srv_ping"));
+        assert!(slash.contains("MCP ping"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -26913,8 +26913,31 @@ fn acp_usage_from_agent_usage(usage: &hermes_core::UsageStats) -> hermes_acp::Us
 struct CliAcpPromptExecutor {
     config: Arc<hermes_config::GatewayConfig>,
     tool_registry: Arc<hermes_tools::ToolRegistry>,
-    tool_schemas: Vec<hermes_core::ToolSchema>,
     interrupts: Arc<Mutex<HashMap<String, hermes_agent::InterruptController>>>,
+}
+
+impl CliAcpPromptExecutor {
+    fn current_tool_schemas(&self) -> Vec<hermes_core::ToolSchema> {
+        let mut schemas = crate::platform_toolsets::resolve_platform_tool_schemas(
+            self.config.as_ref(),
+            "cli",
+            &self.tool_registry,
+        );
+        let mut seen: HashSet<String> = schemas.iter().map(|schema| schema.name.clone()).collect();
+        let mcp_tool_names: HashSet<String> = self
+            .tool_registry
+            .list_tools()
+            .into_iter()
+            .filter(|entry| entry.toolset.starts_with("mcp-"))
+            .map(|entry| entry.name)
+            .collect();
+        for schema in self.tool_registry.get_definitions() {
+            if mcp_tool_names.contains(&schema.name) && seen.insert(schema.name.clone()) {
+                schemas.push(schema);
+            }
+        }
+        schemas
+    }
 }
 
 fn acp_stream_callbacks(
@@ -26984,7 +27007,7 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
         );
         let messages = acp_history_to_messages(history, user_text);
 
-        let result = agent.run(messages, Some(self.tool_schemas.clone())).await;
+        let result = agent.run(messages, Some(self.current_tool_schemas())).await;
         if let Ok(mut active) = self.interrupts.lock() {
             active.remove(&session.session_id);
         }
@@ -27124,16 +27147,13 @@ pub async fn handle_cli_acp(
                 .map_err(|e| hermes_core::AgentError::Config(format!("cron load: {e}")))?;
             cron_scheduler.start().await;
             crate::runtime_tool_wiring::wire_cron_scheduler_backend(&tool_registry, cron_scheduler);
-            let tool_schemas = crate::platform_toolsets::resolve_platform_tool_schemas(
-                &config,
-                "cli",
-                &tool_registry,
-            );
+            let mcp_manager = Arc::new(tokio::sync::Mutex::new(hermes_mcp::McpManager::new(
+                tool_registry.clone(),
+            )));
 
             let prompt_executor = Arc::new(CliAcpPromptExecutor {
                 config: Arc::new(config.clone()),
-                tool_registry,
-                tool_schemas,
+                tool_registry: tool_registry.clone(),
                 interrupts: Arc::new(Mutex::new(HashMap::new())),
             });
 
@@ -27146,6 +27166,7 @@ pub async fn handle_cli_acp(
                     event_sink.clone(),
                     permission_store.clone(),
                 )
+                .with_mcp_components(tool_registry, mcp_manager)
                 .with_prompt_executor(prompt_executor),
             );
             let server = hermes_acp::AcpServer::with_components(
@@ -27738,7 +27759,6 @@ mod tests {
         let executor = CliAcpPromptExecutor {
             config: Arc::new(GatewayConfig::default()),
             tool_registry: Arc::new(hermes_tools::ToolRegistry::new()),
-            tool_schemas: Vec::new(),
             interrupts,
         };
         let session = hermes_acp::SessionState::new(session_id, ".".to_string());
@@ -27758,6 +27778,88 @@ mod tests {
         assert!(marker.contains("prefer the simpler fix"));
         assert!(marker.contains(hermes_agent::STEER_MARKER_CLOSE));
         assert!(!marker.contains("User guidance:"));
+    }
+
+    struct CliNoopTool {
+        schema: hermes_core::ToolSchema,
+    }
+
+    #[async_trait::async_trait]
+    impl hermes_core::ToolHandler for CliNoopTool {
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+        ) -> Result<String, hermes_core::ToolError> {
+            Ok("ok".to_string())
+        }
+
+        fn schema(&self) -> hermes_core::ToolSchema {
+            self.schema.clone()
+        }
+    }
+
+    #[test]
+    fn acp_prompt_executor_resolves_tool_schemas_from_current_registry() {
+        let mut config = GatewayConfig::default();
+        config
+            .platform_toolsets
+            .insert("cli".to_string(), vec!["file".to_string()]);
+        let tool_registry = Arc::new(hermes_tools::ToolRegistry::new());
+        let executor = CliAcpPromptExecutor {
+            config: Arc::new(config),
+            tool_registry: Arc::clone(&tool_registry),
+            interrupts: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let file_schema = hermes_core::tool_schema(
+            "read_file",
+            "Read file",
+            hermes_core::JsonSchema::new("object"),
+        );
+        tool_registry.register(
+            "read_file",
+            "file",
+            file_schema.clone(),
+            Arc::new(CliNoopTool {
+                schema: file_schema,
+            }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "Read file",
+            "file",
+            None,
+        );
+        assert!(executor
+            .current_tool_schemas()
+            .iter()
+            .any(|schema| schema.name == "read_file"));
+        assert!(!executor
+            .current_tool_schemas()
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_ping"));
+
+        let schema = hermes_core::tool_schema(
+            "mcp_srv_ping",
+            "MCP ping",
+            hermes_core::JsonSchema::new("object"),
+        );
+        tool_registry.register(
+            "mcp_srv_ping",
+            "mcp-srv",
+            schema.clone(),
+            Arc::new(CliNoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "MCP ping",
+            "mcp",
+            None,
+        );
+
+        assert!(executor
+            .current_tool_schemas()
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_ping"));
     }
 
     #[tokio::test]

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -5,19 +5,20 @@
 //! sends `notifications/tools/list_changed`, the client automatically
 //! rediscovers tools and updates the registry.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::Engine as _;
+use hermes_core::{JsonSchema, ToolError, ToolHandler, ToolSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
-use hermes_core::{JsonSchema, ToolSchema};
 use hermes_tools::ToolRegistry;
 
 use crate::auth::McpAuthProvider;
@@ -320,6 +321,35 @@ fn transport_type_for_config(config: &McpServerConfig) -> &'static str {
     } else {
         "unknown"
     }
+}
+
+/// Return an MCP server/tool name component safe for provider tool names.
+///
+/// This mirrors the Python adapter's rule: every character outside
+/// `[A-Za-z0-9_]` becomes `_`.
+pub fn sanitize_mcp_name_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn mcp_toolset_name(server_name: &str) -> String {
+    format!("mcp-{}", sanitize_mcp_name_component(server_name))
+}
+
+fn mcp_registered_tool_name(server_name: &str, tool_name: &str) -> String {
+    format!(
+        "mcp_{}_{}",
+        sanitize_mcp_name_component(server_name),
+        sanitize_mcp_name_component(tool_name)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1483,6 +1513,117 @@ impl McpClient {
     }
 }
 
+type SharedMcpClient = Arc<tokio::sync::Mutex<McpClient>>;
+
+struct RegisteredMcpToolHandler {
+    client: SharedMcpClient,
+    original_tool_name: String,
+    schema: ToolSchema,
+    available: Arc<AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl ToolHandler for RegisteredMcpToolHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        if !self.available.load(Ordering::SeqCst) {
+            return Err(ToolError::NotFound(self.schema.name.clone()));
+        }
+
+        let mut client = self.client.lock().await;
+        let result = client
+            .call_tool(&self.original_tool_name, params)
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!(
+                    "MCP tool '{}' failed: {}",
+                    self.original_tool_name, err
+                ))
+            })?;
+        Ok(match result {
+            Value::String(text) => text,
+            other => other.to_string(),
+        })
+    }
+
+    fn schema(&self) -> ToolSchema {
+        self.schema.clone()
+    }
+}
+
+struct ManagedMcpClient {
+    client: SharedMcpClient,
+    config: McpServerConfig,
+    transport_type: String,
+    cached_tools: Vec<ToolSchema>,
+    cached_resources: Vec<ResourceInfo>,
+    registered_tools: Vec<String>,
+    available: Arc<AtomicBool>,
+    connected_at: Instant,
+}
+
+fn register_mcp_tools_in_registry(
+    registry: &ToolRegistry,
+    server_name: &str,
+    client: SharedMcpClient,
+    tools: &[ToolSchema],
+    available: Arc<AtomicBool>,
+) -> Vec<String> {
+    let toolset_name = mcp_toolset_name(server_name);
+    let safe_server_name = sanitize_mcp_name_component(server_name);
+    registry.register_toolset_alias(server_name, &toolset_name);
+    if safe_server_name != server_name {
+        registry.register_toolset_alias(&safe_server_name, &toolset_name);
+    }
+
+    let mut seen = HashSet::new();
+    let mut registered = Vec::new();
+    for tool in tools {
+        let registered_name = mcp_registered_tool_name(server_name, &tool.name);
+        if !seen.insert(registered_name.clone()) {
+            warn!(
+                "Skipping duplicate sanitized MCP tool '{}' from server '{}'",
+                registered_name, server_name
+            );
+            continue;
+        }
+
+        let mut schema = tool.clone();
+        schema.name = registered_name.clone();
+        if schema.description.trim().is_empty() {
+            schema.description = format!("MCP tool '{}' from server '{}'", tool.name, server_name);
+        }
+        let handler = Arc::new(RegisteredMcpToolHandler {
+            client: Arc::clone(&client),
+            original_tool_name: tool.name.clone(),
+            schema: schema.clone(),
+            available: Arc::clone(&available),
+        });
+        registry.register(
+            &registered_name,
+            &toolset_name,
+            schema,
+            handler,
+            {
+                let available = Arc::clone(&available);
+                Arc::new(move || available.load(Ordering::SeqCst))
+            },
+            Vec::new(),
+            true,
+            format!("MCP tool '{}' from server '{}'", tool.name, server_name),
+            "mcp",
+            None,
+        );
+        registered.push(registered_name);
+    }
+    registered
+}
+
+fn deregister_mcp_tools(registry: &ToolRegistry, tool_names: Vec<String>) {
+    for tool_name in tool_names {
+        registry.deregister(&tool_name);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // McpManager — manages multiple McpClient instances
 // ---------------------------------------------------------------------------
@@ -1497,7 +1638,7 @@ impl McpClient {
 /// - Automatically update the tool registry when servers notify of changes
 pub struct McpManager {
     /// Active client connections keyed by server name.
-    clients: HashMap<String, McpClient>,
+    clients: HashMap<String, ManagedMcpClient>,
     /// Shared tool registry for discovered tools.
     tool_registry: Arc<ToolRegistry>,
     sampling_config: Option<SamplingConfig>,
@@ -1522,6 +1663,9 @@ impl McpManager {
     /// name (e.g. `"server_name__tool_name"`).
     pub async fn connect(&mut self, name: &str, config: McpServerConfig) -> Result<(), McpError> {
         info!("Connecting to MCP server: {}", name);
+        if self.clients.contains_key(name) {
+            self.disconnect(name).await?;
+        }
 
         let mut client = McpClient::new(config);
         if let Some(config) = self.sampling_config.clone() {
@@ -1535,12 +1679,74 @@ impl McpManager {
         let tools = client.cached_tools();
         debug!("Discovered {} tools from server '{}'", tools.len(), name);
 
-        for tool in tools {
-            let prefixed_name = format!("{}__{}", name, tool.name);
-            debug!("Registered MCP tool: {}", prefixed_name);
-        }
+        let cached_tools = tools.to_vec();
+        let cached_resources = client.cached_resources().to_vec();
+        let transport_type = transport_type_for_config(&client.config).to_string();
+        let config = client.config.clone();
+        let shared_client = Arc::new(tokio::sync::Mutex::new(client));
+        let available = Arc::new(AtomicBool::new(true));
+        let registered_tools = register_mcp_tools_in_registry(
+            self.tool_registry.as_ref(),
+            name,
+            Arc::clone(&shared_client),
+            &cached_tools,
+            Arc::clone(&available),
+        );
 
-        self.clients.insert(name.to_string(), client);
+        self.clients.insert(
+            name.to_string(),
+            ManagedMcpClient {
+                client: shared_client,
+                config,
+                transport_type,
+                cached_tools,
+                cached_resources,
+                registered_tools,
+                available,
+                connected_at: Instant::now(),
+            },
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn connect_with_transport_for_test(
+        &mut self,
+        name: &str,
+        config: McpServerConfig,
+        transport: Box<dyn McpTransport>,
+    ) -> Result<(), McpError> {
+        if self.clients.contains_key(name) {
+            self.disconnect(name).await?;
+        }
+        let mut client = McpClient::new(config);
+        client.finish_connect_with_transport(transport).await?;
+        let cached_tools = client.cached_tools().to_vec();
+        let cached_resources = client.cached_resources().to_vec();
+        let transport_type = transport_type_for_config(&client.config).to_string();
+        let config = client.config.clone();
+        let shared_client = Arc::new(tokio::sync::Mutex::new(client));
+        let available = Arc::new(AtomicBool::new(true));
+        let registered_tools = register_mcp_tools_in_registry(
+            self.tool_registry.as_ref(),
+            name,
+            Arc::clone(&shared_client),
+            &cached_tools,
+            Arc::clone(&available),
+        );
+        self.clients.insert(
+            name.to_string(),
+            ManagedMcpClient {
+                client: shared_client,
+                config,
+                transport_type,
+                cached_tools,
+                cached_resources,
+                registered_tools,
+                available,
+                connected_at: Instant::now(),
+            },
+        );
         Ok(())
     }
 
@@ -1562,9 +1768,9 @@ impl McpManager {
                     index,
                     McpDiscoveryReport {
                         name,
-                        connected: existing.is_connected(),
-                        transport_type: transport_type_for_config(&existing.config).to_string(),
-                        tool_count: existing.cached_tools().len(),
+                        connected: existing.available.load(Ordering::SeqCst),
+                        transport_type: existing.transport_type.clone(),
+                        tool_count: existing.cached_tools.len(),
                         error: None,
                     },
                 ));
@@ -1624,7 +1830,31 @@ impl McpManager {
                             "Discovered {} tools from MCP server '{}'",
                             report.tool_count, report.name
                         );
-                        self.clients.insert(report.name.clone(), client);
+                        let cached_tools = client.cached_tools().to_vec();
+                        let cached_resources = client.cached_resources().to_vec();
+                        let config = client.config.clone();
+                        let shared_client = Arc::new(tokio::sync::Mutex::new(client));
+                        let available = Arc::new(AtomicBool::new(true));
+                        let registered_tools = register_mcp_tools_in_registry(
+                            self.tool_registry.as_ref(),
+                            &report.name,
+                            Arc::clone(&shared_client),
+                            &cached_tools,
+                            Arc::clone(&available),
+                        );
+                        self.clients.insert(
+                            report.name.clone(),
+                            ManagedMcpClient {
+                                client: shared_client,
+                                config,
+                                transport_type: report.transport_type.clone(),
+                                cached_tools,
+                                cached_resources,
+                                registered_tools,
+                                available,
+                                connected_at: Instant::now(),
+                            },
+                        );
                     }
                     reports.push((index, report));
                 }
@@ -1661,8 +1891,11 @@ impl McpManager {
 
     /// Disconnect from an MCP server and remove it from the active list.
     pub async fn disconnect(&mut self, name: &str) -> Result<(), McpError> {
-        if let Some(mut client) = self.clients.remove(name) {
+        if let Some(managed) = self.clients.remove(name) {
             info!("Disconnecting from MCP server: {}", name);
+            managed.available.store(false, Ordering::SeqCst);
+            deregister_mcp_tools(self.tool_registry.as_ref(), managed.registered_tools);
+            let mut client = managed.client.lock().await;
             client.disconnect().await?;
             Ok(())
         } else {
@@ -1681,7 +1914,9 @@ impl McpManager {
 
     /// Check if a server is connected.
     pub fn is_connected(&self, name: &str) -> bool {
-        self.clients.get(name).map_or(false, |c| c.is_connected())
+        self.clients
+            .get(name)
+            .is_some_and(|c| c.available.load(Ordering::SeqCst))
     }
 
     /// Get the list of connected server names.
@@ -1691,11 +1926,27 @@ impl McpManager {
 
     /// Discover (or re-discover) tools on a connected server.
     pub async fn discover_tools(&mut self, server_name: &str) -> Result<Vec<ToolSchema>, McpError> {
-        let client = self
+        let managed = self
             .clients
             .get_mut(server_name)
             .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
-        client.list_tools().await
+        let tools = {
+            let mut client = managed.client.lock().await;
+            client.list_tools().await?
+        };
+        deregister_mcp_tools(
+            self.tool_registry.as_ref(),
+            std::mem::take(&mut managed.registered_tools),
+        );
+        managed.cached_tools = tools.clone();
+        managed.registered_tools = register_mcp_tools_in_registry(
+            self.tool_registry.as_ref(),
+            server_name,
+            Arc::clone(&managed.client),
+            &tools,
+            Arc::clone(&managed.available),
+        );
+        Ok(tools)
     }
 
     /// Call a tool on a connected MCP server.
@@ -1705,11 +1956,13 @@ impl McpManager {
         tool_name: &str,
         args: Value,
     ) -> Result<Value, McpError> {
+        let managed = self
+            .clients
+            .get_mut(server_name)
+            .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+
         let reconnect_config: McpServerConfig = {
-            let client = self
-                .clients
-                .get_mut(server_name)
-                .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+            let mut client = managed.client.lock().await;
             match client.call_tool(tool_name, args.clone()).await {
                 Ok(value) => return Ok(value),
                 Err(err) => {
@@ -1718,20 +1971,46 @@ impl McpManager {
                             "MCP stale transport detected on '{}' ({}); reconnecting once",
                             server_name, err
                         );
-                        client.config.clone()
+                        managed.config.clone()
                     } else {
                         return Err(err);
                     }
                 }
             }
         };
-        let config = reconnect_config;
-        let _ = self.disconnect(server_name).await;
-        self.connect(server_name, config).await?;
-        let client = self
-            .clients
-            .get_mut(server_name)
-            .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+
+        let mut new_client = McpClient::new(reconnect_config.clone());
+        if let Some(config) = self.sampling_config.clone() {
+            new_client.set_sampling_config(config);
+        }
+        if let Some(callback) = self.sampling_callback.clone() {
+            new_client.set_sampling_callback(callback);
+        }
+        new_client.connect().await?;
+        let tools = new_client.cached_tools().to_vec();
+        let resources = new_client.cached_resources().to_vec();
+        {
+            let mut client = managed.client.lock().await;
+            *client = new_client;
+        }
+        deregister_mcp_tools(
+            self.tool_registry.as_ref(),
+            std::mem::take(&mut managed.registered_tools),
+        );
+        managed.config = reconnect_config;
+        managed.cached_tools = tools.clone();
+        managed.cached_resources = resources;
+        managed.connected_at = Instant::now();
+        managed.available.store(true, Ordering::SeqCst);
+        managed.registered_tools = register_mcp_tools_in_registry(
+            self.tool_registry.as_ref(),
+            server_name,
+            Arc::clone(&managed.client),
+            &tools,
+            Arc::clone(&managed.available),
+        );
+
+        let mut client = managed.client.lock().await;
         client.call_tool(tool_name, args).await
     }
 
@@ -1740,19 +2019,25 @@ impl McpManager {
         &mut self,
         server_name: &str,
     ) -> Result<Vec<ResourceInfo>, McpError> {
-        let client = self
+        let managed = self
             .clients
             .get_mut(server_name)
             .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
-        client.list_resources().await
+        let resources = {
+            let mut client = managed.client.lock().await;
+            client.list_resources().await?
+        };
+        managed.cached_resources = resources.clone();
+        Ok(resources)
     }
 
     /// Read a resource from a connected server.
     pub async fn read_resource(&mut self, server_name: &str, uri: &str) -> Result<Value, McpError> {
-        let client = self
+        let managed = self
             .clients
             .get_mut(server_name)
             .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+        let mut client = managed.client.lock().await;
         client.read_resource(uri).await
     }
 
@@ -1767,22 +2052,32 @@ impl McpManager {
             "Handling tools/list_changed notification from '{}'",
             server_name
         );
-        let client = self
+        let managed = self
             .clients
             .get_mut(server_name)
             .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
-        let tools = client.list_tools().await?;
+        let tools = {
+            let mut client = managed.client.lock().await;
+            client.list_tools().await?
+        };
         debug!(
             "Re-discovered {} tools from server '{}'",
             tools.len(),
             server_name
         );
+        deregister_mcp_tools(
+            self.tool_registry.as_ref(),
+            std::mem::take(&mut managed.registered_tools),
+        );
+        managed.cached_tools = tools.clone();
+        managed.registered_tools = register_mcp_tools_in_registry(
+            self.tool_registry.as_ref(),
+            server_name,
+            Arc::clone(&managed.client),
+            &tools,
+            Arc::clone(&managed.available),
+        );
         Ok(tools)
-    }
-
-    /// Get a mutable reference to a specific client.
-    pub fn get_client_mut(&mut self, name: &str) -> Option<&mut McpClient> {
-        self.clients.get_mut(name)
     }
 
     /// Get a reference to the tool registry.
@@ -1798,7 +2093,9 @@ impl McpManager {
     pub fn set_sampling_config(&mut self, config: SamplingConfig) {
         self.sampling_config = Some(config.clone());
         for client in self.clients.values_mut() {
-            client.set_sampling_config(config.clone());
+            if let Ok(mut client) = client.client.try_lock() {
+                client.set_sampling_config(config.clone());
+            }
         }
     }
 
@@ -1806,15 +2103,18 @@ impl McpManager {
     pub fn set_sampling_callback(&mut self, callback: LlmCallback) {
         self.sampling_callback = Some(callback.clone());
         for client in self.clients.values_mut() {
-            client.set_sampling_callback(callback.clone());
+            if let Ok(mut client) = client.client.try_lock() {
+                client.set_sampling_callback(callback.clone());
+            }
         }
     }
 
     /// Return sampling audit counters for a connected server.
-    pub fn sampling_metrics(&self, server_name: &str) -> Option<&SamplingMetrics> {
+    pub fn sampling_metrics(&self, server_name: &str) -> Option<SamplingMetrics> {
         self.clients
             .get(server_name)
-            .map(McpClient::sampling_metrics)
+            .and_then(|client| client.client.try_lock().ok())
+            .map(|client| client.sampling_metrics().clone())
     }
 
     // -----------------------------------------------------------------------
@@ -1823,10 +2123,11 @@ impl McpManager {
 
     /// List prompts available on a connected server.
     pub async fn list_prompts(&mut self, server_name: &str) -> Result<Vec<PromptInfo>, McpError> {
-        let client = self
+        let managed = self
             .clients
             .get_mut(server_name)
             .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+        let mut client = managed.client.lock().await;
         client.list_prompts().await
     }
 
@@ -1837,10 +2138,11 @@ impl McpManager {
         name: &str,
         args: HashMap<String, String>,
     ) -> Result<PromptResult, McpError> {
-        let client = self
+        let managed = self
             .clients
             .get_mut(server_name)
             .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+        let mut client = managed.client.lock().await;
         client.get_prompt(name, args).await
     }
 
@@ -1853,20 +2155,13 @@ impl McpManager {
         self.clients
             .iter()
             .map(|(name, client)| {
-                let transport_type = if client.config.is_stdio() {
-                    "stdio".to_string()
-                } else if client.config.is_http() {
-                    "http".to_string()
-                } else {
-                    "unknown".to_string()
-                };
                 let status = McpServerStatus {
                     name: name.clone(),
-                    connected: client.is_connected(),
-                    tool_count: client.cached_tools().len(),
-                    resource_count: client.cached_resources().len(),
-                    transport_type,
-                    uptime_secs: client.uptime().map(|d| d.as_secs()),
+                    connected: client.available.load(Ordering::SeqCst),
+                    tool_count: client.cached_tools.len(),
+                    resource_count: client.cached_resources.len(),
+                    transport_type: client.transport_type.clone(),
+                    uptime_secs: Some(client.connected_at.elapsed().as_secs()),
                 };
                 (name.clone(), status)
             })
@@ -1875,18 +2170,26 @@ impl McpManager {
 
     /// Probe a connected MCP server to check reachability and discover capabilities.
     pub async fn probe_server(&mut self, name: &str) -> Result<McpProbeResult, McpError> {
-        let client = self
+        let managed = self
             .clients
             .get_mut(name)
             .ok_or_else(|| McpError::ServerNotFound(name.to_string()))?;
 
         let start = Instant::now();
-        let tools_result = client.list_tools().await;
+        let tools_result = {
+            let mut client = managed.client.lock().await;
+            client.list_tools().await
+        };
         let latency = start.elapsed();
 
         match tools_result {
             Ok(tools) => {
-                let resources = client.list_resources().await.unwrap_or_default();
+                let resources = {
+                    let mut client = managed.client.lock().await;
+                    client.list_resources().await.unwrap_or_default()
+                };
+                managed.cached_tools = tools.clone();
+                managed.cached_resources = resources.clone();
 
                 Ok(McpProbeResult {
                     reachable: true,
@@ -2073,6 +2376,96 @@ mod tests {
         assert!(reports.iter().all(|report| report.error.is_some()));
         assert!(!manager.is_connected("missing-a"));
         assert!(!manager.is_connected("missing-b"));
+    }
+
+    #[tokio::test]
+    async fn manager_registers_discovered_mcp_tools_as_callable_registry_tools() {
+        let registry = Arc::new(hermes_tools::ToolRegistry::new());
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let transport = FakeTransport::new_with_sent(
+            vec![
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {"name": "fake", "version": "0"}
+                    }
+                }),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                        "tools": [{
+                            "name": "search-file",
+                            "description": "search files through MCP",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {"type": "string"}
+                                },
+                                "required": ["query"]
+                            }
+                        }]
+                    }
+                }),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "result": {
+                        "content": [{"type": "text", "text": "mcp search ok"}]
+                    }
+                }),
+            ],
+            closed.clone(),
+            sent.clone(),
+        );
+        let mut manager = McpManager::new(Arc::clone(&registry));
+
+        manager
+            .connect_with_transport_for_test(
+                "dyn.server",
+                McpServerConfig::stdio("fake", Vec::new()),
+                Box::new(transport),
+            )
+            .await
+            .expect("connect fake mcp server");
+
+        let entry = registry
+            .get_tool("mcp_dyn_server_search_file")
+            .expect("registered MCP tool");
+        assert_eq!(entry.toolset, "mcp-dyn_server");
+        assert_eq!(
+            registry.get_toolset_alias_target("dyn.server").as_deref(),
+            Some("mcp-dyn_server")
+        );
+        assert_eq!(
+            registry.tool_names_for_toolset("dyn.server", true),
+            vec!["mcp_dyn_server_search_file".to_string()]
+        );
+
+        let output = registry
+            .dispatch_async("mcp_dyn_server_search_file", json!({"query": "rust"}))
+            .await;
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("tool json");
+        assert_eq!(parsed["result"], "mcp search ok");
+
+        {
+            let sent = sent.lock().expect("sent lock");
+            let call = sent
+                .iter()
+                .find(|msg| msg["method"] == "tools/call")
+                .expect("tools/call sent");
+            assert_eq!(call["params"]["name"], "search-file");
+            assert_eq!(call["params"]["arguments"]["query"], "rust");
+        }
+
+        manager.disconnect("dyn.server").await.expect("disconnect");
+        assert!(closed.load(Ordering::SeqCst));
+        assert!(registry.get_tool("mcp_dyn_server_search_file").is_none());
+        assert_eq!(registry.get_toolset_alias_target("dyn.server"), None);
     }
 
     #[tokio::test]

--- a/crates/hermes-mcp/src/lib.rs
+++ b/crates/hermes-mcp/src/lib.rs
@@ -243,9 +243,9 @@ impl From<serde_json::Error> for McpError {
 // Re-export primary types
 pub use auth::{BearerTokenAuth, McpAuthProvider, OAuthConfig};
 pub use client::{
-    LlmCallback, McpClient, McpDiscoveryReport, McpManager, McpProbeResult, McpServerConfig,
-    McpServerStatus, PromptArgument, PromptInfo, PromptMessage, PromptResult, ResourceInfo,
-    SamplingConfig, SamplingMetrics,
+    sanitize_mcp_name_component, LlmCallback, McpClient, McpDiscoveryReport, McpManager,
+    McpProbeResult, McpServerConfig, McpServerStatus, PromptArgument, PromptInfo, PromptMessage,
+    PromptResult, ResourceInfo, SamplingConfig, SamplingMetrics,
 };
 pub use serve::{
     ApprovalStore as McpApprovalStore, BridgeEvent, EventBridge, HermesMcpServe,

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1287,6 +1287,14 @@
     "c10fea8d264e": {
       "disposition": "ported",
       "notes": "Rust ToolRegistry now supports explicit live toolset aliases such as server-name to mcp-server-name mappings, exposes alias targets for inspection, removes aliases only when the target toolset loses its last tool, and platform toolset filtering resolves configured MCP server aliases with hermes-tools and hermes-cli regression coverage."
+    },
+    "9b2fb1cc2e95": {
+      "disposition": "ported",
+      "notes": "Rust ACP now parses client-provided mcpServers/mcp_servers during session new/load/resume/fork, converts stdio and HTTP/SSE configs into hermes_mcp configs, preserves stdio env and bearer Authorization headers, registers reachable MCP servers through McpManager, and exposes discovered MCP tools as real callable ToolRegistry tools with provider-safe names and focused hermes-mcp/hermes-acp coverage."
+    },
+    "dfc5563641f0": {
+      "disposition": "ported",
+      "notes": "Rust ACP sessions now include client-provided MCP server toolsets through live ToolRegistry mcp-{server} toolsets and explicit aliases, so tools.list, /tools, initialize tool names, ToolsetManager resolution, and registered MCP dispatch all see the session MCP surface. Focused tests cover toolset expansion and ACP MCP tool visibility."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- Register ACP client-provided MCP servers through the Rust MCP manager and expose discovered MCP tools in the live `ToolRegistry`.
- Advertise registered MCP tools through ACP initialize, `tools.list`, and `/tools`, with sanitized `mcp_<server>_<tool>` names and `mcp-<server>` toolsets.
- Share `hermes acp start` runtime tools with the ACP MCP manager and resolve tool schemas per prompt turn so late-registered MCP tools are available to the agent.
- Mark upstream ACP MCP registration/toolset parity rows as ported.

## Verification
- `cargo test -p hermes-cli acp_prompt_executor_resolves_tool_schemas_from_current_registry -- --nocapture`
- `cargo test -p hermes-cli acp_steer_prompt_interrupts_with_trusted_marker -- --nocapture`
- `cargo test -p hermes-mcp manager_registers_discovered_mcp_tools_as_callable_registry_tools -- --nocapture`
- `cargo test -p hermes-acp acp_mcp -- --nocapture`
- `cargo test -p hermes-acp tools_list_and_slash_tools_include_registered_mcp_tools -- --nocapture`
- `cargo test -p hermes-mcp -p hermes-acp -- --nocapture`
- `jq empty docs/parity/queue-overrides.json`
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/generate-upstream-patch-queue.py --repo-root . --no-fetch --out-json /tmp/hermes-parity-acp-mcp-registration.json --out-md /tmp/hermes-parity-acp-mcp-registration.md --overrides docs/parity/queue-overrides.json`
- `cargo build -p hermes-mcp -p hermes-acp -p hermes-cli`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-mcp -p hermes-acp -p hermes-cli`

## Notes
- All cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` and `CARGO_INCREMENTAL=0`.
- Repo-local `target` remained `0B`; wd_black target was `16G` after verification.
- `cargo test -p hermes-cli --lib` still has unrelated pre-existing failures: isolated `model_switch::tests::nous_provider_uses_curated_plus_openrouter_agentic_catalog` fails the same way on `origin/main`; isolated TUI truncation test passes on both branch and `origin/main` but can fail in the full lib run due cross-test state.
