### PR TITLE
parity(web): include crawl in web toolsets

### DIFF
--- a/crates/hermes-cli/src/platform_toolsets.rs
+++ b/crates/hermes-cli/src/platform_toolsets.rs
@@ -219,6 +219,7 @@ mod tests {
         };
         register(&reg, "web_search", "web");
         register(&reg, "web_extract", "web");
+        register(&reg, "web_crawl", "web");
         register(&reg, "terminal", "terminal");
         register(&reg, "process", "terminal");
         register(&reg, "read_file", "file");
@@ -282,6 +283,7 @@ mod tests {
         let reg = registry_with_minimal_tools();
         let names = resolve_platform_tool_names(&cfg, "cli", &reg);
         assert!(names.contains(&"web_search".to_string()));
+        assert!(names.contains(&"web_crawl".to_string()));
         assert!(!names.contains(&"terminal".to_string()));
     }
 
@@ -305,6 +307,7 @@ mod tests {
         for expected in [
             "web_search",
             "web_extract",
+            "web_crawl",
             "terminal",
             "process",
             "read_file",

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -15,8 +15,8 @@ use crate::registry::ToolRegistry;
 // Predefined toolset constants
 // ---------------------------------------------------------------------------
 
-/// Web search and extraction tools.
-pub const TOOLSET_WEB: &[&str] = &["web_search", "web_extract"];
+/// Web search, extraction, and crawl tools.
+pub const TOOLSET_WEB: &[&str] = &["web_search", "web_extract", "web_crawl"];
 /// Terminal command execution tools.
 pub const TOOLSET_TERMINAL: &[&str] = &["terminal", "process", "process_registry"];
 /// File system tools.
@@ -607,6 +607,7 @@ mod tests {
         let tools = manager.resolve_toolset_unfiltered("web").unwrap();
         assert!(tools.contains(&"web_search".to_string()));
         assert!(tools.contains(&"web_extract".to_string()));
+        assert!(tools.contains(&"web_crawl".to_string()));
     }
 
     #[test]
@@ -615,6 +616,7 @@ mod tests {
         let tools = manager.resolve_toolset_unfiltered("all").unwrap();
         // Should include tools from all toolsets
         assert!(tools.contains(&"web_search".to_string()));
+        assert!(tools.contains(&"web_crawl".to_string()));
         assert!(tools.contains(&"terminal".to_string()));
         assert!(tools.contains(&"read_file".to_string()));
     }
@@ -705,6 +707,7 @@ mod tests {
         let tools = manager.resolve_toolset_unfiltered("hermes-cli").unwrap();
         // Should include tools from web, terminal, file, etc.
         assert!(tools.contains(&"web_search".to_string()));
+        assert!(tools.contains(&"web_crawl".to_string()));
         assert!(tools.contains(&"terminal".to_string()));
         assert!(tools.contains(&"read_file".to_string()));
         // Python parity core for CLI.
@@ -732,6 +735,7 @@ mod tests {
         for expected in [
             "web_search",
             "web_extract",
+            "web_crawl",
             "terminal",
             "process",
             "read_file",

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1319,6 +1319,42 @@
     "5d3398aa8a20": {
       "disposition": "superseded",
       "notes": "Upstream terminal approval and CLI feedback refactor is superseded by Rust ApprovalManager plus session-scoped YOLO/approval state, hardline and sudo floors, gateway approval lifecycle, and terminal handler denial/bypass tests."
+    },
+    "bf4223f3818f": {
+      "disposition": "superseded",
+      "notes": "Early Python scrape/crawl compression is superseded by Rust web_extract/web_crawl typed handlers, provider-specific normalized document output, URL secret-exfiltration guards, web content redaction, and tool-result storage/budget controls."
+    },
+    "cde7e64418e0": {
+      "disposition": "ported",
+      "notes": "Rust has first-class web_search/web_extract/web_crawl, vision_analyze, and filtered toolset resolution. This batch adds web_crawl to the web toolset and platform filtering tests, while existing vision tests cover schema, execution, URL safety, local image base64, and response normalization."
+    },
+    "ebb46ba0e6a7": {
+      "disposition": "ported",
+      "notes": "Rust exposes image_generate as a first-class tool with schema/handler coverage and FalImageGenBackend direct/managed transport tests for payload shape, auth routing, model override, and unconfigured errors."
+    },
+    "e1710378b738": {
+      "disposition": "ported",
+      "notes": "Rust builtin registration and toolset resolution now expose image_generate, mixture_of_agents, and the complete web tool trio through typed registries instead of Python model_tools dispatch."
+    },
+    "58d5fa1e4cec": {
+      "disposition": "superseded",
+      "notes": "Python FAL dependency wiring is superseded by Rust reqwest-based FalImageGenBackend with direct FAL_KEY and Nous-managed fal-queue transports plus hermetic backend tests; no Python requirement path remains."
+    },
+    "4ece87efb0dd": {
+      "disposition": "ported",
+      "notes": "Rust Firecrawl support covers search and extract through direct, self-hosted URL, and Nous-managed gateway transports, with response normalization and backend-selection tests for Firecrawl-specific shapes."
+    },
+    "587d1cf72095": {
+      "disposition": "superseded",
+      "notes": "The mixed Python web/MoA/trajectory update is superseded by Rust web provider backends, first-class mixture_of_agents runtime/tests, and Rust session/tool-result persistence. Python trajectory file management is not a separate Rust runtime boundary."
+    },
+    "17608c11422b": {
+      "disposition": "ported",
+      "notes": "Rust ToolsetManager already supports named, recursive, filtered, alias, wildcard, and platform toolsets; this batch ports the upstream web-tools membership by ensuring web_crawl resolves with web_search/web_extract through web and platform defaults."
+    },
+    "8d256779d8fa": {
+      "disposition": "ported",
+      "notes": "Rust OpenAiVisionBackend handles local image files by MIME-sniffing extensions and base64-encoding data URLs, validates remote image URLs against unsafe hosts/schemes, and normalizes empty vision responses with focused tests."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add `web_crawl` to the Rust `web` toolset so web search, extract, and crawl resolve together
- extend CLI/API platform toolset tests to prove crawl flows through default web membership
- classify nine early web/vision/image/toolset upstream rows against existing Rust-native web, vision, image generation, MoA, and toolset implementations

## Verification
- `jq empty docs/parity/queue-overrides.json`
- `cargo test -p hermes-tools test_resolve_web_toolset -- --nocapture`
- `cargo test -p hermes-tools test_hermes_api_server_toolset -- --nocapture`
- `cargo test -p hermes-tools test_hermes_cli_toolset -- --nocapture`
- `cargo test -p hermes-cli config_override_is_used_when_present -- --nocapture`
- `cargo test -p hermes-cli api_server_defaults_to_restricted_toolset -- --nocapture`
- `cargo test -p hermes-tools web -- --nocapture` (`51 passed`)
- `cargo test -p hermes-tools toolset -- --nocapture` (`31 passed` plus property resolver)
- `cargo test -p hermes-cli platform_toolsets -- --nocapture` (`10 passed`)
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo build -p hermes-tools -p hermes-cli`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools -p hermes-cli` (`new=0`, `stale=8`)

## Queue Proof
Generated only to `/tmp`:
- `/tmp/hermes-web-vision-image-toolset-queue.json`
- `/tmp/hermes-web-vision-image-toolset-queue.md`

Summary after overrides:
- `pending=1862`
- `ported=155`
- `superseded=7679`
- `mirrored=162`
- `total=9858`

## Build Artifacts
Cargo ran with:
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
- `CARGO_INCREMENTAL=0`

Repo-local `target` remained `0B` before commit.
