### PR TITLE
parity(terminal): close runtime terminal backlog

### DIFF
--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -730,6 +730,56 @@ mod tests {
         }
     }
 
+    struct NonzeroExitBackend;
+
+    #[async_trait]
+    impl TerminalBackend for NonzeroExitBackend {
+        async fn execute_command(
+            &self,
+            command: &str,
+            timeout: Option<u64>,
+            workdir: Option<&str>,
+            background: bool,
+            pty: bool,
+        ) -> Result<CommandOutput, AgentError> {
+            self.execute_command_with_stdin(command, timeout, workdir, background, pty, None)
+                .await
+        }
+
+        async fn execute_command_with_stdin(
+            &self,
+            cmd: &str,
+            _timeout: Option<u64>,
+            _workdir: Option<&str>,
+            _background: bool,
+            _pty: bool,
+            _stdin_data: Option<&str>,
+        ) -> Result<CommandOutput, AgentError> {
+            Ok(CommandOutput {
+                exit_code: 7,
+                stdout: format!("stdout from {cmd}"),
+                stderr: format!("stderr from {cmd}"),
+            })
+        }
+
+        async fn read_file(
+            &self,
+            _path: &str,
+            _offset: Option<u64>,
+            _limit: Option<u64>,
+        ) -> Result<String, AgentError> {
+            Ok(String::new())
+        }
+
+        async fn write_file(&self, _path: &str, _content: &str) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn file_exists(&self, _path: &str) -> Result<bool, AgentError> {
+            Ok(true)
+        }
+    }
+
     #[derive(Default)]
     struct RecordingBackend {
         calls: Arc<Mutex<Vec<Option<String>>>>,
@@ -1124,5 +1174,19 @@ mod tests {
         assert!(formatted.contains("out"));
         assert!(formatted.contains("err"));
         assert!(formatted.contains("exit code: 1"));
+    }
+
+    #[test]
+    fn terminal_handler_nonzero_exit_code_is_output_not_tool_failure() {
+        let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(Arc::new(NonzeroExitBackend));
+
+        let rendered = block_on(handler.execute(json!({"command": "false"})))
+            .expect("nonzero terminal exits should be returned to the model");
+
+        assert!(rendered.contains("stdout from false"));
+        assert!(rendered.contains("stderr from false"));
+        assert!(rendered.contains("[exit code: 7]"));
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1295,6 +1295,30 @@
     "dfc5563641f0": {
       "disposition": "ported",
       "notes": "Rust ACP sessions now include client-provided MCP server toolsets through live ToolRegistry mcp-{server} toolsets and explicit aliases, so tools.list, /tools, initialize tool names, ToolsetManager resolution, and registered MCP dispatch all see the session MCP surface. Focused tests cover toolset expansion and ACP MCP tool visibility."
+    },
+    "f81395975025": {
+      "disposition": "superseded",
+      "notes": "Upstream simple-terminal registration is superseded by Rust TerminalHandler and LocalBackend command execution, explicit background=true lifecycle tracking, timeout/workdir/schema contracts, and process-management tests without the Python Morph VM dependency."
+    },
+    "ab7293bed652": {
+      "disposition": "ported",
+      "notes": "Rust TerminalHandler now has regression coverage proving a nonzero terminal exit code returns normal model-visible command output with [exit code: N] instead of surfacing as ToolError/agent tool failure."
+    },
+    "ba19d530ad24": {
+      "disposition": "superseded",
+      "notes": "Python mini-swe/hecate terminal backend integration is superseded by Rust-native terminal and process backends: command execution, background lifecycle, stdin/PTY/workdir, schema registration, and local runtime contracts are implemented without Python terminal_tool dispatch."
+    },
+    "771cf41fea1f": {
+      "disposition": "superseded",
+      "notes": "Upstream Singularity/run-script terminal environment tuning is not a separate Rust runtime surface; Rust terminal execution already exposes explicit timeout, workdir, background, PTY, stdin, and process-polling contracts through typed handlers and tests."
+    },
+    "bbeed5b5d12d": {
+      "disposition": "superseded",
+      "notes": "Upstream session logging and interactive sudo support is superseded by Rust session-aware terminal/process logging, task cwd mapping, background log reads, SUDO_PASSWORD sudo transformation, approval manager, and gateway/terminal regression coverage."
+    },
+    "5d3398aa8a20": {
+      "disposition": "superseded",
+      "notes": "Upstream terminal approval and CLI feedback refactor is superseded by Rust ApprovalManager plus session-scoped YOLO/approval state, hardline and sudo floors, gateway approval lifecycle, and terminal handler denial/bypass tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add handler-level Rust regression coverage that terminal nonzero exit codes are model-visible output, not tool execution failures
- classify six upstream Python terminal/runtime commits in the parity override ledger
- keep generated queue refresh out of this PR; queue generator was run to `/tmp` for count evidence only

## Upstream rows closed
- `f81395975025` superseded: simple terminal is covered by Rust TerminalHandler/LocalBackend/process lifecycle
- `ab7293bed652` ported: nonzero terminal exit is output, not a tool failure
- `ba19d530ad24` superseded: Python mini-swe/hecate terminal integration covered by Rust terminal/process architecture
- `771cf41fea1f` superseded: terminal env/script tuning not a separate Rust runtime surface
- `bbeed5b5d12d` superseded: session logging/sudo support covered by Rust session/process logging and sudo transform
- `5d3398aa8a20` superseded: approval/feedback refactor covered by Rust ApprovalManager and gateway/session approval tests

## Verification
- `cargo test -p hermes-tools terminal_handler_nonzero_exit_code_is_output_not_tool_failure -- --nocapture`
- `cargo test -p hermes-tools terminal -- --nocapture`
- `cargo test -p hermes-tools -- --nocapture` -> 585 unit tests plus integration/property/doc tests passed
- `jq empty docs/parity/queue-overrides.json`
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-tools`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools` -> `new=0 stale=8`
- queue generator to `/tmp`: `pending=1871`, `ported=149`, `superseded=7676`, `total=9858`
- build artifact check: repo-local `target` remains `0B`; cargo target dir is `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
