### PR TITLE
Fix Telegram topic cron delivery

### DIFF
--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -404,6 +404,9 @@ pub enum CliCommand {
         /// Delivery target override.
         #[arg(long)]
         deliver: Option<String>,
+        /// Delivery chat/channel id for cron result routing.
+        #[arg(long = "deliver-chat-id")]
+        deliver_chat_id: Option<String>,
         /// Repeat count override.
         #[arg(long)]
         repeat: Option<u32>,

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -60,7 +60,7 @@ use hermes_core::PlatformAdapter;
 use hermes_core::{MessageRole, StreamChunk};
 use hermes_cron::{
     cron_scheduler_for_data_dir, CronCompletionEvent, CronError, CronRunner, CronScheduler,
-    FileJobPersistence,
+    DeliverTarget, FileJobPersistence,
 };
 use hermes_gateway::gateway::GatewayConfig as RuntimeGatewayConfig;
 use hermes_gateway::gateway::IncomingMessage as GatewayIncomingMessage;
@@ -738,6 +738,7 @@ async fn main() {
             prompt,
             name,
             deliver,
+            deliver_chat_id,
             repeat,
             skills,
             add_skills,
@@ -760,6 +761,7 @@ async fn main() {
                 prompt,
                 name,
                 deliver,
+                deliver_chat_id,
                 repeat,
                 skills,
                 add_skills,
@@ -3430,6 +3432,7 @@ async fn run_gateway(
             let cron_runner = Arc::new(CronRunner::new(cron_llm, agent_tools_for_cron));
             let mut cron_scheduler = CronScheduler::new(cron_persistence, cron_runner);
             let (cron_tx, cron_rx) = broadcast::channel::<CronCompletionEvent>(64);
+            let cron_platform_rx = cron_tx.subscribe();
             cron_scheduler.set_completion_broadcast(cron_tx);
             cron_scheduler
                 .load_persisted_jobs()
@@ -3472,6 +3475,12 @@ async fn run_gateway(
             }
 
             gateway.start_all().await?;
+            {
+                let gw_cron_delivery = gateway.clone();
+                sidecar_tasks.push(tokio::spawn(async move {
+                    run_cron_gateway_delivery_loop(cron_platform_rx, gw_cron_delivery).await;
+                }));
+            }
             {
                 let gw_reconnect = gateway.clone();
                 sidecar_tasks.push(tokio::spawn(async move {
@@ -9181,8 +9190,16 @@ fn build_live_cron_scheduler(cli: &Cli, data_dir: &Path) -> Result<CronScheduler
     Ok(CronScheduler::new(persistence, runner))
 }
 
-fn parse_deliver_config(raw: &str) -> Option<hermes_cron::DeliverConfig> {
-    let value = raw.trim().to_ascii_lowercase();
+fn parse_deliver_config(
+    raw: &str,
+    deliver_chat_id: Option<&str>,
+) -> Option<hermes_cron::DeliverConfig> {
+    let trimmed = raw.trim();
+    let (target_raw, inline_chat_id) = trimmed
+        .split_once(':')
+        .map(|(target, rest)| (target.trim(), Some(rest.trim())))
+        .unwrap_or((trimmed, None));
+    let value = target_raw.to_ascii_lowercase();
     let target = match value.as_str() {
         "origin" => hermes_cron::DeliverTarget::Origin,
         "local" => hermes_cron::DeliverTarget::Local,
@@ -9204,10 +9221,12 @@ fn parse_deliver_config(raw: &str) -> Option<hermes_cron::DeliverConfig> {
         "ntfy" => hermes_cron::DeliverTarget::Ntfy,
         _ => return None,
     };
-    Some(hermes_cron::DeliverConfig {
-        target,
-        platform: None,
-    })
+    let platform = deliver_chat_id
+        .or(inline_chat_id)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    Some(hermes_cron::DeliverConfig { target, platform })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -9220,6 +9239,7 @@ async fn run_cron(
     prompt: Option<String>,
     name: Option<String>,
     deliver: Option<String>,
+    deliver_chat_id: Option<String>,
     repeat: Option<u32>,
     skills: Vec<String>,
     add_skills: Vec<String>,
@@ -9277,7 +9297,7 @@ async fn run_cron(
                 job.name = Some(name);
             }
             if let Some(raw) = deliver.as_deref() {
-                if let Some(cfg) = parse_deliver_config(raw) {
+                if let Some(cfg) = parse_deliver_config(raw, deliver_chat_id.as_deref()) {
                     job.deliver = Some(cfg);
                 } else {
                     return Err(AgentError::Config(format!(
@@ -9347,7 +9367,7 @@ async fn run_cron(
                 };
             }
             if let Some(raw) = deliver.as_deref() {
-                if let Some(cfg) = parse_deliver_config(raw) {
+                if let Some(cfg) = parse_deliver_config(raw, deliver_chat_id.as_deref()) {
                     job.deliver = Some(cfg);
                 } else {
                     return Err(AgentError::Config(format!(
@@ -9869,6 +9889,177 @@ async fn run_cron_webhook_delivery_loop(
         .await
         {
             tracing::warn!("cron webhook delivery: {e}");
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CronPlatformDeliveryTarget {
+    platform: &'static str,
+    chat_id: String,
+    thread_id: Option<String>,
+}
+
+fn cron_deliver_target_platform_name(target: &DeliverTarget) -> Option<&'static str> {
+    match target {
+        DeliverTarget::Origin | DeliverTarget::Local => None,
+        DeliverTarget::Telegram => Some("telegram"),
+        DeliverTarget::Discord => Some("discord"),
+        DeliverTarget::Slack => Some("slack"),
+        DeliverTarget::Email => Some("email"),
+        DeliverTarget::WhatsApp => Some("whatsapp"),
+        DeliverTarget::Signal => Some("signal"),
+        DeliverTarget::Matrix => Some("matrix"),
+        DeliverTarget::Mattermost => Some("mattermost"),
+        DeliverTarget::DingTalk => Some("dingtalk"),
+        DeliverTarget::Feishu => Some("feishu"),
+        DeliverTarget::WeCom => Some("wecom"),
+        DeliverTarget::Weixin => Some("weixin"),
+        DeliverTarget::BlueBubbles => Some("bluebubbles"),
+        DeliverTarget::Sms => Some("sms"),
+        DeliverTarget::HomeAssistant => Some("homeassistant"),
+        DeliverTarget::Ntfy => Some("ntfy"),
+    }
+}
+
+fn cron_home_channel_env_vars(platform: &str) -> &'static [&'static str] {
+    match platform {
+        "telegram" => &["TELEGRAM_HOME_CHANNEL"],
+        "discord" => &["DISCORD_HOME_CHANNEL"],
+        "slack" => &["SLACK_HOME_CHANNEL"],
+        "email" => &["EMAIL_HOME_CHANNEL"],
+        "whatsapp" => &["WHATSAPP_HOME_CHANNEL"],
+        "signal" => &["SIGNAL_HOME_CHANNEL"],
+        "matrix" => &["MATRIX_HOME_ROOM", "MATRIX_HOME_CHANNEL"],
+        "mattermost" => &["MATTERMOST_HOME_CHANNEL"],
+        "dingtalk" => &["DINGTALK_HOME_CHANNEL"],
+        "feishu" => &["FEISHU_HOME_CHANNEL"],
+        "wecom" => &["WECOM_HOME_CHANNEL"],
+        "weixin" => &["WEIXIN_HOME_CHANNEL"],
+        "bluebubbles" => &["BLUEBUBBLES_HOME_CHANNEL"],
+        "sms" => &["SMS_HOME_CHANNEL"],
+        "homeassistant" => &["HOMEASSISTANT_HOME_CHANNEL"],
+        "ntfy" => &["NTFY_HOME_CHANNEL"],
+        _ => &[],
+    }
+}
+
+fn cron_home_channel_for_platform(platform: &str) -> Option<String> {
+    cron_home_channel_env_vars(platform)
+        .iter()
+        .find_map(|key| env_string(key))
+}
+
+fn split_telegram_cron_target(chat_id: &str) -> (String, Option<String>) {
+    let chat_id = chat_id.trim();
+    if let Some((base, suffix)) = chat_id.rsplit_once(':') {
+        let base = base.trim();
+        let suffix = suffix.trim();
+        if !base.is_empty() && suffix.parse::<i64>().is_ok() {
+            return (base.to_string(), Some(suffix.to_string()));
+        }
+    }
+    let thread_id = env_string("TELEGRAM_CRON_THREAD_ID");
+    (chat_id.to_string(), thread_id)
+}
+
+fn cron_platform_delivery_target(
+    event: &CronCompletionEvent,
+) -> Option<CronPlatformDeliveryTarget> {
+    let deliver = event.deliver.as_ref()?;
+    let platform = cron_deliver_target_platform_name(&deliver.target)?;
+    let raw_chat_id = deliver
+        .platform
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| cron_home_channel_for_platform(platform))?;
+
+    let (chat_id, thread_id) = if platform == "telegram" {
+        split_telegram_cron_target(&raw_chat_id)
+    } else {
+        (raw_chat_id.trim().to_string(), None)
+    };
+
+    (!chat_id.trim().is_empty()).then_some(CronPlatformDeliveryTarget {
+        platform,
+        chat_id,
+        thread_id,
+    })
+}
+
+fn cron_platform_delivery_text(event: &CronCompletionEvent) -> Option<String> {
+    if event.ok {
+        let text = event
+            .assistant_output
+            .as_deref()
+            .or(event.assistant_snippet.as_deref())?;
+        let trimmed = text.trim();
+        if trimmed.is_empty() || trimmed.trim_start().starts_with("[SILENT]") {
+            return None;
+        }
+        return Some(trimmed.to_string());
+    }
+
+    let name = event
+        .job_name
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&event.job_id);
+    let error = event
+        .error
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown cron failure");
+    Some(format!("Cron job '{name}' failed:\n{error}"))
+}
+
+async fn run_cron_gateway_delivery_loop(
+    mut rx: broadcast::Receiver<CronCompletionEvent>,
+    gateway: Arc<Gateway>,
+) {
+    use tokio::sync::broadcast::error::RecvError;
+
+    loop {
+        let event = match rx.recv().await {
+            Ok(event) => event,
+            Err(RecvError::Lagged(n)) => {
+                tracing::debug!(n, "cron gateway delivery receiver lagged; skipped messages");
+                continue;
+            }
+            Err(RecvError::Closed) => break,
+        };
+
+        let Some(target) = cron_platform_delivery_target(&event) else {
+            continue;
+        };
+        let Some(text) = cron_platform_delivery_text(&event) else {
+            tracing::debug!(
+                job_id = %event.job_id,
+                "cron gateway delivery skipped empty completion text"
+            );
+            continue;
+        };
+
+        if let Err(err) = gateway
+            .send_message_explicit(
+                target.platform,
+                &target.chat_id,
+                &text,
+                None,
+                target.thread_id.as_deref(),
+            )
+            .await
+        {
+            tracing::warn!(
+                job_id = %event.job_id,
+                platform = target.platform,
+                chat_id = %target.chat_id,
+                thread_id = ?target.thread_id,
+                "cron gateway delivery failed: {err}"
+            );
         }
     }
 }
@@ -15029,6 +15220,152 @@ mod tests {
         assert_eq!(routed.chat_id, "-1001:17585");
         assert_eq!(routed.user_id, "42");
         assert!(!routed.is_dm);
+    }
+
+    #[test]
+    fn cron_deliver_config_preserves_chat_id_and_telegram_thread_env() {
+        let _guard = env_lock();
+        let previous_thread = std::env::var("TELEGRAM_CRON_THREAD_ID").ok();
+        std::env::set_var("TELEGRAM_CRON_THREAD_ID", "777");
+
+        let telegram =
+            parse_deliver_config("telegram", Some("208214988")).expect("telegram deliver");
+        assert_eq!(telegram.target, hermes_cron::DeliverTarget::Telegram);
+        assert_eq!(telegram.platform.as_deref(), Some("208214988"));
+
+        let already_threaded =
+            parse_deliver_config("telegram:208214988:999", None).expect("threaded telegram");
+        assert_eq!(
+            already_threaded.target,
+            hermes_cron::DeliverTarget::Telegram
+        );
+        assert_eq!(already_threaded.platform.as_deref(), Some("208214988:999"));
+
+        let slack = parse_deliver_config("slack:C123ABC", None).expect("slack deliver");
+        assert_eq!(slack.target, hermes_cron::DeliverTarget::Slack);
+        assert_eq!(slack.platform.as_deref(), Some("C123ABC"));
+
+        match previous_thread {
+            Some(value) => std::env::set_var("TELEGRAM_CRON_THREAD_ID", value),
+            None => std::env::remove_var("TELEGRAM_CRON_THREAD_ID"),
+        }
+    }
+
+    #[test]
+    fn cron_platform_delivery_target_applies_telegram_cron_thread_at_fire_time() {
+        let _guard = env_lock();
+        let previous_thread = std::env::var("TELEGRAM_CRON_THREAD_ID").ok();
+        let previous_home = std::env::var("TELEGRAM_HOME_CHANNEL").ok();
+        std::env::set_var("TELEGRAM_CRON_THREAD_ID", "777");
+        std::env::set_var("TELEGRAM_HOME_CHANNEL", "208214988");
+
+        let mut explicit_job = hermes_cron::CronJob::new("0 * * * *", "ping");
+        explicit_job.deliver = Some(hermes_cron::DeliverConfig {
+            target: hermes_cron::DeliverTarget::Telegram,
+            platform: Some("208214988:999".to_string()),
+        });
+        let explicit = hermes_cron::CronCompletionEvent::new(
+            &explicit_job,
+            "schedule",
+            Ok(&hermes_core::AgentResult {
+                messages: vec![hermes_core::Message::assistant("done")],
+                finished_naturally: true,
+                total_turns: 1,
+                tool_errors: vec![],
+                usage: None,
+                ..Default::default()
+            }),
+        );
+        assert_eq!(
+            cron_platform_delivery_target(&explicit),
+            Some(CronPlatformDeliveryTarget {
+                platform: "telegram",
+                chat_id: "208214988".to_string(),
+                thread_id: Some("999".to_string()),
+            })
+        );
+
+        let mut home_job = hermes_cron::CronJob::new("0 * * * *", "ping");
+        home_job.deliver = Some(hermes_cron::DeliverConfig {
+            target: hermes_cron::DeliverTarget::Telegram,
+            platform: None,
+        });
+        let home = hermes_cron::CronCompletionEvent::new(
+            &home_job,
+            "schedule",
+            Ok(&hermes_core::AgentResult {
+                messages: vec![hermes_core::Message::assistant("done")],
+                finished_naturally: true,
+                total_turns: 1,
+                tool_errors: vec![],
+                usage: None,
+                ..Default::default()
+            }),
+        );
+        assert_eq!(
+            cron_platform_delivery_target(&home),
+            Some(CronPlatformDeliveryTarget {
+                platform: "telegram",
+                chat_id: "208214988".to_string(),
+                thread_id: Some("777".to_string()),
+            })
+        );
+
+        match previous_thread {
+            Some(value) => std::env::set_var("TELEGRAM_CRON_THREAD_ID", value),
+            None => std::env::remove_var("TELEGRAM_CRON_THREAD_ID"),
+        }
+        match previous_home {
+            Some(value) => std::env::set_var("TELEGRAM_HOME_CHANNEL", value),
+            None => std::env::remove_var("TELEGRAM_HOME_CHANNEL"),
+        }
+    }
+
+    #[test]
+    fn cron_platform_delivery_text_uses_full_output_and_suppresses_silent() {
+        let mut job = hermes_cron::CronJob::new("0 * * * *", "ping");
+        job.deliver = Some(hermes_cron::DeliverConfig {
+            target: hermes_cron::DeliverTarget::Telegram,
+            platform: Some("208214988".to_string()),
+        });
+
+        let full = "x".repeat(2505);
+        let event = hermes_cron::CronCompletionEvent::new(
+            &job,
+            "schedule",
+            Ok(&hermes_core::AgentResult {
+                messages: vec![hermes_core::Message::assistant(full.clone())],
+                finished_naturally: true,
+                total_turns: 1,
+                tool_errors: vec![],
+                usage: None,
+                ..Default::default()
+            }),
+        );
+
+        assert_eq!(cron_platform_delivery_text(&event), Some(full));
+        let json = serde_json::to_value(&event).expect("completion json");
+        assert!(json.get("assistant_output").is_none());
+        assert_eq!(
+            json.get("assistant_snippet")
+                .and_then(serde_json::Value::as_str)
+                .map(|value| value.chars().count()),
+            Some(2001)
+        );
+
+        let silent = hermes_cron::CronCompletionEvent::new(
+            &job,
+            "schedule",
+            Ok(&hermes_core::AgentResult {
+                messages: vec![hermes_core::Message::assistant("[SILENT] no-op")],
+                finished_naturally: true,
+                total_turns: 1,
+                tool_errors: vec![],
+                usage: None,
+                ..Default::default()
+            }),
+        );
+        assert_eq!(cron_platform_delivery_text(&silent), None);
     }
 
     #[test]

--- a/crates/hermes-cron/src/completion.rs
+++ b/crates/hermes-cron/src/completion.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use hermes_core::{AgentResult, MessageRole};
 use serde::Serialize;
 
-use crate::job::CronJob;
+use crate::job::{CronJob, DeliverConfig};
 
 fn truncate_chars(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
@@ -25,11 +25,15 @@ pub struct CronCompletionEvent {
     pub job_name: Option<String>,
     pub schedule: String,
     pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliver: Option<DeliverConfig>,
     pub ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_turns: Option<u32>,
+    #[serde(skip)]
+    pub assistant_output: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assistant_snippet: Option<String>,
     pub finished_at: String,
@@ -43,18 +47,19 @@ impl CronCompletionEvent {
         outcome: Result<&AgentResult, String>,
     ) -> Self {
         let finished_at = Utc::now().to_rfc3339();
-        let (ok, error, total_turns, assistant_snippet) = match outcome {
+        let (ok, error, total_turns, assistant_output, assistant_snippet) = match outcome {
             Ok(r) => {
-                let snippet = r.messages.iter().rev().find_map(|m| {
+                let output = r.messages.iter().rev().find_map(|m| {
                     if m.role == MessageRole::Assistant {
-                        m.content.as_ref().map(|c| truncate_chars(c, 2000))
+                        m.content.clone()
                     } else {
                         None
                     }
                 });
-                (true, None, Some(r.total_turns), snippet)
+                let snippet = output.as_ref().map(|c| truncate_chars(c, 2000));
+                (true, None, Some(r.total_turns), output, snippet)
             }
-            Err(msg) => (false, Some(msg), None, None),
+            Err(msg) => (false, Some(msg), None, None, None),
         };
         Self {
             event: "cron_job_finished",
@@ -63,9 +68,11 @@ impl CronCompletionEvent {
             job_name: job.name.clone(),
             schedule: job.schedule.clone(),
             prompt: truncate_chars(&job.prompt, 4096),
+            deliver: job.deliver.clone(),
             ok,
             error,
             total_turns,
+            assistant_output,
             assistant_snippet,
             finished_at,
         }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -5422,6 +5422,164 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn telegram_topic_chat_ids_are_independent_session_lanes() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr.clone(), dm_manager, GatewayConfig::default());
+        gw.register_adapter("telegram", adapter).await;
+        gw.set_message_handler(Arc::new(|messages| {
+            Box::pin(async move {
+                let user_turns = messages
+                    .iter()
+                    .filter(|message| message.role == MessageRole::User)
+                    .count();
+                Ok(format!("topic-turns={user_turns}"))
+            })
+        }))
+        .await;
+
+        for (chat_id, text) in [
+            ("208214988:111", "topic a first"),
+            ("208214988:222", "topic b first"),
+            ("208214988:111", "topic a second"),
+        ] {
+            gw.route_message(&IncomingMessage {
+                platform: "telegram".into(),
+                chat_id: chat_id.into(),
+                user_id: "user1".into(),
+                text: text.into(),
+                message_id: None,
+                is_dm: true,
+            })
+            .await
+            .expect("route telegram topic message");
+        }
+
+        let topic_a_key = session_mgr.compose_session_key("telegram", "208214988:111", "user1");
+        let topic_b_key = session_mgr.compose_session_key("telegram", "208214988:222", "user1");
+        let topic_a = session_mgr.get_messages(&topic_a_key).await;
+        let topic_b = session_mgr.get_messages(&topic_b_key).await;
+
+        assert_eq!(topic_a.len(), 4);
+        assert_eq!(topic_b.len(), 2);
+        assert_eq!(
+            topic_a
+                .iter()
+                .filter(|message| message.role == MessageRole::User)
+                .filter_map(|message| message.content.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["topic a first", "topic a second"]
+        );
+        assert_eq!(
+            topic_b
+                .iter()
+                .filter(|message| message.role == MessageRole::User)
+                .filter_map(|message| message.content.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["topic b first"]
+        );
+
+        let sent = sent.lock().expect("sent lock");
+        assert_eq!(
+            sent.iter()
+                .map(|(chat_id, text)| (chat_id.as_str(), text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("208214988:111", "topic-turns=1"),
+                ("208214988:222", "topic-turns=1"),
+                ("208214988:111", "topic-turns=2"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn telegram_topic_new_resets_only_current_topic_lane() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr.clone(), dm_manager, GatewayConfig::default());
+        gw.register_adapter("telegram", adapter).await;
+        gw.set_message_handler(Arc::new(|messages| {
+            Box::pin(async move {
+                let user_turns = messages
+                    .iter()
+                    .filter(|message| message.role == MessageRole::User)
+                    .count();
+                Ok(format!("topic-turns={user_turns}"))
+            })
+        }))
+        .await;
+
+        let topic_a = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "208214988:111".into(),
+            user_id: "user1".into(),
+            text: "topic a before reset".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        let topic_b = IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "208214988:222".into(),
+            user_id: "user1".into(),
+            text: "topic b remains".into(),
+            message_id: None,
+            is_dm: true,
+        };
+        gw.route_message(&topic_a).await.expect("route topic a");
+        gw.route_message(&topic_b).await.expect("route topic b");
+
+        gw.route_message(&IncomingMessage {
+            text: "/new".into(),
+            ..topic_a.clone()
+        })
+        .await
+        .expect("reset topic a");
+
+        let topic_a_key = session_mgr.compose_session_key("telegram", "208214988:111", "user1");
+        let topic_b_key = session_mgr.compose_session_key("telegram", "208214988:222", "user1");
+        assert!(session_mgr.get_messages(&topic_a_key).await.is_empty());
+        assert_eq!(session_mgr.get_messages(&topic_b_key).await.len(), 2);
+
+        gw.route_message(&IncomingMessage {
+            text: "topic a after reset".into(),
+            ..topic_a
+        })
+        .await
+        .expect("route topic a after reset");
+
+        let topic_a_messages = session_mgr.get_messages(&topic_a_key).await;
+        let topic_b_messages = session_mgr.get_messages(&topic_b_key).await;
+        assert_eq!(topic_a_messages.len(), 2);
+        assert_eq!(topic_b_messages.len(), 2);
+        assert_eq!(
+            topic_a_messages
+                .iter()
+                .find(|message| message.role == MessageRole::User)
+                .and_then(|message| message.content.as_deref()),
+            Some("topic a after reset")
+        );
+        assert_eq!(
+            topic_b_messages
+                .iter()
+                .find(|message| message.role == MessageRole::User)
+                .and_then(|message| message.content.as_deref()),
+            Some("topic b remains")
+        );
+    }
+
+    #[tokio::test]
     async fn gateway_switch_session_clears_yolo_for_current_chat_context() {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let adapter = Arc::new(TestAdapter {

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -2787,6 +2787,26 @@
     "5e9d7a766107": {
       "disposition": "superseded",
       "notes": "Upstream skills-hub degenerate-index fix applies to website catalog generation; this Rust fork tracks skill source trees directly and treats website skills pages as approved divergence."
+    },
+    "d6615d8ec7d5": {
+      "disposition": "ported",
+      "notes": "Rust Telegram topic lanes are represented by adapter-level message_thread_id to composite chat_id routing plus Gateway session keys scoped by the encoded chat_id. Regression tests cover independent Telegram topic sessions, /new current-topic isolation, adapter topic send routing, topic binding recovery helpers, and config/env allowed_topics/ignored_threads hydration."
+    },
+    "ede47a54be04": {
+      "disposition": "ported",
+      "notes": "Rust gateway pins Telegram DM-topic routing to the active topic by preserving the encoded topic chat_id through route_message, runtime context, session keys, and outbound sends; telegram_topic_chat_ids_are_independent_session_lanes proves later turns in one topic do not drift to sibling topics."
+    },
+    "95a0955e19f8": {
+      "disposition": "ported",
+      "notes": "Rust /new resets only the current encoded Telegram topic session key and keeps sibling topic lanes intact; telegram_topic_new_resets_only_current_topic_lane proves the topic thread identity survives session reset/split."
+    },
+    "60f84c6c28bf": {
+      "disposition": "ported",
+      "notes": "Rust gateway keeps inbox-style Telegram operational chatter quiet by default via default_tool_progress_for_platform, while /verbose remains config-gated and cycles explicit progress modes; gateway_verbose_command_is_config_gated_and_cycles_tool_progress covers this behavior."
+    },
+    "a4fb0a3ac39f": {
+      "disposition": "ported",
+      "notes": "Rust cron delivery routing preserves explicit inline platform chat ids/--deliver-chat-id, carries DeliverConfig on CronCompletionEvent, and the gateway cron delivery loop sends successful or failed cron completions through registered adapters. Telegram cron deliveries resolve TELEGRAM_CRON_THREAD_ID at fire time for unthreaded/home targets while explicit telegram:chat:thread wins. Tests cover stored chat id preservation, home-channel fallback, explicit thread precedence, webhook serialization, and docs now document the env var."
     }
   },
   "subject_patterns": [

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -236,6 +236,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_GROUP_ALLOWED_CHATS` | Comma-separated group/forum chat IDs; any member is authorized |
 | `TELEGRAM_HOME_CHANNEL` | Default Telegram chat/channel for cron delivery |
 | `TELEGRAM_HOME_CHANNEL_NAME` | Display name for the Telegram home channel |
+| `TELEGRAM_CRON_THREAD_ID` | Optional Telegram forum topic/thread ID used for cron delivery only. Explicit `telegram:chat:thread` targets still take precedence. |
 | `TELEGRAM_WEBHOOK_URL` | Public HTTPS URL for webhook mode (enables webhook instead of polling) |
 | `TELEGRAM_WEBHOOK_PORT` | Local listen port for webhook server (default: `8443`) |
 | `TELEGRAM_WEBHOOK_SECRET` | Secret token Telegram echoes back in each update for verification. **Required whenever `TELEGRAM_WEBHOOK_URL` is set** — the gateway refuses to start without it (GHSA-3vpc-7q5r-276h). Generate with `openssl rand -hex 32`. |

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -246,6 +246,11 @@ When scheduling jobs, you specify where the output goes:
 
 The agent's final response is automatically delivered. You do not need to call `send_message` in the cron prompt.
 
+Telegram forum/topic delivery supports a cron-specific override:
+`TELEGRAM_CRON_THREAD_ID`. When a cron job delivers to `telegram` or to an
+unthreaded Telegram chat id, Hermes uses that topic id for the cron result.
+Explicit `telegram:chat:thread` targets keep their explicit thread.
+
 ### Routing intent (`all`)
 
 `all` lets you ship one cron job to every messaging channel you have configured, without having to enumerate them by name. It is **resolved at fire time**, so a job created before you wired up Telegram will pick up Telegram on the next tick after you set `TELEGRAM_HOME_CHANNEL`.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -252,6 +252,16 @@ TELEGRAM_HOME_CHANNEL=-1001234567890
 TELEGRAM_HOME_CHANNEL_NAME="My Notes"
 ```
 
+If the home channel uses Telegram forum topics, cron deliveries can use a
+dedicated topic without changing other home-channel notifications:
+
+```bash
+TELEGRAM_CRON_THREAD_ID=17585
+```
+
+Explicit cron targets such as `telegram:-1001234567890:17585` still take
+precedence over this env var.
+
 :::tip
 Group chat IDs are negative numbers (e.g., `-1001234567890`). Your personal DM chat ID is the same as your user ID.
 :::


### PR DESCRIPTION
## Summary
- preserve Telegram topic chat ids as independent gateway session lanes and prove /new only resets the active topic lane
- carry cron DeliverConfig through completion events and deliver cron results/errors through gateway adapters
- resolve TELEGRAM_CRON_THREAD_ID at fire time for unthreaded/home Telegram cron deliveries while preserving explicit telegram:chat:thread targets
- document TELEGRAM_CRON_THREAD_ID and mark related upstream Telegram parity commits as ported

## Local verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- git diff --check && git diff --cached --check
- jq empty docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --max-commits 0 --out-json /tmp/hermes-loop-queue-telegram-real-delivery.json --out-md /tmp/hermes-loop-queue-telegram-real-delivery.md
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli cron_
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli telegram
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-gateway telegram_topic_
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-gateway -p hermes-cron