### PR TITLE
parity(hindsight): port runtime config fixes

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -13,8 +13,9 @@
 //!   - `HINDSIGHT_MODE` (default: "cloud")
 //!   - `$HERMES_HOME/hindsight/config.json` overrides
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
@@ -25,7 +26,9 @@ use crate::memory_plugins::config_io;
 const DEFAULT_API_URL: &str = "https://api.hindsight.vectorize.io";
 const DEFAULT_LOCAL_URL: &str = "http://localhost:8888";
 const DEFAULT_RECALL_TYPE: &str = "observation";
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
 const VALID_BUDGETS: &[&str] = &["low", "mid", "high"];
+static DOCUMENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 // ---------------------------------------------------------------------------
 // Tool schemas
@@ -125,7 +128,8 @@ impl HindsightConfig {
             timeout_secs: std::env::var("HINDSIGHT_TIMEOUT")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(90),
+                .map(|v| v.max(1))
+                .unwrap_or(DEFAULT_TIMEOUT_SECS),
         };
 
         // Try profile-scoped config first, then legacy path
@@ -231,17 +235,14 @@ impl HindsightConfig {
             }
         }
 
+        config.mode = normalize_hindsight_mode(&config.mode);
+
         // Apply defaults for api_url based on mode
         if config.api_url.is_empty() {
             config.api_url = match config.mode.as_str() {
-                "local_embedded" | "local_external" | "local" => DEFAULT_LOCAL_URL.to_string(),
+                "local_external" => DEFAULT_LOCAL_URL.to_string(),
                 _ => DEFAULT_API_URL.to_string(),
             };
-        }
-
-        // Normalize "local" → "local_embedded"
-        if config.mode == "local" {
-            config.mode = "local_embedded".to_string();
         }
 
         config
