### PR TITLE
parity(memory): port provider session batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ dependencies = [
  "tracing",
  "uuid",
  "which",
+ "zip",
 ]
 
 [[package]]

--- a/crates/hermes-agent/Cargo.toml
+++ b/crates/hermes-agent/Cargo.toml
@@ -36,6 +36,7 @@ syn = { version = "2", features = ["full"] }
 sha2 = "0.10"
 hex = "0.4"
 hmac = "0.12"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/hermes-agent/src/memory_manager.rs
+++ b/crates/hermes-agent/src/memory_manager.rs
@@ -81,6 +81,10 @@ pub trait MemoryProviderPlugin: Send + Sync {
         let _ = messages;
     }
 
+    fn on_session_switch(&self, new_session_id: &str, parent_session_id: &str, reset: bool) {
+        let _ = (new_session_id, parent_session_id, reset);
+    }
+
     fn on_pre_compress(&self, messages: &[Value]) -> String {
         let _ = messages;
         String::new()
@@ -484,6 +488,17 @@ impl MemoryManager {
     pub fn on_session_end(&self, messages: &[Value]) {
         for provider in &self.providers {
             provider.on_session_end(messages);
+        }
+    }
+
+    /// Notify all providers that the active session id changed.
+    pub fn on_session_switch(&self, new_session_id: &str, parent_session_id: &str, reset: bool) {
+        let new_session_id = new_session_id.trim();
+        if new_session_id.is_empty() {
+            return;
+        }
+        for provider in &self.providers {
+            provider.on_session_switch(new_session_id, parent_session_id, reset);
         }
     }
 
@@ -1054,6 +1069,44 @@ mod tests {
 
         let result = mm.handle_tool_call("memory", &serde_json::json!({}));
         assert!(result.contains("memory"));
+    }
+
+    #[test]
+    fn test_session_switch_propagates_to_providers() {
+        struct SwitchProvider {
+            seen: Arc<std::sync::Mutex<Vec<(String, String, bool)>>>,
+        }
+
+        impl MemoryProviderPlugin for SwitchProvider {
+            fn name(&self) -> &str {
+                "switch"
+            }
+
+            fn on_session_switch(
+                &self,
+                new_session_id: &str,
+                parent_session_id: &str,
+                reset: bool,
+            ) {
+                self.seen.lock().unwrap().push((
+                    new_session_id.to_string(),
+                    parent_session_id.to_string(),
+                    reset,
+                ));
+            }
+        }
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut mm = MemoryManager::new();
+        mm.add_provider(Arc::new(SwitchProvider { seen: seen.clone() }));
+
+        mm.on_session_switch("", "old", false);
+        mm.on_session_switch("new-session", "old-session", true);
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![("new-session".to_string(), "old-session".to_string(), true)]
+        );
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -13,8 +13,9 @@
 //!   - `HINDSIGHT_MODE` (default: "cloud")
 //!   - `$HERMES_HOME/hindsight/config.json` overrides
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::blocking::Client;
@@ -27,8 +28,10 @@ const DEFAULT_API_URL: &str = "https://api.hindsight.vectorize.io";
 const DEFAULT_LOCAL_URL: &str = "http://localhost:8888";
 const DEFAULT_RECALL_TYPE: &str = "observation";
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
+const MIN_VERSION_FOR_UPDATE_MODE_APPEND: &str = "0.5.0";
 const VALID_BUDGETS: &[&str] = &["low", "mid", "high"];
 static DOCUMENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+static APPEND_CAPABILITY_CACHE: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
 
 // ---------------------------------------------------------------------------
 // Tool schemas
@@ -261,6 +264,7 @@ pub struct HindsightPlugin {
     prefetch_result: Arc<Mutex<String>>,
     turn_counter: Mutex<u32>,
     session_turns: Mutex<Vec<String>>,
+    retain_batch_counter: Mutex<u64>,
 }
 
 impl HindsightPlugin {
@@ -272,6 +276,7 @@ impl HindsightPlugin {
             prefetch_result: Arc::new(Mutex::new(String::new())),
             turn_counter: Mutex::new(0),
             session_turns: Mutex::new(Vec::new()),
+            retain_batch_counter: Mutex::new(0),
         }
     }
 
@@ -282,6 +287,38 @@ impl HindsightPlugin {
             .as_ref()
             .map(|c| c.memory_mode.clone())
             .unwrap_or_else(|| "hybrid".to_string())
+    }
+
+    fn next_retain_document_id(&self) -> String {
+        let document_id = self.document_id.lock().unwrap().clone();
+        let mut counter = self.retain_batch_counter.lock().unwrap();
+        *counter = counter.saturating_add(1);
+        format!("{}-batch-{}", document_id, *counter)
+    }
+
+    fn take_pending_turns(&self) -> Vec<String> {
+        let mut turns = self.session_turns.lock().unwrap();
+        if turns.is_empty() {
+            Vec::new()
+        } else {
+            std::mem::take(&mut *turns)
+        }
+    }
+
+    fn flush_pending_turns(&self, reason: &'static str) {
+        let cfg = match self.config.lock().unwrap().clone() {
+            Some(c) => c,
+            None => return,
+        };
+        let turns = self.take_pending_turns();
+        if turns.is_empty() {
+            return;
+        }
+        let sid = self.session_id.lock().unwrap().clone();
+        let fallback_document_id = self.next_retain_document_id();
+        std::thread::spawn(move || {
+            retain_hindsight_turns(&cfg, &sid, &fallback_document_id, &turns, reason);
+        });
     }
 }
 
@@ -353,6 +390,7 @@ impl MemoryProviderPlugin for HindsightPlugin {
         *self.session_id.lock().unwrap() = session_id.to_string();
         *self.document_id.lock().unwrap() = scoped_document_id(session_id);
         *self.turn_counter.lock().unwrap() = 0;
+        *self.retain_batch_counter.lock().unwrap() = 0;
         self.session_turns.lock().unwrap().clear();
         *self.config.lock().unwrap() = Some(config);
     }
@@ -494,64 +532,26 @@ impl MemoryProviderPlugin for HindsightPlugin {
             return;
         }
 
+        let now = chrono::Utc::now().to_rfc3339();
+        let turn = hindsight_turn_payload(user_content, assistant_content, &now);
+        self.session_turns.lock().unwrap().push(turn);
+
         let mut counter = self.turn_counter.lock().unwrap();
         *counter += 1;
         if *counter % config.retain_every_n_turns != 0 {
             return;
         }
 
-        let now = chrono::Utc::now().to_rfc3339();
-        let turn = hindsight_turn_payload(user_content, assistant_content, &now);
-
-        self.session_turns.lock().unwrap().push(turn);
-
         let cfg = config.clone();
         let sid = session_id.to_string();
-        let document_id = self.document_id.lock().unwrap().clone();
-        let content = {
-            let mut turns = self.session_turns.lock().unwrap();
-            let joined = turns.join(",");
-            turns.clear();
-            format!("[{}]", joined)
-        };
+        let fallback_document_id = self.next_retain_document_id();
+        let turns = self.take_pending_turns();
+        if turns.is_empty() {
+            return;
+        }
 
         std::thread::spawn(move || {
-            let client = match Client::builder()
-                .timeout(Duration::from_secs(cfg.timeout_secs))
-                .build()
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::debug!("Hindsight sync client: {}", e);
-                    return;
-                }
-            };
-            let base = cfg.api_url.trim_end_matches('/').to_string();
-            let bank = urlencode_path(&cfg.bank_id);
-            let url = format!("{}/v1/default/banks/{}/memories", base, bank);
-            let body = hindsight_sync_turn_body(
-                &content,
-                &cfg.retain_context,
-                cfg.retain_async,
-                nonempty_str(&document_id),
-            );
-            let mut req = client.post(&url).json(&body);
-            if !cfg.api_key.is_empty() {
-                req = req.bearer_auth(&cfg.api_key);
-            }
-            match req.send() {
-                Ok(resp) if resp.status().is_success() => {
-                    tracing::debug!("Hindsight retain_batch ok for session {}", sid);
-                }
-                Ok(resp) => {
-                    tracing::debug!(
-                        "Hindsight retain_batch HTTP {} for session {}",
-                        resp.status(),
-                        sid
-                    );
-                }
-                Err(e) => tracing::debug!("Hindsight retain_batch error: {}", e),
-            }
+            retain_hindsight_turns(&cfg, &sid, &fallback_document_id, &turns, "sync_turn");
         });
     }
 
