### PR TITLE
parity(config): harden TUI startup config

### DIFF
--- a/crates/hermes-agent/src/context.rs
+++ b/crates/hermes-agent/src/context.rs
@@ -1367,6 +1367,11 @@ mod tests {
     }
 
     #[test]
+    fn test_persona_default_is_neutral() {
+        assert!(resolve_personality("default", None).is_none());
+    }
+
+    #[test]
     fn test_persona_system_prompt_deltas() {
         let base = {
             let mut b = SystemPromptBuilder::new().with_personality(None);

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -76,6 +76,36 @@ pub fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), ConfigError> 
     result
 }
 
+#[cfg(unix)]
+fn config_chmod_enabled() -> bool {
+    let env_opt_out = ["HERMES_SKIP_CHMOD", "HERMES_CONTAINER"]
+        .iter()
+        .any(|key| std::env::var(key).is_ok_and(|value| !value.trim().is_empty()));
+    !env_opt_out && !Path::new("/.dockerenv").exists()
+}
+
+#[cfg(unix)]
+fn secure_config_file(path: &Path) -> Result<(), ConfigError> {
+    if !config_chmod_enabled() {
+        return Ok(());
+    }
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path)
+        .map_err(io_to_config_error)?
+        .permissions();
+    if permissions.mode() & 0o777 != 0o600 {
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(path, permissions).map_err(io_to_config_error)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn secure_config_file(_path: &Path) -> Result<(), ConfigError> {
+    Ok(())
+}
+
 /// Crash-safe JSON write compatible with upstream `utils.atomic_json_write`.
 pub fn atomic_json_write(path: &Path, value: &serde_json::Value) -> Result<(), ConfigError> {
     let bytes = serde_json::to_vec(value).map_err(json_to_config_error)?;
@@ -1233,6 +1263,7 @@ pub fn save_config_yaml(path: &Path, config: &GatewayConfig) -> Result<(), Confi
     to_save.home_dir = None;
     let yaml = serde_yaml::to_string(&to_save).map_err(yaml_to_config_error)?;
     atomic_write_bytes(path, yaml.as_bytes())?;
+    secure_config_file(path)?;
     Ok(())
 }
 
@@ -1308,6 +1339,7 @@ pub fn set_user_config_value(
         set_yaml_path(&mut root, &split_config_key(key), scalar_yaml_value(value))?;
         validate_user_config_value(&root)?;
         atomic_yaml_write(&config_path, &root, None)?;
+        secure_config_file(&config_path)?;
         result.config_path = Some(config_path);
         result.config_key = Some(key.to_string());
     }
@@ -2565,6 +2597,46 @@ llm_providers:
     }
 
     #[test]