@@ -256,6 +257,7 @@ impl HindsightConfig {
 pub struct HindsightPlugin {
     config: Mutex<Option<HindsightConfig>>,
     session_id: Mutex<String>,
+    document_id: Mutex<String>,
     prefetch_result: Arc<Mutex<String>>,
     turn_counter: Mutex<u32>,
     session_turns: Mutex<Vec<String>>,
@@ -266,6 +268,7 @@ impl HindsightPlugin {
         Self {
             config: Mutex::new(None),
             session_id: Mutex::new(String::new()),
+            document_id: Mutex::new(String::new()),
             prefetch_result: Arc::new(Mutex::new(String::new())),
             turn_counter: Mutex::new(0),
             session_turns: Mutex::new(Vec::new()),
@@ -290,19 +293,31 @@ impl MemoryProviderPlugin for HindsightPlugin {
     fn is_available(&self) -> bool {
         let api_key = std::env::var("HINDSIGHT_API_KEY").unwrap_or_default();
         let api_url = std::env::var("HINDSIGHT_API_URL").unwrap_or_default();
-        let mode = std::env::var("HINDSIGHT_MODE").unwrap_or_default();
-        if matches!(mode.as_str(), "local" | "local_embedded" | "local_external") {
+        let mode = normalize_hindsight_mode(&std::env::var("HINDSIGHT_MODE").unwrap_or_default());
+        if mode == "local_external" {
+            return true;
+        }
+        let config_path = config_io::default_hermes_home()
+            .join("hindsight")
+            .join("config.json");
+        let config = config_io::read_json_object(&config_path);
+        if config
+            .get("mode")
+            .and_then(Value::as_str)
+            .map(normalize_hindsight_mode)
+            .is_some_and(|mode| mode == "local_external")
+        {
             return true;
         }
         // Cloud mode requires credentials (or explicit API URL for self-hosted).
         !api_key.is_empty()
             || !api_url.is_empty()
-            || config_io::json_file_has_nonempty_string(
-                &config_io::default_hermes_home()
-                    .join("hindsight")
-                    .join("config.json"),
-                &["api_key", "apiKey", "api_url"],
-            )
+            || ["api_key", "apiKey", "api_url"].iter().any(|key| {
+                config
+                    .get(*key)
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.trim().is_empty())
+            })
     }
 
     fn initialize(&self, session_id: &str, hermes_home: &str) {
@@ -336,6 +351,7 @@ impl MemoryProviderPlugin for HindsightPlugin {
             config.memory_mode
         );
         *self.session_id.lock().unwrap() = session_id.to_string();
+        *self.document_id.lock().unwrap() = scoped_document_id(session_id);
         *self.turn_counter.lock().unwrap() = 0;
         self.session_turns.lock().unwrap().clear();
         *self.config.lock().unwrap() = Some(config);
@@ -485,16 +501,13 @@ impl MemoryProviderPlugin for HindsightPlugin {
         }
 
         let now = chrono::Utc::now().to_rfc3339();
-        let turn = json!([
-            {"role": "user", "content": user_content, "timestamp": &now},
-            {"role": "assistant", "content": assistant_content, "timestamp": &now},
-        ])
-        .to_string();
+        let turn = hindsight_turn_payload(user_content, assistant_content, &now);
 
         self.session_turns.lock().unwrap().push(turn);
 
         let cfg = config.clone();
         let sid = session_id.to_string();
+        let document_id = self.document_id.lock().unwrap().clone();
         let content = {
             let mut turns = self.session_turns.lock().unwrap();
             let joined = turns.join(",");
@@ -516,10 +529,12 @@ impl MemoryProviderPlugin for HindsightPlugin {
             let base = cfg.api_url.trim_end_matches('/').to_string();
             let bank = urlencode_path(&cfg.bank_id);
             let url = format!("{}/v1/default/banks/{}/memories", base, bank);
-            let body = json!({
-                "items": [{"content": content, "context": cfg.retain_context}],
-                "async": cfg.retain_async,
-            });
+            let body = hindsight_sync_turn_body(
+                &content,
+                &cfg.retain_context,
+                cfg.retain_async,
+                nonempty_str(&document_id),
+            );
             let mut req = client.post(&url).json(&body);
             if !cfg.api_key.is_empty() {
                 req = req.bearer_auth(&cfg.api_key);
@@ -634,12 +649,12 @@ impl MemoryProviderPlugin for HindsightPlugin {
 
     fn get_config_schema(&self) -> Option<Value> {
         Some(json!([
-            {"key": "mode", "description": "Connection mode", "default": "cloud", "choices": ["cloud", "local_embedded", "local_external"]},
+            {"key": "mode", "description": "Connection mode. Legacy local/local_embedded values are treated as local_external in the Rust runtime.", "default": "cloud", "choices": ["cloud", "local_external"]},
             {"key": "api_url", "description": "Hindsight API URL", "default": DEFAULT_API_URL},
             {"key": "api_key", "description": "Hindsight API key", "secret": true, "env_var": "HINDSIGHT_API_KEY", "url": "https://ui.hindsight.vectorize.io"},
             {"key": "bank_id", "description": "Memory bank name", "default": "hermes"},
             {"key": "bank_id_template", "description": "Optional dynamic bank template with placeholders: {profile}, {workspace}, {platform}, {user}, {session}", "default": ""},
-            {"key": "hindsight_timeout", "description": "HTTP timeout in seconds", "default": 90},
+            {"key": "hindsight_timeout", "description": "HTTP timeout in seconds", "default": DEFAULT_TIMEOUT_SECS},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "recall_types", "description": "Fact types returned by recall", "default": DEFAULT_RECALL_TYPE},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]}
@@ -651,6 +666,37 @@ impl MemoryProviderPlugin for HindsightPlugin {
             .join("hindsight")
             .join("config.json");
         config_io::merge_and_write_owner_only(&path, config)
+    }
+}
+
+fn normalize_hindsight_mode(mode: &str) -> String {
+    match mode.trim() {
+        "local" | "local_embedded" => "local_external".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn nonempty_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn scoped_document_id(session_id: &str) -> String {
+    let counter = DOCUMENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let started_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let suffix = format!("{}-{}-{}", std::process::id(), started_at, counter);
+    let session = session_id.trim();
+    if session.is_empty() {
+        suffix
+    } else {
+        format!("{}-{}", session, suffix)
     }
 }
 
@@ -760,6 +806,30 @@ fn hindsight_recall_body(
         "max_tokens": max_tokens,
         "types": recall_types,
     })
+}
+
+fn hindsight_turn_payload(user_content: &str, assistant_content: &str, timestamp: &str) -> String {
+    json!([
+        {"role": "user", "content": user_content, "timestamp": timestamp},
+        {"role": "assistant", "content": assistant_content, "timestamp": timestamp},
+    ])
+    .to_string()
+}
+
+fn hindsight_sync_turn_body(
+    content: &str,
+    context: &str,
+    async_mode: bool,
+    document_id: Option<&str>,
+) -> Value {
+    let mut body = json!({
+        "items": [{"content": content, "context": context}],
+        "async": async_mode,
+    });
+    if let Some(document_id) = document_id {
+        body["document_id"] = json!(document_id);
+    }
+    body
 }
 
 struct HindsightRecallRequest<'a> {
@@ -896,6 +966,12 @@ mod tests {
             std::env::set_var(key, value);
             Self { key, previous }
         }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
     }
 
     impl Drop for EnvGuard {
@@ -949,7 +1025,7 @@ mod tests {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
-            timeout_secs: 90,
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
         });
         assert!(plugin.get_tool_schemas().is_empty());
     }
@@ -976,7 +1052,7 @@ mod tests {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
-            timeout_secs: 90,
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
         };
 
         *plugin.config.lock().unwrap() = Some(make_config("hybrid"));
@@ -1076,5 +1152,120 @@ mod tests {
             &[("profile", "p1".to_string())],
         );
         assert_eq!(bank, "fallback-bank");
+    }
+
+    fn write_hindsight_config(hermes_home: &std::path::Path, value: &Value) {
+        let path = hermes_home.join("hindsight").join("config.json");
+        std::fs::create_dir_all(path.parent().expect("config parent")).expect("mkdir config");
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(value).expect("serialize config"),
+        )
+        .expect("write config");
+    }
+
+    #[test]
+    fn test_config_accepts_snake_case_api_key_and_timeout_aliases() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let _api_key = EnvGuard::remove("HINDSIGHT_API_KEY");
+        let _api_url = EnvGuard::remove("HINDSIGHT_API_URL");
+        let _bank_id = EnvGuard::remove("HINDSIGHT_BANK_ID");
+        let _mode = EnvGuard::remove("HINDSIGHT_MODE");
+        let _timeout = EnvGuard::remove("HINDSIGHT_TIMEOUT");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_hindsight_config(
+            tmp.path(),
+            &json!({"mode": "cloud", "api_key": "snake-secret", "timeout": 42}),
+        );
+        let cfg = HindsightConfig::load(tmp.path().to_str().expect("tmp path"));
+        assert_eq!(cfg.api_key, "snake-secret");
+        assert_eq!(cfg.timeout_secs, 42);
+
+        write_hindsight_config(
+            tmp.path(),
+            &json!({"mode": "cloud", "apiKey": "camel-secret", "hindsight_timeout": 17}),
+        );
+        let cfg = HindsightConfig::load(tmp.path().to_str().expect("tmp path"));
+        assert_eq!(cfg.api_key, "camel-secret");
+        assert_eq!(cfg.timeout_secs, 17);
+    }
+
+    #[test]
+    fn test_config_uses_env_timeout_and_normalizes_legacy_local_mode() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let _api_key = EnvGuard::remove("HINDSIGHT_API_KEY");
+        let _api_url = EnvGuard::remove("HINDSIGHT_API_URL");
+        let _bank_id = EnvGuard::remove("HINDSIGHT_BANK_ID");
+        let _mode = EnvGuard::set("HINDSIGHT_MODE", "local_embedded");
+        let _timeout = EnvGuard::set("HINDSIGHT_TIMEOUT", "77");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_hindsight_config(tmp.path(), &json!({}));
+
+        let cfg = HindsightConfig::load(tmp.path().to_str().expect("tmp path"));
+        assert_eq!(cfg.mode, "local_external");
+        assert_eq!(cfg.api_url, DEFAULT_LOCAL_URL);
+        assert_eq!(cfg.timeout_secs, 77);
+    }
+
+    #[test]
+    fn test_available_with_local_external_config_mode() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _ultra_home = EnvGuard::remove("HERMES_AGENT_ULTRA_HOME");
+        let _api_key = EnvGuard::remove("HINDSIGHT_API_KEY");
+        let _api_url = EnvGuard::remove("HINDSIGHT_API_URL");
+        let _mode = EnvGuard::remove("HINDSIGHT_MODE");
+
+        write_hindsight_config(tmp.path(), &json!({"mode": "local_external"}));
+
+        assert!(HindsightPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_turn_payload_preserves_non_ascii_and_document_id() {
+        let turn =
+            hindsight_turn_payload("Café 東京 🚀", "Zażółć gęślą jaźń", "2026-06-08T00:00:00Z");
+        assert!(turn.contains("Café 東京 🚀"));
+        assert!(turn.contains("Zażółć gęślą jaźń"));
+        assert!(!turn.contains("\\u"));
+
+        let parsed: Value = serde_json::from_str(&turn).expect("turn json");
+        assert_eq!(parsed[0]["role"], "user");
+        assert_eq!(parsed[0]["content"], "Café 東京 🚀");
+        assert_eq!(parsed[1]["role"], "assistant");
+        assert_eq!(parsed[1]["content"], "Zażółć gęślą jaźń");
+
+        let content = format!("[{}]", turn);
+        let body = hindsight_sync_turn_body(&content, "conversation", false, Some("session-1-doc"));
+        assert_eq!(body["async"], false);
+        assert_eq!(body["document_id"], "session-1-doc");
+        assert_eq!(body["items"][0]["content"], content);
+        assert_eq!(body["items"][0]["context"], "conversation");
+    }
+
+    #[test]
+    fn test_initialize_scopes_document_id_per_lifecycle() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let _api_key = EnvGuard::remove("HINDSIGHT_API_KEY");
+        let _api_url = EnvGuard::remove("HINDSIGHT_API_URL");
+        let _bank_id = EnvGuard::remove("HINDSIGHT_BANK_ID");
+        let _mode = EnvGuard::remove("HINDSIGHT_MODE");
+        let _timeout = EnvGuard::remove("HINDSIGHT_TIMEOUT");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_hindsight_config(tmp.path(), &json!({"mode": "cloud", "api_key": "test"}));
+
+        let plugin = HindsightPlugin::new();
+        plugin.initialize("session-1", tmp.path().to_str().expect("tmp path"));
+        let first = plugin.document_id.lock().unwrap().clone();
+        plugin.initialize("session-1", tmp.path().to_str().expect("tmp path"));
+        let second = plugin.document_id.lock().unwrap().clone();
+
+        assert!(first.starts_with("session-1-"));
+        assert!(second.starts_with("session-1-"));
+        assert_ne!(first, second);
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -64,6 +64,46 @@
       "disposition": "superseded",
       "notes": "The upstream per-task Morph instance cleanup/leakage patch is superseded by Rust's non-Morph terminal runtime plus task-scoped cwd registry. TerminalHandler tests now prove task_id isolation and explicit workdir precedence, so one task cannot inherit another task's terminal cwd context."
     },
+    "a5c7422f2315": {
+      "disposition": "superseded",
+      "notes": "Python embedded Hindsight .env setup is superseded by the Rust-only Hindsight runtime: it does not launch hindsight-embed, and legacy local/local_embedded config is normalized to local_external HTTP mode."
+    },
+    "d6b65bbc47cf": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight auto-retain builds structured turn JSON without ASCII escaping, and tests prove non-ASCII user and assistant content survives in the retained payload."
+    },
+    "127048e6430f": {
+      "disposition": "ported",
+      "notes": "Rust HindsightConfig accepts both apiKey and snake_case api_key from config.json, with regression coverage for the snake_case path."
+    },
+    "3e994e38f763": {
+      "disposition": "superseded",
+      "notes": "Hindsight profile env materialization only applies to the upstream Python embedded daemon; the Rust runtime now documents and exposes cloud/local_external HTTP modes only."
+    },
+    "df55660e3c3c": {
+      "disposition": "superseded",
+      "notes": "The unsupported-CPU guard is a Python import workaround for local embedded Hindsight; Rust Hindsight never imports that Python stack and normalizes embedded aliases to local_external."
+    },
+    "93a74f74bf93": {
+      "disposition": "superseded",
+      "notes": "The shared asyncio event-loop shutdown fix is Python-runtime-only; Rust Hindsight uses reqwest blocking clients per operation and has no provider-owned event loop to stop."
+    },
+    "403c82b6b65b": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight supports HINDSIGHT_TIMEOUT and config timeout/hindsight_timeout aliases with a 120s default and focused config coverage."
+    },
+    "f1ba2f0c0b06": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight request clients for auto-recall, auto-retain, and tool calls all use the configured timeout_secs value."
+    },
+    "f9c6c5ab8472": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight now creates a per-initialization document_id and includes it in auto-retain batch bodies, with tests proving resumed sessions get distinct document IDs."
+    },
+    "edff2fbe7efd": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight supports bank_id_template with profile/workspace/platform/user/session placeholders, sanitization tests, schema exposure, and README coverage."
+    },
     "395dbcc873c8": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -1,90 +1,78 @@
 # Hindsight Memory Provider
 