@@ -640,10 +640,32 @@ impl MemoryProviderPlugin for HindsightPlugin {
     }
 
     fn on_session_end(&self, _messages: &[Value]) {
+        self.flush_pending_turns("session_end");
         tracing::debug!("Hindsight session end");
     }
 
+    fn on_session_switch(&self, new_session_id: &str, parent_session_id: &str, reset: bool) {
+        let new_session_id = new_session_id.trim();
+        if new_session_id.is_empty() {
+            return;
+        }
+        self.flush_pending_turns("session_switch");
+        *self.prefetch_result.lock().unwrap() = String::new();
+        *self.session_id.lock().unwrap() = new_session_id.to_string();
+        *self.document_id.lock().unwrap() = scoped_document_id(new_session_id);
+        *self.turn_counter.lock().unwrap() = 0;
+        *self.retain_batch_counter.lock().unwrap() = 0;
+        self.session_turns.lock().unwrap().clear();
+        tracing::debug!(
+            "Hindsight session switch: new_session={} parent={} reset={}",
+            new_session_id,
+            parent_session_id,
+            reset
+        );
+    }
+
     fn shutdown(&self) {
+        self.flush_pending_turns("shutdown");
         tracing::debug!("Hindsight memory plugin shutdown");
     }
 
@@ -821,15 +843,166 @@ fn hindsight_sync_turn_body(
     context: &str,
     async_mode: bool,
     document_id: Option<&str>,
+    update_mode: Option<&str>,
 ) -> Value {
+    let mut item = json!({"content": content, "context": context});
+    if let Some(update_mode) = update_mode {
+        item["update_mode"] = json!(update_mode);
+    }
     let mut body = json!({
-        "items": [{"content": content, "context": context}],
+        "items": [item],
         "async": async_mode,
     });
     if let Some(document_id) = document_id {
         body["document_id"] = json!(document_id);
     }
     body
+}
+
+fn retain_hindsight_turns(
+    cfg: &HindsightConfig,
+    session_id: &str,
+    fallback_document_id: &str,
+    turns: &[String],
+    reason: &str,
+) {
+    if turns.is_empty() {
+        return;
+    }
+    let client = match Client::builder()
+        .timeout(Duration::from_secs(cfg.timeout_secs))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!("Hindsight sync client: {}", e);
+            return;
+        }
+    };
+    let base = cfg.api_url.trim_end_matches('/').to_string();
+    let bank = urlencode_path(&cfg.bank_id);
+    let (document_id, update_mode) = hindsight_retain_target(
+        &client,
+        &base,
+        &cfg.api_key,
+        session_id,
+        fallback_document_id,
+    );
+    let content = format!("[{}]", turns.join(","));
+    let url = format!("{}/v1/default/banks/{}/memories", base, bank);
+    let body = hindsight_sync_turn_body(
+        &content,
+        &cfg.retain_context,
+        cfg.retain_async,
+        nonempty_str(&document_id),
+        update_mode,
+    );
+    let mut req = client.post(&url).json(&body);
+    if !cfg.api_key.is_empty() {
+        req = req.bearer_auth(&cfg.api_key);
+    }
+    match req.send() {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!(
+                "Hindsight retain_batch ok for session {} (reason={}, turns={}, update_mode={:?})",
+                session_id,
+                reason,
+                turns.len(),
+                update_mode
+            );
+        }
+        Ok(resp) => {
+            tracing::debug!(
+                "Hindsight retain_batch HTTP {} for session {} (reason={})",
+                resp.status(),
+                session_id,
+                reason
+            );
+        }
+        Err(e) => tracing::debug!("Hindsight retain_batch error (reason={}): {}", reason, e),
+    }
+}
+
+fn hindsight_retain_target(
+    client: &Client,
+    base: &str,
+    api_key: &str,
+    session_id: &str,
+    fallback_document_id: &str,
+) -> (String, Option<&'static str>) {
+    let stable_session = session_id.trim();
+    if !stable_session.is_empty() && hindsight_api_supports_append(client, base, api_key) {
+        (stable_session.to_string(), Some("append"))
+    } else {
+        (fallback_document_id.to_string(), None)
+    }
+}
+
+fn hindsight_api_supports_append(client: &Client, base: &str, api_key: &str) -> bool {
+    let base = base.trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return false;
+    }
+    let cache = APPEND_CAPABILITY_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(cached) = cache.lock().unwrap().get(&base).copied() {
+        return cached;
+    }
+
+    let url = format!("{}/version", base);
+    let mut req = client.get(&url);
+    if !api_key.is_empty() {
+        req = req.bearer_auth(api_key);
+    }
+    let version = req
+        .send()
+        .ok()
+        .filter(|resp| resp.status().is_success())
+        .and_then(|resp| resp.json::<Value>().ok())
+        .and_then(|value| {
+            value
+                .get("version")
+                .or_else(|| value.get("api_version"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        });
+    let supported =
+        hindsight_version_meets_minimum(version.as_deref(), MIN_VERSION_FOR_UPDATE_MODE_APPEND);
+    cache.lock().unwrap().insert(base.clone(), supported);
+    if !supported {
+        tracing::warn!(
+            "Hindsight API at {} does not report {}+ append support; using unique batch document ids",
+            base,
+            MIN_VERSION_FOR_UPDATE_MODE_APPEND
+        );
+    }
+    supported
+}
+
+fn hindsight_version_meets_minimum(actual: Option<&str>, required: &str) -> bool {
+    let Some(actual) = actual.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    let Some(actual_parts) = parse_semver_core(actual) else {
+        return false;
+    };
+    let Some(required_parts) = parse_semver_core(required) else {
+        return false;
+    };
+    actual_parts >= required_parts
+}
+
+fn parse_semver_core(raw: &str) -> Option<[u64; 3]> {
+    let core = raw
+        .trim()
+        .trim_start_matches('v')
+        .split(['-', '+'])
+        .next()
+        .unwrap_or("");
+    let mut parts = [0_u64; 3];
+    for (idx, piece) in core.split('.').take(3).enumerate() {
+        parts[idx] = piece.parse::<u64>().ok()?;
+    }
+    Some(parts)
 }
 
 struct HindsightRecallRequest<'a> {
@@ -1239,11 +1412,113 @@ mod tests {
         assert_eq!(parsed[1]["content"], "Zażółć gęślą jaźń");
 
         let content = format!("[{}]", turn);
-        let body = hindsight_sync_turn_body(&content, "conversation", false, Some("session-1-doc"));
+        let body = hindsight_sync_turn_body(
+            &content,
+            "conversation",
+            false,
+            Some("session-1-doc"),
+            Some("append"),
+        );
         assert_eq!(body["async"], false);
         assert_eq!(body["document_id"], "session-1-doc");
+        assert_eq!(body["items"][0]["update_mode"], "append");
         assert_eq!(body["items"][0]["content"], content);
         assert_eq!(body["items"][0]["context"], "conversation");
+    }
+
+    #[test]
+    fn test_hindsight_version_probe_semver_gate() {
+        assert!(hindsight_version_meets_minimum(Some("0.5.0"), "0.5.0"));
+        assert!(hindsight_version_meets_minimum(Some("v0.5.6"), "0.5.0"));
+        assert!(hindsight_version_meets_minimum(
+            Some("0.6.0+local"),
+            "0.5.0"
+        ));
+        assert!(!hindsight_version_meets_minimum(Some("0.4.99"), "0.5.0"));
+        assert!(!hindsight_version_meets_minimum(
+            Some("not-a-version"),
+            "0.5.0"
+        ));
+        assert!(!hindsight_version_meets_minimum(None, "0.5.0"));
+    }
+
+    #[test]
+    fn test_sync_turn_buffers_until_retain_threshold_then_drains() {
+        let plugin = HindsightPlugin::new();
+        *plugin.config.lock().unwrap() = Some(HindsightConfig {
+            api_key: "test".into(),
+            api_url: DEFAULT_API_URL.into(),
+            bank_id: "hermes".into(),
+            bank_id_template: String::new(),
+            budget: "mid".into(),
+            mode: "cloud".into(),
+            memory_mode: "hybrid".into(),
+            prefetch_method: "recall".into(),
+            auto_retain: true,
+            auto_recall: true,
+            retain_every_n_turns: 3,
+            retain_context: "conversation".into(),
+            recall_max_tokens: 4096,
+            recall_max_input_chars: 800,
+            recall_types: default_recall_types(),
+            recall_prompt_preamble: String::new(),
+            bank_mission: String::new(),
+            retain_async: true,
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+        });
+
+        plugin.sync_turn("u1", "a1", "session-1");
+        assert_eq!(plugin.session_turns.lock().unwrap().len(), 1);
+        plugin.sync_turn("u2", "a2", "session-1");
+        assert_eq!(plugin.session_turns.lock().unwrap().len(), 2);
+        plugin.sync_turn("u3", "a3", "session-1");
+        assert!(plugin.session_turns.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_session_switch_flushes_pending_turns_and_clears_prefetch() {
+        let plugin = HindsightPlugin::new();
+        *plugin.config.lock().unwrap() = Some(HindsightConfig {
+            api_key: "test".into(),
+            api_url: DEFAULT_API_URL.into(),
+            bank_id: "hermes".into(),
+            bank_id_template: String::new(),
+            budget: "mid".into(),
+            mode: "cloud".into(),
+            memory_mode: "hybrid".into(),
+            prefetch_method: "recall".into(),
+            auto_retain: true,
+            auto_recall: true,
+            retain_every_n_turns: 10,
+            retain_context: "conversation".into(),
+            recall_max_tokens: 4096,
+            recall_max_input_chars: 800,
+            recall_types: default_recall_types(),
+            recall_prompt_preamble: String::new(),
+            bank_mission: String::new(),
+            retain_async: true,
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+        });
+        *plugin.session_id.lock().unwrap() = "old-session".into();
+        *plugin.document_id.lock().unwrap() = "old-doc".into();
+        *plugin.prefetch_result.lock().unwrap() = "stale context".into();
+        plugin
+            .session_turns
+            .lock()
+            .unwrap()
+            .push(hindsight_turn_payload("u", "a", "2026-06-08T00:00:00Z"));
+
+        plugin.on_session_switch("new-session", "old-session", false);
+
+        assert!(plugin.session_turns.lock().unwrap().is_empty());
+        assert_eq!(*plugin.session_id.lock().unwrap(), "new-session");
+        assert!(plugin
+            .document_id
+            .lock()
+            .unwrap()
+            .starts_with("new-session-"));
+        assert!(plugin.prefetch_result.lock().unwrap().is_empty());
+        assert_eq!(*plugin.turn_counter.lock().unwrap(), 0);
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/honcho.rs
+++ b/crates/hermes-agent/src/memory_plugins/honcho.rs
@@ -25,6 +25,7 @@ use crate::memory_plugins::config_io;
 
 const HOST: &str = "hermes";
 const DEFAULT_BASE_URL: &str = "https://api.honcho.dev";
+const DEFAULT_TIMEOUT_SECS: f64 = 30.0;
 const PEER_ID_HASH_ESCALATION_LENGTHS: &[usize] = &[8, 12, 16, 24, 32, 64];
 
 // ---------------------------------------------------------------------------
@@ -123,7 +124,7 @@ impl HonchoConfig {
         let timeout_secs = std::env::var("HONCHO_TIMEOUT_SECS")
             .ok()
             .and_then(|s| s.parse::<f64>().ok())
-            .unwrap_or(12.0)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
             .clamp(1.0, 60.0);
         let mut endpoints = HashMap::new();
         for (key, env) in [
@@ -163,8 +164,10 @@ impl HonchoConfig {
         let host = active_host();
         config.workspace_id = host.clone();
         config.ai_peer = host.clone();
-        let config_path = Self::config_path(hermes_home);
-        if let Ok(content) = std::fs::read_to_string(&config_path) {
+        for config_path in honcho_config_load_paths(hermes_home) {
+            let Ok(content) = std::fs::read_to_string(&config_path) else {
+                continue;
+            };
             if let Ok(raw) = serde_json::from_str::<Value>(&content) {
                 Self::apply_config_value(&mut config, &raw);
                 if let Some(host_block) = honcho_host_block(&raw, &host) {
@@ -173,7 +176,7 @@ impl HonchoConfig {
                 }
             }
         }
-        config.base_url = strip_honcho_base_url_version(&config.base_url);
+        config.base_url = normalize_honcho_base_url(&config.base_url);
         if config.base_url.is_empty() {
             config.base_url = DEFAULT_BASE_URL.to_string();
         }
@@ -336,11 +339,42 @@ fn honcho_host_block<'a>(raw: &'a Value, host: &str) -> Option<&'a Value> {
     legacy_profile_host_key(host).and_then(|legacy| hosts.get(&legacy))
 }
 
+fn honcho_config_load_paths(hermes_home: &str) -> Vec<std::path::PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".honcho").join("config.json"));
+        paths.push(home.join(".hermes").join("honcho.json"));
+    }
+    paths.push(HonchoConfig::config_path(hermes_home));
+
+    let mut deduped = Vec::new();
+    for path in paths {
+        if !deduped.iter().any(|existing| existing == &path) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
 fn value_has_nonempty_api_key(raw: &Value) -> bool {
     raw.get("apiKey")
         .or_else(|| raw.get("api_key"))
         .and_then(Value::as_str)
         .is_some_and(|key| !key.trim().is_empty())
+}
+
+fn normalize_honcho_base_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return strip_honcho_base_url_version(trimmed);
+    }
+    if trimmed.contains("://") {
+        return String::new();
+    }
+    strip_honcho_base_url_version(&format!("https://{trimmed}"))
 }
 
 fn strip_honcho_base_url_version(raw: &str) -> String {
@@ -755,6 +789,14 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
                             .or_else(|| v.get("result"))
                             .and_then(|c| c.as_array())
                         {
+                            if card.is_empty() {
+                                return json!({
+                                    "result": card,
+                                    "count": 0,
+                                    "hint": honcho_empty_profile_hint(&peer)
+                                })
+                                .to_string();
+                            }
                             return json!({"result": card, "count": card.len()}).to_string();
                         }
                         json!({"result": v}).to_string()
@@ -885,6 +927,22 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
         }
     }
 
+    fn on_session_switch(&self, new_session_id: &str, parent_session_id: &str, reset: bool) {
+        let new_session_id = new_session_id.trim();
+        if new_session_id.is_empty() {
+            return;
+        }
+        *self.session_key.lock().unwrap() = new_session_id.to_string();
+        *self.turn_count.lock().unwrap() = 0;
+        *self.prefetch_result.lock().unwrap() = String::new();
+        tracing::debug!(
+            "Honcho session switch: new_session={} parent={} reset={}",
+            new_session_id,
+            parent_session_id,
+            reset
+        );
+    }
+
     fn on_memory_write(&self, action: &str, target: &str, content: &str) {
         if action != "add" || target != "user" || content.trim().is_empty() {
             return;
@@ -918,7 +976,7 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
         Some(json!([
             {"key": "api_key", "description": "Honcho API key", "secret": true, "env_var": "HONCHO_API_KEY", "url": "https://app.honcho.dev"},
             {"key": "baseUrl", "description": "Honcho base URL (for self-hosted)"},
-            {"key": "timeout", "description": "HTTP timeout seconds", "default": 12},
+            {"key": "timeout", "description": "HTTP timeout seconds", "default": DEFAULT_TIMEOUT_SECS},
             {"key": "pinUserPeer", "description": "Pin gateway runtime users to peerName", "default": false},
             {"key": "userPeerAliases", "description": "Runtime user ID to Honcho peer ID map"},
             {"key": "runtimePeerPrefix", "description": "Prefix for unknown gateway runtime user peers", "default": ""},
@@ -1032,6 +1090,14 @@ fn generated_runtime_peer_id(config: &HonchoConfig, prefix: &str, runtime_id: &s
         return format!("{sanitized_peer_id}-{hex}");
     }
     sanitized_peer_id
+}
+
+fn honcho_empty_profile_hint(peer: &str) -> String {
+    let peer = peer.trim();
+    let label = if peer.is_empty() { "this peer" } else { peer };
+    format!(
+        "Honcho returned an empty profile card for {label}. Use honcho_search for raw context, honcho_context for a synthesized answer, or honcho_conclude to save a durable user fact."
+    )
 }
 
 #[cfg(test)]
@@ -1217,7 +1283,7 @@ mod tests {
             pin_user_peer: false,
             user_peer_aliases: HashMap::new(),
             runtime_peer_prefix: String::new(),
-            timeout_secs: 12.0,
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
             endpoints: HashMap::new(),
             host_had_explicit_api_key: false,
         }
@@ -1268,6 +1334,31 @@ mod tests {
         assert_eq!(cfg.ai_peer, "coder-ai");
         assert_eq!(cfg.peer_name.as_deref(), Some("operator"));
         assert!(cfg.host_had_explicit_api_key);
+    }
+
+    #[test]
+    fn test_honcho_config_loads_global_fallback_and_normalizes_base_url() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let hermes_home = tmp.path().join("profile-home");
+        let global_dir = tmp.path().join(".honcho");
+        std::fs::create_dir_all(&global_dir).expect("mkdir global");
+        let _home = EnvGuard::set("HOME", tmp.path());
+        let _hermes_home = EnvGuard::set("HERMES_HOME", &hermes_home);
+        let _profile = EnvGuard::remove("HERMES_PROFILE");
+        let _api = EnvGuard::remove("HONCHO_API_KEY");
+        let _url = EnvGuard::remove("HONCHO_BASE_URL");
+        std::fs::write(
+            global_dir.join("config.json"),
+            r#"{"baseUrl":"honcho.example.com/v1","enabled":true,"timeout":45}"#,
+        )
+        .expect("write global config");
+
+        let cfg = HonchoConfig::from_config_file(&hermes_home.to_string_lossy());
+
+        assert_eq!(cfg.base_url, "https://honcho.example.com");
+        assert_eq!(cfg.timeout_secs, 45.0);
+        assert!(cfg.enabled);
     }
 
     #[test]
@@ -1367,6 +1458,15 @@ mod tests {
             HonchoMemoryPlugin::extract_peer(&config, &json!({"peer": "ai"})),
             "hermes"
         );
+    }
+
+    #[test]
+    fn test_honcho_empty_profile_hint_points_to_memory_actions() {
+        let hint = honcho_empty_profile_hint("user-peer");
+        assert!(hint.contains("user-peer"));
+        assert!(hint.contains("honcho_search"));
+        assert!(hint.contains("honcho_context"));
+        assert!(hint.contains("honcho_conclude"));
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/openviking.rs
+++ b/crates/hermes-agent/src/memory_plugins/openviking.rs
@@ -2,9 +2,12 @@
 //!
 //! Mirrors Python `plugins/memory/openviking/__init__.py` (HTTP subset).
 
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 
+use reqwest::blocking::multipart::{Form, Part};
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
 
@@ -13,6 +16,7 @@ use crate::memory_manager::MemoryProviderPlugin;
 const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:1933";
 const DEFAULT_AGENT: &str = "hermes";
 const DEFAULT_MEMORY_SUBDIR: &str = "preferences";
+const REMOTE_RESOURCE_PREFIXES: &[&str] = &["http://", "https://", "git@", "ssh://", "git://"];
 
 fn search_schema() -> Value {
     json!({
@@ -79,12 +83,17 @@ fn remember_schema() -> Value {
 fn add_resource_schema() -> Value {
     json!({
         "name": "viking_add_resource",
-        "description": "Add a URL or document path to the knowledge base.",
+        "description": "Add a remote URL or local file/directory to the knowledge base.",
         "parameters": {
             "type": "object",
             "properties": {
                 "url": {"type": "string"},
-                "reason": {"type": "string"}
+                "reason": {"type": "string"},
+                "to": {"type": "string"},
+                "parent": {"type": "string"},
+                "instruction": {"type": "string"},
+                "wait": {"type": "boolean"},
+                "timeout": {"type": "number"}
             },
             "required": ["url"]
         }
@@ -111,6 +120,17 @@ pub struct OpenVikingMemoryPlugin {
 fn viking_headers(st: &VikingState) -> reqwest::header::HeaderMap {
     let mut h = reqwest::header::HeaderMap::new();
     h.insert("Content-Type", "application/json".parse().expect("mime"));
+    append_viking_tenant_headers(&mut h, st);
+    h
+}
+
+fn viking_multipart_headers(st: &VikingState) -> reqwest::header::HeaderMap {
+    let mut h = reqwest::header::HeaderMap::new();
+    append_viking_tenant_headers(&mut h, st);
+    h
+}
+
+fn append_viking_tenant_headers(h: &mut reqwest::header::HeaderMap, st: &VikingState) {
     h.insert("X-OpenViking-Account", st.account.parse().expect("account"));
     h.insert("X-OpenViking-User", st.user.parse().expect("user"));
     h.insert("X-OpenViking-Agent", st.agent.parse().expect("agent"));
@@ -121,7 +141,6 @@ fn viking_headers(st: &VikingState) -> reqwest::header::HeaderMap {
             format!("Bearer {}", st.api_key).parse().expect("bearer"),
         );
     }
-    h
 }
 
 fn viking_uri_segment(raw: &str) -> String {
@@ -176,6 +195,274 @@ fn content_write_body(st: &VikingState, subdir: &str, content: &str) -> Value {
         "content": content,
         "mode": "create",
     })
+}
+
+fn is_remote_resource_source(value: &str) -> bool {
+    REMOTE_RESOURCE_PREFIXES
+        .iter()
+        .any(|prefix| value.starts_with(prefix))
+}
+
+fn is_windows_absolute_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+fn is_local_path_reference(value: &str) -> bool {
+    if value.is_empty() || value.contains('\n') || value.contains('\r') {
+        return false;
+    }
+    if is_remote_resource_source(value) {
+        return false;
+    }
+    is_windows_absolute_path(value)
+        || value.starts_with('/')
+        || value.starts_with("./")
+        || value.starts_with("../")
+        || value.starts_with("~/")
+        || value.starts_with(".\\")
+        || value.starts_with("..\\")
+        || value.starts_with("~\\")
+        || value.contains('/')
+        || value.contains('\\')
+}
+
+fn file_uri_to_path(uri: &str) -> Result<PathBuf, String> {
+    let Some(rest) = uri.strip_prefix("file://") else {
+        return Err(format!("Unsupported file URI: {uri}"));
+    };
+    let path = if let Some(path) = rest.strip_prefix("localhost/") {
+        format!("/{path}")
+    } else if rest.starts_with('/') {
+        rest.to_string()
+    } else {
+        return Err(format!("Unsupported non-local file URI: {uri}"));
+    };
+    percent_decode_path(&path).map(PathBuf::from)
+}
+
+fn percent_decode_path(raw: &str) -> Result<String, String> {
+    let mut out = Vec::with_capacity(raw.len());
+    let bytes = raw.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if bytes[idx] == b'%' {
+            if idx + 2 >= bytes.len() {
+                return Err(format!("Invalid percent escape in path: {raw}"));
+            }
+            let hex = std::str::from_utf8(&bytes[idx + 1..idx + 3])
+                .map_err(|_| format!("Invalid percent escape in path: {raw}"))?;
+            let value = u8::from_str_radix(hex, 16)
+                .map_err(|_| format!("Invalid percent escape in path: {raw}"))?;
+            out.push(value);
+            idx += 3;
+        } else {
+            out.push(bytes[idx]);
+            idx += 1;
+        }
+    }
+    String::from_utf8(out).map_err(|_| format!("Invalid UTF-8 in path URI: {raw}"))
+}
+
+fn zip_directory(dir_path: &Path) -> Result<PathBuf, String> {
+    let zip_path = std::env::temp_dir().join(format!(
+        "openviking_upload_{}.zip",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let file = std::fs::File::create(&zip_path)
+        .map_err(|e| format!("create {}: {e}", zip_path.display()))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+    add_directory_to_zip(dir_path, dir_path, &mut zip, options)?;
+    zip.finish()
+        .map_err(|e| format!("finish {}: {e}", zip_path.display()))?;
+    Ok(zip_path)
+}
+
+fn add_directory_to_zip(
+    root: &Path,
+    current: &Path,
+    zip: &mut zip::ZipWriter<std::fs::File>,
+    options: zip::write::SimpleFileOptions,
+) -> Result<(), String> {
+    for entry in
+        std::fs::read_dir(current).map_err(|e| format!("read_dir {}: {e}", current.display()))?
+    {
+        let entry = entry.map_err(|e| format!("read_dir entry {}: {e}", current.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("file_type {}: {e}", path.display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let metadata = entry
+            .metadata()
+            .map_err(|e| format!("metadata {}: {e}", path.display()))?;
+        if metadata.is_dir() {
+            add_directory_to_zip(root, &path, zip, options)?;
+            continue;
+        }
+        if !metadata.is_file() {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .map_err(|e| format!("strip_prefix {}: {e}", path.display()))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        zip.start_file(rel, options)
+            .map_err(|e| format!("zip start_file {}: {e}", path.display()))?;
+        let mut file =
+            std::fs::File::open(&path).map_err(|e| format!("open {}: {e}", path.display()))?;
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|e| format!("read {}: {e}", path.display()))?;
+        zip.write_all(&buffer)
+            .map_err(|e| format!("zip write {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn upload_temp_file(st: &VikingState, file_path: &Path) -> Result<String, String> {
+    let file_name = file_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("upload.bin")
+        .to_string();
+    let bytes =
+        std::fs::read(file_path).map_err(|e| format!("read {}: {e}", file_path.display()))?;
+    let part = Part::bytes(bytes).file_name(file_name);
+    let form = Form::new().part("file", part);
+    let url = format!("{}/api/v1/resources/temp_upload", st.endpoint);
+    let resp = st
+        .client
+        .post(&url)
+        .headers(viking_multipart_headers(st))
+        .multipart(form)
+        .send()
+        .map_err(|e| format!("OpenViking temp_upload failed: {e}"))?;
+    let status = resp.status();
+    let text = resp.text().unwrap_or_default();
+    if !status.is_success() {
+        return Err(format!("OpenViking temp_upload HTTP {status}: {text}"));
+    }
+    let value: Value =
+        serde_json::from_str(&text).map_err(|e| format!("OpenViking temp_upload JSON: {e}"))?;
+    value
+        .get("result")
+        .and_then(|result| result.get("temp_file_id"))
+        .or_else(|| value.get("temp_file_id"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| "OpenViking temp_upload did not return temp_file_id".to_string())
+}
+
+fn add_resource_payload_for_source(
+    source: &str,
+    args: &Value,
+) -> Result<(Value, Option<PathBuf>), String> {
+    if args
+        .get("to")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+        && args
+            .get("parent")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    {
+        return Err("Cannot specify both 'to' and 'parent'".to_string());
+    }
+
+    let mut body = json!({});
+    for key in ["reason", "to", "parent", "instruction"] {
+        if let Some(value) = args.get(key).and_then(Value::as_str) {
+            if !value.trim().is_empty() {
+                body[key] = json!(value);
+            }
+        }
+    }
+    for key in ["wait", "timeout"] {
+        if let Some(value) = args.get(key) {
+            if !value.is_null() {
+                body[key] = value.clone();
+            }
+        }
+    }
+
+    let source = source.trim();
+    if is_remote_resource_source(source) {
+        body["path"] = json!(source);
+        return Ok((body, None));
+    }
+
+    let path = if source.starts_with("file://") {
+        file_uri_to_path(source)?
+    } else if source.contains("://") && !is_windows_absolute_path(source) {
+        body["path"] = json!(source);
+        return Ok((body, None));
+    } else {
+        PathBuf::from(source).expanduser()
+    };
+
+    if !path.exists() {
+        if is_local_path_reference(source) {
+            return Err(format!("Local resource path does not exist: {source}"));
+        }
+        body["path"] = json!(source);
+        return Ok((body, None));
+    }
+
+    if path
+        .symlink_metadata()
+        .map_err(|e| format!("metadata {}: {e}", path.display()))?
+        .file_type()
+        .is_symlink()
+    {
+        return Err(format!(
+            "Local resource path is a symlink and will not be uploaded: {source}"
+        ));
+    }
+
+    if path.is_file() {
+        body["source_name"] = json!(path.file_name().and_then(|v| v.to_str()).unwrap_or("file"));
+        Ok((body, Some(path)))
+    } else if path.is_dir() {
+        body["source_name"] = json!(path
+            .file_name()
+            .and_then(|v| v.to_str())
+            .unwrap_or("directory"));
+        Ok((body, Some(zip_directory(&path)?)))
+    } else {
+        Err(format!("Unsupported local resource path: {source}"))
+    }
+}
+
+trait ExpandUserPath {
+    fn expanduser(self) -> PathBuf;
+}
+
+impl ExpandUserPath for PathBuf {
+    fn expanduser(self) -> PathBuf {
+        let raw = self.to_string_lossy();
+        if raw == "~" {
+            if let Some(home) = dirs::home_dir() {
+                return home;
+            }
+        }
+        if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
+            if let Some(home) = dirs::home_dir() {
+                return home.join(rest);
+            }
+        }
+        self
+    }
 }
 
 impl OpenVikingMemoryPlugin {
@@ -331,6 +618,18 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         let _ = st.client.post(&url).headers(h).send();
     }
 
+    fn on_session_switch(&self, new_session_id: &str, _parent_session_id: &str, _reset: bool) {
+        let new_session_id = new_session_id.trim();
+        if new_session_id.is_empty() {
+            return;
+        }
+        if let Some(st) = self.state.lock().unwrap().as_mut() {
+            st.session_id = new_session_id.to_string();
+            st.turn_count = 0;
+        }
+        *self.prefetch.lock().unwrap() = String::new();
+    }
+
     fn on_memory_write(&self, action: &str, target: &str, content: &str) {
         if !action.trim().eq_ignore_ascii_case("add") || content.trim().is_empty() {
             return;
@@ -460,19 +759,42 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
                 if url_arg.is_empty() {
                     return json!({"error": "url is required"}).to_string();
                 }
-                let mut body = json!({"path": url_arg});
-                if let Some(r) = args.get("reason").and_then(|v| v.as_str()) {
-                    body["reason"] = json!(r);
+                let (mut body, upload_path) = match add_resource_payload_for_source(url_arg, args) {
+                    Ok(value) => value,
+                    Err(e) => return json!({"error": e}).to_string(),
+                };
+                let cleanup_path = upload_path
+                    .as_ref()
+                    .filter(|path| {
+                        path.file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.starts_with("openviking_upload_"))
+                    })
+                    .cloned();
+                if let Some(path) = upload_path.as_deref() {
+                    match upload_temp_file(&st, path) {
+                        Ok(temp_file_id) => body["temp_file_id"] = json!(temp_file_id),
+                        Err(e) => {
+                            if let Some(cleanup_path) = cleanup_path {
+                                let _ = std::fs::remove_file(cleanup_path);
+                            }
+                            return json!({"error": e}).to_string();
+                        }
+                    }
                 }
                 let url = format!("{}/api/v1/resources", st.endpoint);
-                match st.client.post(&url).headers(h).json(&body).send() {
+                let result = match st.client.post(&url).headers(h).json(&body).send() {
                     Ok(resp) if resp.status().is_success() => resp
                         .json()
                         .unwrap_or(json!({"status": "added"}))
                         .to_string(),
                     Ok(r) => json!({"error": format!("HTTP {}", r.status())}).to_string(),
                     Err(e) => json!({"error": e.to_string()}).to_string(),
+                };
+                if let Some(cleanup_path) = cleanup_path {
+                    let _ = std::fs::remove_file(cleanup_path);
                 }
+                result
             }
             _ => json!({"error": format!("Unknown tool: {}", tool_name)}).to_string(),
         }
@@ -600,5 +922,110 @@ mod tests {
         assert!(uri.starts_with("viking://user/she_a/agent/hermes_ultra/memories/patterns/"));
         assert_eq!(body["content"], "fact");
         assert_eq!(body["mode"], "create");
+    }
+
+    #[test]
+    fn session_switch_updates_session_and_clears_prefetch() {
+        let plugin = OpenVikingMemoryPlugin::new();
+        *plugin.state.lock().unwrap() = Some(VikingState {
+            client: Client::new(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            api_key: String::new(),
+            account: "acct".to_string(),
+            user: "user".to_string(),
+            agent: "agent".to_string(),
+            session_id: "old".to_string(),
+            turn_count: 7,
+        });
+        *plugin.prefetch.lock().unwrap() = "stale".to_string();
+
+        plugin.on_session_switch("new", "old", false);
+
+        let state = plugin.state.lock().unwrap().clone().expect("state");
+        assert_eq!(state.session_id, "new");
+        assert_eq!(state.turn_count, 0);
+        assert!(plugin.prefetch.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn add_resource_payload_routes_remote_url_as_path() {
+        let (body, upload) = add_resource_payload_for_source(
+            "https://example.com/doc.md",
+            &json!({"reason": "docs", "wait": true}),
+        )
+        .expect("payload");
+
+        assert_eq!(body["path"], "https://example.com/doc.md");
+        assert_eq!(body["reason"], "docs");
+        assert_eq!(body["wait"], true);
+        assert!(upload.is_none());
+    }
+
+    #[test]
+    fn add_resource_payload_uploads_existing_local_file_and_file_uri() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sample = tmp.path().join("sample file.md");
+        std::fs::write(&sample, "# Local\n").expect("write sample");
+
+        let (body, upload) =
+            add_resource_payload_for_source(sample.to_str().expect("sample path"), &json!({}))
+                .expect("payload");
+        assert_eq!(body["source_name"], "sample file.md");
+        assert_eq!(upload.as_deref(), Some(sample.as_path()));
+
+        let uri = format!("file://{}", sample.to_string_lossy().replace(' ', "%20"));
+        let (body, upload) = add_resource_payload_for_source(&uri, &json!({"reason": "file uri"}))
+            .expect("file uri payload");
+        assert_eq!(body["source_name"], "sample file.md");
+        assert_eq!(body["reason"], "file uri");
+        assert_eq!(upload.as_deref(), Some(sample.as_path()));
+    }
+
+    #[test]
+    fn add_resource_payload_rejects_missing_local_path_and_to_parent_conflict() {
+        let err = add_resource_payload_for_source("./definitely-missing-openviking.md", &json!({}))
+            .expect_err("missing local path");
+        assert!(err.contains("does not exist"));
+
+        let err = add_resource_payload_for_source(
+            "https://example.com/doc.md",
+            &json!({"to": "viking://a", "parent": "viking://b"}),
+        )
+        .expect_err("to parent conflict");
+        assert!(err.contains("Cannot specify both"));
+    }
+
+    #[test]
+    fn add_resource_payload_zips_directory_and_skips_symlinks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let docs = tmp.path().join("docs");
+        std::fs::create_dir_all(docs.join("nested")).expect("mkdir");
+        std::fs::write(docs.join("guide.md"), "# Guide\n").expect("write guide");
+        std::fs::write(docs.join("nested").join("api.md"), "# API\n").expect("write api");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(docs.join("guide.md"), docs.join("guide-link.md"))
+            .expect("symlink");
+
+        let (body, upload) =
+            add_resource_payload_for_source(docs.to_str().expect("docs path"), &json!({}))
+                .expect("payload");
+        let zip_path = upload.expect("zip path");
+        assert_eq!(body["source_name"], "docs");
+        assert!(zip_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("openviking_upload_")));
+
+        let zip_file = std::fs::File::open(&zip_path).expect("open zip");
+        let mut archive = zip::ZipArchive::new(zip_file).expect("zip archive");
+        let mut names = Vec::new();
+        for idx in 0..archive.len() {
+            names.push(archive.by_index(idx).expect("zip entry").name().to_string());
+        }
+        assert!(names.contains(&"guide.md".to_string()));
+        assert!(names.contains(&"nested/api.md".to_string()));
+        assert!(!names.contains(&"guide-link.md".to_string()));
+
+        std::fs::remove_file(zip_path).expect("cleanup zip");
     }
 }

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2125,7 +2125,9 @@ impl App {
         let tool_schemas =
             crate::platform_toolsets::resolve_platform_tool_schemas(&config, "cli", &tool_registry);
 
-        let agent_config = build_agent_config(&config, &current_model);
+        let session_id = Uuid::new_v4().to_string();
+        let mut agent_config = build_agent_config(&config, &current_model);
+        agent_config.session_id = Some(session_id.clone());
         let provider = build_provider(&config, &current_model);
 
         let agent_inner = hermes_agent::attach_discovered_memory(AgentLoop::new(
@@ -2156,7 +2158,7 @@ impl App {
             tool_schemas,
             messages: Vec::new(),
             ui_messages: Vec::new(),
-            session_id: Uuid::new_v4().to_string(),
+            session_id,
             running: true,
             current_model,
             last_usage: None,
@@ -2380,6 +2382,7 @@ impl App {
         let old_session_id = self.session_id.clone();
         self.invoke_session_lifecycle_hook(HookType::OnSessionFinalize, &old_session_id);
         self.session_id = Uuid::new_v4().to_string();
+        self.notify_memory_session_switch(&self.session_id, &old_session_id, false);
         self.messages.clear();
         self.ui_messages.clear();
         self.last_usage = None;
@@ -2391,12 +2394,14 @@ impl App {
         self.history_index = 0;
         self.ensure_session_stub_snapshot();
         self.invoke_session_lifecycle_hook(HookType::OnSessionReset, &self.session_id);
+        self.rebuild_agent_for_active_session();
     }
 
     /// Reset the current session (clear messages but keep session ID).
     pub fn reset_session(&mut self) {
         let session_id = self.session_id.clone();
         self.invoke_session_lifecycle_hook(HookType::OnSessionFinalize, &session_id);
+        self.notify_memory_session_switch(&session_id, "", true);
         self.messages.clear();
         self.ui_messages.clear();
         self.last_usage = None;
@@ -2422,6 +2427,22 @@ impl App {
             "platform": "cli",
         });
         let _ = plugin_manager.invoke_hook(hook, &context);
+    }
+
+    fn notify_memory_session_switch(
+        &self,
+        new_session_id: &str,
+        parent_session_id: &str,
+        reset: bool,
+    ) {
+        let Some(memory_manager) = self.agent.memory_manager.as_ref() else {
+            return;
+        };
+        let Ok(memory_manager) = memory_manager.lock() else {
+            tracing::warn!("Memory manager lock poisoned during session switch");
+            return;
+        };
+        memory_manager.on_session_switch(new_session_id, parent_session_id, reset);
     }
 
     /// Set or clear a durable session objective.
@@ -2533,21 +2554,7 @@ impl App {
         self.current_model = provider_model.to_string();
         sync_runtime_model_env(&self.config, &self.current_model);
 
-        let provider = build_provider(&self.config, &self.current_model);
-        let agent_config = build_agent_config(&self.config, &self.current_model);
-        let agent_tool_registry = Arc::new(bridge_tool_registry(&self.tool_registry));
-
-        let agent_inner = hermes_agent::attach_discovered_memory(AgentLoop::new(
-            agent_config,
-            agent_tool_registry,
-            provider,
-        ))
-        .with_callbacks(Self::stream_callbacks(self.stream_handle_shared.clone()));
-        let orchestrator = Arc::new(SubAgentOrchestrator::from_parent(
-            &agent_inner,
-            self.state_root.clone(),
-        ));
-        self.agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
+        self.rebuild_agent_for_active_session();
 
         match SessionPersistence::new(&self.state_root)
             .update_session_model(&self.session_id, &self.current_model)
@@ -2562,6 +2569,25 @@ impl App {
         }
 
         tracing::info!("Switched model to: {}", provider_model);
+    }
+
+    fn rebuild_agent_for_active_session(&mut self) {
+        let provider = build_provider(&self.config, &self.current_model);
+        let mut agent_config = build_agent_config(&self.config, &self.current_model);
+        agent_config.session_id = Some(self.session_id.clone());
+        let agent_tool_registry = Arc::new(bridge_tool_registry(&self.tool_registry));
+
+        let agent_inner = hermes_agent::attach_discovered_memory(AgentLoop::new(
+            agent_config,
+            agent_tool_registry,
+            provider,
+        ))
+        .with_callbacks(Self::stream_callbacks(self.stream_handle_shared.clone()));
+        let orchestrator = Arc::new(SubAgentOrchestrator::from_parent(
+            &agent_inner,
+            self.state_root.clone(),
+        ));
+        self.agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
     }
 
     /// Switch the active personality.
@@ -3918,7 +3944,9 @@ mod tests {
         let config = Arc::new(GatewayConfig::default());
         let tool_registry = Arc::new(ToolRegistry::new());
         let agent_tool_registry = Arc::new(bridge_tool_registry(&tool_registry));
-        let agent_config = build_agent_config(config.as_ref(), "openai:gpt-4o");
+        let session_id = "test-session".to_string();
+        let mut agent_config = build_agent_config(config.as_ref(), "openai:gpt-4o");
+        agent_config.session_id = Some(session_id.clone());
         let provider: Arc<dyn LlmProvider> = Arc::new(NoBackendProvider {
             model: "openai:gpt-4o".to_string(),
         });
@@ -3942,7 +3970,7 @@ mod tests {
             tool_schemas: Vec::new(),
             messages: Vec::new(),
             ui_messages: Vec::new(),
-            session_id: "test-session".to_string(),
+            session_id,
             running: true,
             current_model: "openai:gpt-4o".to_string(),
             last_usage: None,
@@ -3998,6 +4026,10 @@ mod tests {
         assert_eq!(
             persistence.get_session_model(&app.session_id).unwrap(),
             Some("anthropic:claude-sonnet-4-6".to_string())
+        );
+        assert_eq!(
+            app.agent.config.session_id.as_deref(),
+            Some(app.session_id.as_str())
         );
 
         for (key, value) in saved_env {
@@ -4172,6 +4204,10 @@ mod tests {
         assert_eq!(events[1].0, "on_session_reset");
         assert_eq!(events[1].1, app.session_id);
         assert_ne!(events[0].1, events[1].1);
+        assert_eq!(
+            app.agent.config.session_id.as_deref(),
+            Some(app.session_id.as_str())
+        );
     }
 
     #[test]
@@ -4192,6 +4228,7 @@ mod tests {
             ]
         );
         assert_eq!(app.session_id, "test-session");
+        assert_eq!(app.agent.config.session_id.as_deref(), Some("test-session"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -104,6 +104,166 @@
       "disposition": "ported",
       "notes": "Rust Hindsight supports bank_id_template with profile/workspace/platform/user/session placeholders, sanitization tests, schema exposure, and README coverage."
     },
+    "13683c0842f0": {
+      "disposition": "ported",
+      "notes": "Rust MemoryProviderPlugin now has an on_session_switch hook, MemoryManager broadcasts it to enabled providers, and the TUI calls it when sessions rotate or reset while preserving the active AgentConfig session_id."
+    },
+    "0565497dcc2f": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight drains buffered auto-retain turns through the same retain path during session end and shutdown, with pending-turn state reset after the drain."
+    },
+    "c38dac742b22": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight flushes buffered turns before adopting a new session_id, clears stale prefetch context, resets counters, and has regression coverage for session switch behavior."
+    },
+    "0a5ee01e487a": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight session-switch flushing routes through retain_hindsight_turns and the same document/update-mode targeting helper used by normal auto-retain batches."
+    },
+    "3082fa0829e0": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight probes /version once per API base for update_mode append support, accepts version/api_version response shapes, gates append on semver >= 0.5.0, and falls back to batch document IDs."
+    },
+    "09d66037f8f7": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight append retains send only the pending-turn delta and use the stable session document only when the API advertises append support."
+    },
+    "ea01bdcebe1f": {
+      "disposition": "superseded",
+      "notes": "The Python flush_memories API has no Rust runtime equivalent; Rust providers use lifecycle hooks, shutdown, and explicit retain/write paths instead."
+    },
+    "18beb69b4996": {
+      "disposition": "superseded",
+      "notes": "The embedded Hindsight async-client close fix is Python-only; Rust Hindsight does not start hindsight-embed and uses bounded reqwest clients for HTTP operations."
+    },
+    "0ba6471dd191": {
+      "disposition": "superseded",
+      "notes": "The embedded Hindsight idle-daemon recovery path is superseded by the Rust-only local_external/cloud HTTP modes; no embedded Python daemon is launched."
+    },
+    "96f0ddc6a946": {
+      "disposition": "superseded",
+      "notes": "Baking hindsight-client into Docker only applies to the upstream embedded Python runtime; the Rust runtime keeps Hindsight integration in native HTTP code."
+    },
+    "d03c6fcc45cf": {
+      "disposition": "ported",
+      "notes": "Rust Honcho supports opt-in pinUserPeer/pinPeerName identity mapping so gateway runtime users can resolve to stable configured peers across platforms."
+    },
+    "326c9daa695b": {
+      "disposition": "ported",
+      "notes": "Rust Honcho only treats pinUserPeer/pinPeerName as enabled when the JSON value is a strict boolean true, avoiding truthy-string or mock-style coercion."
+    },
+    "5d36871d923c": {
+      "disposition": "ported",
+      "notes": "Rust Honcho loads global fallback config from ~/.honcho/config.json and ~/.hermes/honcho.json before the active HERMES_HOME honcho.json path."
+    },
+    "d18618f48f18": {
+      "disposition": "ported",
+      "notes": "Rust Honcho respects HOME-anchored default profile fallback paths while still allowing the active HERMES_HOME profile to override them."
+    },
+    "82205276c1ae": {
+      "disposition": "ported",
+      "notes": "Rust Honcho defaults HTTP timeout_secs to 30 seconds and still clamps explicit HONCHO_TIMEOUT_SECS/config values to the supported range."
+    },
+    "02ab255a0d52": {
+      "disposition": "ported",
+      "notes": "Rust Honcho validates baseUrl schemes, strips trailing /vN API suffixes, keeps schemeless hosts as HTTPS, and rejects unsupported URL schemes."
+    },
+    "5883df5574de": {
+      "disposition": "ported",
+      "notes": "Rust Honcho preserves legacy schemeless baseUrl configs by normalizing them to HTTPS instead of dropping the configured host."
+    },
+    "894e0b935bb8": {
+      "disposition": "ported",
+      "notes": "Rust honcho_profile now explains an empty peer card and points users to honcho_search, honcho_context, or honcho_conclude for memory retrieval."
+    },
+    "bea2562fc4b3": {
+      "disposition": "ported",
+      "notes": "Rust Honcho numeric config parsing uses typed f64/usize accessors and bounded defaults instead of raw integer coercion."
+    },
+    "dad021745000": {
+      "disposition": "superseded",
+      "notes": "Python session-cache RLock fixes are superseded by Rust Honcho's Mutex-protected session_key, prefetch, and turn-count state with no shared Python SDK cache."
+    },
+    "5d349ea857d4": {
+      "disposition": "superseded",
+      "notes": "Python get_or_create cache locking is superseded by Rust Honcho's stateless HTTP session operations and Mutex-protected local session key."
+    },
+    "ec4cb16a29ec": {
+      "disposition": "superseded",
+      "notes": "Python peers/sessions cache read locking is superseded by Rust Honcho identity resolution from immutable config plus Mutex-protected plugin state."
+    },
+    "47d5177a7d61": {
+      "disposition": "superseded",
+      "notes": "Python lazy-singleton and Honcho TOCTOU fixes are superseded by Rust plugin instances and explicit Mutex state; no Python lazy singleton remains."
+    },
+    "cd276eef7805": {
+      "disposition": "superseded",
+      "notes": "The Python on_memory_write metadata ABC compatibility shim is not a Rust API surface; Rust memory writes use typed trait methods and provider tool handlers."
+    },
+    "2e3c6627ceac": {
+      "disposition": "ported",
+      "notes": "Rust Honcho includes runtime peer mapping with configured aliases, optional runtime prefixes, and deterministic collision-resistant peer IDs."
+    },
+    "30b391ab366e": {
+      "disposition": "ported",
+      "notes": "Rust Honcho avoids runtime peer collisions by hashing runtime IDs when generating prefixed peer names, with regression coverage."
+    },
+    "00e683020443": {
+      "disposition": "ported",
+      "notes": "Rust Honcho host-level identity mapping config overrides root mappings cleanly, including aiPeer and user peer alias inheritance behavior."
+    },
+    "3cf5e8225d88": {
+      "disposition": "ported",
+      "notes": "Rust Honcho accepts pinUserPeer as the backwards-compatible alias for pinPeerName while keeping strict boolean parsing."
+    },
+    "6feb2afd50cb": {
+      "disposition": "ported",
+      "notes": "Rust Honcho covers pinUserPeer/pinPeerName transition behavior through alias parsing, host-block config, and identity-resolution regression tests."
+    },
+    "1a8e67076a0b": {
+      "disposition": "ported",
+      "notes": "Rust Honcho covers pinUserPeer plus aiPeer edge cases in setup/config parsing and peer-resolution tests."
+    },
+    "7137cccbd134": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking viking_add_resource uploads existing local files and directories through temp_upload and then creates resources with temp_file_id/source_name."
+    },
+    "187951ec6b88": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking local-upload behavior is covered by tests for file URI handling, missing local path rejection, to/parent conflicts, directory zips, and symlink skips."
+    },
+    "2b6345cee302": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking hardens local path uploads by detecting path-like missing sources, expanding ~, rejecting top-level symlinks, and preserving remote URL passthrough."
+    },
+    "6e250a55de50": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking sends bearer Authorization for API-key auth and uses multipart upload headers without forcing JSON Content-Type."
+    },
+    "8fb3e2d63afb": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking always sends configured account/user/agent tenant headers on JSON and multipart requests."
+    },
+    "63991bbd9751": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking skips symlinks when zipping uploaded directories and rejects top-level symlink upload paths."
+    },
+    "2d587c56622f": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking stores provider memory writes through content/write with generated viking:// memory URIs instead of session-message ingestion."
+    },
+    "d61785889678": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking uses target/category-aware memory subdirectories and a shared URI builder instead of private attribute access."
+    },
+    "490b3e76b138": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight defaults recall_types to observation and sends the same configured type list through automatic recall and hindsight_recall tool calls."
+    },
+    "4df62d239e38": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight applies recall_types narrowing to both context injection and explicit tool recall paths."
+    },
     "395dbcc873c8": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"


### PR DESCRIPTION
## Summary
- add MemoryProviderPlugin session-switch lifecycle propagation and wire TUI session rotations/resets to provider managers
- port Hindsight append-retain probing, buffered retain flushing on session end/switch/shutdown, and delta-only append semantics
- harden Honcho config fallback/base URL parsing, default timeout, empty-profile hinting, and session-switch state reset
- add OpenViking local file/directory upload support with temp_upload, directory zipping, symlink rejection/skipping, tenant/bearer headers, and session-switch reset
- classify covered upstream memory-provider rows in docs/parity/queue-overrides.json

## Local Verification
- cargo fmt --all --check
- git diff --check
- jq empty docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref HEAD --upstream-remote upstream --upstream-branch main --no-fetch --max-commits 0 --out-json /tmp/hermes-memory-batch-queue.json --out-md /tmp/hermes-memory-batch-queue.md
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent memory_plugins -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent memory_manager::tests::test_session_switch_propagates_to_providers -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli session_lifecycle_hooks -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli test_switch_model_updates_existing_session_db_row -- --nocapture
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-cli
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-agent -p hermes-cli

## Notes
- Cargo artifacts were written to /Volumes/wd_black/cargo-targets.
- Clippy gate reported no new warnings; existing stale allowlist entries were left untouched.
- GitHub hosted CI is optional for this repo; local gates above are the merge proof.