+    fn load_from_yaml_tolerates_null_top_level_sections() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+model: null
+personality: null
+tools: null
+platforms: null
+platform_toolsets: null
+llm_providers: null
+display: null
+terminal: null
+web: null
+sessions: null
+agent: null
+personalities: null
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_from_yaml(&path).unwrap();
+        let default = GatewayConfig::default();
+        assert_eq!(cfg.model, default.model);
+        assert_eq!(cfg.personality, default.personality);
+        assert_eq!(cfg.tools, default.tools);
+        assert_eq!(cfg.platforms, default.platforms);
+        assert_eq!(cfg.platform_toolsets, default.platform_toolsets);
+        assert_eq!(cfg.llm_providers, default.llm_providers);
+        assert_eq!(cfg.display, default.display);
+        assert_eq!(cfg.terminal, default.terminal);
+        assert_eq!(cfg.web, default.web);
+        assert_eq!(cfg.sessions, default.sessions);
+        assert_eq!(cfg.agent, default.agent);
+    }
+
+    #[test]
     fn set_user_config_value_routes_secret_keys_to_env() {
         use tempfile::tempdir;
 
@@ -2924,6 +2996,43 @@ custom_providers:
         let loaded = load_user_config_file(&path).unwrap();
         assert_eq!(loaded.model.as_deref(), Some("openai:gpt-4o-mini"));
         assert_eq!(loaded.max_turns, 15);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_config_yaml_writes_owner_only_file_when_chmod_enabled() {
+        if !config_chmod_enabled() {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        save_config_yaml(&path, &GatewayConfig::default()).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_user_config_value_writes_owner_only_config_when_chmod_enabled() {
+        if !config_chmod_enabled() {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        set_user_config_value(dir.path(), "max_turns", "42").unwrap();
+
+        let mode = std::fs::metadata(dir.path().join("config.yaml"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     #[test]

--- a/crates/hermes-config/src/python_yaml_compat.rs
+++ b/crates/hermes-config/src/python_yaml_compat.rs
@@ -29,6 +29,19 @@ fn scalar_to_string(v: &Value) -> Option<String> {
     }
 }
 
+fn drop_null_top_level_values(map: &mut Mapping) {
+    let null_keys: Vec<Value> = map
+        .iter()
+        .filter_map(|(k, v)| matches!(v, Value::Null).then_some(k.clone()))
+        .collect();
+    for key in null_keys {
+        if let Some(name) = key.as_str() {
+            tracing::warn!("Ignoring null top-level config key `{name}`; using default");
+        }
+        map.remove(&key);
+    }
+}
+
 fn normalized_base_url(value: &Value) -> Option<String> {
     value
         .as_str()
@@ -540,6 +553,7 @@ fn lift_root_platform_blocks(map: &mut Mapping) {
 
 /// Apply in-place transforms so Python-style Hermes YAML deserializes into [`crate::config::GatewayConfig`].
 pub(crate) fn normalize_config_yaml_root(map: &mut Mapping) {
+    drop_null_top_level_values(map);
     // Order matters: model before merge_providers (may touch llm_providers)
     normalize_model_block(map);
     merge_custom_providers_into_llm(map);
@@ -660,6 +674,42 @@ toolsets:
         normalize_config_yaml_root(m);
         let cfg: crate::config::GatewayConfig = serde_yaml::from_value(root).unwrap();
         assert_eq!(cfg.tools, vec!["hermes-cli", "web"]);
+    }
+
+    #[test]
+    fn null_top_level_config_values_fall_back_to_defaults() {
+        let raw = r#"
+model: null
+personality: null
+max_turns: null
+tools: null
+platforms: null
+platform_toolsets: null
+llm_providers: null
+display: null
+terminal: null
+web: null
+sessions: null
+agent: null
+personalities: null
+"#;
+        let mut root: Value = serde_yaml::from_str(raw).unwrap();
+        let Value::Mapping(ref mut m) = root else {
+            panic!();
+        };
+        normalize_config_yaml_root(m);
+        assert!(!m.contains_key(&key("personalities")));
+        let cfg: crate::config::GatewayConfig = serde_yaml::from_value(root).unwrap();
+        let default = crate::config::GatewayConfig::default();
+        assert_eq!(cfg.model, default.model);
+        assert_eq!(cfg.personality, default.personality);
+        assert_eq!(cfg.max_turns, default.max_turns);
+        assert_eq!(cfg.tools, default.tools);
+        assert_eq!(cfg.display, default.display);
+        assert_eq!(cfg.terminal, default.terminal);
+        assert_eq!(cfg.web, default.web);
+        assert_eq!(cfg.sessions, default.sessions);
+        assert_eq!(cfg.agent, default.agent);
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -264,6 +264,26 @@
       "disposition": "ported",
       "notes": "Rust Hindsight applies recall_types narrowing to both context injection and explicit tool recall paths."
     },
+    "b24d239ce177": {
+      "disposition": "ported",
+      "notes": "Rust config.yaml writes now preserve atomic replacement and tighten Unix permissions to owner-only 0600, with container/HERMES_SKIP_CHMOD opt-outs and save/config-set regression coverage."
+    },
+    "fd9b692d330f": {
+      "disposition": "ported",
+      "notes": "Rust config loading now tolerates null top-level config.yaml keys by dropping them before serde deserialization so defaults are used instead of failing startup."
+    },
+    "bfa60234c8bb": {
+      "disposition": "ported",
+      "notes": "Rust config normalization emits a warning for null top-level config.yaml keys while continuing with defaults."
+    },
+    "e3940f980799": {
+      "disposition": "ported",
+      "notes": "Rust config normalization drops a null personalities block before deserialization, preventing stale Python-style personality overlay config from breaking TUI startup."
+    },
+    "53fc10fc9a8b": {
+      "disposition": "ported",
+      "notes": "Rust default personality remains neutral: config defaults to no persona and the explicit default marker resolves to the base Hermes identity without adding a built-in personality overlay."
+    },
     "395dbcc873c8": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"


### PR DESCRIPTION
## Summary
- tolerate null top-level config.yaml keys by dropping them before Rust serde deserialization and warning before falling back to defaults
- preserve neutral default personality behavior with a regression test for the explicit default marker
- tighten Unix config.yaml permissions to owner-only 0600 after save/config-set writes, with container and HERMES_SKIP_CHMOD opt-outs
- classify covered upstream config/personality rows in docs/parity/queue-overrides.json

## Local Verification
- cargo fmt --all --check
- git diff --check
- jq empty docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref HEAD --upstream-remote upstream --upstream-branch main --no-fetch --max-commits 0 --out-json /tmp/hermes-tui-config-queue.json --out-md /tmp/hermes-tui-config-queue.md
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-config null_top_level -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-config owner_only -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-config -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent context::tests::test_persona_default_is_neutral -- --nocapture
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-agent -p hermes-cli
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-config -p hermes-agent -p hermes-cli

## Notes
- Cargo artifacts were written to /Volumes/wd_black/cargo-targets.
- One initial cargo test invocation used multiple filters and failed before running tests; reran with valid filters and full hermes-config package tests passed.
- Clippy gate reported no new warnings; existing stale allowlist entries were left untouched.
