### PR TITLE
Add test coverage audit parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           python3 scripts/generate-parity-matrix.py --local-ref HEAD
           python3 scripts/generate-workstream-status.py
           python3 scripts/generate-test-intent-mapping.py
+          python3 scripts/generate-test-coverage-audit.py --check
           python3 scripts/generate-adapter-matrix.py
           python3 scripts/validate-intentional-divergence.py --check --allow-warnings
           python3 scripts/generate-shared-diff-backlog.py --local-ref HEAD --no-fetch
@@ -55,6 +56,7 @@ jobs:
           python3 -m py_compile scripts/run-upstream-slash-parity-gate.py
           python3 -m py_compile scripts/run-upstream-surface-coverage-gate.py
           python3 -m py_compile scripts/generate-shared-diff-backlog.py
+          python3 -m py_compile scripts/generate-test-coverage-audit.py
           python3 -m py_compile scripts/release_secret_scan.py
 
   cross-build:

--- a/.github/workflows/parity-audit.yml
+++ b/.github/workflows/parity-audit.yml
@@ -24,6 +24,7 @@ jobs:
           python3 scripts/generate-parity-matrix.py --local-ref origin/main
           python3 scripts/generate-workstream-status.py
           python3 scripts/generate-test-intent-mapping.py
+          python3 scripts/generate-test-coverage-audit.py --check
           python3 scripts/generate-adapter-matrix.py
           python3 scripts/validate-intentional-divergence.py --check --allow-warnings
           python3 scripts/generate-shared-diff-backlog.py --local-ref origin/main --no-fetch
@@ -54,6 +55,8 @@ jobs:
             docs/parity/workstream-status.md
             docs/parity/test-intent-mapping.json
             docs/parity/test-intent-mapping.md
+            docs/parity/test-coverage-audit.json
+            docs/parity/test-coverage-audit.md
             docs/parity/adapter-feature-matrix.json
             docs/parity/adapter-feature-matrix.md
             docs/parity/divergence-validation.json
@@ -88,6 +91,9 @@ jobs:
               print(f"- commits_behind: `{metrics.get('max_commits_behind')}`")
               print(f"- upstream_patch_missing: `{metrics.get('max_upstream_patch_missing')}`")
               print(f"- files_only_upstream: `{metrics.get('max_files_only_upstream')}`")
+              print(f"- test_coverage_ratio: `{metrics.get('min_test_coverage_tracked_behavior_ratio')}`")
+              print(f"- test_coverage_critical_gaps: `{metrics.get('max_test_coverage_audit_critical_gaps')}`")
+              print(f"- test_coverage_missing_rust_refs: `{metrics.get('max_test_coverage_missing_rust_refs')}`")
               if backlog_summary:
                   print(f"- shared_diff_pending_classification: `{backlog_summary.get('pending_classification')}`")
                   print(f"- shared_diff_pending_review: `{backlog_summary.get('pending_review')}`")

--- a/crates/hermes-parity-tests/tests/global_parity_governance.rs
+++ b/crates/hermes-parity-tests/tests/global_parity_governance.rs
@@ -28,6 +28,41 @@ fn test_intent_mapping_ratio_meets_gate() {
 }
 
 #[test]
+fn test_coverage_audit_gate_passes() {
+    let payload = read_json("docs/parity/test-coverage-audit.json");
+    assert_eq!(
+        payload["audit_gate"]["pass"].as_bool(),
+        Some(true),
+        "test coverage audit gate must pass"
+    );
+    assert_eq!(
+        payload["audit_gate"]["critical_gaps"].as_u64(),
+        Some(0),
+        "test coverage audit must have zero critical gaps"
+    );
+    assert_eq!(
+        payload["summary"]["missing_rust_test_refs"].as_u64(),
+        Some(0),
+        "test coverage audit must have zero missing Rust test refs"
+    );
+    let ratio = payload["summary"]["tracked_behavior_coverage_ratio"]
+        .as_f64()
+        .expect("tracked_behavior_coverage_ratio should be number");
+    assert!(
+        ratio >= 1.0,
+        "tracked behavior coverage ratio below gate: {}",
+        ratio
+    );
+    let rust_tests = payload["summary"]["rust_test_functions"]
+        .as_u64()
+        .expect("rust_test_functions should be integer");
+    assert!(
+        rust_tests > 0,
+        "test coverage audit must observe Rust test functions"
+    );
+}
+
+#[test]
 fn test_adapter_matrix_has_no_placeholder_status() {
     let payload = read_json("docs/parity/adapter-feature-matrix.json");
     let non_native = payload["summary"]["non_rust_native"]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,6 +1,6 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-09T17:45:05.699969+00:00`_
+_Generated from source artifacts: `2026-06-10T08:53:14.867685+00:00`_
 
 ## Snapshot
 
@@ -8,14 +8,26 @@ _Generated from source artifacts: `2026-06-09T17:45:05.699969+00:00`_
 - Workstream snapshot generated: `2026-05-29T14:31:44-06:00`
 - Parity matrix generated: `2026-05-30T18:13:57.840432+00:00`
 - Queue snapshot generated: `2026-06-09T17:29:51.616492+00:00`
-- Proof snapshot generated: `2026-06-09T17:45:05.699969+00:00`
+- Proof snapshot generated: `2026-06-10T08:53:14.867685+00:00`
 
 ## Gate Status
 
 - Release gate: **PASS**
 - CI/tree-drift gate: **PASS**
+- Test coverage audit: **PASS**
 - Release gate failures: none
 - CI gate failures: none
+
+## Test Coverage Audit
+
+| Metric | Value |
+| --- | ---: |
+| Tracked behavior rows | 384 |
+| Covered behavior rows | 384 |
+| Tracked behavior coverage ratio | 1.0000 |
+| Rust test functions | 3409 |
+| Missing Rust test refs | 0 |
+| Critical gaps | 0 |
 
 ## Queue Summary
 
@@ -64,4 +76,5 @@ _Generated from source artifacts: `2026-06-09T17:45:05.699969+00:00`_
 - `docs/parity/workstream-status.json`
 - `docs/parity/upstream-missing-queue.json`
 - `docs/parity/global-parity-proof.json`
+- `docs/parity/test-coverage-audit.json`
 

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -11,6 +11,7 @@ From repository root:
 python3 scripts/generate-parity-matrix.py
 python3 scripts/generate-workstream-status.py
 python3 scripts/generate-test-intent-mapping.py
+python3 scripts/generate-test-coverage-audit.py --check
 python3 scripts/generate-adapter-matrix.py
 python3 scripts/validate-intentional-divergence.py --check --allow-warnings
 python3 scripts/generate-upstream-patch-queue.py --max-commits 0
@@ -31,6 +32,8 @@ By default this command fetches upstream directly from GitHub
 - `workstream-status.md`: human-readable WS2-WS8 status report
 - `test-intent-mapping.json`: upstream test-intent domain coverage mapped to Rust evidence
 - `test-intent-mapping.md`: human-readable intent mapping table
+- `test-coverage-audit.json`: upstream behavior/test-intent coverage audit with Rust test-reference validation
+- `test-coverage-audit.md`: human-readable coverage audit, advisory gaps, and next harness moves
 - `adapter-feature-matrix.json`: platform adapter + memory plugin matrix
 - `adapter-feature-matrix.md`: human-readable adapter matrix
 - `divergence-validation.json`: ownership/review freshness and coverage checks for intentional divergences

--- a/docs/parity/global-parity-program.md
+++ b/docs/parity/global-parity-program.md
@@ -6,6 +6,7 @@ This runbook maps each GPAR ticket to executable artifacts and checks.
 
 - `#20 GPAR-01` tests + CI parity closure
   - `docs/parity/test-intent-mapping.json`
+  - `docs/parity/test-coverage-audit.json`
   - `crates/hermes-parity-tests/tests/global_parity_governance.rs`
   - `crates/hermes-parity-tests/fixtures/hermes_core/tool_call_parser.json`
 - `#21 GPAR-02` skills + optional-skills parity
@@ -30,7 +31,9 @@ This runbook maps each GPAR ticket to executable artifacts and checks.
   - `docs/parity/divergence-validation.json`
 - `#28 GPAR-09` final parity proof gate + release checklist
   - `scripts/generate-global-parity-proof.py`
+  - `scripts/generate-test-coverage-audit.py`
   - `docs/parity/global-parity-proof.json`
+  - `docs/parity/test-coverage-audit.json`
   - `.github/workflows/parity-audit.yml`
 
 ## Continuous Upkeep

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -38,6 +38,24 @@
         "status": "pass"
       },
       {
+        "actual": 1.0,
+        "limit": 1.0,
+        "metric": "min_test_coverage_tracked_behavior_ratio",
+        "status": "pass"
+      },
+      {
+        "actual": 0.0,
+        "limit": 0,
+        "metric": "max_test_coverage_audit_critical_gaps",
+        "status": "pass"
+      },
+      {
+        "actual": 0.0,
+        "limit": 0,
+        "metric": "max_test_coverage_missing_rust_refs",
+        "status": "pass"
+      },
+      {
         "actual": 0.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
@@ -47,7 +65,7 @@
     "mode": "tree-drift",
     "pass": true
   },
