### PR TITLE
test(tui): isolate compression env overrides

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -27328,6 +27328,10 @@ mod tests {
                 "HERMES_INFERENCE_MODEL",
                 "HERMES_INFERENCE_PROVIDER",
                 "HERMES_TUI_PROVIDER",
+                "HERMES_TUI_MAX_ASSISTANT_RENDER_LINES",
+                "HERMES_TUI_MAX_TOOL_OUTPUT_LINES",
+                "HERMES_TUI_MAX_TOOL_OUTPUT_LINE_CHARS",
+                "HERMES_TUI_MAX_TOOL_OUTPUT_TOTAL_CHARS",
             ]
             .iter()
             .map(|key| (*key, std::env::var(key).ok()))

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -5685,8 +5685,13 @@ impl From<mpsc::UnboundedSender<Event>> for StreamHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock;
     use hermes_core::Message;
     use unicode_width::UnicodeWidthStr;
+
+    fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        test_env_lock::lock()
+    }
 
     #[test]
     fn test_input_mode_display() {
@@ -6288,6 +6293,7 @@ mod tests {
 
     #[test]
     fn test_format_tool_message_lines_parses_json_payload() {
+        let _guard = env_test_lock();
         let payload = r#"{"result":"line1\nline2","_budget_warning":"[BUDGET WARNING: Iteration 40/50.]","error":"boom"}"#;
         let lines = format_tool_message_lines(payload);
         let joined = lines.join("\n");
@@ -6300,6 +6306,7 @@ mod tests {
 
     #[test]
     fn test_format_tool_message_lines_adds_policy_remediation_block() {
+        let _guard = env_test_lock();
         let payload = r#"{
   "error":"Blocked by tool policy: tool params matched deny pattern '(?i)api[_-]?key'",
   "policy":{"code":"params_pattern_denied","mode":"enforce"}
@@ -6312,6 +6319,7 @@ mod tests {
 
     #[test]
     fn test_format_tool_message_lines_truncates_large_payload() {
+        let _guard = env_test_lock();
         let cap = max_tool_output_lines();
         let long = (0..(cap + 40))
             .map(|idx| format!("row-{idx}-{}", "x".repeat(120)))
@@ -6326,6 +6334,7 @@ mod tests {
 
     #[test]
     fn test_format_tool_message_lines_keeps_verbose_preview_small() {
+        let _guard = env_test_lock();
         let long = (0..80)
             .map(|idx| format!("row-{idx}-{}", "x".repeat(120)))
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- Restore TUI compression env vars in the slash-command test home guard so `/compress rules autotune apply` does not leak `HERMES_TUI_MAX_TOOL_OUTPUT_*` values into later tests.
- Serialize TUI tool-preview formatter tests on the existing shared test env lock while they read env-derived caps.

## Why
Post-merge `cargo test --workspace` exposed an order/parallelism-sensitive failure in `tui::tests::test_format_tool_message_lines_keeps_verbose_preview_small`. The test passed alone, confirming shared env interference rather than a Hindsight regression.

## Verification
- `cargo test -p hermes-cli test_format_tool_message_lines -- --nocapture`
- `cargo test -p hermes-cli p2_compress_rules_autotune_apply_updates_runtime_env -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
