### PR TITLE
Finish Telegram topic and progress parity

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -48,7 +48,9 @@ use hermes_cli::runtime_tool_wiring::{
     wire_cron_scheduler_backend, wire_gateway_clarify_backend, wire_gateway_messaging_backend,
 };
 use hermes_cli::terminal_backend::build_terminal_backend;
-use hermes_cli::tool_preview::{build_tool_preview_from_value, tool_emoji};
+use hermes_cli::tool_preview::{
+    build_gateway_tool_progress_message, build_tool_preview_from_value, tool_emoji,
+};
 use hermes_cli::App;
 use hermes_config::{
     gateway_pid_path_in, hermes_home, load_config, load_user_config_file, save_config_yaml,
@@ -56,8 +58,8 @@ use hermes_config::{
     GatewayConfig, PlatformConfig, UnauthorizedDmBehavior,
 };
 use hermes_core::AgentError;
-use hermes_core::PlatformAdapter;
 use hermes_core::{MessageRole, StreamChunk};
+use hermes_core::{ParseMode, PlatformAdapter};
 use hermes_cron::{
     cron_scheduler_for_data_dir, CronCompletionEvent, CronError, CronRunner, CronScheduler,
     DeliverTarget, FileJobPersistence,
@@ -3047,6 +3049,15 @@ async fn run_gateway(
                         });
                         let tool_events = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
                         let tool_events_for_start = tool_events.clone();
+                        let tool_progress_mode = resolve_gateway_tool_progress_mode(
+                            config.as_ref(),
+                            &ctx.platform,
+                            ctx.tool_progress.as_deref(),
+                        );
+                        let tool_progress_seen = Arc::new(Mutex::new(HashSet::<String>::new()));
+                        let gateway_for_tool_progress = gateway_for_review.clone();
+                        let platform_for_tool_progress = ctx.platform.clone();
+                        let chat_for_tool_progress = ctx.chat_id.clone();
                         let on_tool_start: Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> =
                             Box::new(move |name: &str, args: &serde_json::Value| {
                                 let preview = build_tool_preview_from_value(name, args, 60)
@@ -3061,6 +3072,32 @@ async fn run_gateway(
                                 }
                                 if let Ok(mut guard) = tool_events_for_start.lock() {
                                     guard.push(event);
+                                }
+                                if should_emit_gateway_tool_progress(
+                                    &tool_progress_mode,
+                                    name,
+                                    &tool_progress_seen,
+                                ) {
+                                    if let Some(message) = build_gateway_tool_progress_message(
+                                        &platform_for_tool_progress,
+                                        name,
+                                        args,
+                                        &tool_progress_mode,
+                                        60,
+                                    ) {
+                                        let gw = gateway_for_tool_progress.clone();
+                                        let platform = platform_for_tool_progress.clone();
+                                        let chat_id = chat_for_tool_progress.clone();
+                                        let parse_mode =
+                                            gateway_tool_progress_parse_mode(&platform, &message);
+                                        tokio::spawn(async move {
+                                            let _ = gw
+                                                .send_message(
+                                                    &platform, &chat_id, &message, parse_mode,
+                                                )
+                                                .await;
+                                        });
+                                    }
                                 }
                             });
                         let tool_events_for_complete = tool_events.clone();
@@ -3274,6 +3311,15 @@ async fn run_gateway(
                         });
                         let tool_events = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
                         let tool_events_for_start = tool_events.clone();
+                        let tool_progress_mode = resolve_gateway_tool_progress_mode(
+                            config.as_ref(),
+                            &ctx.platform,
+                            ctx.tool_progress.as_deref(),
+                        );
+                        let tool_progress_seen = Arc::new(Mutex::new(HashSet::<String>::new()));
+                        let gateway_for_tool_progress = gateway_for_review.clone();
+                        let platform_for_tool_progress = ctx.platform.clone();
+                        let chat_for_tool_progress = ctx.chat_id.clone();
                         let on_tool_start: Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> =
                             Box::new(move |name: &str, args: &serde_json::Value| {
                                 let preview = build_tool_preview_from_value(name, args, 60)
@@ -3288,6 +3334,32 @@ async fn run_gateway(
                                 }
                                 if let Ok(mut guard) = tool_events_for_start.lock() {
                                     guard.push(event);
+                                }
+                                if should_emit_gateway_tool_progress(
+                                    &tool_progress_mode,
+                                    name,
+                                    &tool_progress_seen,
+                                ) {
+                                    if let Some(message) = build_gateway_tool_progress_message(
+                                        &platform_for_tool_progress,
+                                        name,
+                                        args,
+                                        &tool_progress_mode,
+                                        60,
+                                    ) {
+                                        let gw = gateway_for_tool_progress.clone();
+                                        let platform = platform_for_tool_progress.clone();
+                                        let chat_id = chat_for_tool_progress.clone();
+                                        let parse_mode =
+                                            gateway_tool_progress_parse_mode(&platform, &message);
+                                        tokio::spawn(async move {
+                                            let _ = gw
+                                                .send_message(
+                                                    &platform, &chat_id, &message, parse_mode,
+                                                )
+                                                .await;
+                                        });
+                                    }
                                 }
                             });
                         let tool_events_for_complete = tool_events.clone();
