### PR TITLE
parity(agent): prove ephemeral system prompt persistence

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -10028,6 +10028,87 @@ mod tests {
             .any(|m| m.content.as_deref() == Some("done")));
     }
 
+    #[tokio::test]
+    async fn ephemeral_system_prompt_is_model_visible_but_not_returned_for_persistence() {
+        #[derive(Default)]
+        struct CapturingProvider {
+            seen_messages: Mutex<Vec<Message>>,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for CapturingProvider {
+            async fn chat_completion(
+                &self,
+                messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<LlmResponse, AgentError> {
+                *self.seen_messages.lock().expect("seen messages lock") = messages.to_vec();
+                Ok(LlmResponse {
+                    message: Message::assistant("done"),
+                    usage: None,
+                    model: "test".to_string(),
+                    finish_reason: Some("stop".to_string()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let provider = std::sync::Arc::new(CapturingProvider::default());
+        let mut config = AgentConfig {
+            skip_memory: true,
+            skip_context_files: true,
+            ephemeral_system_prompt: Some("ephemeral test-only system prompt".to_string()),
+            ..AgentConfig::default()
+        };
+        let _home = isolate_route_learning_home(&mut config);
+        let agent = AgentLoop::new(
+            config,
+            std::sync::Arc::new(ToolRegistry::new()),
+            provider.clone(),
+        );
+
+        let result = agent
+            .run(vec![Message::user("real question")], Some(Vec::new()))
+            .await
+            .expect("agent run");
+
+        let seen = provider.seen_messages.lock().expect("seen messages lock");
+        assert!(seen
+            .iter()
+            .any(|m| m.content.as_deref() == Some("ephemeral test-only system prompt")));
+        assert!(seen
+            .iter()
+            .any(|m| m.content.as_deref() == Some("real question")));
+
+        assert!(!result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("ephemeral test-only system prompt")));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("real question")));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.as_deref() == Some("done")));
+    }
+
     #[test]
     fn delegate_depth_parser_floors_without_legacy_ceiling() {
         assert_eq!(parse_delegate_depth("99"), Some(99));

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -40,6 +40,10 @@
       "disposition": "ported",
       "notes": "Rust hermes_intelligence::rl now has a deterministic BatchDatasetRunner with JSONL prompt/conversation parsing, max-sample batching, resume checkpoints by prompt index/text, per-batch processed/skipped statistics, toolset distribution metadata, JSONL trajectory serialization, and tests for checkpoint resume plus ephemeral prompt non-persistence."
     },
+    "d36790de9153": {
+      "disposition": "ported",
+      "notes": "Ephemeral system prompts are first-class in Rust for both batch and agent runners: BatchDatasetRunConfig tracks an ephemeral prompt without persisting it to trajectory JSONL or checkpoints, and AgentConfig::ephemeral_system_prompt is appended only to provider API-call messages and stripped from AgentResult persistence, with focused tests for both paths."
+    },
     "395dbcc873c8": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"


### PR DESCRIPTION
## Summary
- add direct Rust agent-loop regression coverage for `AgentConfig::ephemeral_system_prompt`
- verify ephemeral system prompts are visible to the provider request but absent from returned/persisted `AgentResult.messages`
- classify upstream `d36790de9153` as ported, combining this agent coverage with the already-merged batch dataset runner ephemeral prompt non-persistence tests

## Verification
- `jq empty docs/parity/queue-overrides.json`
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-agent ephemeral_system_prompt_is_model_visible_but_not_returned_for_persistence -- --nocapture`
- `cargo test -p hermes-intelligence batch_dataset -- --nocapture`
- `cargo build -p hermes-agent -p hermes-intelligence`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-intelligence` (`new=0`, `stale=8`)
- `python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref origin/main --upstream-remote upstream --upstream-branch main --no-fetch --out-json /tmp/hermes-agent-ephemeral-system-prompt-queue.json --out-md /tmp/hermes-agent-ephemeral-system-prompt-queue.md`

## Queue Delta
- pending: `1856 -> 1855`
- ported: `160 -> 161`

## Disk Guard
- repo `target`: `0B`
- external target: `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
