### PR TITLE
parity(tui): sync model provider env

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -5319,6 +5319,51 @@ mod tests {
     }
 
     #[test]
+    fn test_sync_runtime_model_env_sets_tui_provider_when_absent() {
+        let _guard = env_test_lock();
+        let mut cfg = GatewayConfig::default();
+        cfg.llm_providers.insert(
+            "custom-xuanji".to_string(),
+            LlmProviderConfig {
+                model: Some("deepseek-v4-pro".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let keys = [
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+            "HERMES_TUI_PROVIDER",
+        ];
+        let previous: Vec<(&str, Option<String>)> = keys
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+        for key in keys {
+            std::env::remove_var(key);
+        }
+
+        sync_runtime_model_env(&cfg, "custom-xuanji:deepseek-v4-pro");
+
+        assert_eq!(
+            std::env::var("HERMES_TUI_PROVIDER").ok().as_deref(),
+            Some("custom-xuanji")
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_PROVIDER").ok().as_deref(),
+            Some("custom-xuanji")
+        );
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
     fn test_startup_model_env_sync_uses_config_provider_not_stale_env() {
         let _guard = env_test_lock();
         let keys = [
@@ -6853,9 +6898,7 @@ fn sync_runtime_model_env(config: &GatewayConfig, provider_model: &str) {
     std::env::set_var("HERMES_MODEL", model);
     std::env::set_var("HERMES_INFERENCE_MODEL", model);
     std::env::set_var("HERMES_INFERENCE_PROVIDER", provider.as_str());
-    if std::env::var_os("HERMES_TUI_PROVIDER").is_some() {
-        std::env::set_var("HERMES_TUI_PROVIDER", provider.as_str());
-    }
+    std::env::set_var("HERMES_TUI_PROVIDER", provider.as_str());
 }
 
 fn resolve_api_key_literal_or_env_ref(value: &str) -> Option<String> {

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -21334,9 +21334,7 @@ fn apply_cli_chat_runtime_env(provider_model: &str) {
         let provider = provider.trim();
         if !provider.is_empty() {
             std::env::set_var("HERMES_INFERENCE_PROVIDER", provider);
-            if std::env::var_os("HERMES_TUI_PROVIDER").is_some() {
-                std::env::set_var("HERMES_TUI_PROVIDER", provider);
-            }
+            std::env::set_var("HERMES_TUI_PROVIDER", provider);
         }
     }
 }
@@ -30622,6 +30620,35 @@ install_command: "uv pip install -r requirements.txt"
         assert_eq!(
             std::env::var("HERMES_TUI_PROVIDER").ok().as_deref(),
             Some("nous")
+        );
+
+        for key in keys {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn apply_cli_chat_runtime_env_sets_tui_provider_when_absent() {
+        let _lock = env_test_lock();
+        let keys = [
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+            "HERMES_TUI_PROVIDER",
+        ];
+        for key in keys {
+            std::env::remove_var(key);
+        }
+
+        apply_cli_chat_runtime_env("custom-xuanji:deepseek-v4-pro");
+
+        assert_eq!(
+            std::env::var("HERMES_TUI_PROVIDER").ok().as_deref(),
+            Some("custom-xuanji")
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_PROVIDER").ok().as_deref(),
+            Some("custom-xuanji")
         );
 
         for key in keys {

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1,5 +1,41 @@
 {
   "sha": {
+    "e9c47c70422d": {
+      "disposition": "ported",
+      "notes": "Rust CLI/TUI launch model overrides are represented by resolve_cli_chat_provider_model, apply_cli_chat_runtime_env, App::new startup resolution, and sync_runtime_model_env tests covering HERMES_MODEL/HERMES_INFERENCE_MODEL plus provider env synchronization."
+    },
+    "57b43fdd4bf9": {
+      "disposition": "ported",
+      "notes": "Rust startup provider precedence is typed through provider:model resolution and config.llm_providers lookup without treating stale HERMES_INFERENCE_PROVIDER as an explicit launch provider; regression coverage keeps config-selected providers authoritative."
+    },
+    "4db58d45d4e0": {
+      "disposition": "ported",
+      "notes": "Rust startup model parsing trims configured and env-sourced model strings through resolve_startup_model/resolve_provider_and_model, and runtime env synchronization keeps model/provider variables aligned for TUI sessions."
+    },
+    "2dfcc8087a8e": {
+      "disposition": "ported",
+      "notes": "Rust TUI startup uses static config/provider resolution and curated provider defaults only; live model discovery is isolated to explicit model-picker catalog paths, avoiding network lookup during App::new startup."
+    },
+    "e48a497d166b": {
+      "disposition": "ported",
+      "notes": "Rust shares static provider/model knowledge through model_switch curated catalogs, canonical provider IDs, and provider_model_ids_for_config tests for custom provider maps instead of duplicating startup detector code."
+    },
+    "c6fdf48b79eb": {
+      "disposition": "ported",
+      "notes": "Rust model switches call sync_runtime_model_env before rebuilding the active agent, updating HERMES_MODEL, HERMES_INFERENCE_MODEL, HERMES_INFERENCE_PROVIDER, and HERMES_TUI_PROVIDER for subsequent inference paths."
+    },
+    "458ce792d24e": {
+      "disposition": "ported",
+      "notes": "Rust App::switch_model persists the active session model in SessionPersistence by default and rebuilds the agent for the current session, with regression coverage for the session DB row."
+    },
+    "9e4d79b17fcf": {
+      "disposition": "ported",
+      "notes": "Rust sync_runtime_model_env and CLI chat env setup now write HERMES_TUI_PROVIDER unconditionally alongside HERMES_INFERENCE_PROVIDER, covering the explicit-provider carrier bug fixed upstream for /model followed by new sessions."
+    },
+    "443950e82736": {
+      "disposition": "ported",
+      "notes": "Rust model switching consumes GatewayConfig.llm_providers as a provider-keyed map, and model_switch tests cover custom provider slugs, explicit model lists, discover_models=false, and provider catalog entries without list coercion."
+    },
     "3d90292eda55": {
       "disposition": "superseded",
       "notes": "rust models_dev registry already resolves provider aliases in list_provider_models with regression coverage in crates/hermes-intelligence/src/models_dev/client.rs"


### PR DESCRIPTION
## Summary
- set HERMES_TUI_PROVIDER unconditionally when Rust TUI/App model runtime env is synchronized
- set HERMES_TUI_PROVIDER unconditionally for CLI chat launch model/provider env setup
- mark the upstream TUI model startup/switching cluster as ported with Rust evidence

## Local verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli test_sync_runtime_model_env_sets_tui_provider_when_absent -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli apply_cli_chat_runtime_env_sets_tui_provider_when_absent -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli test_switch_model_updates_existing_session_db_row -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli test_sync_runtime_model_env_sets_model_and_provider_values -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli apply_cli_chat_runtime_env_sets_provider_model -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli config_catalog_entries_include_custom_provider_models -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli configured_provider_discover_false_keeps_explicit_models -- --nocapture
- git diff --check
- jq empty docs/parity/queue-overrides.json
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref HEAD --upstream-remote upstream --upstream-branch main --no-fetch --max-commits 0 --out-json /tmp/hermes-loop-queue-after-model.json --out-md /tmp/hermes-loop-queue-after-model.md
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-cli
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check -- -p hermes-cli