@@ -4113,6 +4185,61 @@ fn resolve_model_for_gateway(default_model: &str, ctx: &GatewayRuntimeContext) -
     }
 
     default_model.to_string()
+}
+
+fn normalize_gateway_tool_progress_mode(raw: &str) -> Option<String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "off" | "none" | "false" | "0" => Some("off".to_string()),
+        "new" => Some("new".to_string()),
+        "all" | "true" | "1" => Some("all".to_string()),
+        "verbose" => Some("verbose".to_string()),
+        _ => None,
+    }
+}
+
+fn resolve_gateway_tool_progress_mode(
+    config: &hermes_config::GatewayConfig,
+    platform: &str,
+    session_override: Option<&str>,
+) -> String {
+    if let Some(mode) = session_override.and_then(normalize_gateway_tool_progress_mode) {
+        return mode;
+    }
+
+    let platform_key = platform.trim().to_ascii_lowercase().replace('-', "_");
+    config
+        .display
+        .platform_tool_progress(&platform_key)
+        .and_then(normalize_gateway_tool_progress_mode)
+        .unwrap_or_else(|| match platform_key.as_str() {
+            "telegram" | "slack" => "off".to_string(),
+            _ => "all".to_string(),
+        })
+}
+
+fn should_emit_gateway_tool_progress(
+    mode: &str,
+    tool_name: &str,
+    seen_tools: &Arc<Mutex<HashSet<String>>>,
+) -> bool {
+    match mode {
+        "off" => false,
+        "new" => seen_tools
+            .lock()
+            .map(|mut seen| seen.insert(tool_name.to_string()))
+            .unwrap_or(true),
+        "all" | "verbose" => true,
+        _ => false,
+    }
+}
+
+fn gateway_tool_progress_parse_mode(platform: &str, text: &str) -> Option<ParseMode> {
+    let markdown_code_block = text.trim_start().starts_with("```") || text.contains("\n```");
+    if markdown_code_block && platform.eq_ignore_ascii_case("telegram") {
+        Some(ParseMode::Markdown)
+    } else {
+        None
+    }
 }
 
 fn build_agent_for_gateway_context(
@@ -5770,6 +5897,13 @@ fn telegram_should_batch_text(msg: &TelegramIncomingMessage) -> bool {
         && msg.callback_data.is_none()
 }
 
+fn telegram_routable_topic_thread(thread_id: Option<i64>) -> Option<i64> {
+    match thread_id {
+        Some(id) if id > 1 => Some(id),
+        _ => None,
+    }
+}
+
 fn telegram_gateway_message(msg: TelegramIncomingMessage) -> GatewayIncomingMessage {
     let text = msg.text.unwrap_or_else(|| {
         if msg.is_voice {
@@ -5786,10 +5920,8 @@ fn telegram_gateway_message(msg: TelegramIncomingMessage) -> GatewayIncomingMess
         .or(msg.username)
         .unwrap_or_else(|| "unknown".to_string());
 
-    let chat_id = match msg.message_thread_id {
-        Some(thread_id) if msg.is_group && thread_id != 0 => {
-            format!("{}:{}", msg.chat_id, thread_id)
-        }
+    let chat_id = match telegram_routable_topic_thread(msg.message_thread_id) {
+        Some(thread_id) => format!("{}:{}", msg.chat_id, thread_id),
         _ => msg.chat_id.to_string(),
     };
 
@@ -15220,6 +15352,71 @@ mod tests {
         assert_eq!(routed.chat_id, "-1001:17585");
         assert_eq!(routed.user_id, "42");
         assert!(!routed.is_dm);
+    }
+
+    #[test]
+    fn telegram_gateway_message_preserves_private_topic_in_chat_id() {
+        let incoming = TelegramIncomingMessage {
+            chat_id: 208214988,
+            user_id: Some(42),
+            username: Some("alice".to_string()),
+            text: Some("topic hello".to_string()),
+            message_id: 77,
+            is_voice: false,
+            is_photo: false,
+            is_sticker: false,
+            is_document: false,
+            voice_file_id: None,
+            photo_file_id: None,
+            sticker_file_id: None,
+            document_file_id: None,
+            document_file_name: None,
+            document_mime_type: None,
+            document_file_size: None,
+            reply_to_message_id: None,
+            message_thread_id: Some(17585),
+            chat_type: hermes_gateway::platforms::telegram::ChatKind::Private,
+            is_group: false,
+            callback_query_id: None,
+            callback_data: None,
+        };
+
+        let routed = telegram_gateway_message(incoming);
+        assert_eq!(routed.chat_id, "208214988:17585");
+        assert_eq!(routed.user_id, "42");
+        assert!(routed.is_dm);
+    }
+
+    #[test]
+    fn telegram_gateway_message_treats_general_topic_as_root_lobby() {
+        let incoming = TelegramIncomingMessage {
+            chat_id: 208214988,
+            user_id: Some(42),
+            username: Some("alice".to_string()),
+            text: Some("root lobby".to_string()),
+            message_id: 77,
+            is_voice: false,
+            is_photo: false,
+            is_sticker: false,
+            is_document: false,
+            voice_file_id: None,
+            photo_file_id: None,
+            sticker_file_id: None,
+            document_file_id: None,
+            document_file_name: None,
+            document_mime_type: None,
+            document_file_size: None,
+            reply_to_message_id: None,
+            message_thread_id: Some(1),
+            chat_type: hermes_gateway::platforms::telegram::ChatKind::Private,
+            is_group: false,
+            callback_query_id: None,
+            callback_data: None,
+        };
+
+        let routed = telegram_gateway_message(incoming);
+        assert_eq!(routed.chat_id, "208214988");
+        assert!(routed.is_dm);
     }
 
     #[test]

--- a/crates/hermes-cli/src/tool_preview.rs
+++ b/crates/hermes-cli/src/tool_preview.rs
@@ -205,6 +205,79 @@ pub fn build_tool_preview_from_value(
     Some(truncate_chars(&preview, max_len))
 }
 
+fn fenced_code_block(language: &str, body: &str) -> String {
+    let body = body.trim_end();
+    let fence = if body.contains("```") { "````" } else { "```" };
+    format!("{fence}{language}\n{body}\n{fence}")
+}
+
+pub fn platform_supports_markdown_code_blocks(platform: &str) -> bool {
+    matches!(
+        platform
+            .trim()
+            .to_ascii_lowercase()
+            .replace('-', "_")
+            .as_str(),
+        "telegram"
+            | "slack"
+            | "matrix"
+            | "whatsapp"
+            | "feishu"
+            | "weixin"
+            | "discord"
+            | "mattermost"
+    )
+}
+
+pub fn build_gateway_tool_progress_message(
+    platform: &str,
+    tool_name: &str,
+    args: &Value,
+    mode: &str,
+    max_len: usize,
+) -> Option<String> {
+    let mode = mode.trim().to_ascii_lowercase();
+    if matches!(mode.as_str(), "" | "off" | "none" | "false" | "0") {
+        return None;
+    }
+
+    let supports_code_blocks = platform_supports_markdown_code_blocks(platform);
+    if supports_code_blocks && tool_name == "terminal" {
+        if let Some(command) = args
+            .as_object()
+            .and_then(|map| map.get("command"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+        {
+            return Some(fenced_code_block("bash", command));
+        }
+    }
+
+    let emoji = tool_emoji(tool_name);
+    if mode == "verbose" {
+        let rendered_args = serde_json::to_string_pretty(args).unwrap_or_else(|_| args.to_string());
+        if supports_code_blocks && rendered_args.trim() != "null" {
+            return Some(format!(
+                "{emoji} {tool_name}:\n{}",
+                fenced_code_block("json", &rendered_args)
+            ));
+        }
+        let cap = max_len.max(40);
+        return Some(format!(
+            "{emoji} {tool_name}: {}",
+            truncate_chars(&rendered_args, cap)
+        ));
+    }
+
+    match build_tool_preview_from_value(tool_name, args, max_len.max(40)) {
+        Some(preview) if !preview.trim().is_empty() => {
+            Some(format!("{emoji} {tool_name}: {preview}"))
+        }
+        _ => Some(format!("{emoji} {tool_name}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,5 +353,49 @@ mod tests {
         assert_eq!(tool_emoji("video_generate"), "🎞️");
         assert_eq!(tool_emoji("spotify_playback"), "🎵");
         assert_eq!(tool_emoji("unknown"), "⚙️");
+    }
+
+    #[test]
+    fn gateway_tool_progress_uses_bash_blocks_for_terminal_on_markdown_platforms() {
+        let msg = build_gateway_tool_progress_message(
+            "telegram",
+            "terminal",
+            &json!({"command":"cargo test --workspace --quiet", "timeout": 120}),
+            "all",
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(msg, "```bash\ncargo test --workspace --quiet\n```");
+    }
+
+    #[test]
+    fn gateway_tool_progress_keeps_plain_platforms_compact() {
+        let msg = build_gateway_tool_progress_message(
+            "sms",
+            "terminal",
+            &json!({"command":"cargo test --workspace --quiet"}),
+            "all",
+            24,
+        )
+        .unwrap();
+
+        assert!(msg.starts_with("💻 terminal: "));
+        assert!(!msg.contains("```bash"));
+    }
+
+    #[test]
+    fn gateway_tool_progress_falls_back_when_terminal_command_is_blank() {
+        let msg = build_gateway_tool_progress_message(
+            "telegram",
+            "terminal",
+            &json!({"command":"   "}),
+            "verbose",
+            80,
+        )
+        .unwrap();
+
+        assert!(msg.starts_with("💻 terminal:\n```json"));
+        assert!(msg.contains("\"command\""));
     }
 }

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -124,6 +124,12 @@ pub fn all_commands() -> Vec<CommandInfo> {
             usage: "/reset",
         },
         CommandInfo {
+            name: "/topic",
+            aliases: &[],
+            description: "Inspect or restore Telegram topic sessions",
+            usage: "/topic [off|help|session-id]",
+        },
+        CommandInfo {
             name: "/model",
             aliases: &[],
             description: "Show or switch the LLM model",
@@ -390,6 +396,35 @@ pub fn should_bypass_active_session(raw: Option<&str>) -> bool {
     raw.is_some_and(is_registered_command_name)
 }
 
+fn telegram_topic_help_text() -> String {
+    "/topic — Telegram multi-session topic controls\n\n\
+Usage:\n\
+  /topic             Show Telegram topic-session status\n\
+  /topic help        Show this message\n\
+  /topic off         Disable Python-style topic binding state (no-op in Rust)\n\
+  /topic <id>        Restore a previous session into the current topic\n\n\
+Rust gateway behavior:\n\
+  Telegram messages with a non-General topic thread are routed as independent \
+session lanes using chat_id:thread_id. /new inside a topic resets only that \
+topic lane; General topic (thread 1) and threadless messages stay in the root chat."
+        .to_string()
+}
+
+fn telegram_topic_status_text() -> String {
+    "Telegram topic sessions are handled natively by the Rust gateway. \
+Non-General Telegram topics use independent session lanes; use /new inside a \
+topic to reset only that topic, /sessions to list prior sessions, or \
+/topic <session-id> to restore one into the current topic."
+        .to_string()
+}
+
+fn telegram_topic_off_text() -> String {
+    "Telegram Python-style topic binding mode is not enabled in the Rust gateway. \
+There are no SQLite topic bindings to clear; existing Telegram topic lanes remain \
+isolated by thread ID. The root DM remains a normal Hermes chat."
+        .to_string()
+}
+
 /// Parse and dispatch a gateway slash command.
 pub fn handle_command(input: &str) -> GatewayCommandResult {
     let trimmed = input.trim();
@@ -407,6 +442,16 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         "/start" => GatewayCommandResult::Noop,
         "/new" => GatewayCommandResult::ResetSession("🆕 New conversation started.".to_string()),
         "/reset" | "/clear" => GatewayCommandResult::ResetSession("🔄 Session reset.".to_string()),
+        "/topic" => match args.to_ascii_lowercase().as_str() {
+            "" | "status" => GatewayCommandResult::Reply(telegram_topic_status_text()),
+            "help" | "?" | "-h" | "--help" => {
+                GatewayCommandResult::Reply(telegram_topic_help_text())
+            }
+            "off" | "disable" | "stop" => GatewayCommandResult::Reply(telegram_topic_off_text()),
+            _ => GatewayCommandResult::SwitchSession {
+                session_id: args.clone(),
+            },
+        },
         "/model" => {
             if args.is_empty() {
                 GatewayCommandResult::Reply(
@@ -795,6 +840,41 @@ mod tests {
     }
 
     #[test]
+    fn test_topic_command_help_off_and_restore() {
+        match handle_command("/topic") {
+            GatewayCommandResult::Reply(text) => {
+                assert!(text.contains("Telegram topic sessions"));
+                assert!(text.contains("Rust gateway"));
+            }
+            other => panic!("Expected topic status reply, got {:?}", other),
+        }
+
+        match handle_command("/topic help") {
+            GatewayCommandResult::Reply(text) => {
+                assert!(text.contains("/topic off"));
+                assert!(text.contains("/topic <id>"));
+                assert!(text.contains("General topic"));
+            }
+            other => panic!("Expected topic help reply, got {:?}", other),
+        }
+
+        match handle_command("/topic off") {
+            GatewayCommandResult::Reply(text) => {
+                assert!(text.contains("not enabled in the Rust gateway"));
+                assert!(text.contains("no SQLite topic bindings"));
+            }
+            other => panic!("Expected topic off reply, got {:?}", other),
+        }
+
+        match handle_command("/topic session-123") {
+            GatewayCommandResult::SwitchSession { session_id } => {
+                assert_eq!(session_id, "session-123");
+            }
+            other => panic!("Expected topic restore to switch session, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_unknown_command() {
         match handle_command("/xyz123") {
             GatewayCommandResult::Unknown(_) => {}
@@ -892,6 +972,7 @@ mod tests {
             "usage",
             "reload-mcp",
             "sethome",
+            "topic",
         ] {
             assert!(should_bypass_active_session(Some(cmd)), "{cmd}");
         }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -5580,6 +5580,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn telegram_topic_restore_reuses_session_switch_path() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr.clone(), dm_manager, GatewayConfig::default());
+        gw.register_adapter("telegram", adapter).await;
+
+        let target_key = session_mgr.compose_session_key("telegram", "208214988:111", "user1");
+        let current_key = session_mgr.compose_session_key("telegram", "208214988:222", "user1");
+        let sibling_key = session_mgr.compose_session_key("telegram", "208214988:333", "user1");
+
+        let _ = session_mgr
+            .get_or_create_session("telegram", "208214988:111", "user1")
+            .await;
+        session_mgr
+            .add_message(&target_key, Message::user("restored topic history"))
+            .await;
+        let _ = session_mgr
+            .get_or_create_session("telegram", "208214988:333", "user1")
+            .await;
+        session_mgr
+            .add_message(&sibling_key, Message::user("sibling history"))
+            .await;
+
+        gw.route_message(&IncomingMessage {
+            platform: "telegram".into(),
+            chat_id: "208214988:222".into(),
+            user_id: "user1".into(),
+            text: format!("/topic {}", target_key),
+            message_id: None,
+            is_dm: true,
+        })
+        .await
+        .expect("restore topic session");
+
+        let current_messages = session_mgr.get_messages(&current_key).await;
+        let sibling_messages = session_mgr.get_messages(&sibling_key).await;
+        assert_eq!(
+            current_messages
+                .iter()
+                .find(|message| message.role == MessageRole::User)
+                .and_then(|message| message.content.as_deref()),
+            Some("restored topic history")
+        );
+        assert_eq!(
+            sibling_messages
+                .iter()
+                .find(|message| message.role == MessageRole::User)
+                .and_then(|message| message.content.as_deref()),
+            Some("sibling history")
+        );
+        assert!(sent
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(_, text)| text.contains("Switched to session")));
+    }
+
+    #[tokio::test]
     async fn gateway_switch_session_clears_yolo_for_current_chat_context() {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let adapter = Arc::new(TestAdapter {

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -2807,6 +2807,30 @@
     "a4fb0a3ac39f": {
       "disposition": "ported",
       "notes": "Rust cron delivery routing preserves explicit inline platform chat ids/--deliver-chat-id, carries DeliverConfig on CronCompletionEvent, and the gateway cron delivery loop sends successful or failed cron completions through registered adapters. Telegram cron deliveries resolve TELEGRAM_CRON_THREAD_ID at fire time for unthreaded/home targets while explicit telegram:chat:thread wins. Tests cover stored chat id preservation, home-channel fallback, explicit thread precedence, webhook serialization, and docs now document the env var."
+    },
+    "a7683d04a964": {
+      "disposition": "ported",
+      "notes": "Rust Telegram topic sessions do not mutate Python SessionStore/SQLite bindings; topic identity is the encoded chat_id:thread_id session key. /new resets only that current encoded key, and /topic <session-id> now reuses the persisted session switch path for restores without split-brain binding state."
+    },
+    "1381c89e56fd": {
+      "disposition": "ported",
+      "notes": "Rust topic routing treats Telegram General topic thread_id=1 and threadless messages as the root chat, while every non-General thread gets an independent encoded session key. Python-specific cascade migration and auto-rename guards are superseded because this Rust runtime has no telegram_dm_topic_bindings table and no Telegram topic auto-rename path."
+    },
+    "d35efb989884": {
+      "disposition": "ported",
+      "notes": "Rust gateway now exposes /topic, /topic help, /topic off, and /topic <session-id>. Authorization is enforced by existing DM/platform access gates before command execution; /topic off is an idempotent no-op because there are no Python SQLite topic bindings to clear."
+    },
+    "0325e18f3426": {
+      "disposition": "ported",
+      "notes": "Rust Telegram status updates already use send_or_update_status with edit-in-place fallback, and gateway tool progress remains quiet for Telegram by default while /verbose can explicitly raise it. Progress/status docs now describe the Rust-native behavior instead of Python heartbeat binding state."
+    },
+    "2f0c8e90e613": {
+      "disposition": "superseded",
+      "notes": "Upstream Telegram QR dashboard onboarding targets the Python web dashboard, which is not a Rust runtime surface in this fork. Rust CLI QR onboarding remains the supported local setup path; adding the upstream Python web_server/dashboard flow would violate the Rust-only runtime boundary."
+    },
+    "dde9c0d19d16": {
+      "disposition": "ported",
+      "notes": "Rust gateway tool-progress callbacks now emit explicit progress messages when enabled, and markdown-capable platforms render terminal commands as full bash fenced code blocks through build_gateway_tool_progress_message. Tests cover Telegram bash blocks, plain-platform compact fallback, and blank-command fallback."
     }
   },
   "subject_patterns": [

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -185,7 +185,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/undo` | Remove the last exchange. |
 | `/sethome` (alias: `/set-home`) | Mark the current chat as the platform home channel for deliveries. |
 | `/compress [focus topic]` | Manually compress conversation context. Optional focus topic narrows what the summary preserves. |
-| `/topic [off\|help\|session-id]` | **Telegram DM only.** Manage user-managed multi-session topic mode. `/topic` enables it or shows status; `/topic off` disables it and clears bindings; `/topic help` shows usage; `/topic <session-id>` inside a topic restores a previous session. See [Multi-session DM mode](/docs/user-guide/messaging/telegram#multi-session-dm-mode-topic). |
+| `/topic [off\|help\|session-id]` | **Telegram DM only.** Inspect Rust-native topic sessions. `/topic off` is an idempotent no-op because this fork has no Python topic binding tables; `/topic help` shows usage; `/topic <session-id>` restores a previous session into the current topic. See [Multi-session DM mode](/docs/user-guide/messaging/telegram#multi-session-dm-mode-topic). |
 | `/title [name]` | Set or show the session title. |
 | `/resume [name]` | Resume a previously named session. |
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -430,20 +430,18 @@ Topics created outside of the config (e.g., by manually calling the Telegram API
 
 ## Multi-session DM mode (`/topic`)
 
-A ChatGPT-style multi-session DM — one bot, many parallel conversations. Unlike the operator-curated `extra.dm_topics` above, this mode is **user-driven**: no config, no pre-declared topic names. The end user flips it on with `/topic`, then taps the Telegram **+** button to create as many topics as they want, each one a fully independent Hermes session.
+A ChatGPT-style multi-session DM — one bot, many parallel conversations. In the Rust gateway, Telegram topic isolation is native: any non-General `message_thread_id` is encoded into the gateway chat key as `chat_id:thread_id`, so each topic has its own session history and runtime state without a Python SQLite binding table.
 
 ### `/topic` subcommands
 
 | Form | Context | Effect |
 |------|---------|--------|
-| `/topic` | Root DM, not yet enabled | Check BotFather capabilities, enable multi-session mode, create pinned System topic |
-| `/topic` | Root DM, already enabled | Show status: unlinked sessions available for restore |
-| `/topic` | Inside a topic | Show the current topic's session binding |
+| `/topic` | Any Telegram DM | Show Rust topic-session status |
 | `/topic help` | Any | Inline usage |
-| `/topic off` | Root DM | Disable multi-session mode and clear all topic bindings for this chat |
-| `/topic <session-id>` | Inside a topic | Restore a previous Telegram session into the current topic |
+| `/topic off` | Any Telegram DM | Idempotent no-op for Python-style topic bindings; Rust has no topic SQLite state to clear |
+| `/topic <session-id>` | Inside a topic | Restore a previous session into the current topic via the normal `/sessions` switch path |
 
-Only authorized users (allowlist via `TELEGRAM_ALLOWED_USERS` / platform auth config) can run `/topic`. An unauthorized sender gets a refusal instead of activation.
+Only authorized users (allowlist via `TELEGRAM_ALLOWED_USERS` / platform auth config) can run `/topic`. Unauthorized DMs are rejected by the gateway before command execution.
 
 ### DM Topics vs Multi-session DM mode
 
@@ -451,10 +449,10 @@ Only authorized users (allowlist via `TELEGRAM_ALLOWED_USERS` / platform auth co
 |---|---|---|
 | Who activates it | Operator, in `config.yaml` | End user, by sending `/topic` |
 | Topic list | Fixed set declared in config | User creates/deletes topics freely |
-| Topic names | Chosen by operator | Chosen by user; auto-renamed to match Hermes session title |
-| Root DM behavior | Unchanged — normal chat | Becomes a system lobby (non-command messages are rejected) |
+| Topic names | Chosen by operator | Chosen by user |
+| Root DM behavior | Unchanged — normal chat | Unchanged — normal chat |
 | Primary use case | Permanent workspaces with optional skill binding | Ad-hoc parallel sessions |
-| Persistence | `extra.dm_topics` in config | `telegram_dm_topic_mode` + `telegram_dm_topic_bindings` SQLite tables |
+| Persistence | `extra.dm_topics` in config | Rust session keys scoped by `chat_id:thread_id` |
 
 Both features can coexist on the same bot — you'd run `/topic` from a user's DM, and `extra.dm_topics` continues to manage operator-declared topics for other chats.
 
@@ -465,7 +463,7 @@ In **@BotFather**, open your bot → **Bot Settings → Threads Settings**:
 1. Turn on **Threaded Mode** (enables `has_topics_enabled`)
 2. Do **not** disable users creating topics (keeps `allows_users_to_create_topics` on)
 
-When the user first runs `/topic`, Hermes calls `getMe` to verify both flags. If either is off, Hermes sends a screenshot of the BotFather Threads Settings page and explains what to toggle — no activation happens until prerequisites are met.
+The Rust gateway does not mutate BotFather settings for you. Configure Telegram once, then Hermes routes topic messages by the thread ID Telegram sends with each update.
 
 ### Activation flow
 
@@ -475,14 +473,7 @@ From the root DM, send:
 /topic
 ```
 
-Hermes will:
-
-1. Check `getMe().has_topics_enabled` and `allows_users_to_create_topics`
-2. If both are true, enable multi-session topic mode for this DM
-3. Create and pin a **System** topic for status/commands (best-effort)
-4. Reply with a list of previous unlinked Telegram sessions the user can restore
-
-After activation, the **root DM is a lobby**: normal prompts are rejected with guidance pointing at **All Messages**. System commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root.
+Hermes replies with the Rust topic-session status and usage. No database migration runs and the root DM remains a normal Hermes chat.
 
 ### Creating a new topic (end-user flow)
 
@@ -491,15 +482,11 @@ After activation, the **root DM is a lobby**: normal prompts are rejected with g
 3. Telegram creates a new topic for that message
 4. Hermes responds inside that topic — the topic is now a standalone session
 
-Every topic gets its own conversation history, model state, tool execution, and session ID. The isolation key is `agent:main:telegram:dm:{chat_id}:{thread_id}` — identical to the config-driven DM topics isolation.
-
-### Auto-renamed topics
-
-When Hermes generates a session title for a topic (via the auto-title pipeline, after the first exchange), the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database migration plan". The rename is best-effort: failures are logged but don't break the session.
+Every topic gets its own conversation history, model state, tool execution, and session ID. The isolation key is the gateway session key for `telegram:{chat_id}:{thread_id}:{user_id}`. Telegram's General topic (`message_thread_id=1`) and threadless messages are treated as the root chat, not as separate topic lanes.
 
 ### `/new` inside a topic
 
-Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, creating another topic (via **All Messages**) is usually what you want.
+Resets the current topic's session without touching other topics.
 
 ### Restoring a previous session
 
@@ -509,48 +496,28 @@ Inside a topic, send:
 /topic <session-id>
 ```
 
-This binds the current topic to an existing Hermes session instead of starting fresh. Useful for continuing a conversation that started before topic mode was enabled. Restrictions:
-
-- The target session must belong to the same Telegram user
-- The target session must not already be bound to another topic
-
-Hermes confirms with the session title and replays the last assistant message for context.
-
-To discover session IDs, send `/topic` (no argument) in the root DM — Hermes lists the user's unlinked Telegram sessions.
+This copies a previous session's messages and title into the current topic context using the same switch path as `/sessions <session-id>`. To discover session IDs, use `/sessions`.
 
 ### `/topic` inside a topic (no argument)
 
-Shows the current topic's binding: session title, session ID, and hints for `/new` vs creating another topic.
+Shows the Rust topic-session status and usage.
 
 ### Under the hood
 
-- Activation persists to `telegram_dm_topic_mode(chat_id, user_id, enabled, ...)` in `state.db`
-- Each topic binding persists to `telegram_dm_topic_bindings(chat_id, thread_id, session_id, ...)` with `ON DELETE CASCADE` on `session_id` — pruning a session automatically clears its topic binding
-- The topic-mode SQLite migration is **opt-in**: it runs on the first `/topic` call, never on gateway startup. Until a user runs `/topic` in this profile, `state.db` is unchanged
-- Each inbound DM message looks up its `(chat_id, thread_id)` binding. If present, the lookup routes the message to the bound session via `SessionStore.switch_session()` so the session-key-to-session-id mapping stays consistent on disk
-- `/new` inside a topic rewrites the binding row to point at the new session ID, so the next message stays on the fresh session
-- Topics declared in `extra.dm_topics` are **never auto-renamed** — the operator-chosen name is preserved even when multi-session mode is enabled
-- The General (pinned top) topic in a forum-enabled DM is treated as the root lobby, regardless of whether Telegram delivers its messages with `message_thread_id=1` or with no thread_id
-- Root-lobby reminders are rate-limited to one message per 30 seconds per chat — a user who forgets topic mode is on and types ten prompts in the root won't get ten replies
-- BotFather setup screenshots are rate-limited to one send per 5 minutes per chat — repeated `/topic` attempts while Threads Settings are still disabled won't re-upload the same image
-- `/background <prompt>` started inside a topic delivers its result back to the same topic; background sessions don't trigger auto-rename of the owning topic
-- `/topic` itself is gated by the bot's user authorization check — unauthorized DMs get a refusal instead of activation
+- Rust routes Telegram topic updates by preserving the non-General `message_thread_id` in the gateway chat ID.
+- `/new` inside a topic resets only that encoded topic session key.
+- `/topic <session-id>` uses the same session switch path as `/sessions <session-id>`.
+- There is no Python `telegram_dm_topic_mode` or `telegram_dm_topic_bindings` runtime state in this fork.
+- `/background <prompt>` started inside a topic delivers its result back to the same encoded topic chat.
+- `/topic` itself is gated by the bot's user authorization check.
 
 ### Disabling multi-session mode
 
-Send `/topic off` in the root DM. Hermes flips the row off, clears the chat's `(thread_id → session_id)` bindings, and the root DM reverts to a normal Hermes chat. Existing topics in Telegram aren't deleted — they just stop being gated as independent sessions. Re-run `/topic` later to turn it back on.
-
-If you need to clean up by hand (e.g. a bulk reset across many chats), remove the rows directly:
-
-```bash
-sqlite3 ~/.hermes/state.db \
-  "UPDATE telegram_dm_topic_mode SET enabled = 0 WHERE chat_id = '<your_chat_id>'; \
-   DELETE FROM telegram_dm_topic_bindings WHERE chat_id = '<your_chat_id>';"
-```
+Send `/topic off` to confirm that no Python-style topic binding state is active. Existing Telegram topic sessions remain isolated by thread ID.
 
 ### Downgrading Hermes
 
-If you downgrade to a Hermes version that predates `/topic`, the feature simply stops working — the `telegram_dm_topic_mode` and `telegram_dm_topic_bindings` tables remain in `state.db` but are ignored by older code. DMs revert to the native per-thread isolation (each `message_thread_id` still gets its own session via `build_session_key`), so your existing Telegram topics keep working as parallel sessions. The root DM is no longer a lobby — messages there go into the agent like they used to. Re-upgrading reactivates multi-session mode exactly where it was.
+Because Rust topic routing is derived from Telegram update metadata, there is no topic-mode database to migrate or downgrade. Older builds that preserve `message_thread_id` routing keep topic sessions isolated; builds without topic routing fall back to root-chat behavior.
 
 ## Group Forum Topic Skill Binding
 


### PR DESCRIPTION
## Summary
- port Telegram topic routing and /topic command semantics into the Rust gateway path
- add gateway tool-progress emission with markdown/bash code blocks for Telegram-capable platforms
- document Rust-native Telegram topic behavior and mark six upstream Telegram commits as handled/superseded

## Local verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- jq empty docs/parity/queue-overrides.json
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- scripts/clippy-warning-gate.sh --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --workspace
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --quiet

## Notes
- Upstream QR dashboard onboarding is classified as superseded by Rust CLI QR onboarding; no Python dashboard runtime was added.