### PR TITLE
test(terminal): prove output and task isolation parity

### DIFF
--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -920,6 +920,19 @@ mod tests {
     }
 
     #[test]
+    fn terminal_handler_surfaces_backend_stdout_as_user_visible_output() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let result = block_on(handler.execute(json!({"command": "stdout-only"}))).unwrap();
+
+        assert_eq!(result, "output of: stdout-only / stdin=");
+    }
+
+    #[test]
     fn test_terminal_handler_uses_registered_task_cwd_when_workdir_omitted() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
@@ -938,6 +951,33 @@ mod tests {
 
         let calls = calls.lock().unwrap_or_else(|e| e.into_inner());
         assert_eq!(calls.as_slice(), [Some("/workspace/acp".to_string())]);
+    }
+
+    #[test]
+    fn terminal_handler_task_cwds_are_isolated_by_task_id() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let backend = Arc::new(RecordingBackend::default());
+        let calls = backend.calls.clone();
+        let handler = TerminalHandler::new(backend);
+        handler.set_task_cwd("task-a", "/workspace/task-a");
+        handler.set_task_cwd("task-b", "/workspace/task-b");
+
+        block_on(handler.execute(json!({"command": "pwd", "task_id": "task-a"}))).unwrap();
+        block_on(handler.execute(json!({"command": "pwd", "task_id": "task-b"}))).unwrap();
+        block_on(handler.execute(json!({"command": "pwd"}))).unwrap();
+
+        let calls = calls.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            calls.as_slice(),
+            [
+                Some("/workspace/task-a".to_string()),
+                Some("/workspace/task-b".to_string()),
+                None
+            ]
+        );
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -52,6 +52,18 @@
       "disposition": "ported",
       "notes": "The upstream atomic_json_write/checkpoint test refactor is ported as Rust hermes_intelligence::rl atomic_json_write plus BatchRunCheckpoint load/save helpers and BatchDatasetRunner checkpoint-path resume. Focused tests cover valid/overwrite writes, parent dirs, original preservation on serialization failure, no temp leaks, Unicode/concurrent writes, missing/corrupt checkpoint handling, run-name mismatch fresh starts, last_updated, and persisted resume progress."
     },
+    "10b4cfeace24": {
+      "disposition": "ported",
+      "notes": "Rust TerminalHandler already surfaces backend CommandOutput.stdout as the user-visible tool return string through format_command_output, including nonzero exit handling. This batch adds an explicit regression test proving backend stdout is returned without relying on a legacy output/stdout compatibility shim."
+    },
+    "a4db3fdee5b9": {
+      "disposition": "superseded",
+      "notes": "The upstream Morph leakage fix is superseded by Rust terminal architecture: terminal execution uses injected TerminalBackend implementations rather than shared Hecate/Morph module globals, and task_id only resolves scoped cwd state. Focused tests prove task-a, task-b, and no-task calls do not share task cwd state."
+    },
+    "fbd3a2fdb88e": {
+      "disposition": "superseded",
+      "notes": "The upstream per-task Morph instance cleanup/leakage patch is superseded by Rust's non-Morph terminal runtime plus task-scoped cwd registry. TerminalHandler tests now prove task_id isolation and explicit workdir precedence, so one task cannot inherit another task's terminal cwd context."
+    },
     "395dbcc873c8": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"


### PR DESCRIPTION
## Summary
- add explicit terminal regression coverage that backend `stdout` is surfaced as user-visible tool output
- add task-id cwd isolation coverage for task-a/task-b/no-task terminal calls
- classify upstream `10b4cfeace24` as ported
- classify upstream Morph leakage rows `a4db3fdee5b9` and `fbd3a2fdb88e` as superseded by Rust terminal architecture and task-scoped cwd state

## Verification
- `jq empty docs/parity/queue-overrides.json`
- `git diff --check`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-tools terminal_handler_surfaces_backend_stdout_as_user_visible_output -- --nocapture`
- `cargo test -p hermes-tools terminal_handler_task_cwds_are_isolated_by_task_id -- --nocapture`
- `cargo test -p hermes-tools terminal_handler -- --nocapture`
- `cargo build -p hermes-tools`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools` (`new=0`, `stale=8`)
- `python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref origin/main --upstream-remote upstream --upstream-branch main --no-fetch --out-json /tmp/hermes-terminal-output-task-isolation-queue.json --out-md /tmp/hermes-terminal-output-task-isolation-queue.md`

## Queue Delta
- pending: `1853 -> 1850`
- ported: `163 -> 164`
- superseded: `7680 -> 7682`

## Disk Guard
- repo `target`: `0B`
- external target: `/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation`