-Long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval. Supports cloud, local embedded, and local external modes.
+Rust-native long-term memory integration for Hindsight, with retain, recall, and
+reflect support over the Hindsight HTTP API.
 
-## Requirements
+Hermes Agent Ultra prefers ContextLattice as the primary memory backbone.
+Hindsight is an optional provider for deployments that explicitly choose a
+Hindsight cloud or self-hosted memory bank.
 
-- **Cloud:** API key from [ui.hindsight.vectorize.io](https://ui.hindsight.vectorize.io)
-- **Local Embedded:** API key for a supported LLM provider (OpenAI, Anthropic, Gemini, Groq, OpenRouter, MiniMax, Ollama, or any OpenAI-compatible endpoint). Embeddings and reranking run locally — no additional API keys needed.
-- **Local External:** A running Hindsight instance (Docker or self-hosted) reachable over HTTP.
+## Supported Modes
+
+- **Cloud:** Hindsight Cloud API. Requires `HINDSIGHT_API_KEY`.
+- **Local External:** A running Hindsight-compatible service reachable over HTTP,
+  such as a Docker or self-hosted instance.
+
+The Rust runtime does not launch or manage a Python embedded Hindsight daemon.
+Legacy `local` and `local_embedded` config values are accepted for compatibility
+and normalized to `local_external`; provide `api_url` or `HINDSIGHT_API_URL` for
+that service.
 
 ## Setup
 
 ```bash
-hermes memory setup    # select "hindsight"
+hermes memory setup
 ```
 
-The setup wizard will install dependencies automatically via `uv` and walk you through configuration.
+Manual cloud configuration:
 
-Or manually (cloud mode with defaults):
 ```bash
 hermes config set memory.provider hindsight
-echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
+echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes-agent-ultra/.env
 ```
 
-### Cloud
+Manual local-external configuration:
 
-Connects to the Hindsight Cloud API. Requires an API key from [ui.hindsight.vectorize.io](https://ui.hindsight.vectorize.io).
-
-### Local Embedded
-
-Hermes spins up a local Hindsight daemon with built-in PostgreSQL. Requires an LLM API key for memory extraction and synthesis. The daemon starts automatically in the background on first use and stops after 5 minutes of inactivity.
-
-Supports any OpenAI-compatible LLM endpoint (llama.cpp, vLLM, LM Studio, etc.) — pick `openai_compatible` as the provider and enter the base URL.
-
-Daemon startup logs: `~/.hermes/logs/hindsight-embed.log`
-Daemon runtime logs: `~/.hindsight/profiles/<profile>.log`
-
-To open the Hindsight web UI (local embedded mode only):
-```bash
-hindsight-embed -p hermes ui start
+```json
+{
+  "mode": "local_external",
+  "api_url": "http://localhost:8888",
+  "bank_id": "hermes"
+}
 ```
-
-### Local External
-
-Points the plugin at an existing Hindsight instance you're already running (Docker, self-hosted, etc.). No daemon management — just a URL and an optional API key.
 
 ## Config
 
-Config file: `~/.hermes/hindsight/config.json`
+Config file: `$HERMES_HOME/hindsight/config.json`; by default this is
+`~/.hermes-agent-ultra/hindsight/config.json`.
 
 ### Connection
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `mode` | `cloud` | `cloud`, `local_embedded`, or `local_external` |
-| `api_url` | `https://api.hindsight.vectorize.io` | API URL (cloud and local_external modes) |
+| `mode` | `cloud` | `cloud` or `local_external`; legacy `local`/`local_embedded` values normalize to `local_external` |
+| `api_url` | cloud API URL | Hindsight HTTP API endpoint |
+| `api_key` | env | Optional API key; `apiKey` is also accepted for compatibility |
+| `hindsight_timeout` | `120` | HTTP timeout in seconds; `timeout` and `HINDSIGHT_TIMEOUT` are also accepted |
 
 ### Memory Bank
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
-| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
-| `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
-| `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
+| `bank_id` | `hermes` | Static memory bank fallback |
+| `bank_id_template` | empty | Optional dynamic bank template with `{profile}`, `{workspace}`, `{platform}`, `{user}`, and `{session}` placeholders |
 
 ### Recall
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
-| `recall_prefetch_method` | `recall` | Auto-recall method: `recall` (raw facts) or `reflect` (LLM synthesis) |
-| `recall_max_tokens` | `4096` | Maximum tokens for recall results |
+| `recall_budget` | `mid` | Recall thoroughness: `low`, `mid`, or `high` |
+| `recall_prefetch_method` | `recall` | Auto-prefetch method: `recall` or `reflect` |
+| `recall_max_tokens` | `4096` | Maximum tokens requested for recall results |
 | `recall_max_input_chars` | `800` | Maximum input query length for auto-recall |
-| `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
-| `recall_tags` | — | Tags to filter when searching memories |
-| `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
-| `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
+| `recall_prompt_preamble` | empty | Custom preamble for recalled memories injected into context |
+| `recall_types` | `observation` | Fact types surfaced by recall; comma-separated string or JSON list |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
-
-> **Behavior change — `recall_types` defaults to `observation` only.**
->
-> Previously recall returned all three fact types. It now returns only observations.
->
-> Per [Hindsight's docs](https://hindsight.vectorize.io/developer/observations), observations are the **consolidated** knowledge layer Hindsight builds on top of raw facts: deduplicated beliefs grounded in evidence, refined as new facts arrive, with proof counts and freshness signals. Raw `world` / `experience` facts are the individual supporting evidence that feeds them. For per-turn context injection, observations are denser per token and avoid feeding the model multiple raw facts that one observation already summarizes.
->
-> Restore the broad recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. This applies to **both** auto-recall and the `hindsight_recall` tool — both read the same `recall_types` setting (the tool schema has no per-call `types` argument), so narrowing the default narrows both paths.
 
 ### Retain
 
@@ -92,33 +80,22 @@ Config file: `~/.hermes/hindsight/config.json`
 |-----|---------|-------------|
 | `auto_retain` | `true` | Automatically retain conversation turns |
 | `retain_async` | `true` | Process retain asynchronously on the Hindsight server |
-| `retain_every_n_turns` | `1` | Retain every N turns (1 = every turn) |
+| `retain_every_n_turns` | `1` | Retain every N turns |
 | `retain_context` | `conversation between Hermes Agent and the User` | Context label for retained memories |
-| `retain_tags` | — | Default tags applied to retained memories; merged with per-call tool tags |
-| `retain_source` | — | Optional `metadata.source` attached to retained memories |
-| `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
-| `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
+
+Automatically retained turns are serialized as structured JSON and sent with a
+per-initialization `document_id` so resumed sessions append to a fresh process
+document instead of overwriting prior retained content.
 
 ### Integration
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `memory_mode` | `hybrid` | How memories are integrated into the agent |
+| `memory_mode` | `hybrid` | `hybrid`, `context`, or `tools` |
 
-**memory_mode:**
-- `hybrid` — automatic context injection + tools available to the LLM
-- `context` — automatic injection only, no tools exposed
-- `tools` — tools only, no automatic injection
-
-### Local Embedded LLM
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `llm_provider` | `openai` | `openai`, `anthropic`, `gemini`, `groq`, `openrouter`, `minimax`, `ollama`, `lmstudio`, `openai_compatible` |
-| `llm_model` | per-provider | Model name (e.g. `gpt-4o-mini`, `qwen/qwen3.5-9b`) |
-| `llm_base_url` | — | Endpoint URL for `openai_compatible` (e.g. `http://192.168.1.10:8080/v1`) |
-
-The LLM API key is stored in `~/.hermes/.env` as `HINDSIGHT_LLM_API_KEY`.
+`hybrid` injects automatic recall context and exposes tools. `context` injects
+automatic recall context without tools. `tools` exposes tools without automatic
+context injection.
 
 ## Tools
 
@@ -126,22 +103,18 @@ Available in `hybrid` and `tools` memory modes:
 
 | Tool | Description |
 |------|-------------|
-| `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
-| `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
+| `hindsight_retain` | Store a memory with optional `context` |
+| `hindsight_recall` | Multi-strategy memory search |
+| `hindsight_reflect` | Cross-memory synthesis |
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `HINDSIGHT_API_KEY` | API key for Hindsight Cloud |
-| `HINDSIGHT_LLM_API_KEY` | LLM API key for local mode |
-| `HINDSIGHT_API_LLM_BASE_URL` | LLM Base URL for local mode (e.g. OpenRouter) |
+| `HINDSIGHT_API_KEY` | API key for Hindsight Cloud or protected local services |
 | `HINDSIGHT_API_URL` | Override API endpoint |
 | `HINDSIGHT_BANK_ID` | Override bank name |
+| `HINDSIGHT_BANK_ID_TEMPLATE` | Dynamic bank template |
 | `HINDSIGHT_BUDGET` | Override recall budget |
-| `HINDSIGHT_MODE` | Override mode (`cloud`, `local_embedded`, `local_external`) |
-
-## Client Version
-
-Requires `hindsight-client >= 0.4.22`. The plugin auto-upgrades on session start if an older version is detected.
+| `HINDSIGHT_MODE` | Override mode (`cloud` or `local_external`; legacy local values normalize to `local_external`) |
+| `HINDSIGHT_TIMEOUT` | HTTP timeout in seconds |


### PR DESCRIPTION
## Summary
- Port Hindsight runtime/config parity fixes into the Rust memory provider: snake_case `api_key`, timeout aliases/env, per-initialization retain `document_id`, and non-ASCII retain payload coverage.
- Normalize legacy `local`/`local_embedded` Hindsight values to Rust-supported `local_external` HTTP mode instead of reintroducing the upstream Python embedded daemon path.
- Update Hindsight docs to state ContextLattice remains Hermes Agent Ultra's preferred memory backbone and Hindsight is optional, plus classify the 10-row upstream Hindsight subsection in `queue-overrides.json`.

## Verification
- `cargo test -p hermes-agent hindsight -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref HEAD --upstream-remote upstream --upstream-branch main --no-fetch --out-json /tmp/hermes-hindsight-queue.json --out-md /tmp/hermes-hindsight-queue.md`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent`
- `cargo build -p hermes-agent`

Queue proof: selected Hindsight rows are 6 ported / 4 superseded, and summary moved to `pending=868`, `ported=89`, `superseded=3890`.
