### PR TITLE
test(terminal): share env lock across terminal gates

### DIFF
--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -794,14 +794,13 @@ fn dirs_home() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
+    use crate::approval::TEST_ENV_LOCK;
     use async_trait::async_trait;
     use hermes_core::{AgentError, CommandOutput, Skill, SkillMeta};
     use serde_json::Value;
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
+        TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }

--- a/crates/hermes-tools/src/terminal_requirements.rs
+++ b/crates/hermes-tools/src/terminal_requirements.rs
@@ -315,8 +315,7 @@ fn command_success_with_timeout(executable: &Path, args: &[&str], timeout: Durat
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use crate::approval::TEST_ENV_LOCK;
 
     struct EnvGuard {
         key: &'static str,
@@ -373,14 +372,14 @@ mod tests {
 
     #[test]
     fn local_terminal_requirements_pass_by_default() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guards = clear_terminal_env();
         assert!(check_terminal_requirements());
     }
 
     #[test]
     fn unknown_terminal_env_is_unavailable() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guards = clear_terminal_env();
         let _env = EnvGuard::set("TERMINAL_ENV", "unknown-backend");
         let report = terminal_requirements_report();
@@ -394,7 +393,7 @@ mod tests {
 
     #[test]
     fn ssh_requires_host_and_user() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guards = clear_terminal_env();
         let _env = EnvGuard::set("TERMINAL_ENV", "ssh");
         let report = terminal_requirements_report();
@@ -412,7 +411,7 @@ mod tests {
 
     #[test]
     fn modal_managed_mode_requires_managed_gateway() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guards = clear_terminal_env();
         let _env = EnvGuard::set("TERMINAL_ENV", "modal");
         let _mode = EnvGuard::set("TERMINAL_MODAL_MODE", "managed");
@@ -428,7 +427,7 @@ mod tests {
 
     #[test]
     fn modal_direct_mode_requires_direct_credentials() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guards = clear_terminal_env();
         let _env = EnvGuard::set("TERMINAL_ENV", "modal");
         let _mode = EnvGuard::set("TERMINAL_MODAL_MODE", "direct");
@@ -442,7 +441,7 @@ mod tests {
 
     #[test]
     fn vercel_sandbox_is_known_but_not_exposed_without_rust_backend() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guards = clear_terminal_env();
         let _env = EnvGuard::set("TERMINAL_ENV", "vercel_sandbox");
         let report = terminal_requirements_report();


### PR DESCRIPTION
## Summary
- make terminal requirement tests and builtin registration tests share the crate-wide `TEST_ENV_LOCK`
- fixes the parallel `cargo test -p hermes-tools terminal` env race exposed during post-merge verification of PR #519
- test-only change; no runtime behavior changes

## Evidence
- pre-fix post-merge `cargo test -p hermes-tools terminal -- --nocapture` failed in parallel with `TERMINAL_ENV`/lock poisoning symptoms
- after fix, the same parallel command passed: `34 passed`

## Verification
- `cargo test -p hermes-tools terminal -- --nocapture` -> `34 passed`
- `cargo test -p hermes-tools -- --nocapture` -> 585 unit tests plus package integration/property/doc tests passed
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-tools`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools` -> `new=0 stale=8`
- artifact check: repo-local `target` is `0B`; cargo target dir is `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