-  "generated_at_utc": "2026-06-09T17:45:05.699969+00:00",
+  "generated_at_utc": "2026-06-10T08:53:14.867685+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -64,8 +82,11 @@
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 1493.0,
     "max_queue_pending_commits": 0.0,
+    "max_test_coverage_audit_critical_gaps": 0.0,
+    "max_test_coverage_missing_rust_refs": 0.0,
     "max_unowned_divergences": 0.0,
     "max_upstream_patch_missing": 4374.0,
+    "min_test_coverage_tracked_behavior_ratio": 1.0,
     "min_test_intent_mapping_ratio": 1.0
   },
   "program": {
@@ -112,6 +133,24 @@
         "status": "pass"
       },
       {
+        "actual": 1.0,
+        "limit": 1.0,
+        "metric": "min_test_coverage_tracked_behavior_ratio",
+        "status": "pass"
+      },
+      {
+        "actual": 0.0,
+        "limit": 0,
+        "metric": "max_test_coverage_audit_critical_gaps",
+        "status": "pass"
+      },
+      {
+        "actual": 0.0,
+        "limit": 0,
+        "metric": "max_test_coverage_missing_rust_refs",
+        "status": "pass"
+      },
+      {
         "actual": 0.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
@@ -144,8 +183,34 @@
     "parity_matrix": "docs/parity/parity-matrix.json",
     "patch_queue": "docs/parity/upstream-missing-queue.json",
     "shared_diff_classification": "docs/parity/shared-different-classification.json",
+    "test_coverage_audit": "docs/parity/test-coverage-audit.json",
     "thresholds": "docs/parity/global-parity-thresholds.json",
     "workstream_status": "docs/parity/workstream-status.json"
+  },
+  "test_coverage_audit_summary": {
+    "audit_gate": {
+      "advisory_gaps": 3,
+      "critical_gaps": 0,
+      "pass": true
+    },
+    "summary": {
+      "coverage_manifest_entries": 374,
+      "coverage_manifest_entries_with_valid_rust_tests": 374,
+      "covered_behavior_rows": 384,
+      "divergence_errors": 0,
+      "divergence_review_overdue": 0,
+      "divergence_unowned": 0,
+      "missing_rust_test_refs": 0,
+      "queue_pending": 0,
+      "queue_total": 5375,
+      "rust_test_files": 302,
+      "rust_test_functions": 3409,
+      "test_intent_mapping_ratio": 1.0,
+      "test_intents_mapped": 10,
+      "test_intents_total": 10,
+      "tracked_behavior_coverage_ratio": 1.0,
+      "tracked_behavior_rows": 384
+    }
   },
   "ws_legacy_states": {
     "complete": 7

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-09T17:45:05.699969+00:00`
+Generated: `2026-06-10T08:53:14.867685+00:00`
 
 ## Gate Status
 
@@ -19,6 +19,9 @@ Generated: `2026-06-09T17:45:05.699969+00:00`
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
+| `min_test_coverage_tracked_behavior_ratio` | 1.0 |
+| `max_test_coverage_audit_critical_gaps` | 0.0 |
+| `max_test_coverage_missing_rust_refs` | 0.0 |
 | `max_queue_pending_commits` | 0.0 |
 
 ## GPAR Ticket Completion
@@ -34,6 +37,13 @@ Generated: `2026-06-09T17:45:05.699969+00:00`
 | `GPAR-07` | yes |
 | `GPAR-08` | yes |
 | `GPAR-09` | yes |
+
+## Test Coverage Audit
+
+- Audit gate: **PASS**
+- Tracked behavior coverage ratio: `1.0`
+- Critical gaps: `0`
+- Missing Rust test refs: `0`
 
 ## Queue Summary
 

--- a/docs/parity/global-parity-thresholds.json
+++ b/docs/parity/global-parity-thresholds.json
@@ -12,6 +12,9 @@
       "max_unowned_divergences": 0,
       "max_divergence_review_overdue": 0,
       "min_test_intent_mapping_ratio": 0.9,
+      "min_test_coverage_tracked_behavior_ratio": 1.0,
+      "max_test_coverage_audit_critical_gaps": 0,
+      "max_test_coverage_missing_rust_refs": 0,
       "max_queue_pending_commits": 0
     },
     "required_workstreams_complete": [
@@ -34,6 +37,9 @@
     "max_unowned_divergences": 0,
     "max_divergence_review_overdue": 0,
     "min_test_intent_mapping_ratio": 0.9,
+    "min_test_coverage_tracked_behavior_ratio": 1.0,
+    "max_test_coverage_audit_critical_gaps": 0,
+    "max_test_coverage_missing_rust_refs": 0,
     "max_queue_pending_commits": 100,
     "special_rules": {
       "allow_files_only_upstream_overshoot_when_functional_clean": {

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -1,0 +1,564 @@
+{
+  "advisory_gaps": [
+    {
+      "kind": "nonzero_tree_drift",
+      "message": "max_commits_behind remains nonzero in parity matrix",
+      "metric": "max_commits_behind",
+      "value": 4494.0
+    },
+    {
+      "kind": "nonzero_tree_drift",
+      "message": "max_upstream_patch_missing remains nonzero in parity matrix",
+      "metric": "max_upstream_patch_missing",
+      "value": 4374.0
+    },
+    {
+      "kind": "nonzero_tree_drift",
+      "message": "max_files_only_upstream remains nonzero in parity matrix",
+      "metric": "max_files_only_upstream",
+      "value": 1493.0
+    }
+  ],
+  "audit_gate": {
+    "advisory_gaps": 3,
+    "critical_gaps": 0,
+    "pass": true
+  },
+  "audit_unit": "upstream_behavior_or_test_intent",
+  "coverage_manifests": [
+    {
+      "entries": 174,
+      "missing_rust_test_refs": [],
+      "missing_rust_tests_entries": [],
+      "path": "docs/parity/python-test-suite-coverage.json",
+      "referenced_rust_tests": 91,
+      "status_counts": {
+        "covered_by_rust_test_suite_contracts": 174
+      },
+      "valid_entries_with_rust_tests": 174
+    },
+    {
+      "entries": 113,
+      "missing_rust_test_refs": [],
+      "missing_rust_tests_entries": [],
+      "path": "docs/parity/hermes-cli-test-coverage.json",
+      "referenced_rust_tests": 61,
+      "status_counts": {
+        "covered_by_rust_contracts": 113
+      },
+      "valid_entries_with_rust_tests": 113
+    },
+    {
+      "entries": 87,
+      "missing_rust_test_refs": [],
+      "missing_rust_tests_entries": [],
+      "path": "docs/parity/ui-tui-source-coverage.json",
+      "referenced_rust_tests": 55,
+      "status_counts": {
+        "covered_by_rust_primary_tui_contracts": 87
+      },
+      "valid_entries_with_rust_tests": 87
+    }
+  ],
+  "critical_gaps": [],
+  "generated_at_utc": "2026-06-10T08:53:14.773456+00:00",
+  "intent_domains": [
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 22,
+      "direct_test_evidence_sample": [
+        "crates/hermes-cli/tests/e2e_gateway_cron_webhook.rs",
+        "crates/hermes-cli/tests/e2e_gateway_process.rs",
+        "crates/hermes-gateway/src/platforms/api_server.rs",
+        "crates/hermes-gateway/src/platforms/bluebubbles.rs",
+        "crates/hermes-gateway/src/platforms/dingtalk.rs",
+        "crates/hermes-gateway/src/platforms/discord.rs",
+        "crates/hermes-gateway/src/platforms/email.rs",
+        "crates/hermes-gateway/src/platforms/feishu.rs",
+        "crates/hermes-gateway/src/platforms/helpers.rs",
+        "crates/hermes-gateway/src/platforms/matrix.rs",
+        "crates/hermes-gateway/src/platforms/mattermost.rs",
+        "crates/hermes-gateway/src/platforms/ntfy.rs",
+        "crates/hermes-gateway/src/platforms/qqbot.rs",
+        "crates/hermes-gateway/src/platforms/signal.rs",
+        "crates/hermes-gateway/src/platforms/signal_rate_limit.rs",
+        "crates/hermes-gateway/src/platforms/slack.rs",
+        "crates/hermes-gateway/src/platforms/telegram.rs",
+        "crates/hermes-gateway/src/platforms/webhook.rs",
+        "crates/hermes-gateway/src/platforms/wecom.rs",
+        "crates/hermes-gateway/src/platforms/wecom_callback.rs",
+        "crates/hermes-gateway/src/platforms/weixin.rs",
+        "crates/hermes-gateway/src/platforms/whatsapp.rs"
+      ],
+      "evidence_count": 25,
+      "evidence_sample": [
+        "crates/hermes-cli/tests/e2e_gateway_cron_webhook.rs",
+        "crates/hermes-cli/tests/e2e_gateway_process.rs",
+        "crates/hermes-gateway/src/platforms/api_server.rs",
+        "crates/hermes-gateway/src/platforms/bluebubbles.rs",
+        "crates/hermes-gateway/src/platforms/dingtalk.rs",
+        "crates/hermes-gateway/src/platforms/discord.rs",
+        "crates/hermes-gateway/src/platforms/email.rs",
+        "crates/hermes-gateway/src/platforms/feishu.rs",
+        "crates/hermes-gateway/src/platforms/helpers.rs",
+        "crates/hermes-gateway/src/platforms/homeassistant.rs",
+        "crates/hermes-gateway/src/platforms/matrix.rs",
+        "crates/hermes-gateway/src/platforms/mattermost.rs",
+        "crates/hermes-gateway/src/platforms/mod.rs",
+        "crates/hermes-gateway/src/platforms/ntfy.rs",
+        "crates/hermes-gateway/src/platforms/qqbot.rs",
+        "crates/hermes-gateway/src/platforms/signal.rs",
+        "crates/hermes-gateway/src/platforms/signal_rate_limit.rs",
+        "crates/hermes-gateway/src/platforms/slack.rs",
+        "crates/hermes-gateway/src/platforms/sms.rs",
+        "crates/hermes-gateway/src/platforms/telegram.rs",
+        "crates/hermes-gateway/src/platforms/webhook.rs",
+        "crates/hermes-gateway/src/platforms/wecom.rs",
+        "crates/hermes-gateway/src/platforms/wecom_callback.rs",
+        "crates/hermes-gateway/src/platforms/weixin.rs",
+        "crates/hermes-gateway/src/platforms/whatsapp.rs"
+      ],
+      "id": "gateway-platform-behavior",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/gateway",
+        "gateway/platforms"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 82,
+      "direct_test_evidence_sample": [
+        "crates/hermes-tools/src/approval.rs",
+        "crates/hermes-tools/src/backends/browser.rs",
+        "crates/hermes-tools/src/backends/code_execution.rs",
+        "crates/hermes-tools/src/backends/delegation.rs",
+        "crates/hermes-tools/src/backends/file.rs",
+        "crates/hermes-tools/src/backends/homeassistant.rs",
+        "crates/hermes-tools/src/backends/image_gen.rs",
+        "crates/hermes-tools/src/backends/memory.rs",
+        "crates/hermes-tools/src/backends/session_search.rs",
+        "crates/hermes-tools/src/backends/spotify.rs",
+        "crates/hermes-tools/src/backends/tts.rs",
+        "crates/hermes-tools/src/backends/video.rs",
+        "crates/hermes-tools/src/backends/video_gen.rs",
+        "crates/hermes-tools/src/backends/vision.rs",
+        "crates/hermes-tools/src/backends/web.rs",
+        "crates/hermes-tools/src/credential_guard.rs",
+        "crates/hermes-tools/src/dispatch.rs",
+        "crates/hermes-tools/src/register_builtins.rs",
+        "crates/hermes-tools/src/registry.rs",
+        "crates/hermes-tools/src/repo.rs",
+        "crates/hermes-tools/src/rtk_filter.rs",
+        "crates/hermes-tools/src/teams_pipeline.rs",
+        "crates/hermes-tools/src/terminal_requirements.rs",
+        "crates/hermes-tools/src/tool_policy.rs",
+        "crates/hermes-tools/src/tools/alpha_snapshot.rs"
+      ],
+      "evidence_count": 91,
+      "evidence_sample": [
+        "crates/hermes-tools/src/approval.rs",
+        "crates/hermes-tools/src/backends/browser.rs",
+        "crates/hermes-tools/src/backends/clarify.rs",
+        "crates/hermes-tools/src/backends/code_execution.rs",
+        "crates/hermes-tools/src/backends/cronjob.rs",
+        "crates/hermes-tools/src/backends/delegation.rs",
+        "crates/hermes-tools/src/backends/file.rs",
+        "crates/hermes-tools/src/backends/homeassistant.rs",
+        "crates/hermes-tools/src/backends/image_gen.rs",
+        "crates/hermes-tools/src/backends/memory.rs",
+        "crates/hermes-tools/src/backends/messaging.rs",
+        "crates/hermes-tools/src/backends/mod.rs",
+        "crates/hermes-tools/src/backends/session_search.rs",
+        "crates/hermes-tools/src/backends/spotify.rs",
+        "crates/hermes-tools/src/backends/todo.rs",
+        "crates/hermes-tools/src/backends/tts.rs",
+        "crates/hermes-tools/src/backends/video.rs",
+        "crates/hermes-tools/src/backends/video_gen.rs",
+        "crates/hermes-tools/src/backends/vision.rs",
+        "crates/hermes-tools/src/backends/web.rs",
+        "crates/hermes-tools/src/credential_guard.rs",
+        "crates/hermes-tools/src/dispatch.rs",
+        "crates/hermes-tools/src/lib.rs",
+        "crates/hermes-tools/src/register_builtins.rs",
+        "crates/hermes-tools/src/registry.rs"
+      ],
+      "id": "tool-runtime-behavior",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/tools",
+        "tools/environments"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 24,
+      "direct_test_evidence_sample": [
+        "crates/hermes-cli/src/alpha_runtime.rs",
+        "crates/hermes-cli/src/app.rs",
+        "crates/hermes-cli/src/auth.rs",
+        "crates/hermes-cli/src/checklist.rs",
+        "crates/hermes-cli/src/claw_migrate.rs",
+        "crates/hermes-cli/src/cli.rs",
+        "crates/hermes-cli/src/commands.rs",
+        "crates/hermes-cli/src/config_env.rs",
+        "crates/hermes-cli/src/kanban.rs",
+        "crates/hermes-cli/src/lumio.rs",
+        "crates/hermes-cli/src/main.rs",
+        "crates/hermes-cli/src/mcp_config.rs",
+        "crates/hermes-cli/src/model_switch.rs",
+        "crates/hermes-cli/src/pairing_store.rs",
+        "crates/hermes-cli/src/platform_toolsets.rs",
+        "crates/hermes-cli/src/runtime_tool_wiring.rs",
+        "crates/hermes-cli/src/skin_engine.rs",
+        "crates/hermes-cli/src/systems.rs",
+        "crates/hermes-cli/src/teams_pipeline_cli.rs",
+        "crates/hermes-cli/src/terminal_backend.rs",
+        "crates/hermes-cli/src/theme.rs",
+        "crates/hermes-cli/src/tool_preview.rs",
+        "crates/hermes-cli/src/tui.rs",
+        "crates/hermes-parity-tests/tests/cli_command_contract.rs"
+      ],
+      "evidence_count": 40,
+      "evidence_sample": [
+        "crates/hermes-cli/src/alpha_runtime.rs",
+        "crates/hermes-cli/src/app.rs",
+        "crates/hermes-cli/src/auth.rs",
+        "crates/hermes-cli/src/banner.rs",
+        "crates/hermes-cli/src/bin/hermes-ultra.rs",
+        "crates/hermes-cli/src/bin/hermes.rs",
+        "crates/hermes-cli/src/checklist.rs",
+        "crates/hermes-cli/src/claw_migrate.rs",
+        "crates/hermes-cli/src/cli.rs",
+        "crates/hermes-cli/src/commands.rs",
+        "crates/hermes-cli/src/config_env.rs",
+        "crates/hermes-cli/src/copilot_auth.rs",
+        "crates/hermes-cli/src/doctor.rs",
+        "crates/hermes-cli/src/env_loader.rs",
+        "crates/hermes-cli/src/gateway_cmd.rs",
+        "crates/hermes-cli/src/kanban.rs",
+        "crates/hermes-cli/src/lib.rs",
+        "crates/hermes-cli/src/lumio.rs",
+        "crates/hermes-cli/src/main.rs",
+        "crates/hermes-cli/src/mcp_config.rs",
+        "crates/hermes-cli/src/model_switch.rs",
+        "crates/hermes-cli/src/pairing_store.rs",
+        "crates/hermes-cli/src/platform_toolsets.rs",
+        "crates/hermes-cli/src/profiles.rs",
+        "crates/hermes-cli/src/providers.rs"
+      ],
+      "id": "cli-command-surface",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/hermes_cli",
+        "tests/cli"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 45,
+      "direct_test_evidence_sample": [
+        "crates/hermes-agent/src/agent_loop.rs",
+        "crates/hermes-agent/src/api_bridge.rs",
+        "crates/hermes-agent/src/auxiliary_builder.rs",
+        "crates/hermes-agent/src/bedrock.rs",
+        "crates/hermes-agent/src/budget.rs",
+        "crates/hermes-agent/src/code_index.rs",
+        "crates/hermes-agent/src/compression.rs",
+        "crates/hermes-agent/src/context.rs",
+        "crates/hermes-agent/src/context_files.rs",
+        "crates/hermes-agent/src/context_references.rs",
+        "crates/hermes-agent/src/credential_pool.rs",
+        "crates/hermes-agent/src/honcho_provider.rs",
+        "crates/hermes-agent/src/interrupt.rs",
+        "crates/hermes-agent/src/lsp_context.rs",
+        "crates/hermes-agent/src/memory_manager.rs",
+        "crates/hermes-agent/src/memory_plugins/byterover.rs",
+        "crates/hermes-agent/src/memory_plugins/config_io.rs",
+        "crates/hermes-agent/src/memory_plugins/contextlattice.rs",
+        "crates/hermes-agent/src/memory_plugins/hindsight.rs",
+        "crates/hermes-agent/src/memory_plugins/holographic.rs",
+        "crates/hermes-agent/src/memory_plugins/honcho.rs",
+        "crates/hermes-agent/src/memory_plugins/mem0.rs",
+        "crates/hermes-agent/src/memory_plugins/openviking.rs",
+        "crates/hermes-agent/src/memory_plugins/retaindb.rs",
+        "crates/hermes-agent/src/memory_plugins/supermemory.rs"
+      ],
+      "evidence_count": 49,
+      "evidence_sample": [
+        "crates/hermes-agent/src/agent_loop.rs",
+        "crates/hermes-agent/src/api_bridge.rs",
+        "crates/hermes-agent/src/auxiliary_builder.rs",
+        "crates/hermes-agent/src/bedrock.rs",
+        "crates/hermes-agent/src/budget.rs",
+        "crates/hermes-agent/src/code_index.rs",
+        "crates/hermes-agent/src/compression.rs",
+        "crates/hermes-agent/src/context.rs",
+        "crates/hermes-agent/src/context_files.rs",
+        "crates/hermes-agent/src/context_references.rs",
+        "crates/hermes-agent/src/credential_pool.rs",
+        "crates/hermes-agent/src/fallback.rs",
+        "crates/hermes-agent/src/honcho_provider.rs",
+        "crates/hermes-agent/src/interrupt.rs",
+        "crates/hermes-agent/src/lib.rs",
+        "crates/hermes-agent/src/lsp_context.rs",
+        "crates/hermes-agent/src/memory_manager.rs",
+        "crates/hermes-agent/src/memory_plugins/byterover.rs",
+        "crates/hermes-agent/src/memory_plugins/config_io.rs",
+        "crates/hermes-agent/src/memory_plugins/contextlattice.rs",
+        "crates/hermes-agent/src/memory_plugins/hindsight.rs",
+        "crates/hermes-agent/src/memory_plugins/holographic.rs",
+        "crates/hermes-agent/src/memory_plugins/honcho.rs",
+        "crates/hermes-agent/src/memory_plugins/mem0.rs",
+        "crates/hermes-agent/src/memory_plugins/mod.rs"
+      ],
+      "id": "agent-loop-and-runtime",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/run_agent",
+        "tests/agent"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 8,
+      "direct_test_evidence_sample": [
+        "crates/hermes-acp/src/auth.rs",
+        "crates/hermes-acp/src/events.rs",
+        "crates/hermes-acp/src/handler.rs",
+        "crates/hermes-acp/src/permissions.rs",
+        "crates/hermes-acp/src/protocol.rs",
+        "crates/hermes-acp/src/server.rs",
+        "crates/hermes-acp/src/session.rs",
+        "crates/hermes-acp/src/tools.rs"
+      ],
+      "evidence_count": 9,
+      "evidence_sample": [
+        "crates/hermes-acp/src/auth.rs",
+        "crates/hermes-acp/src/events.rs",
+        "crates/hermes-acp/src/handler.rs",
+        "crates/hermes-acp/src/lib.rs",
+        "crates/hermes-acp/src/permissions.rs",
+        "crates/hermes-acp/src/protocol.rs",
+        "crates/hermes-acp/src/server.rs",
+        "crates/hermes-acp/src/session.rs",
+        "crates/hermes-acp/src/tools.rs"
+      ],
+      "id": "acp-protocol-and-transport",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/acp"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 9,
+      "direct_test_evidence_sample": [
+        "crates/hermes-cli/src/commands.rs",
+        "crates/hermes-skills/src/guard.rs",
+        "crates/hermes-skills/src/hub.rs",
+        "crates/hermes-skills/src/provenance.rs",
+        "crates/hermes-skills/src/skill.rs",
+        "crates/hermes-skills/src/store.rs",
+        "crates/hermes-skills/src/sync.rs",
+        "crates/hermes-skills/src/usage.rs",
+        "crates/hermes-skills/src/version.rs"
+      ],
+      "evidence_count": 10,
+      "evidence_sample": [
+        "crates/hermes-cli/src/commands.rs",
+        "crates/hermes-skills/src/guard.rs",
+        "crates/hermes-skills/src/hub.rs",
+        "crates/hermes-skills/src/lib.rs",
+        "crates/hermes-skills/src/provenance.rs",
+        "crates/hermes-skills/src/skill.rs",
+        "crates/hermes-skills/src/store.rs",
+        "crates/hermes-skills/src/sync.rs",
+        "crates/hermes-skills/src/usage.rs",
+        "crates/hermes-skills/src/version.rs"
+      ],
+      "id": "skills-management-contract",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/skills",
+        "skills",
+        "optional-skills"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 6,
+      "direct_test_evidence_sample": [
+        "crates/hermes-cli/src/commands.rs",
+        "crates/hermes-cron/src/backend.rs",
+        "crates/hermes-cron/src/job.rs",
+        "crates/hermes-cron/src/persistence.rs",
+        "crates/hermes-cron/src/runner.rs",
+        "crates/hermes-cron/src/scheduler.rs"
+      ],
+      "evidence_count": 9,
+      "evidence_sample": [
+        "crates/hermes-cli/src/commands.rs",
+        "crates/hermes-cron/src/backend.rs",
+        "crates/hermes-cron/src/cli_support.rs",
+        "crates/hermes-cron/src/completion.rs",
+        "crates/hermes-cron/src/job.rs",
+        "crates/hermes-cron/src/lib.rs",
+        "crates/hermes-cron/src/persistence.rs",
+        "crates/hermes-cron/src/runner.rs",
+        "crates/hermes-cron/src/scheduler.rs"
+      ],
+      "id": "cron-and-scheduler-runtime",
+      "mapped": true,
+      "upstream_scope": [
+        "tests/cron"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 11,
+      "direct_test_evidence_sample": [
+        "crates/hermes-agent/src/memory_plugins/byterover.rs",
+        "crates/hermes-agent/src/memory_plugins/config_io.rs",
+        "crates/hermes-agent/src/memory_plugins/contextlattice.rs",
+        "crates/hermes-agent/src/memory_plugins/hindsight.rs",
+        "crates/hermes-agent/src/memory_plugins/holographic.rs",
+        "crates/hermes-agent/src/memory_plugins/honcho.rs",
+        "crates/hermes-agent/src/memory_plugins/mem0.rs",
+        "crates/hermes-agent/src/memory_plugins/openviking.rs",
+        "crates/hermes-agent/src/memory_plugins/retaindb.rs",
+        "crates/hermes-agent/src/memory_plugins/supermemory.rs",
+        "crates/hermes-agent/tests/parity_self_evolution_fixtures.rs"
+      ],
+      "evidence_count": 12,
+      "evidence_sample": [
+        "crates/hermes-agent/src/memory_plugins/byterover.rs",
+        "crates/hermes-agent/src/memory_plugins/config_io.rs",
+        "crates/hermes-agent/src/memory_plugins/contextlattice.rs",
+        "crates/hermes-agent/src/memory_plugins/hindsight.rs",
+        "crates/hermes-agent/src/memory_plugins/holographic.rs",
+        "crates/hermes-agent/src/memory_plugins/honcho.rs",
+        "crates/hermes-agent/src/memory_plugins/mem0.rs",
+        "crates/hermes-agent/src/memory_plugins/mod.rs",
+        "crates/hermes-agent/src/memory_plugins/openviking.rs",
+        "crates/hermes-agent/src/memory_plugins/retaindb.rs",
+        "crates/hermes-agent/src/memory_plugins/supermemory.rs",
+        "crates/hermes-agent/tests/parity_self_evolution_fixtures.rs"
+      ],
+      "id": "memory-plugin-integration",
+      "mapped": true,
+      "upstream_scope": [
+        "plugins/memory",
+        "tests/plugins"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 8,
+      "direct_test_evidence_sample": [
+        "crates/hermes-environments/src/docker.rs",
+        "crates/hermes-environments/src/file_sync.rs",
+        "crates/hermes-environments/src/local.rs",
+        "crates/hermes-environments/src/managed_modal.rs",
+        "crates/hermes-environments/src/manager.rs",
+        "crates/hermes-environments/src/singularity.rs",
+        "crates/hermes-environments/src/ssh.rs",
+        "crates/hermes-environments/tests/backend_integration.rs"
+      ],
+      "evidence_count": 12,
+      "evidence_sample": [
+        "crates/hermes-environments/src/daytona.rs",
+        "crates/hermes-environments/src/docker.rs",
+        "crates/hermes-environments/src/file_sync.rs",
+        "crates/hermes-environments/src/lib.rs",
+        "crates/hermes-environments/src/local.rs",
+        "crates/hermes-environments/src/managed_modal.rs",
+        "crates/hermes-environments/src/manager.rs",
+        "crates/hermes-environments/src/modal.rs",
+        "crates/hermes-environments/src/singularity.rs",
+        "crates/hermes-environments/src/ssh.rs",
+        "crates/hermes-environments/src/training/mod.rs",
+        "crates/hermes-environments/tests/backend_integration.rs"
+      ],
+      "id": "environment-lifecycle-contract",
+      "mapped": true,
+      "upstream_scope": [
+        "environments/benchmarks",
+        "tools/environments"
+      ]
+    },
+    {
+      "classification": "direct_rust_test",
+      "direct_test_evidence_count": 3,
+      "direct_test_evidence_sample": [
+        "crates/hermes-core/src/tool_call_parser.rs",
+        "crates/hermes-parity-tests/fixtures/hermes_core/format_tool_calls.json",
+        "crates/hermes-parity-tests/fixtures/hermes_core/tool_call_parser.json"
+      ],
+      "evidence_count": 3,
+      "evidence_sample": [
+        "crates/hermes-core/src/tool_call_parser.rs",
+        "crates/hermes-parity-tests/fixtures/hermes_core/format_tool_calls.json",
+        "crates/hermes-parity-tests/fixtures/hermes_core/tool_call_parser.json"
+      ],
+      "id": "tool-call-parser-contract",
+      "mapped": true,
+      "upstream_scope": [
+        "environments/tool_call_parsers",
+        "tests/integration"
+      ]
+    }
+  ],
+  "next_sigma_harness_moves": [
+    {
+      "rationale": "Record CLI/TUI/gateway task journeys as deterministic fixtures so regressions are caught at the workflow level, not only at unit boundaries.",
+      "title": "User-journey replay corpus"
+    },
+    {
+      "rationale": "Run provider, MCP, ACP, and gateway request/response fixtures through normalized differential checks against upstream intent and Ultra policy.",
+      "title": "Protocol differential contracts"
+    },
+    {
+      "rationale": "Inject network stalls, partial streams, auth expiry, tool failures, and malformed model/tool payloads into the Rust runtime to prove recovery behavior.",
+      "title": "Fault-injection matrix"
+    },
+    {
+      "rationale": "Exercise real terminal input/output flows and snapshot critical UX states so command ergonomics and status rendering are protected.",
+      "title": "PTY and TUI golden snapshots"
+    },
+    {
+      "rationale": "Track behavior coverage over time so new upstream rows or local harness regressions create visible deltas before release prep.",
+      "title": "Coverage trend ledger"
+    }
+  ],
+  "schema_version": 1,
+  "source_artifacts": {
+    "coverage_manifests": [
+      "docs/parity/python-test-suite-coverage.json",
+      "docs/parity/hermes-cli-test-coverage.json",
+      "docs/parity/ui-tui-source-coverage.json"
+    ],
+    "divergence_validation": "docs/parity/divergence-validation.json",
+    "parity_matrix": "docs/parity/parity-matrix.json",
+    "test_intent_mapping": "docs/parity/test-intent-mapping.json",
+    "upstream_missing_queue": "docs/parity/upstream-missing-queue.json"
+  },
+  "summary": {
+    "coverage_manifest_entries": 374,
+    "coverage_manifest_entries_with_valid_rust_tests": 374,
+    "covered_behavior_rows": 384,
+    "divergence_errors": 0,
+    "divergence_review_overdue": 0,
+    "divergence_unowned": 0,
+    "missing_rust_test_refs": 0,
+    "queue_pending": 0,
+    "queue_total": 5375,
+    "rust_test_files": 302,
+    "rust_test_functions": 3409,
+    "test_intent_mapping_ratio": 1.0,
+    "test_intents_mapped": 10,
+    "test_intents_total": 10,
+    "tracked_behavior_coverage_ratio": 1.0,
+    "tracked_behavior_rows": 384
+  }
+}

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,0 +1,67 @@
+# Test Coverage Audit
+
+Generated: `2026-06-10T08:53:14.773456+00:00`
+
+## Gate
+
+- Audit gate: **PASS**
+- Critical gaps: `0`
+- Advisory gaps: `3`
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| `tracked_behavior_rows` | 384 |
+| `covered_behavior_rows` | 384 |
+| `tracked_behavior_coverage_ratio` | 1.0 |
+| `rust_test_files` | 302 |
+| `rust_test_functions` | 3409 |
+| `coverage_manifest_entries` | 374 |
+| `coverage_manifest_entries_with_valid_rust_tests` | 374 |
+| `missing_rust_test_refs` | 0 |
+| `queue_pending` | 0 |
+| `queue_total` | 5375 |
+| `test_intents_total` | 10 |
+| `test_intents_mapped` | 10 |
+
+## Coverage Manifests
+
+| Manifest | Entries | Valid Rust-test entries | Referenced Rust tests | Missing refs |
+| --- | ---: | ---: | ---: | ---: |
+| `docs/parity/python-test-suite-coverage.json` | 174 | 174 | 91 | 0 |
+| `docs/parity/hermes-cli-test-coverage.json` | 113 | 113 | 61 | 0 |
+| `docs/parity/ui-tui-source-coverage.json` | 87 | 87 | 55 | 0 |
+
+## Test Intent Domains
+
+| Intent | Classification | Evidence files | Direct test evidence |
+| --- | --- | ---: | ---: |
+| `gateway-platform-behavior` | `direct_rust_test` | 25 | 22 |
+| `tool-runtime-behavior` | `direct_rust_test` | 91 | 82 |
+| `cli-command-surface` | `direct_rust_test` | 40 | 24 |
+| `agent-loop-and-runtime` | `direct_rust_test` | 49 | 45 |
+| `acp-protocol-and-transport` | `direct_rust_test` | 9 | 8 |
+| `skills-management-contract` | `direct_rust_test` | 10 | 9 |
+| `cron-and-scheduler-runtime` | `direct_rust_test` | 9 | 6 |
+| `memory-plugin-integration` | `direct_rust_test` | 12 | 11 |
+| `environment-lifecycle-contract` | `direct_rust_test` | 12 | 8 |
+| `tool-call-parser-contract` | `direct_rust_test` | 3 | 3 |
+
+## Critical Gaps
+
+- none
+
+## Advisory Gaps
+
+- `nonzero_tree_drift`: max_commits_behind remains nonzero in parity matrix
+- `nonzero_tree_drift`: max_upstream_patch_missing remains nonzero in parity matrix
+- `nonzero_tree_drift`: max_files_only_upstream remains nonzero in parity matrix
+
+## Next Sigma Harness Moves
+
+- **User-journey replay corpus**: Record CLI/TUI/gateway task journeys as deterministic fixtures so regressions are caught at the workflow level, not only at unit boundaries.
+- **Protocol differential contracts**: Run provider, MCP, ACP, and gateway request/response fixtures through normalized differential checks against upstream intent and Ultra policy.
+- **Fault-injection matrix**: Inject network stalls, partial streams, auth expiry, tool failures, and malformed model/tool payloads into the Rust runtime to prove recovery behavior.
+- **PTY and TUI golden snapshots**: Exercise real terminal input/output flows and snapshot critical UX states so command ergonomics and status rendering are protected.
+- **Coverage trend ledger**: Track behavior coverage over time so new upstream rows or local harness regressions create visible deltas before release prep.

--- a/scripts/generate-global-parity-proof.py
+++ b/scripts/generate-global-parity-proof.py
@@ -192,6 +192,12 @@ def main() -> int:
         help="Upstream patch queue JSON file",
     )
     parser.add_argument(
+        "--test-coverage-audit",
+        default="docs/parity/test-coverage-audit.json",
+        type=Path,
+        help="Test coverage audit JSON file",
+    )
+    parser.add_argument(
         "--out-json",
         default="docs/parity/global-parity-proof.json",
         type=Path,
@@ -216,12 +222,15 @@ def main() -> int:
     shared_diff = load_json((repo_root / args.shared_diff_classification).resolve())
     divergence = load_json((repo_root / args.divergence_validation).resolve())
     patch_queue = load_json((repo_root / args.patch_queue).resolve())
+    test_coverage = load_json((repo_root / args.test_coverage_audit).resolve())
 
     parity_summary = parity.get("summary", {})
     intent_summary = intents.get("summary", {})
     adapter_summary = adapters.get("summary", {})
     divergence_summary = divergence.get("summary", {})
     queue_summary = patch_queue.get("summary", {})
+    test_coverage_summary = test_coverage.get("summary", {})
+    test_coverage_gate = test_coverage.get("audit_gate", {})
     ws_states = ws.get("states", {})
     shared_diff_items = {str(i.get("path", "")) for i in shared_diff.get("items", [])}
     parity_shared = {str(i.get("path", "")) for i in parity.get("top_shared_different", [])}
@@ -238,7 +247,7 @@ def main() -> int:
         "GPAR-08": int(divergence_summary.get("errors", 0)) == 0
         and int(divergence_summary.get("unowned", 0)) == 0
         and int(divergence_summary.get("review_overdue", 0)) == 0,
-        "GPAR-09": True,
+        "GPAR-09": bool(test_coverage_gate.get("pass", False)),
     }
 
     metrics = {
@@ -248,6 +257,15 @@ def main() -> int:
         "max_unowned_divergences": float(divergence_summary.get("unowned", 0)),
         "max_divergence_review_overdue": float(divergence_summary.get("review_overdue", 0)),
         "min_test_intent_mapping_ratio": float(intent_summary.get("mapping_ratio", 0.0)),
+        "min_test_coverage_tracked_behavior_ratio": float(
+            test_coverage_summary.get("tracked_behavior_coverage_ratio", 0.0)
+        ),
+        "max_test_coverage_audit_critical_gaps": float(
+            test_coverage_gate.get("critical_gaps", 0)
+        ),
+        "max_test_coverage_missing_rust_refs": float(
+            test_coverage_summary.get("missing_rust_test_refs", 0)
+        ),
         "max_queue_pending_commits": float(
             queue_summary.get("by_disposition", {}).get("pending", 0)
         ),
@@ -304,8 +322,13 @@ def main() -> int:
             "shared_diff_classification": str(args.shared_diff_classification),
             "divergence_validation": str(args.divergence_validation),
             "patch_queue": str(args.patch_queue),
+            "test_coverage_audit": str(args.test_coverage_audit),
         },
         "queue_summary": queue_summary,
+        "test_coverage_audit_summary": {
+            "summary": test_coverage_summary,
+            "audit_gate": test_coverage_gate,
+        },
     }
 
     out_json = (repo_root / args.out_json).resolve()
@@ -340,6 +363,20 @@ def main() -> int:
     md.append("| --- | --- |")
     for key in sorted(gpar_completion.keys()):
         md.append(f"| `{key}` | {'yes' if gpar_completion[key] else 'no'} |")
+    md.append("")
+
+    md.append("## Test Coverage Audit")
+    md.append("")
+    md.append(f"- Audit gate: **{'PASS' if test_coverage_gate.get('pass') else 'FAIL'}**")
+    md.append(
+        "- Tracked behavior coverage ratio: "
+        f"`{test_coverage_summary.get('tracked_behavior_coverage_ratio', 0)}`"
+    )
+    md.append(f"- Critical gaps: `{test_coverage_gate.get('critical_gaps', 0)}`")
+    md.append(
+        "- Missing Rust test refs: "
+        f"`{test_coverage_summary.get('missing_rust_test_refs', 0)}`"
+    )
     md.append("")
 
     md.append("## Queue Summary")

--- a/scripts/generate-parity-dashboard.py
+++ b/scripts/generate-parity-dashboard.py
@@ -33,6 +33,11 @@ def parse_args() -> argparse.Namespace:
         help="Global parity proof JSON path relative to repo root",
     )
     parser.add_argument(
+        "--test-coverage-audit",
+        default="docs/parity/test-coverage-audit.json",
+        help="Test coverage audit JSON path relative to repo root",
+    )
+    parser.add_argument(
         "--output",
         default="docs/parity/PARITY_DASHBOARD.md",
         help="Output markdown path relative to repo root",
@@ -82,6 +87,7 @@ def render_dashboard(
     workstream_status: dict[str, Any],
     queue_json: dict[str, Any],
     proof_json: dict[str, Any],
+    test_coverage_audit: dict[str, Any],
 ) -> str:
     summary = parity_matrix.get("summary", {}) if isinstance(parity_matrix.get("summary"), dict) else {}
     queue_summary = queue_json.get("summary", {}) if isinstance(queue_json.get("summary"), dict) else {}
@@ -90,6 +96,16 @@ def render_dashboard(
 
     release_gate = proof_json.get("release_gate", {}) if isinstance(proof_json.get("release_gate"), dict) else {}
     ci_gate = proof_json.get("ci_gate", {}) if isinstance(proof_json.get("ci_gate"), dict) else {}
+    coverage_summary = (
+        test_coverage_audit.get("summary", {})
+        if isinstance(test_coverage_audit.get("summary"), dict)
+        else {}
+    )
+    coverage_gate = (
+        test_coverage_audit.get("audit_gate", {})
+        if isinstance(test_coverage_audit.get("audit_gate"), dict)
+        else {}
+    )
 
     upstream_ref = str(workstream_status.get("upstream_ref") or "unknown")
     upstream_sha = str(workstream_status.get("upstream_sha") or "unknown")
@@ -123,8 +139,33 @@ def render_dashboard(
     lines.append("")
     lines.append(f"- Release gate: **{gate_status(release_gate.get('pass'))}**")
     lines.append(f"- CI/tree-drift gate: **{gate_status(ci_gate.get('pass'))}**")
+    lines.append(f"- Test coverage audit: **{gate_status(coverage_gate.get('pass'))}**")
     lines.append(f"- Release gate failures: {format_failed_checks(release_gate)}")
     lines.append(f"- CI gate failures: {format_failed_checks(ci_gate)}")
+    lines.append("")
+    lines.append("## Test Coverage Audit")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | ---: |")
+    lines.append(
+        f"| Tracked behavior rows | {int(coverage_summary.get('tracked_behavior_rows', 0) or 0)} |"
+    )
+    lines.append(
+        f"| Covered behavior rows | {int(coverage_summary.get('covered_behavior_rows', 0) or 0)} |"
+    )
+    lines.append(
+        "| Tracked behavior coverage ratio | "
+        f"{float(coverage_summary.get('tracked_behavior_coverage_ratio', 0.0) or 0.0):.4f} |"
+    )
+    lines.append(
+        f"| Rust test functions | {int(coverage_summary.get('rust_test_functions', 0) or 0)} |"
+    )
+    lines.append(
+        f"| Missing Rust test refs | {int(coverage_summary.get('missing_rust_test_refs', 0) or 0)} |"
+    )
+    lines.append(
+        f"| Critical gaps | {int(coverage_gate.get('critical_gaps', 0) or 0)} |"
+    )
     lines.append("")
     lines.append("## Queue Summary")
     lines.append("")
@@ -181,6 +222,7 @@ def render_dashboard(
     lines.append("- `docs/parity/workstream-status.json`")
     lines.append("- `docs/parity/upstream-missing-queue.json`")
     lines.append("- `docs/parity/global-parity-proof.json`")
+    lines.append("- `docs/parity/test-coverage-audit.json`")
     lines.append("")
     return "\n".join(lines)
 
@@ -193,10 +235,17 @@ def main() -> int:
     workstream_status = load_json((repo_root / args.workstream_status).resolve())
     queue_json = load_json((repo_root / args.queue_json).resolve())
     proof_json = load_json((repo_root / args.proof_json).resolve())
+    test_coverage_audit = load_json((repo_root / args.test_coverage_audit).resolve())
 
     output = (repo_root / args.output).resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
-    dashboard = render_dashboard(parity_matrix, workstream_status, queue_json, proof_json)
+    dashboard = render_dashboard(
+        parity_matrix,
+        workstream_status,
+        queue_json,
+        proof_json,
+        test_coverage_audit,
+    )
     output.write_text(dashboard + "\n", encoding="utf-8")
     print(f"Wrote parity dashboard: {output}")
     return 0

--- a/scripts/generate-test-coverage-audit.py
+++ b/scripts/generate-test-coverage-audit.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Generate an upstream-vs-Ultra behavior test coverage audit."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+RUST_TEST_ATTR_RE = re.compile(r"#\[\s*(?:tokio::)?test(?:\([^]]*\))?\s*\]")
+RUST_FN_RE = re.compile(r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def rel(path: Path, repo_root: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
+def scan_rust_tests(repo_root: Path) -> dict[str, set[str]]:
+    tests_by_file: dict[str, set[str]] = {}
+    for path in sorted((repo_root / "crates").glob("**/*.rs")) + sorted(
+        (repo_root / "tests").glob("**/*.rs")
+    ):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        names: set[str] = set()
+        for match in RUST_FN_RE.finditer(text):
+            prefix = text[max(0, match.start() - 700) : match.start()]
+            if RUST_TEST_ATTR_RE.search(prefix):
+                names.add(match.group(1))
+        if names:
+            tests_by_file[rel(path, repo_root)] = names
+    return tests_by_file
+
+
+def rust_test_exists(tests_by_file: dict[str, set[str]], file: str, name: str) -> bool:
+    return name in tests_by_file.get(file, set())
+
+
+def load_intent_specs(repo_root: Path) -> list[dict[str, Any]]:
+    script = repo_root / "scripts" / "generate-test-intent-mapping.py"
+    spec = importlib.util.spec_from_file_location("generate_test_intent_mapping", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed loading {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    rows: list[dict[str, Any]] = []
+    for intent in module.INTENTS:
+        evidence = module.collect_matches(repo_root, intent.local_evidence_globs)
+        rows.append(
+            {
+                "id": intent.id,
+                "upstream_scope": list(intent.upstream_scope),
+                "local_evidence_globs": list(intent.local_evidence_globs),
+                "evidence": evidence,
+            }
+        )
+    return rows
+
+
+def evidence_has_direct_test(path: str, tests_by_file: dict[str, set[str]]) -> bool:
+    if path in tests_by_file and tests_by_file[path]:
+        return True
+    if path.startswith("tests/"):
+        return True
+    if "/tests/" in path:
+        return True
+    if "/fixtures/" in path or path.startswith("crates/hermes-parity-tests/fixtures/"):
+        return True
+    return False
+
+
+def load_coverage_manifest(repo_root: Path, path: str) -> dict[str, Any]:
+    full = repo_root / path
+    payload = load_json(full)
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        entries = []
+    return {
+        "path": path,
+        "summary": payload.get("summary", {}),
+        "entries": entries,
+    }
+
+
+def validate_manifest_refs(
+    manifest: dict[str, Any],
+    tests_by_file: dict[str, set[str]],
+) -> dict[str, Any]:
+    missing_test_arrays: list[str] = []
+    missing_refs: list[dict[str, str]] = []
+    status_counts: Counter[str] = Counter()
+    referenced_tests: set[tuple[str, str]] = set()
+
+    for entry in manifest["entries"]:
+        if not isinstance(entry, dict):
+            continue
+        path = str(entry.get("path", "unknown"))
+        status_counts[str(entry.get("status", "unknown"))] += 1
+        rust_tests = entry.get("rust_tests")
+        if not isinstance(rust_tests, list) or not rust_tests:
+            missing_test_arrays.append(path)
+            continue
+        for test in rust_tests:
+            if not isinstance(test, dict):
+                missing_refs.append({"path": path, "file": "unknown", "name": "unknown"})
+                continue
+            file = str(test.get("file", ""))
+            name = str(test.get("name", ""))
+            if file and name:
+                referenced_tests.add((file, name))
+            if not file or not name or not rust_test_exists(tests_by_file, file, name):
+                missing_refs.append({"path": path, "file": file, "name": name})
+
+    valid_entries = len(manifest["entries"]) - len(missing_test_arrays)
+    return {
+        "path": manifest["path"],
+        "entries": len(manifest["entries"]),
+        "valid_entries_with_rust_tests": valid_entries,
+        "missing_rust_tests_entries": missing_test_arrays,
+        "missing_rust_test_refs": missing_refs,
+        "referenced_rust_tests": len(referenced_tests),
+        "status_counts": dict(sorted(status_counts.items())),
+    }
+
+
+def critical_gap(kind: str, message: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": kind, "message": message}
+    payload.update(extra)
+    return payload
+
+
+def advisory(kind: str, message: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": kind, "message": message}
+    payload.update(extra)
+    return payload
+
+
+def render_md(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    gate = payload["audit_gate"]
+    lines: list[str] = []
+    lines.append("# Test Coverage Audit")
+    lines.append("")
+    lines.append(f"Generated: `{payload['generated_at_utc']}`")
+    lines.append("")
+    lines.append("## Gate")
+    lines.append("")
+    lines.append(f"- Audit gate: **{'PASS' if gate['pass'] else 'FAIL'}**")
+    lines.append(f"- Critical gaps: `{gate['critical_gaps']}`")
+    lines.append(f"- Advisory gaps: `{gate['advisory_gaps']}`")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | ---: |")
+    for key in [
+        "tracked_behavior_rows",
+        "covered_behavior_rows",
+        "tracked_behavior_coverage_ratio",
+        "rust_test_files",
+        "rust_test_functions",
+        "coverage_manifest_entries",
+        "coverage_manifest_entries_with_valid_rust_tests",
+        "missing_rust_test_refs",
+        "queue_pending",
+        "queue_total",
+        "test_intents_total",
+        "test_intents_mapped",
+    ]:
+        lines.append(f"| `{key}` | {summary.get(key, 0)} |")
+    lines.append("")
+    lines.append("## Coverage Manifests")
+    lines.append("")
+    lines.append("| Manifest | Entries | Valid Rust-test entries | Referenced Rust tests | Missing refs |")
+    lines.append("| --- | ---: | ---: | ---: | ---: |")
+    for manifest in payload["coverage_manifests"]:
+        lines.append(
+            f"| `{manifest['path']}` | {manifest['entries']} | "
+            f"{manifest['valid_entries_with_rust_tests']} | "
+            f"{manifest['referenced_rust_tests']} | "
+            f"{len(manifest['missing_rust_test_refs'])} |"
+        )
+    lines.append("")
+    lines.append("## Test Intent Domains")
+    lines.append("")
+    lines.append("| Intent | Classification | Evidence files | Direct test evidence |")
+    lines.append("| --- | --- | ---: | ---: |")
+    for row in payload["intent_domains"]:
+        lines.append(
+            f"| `{row['id']}` | `{row['classification']}` | "
+            f"{row['evidence_count']} | {row['direct_test_evidence_count']} |"
+        )
+    lines.append("")
+    lines.append("## Critical Gaps")
+    lines.append("")
+    if payload["critical_gaps"]:
+        for gap in payload["critical_gaps"]:
+            lines.append(f"- `{gap['kind']}`: {gap['message']}")
+    else:
+        lines.append("- none")
+    lines.append("")
+    lines.append("## Advisory Gaps")
+    lines.append("")
+    if payload["advisory_gaps"]:
+        for gap in payload["advisory_gaps"]:
+            lines.append(f"- `{gap['kind']}`: {gap['message']}")
+    else:
+        lines.append("- none")
+    lines.append("")
+    lines.append("## Next Sigma Harness Moves")
+    lines.append("")
+    for item in payload["next_sigma_harness_moves"]:
+        lines.append(f"- **{item['title']}**: {item['rationale']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument(
+        "--out-json",
+        default="docs/parity/test-coverage-audit.json",
+        type=Path,
+        help="Output JSON path relative to repo root",
+    )
+    parser.add_argument(
+        "--out-md",
+        default="docs/parity/test-coverage-audit.md",
+        type=Path,
+        help="Output Markdown path relative to repo root",
+    )
+    parser.add_argument("--check", action="store_true", help="Fail when audit gate fails")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    tests_by_file = scan_rust_tests(repo_root)
+    rust_test_functions = sum(len(names) for names in tests_by_file.values())
+
+    intent_mapping = load_json(repo_root / "docs/parity/test-intent-mapping.json")
+    parity_matrix = load_json(repo_root / "docs/parity/parity-matrix.json")
+    patch_queue = load_json(repo_root / "docs/parity/upstream-missing-queue.json")
+    divergence_validation = load_json(repo_root / "docs/parity/divergence-validation.json")
+
+    intent_specs = load_intent_specs(repo_root)
+    intent_rows: list[dict[str, Any]] = []
+    for intent in intent_specs:
+        evidence = list(intent["evidence"])
+        direct_test_evidence = [
+            path for path in evidence if evidence_has_direct_test(path, tests_by_file)
+        ]
+        mapped = bool(evidence)
+        classification = "direct_rust_test" if direct_test_evidence else "domain_contract"
+        if not mapped:
+            classification = "missing"
+        intent_rows.append(
+            {
+                "id": intent["id"],
+                "classification": classification,
+                "mapped": mapped,
+                "upstream_scope": intent["upstream_scope"],
+                "evidence_count": len(evidence),
+                "direct_test_evidence_count": len(direct_test_evidence),
+                "evidence_sample": evidence[:25],
+                "direct_test_evidence_sample": direct_test_evidence[:25],
+            }
+        )
+
+    manifest_paths = [
+        "docs/parity/python-test-suite-coverage.json",
+        "docs/parity/hermes-cli-test-coverage.json",
+        "docs/parity/ui-tui-source-coverage.json",
+    ]
+    manifest_rows = [
+        validate_manifest_refs(load_coverage_manifest(repo_root, path), tests_by_file)
+        for path in manifest_paths
+    ]
+
+    critical_gaps: list[dict[str, Any]] = []
+    advisory_gaps: list[dict[str, Any]] = []
+
+    queue_summary = patch_queue.get("summary", {})
+    by_disposition = queue_summary.get("by_disposition", {})
+    queue_pending = int(by_disposition.get("pending", 0) or 0)
+    if queue_pending:
+        critical_gaps.append(
+            critical_gap("upstream_queue_pending", "upstream missing queue has pending rows", pending=queue_pending)
+        )
+
+    intent_summary = intent_mapping.get("summary", {})
+    unmapped_intents = int(intent_summary.get("unmapped_intents", 0) or 0)
+    if unmapped_intents:
+        critical_gaps.append(
+            critical_gap("unmapped_test_intents", "test-intent mapping has unmapped domains", unmapped=unmapped_intents)
+        )
+
+    divergence_summary = divergence_validation.get("summary", {})
+    for key in ["errors", "unowned", "review_overdue"]:
+        value = int(divergence_summary.get(key, 0) or 0)
+        if value:
+            critical_gaps.append(
+                critical_gap("divergence_governance", f"divergence validation has {key}", count=value)
+            )
+
+    for manifest in manifest_rows:
+        if manifest["missing_rust_tests_entries"]:
+            critical_gaps.append(
+                critical_gap(
+                    "coverage_manifest_missing_tests",
+                    f"{manifest['path']} has entries without rust_tests",
+                    count=len(manifest["missing_rust_tests_entries"]),
+                )
+            )
+        if manifest["missing_rust_test_refs"]:
+            critical_gaps.append(
+                critical_gap(
+                    "coverage_manifest_missing_refs",
+                    f"{manifest['path']} references missing Rust test functions",
+                    count=len(manifest["missing_rust_test_refs"]),
+                )
+            )
+
+    missing_domain_contracts = [row["id"] for row in intent_rows if row["classification"] == "missing"]
+    if missing_domain_contracts:
+        critical_gaps.append(
+            critical_gap(
+                "missing_domain_contracts",
+                "test-intent domains have no local evidence",
+                ids=missing_domain_contracts,
+            )
+        )
+
+    source_only_domains = [
+        row["id"]
+        for row in intent_rows
+        if row["classification"] == "domain_contract" and row["direct_test_evidence_count"] == 0
+    ]
+    if source_only_domains:
+        advisory_gaps.append(
+            advisory(
+                "domain_contract_without_direct_test_file",
+                "some mapped intent domains are backed by source contracts without direct test-file evidence in the intent map",
+                ids=source_only_domains,
+            )
+        )
+
+    parity_summary = parity_matrix.get("summary", {})
+    for source_key, metric_name in [
+        ("commits_behind", "max_commits_behind"),
+        ("upstream_patch_missing", "max_upstream_patch_missing"),
+        ("files_only_upstream", "max_files_only_upstream"),
+    ]:
+        value = float(parity_summary.get(source_key, 0.0) or 0.0)
+        if value > 0:
+            advisory_gaps.append(
+                advisory(
+                    "nonzero_tree_drift",
+                    f"{metric_name} remains nonzero in parity matrix",
+                    metric=metric_name,
+                    value=value,
+                )
+            )
+
+    manifest_entries = sum(int(row["entries"]) for row in manifest_rows)
+    manifest_entries_valid = sum(int(row["valid_entries_with_rust_tests"]) for row in manifest_rows)
+    missing_refs = sum(len(row["missing_rust_test_refs"]) for row in manifest_rows)
+    tracked_rows = len(intent_rows) + manifest_entries
+    covered_rows = sum(1 for row in intent_rows if row["mapped"]) + manifest_entries_valid
+    coverage_ratio = covered_rows / tracked_rows if tracked_rows else 0.0
+
+    summary = {
+        "tracked_behavior_rows": tracked_rows,
+        "covered_behavior_rows": covered_rows,
+        "tracked_behavior_coverage_ratio": round(coverage_ratio, 4),
+        "rust_test_files": len(tests_by_file),
+        "rust_test_functions": rust_test_functions,
+        "coverage_manifest_entries": manifest_entries,
+        "coverage_manifest_entries_with_valid_rust_tests": manifest_entries_valid,
+        "missing_rust_test_refs": missing_refs,
+        "queue_pending": queue_pending,
+        "queue_total": int(queue_summary.get("total_commits", 0) or 0),
+        "test_intents_total": int(intent_summary.get("total_intents", 0) or 0),
+        "test_intents_mapped": int(intent_summary.get("mapped_intents", 0) or 0),
+        "test_intent_mapping_ratio": float(intent_summary.get("mapping_ratio", 0.0) or 0.0),
+        "divergence_errors": int(divergence_summary.get("errors", 0) or 0),
+        "divergence_unowned": int(divergence_summary.get("unowned", 0) or 0),
+        "divergence_review_overdue": int(divergence_summary.get("review_overdue", 0) or 0),
+    }
+
+    payload = {
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "schema_version": 1,
+        "audit_unit": "upstream_behavior_or_test_intent",
+        "summary": summary,
+        "audit_gate": {
+            "pass": not critical_gaps,
+            "critical_gaps": len(critical_gaps),
+            "advisory_gaps": len(advisory_gaps),
+        },
+        "source_artifacts": {
+            "test_intent_mapping": "docs/parity/test-intent-mapping.json",
+            "parity_matrix": "docs/parity/parity-matrix.json",
+            "upstream_missing_queue": "docs/parity/upstream-missing-queue.json",
+            "divergence_validation": "docs/parity/divergence-validation.json",
+            "coverage_manifests": manifest_paths,
+        },
+        "intent_domains": intent_rows,
+        "coverage_manifests": manifest_rows,
+        "critical_gaps": critical_gaps,
+        "advisory_gaps": advisory_gaps,
+        "next_sigma_harness_moves": [
+            {
+                "title": "User-journey replay corpus",
+                "rationale": "Record CLI/TUI/gateway task journeys as deterministic fixtures so regressions are caught at the workflow level, not only at unit boundaries.",
+            },
+            {
+                "title": "Protocol differential contracts",
+                "rationale": "Run provider, MCP, ACP, and gateway request/response fixtures through normalized differential checks against upstream intent and Ultra policy.",
+            },
+            {
+                "title": "Fault-injection matrix",
+                "rationale": "Inject network stalls, partial streams, auth expiry, tool failures, and malformed model/tool payloads into the Rust runtime to prove recovery behavior.",
+            },
+            {
+                "title": "PTY and TUI golden snapshots",
+                "rationale": "Exercise real terminal input/output flows and snapshot critical UX states so command ergonomics and status rendering are protected.",
+            },
+            {
+                "title": "Coverage trend ledger",
+                "rationale": "Track behavior coverage over time so new upstream rows or local harness regressions create visible deltas before release prep.",
+            },
+        ],
+    }
+
+    out_json = (repo_root / args.out_json).resolve()
+    out_md = (repo_root / args.out_md).resolve()
+    write_json(out_json, payload)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_md(payload), encoding="utf-8")
+    print(f"Wrote {out_json}")
+    print(f"Wrote {out_md}")
+
+    if args.check and not payload["audit_gate"]["pass"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-differential-parity-gate.py
+++ b/scripts/run-differential-parity-gate.py
@@ -35,7 +35,10 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--fallback-cmd",
-        default="python3 scripts/generate-global-parity-proof.py --check-ci",
+        default=(
+            "python3 scripts/generate-test-coverage-audit.py --check && "
+            "python3 scripts/generate-global-parity-proof.py --check-ci"
+        ),
         help="Fallback command when CLI surface extraction is unavailable for compared refs",
     )
     parser.add_argument(

--- a/scripts/upstream_webhook_sync.py
+++ b/scripts/upstream_webhook_sync.py
@@ -888,6 +888,7 @@ def maybe_check_global_parity_drift(
         ["scripts/generate-parity-matrix.py"],
         ["scripts/generate-workstream-status.py"],
         ["scripts/generate-test-intent-mapping.py"],
+        ["scripts/generate-test-coverage-audit.py", "--check"],
         ["scripts/generate-adapter-matrix.py"],
         ["scripts/validate-intentional-divergence.py", "--check", "--allow-warnings"],
         [


### PR DESCRIPTION
## Summary
- add docs/parity/test-coverage-audit.json and .md generated from parity manifests, test-intent mapping, divergence governance, and Rust test discovery
- wire the audit into global parity proof, dashboard, parity workflows, webhook drift checks, and differential fallback gate
- add Rust governance coverage asserting the audit gate passes with zero critical gaps and zero missing Rust test refs

## Local verification
- python3 scripts/generate-test-coverage-audit.py --check && python3 scripts/generate-global-parity-proof.py --check-ci --check-release && python3 scripts/generate-parity-dashboard.py --repo-root .
- python3 -m py_compile scripts/generate-test-coverage-audit.py scripts/generate-global-parity-proof.py scripts/generate-parity-dashboard.py scripts/upstream_webhook_sync.py scripts/run-differential-parity-gate.py
- jq empty docs/parity/test-coverage-audit.json docs/parity/global-parity-proof.json docs/parity/global-parity-thresholds.json docs/parity/upstream-missing-queue.json
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --workspace
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --quiet