### PR TITLE
parity: clear upstream provider coding and draft deltas

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -35,6 +35,7 @@ use crate::bedrock::{
 };
 use crate::budget;
 use crate::code_index::CodeIndex;
+use crate::coding_context::resolve_runtime_mode;
 use crate::context::{
     load_builtin_memory_snapshot, load_soul_md, resolve_personality, ContextManager,
     SystemPromptBuilder,
@@ -484,6 +485,10 @@ pub struct AgentConfig {
     #[serde(default)]
     pub skip_context_files: bool,
 
+    /// Coding-context posture mode: auto/focus/on/off.
+    #[serde(default = "default_coding_context")]
+    pub coding_context: String,
+
     /// Optional cheap-vs-strong per-turn routing.
     #[serde(default)]
     pub smart_model_routing: SmartModelRoutingConfig,
@@ -807,6 +812,10 @@ fn default_lsp_context_max_chars() -> usize {
     2_800
 }
 
+fn default_coding_context() -> String {
+    "auto".to_string()
+}
+
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
@@ -833,6 +842,7 @@ impl Default for AgentConfig {
             hermes_home: None,
             skip_memory: false,
             skip_context_files: false,
+            coding_context: default_coding_context(),
             smart_model_routing: SmartModelRoutingConfig::default(),
             provider: None,
             platform: None,
@@ -2621,14 +2631,35 @@ impl AgentLoop {
         }
     }
 
-    fn skills_system_prompt(&self, tool_names: &HashSet<&str>) -> Option<String> {
+    fn skills_system_prompt(
+        &self,
+        tool_names: &HashSet<&str>,
+        hidden_categories: &[&str],
+    ) -> Option<String> {
         let has_skills_tools = ["skills_list", "skill_view", "skill_manage"]
             .iter()
             .any(|t| tool_names.contains(*t));
         if !has_skills_tools {
             return None;
         }
-        let mut orch = SkillOrchestrator::default_dir();
+        let skills_dir = self
+            .config
+            .hermes_home
+            .as_deref()
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                std::env::var("HERMES_HOME")
+                    .ok()
+                    .map(std::path::PathBuf::from)
+            })
+            .map(|home| home.join("skills"))
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    .join(".hermes")
+                    .join("skills")
+            });
+        let mut orch = SkillOrchestrator::new(skills_dir.clone());
         orch.set_enabled_disabled(&self.config.enabled_skills, &self.config.disabled_skills);
         let commands = orch.scan_skill_commands();
         if commands.is_empty() {
@@ -2642,6 +2673,20 @@ impl AgentLoop {
         let mut rows: Vec<_> = commands
             .iter()
             .filter(|(cmd, info)| {
+                if let Some(category) = info
+                    .skill_dir
+                    .strip_prefix(&skills_dir)
+                    .ok()
+                    .and_then(|relative| relative.components().next())
+                    .and_then(|component| component.as_os_str().to_str())
+                {
+                    if hidden_categories
+                        .iter()
+                        .any(|hidden| category.eq_ignore_ascii_case(hidden))
+                    {
+                        return false;
+                    }
+                }
                 if bypass || tier == "open" {
                     return true;
                 }
@@ -2666,6 +2711,12 @@ impl AgentLoop {
             if bypass { "on" } else { "off" },
             filtered
         ));
+        if !hidden_categories.is_empty() {
+            body.push_str(&format!(
+                "<skills_prompt_pruned hidden_categories=\"{}\" disclosure=\"full catalog remains available through skills_list and skill_view\" />\n",
+                hidden_categories.join(",")
+            ));
+        }
         for (cmd, info) in rows.into_iter().take(80) {
             body.push_str(&format!(
                 "- {}: {} ({})\n",
@@ -3854,6 +3905,31 @@ impl AgentLoop {
         {
             builder = builder.with_block(CONTEXTLATTICE_OPERATIONAL_GUIDANCE);
         }
+        let runtime_mode = resolve_runtime_mode(
+            self.config.platform.as_deref(),
+            None,
+            Some(&self.config.coding_context),
+            Some(model_for_prompt),
+        );
+        let has_coding_tools = [
+            "terminal",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+        ]
+        .iter()
+        .any(|tool| tool_names.contains(tool));
+        let hidden_skill_categories = if has_coding_tools {
+            runtime_mode.hidden_skill_categories()
+        } else {
+            &[]
+        };
+        if has_coding_tools {
+            for block in runtime_mode.system_blocks() {
+                builder = builder.with_block(&block);
+            }
+        }
 
         if let Some(ref personality) = self.config.personality {
             let requested = personality.trim();
@@ -3896,7 +3972,8 @@ impl AgentLoop {
             builder = builder.with_memory_context(&mem_block);
         }
 
-        if let Some(skills_prompt) = self.skills_system_prompt(&tool_names) {
+        if let Some(skills_prompt) = self.skills_system_prompt(&tool_names, hidden_skill_categories)
+        {
             builder = builder.with_skills_prompt(&skills_prompt);
         }
 
@@ -12163,6 +12240,253 @@ mod tests {
         assert!(with_tools.contains(STEER_CHANNEL_NOTE));
         assert!(with_tools.contains(crate::steer::STEER_MARKER_OPEN));
         assert!(with_tools.contains(crate::steer::STEER_MARKER_CLOSE));
+    }
+
+    #[test]
+    fn coding_context_prompt_injected_for_cli_workspace_with_tools() {
+        use futures::stream::BoxStream;
+        use hermes_core::JsonSchema;
+
+        let _lock = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .expect("write manifest");
+        let _cwd = EnvVarGuard::set("TERMINAL_CWD", tmp.path().to_str().unwrap());
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let config = AgentConfig {
+            platform: Some("cli".to_string()),
+            coding_context: "auto".to_string(),
+            skip_memory: true,
+            skip_context_files: true,
+            ..AgentConfig::default()
+        };
+        let agent = AgentLoop::new(
+            config,
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+        let tools = vec![
+            ToolSchema::new("terminal", "Terminal", JsonSchema::new("object")),
+            ToolSchema::new("read_file", "Read", JsonSchema::new("object")),
+            ToolSchema::new("write_file", "Write", JsonSchema::new("object")),
+            ToolSchema::new("patch", "Patch", JsonSchema::new("object")),
+            ToolSchema::new("search_files", "Search", JsonSchema::new("object")),
+        ];
+        let prompt = agent.build_system_prompt("", &tools, "openai/gpt-5.4");
+        assert!(
+            prompt.contains("You are a coding agent pairing with the user inside their codebase")
+        );
+        assert!(prompt.contains("Workspace"));
+        assert!(prompt.contains("Cargo.toml"));
+        assert!(prompt.contains("cargo test"));
+        assert!(prompt.contains("mode='patch'"));
+
+        let without_tools = agent.build_system_prompt("", &[], "openai/gpt-5.4");
+        assert!(!without_tools.contains("You are a coding agent pairing"));
+    }
+
+    #[test]
+    fn coding_context_prompt_respects_platform_and_off_mode() {
+        use futures::stream::BoxStream;
+        use hermes_core::JsonSchema;
+
+        let _lock = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .expect("write manifest");
+        let _cwd = EnvVarGuard::set("TERMINAL_CWD", tmp.path().to_str().unwrap());
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let tools = vec![ToolSchema::new(
+            "terminal",
+            "Terminal",
+            JsonSchema::new("object"),
+        )];
+        for config in [
+            AgentConfig {
+                platform: Some("telegram".to_string()),
+                coding_context: "auto".to_string(),
+                skip_memory: true,
+                skip_context_files: true,
+                ..AgentConfig::default()
+            },
+            AgentConfig {
+                platform: Some("cli".to_string()),
+                coding_context: "off".to_string(),
+                skip_memory: true,
+                skip_context_files: true,
+                ..AgentConfig::default()
+            },
+        ] {
+            let agent = AgentLoop::new(
+                config,
+                Arc::new(ToolRegistry::new()),
+                Arc::new(DummyProvider),
+            );
+            let prompt = agent.build_system_prompt("", &tools, "openai/gpt-5.4");
+            assert!(!prompt.contains("You are a coding agent pairing"));
+        }
+    }
+
+    #[test]
+    fn coding_context_prunes_non_coding_skill_categories_in_prompt_only() {
+        use futures::stream::BoxStream;
+        use hermes_core::JsonSchema;
+
+        let _lock = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .expect("write manifest");
+        let home = tmp.path().join("home");
+        let social = home.join("skills").join("social-media").join("tweet-stuff");
+        let github = home.join("skills").join("github").join("pr-review");
+        std::fs::create_dir_all(&social).expect("social skill dir");
+        std::fs::create_dir_all(&github).expect("github skill dir");
+        std::fs::write(
+            social.join("SKILL.md"),
+            "---\nname: tweet-stuff\ndescription: Draft social posts\n---\nBody",
+        )
+        .expect("write social skill");
+        std::fs::write(
+            github.join("SKILL.md"),
+            "---\nname: pr-review\ndescription: Review pull requests\n---\nBody",
+        )
+        .expect("write github skill");
+        let _cwd = EnvVarGuard::set("TERMINAL_CWD", tmp.path().to_str().unwrap());
+
+        struct DummyProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for DummyProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                Ok(hermes_core::LlmResponse {
+                    message: Message::assistant("dummy"),
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        let config = AgentConfig {
+            platform: Some("cli".to_string()),
+            coding_context: "auto".to_string(),
+            hermes_home: Some(home.to_string_lossy().to_string()),
+            skip_memory: true,
+            skip_context_files: true,
+            ..AgentConfig::default()
+        };
+        let agent = AgentLoop::new(
+            config,
+            Arc::new(ToolRegistry::new()),
+            Arc::new(DummyProvider),
+        );
+        let tools = vec![
+            ToolSchema::new("terminal", "Terminal", JsonSchema::new("object")),
+            ToolSchema::new("skills_list", "List skills", JsonSchema::new("object")),
+            ToolSchema::new("skill_view", "View skill", JsonSchema::new("object")),
+        ];
+        let prompt = agent.build_system_prompt("", &tools, "anthropic/claude-sonnet-4");
+        assert!(prompt.contains("pr-review"));
+        assert!(!prompt.contains("tweet-stuff"));
+        assert!(prompt.contains("skills_prompt_pruned"));
+        assert!(
+            prompt.contains("full catalog remains available through skills_list and skill_view")
+        );
+        assert!(prompt.contains("mode='replace'"));
     }
 
     #[tokio::test]

--- a/crates/hermes-agent/src/api_bridge.rs
+++ b/crates/hermes-agent/src/api_bridge.rs
@@ -288,6 +288,7 @@ impl CodexProvider {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         };
 
@@ -603,6 +604,7 @@ mod tests {
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                anthropic_content_blocks: None,
                 cache_control: None,
             },
             Message::tool_result("call_1", "file contents"),

--- a/crates/hermes-agent/src/bedrock.rs
+++ b/crates/hermes-agent/src/bedrock.rs
@@ -1064,6 +1064,7 @@ pub fn parse_bedrock_response(json: &Value, model: &str) -> Result<LlmResponse, 
             } else {
                 Some(reasoning_parts.join("\n"))
             },
+            anthropic_content_blocks: None,
             cache_control: None,
         },
         usage,
@@ -1184,6 +1185,7 @@ pub fn parse_bedrock_stream_events(json: &Value, model: &str) -> Result<LlmRespo
             } else {
                 Some(reasoning)
             },
+            anthropic_content_blocks: None,
             cache_control: None,
         },
         usage,
@@ -1674,6 +1676,7 @@ fn parse_openai_like_response(json: &Value, fallback_model: &str) -> Option<LlmR
                 .or_else(|| message_obj.get("reasoning_content"))
                 .and_then(Value::as_str)
                 .map(str::to_string),
+            anthropic_content_blocks: None,
             cache_control: None,
         },
         usage,

--- a/crates/hermes-agent/src/coding_context.rs
+++ b/crates/hermes-agent/src/coding_context.rs
@@ -1,0 +1,694 @@
+//! Coding-context posture detection and prompt blocks.
+//!
+//! This mirrors upstream's `agent.coding_context` contract in the Rust runtime:
+//! interactive coding surfaces in a code workspace get a coding operating brief
+//! plus a frozen workspace snapshot. `focus` mode additionally lets callers
+//! collapse tools to the coding toolset; `auto` and `on` stay prompt-only.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub const CODING_TOOLSET: &str = "coding";
+
+const INTERACTIVE_CODING_PLATFORMS: &[&str] = &["", "cli", "tui", "acp", "desktop", "local"];
+const PROJECT_MARKERS: &[&str] = &[
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+    "package.json",
+    "tsconfig.json",
+    "deno.json",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+    "composer.json",
+    "mix.exs",
+    "pubspec.yaml",
+    "CMakeLists.txt",
+    "Makefile",
+    "Dockerfile",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".cursorrules",
+];
+const CONTEXT_FILES: &[&str] = &["AGENTS.md", "CLAUDE.md", ".cursorrules"];
+const VERIFY_TARGETS: &[&str] = &[
+    "test",
+    "tests",
+    "lint",
+    "typecheck",
+    "check",
+    "build",
+    "fmt",
+    "format",
+];
+const MAX_VERIFY_COMMANDS: usize = 8;
+const MAX_FACT_FILE_BYTES: u64 = 256 * 1024;
+
+const NON_CODING_SKILL_CATEGORIES: &[&str] = &[
+    "apple",
+    "communication",
+    "cooking",
+    "creative",
+    "email",
+    "finance",
+    "gaming",
+    "gifs",
+    "health",
+    "media",
+    "music",
+    "note-taking",
+    "productivity",
+    "shopping",
+    "smart-home",
+    "social-media",
+    "travel",
+    "yuanbao",
+];
+
+const CODING_AGENT_GUIDANCE: &str =
+    "You are a coding agent pairing with the user inside their codebase. Operate like a careful senior engineer.\n\
+\n\
+Gather context first:\n\
+- Read the relevant files and locate code before changing anything. Trace a symbol to its definition and usages rather than guessing its shape.\n\
+- Batch independent reads/searches when they do not depend on each other.\n\
+- If ContextLattice tools are available, use them as the project memory and retrieval backbone before redoing broad discovery.\n\
+- Never invent files, symbols, APIs, imports, or dependencies. Check manifests and nearby imports before using a library.\n\
+\n\
+Make changes through the tools, not the chat:\n\
+- Edit with patch/write_file. Do not print code blocks to the user as a substitute for applying the change.\n\
+- Match the project's existing style and instructions. Touch only what the task needs; avoid drive-by refactors, renames, or formatting churn.\n\
+- If a patch fails, re-read the exact file contents before retrying. If the same region fails twice, rewrite the enclosing function or file with write_file instead of attempting a third stale patch.\n\
+\n\
+Verify, and know when to stop:\n\
+- Use the terminal for git, builds, tests, and inspection. Run the relevant tests, linter, or build before claiming the work is done.\n\
+- Fix root causes and sibling call paths for the same bug class, not only the reported site.\n\
+- When fixing linter/type errors on a file, stop after about three attempts on the same file and ask the user rather than looping.\n\
+- Track multi-step work with todo. Reference code as path:line instead of pasting whole files.\n\
+\n\
+Respect the user's repo: do not commit, push, or rewrite history unless asked, and never read, print, or commit secrets. The Workspace block below is a session-start snapshot; re-run git status/git branch before relying on it. Be concise: lead with the change or answer, not a preamble.";
+
+const EDIT_FORMAT_PATCH: &str =
+    "- Edit format: author new files with write_file; for edits to existing code prefer patch with mode='patch' (V4A multi-file diff) for structured or multi-file changes. Use mode='replace' for a single small swap.";
+const EDIT_FORMAT_REPLACE: &str =
+    "- Edit format: author new files with write_file; for edits to existing code prefer patch in mode='replace' by matching a unique snippet and swapping it. Reach for mode='patch' (V4A) only when an edit genuinely spans several files at once.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodingContextMode {
+    Auto,
+    Focus,
+    On,
+    Off,
+}
+
+impl CodingContextMode {
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.unwrap_or("auto").trim().to_ascii_lowercase().as_str() {
+            "focus" | "strict" | "lean" => Self::Focus,
+            "on" | "true" | "yes" | "1" | "always" => Self::On,
+            "off" | "false" | "no" | "0" | "never" => Self::Off,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn is_focus(self) -> bool {
+        self == Self::Focus
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextProfileKind {
+    General,
+    Coding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeMode {
+    pub profile: ContextProfileKind,
+    pub mode: CodingContextMode,
+    pub workspace_root: Option<PathBuf>,
+    pub model: Option<String>,
+}
+
+impl RuntimeMode {
+    pub fn is_coding(&self) -> bool {
+        self.profile == ContextProfileKind::Coding
+    }
+
+    pub fn toolset_selection(&self) -> Option<&'static str> {
+        (self.is_coding() && self.mode.is_focus()).then_some(CODING_TOOLSET)
+    }
+
+    pub fn hidden_skill_categories(&self) -> &'static [&'static str] {
+        if self.is_coding() {
+            NON_CODING_SKILL_CATEGORIES
+        } else {
+            &[]
+        }
+    }
+
+    pub fn system_blocks(&self) -> Vec<String> {
+        if !self.is_coding() {
+            return Vec::new();
+        }
+        let mut blocks = Vec::new();
+        let mut guidance = CODING_AGENT_GUIDANCE.to_string();
+        if let Some(line) = edit_format_line(self.model.as_deref()) {
+            guidance.push('\n');
+            guidance.push_str(line);
+        }
+        blocks.push(guidance);
+        if let Some(root) = &self.workspace_root {
+            if let Some(block) = build_coding_workspace_block(root) {
+                blocks.push(block);
+            }
+        }
+        blocks
+    }
+}
+
+pub fn resolve_runtime_mode(
+    platform: Option<&str>,
+    cwd: Option<&Path>,
+    raw_mode: Option<&str>,
+    model: Option<&str>,
+) -> RuntimeMode {
+    let mode = CodingContextMode::parse(raw_mode);
+    let resolved_cwd = resolve_cwd(cwd);
+    let workspace_root = workspace_root(&resolved_cwd);
+    let platform = normalize_platform(platform);
+    let active = match mode {
+        CodingContextMode::Off => false,
+        CodingContextMode::On => true,
+        CodingContextMode::Auto | CodingContextMode::Focus => {
+            is_interactive_coding_platform(&platform) && workspace_root.is_some()
+        }
+    };
+    RuntimeMode {
+        profile: if active {
+            ContextProfileKind::Coding
+        } else {
+            ContextProfileKind::General
+        },
+        mode,
+        workspace_root: if active {
+            workspace_root.or(Some(resolved_cwd))
+        } else {
+            None
+        },
+        model: model.map(str::to_string),
+    }
+}
+
+pub fn coding_toolset_selection(
+    platform: Option<&str>,
+    cwd: Option<&Path>,
+    raw_mode: Option<&str>,
+) -> Option<&'static str> {
+    resolve_runtime_mode(platform, cwd, raw_mode, None).toolset_selection()
+}
+
+pub fn coding_hidden_skill_categories(
+    platform: Option<&str>,
+    cwd: Option<&Path>,
+    raw_mode: Option<&str>,
+) -> &'static [&'static str] {
+    resolve_runtime_mode(platform, cwd, raw_mode, None).hidden_skill_categories()
+}
+
+pub fn model_family(model: Option<&str>) -> Option<&'static str> {
+    let lowered = model?.to_ascii_lowercase();
+    if ["gpt", "codex"]
+        .iter()
+        .any(|needle| lowered.contains(needle))
+    {
+        return Some("patch");
+    }
+    if [
+        "claude", "sonnet", "opus", "haiku", "gemini", "gemma", "deepseek", "qwen", "kimi", "glm",
+        "grok", "hermes", "llama", "mistral", "devstral", "minimax",
+    ]
+    .iter()
+    .any(|needle| lowered.contains(needle))
+    {
+        return Some("replace");
+    }
+    None
+}
+
+pub fn edit_format_line(model: Option<&str>) -> Option<&'static str> {
+    match model_family(model) {
+        Some("patch") => Some(EDIT_FORMAT_PATCH),
+        Some("replace") => Some(EDIT_FORMAT_REPLACE),
+        _ => None,
+    }
+}
+
+pub fn build_coding_workspace_block(root: &Path) -> Option<String> {
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    if !root.exists() {
+        return None;
+    }
+    let mut lines = vec![
+        "## Workspace".to_string(),
+        format!("Root: {}", root.display()),
+    ];
+
+    let manifests = detected_project_markers(&root);
+    if !manifests.is_empty() {
+        lines.push(format!("Project: {}", manifests.join(", ")));
+    }
+
+    let verify = verify_commands(&root);
+    if !verify.is_empty() {
+        lines.push(format!("Verify: {}", verify.join("; ")));
+    }
+
+    let context_files = CONTEXT_FILES
+        .iter()
+        .copied()
+        .filter(|name| root.join(name).is_file())
+        .collect::<Vec<_>>();
+    if !context_files.is_empty() {
+        lines.push(format!("Context files: {}", context_files.join(", ")));
+    }
+
+    if git_root(&root).as_deref() == Some(root.as_path()) {
+        append_git_snapshot(&root, &mut lines);
+    }
+
+    (lines.len() > 2).then(|| lines.join("\n"))
+}
+
+fn normalize_platform(platform: Option<&str>) -> String {
+    platform
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+        .replace('-', "_")
+}
+
+fn is_interactive_coding_platform(platform: &str) -> bool {
+    INTERACTIVE_CODING_PLATFORMS.contains(&platform)
+}
+
+fn resolve_cwd(cwd: Option<&Path>) -> PathBuf {
+    cwd.map(Path::to_path_buf)
+        .or_else(|| std::env::var_os("TERMINAL_CWD").map(PathBuf::from))
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn workspace_root(cwd: &Path) -> Option<PathBuf> {
+    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let home = home_dir();
+    let marker = marker_root(&cwd);
+    if let Some(marker) = marker {
+        if home.as_deref() != Some(marker.as_path()) {
+            return Some(marker);
+        }
+    }
+    let git = git_root(&cwd);
+    if let Some(git) = git {
+        if home.as_deref() != Some(git.as_path()) {
+            return Some(git);
+        }
+    }
+    None
+}
+
+fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir().and_then(|path| path.canonicalize().ok())
+}
+
+fn ancestors_nearest_first(start: &Path) -> Vec<PathBuf> {
+    let mut out = vec![start.to_path_buf()];
+    out.extend(start.ancestors().skip(1).map(Path::to_path_buf));
+    out
+}
+
+fn marker_root(cwd: &Path) -> Option<PathBuf> {
+    ancestors_nearest_first(cwd)
+        .into_iter()
+        .take(12)
+        .find(|parent| {
+            PROJECT_MARKERS
+                .iter()
+                .any(|marker| parent.join(marker).exists())
+        })
+}
+
+fn git_root(cwd: &Path) -> Option<PathBuf> {
+    ancestors_nearest_first(cwd)
+        .into_iter()
+        .find(|parent| parent.join(".git").exists())
+}
+
+fn detected_project_markers(root: &Path) -> Vec<String> {
+    let mut markers = Vec::new();
+    for marker in PROJECT_MARKERS {
+        if root.join(marker).exists() {
+            if *marker == "package.json" {
+                if let Some(pm) = js_package_manager(root) {
+                    markers.push(format!("package.json ({pm})"));
+                } else {
+                    markers.push((*marker).to_string());
+                }
+            } else if *marker == "pyproject.toml" {
+                if let Some(pm) = python_package_manager(root) {
+                    markers.push(format!("pyproject.toml ({pm})"));
+                } else {
+                    markers.push((*marker).to_string());
+                }
+            } else {
+                markers.push((*marker).to_string());
+            }
+        }
+    }
+    markers
+}
+
+fn js_package_manager(root: &Path) -> Option<&'static str> {
+    [
+        ("pnpm-lock.yaml", "pnpm"),
+        ("bun.lockb", "bun"),
+        ("bun.lock", "bun"),
+        ("yarn.lock", "yarn"),
+        ("package-lock.json", "npm"),
+    ]
+    .iter()
+    .find_map(|(file, manager)| root.join(file).exists().then_some(*manager))
+}
+
+fn python_package_manager(root: &Path) -> Option<&'static str> {
+    [
+        ("uv.lock", "uv"),
+        ("poetry.lock", "poetry"),
+        ("Pipfile.lock", "pipenv"),
+    ]
+    .iter()
+    .find_map(|(file, manager)| root.join(file).exists().then_some(*manager))
+}
+
+fn verify_commands(root: &Path) -> Vec<String> {
+    let mut commands = Vec::new();
+    append_package_json_verify(root, &mut commands);
+    append_makefile_verify(root, &mut commands);
+    if root.join("scripts").join("run_tests.sh").is_file() {
+        commands.push("scripts/run_tests.sh".to_string());
+    }
+    if root.join("Cargo.toml").is_file() {
+        commands.push("cargo test".to_string());
+    }
+    if root.join("go.mod").is_file() {
+        commands.push("go test ./...".to_string());
+    }
+    if has_pytest_config(root) {
+        commands.push("pytest".to_string());
+    }
+    dedup_truncate(commands)
+}
+
+fn append_package_json_verify(root: &Path, commands: &mut Vec<String>) {
+    let path = root.join("package.json");
+    if !small_file(&path) {
+        return;
+    }
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
+    let Some(scripts) = value.get("scripts").and_then(|v| v.as_object()) else {
+        return;
+    };
+    let manager = js_package_manager(root).unwrap_or("npm");
+    for target in VERIFY_TARGETS {
+        if scripts.contains_key(*target) {
+            commands.push(format!("{manager} run {target}"));
+        }
+    }
+}
+
+fn append_makefile_verify(root: &Path, commands: &mut Vec<String>) {
+    let path = root.join("Makefile");
+    if !small_file(&path) {
+        return;
+    }
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let targets = VERIFY_TARGETS
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+    for line in raw.lines() {
+        let Some((name, _)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        if !name.is_empty()
+            && !name.contains(char::is_whitespace)
+            && !name.starts_with('.')
+            && targets.contains(name)
+        {
+            commands.push(format!("make {name}"));
+        }
+    }
+}
+
+fn has_pytest_config(root: &Path) -> bool {
+    if root.join("pytest.ini").is_file() || root.join("tox.ini").is_file() {
+        return true;
+    }
+    let pyproject = root.join("pyproject.toml");
+    if !small_file(&pyproject) {
+        return false;
+    }
+    std::fs::read_to_string(pyproject)
+        .map(|raw| raw.contains("[tool.pytest"))
+        .unwrap_or(false)
+}
+
+fn small_file(path: &Path) -> bool {
+    path.metadata()
+        .map(|meta| meta.is_file() && meta.len() <= MAX_FACT_FILE_BYTES)
+        .unwrap_or(false)
+}
+
+fn dedup_truncate(commands: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeMap::new();
+    for command in commands {
+        seen.entry(command).or_insert(());
+    }
+    seen.into_keys().take(MAX_VERIFY_COMMANDS).collect()
+}
+
+fn append_git_snapshot(root: &Path, lines: &mut Vec<String>) {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["status", "--short", "--branch"])
+        .output();
+    let Ok(output) = status else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut status_counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for line in stdout.lines() {
+        if let Some(branch) = line.strip_prefix("## ") {
+            if !branch.trim().is_empty() {
+                lines.push(format!("Branch: {}", branch.trim()));
+            }
+            continue;
+        }
+        let code = line.get(..2).unwrap_or(line).trim();
+        let key = if line.starts_with("??") {
+            "untracked"
+        } else if code == "UU" || code == "AA" || code == "DD" {
+            "conflicts"
+        } else if code.chars().next().is_some_and(|c| c != ' ') {
+            "staged"
+        } else {
+            "modified"
+        };
+        *status_counts.entry(key).or_default() += 1;
+    }
+    if status_counts.is_empty() {
+        lines.push("Status: clean".to_string());
+    } else {
+        let rendered = status_counts
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("Status: {rendered}"));
+    }
+    if let Some(commit) = git_last_commit(root) {
+        lines.push(format!("Last commit: {commit}"));
+    }
+}
+
+fn git_last_commit(root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["log", "-1", "--oneline"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    (!line.is_empty()).then_some(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_init(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["init", "-q"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["config", "user.email", "test@example.com"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["config", "user.name", "Hermes Test"])
+            .status()
+            .unwrap();
+        std::fs::write(path.join("README.md"), "test").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["add", "README.md"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(["commit", "-qm", "init commit"])
+            .status()
+            .unwrap();
+    }
+
+    #[test]
+    fn coding_detection_respects_platform_and_modes() {
+        let tmp = tempfile::tempdir().unwrap();
+        git_init(tmp.path());
+        assert!(
+            resolve_runtime_mode(Some("cli"), Some(tmp.path()), Some("auto"), None).is_coding()
+        );
+        assert!(
+            !resolve_runtime_mode(Some("telegram"), Some(tmp.path()), Some("auto"), None)
+                .is_coding()
+        );
+        assert!(
+            resolve_runtime_mode(Some("telegram"), Some(tmp.path()), Some("on"), None).is_coding()
+        );
+        assert!(
+            !resolve_runtime_mode(Some("cli"), Some(tmp.path()), Some("off"), None).is_coding()
+        );
+    }
+
+    #[test]
+    fn focus_mode_selects_coding_toolset_only_inside_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            coding_toolset_selection(Some("cli"), Some(tmp.path()), Some("focus")),
+            None
+        );
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        assert_eq!(
+            coding_toolset_selection(Some("cli"), Some(tmp.path()), Some("focus")),
+            Some(CODING_TOOLSET)
+        );
+        assert_eq!(
+            coding_toolset_selection(Some("cli"), Some(tmp.path()), Some("auto")),
+            None
+        );
+    }
+
+    #[test]
+    fn workspace_block_reports_verify_loop_facts() {
+        let tmp = tempfile::tempdir().unwrap();
+        git_init(tmp.path());
+        std::fs::write(
+            tmp.path().join("package.json"),
+            r#"{"scripts":{"test":"vitest","lint":"eslint .","dev":"vite"}}"#,
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("pnpm-lock.yaml"), "").unwrap();
+        std::fs::write(tmp.path().join("AGENTS.md"), "# rules").unwrap();
+        let block = build_coding_workspace_block(tmp.path()).unwrap();
+        assert!(block.contains("Workspace"));
+        assert!(block.contains("package.json (pnpm)"));
+        assert!(block.contains("pnpm run test"));
+        assert!(block.contains("pnpm run lint"));
+        assert!(!block.contains("run dev"));
+        assert!(block.contains("Context files: AGENTS.md"));
+        assert!(block.contains("Status:"));
+    }
+
+    #[test]
+    fn marker_only_project_gets_snapshot_without_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        let mode = resolve_runtime_mode(Some("cli"), Some(tmp.path()), Some("auto"), None);
+        assert!(mode.is_coding());
+        let block = mode.system_blocks().join("\n");
+        assert!(block.contains("Cargo.toml"));
+        assert!(block.contains("cargo test"));
+        assert!(!block.contains("Branch:"));
+    }
+
+    #[test]
+    fn edit_format_family_detection_covers_open_and_closed_models() {
+        assert_eq!(model_family(Some("openai/gpt-5.4")), Some("patch"));
+        assert_eq!(model_family(Some("openai/codex-mini")), Some("patch"));
+        for model in [
+            "anthropic/claude-sonnet-4",
+            "google/gemini-3-pro",
+            "deepseek-v3.2",
+            "qwen3-coder",
+            "moonshot/kimi-k2",
+            "nousresearch/hermes-4-405b",
+        ] {
+            assert_eq!(model_family(Some(model)), Some("replace"));
+        }
+        assert_eq!(model_family(Some("acme/foo-1")), None);
+        assert_eq!(model_family(None), None);
+    }
+}

--- a/crates/hermes-agent/src/compression.rs
+++ b/crates/hermes-agent/src/compression.rs
@@ -600,6 +600,7 @@ Write only the summary body. Do not include any preamble or prefix."
                                 tool_call_id: Some(tc.id.clone()),
                                 name: None,
                                 reasoning_content: None,
+                                anthropic_content_blocks: None,
                                 cache_control: None,
                             });
                         }
@@ -855,6 +856,7 @@ Write only the summary body. Do not include any preamble or prefix."
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                anthropic_content_blocks: None,
                 cache_control: None,
             });
         }
@@ -1034,6 +1036,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -1046,6 +1049,7 @@ mod tests {
             tool_call_id: Some(call_id.into()),
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -1065,6 +1069,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -1118,6 +1123,7 @@ mod tests {
                     tool_call_id: None,
                     name: None,
                     reasoning_content: None,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 },
                 finish_reason: Some("stop".into()),
@@ -1217,6 +1223,7 @@ mod tests {
                         tool_call_id: None,
                         name: None,
                         reasoning_content: None,
+                        anthropic_content_blocks: None,
                         cache_control: None,
                     },
                     finish_reason: Some("stop".into()),

--- a/crates/hermes-agent/src/lib.rs
+++ b/crates/hermes-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod auxiliary_builder;
 pub mod bedrock;
 pub mod budget;
 pub mod code_index;
+pub mod coding_context;
 pub mod compression;
 pub mod context;
 pub mod context_files;

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -1656,6 +1656,18 @@ impl AnthropicProvider {
                 }
                 MessageRole::Assistant => {
                     let mut content_blocks = Vec::new();
+                    if let Some(ordered_blocks) = msg
+                        .anthropic_content_blocks
+                        .as_deref()
+                        .map(Self::replay_anthropic_content_blocks)
+                        .filter(|blocks| !blocks.is_empty())
+                    {
+                        anthropic_messages.push(serde_json::json!({
+                            "role": "assistant",
+                            "content": ordered_blocks,
+                        }));
+                        continue;
+                    }
                     if is_kimi_endpoint
                         && msg
                             .tool_calls
@@ -1713,6 +1725,14 @@ impl AnthropicProvider {
         (system_text, anthropic_messages)
     }
 
+    fn replay_anthropic_content_blocks(blocks: &[Value]) -> Vec<Value> {
+        blocks
+            .iter()
+            .filter(|block| block.is_object())
+            .cloned()
+            .collect()
+    }
+
     /// Convert tool schemas to Anthropic tool format.
     fn convert_tools(tools: &[ToolSchema]) -> Vec<Value> {
         tools
@@ -1732,8 +1752,10 @@ impl AnthropicProvider {
         let mut content_text = String::new();
         let mut reasoning_content = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
+        let mut anthropic_content_blocks: Option<Vec<Value>> = None;
 
         if let Some(content_arr) = json.get("content").and_then(|c| c.as_array()) {
+            anthropic_content_blocks = Self::interleaved_anthropic_content_blocks(content_arr);
             for block in content_arr {
                 let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
                 match block_type {
@@ -1819,6 +1841,7 @@ impl AnthropicProvider {
             } else {
                 Some(reasoning_content)
             },
+            anthropic_content_blocks,
             cache_control: None,
         };
 
@@ -1828,6 +1851,19 @@ impl AnthropicProvider {
             model,
             finish_reason: stop_reason,
         })
+    }
+
+    fn interleaved_anthropic_content_blocks(content_arr: &[Value]) -> Option<Vec<Value>> {
+        let has_signed_thinking = content_arr.iter().any(|block| {
+            matches!(
+                block.get("type").and_then(Value::as_str),
+                Some("thinking" | "redacted_thinking")
+            ) && (block.get("signature").is_some() || block.get("data").is_some())
+        });
+        let has_tool_use = content_arr
+            .iter()
+            .any(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"));
+        (has_signed_thinking && has_tool_use).then(|| content_arr.to_vec())
     }
 }
 
@@ -2692,6 +2728,7 @@ fn parse_openai_response(json: &Value) -> Result<LlmResponse, AgentError> {
         tool_call_id: None,
         name: None,
         reasoning_content,
+        anthropic_content_blocks: None,
         cache_control: None,
     };
 
@@ -3764,6 +3801,7 @@ mod tests {
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                anthropic_content_blocks: None,
                 cache_control: None,
             },
             Message::tool_result("tc_1", "file contents here"),
@@ -3782,6 +3820,68 @@ mod tests {
     }
 
     #[test]
+    fn test_anthropic_convert_messages_preserves_ordered_content_blocks() {
+        let ordered_blocks = vec![
+            serde_json::json!({"type": "thinking", "thinking": "first", "signature": "sig-1"}),
+            serde_json::json!({"type": "tool_use", "id": "toolu_1", "name": "read_file", "input": {"path": "a.py"}}),
+            serde_json::json!({"type": "thinking", "thinking": "second", "signature": "sig-2"}),
+            serde_json::json!({"type": "tool_use", "id": "toolu_2", "name": "read_file", "input": {"path": "b.py"}}),
+        ];
+        let messages = vec![Message {
+            role: MessageRole::Assistant,
+            content: None,
+            tool_calls: Some(vec![
+                ToolCall {
+                    id: "toolu_1".to_string(),
+                    function: FunctionCall {
+                        name: "read_file".to_string(),
+                        arguments: r#"{"path":"a.py"}"#.to_string(),
+                    },
+                    extra_content: None,
+                },
+                ToolCall {
+                    id: "toolu_2".to_string(),
+                    function: FunctionCall {
+                        name: "read_file".to_string(),
+                        arguments: r#"{"path":"b.py"}"#.to_string(),
+                    },
+                    extra_content: None,
+                },
+            ]),
+            tool_call_id: None,
+            name: None,
+            reasoning_content: Some("first\nsecond".to_string()),
+            anthropic_content_blocks: Some(ordered_blocks.clone()),
+            cache_control: None,
+        }];
+
+        let (_, msgs) = AnthropicProvider::convert_messages(&messages, None);
+        let content = msgs[0]["content"].as_array().unwrap();
+        let order: Vec<(&str, String)> = content
+            .iter()
+            .map(|block| {
+                let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
+                let key = block
+                    .get("signature")
+                    .or_else(|| block.get("id"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                (block_type, key)
+            })
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("thinking", "sig-1".to_string()),
+                ("tool_use", "toolu_1".to_string()),
+                ("thinking", "sig-2".to_string()),
+                ("tool_use", "toolu_2".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn test_anthropic_convert_messages_kimi_tool_replay_preserves_reasoning_content() {
         let messages = vec![Message {
             role: MessageRole::Assistant,
@@ -3797,6 +3897,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: Some("provider scratchpad".to_string()),
+            anthropic_content_blocks: None,
             cache_control: None,
         }];
         let (_, msgs) =
@@ -3823,6 +3924,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: Some(String::new()),
+            anthropic_content_blocks: None,
             cache_control: None,
         }];
         let (_, msgs) =
@@ -3848,6 +3950,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: Some("scratchpad".to_string()),
+            anthropic_content_blocks: None,
             cache_control: None,
         }];
         let (_, msgs) =
@@ -4037,6 +4140,35 @@ mod tests {
         let resp = AnthropicProvider::parse_response(&json).unwrap();
         assert_eq!(resp.message.content.as_deref(), Some("answer"));
         assert_eq!(resp.message.reasoning_content.as_deref(), Some("step 1"));
+    }
+
+    #[test]
+    fn test_anthropic_parse_response_preserves_interleaved_content_blocks() {
+        let json = serde_json::json!({
+            "content": [
+                {"type": "thinking", "thinking": "first", "signature": "sig-1"},
+                {"type": "tool_use", "id": "toolu_1", "name": "read_file", "input": {"path": "a.py"}},
+                {"type": "redacted_thinking", "data": "ciphertext"},
+                {"type": "tool_use", "id": "toolu_2", "name": "read_file", "input": {"path": "b.py"}}
+            ],
+            "model": "claude-opus-4-8",
+            "stop_reason": "tool_use",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5
+            }
+        });
+        let resp = AnthropicProvider::parse_response(&json).unwrap();
+        let blocks = resp
+            .message
+            .anthropic_content_blocks
+            .as_ref()
+            .expect("ordered blocks");
+        assert_eq!(blocks.len(), 4);
+        assert_eq!(blocks[0]["signature"], "sig-1");
+        assert_eq!(blocks[1]["id"], "toolu_1");
+        assert_eq!(blocks[2]["type"], "redacted_thinking");
+        assert_eq!(blocks[3]["id"], "toolu_2");
     }
 
     #[test]

--- a/crates/hermes-agent/src/python_alignment.rs
+++ b/crates/hermes-agent/src/python_alignment.rs
@@ -231,6 +231,7 @@ mod tests {
             tool_call_id: Some("1".into()),
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }];
         strip_budget_warnings_from_messages(&mut messages);

--- a/crates/hermes-agent/src/session_persistence.rs
+++ b/crates/hermes-agent/src/session_persistence.rs
@@ -1336,6 +1336,7 @@ impl SessionPersistence {
                     tool_call_id,
                     name,
                     reasoning_content,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 })
             })

--- a/crates/hermes-agent/src/skill_orchestrator.rs
+++ b/crates/hermes-agent/src/skill_orchestrator.rs
@@ -355,6 +355,17 @@ impl SkillOrchestrator {
         &self.commands
     }
 
+    /// Return the top-level category folder for a discovered skill.
+    pub fn skill_category(&self, info: &SkillCommandInfo) -> Option<String> {
+        info.skill_dir
+            .strip_prefix(&self.skills_dir)
+            .ok()
+            .and_then(|relative| relative.components().next())
+            .and_then(|component| component.as_os_str().to_str())
+            .map(str::to_string)
+            .filter(|category| !category.trim().is_empty())
+    }
+
     /// Resolve a user-typed `/command` to its canonical key.
     ///
     /// Hyphens and underscores are treated interchangeably.

--- a/crates/hermes-agent/tests/alignment_contracts.rs
+++ b/crates/hermes-agent/tests/alignment_contracts.rs
@@ -54,6 +54,7 @@ fn strip_budget_tool_message_matches_python_fixture() {
         tool_call_id: Some("t1".into()),
         name: None,
         reasoning_content: None,
+        anthropic_content_blocks: None,
         cache_control: None,
     }];
     python_alignment::strip_budget_warnings_from_messages(&mut messages);

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -67,6 +67,23 @@ const QUORUM_DEFAULT_VOTER_PASSES: usize = 6;
 const RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS: usize = 1_600;
 const QUORUM_AGENT_CONTRACT_DEFAULT_PATH: &str =
     "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/QUORUM_AGENTS.md";
+const COMPOSER_DRAFTS_FILE: &str = "composer-drafts.json";
+const MAX_COMPOSER_DRAFTS: usize = 50;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct ComposerDraftStore {
+    #[serde(default)]
+    version: u8,
+    #[serde(default)]
+    drafts: Vec<ComposerDraftRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ComposerDraftRecord {
+    session_id: String,
+    text: String,
+    updated_at: String,
+}
 
 #[derive(Debug, Clone)]
 struct SessionSnapshotEntry {
@@ -2256,6 +2273,132 @@ impl App {
         self.pending_input_prefill.take()
     }
 
+    fn composer_drafts_path(&self) -> PathBuf {
+        self.state_root.join(COMPOSER_DRAFTS_FILE)
+    }
+
+    fn composer_draft_key(&self) -> String {
+        let trimmed = self.session_id.trim();
+        if trimmed.is_empty() {
+            "__new__".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    fn load_composer_draft_store(&self) -> Result<ComposerDraftStore, AgentError> {
+        let path = self.composer_drafts_path();
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ComposerDraftStore {
+                    version: 1,
+                    drafts: Vec::new(),
+                });
+            }
+            Err(err) => {
+                return Err(AgentError::Io(format!(
+                    "Failed to read composer drafts {}: {}",
+                    path.display(),
+                    err
+                )));
+            }
+        };
+        let mut store: ComposerDraftStore = serde_json::from_str(&raw).map_err(|err| {
+            AgentError::Config(format!(
+                "Failed to parse composer drafts {}: {}",
+                path.display(),
+                err
+            ))
+        })?;
+        store.version = 1;
+        Ok(store)
+    }
+
+    fn write_composer_draft_store(&self, store: &ComposerDraftStore) -> Result<(), AgentError> {
+        let path = self.composer_drafts_path();
+        if store.drafts.is_empty() {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(AgentError::Io(format!(
+                        "Failed to remove composer drafts {}: {}",
+                        path.display(),
+                        err
+                    )));
+                }
+            }
+            return Ok(());
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                AgentError::Io(format!(
+                    "Failed to create composer draft dir {}: {}",
+                    parent.display(),
+                    err
+                ))
+            })?;
+        }
+        let raw = serde_json::to_string_pretty(store).map_err(|err| {
+            AgentError::Config(format!("Failed to serialize composer drafts: {err}"))
+        })?;
+        let tmp_path = path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, raw).map_err(|err| {
+            AgentError::Io(format!(
+                "Failed to write composer drafts {}: {}",
+                tmp_path.display(),
+                err
+            ))
+        })?;
+        std::fs::rename(&tmp_path, &path).map_err(|err| {
+            AgentError::Io(format!(
+                "Failed to replace composer drafts {}: {}",
+                path.display(),
+                err
+            ))
+        })?;
+        Ok(())
+    }
+
+    /// Load unsent composer text for the active session.
+    pub fn load_current_composer_draft(&self) -> Result<Option<String>, AgentError> {
+        let key = self.composer_draft_key();
+        let store = self.load_composer_draft_store()?;
+        Ok(store
+            .drafts
+            .into_iter()
+            .rev()
+            .find(|draft| draft.session_id == key && !draft.text.trim().is_empty())
+            .map(|draft| draft.text))
+    }
+
+    /// Persist unsent composer text for the active session.
+    pub fn persist_current_composer_draft(&self, text: &str) -> Result<(), AgentError> {
+        let key = self.composer_draft_key();
+        let mut store = self.load_composer_draft_store()?;
+        store.drafts.retain(|draft| draft.session_id != key);
+        if !text.trim().is_empty() {
+            store.drafts.push(ComposerDraftRecord {
+                session_id: key,
+                text: text.to_string(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+            });
+        }
+        if store.drafts.len() > MAX_COMPOSER_DRAFTS {
+            let keep_from = store.drafts.len() - MAX_COMPOSER_DRAFTS;
+            store.drafts.drain(0..keep_from);
+        }
+        store.version = 1;
+        self.write_composer_draft_store(&store)
+    }
+
+    /// Clear unsent composer text for the active session.
+    pub fn clear_current_composer_draft(&self) -> Result<(), AgentError> {
+        self.persist_current_composer_draft("")
+    }
+
     /// Prepare outbound user text, consuming any queued image hint.
     pub fn prepare_user_message(&mut self, raw: &str) -> String {
         let base = raw.trim();
@@ -4061,6 +4204,60 @@ mod tests {
         assert_eq!(app.history_next(), None);
         assert_eq!(app.history_index, app.input_history.len());
         assert_eq!(app.history_next(), None);
+    }
+
+    #[test]
+    fn composer_drafts_persist_per_session_without_touching_messages() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = build_minimal_test_app_with_state_root(tmp.path().to_path_buf());
+        app.session_id = "session-a".to_string();
+
+        app.persist_current_composer_draft("alpha draft").unwrap();
+        app.session_id = "session-b".to_string();
+        app.persist_current_composer_draft("beta draft").unwrap();
+
+        assert_eq!(
+            app.load_current_composer_draft().unwrap().as_deref(),
+            Some("beta draft")
+        );
+        app.session_id = "session-a".to_string();
+        assert_eq!(
+            app.load_current_composer_draft().unwrap().as_deref(),
+            Some("alpha draft")
+        );
+
+        app.clear_current_composer_draft().unwrap();
+        assert_eq!(app.load_current_composer_draft().unwrap(), None);
+        app.session_id = "session-b".to_string();
+        assert_eq!(
+            app.load_current_composer_draft().unwrap().as_deref(),
+            Some("beta draft")
+        );
+
+        let persistence = SessionPersistence::new(tmp.path());
+        assert!(persistence.load_session("session-a").unwrap().is_empty());
+        assert!(persistence.load_session("session-b").unwrap().is_empty());
+    }
+
+    #[test]
+    fn composer_drafts_keep_mru_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = build_minimal_test_app_with_state_root(tmp.path().to_path_buf());
+
+        for idx in 0..(MAX_COMPOSER_DRAFTS + 3) {
+            app.session_id = format!("session-{idx}");
+            app.persist_current_composer_draft(&format!("draft-{idx}"))
+                .unwrap();
+        }
+
+        let raw = std::fs::read_to_string(app.composer_drafts_path()).unwrap();
+        let store: ComposerDraftStore = serde_json::from_str(&raw).unwrap();
+        assert_eq!(store.drafts.len(), MAX_COMPOSER_DRAFTS);
+        assert_eq!(store.drafts.first().unwrap().session_id, "session-3");
+        assert_eq!(
+            store.drafts.last().unwrap().session_id,
+            format!("session-{}", MAX_COMPOSER_DRAFTS + 2)
+        );
     }
 
     #[test]
@@ -6595,6 +6792,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
             .map(str::to_string),
         skip_memory,
         skip_context_files,
+        coding_context: config.agent.coding_context.clone(),
         platform: Some("cli".to_string()),
         enabled_skills: config.skills.enabled.clone(),
         disabled_skills: config.skills.disabled.clone(),

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -3021,6 +3021,28 @@ pub fn autocomplete(partial: &str) -> Vec<&'static str> {
 /// Unlike [`autocomplete`], this understands command argument position and can
 /// suggest nested values like `/swarm run <passes> <mode>`.
 pub fn autocomplete_contextual(partial: &str) -> Vec<String> {
+    autocomplete_contextual_with_runtime(partial, None)
+}
+
+pub fn autocomplete_contextual_for_app(partial: &str, app: &App) -> Vec<String> {
+    autocomplete_contextual_with_runtime(
+        partial,
+        Some(CompletionRuntime {
+            config: app.config.as_ref(),
+            tool_registry: app.tool_registry.as_ref(),
+        }),
+    )
+}
+
+struct CompletionRuntime<'a> {
+    config: &'a GatewayConfig,
+    tool_registry: &'a hermes_tools::ToolRegistry,
+}
+
+fn autocomplete_contextual_with_runtime(
+    partial: &str,
+    runtime: Option<CompletionRuntime<'_>>,
+) -> Vec<String> {
     let trimmed_start = partial.trim_start();
     if !trimmed_start.starts_with('/') {
         return Vec::new();
@@ -3063,11 +3085,7 @@ pub fn autocomplete_contextual(partial: &str) -> Vec<String> {
         (args.len() - 1, args[args.len() - 1])
     };
 
-    let candidates = if arg_position == 0 {
-        command_subcommand_candidates(&cmd)
-    } else {
-        command_nested_candidates(&cmd, args[0], arg_position)
-    };
+    let candidates = command_argument_candidates(&cmd, &args, arg_position, runtime.as_ref());
 
     if candidates.is_empty() {
         return Vec::new();
@@ -3096,6 +3114,93 @@ pub fn autocomplete_contextual(partial: &str) -> Vec<String> {
             out.push(suggestion);
         }
     }
+    out
+}
+
+fn command_argument_candidates(
+    cmd: &str,
+    args: &[&str],
+    arg_position: usize,
+    runtime: Option<&CompletionRuntime<'_>>,
+) -> Vec<String> {
+    match (cmd, arg_position) {
+        ("/personality", 0) => personality_completion_candidates(),
+        ("/handoff", 0) => handoff_completion_candidates(runtime),
+        ("/tools", 0) => ["list", "trust", "enable", "disable"]
+            .iter()
+            .map(|v| (*v).to_string())
+            .collect(),
+        ("/tools", 1) => args
+            .first()
+            .map(|sub| tool_completion_candidates(runtime, sub))
+            .unwrap_or_default(),
+        _ if arg_position == 0 => command_subcommand_candidates(cmd),
+        _ => command_nested_candidates(cmd, args[0], arg_position),
+    }
+}
+
+fn personality_completion_candidates() -> Vec<String> {
+    let mut out = vec!["list".to_string(), "none".to_string()];
+    out.extend(
+        hermes_agent::builtin_personality_names()
+            .iter()
+            .map(|v| (*v).to_string()),
+    );
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn handoff_completion_candidates(runtime: Option<&CompletionRuntime<'_>>) -> Vec<String> {
+    let Some(runtime) = runtime else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = runtime
+        .config
+        .platforms
+        .iter()
+        .filter(|(_, platform)| platform.enabled)
+        .map(|(name, _)| name.clone())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn tool_completion_candidates(
+    runtime: Option<&CompletionRuntime<'_>>,
+    subcommand: &str,
+) -> Vec<String> {
+    let Some(runtime) = runtime else {
+        return Vec::new();
+    };
+    let action = subcommand.trim().to_ascii_lowercase();
+    if action != "enable" && action != "disable" {
+        return Vec::new();
+    }
+
+    let disabled: HashSet<&str> = runtime
+        .config
+        .tools_config
+        .disabled
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    let mut out: Vec<String> = runtime
+        .tool_registry
+        .list_tools()
+        .into_iter()
+        .filter_map(|tool| {
+            let active = !disabled.contains(tool.name.as_str());
+            match (action.as_str(), active) {
+                ("enable", false) | ("disable", true) => Some(tool.name),
+                _ => None,
+            }
+        })
+        .collect();
+    out.sort();
+    out.dedup();
     out
 }
 
@@ -5545,6 +5650,12 @@ async fn handle_skills_command(app: &mut App, args: &[&str]) -> Result<CommandRe
 }
 
 fn handle_tools_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    if args.first().is_some_and(|sub| {
+        sub.eq_ignore_ascii_case("enable") || sub.eq_ignore_ascii_case("disable")
+    }) {
+        return handle_tools_toggle_command(app, args);
+    }
+
     if args
         .first()
         .is_some_and(|sub| sub.eq_ignore_ascii_case("trust"))
@@ -5613,13 +5724,88 @@ fn handle_tools_command(app: &mut App, args: &[&str]) -> Result<CommandResult, A
     if tools.is_empty() {
         emit_command_output(app, "No tools registered.");
     } else {
+        let disabled: HashSet<&str> = app
+            .config
+            .tools_config
+            .disabled
+            .iter()
+            .map(String::as_str)
+            .collect();
         let mut out = format!("Registered tools ({}):\n", tools.len());
         for tool in &tools {
-            out.push_str(&format!("- `{}` — {}\n", tool.name, tool.description));
+            let state = if disabled.contains(tool.name.as_str()) {
+                "disabled"
+            } else {
+                "enabled"
+            };
+            out.push_str(&format!(
+                "- `{}` [{}] — {}\n",
+                tool.name, state, tool.description
+            ));
         }
-        out.push_str("\n\nUse `/tools trust` for a risk/score summary.");
+        out.push_str(
+            "\n\nUse `/tools trust` for a risk/score summary, `/tools enable <name>` to enable, or `/tools disable <name>` to disable.",
+        );
         emit_command_output(app, out.trim_end());
     }
+    Ok(CommandResult::Handled)
+}
+
+fn handle_tools_toggle_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
+    let action = args[0].to_ascii_lowercase();
+    let tool_name = args.get(1..).unwrap_or_default().join(" ");
+    let tool_name = tool_name.trim();
+    if tool_name.is_empty() {
+        emit_command_output(
+            app,
+            "Usage: /tools [list] [filter] | /tools enable <name> | /tools disable <name>",
+        );
+        return Ok(CommandResult::Handled);
+    }
+
+    let cfg_path = app.state_root.join("config.yaml");
+    let mut disk = hermes_config::load_user_config_file(&cfg_path)
+        .map_err(|e| AgentError::Config(e.to_string()))?;
+    match action.as_str() {
+        "enable" => {
+            if !disk.tools_config.enabled.iter().any(|t| t == tool_name) {
+                disk.tools_config.enabled.push(tool_name.to_string());
+            }
+            disk.tools_config.disabled.retain(|t| t != tool_name);
+        }
+        "disable" => {
+            if !disk.tools_config.disabled.iter().any(|t| t == tool_name) {
+                disk.tools_config.disabled.push(tool_name.to_string());
+            }
+            disk.tools_config.enabled.retain(|t| t != tool_name);
+        }
+        _ => unreachable!("validated tools action"),
+    }
+    hermes_config::save_config_yaml(&cfg_path, &disk)
+        .map_err(|e| AgentError::Config(e.to_string()))?;
+
+    {
+        let config = Arc::make_mut(&mut app.config);
+        config.tools_config = disk.tools_config.clone();
+    }
+    app.tool_schemas = crate::platform_toolsets::resolve_platform_tool_schemas(
+        &app.config,
+        "cli",
+        &app.tool_registry,
+    );
+
+    let state = if action == "enable" {
+        "Enabled"
+    } else {
+        "Disabled"
+    };
+    emit_command_output(
+        app,
+        format!(
+            "{state} tool `{tool_name}` for this session and saved it to {}.",
+            cfg_path.display()
+        ),
+    );
     Ok(CommandResult::Handled)
 }
 
@@ -27564,6 +27750,13 @@ mod tests {
         assert!(results.contains(&"/objective behavior sigma ".to_string()));
     }
 
+    #[test]
+    fn test_contextual_autocomplete_personality_candidates() {
+        let results = autocomplete_contextual("/personality ");
+        assert!(results.contains(&"/personality coder ".to_string()));
+        assert!(results.contains(&"/personality none ".to_string()));
+    }
+
     #[tokio::test]
     async fn version_slash_command_renders_shared_version_label() {
         let _guard = env_test_lock();
@@ -27664,6 +27857,71 @@ mod tests {
             .expect("alias command");
 
         assert!(latest_ui_assistant_text(&app).contains("some args"));
+    }
+
+    #[tokio::test]
+    async fn app_contextual_autocomplete_and_tools_toggle_use_runtime_state() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        {
+            let config = Arc::make_mut(&mut app.config);
+            config.platforms.insert(
+                "telegram".to_string(),
+                hermes_config::PlatformConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+            );
+            config.tools_config.disabled.push("read_file".to_string());
+        }
+        app.tool_schemas = crate::platform_toolsets::resolve_platform_tool_schemas(
+            &app.config,
+            "cli",
+            &app.tool_registry,
+        );
+
+        let handoff = autocomplete_contextual_for_app("/handoff ", &app);
+        assert!(handoff.contains(&"/handoff telegram ".to_string()));
+        let enable = autocomplete_contextual_for_app("/tools enable ", &app);
+        assert!(enable.contains(&"/tools enable read_file ".to_string()));
+        let disable = autocomplete_contextual_for_app("/tools disable ", &app);
+        assert!(disable.contains(&"/tools disable write_file ".to_string()));
+        assert!(!app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "read_file"));
+
+        handle_slash_command(&mut app, "/tools", &["enable", "read_file"])
+            .await
+            .expect("enable tool");
+        assert!(latest_ui_assistant_text(&app).contains("Enabled tool `read_file`"));
+        assert!(app
+            .config
+            .tools_config
+            .enabled
+            .iter()
+            .any(|name| name == "read_file"));
+        assert!(app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "read_file"));
+
+        handle_slash_command(&mut app, "/tools", &["disable", "read_file"])
+            .await
+            .expect("disable tool");
+        assert!(latest_ui_assistant_text(&app).contains("Disabled tool `read_file`"));
+        assert!(app
+            .config
+            .tools_config
+            .disabled
+            .iter()
+            .any(|name| name == "read_file"));
+        assert!(!app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "read_file"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/platform_toolsets.rs
+++ b/crates/hermes-cli/src/platform_toolsets.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use hermes_agent::coding_context::coding_toolset_selection;
 use hermes_config::GatewayConfig;
 use hermes_core::ToolSchema;
 use hermes_tools::{ToolRegistry, ToolsetManager};
@@ -21,6 +22,9 @@ pub fn normalize_platform_key(platform: &str) -> String {
 pub fn default_platform_toolsets() -> HashMap<String, Vec<String>> {
     let mut map = HashMap::new();
     map.insert("cli".to_string(), vec!["hermes-cli".to_string()]);
+    map.insert("tui".to_string(), vec!["hermes-cli".to_string()]);
+    map.insert("desktop".to_string(), vec!["hermes-cli".to_string()]);
+    map.insert("acp".to_string(), vec!["hermes-acp".to_string()]);
     map.insert("telegram".to_string(), vec!["hermes-telegram".to_string()]);
     map.insert("discord".to_string(), vec!["hermes-discord".to_string()]);
     map.insert("whatsapp".to_string(), vec!["hermes-whatsapp".to_string()]);
@@ -65,6 +69,7 @@ fn canonical_toolset_token(token: &str) -> String {
         "browser-use" | "browser_use" => "browser".to_string(),
         "voice-mode" | "voice_mode" => "voice".to_string(),
         "hermes_cli" => "hermes-cli".to_string(),
+        "hermes_acp" => "hermes-acp".to_string(),
         "hermes_api_server" => "hermes-api-server".to_string(),
         "hermes_telegram" => "hermes-telegram".to_string(),
         "hermes_discord" => "hermes-discord".to_string(),
@@ -74,14 +79,54 @@ fn canonical_toolset_token(token: &str) -> String {
     }
 }
 
+fn platform_has_custom_toolsets(config: &GatewayConfig, key: &str) -> bool {
+    let Some(configured) = config.platform_toolsets.get(key) else {
+        return false;
+    };
+    if configured.is_empty() {
+        return false;
+    }
+    match default_platform_toolsets().get(key) {
+        Some(defaults) => configured != defaults,
+        None => true,
+    }
+}
+
+fn coding_focus_toolsets(
+    config: &GatewayConfig,
+    platform: &str,
+    manager: &ToolsetManager,
+) -> Option<Vec<String>> {
+    let key = normalize_platform_key(platform);
+    if platform_has_custom_toolsets(config, &key) {
+        return None;
+    }
+    coding_toolset_selection(Some(&key), None, Some(&config.agent.coding_context))?;
+
+    let mut requested = vec!["coding".to_string()];
+    let mut live_mcp: Vec<String> = manager
+        .list_toolsets()
+        .into_iter()
+        .filter(|name| name.starts_with("mcp-"))
+        .collect();
+    live_mcp.sort();
+    for name in live_mcp {
+        if !requested.contains(&name) {
+            requested.push(name);
+        }
+    }
+    Some(requested)
+}
+
 /// Resolve tool names allowed for this platform based on configured toolsets.
 pub fn resolve_platform_tool_names(
     config: &GatewayConfig,
     platform: &str,
     registry: &Arc<ToolRegistry>,
 ) -> Vec<String> {
-    let requested = configured_platform_toolsets(config, platform);
     let manager = ToolsetManager::new(Arc::clone(registry));
+    let requested = coding_focus_toolsets(config, platform, &manager)
+        .unwrap_or_else(|| configured_platform_toolsets(config, platform));
 
     let mut names: HashSet<String> = HashSet::new();
     for token in requested {
@@ -183,13 +228,43 @@ pub fn tool_definition_summary(defs: &[ToolSchema]) -> Vec<serde_json::Value> {
 mod tests {
     use super::*;
 
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
     use async_trait::async_trait;
     use hermes_core::{tool_schema, JsonSchema, ToolError};
 
     struct NoopTool {
         schema: ToolSchema,
+    }
+
+    fn env_test_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env test lock poisoned")
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(old) = &self.old {
+                std::env::set_var(self.key, old);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
     }
 
     #[async_trait]
@@ -265,6 +340,8 @@ mod tests {
         register(&reg, "browser_get_images", "browser");
         register(&reg, "browser_vision", "browser");
         register(&reg, "browser_console", "browser");
+        register(&reg, "browser_cdp", "browser");
+        register(&reg, "browser_dialog", "browser");
         register(&reg, "video_analyze", "vision");
         register(&reg, "video_generate", "video_gen");
         register(&reg, "mixture_of_agents", "mixture_of_agents");
@@ -303,6 +380,26 @@ mod tests {
         assert!(names.contains(&"integrations_snapshot".to_string()));
         assert!(names.contains(&"objective_snapshot".to_string()));
         assert!(names.contains(&"mission_snapshot".to_string()));
+    }
+
+    #[test]
+    fn acp_default_resolves_editor_toolset() {
+        let cfg = GatewayConfig::default();
+        let reg = registry_with_minimal_tools();
+        let names = resolve_platform_tool_names(&cfg, "acp", &reg);
+        for expected in [
+            "terminal",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+        ] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "acp should include {expected}"
+            );
+        }
+        assert!(!names.contains(&"send_message".to_string()));
     }
 
     #[test]
@@ -374,6 +471,73 @@ mod tests {
         let reg = registry_with_minimal_tools();
         let names = resolve_platform_tool_names(&cfg, "cli", &reg);
         assert!(!names.contains(&"terminal".to_string()));
+    }
+
+    #[test]
+    fn coding_focus_collapses_default_cli_toolset_and_keeps_live_mcp() {
+        let _lock = env_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        let _cwd = EnvGuard::set("TERMINAL_CWD", tmp.path().to_str().unwrap());
+        let mut cfg = GatewayConfig::default();
+        cfg.agent.coding_context = "focus".to_string();
+        let reg = registry_with_minimal_tools();
+        let schema = tool_schema(
+            "mcp_lattice_search",
+            "ContextLattice search",
+            JsonSchema::new("object"),
+        );
+        reg.register(
+            "mcp_lattice_search",
+            "mcp-lattice",
+            schema.clone(),
+            Arc::new(NoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "ContextLattice search",
+            "x",
+            None,
+        );
+
+        let names = resolve_platform_tool_names(&cfg, "cli", &reg);
+        assert!(names.contains(&"terminal".to_string()));
+        assert!(names.contains(&"read_file".to_string()));
+        assert!(names.contains(&"mcp_lattice_search".to_string()));
+        assert!(!names.contains(&"send_message".to_string()));
+        assert!(!names.contains(&"image_generate".to_string()));
+    }
+
+    #[test]
+    fn coding_auto_is_prompt_only_and_custom_toolset_wins_over_focus() {
+        let _lock = env_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        let _cwd = EnvGuard::set("TERMINAL_CWD", tmp.path().to_str().unwrap());
+        let reg = registry_with_minimal_tools();
+
+        let mut auto_cfg = GatewayConfig::default();
+        auto_cfg.agent.coding_context = "auto".to_string();
+        let auto_names = resolve_platform_tool_names(&auto_cfg, "cli", &reg);
+        assert!(auto_names.contains(&"send_message".to_string()));
+        assert!(auto_names.contains(&"image_generate".to_string()));
+
+        let mut custom_focus = GatewayConfig::default();
+        custom_focus.agent.coding_context = "focus".to_string();
+        custom_focus
+            .platform_toolsets
+            .insert("cli".to_string(), vec!["web".to_string()]);
+        let custom_names = resolve_platform_tool_names(&custom_focus, "cli", &reg);
+        assert!(custom_names.contains(&"web_search".to_string()));
+        assert!(!custom_names.contains(&"terminal".to_string()));
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -1115,13 +1115,13 @@ impl TuiState {
             KeyCode::Enter if mods.contains(KeyModifiers::SHIFT) => {
                 self.insert_newline_at_cursor();
                 self.selection_anchor = None;
-                self.refresh_completions();
+                self.refresh_completions_for_app(Some(app));
                 false
             }
             KeyCode::Char('j') if mods.contains(KeyModifiers::CONTROL) => {
                 self.insert_newline_at_cursor();
                 self.selection_anchor = None;
-                self.refresh_completions();
+                self.refresh_completions_for_app(Some(app));
                 false
             }
             // Submit shortcuts are handled in the run-loop after key handling.
@@ -1166,7 +1166,7 @@ impl TuiState {
                     self.input = prev.to_string();
                     self.cursor_position = self.input.len();
                 }
-                self.refresh_completions();
+                self.refresh_completions_for_app(Some(app));
                 false
             }
             KeyCode::Down
@@ -1176,7 +1176,7 @@ impl TuiState {
                     self.input = next.to_string();
                     self.cursor_position = self.input.len();
                 }
-                self.refresh_completions();
+                self.refresh_completions_for_app(Some(app));
                 false
             }
             KeyCode::Esc => {
@@ -1202,7 +1202,7 @@ impl TuiState {
             _ => {
                 self.apply_textarea_input(key);
                 self.selection_anchor = None;
-                self.refresh_completions();
+                self.refresh_completions_for_app(Some(app));
                 false
             }
         }
@@ -1316,9 +1316,17 @@ impl TuiState {
     }
 
     /// Update auto-completion suggestions based on current input.
+    #[cfg(test)]
     fn update_completions(&mut self) {
+        self.update_completions_for_app(None);
+    }
+
+    fn update_completions_for_app(&mut self, app: Option<&App>) {
         if self.input.starts_with('/') {
-            self.completions = commands::autocomplete_contextual(&self.input);
+            self.completions = match app {
+                Some(app) => commands::autocomplete_contextual_for_app(&self.input, app),
+                None => commands::autocomplete_contextual(&self.input),
+            };
             self.completion_index = None;
         } else {
             self.completions.clear();
@@ -1327,8 +1335,12 @@ impl TuiState {
     }
 
     fn refresh_completions(&mut self) {
+        self.refresh_completions_for_app(None);
+    }
+
+    fn refresh_completions_for_app(&mut self, app: Option<&App>) {
         if self.input.starts_with('/') {
-            self.update_completions();
+            self.update_completions_for_app(app);
         } else {
             self.completions.clear();
             self.completion_index = None;
@@ -1765,6 +1777,35 @@ fn should_render_completions_popup(state: &TuiState) -> bool {
         && !state.input.contains('\n')
         && !state.history_search_active
         && !state.completions.is_empty()
+}
+
+fn restore_tui_composer_draft(app: &App, state: &mut TuiState) -> bool {
+    match app.load_current_composer_draft() {
+        Ok(Some(draft)) if !draft.trim().is_empty() => {
+            state.input = draft;
+            state.cursor_position = state.input.len();
+            state.refresh_completions_for_app(Some(app));
+            state.status_message = "Restored unsent composer draft for this session.".to_string();
+            true
+        }
+        Ok(_) => false,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to restore composer draft");
+            false
+        }
+    }
+}
+
+fn persist_tui_composer_draft(app: &App, state: &TuiState) {
+    if let Err(err) = app.persist_current_composer_draft(&state.input) {
+        tracing::warn!(error = %err, "failed to persist composer draft");
+    }
+}
+
+fn clear_tui_composer_draft(app: &App) {
+    if let Err(err) = app.clear_current_composer_draft() {
+        tracing::warn!(error = %err, "failed to clear composer draft");
+    }
 }
 
 fn should_route_prompt_via_managed_agent(quorum_armed_once: bool, messages: &[Message]) -> bool {
@@ -4713,7 +4754,7 @@ async fn process_modal_confirm(state: &mut TuiState, app: &mut App) -> Result<()
             state.cursor_position = state.input.len();
             state.close_modal();
             state.status_message = "Interactive answer inserted. Press Enter to send.".to_string();
-            state.refresh_completions();
+            state.refresh_completions_for_app(Some(app));
         }
     }
     Ok(())
@@ -5099,6 +5140,7 @@ fn process_stream_lane_event(app: &mut App, state: &mut TuiState, event: Event) 
 pub async fn run(mut app: App) -> Result<(), AgentError> {
     let mut tui = Tui::new().map_err(|e| AgentError::Config(e.to_string()))?;
     let mut state = TuiState::default();
+    restore_tui_composer_draft(&app, &mut state);
     let mut last_jobs_refresh = Instant::now()
         .checked_sub(Duration::from_secs(2))
         .unwrap_or_else(Instant::now);
@@ -5209,6 +5251,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                         } else {
                             let line_count = text.lines().count().max(1);
                             state.insert_paste_at_cursor(&text);
+                            persist_tui_composer_draft(&app, &state);
                             state.status_message = format!("Pasted {} line(s)", line_count);
                         }
                         needs_redraw = true;
@@ -5234,7 +5277,11 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                                     state.status_message = "Picker closed".to_string();
                                 }
                                 ModalAction::Confirm => {
+                                    let input_before_confirm = state.input.clone();
                                     process_modal_confirm(&mut state, &mut app).await?;
+                                    if state.input != input_before_confirm {
+                                        persist_tui_composer_draft(&app, &state);
+                                    }
                                 }
                                 ModalAction::DisconnectProvider => {
                                     process_modal_disconnect(&mut state, &mut app).await?;
@@ -5245,6 +5292,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                             continue;
                         }
 
+                        let input_before_key = state.input.clone();
                         let should_quit = state.handle_key(key, &mut app);
                         if should_quit {
                             app.interrupt_controller.interrupt(None);
@@ -5252,6 +5300,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                             app.running = false;
                             break;
                         }
+                        let input_changed_by_key = state.input != input_before_key;
 
                         let is_submit = is_submit_shortcut(&key, &state.input);
 
@@ -5269,6 +5318,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                             state.completions.clear();
                             state.completion_index = None;
                             state.jump_to_latest();
+                            clear_tui_composer_draft(&app);
 
                             if !input.is_empty() {
                                 let mut handled_by_tui = false;
@@ -5365,6 +5415,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                                         state.status_message =
                                             format!("Running {command_name}…");
                                         draw_frame_now(&mut tui, &app, &mut state)?;
+                                        let session_before_command = app.session_id.clone();
                                         match app.handle_input(&input).await {
                                             Ok(_) => {
                                                 state.finish_processing_cycle("✔ completed in");
@@ -5372,12 +5423,19 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                                                     app.take_pending_input_prefill()
                                                 {
                                                     state.input = prefill;
-                                                    state.cursor_position =
-                                                        state.input.chars().count();
+                                                    state.cursor_position = state.input.len();
+                                                    persist_tui_composer_draft(&app, &state);
                                                     state.status_message =
                                                         "Prompt restored for editing. Press Enter to send.".to_string();
                                                 } else {
-                                                    state.status_message.clear();
+                                                    let restored_after_session_switch =
+                                                        app.session_id != session_before_command
+                                                            && restore_tui_composer_draft(
+                                                                &app, &mut state,
+                                                            );
+                                                    if !restored_after_session_switch {
+                                                        state.status_message.clear();
+                                                    }
                                                 }
                                             }
                                             Err(e) => {
@@ -5481,6 +5539,9 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                                     }
                                 }
                             }
+                        }
+                        else if input_changed_by_key {
+                            persist_tui_composer_draft(&app, &state);
                         }
                         needs_redraw = true;
                     }

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -702,6 +702,9 @@ fn default_sessions_min_interval_hours() -> u32 {
 pub fn default_platform_toolsets() -> HashMap<String, Vec<String>> {
     let mut map = HashMap::new();
     map.insert("cli".to_string(), vec!["hermes-cli".to_string()]);
+    map.insert("tui".to_string(), vec!["hermes-cli".to_string()]);
+    map.insert("desktop".to_string(), vec!["hermes-cli".to_string()]);
+    map.insert("acp".to_string(), vec!["hermes-acp".to_string()]);
     map.insert("telegram".to_string(), vec!["hermes-telegram".to_string()]);
     map.insert("discord".to_string(), vec!["hermes-discord".to_string()]);
     map.insert("whatsapp".to_string(), vec!["hermes-whatsapp".to_string()]);
@@ -726,6 +729,13 @@ pub struct AgentLoopBehaviorConfig {
     /// Useful for batch-style runs where personalized instructions would pollute trajectories.
     #[serde(default = "default_agent_skip_context_files")]
     pub skip_context_files: bool,
+    /// Coding posture activation: auto/focus/on/off.
+    ///
+    /// `auto` injects prompt-only coding guidance on interactive coding surfaces
+    /// in a code workspace. `focus` also collapses tools to the lean coding
+    /// toolset. `on` forces prompt-only posture; `off` disables it.
+    #[serde(default = "default_agent_coding_context")]
+    pub coding_context: String,
     /// When true (default), spawn the extra LLM pass for memory/skill review — Python has no master off-switch.
     #[serde(default = "default_agent_background_review_enabled")]
     pub background_review_enabled: bool,
@@ -774,6 +784,10 @@ fn default_agent_skip_context_files() -> bool {
     false
 }
 
+fn default_agent_coding_context() -> String {
+    "auto".to_string()
+}
+
 fn default_agent_background_review_enabled() -> bool {
     true
 }
@@ -804,6 +818,7 @@ impl Default for AgentLoopBehaviorConfig {
             memory_nudge_interval: default_agent_memory_nudge_interval(),
             skill_creation_nudge_interval: default_agent_skill_nudge_interval(),
             skip_context_files: default_agent_skip_context_files(),
+            coding_context: default_agent_coding_context(),
             background_review_enabled: default_agent_background_review_enabled(),
             code_index_enabled: default_agent_code_index_enabled(),
             code_index_max_files: default_agent_code_index_max_files(),

--- a/crates/hermes-core/src/test_generators.rs
+++ b/crates/hermes-core/src/test_generators.rs
@@ -97,6 +97,7 @@ pub fn arb_message() -> impl Strategy<Value = Message> {
                     tool_call_id,
                     name,
                     reasoning_content,
+                    anthropic_content_blocks: None,
                     cache_control,
                 }
             },

--- a/crates/hermes-core/src/types.rs
+++ b/crates/hermes-core/src/types.rs
@@ -138,6 +138,8 @@ pub struct Message {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic_content_blocks: Option<Vec<serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -151,6 +153,7 @@ impl Message {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -164,6 +167,7 @@ impl Message {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -177,6 +181,7 @@ impl Message {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -190,6 +195,7 @@ impl Message {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -203,6 +209,7 @@ impl Message {
             tool_call_id: Some(tool_call_id.into()),
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }
@@ -221,6 +228,7 @@ impl Message {
             tool_call_id: Some(tool_call_id.into()),
             name: (!name.trim().is_empty()).then_some(name),
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -4649,6 +4649,7 @@ mod tests {
                         tool_call_id: None,
                         name: None,
                         reasoning_content: None,
+                        anthropic_content_blocks: None,
                         cache_control: None,
                     },
                 )

--- a/crates/hermes-intelligence/src/auxiliary/builtins.rs
+++ b/crates/hermes-intelligence/src/auxiliary/builtins.rs
@@ -18,6 +18,7 @@ fn system(text: impl Into<String>) -> Message {
         tool_call_id: None,
         name: None,
         reasoning_content: None,
+        anthropic_content_blocks: None,
         cache_control: None,
     }
 }
@@ -30,6 +31,7 @@ fn user(text: impl Into<String>) -> Message {
         tool_call_id: None,
         name: None,
         reasoning_content: None,
+        anthropic_content_blocks: None,
         cache_control: None,
     }
 }

--- a/crates/hermes-intelligence/src/auxiliary/client.rs
+++ b/crates/hermes-intelligence/src/auxiliary/client.rs
@@ -497,6 +497,7 @@ mod tests {
                         tool_call_id: None,
                         name: None,
                         reasoning_content: None,
+                        anthropic_content_blocks: None,
                         cache_control: None,
                     },
                     finish_reason: Some("stop".into()),
@@ -533,6 +534,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            anthropic_content_blocks: None,
             cache_control: None,
         }
     }

--- a/crates/hermes-intelligence/src/redact.rs
+++ b/crates/hermes-intelligence/src/redact.rs
@@ -569,6 +569,7 @@ impl Redactor {
             tool_call_id: message.tool_call_id.clone(),
             name: message.name.clone(),
             reasoning_content: message.reasoning_content.as_ref().map(|c| self.redact(c)),
+            anthropic_content_blocks: message.anthropic_content_blocks.clone(),
             cache_control: message.cache_control.clone(),
         }
     }

--- a/crates/hermes-intelligence/src/rl.rs
+++ b/crates/hermes-intelligence/src/rl.rs
@@ -1060,6 +1060,7 @@ mod tests {
                     tool_call_id: None,
                     name: None,
                     reasoning_content: None,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 },
                 Message {
@@ -1076,6 +1077,7 @@ mod tests {
                     tool_call_id: None,
                     name: None,
                     reasoning_content: None,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 },
                 Message {
@@ -1085,6 +1087,7 @@ mod tests {
                     tool_call_id: Some("tc-1".to_string()),
                     name: None,
                     reasoning_content: None,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 },
                 Message {
@@ -1094,6 +1097,7 @@ mod tests {
                     tool_call_id: None,
                     name: None,
                     reasoning_content: None,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 },
             ],

--- a/crates/hermes-intelligence/src/title.rs
+++ b/crates/hermes-intelligence/src/title.rs
@@ -251,6 +251,7 @@ mod tests {
                     tool_call_id: None,
                     name: None,
                     reasoning_content: None,
+                    anthropic_content_blocks: None,
                     cache_control: None,
                 },
                 usage: None,

--- a/crates/hermes-tools/src/backends/web.rs
+++ b/crates/hermes-tools/src/backends/web.rs
@@ -7,6 +7,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::sync::OnceLock;
 use url::Url;
+use uuid::Uuid;
 
 use crate::tools::web::{WebCrawlBackend, WebExtractBackend, WebSearchBackend};
 use hermes_config::managed_gateway::{
@@ -49,6 +50,8 @@ impl WebSearchBackend for FallbackSearchBackend {
                  - EXA_API_KEY (https://exa.ai)\n\
                  - TAVILY_API_KEY (https://tavily.com)\n\
                  - FIRECRAWL_API_KEY or FIRECRAWL_API_URL (https://firecrawl.dev)\n\
+                 - PARALLEL_API_KEY with HERMES_WEB_SEARCH_BACKEND=parallel (https://parallel.ai)\n\
+                 - HERMES_WEB_SEARCH_BACKEND=parallel for keyless Parallel Search MCP\n\
                  - XAI_API_KEY with HERMES_WEB_SEARCH_BACKEND=xai (https://x.ai)\n\
                  - SERPER_API_KEY (https://serper.dev)\n\
                  - SEARXNG_BASE_URL or SEARXNG_URL (https://docs.searxng.org/dev/search_api.html)\n\
@@ -109,6 +112,16 @@ const TAVILY_BASE_URL_DEFAULT: &str = "https://api.tavily.com";
 const SEARXNG_SEARCH_PATH: &str = "/search";
 const BRAVE_SEARCH_URL_DEFAULT: &str = "https://api.search.brave.com/res/v1/web/search";
 const DDG_INSTANT_ANSWER_URL_DEFAULT: &str = "https://api.duckduckgo.com/";
+const PARALLEL_BASE_URL_DEFAULT: &str = "https://api.parallel.ai";
+const PARALLEL_MCP_SEARCH_URL_DEFAULT: &str = "https://search.parallel.ai/mcp";
+const PARALLEL_MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+const PARALLEL_MCP_CLIENT_NAME: &str = "mcp-web-client";
+const PARALLEL_MCP_CLIENT_VERSION: &str = "1.0.0";
+const PARALLEL_MCP_USER_AGENT: &str = "mcp-web-client/1.0.0";
+const PARALLEL_FREE_SEARCH_ATTRIBUTION: &str =
+    "Search powered by the free Parallel Web Search MCP (https://parallel.ai).";
+const PARALLEL_FREE_EXTRACT_ATTRIBUTION: &str =
+    "Extraction powered by the free Parallel Web Search MCP (https://parallel.ai).";
 const FIRECRAWL_BASE_URL_DEFAULT: &str = "https://api.firecrawl.dev";
 const XAI_BASE_URL_DEFAULT: &str = "https://api.x.ai/v1";
 const XAI_WEB_MODEL_DEFAULT: &str = "grok-4.3";
@@ -1173,17 +1186,566 @@ fn collect_duckduckgo_related(value: Option<&Value>, rows: &mut Vec<Value>) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ParallelWebBackend
+// ---------------------------------------------------------------------------
+
+/// Parallel.ai search/extract backend.
+///
+/// With `PARALLEL_API_KEY`, this uses Parallel's v1 REST endpoints. Without a
+/// key, it uses the hosted Search MCP endpoint with a neutral client identity.
+pub struct ParallelWebBackend {
+    client: Client,
+    api_key: Option<String>,
+    rest_base_url: String,
+    mcp_url: String,
+    search_mode: String,
+}
+
+impl ParallelWebBackend {
+    pub fn from_env() -> Self {
+        Self::with_endpoints(
+            env_optional_nonempty("PARALLEL_API_KEY"),
+            env_optional_nonempty("PARALLEL_BASE_URL")
+                .unwrap_or_else(|| PARALLEL_BASE_URL_DEFAULT.to_string()),
+            env_optional_nonempty("PARALLEL_MCP_URL")
+                .unwrap_or_else(|| PARALLEL_MCP_SEARCH_URL_DEFAULT.to_string()),
+            parallel_search_mode_from_env(),
+        )
+    }
+
+    fn with_endpoints(
+        api_key: Option<String>,
+        rest_base_url: String,
+        mcp_url: String,
+        search_mode: String,
+    ) -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .user_agent(PARALLEL_MCP_USER_AGENT)
+                .build()
+                .unwrap_or_else(|_| Client::new()),
+            api_key,
+            rest_base_url: rest_base_url.trim().trim_end_matches('/').to_string(),
+            mcp_url,
+            search_mode,
+        }
+    }
+
+    fn new_session_id() -> String {
+        format!("{}-{}", PARALLEL_MCP_CLIENT_NAME, Uuid::new_v4().simple())
+    }
+
+    async fn search_rest(
+        &self,
+        api_key: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<String, ToolError> {
+        let body = json!({
+            "search_queries": [query],
+            "objective": query,
+            "mode": self.search_mode,
+            "session_id": Self::new_session_id(),
+            "advanced_settings": {"max_results": limit.min(20)},
+        });
+        let data = self
+            .post_json(
+                &format!("{}/v1/search", self.rest_base_url),
+                Some(api_key),
+                &body,
+            )
+            .await?;
+        let formatted = normalize_parallel_search_results(&data, limit);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "provider": "parallel",
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
+    }
+
+    async fn search_mcp(&self, query: &str, limit: usize) -> Result<String, ToolError> {
+        let payload = self
+            .mcp_call(
+                "web_search",
+                json!({
+                    "objective": query,
+                    "search_queries": [query],
+                    "session_id": Self::new_session_id(),
+                }),
+            )
+            .await?;
+        let formatted = normalize_parallel_search_results(&payload, limit);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "provider": "parallel",
+            "attribution": PARALLEL_FREE_SEARCH_ATTRIBUTION,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
+    }
+
+    async fn extract_rest(&self, api_key: &str, url: &str) -> Result<String, ToolError> {
+        let body = json!({
+            "urls": [url],
+            "advanced_settings": {"full_content": true},
+            "session_id": Self::new_session_id(),
+        });
+        let data = self
+            .post_json(
+                &format!("{}/v1/extract", self.rest_base_url),
+                Some(api_key),
+                &body,
+            )
+            .await?;
+        let documents = normalize_parallel_extract_documents(&data, &[url]);
+        parallel_extract_response(url, documents, false)
+    }
+
+    async fn extract_mcp(&self, url: &str) -> Result<String, ToolError> {
+        let payload = self
+            .mcp_call(
+                "web_fetch",
+                json!({
+                    "urls": [url],
+                    "full_content": true,
+                    "session_id": Self::new_session_id(),
+                }),
+            )
+            .await?;
+        let documents = normalize_parallel_extract_documents(&payload, &[url]);
+        parallel_extract_response(url, documents, true)
+    }
+
+    async fn post_json(
+        &self,
+        endpoint: &str,
+        api_key: Option<&str>,
+        body: &Value,
+    ) -> Result<Value, ToolError> {
+        let mut req = self
+            .client
+            .post(endpoint)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(reqwest::header::USER_AGENT, PARALLEL_MCP_USER_AGENT)
+            .json(body);
+        if let Some(api_key) = api_key.filter(|v| !v.trim().is_empty()) {
+            req = req.bearer_auth(api_key);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Parallel request failed: {e}")))?;
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to read Parallel response: {e}"))
+        })?;
+        if !status.is_success() {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Parallel API error ({status}): {text}"
+            )));
+        }
+        serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to parse Parallel response: {e}"))
+        })
+    }
+
+    async fn mcp_call(&self, tool_name: &str, arguments: Value) -> Result<Value, ToolError> {
+        let init_id = Uuid::new_v4().to_string();
+        let init = self
+            .mcp_post(
+                None,
+                None,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": init_id,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": PARALLEL_MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": PARALLEL_MCP_CLIENT_NAME,
+                            "version": PARALLEL_MCP_CLIENT_VERSION,
+                        },
+                    },
+                }),
+            )
+            .await?;
+        let mcp_session_id = init
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        let init_text = init.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!(
+                "Failed to read Parallel MCP initialize response: {e}"
+            ))
+        })?;
+        let init_envelope = parallel_mcp_response_envelope(&init_text, &init_id);
+        let negotiated_version = init_envelope
+            .get("result")
+            .and_then(|v| v.get("protocolVersion"))
+            .and_then(Value::as_str)
+            .unwrap_or(PARALLEL_MCP_PROTOCOL_VERSION)
+            .to_string();
+
+        let _ = self
+            .mcp_post(
+                mcp_session_id.as_deref(),
+                Some(&negotiated_version),
+                &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+            )
+            .await?;
+
+        let call_id = Uuid::new_v4().to_string();
+        let call = self
+            .mcp_post(
+                mcp_session_id.as_deref(),
+                Some(&negotiated_version),
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": call_id,
+                    "method": "tools/call",
+                    "params": {"name": tool_name, "arguments": arguments},
+                }),
+            )
+            .await?;
+        let call_text = call.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to read Parallel MCP tool response: {e}"))
+        })?;
+        parallel_mcp_payload(&parallel_mcp_response_envelope(&call_text, &call_id))
+    }
+
+    async fn mcp_post(
+        &self,
+        mcp_session_id: Option<&str>,
+        protocol_version: Option<&str>,
+        body: &Value,
+    ) -> Result<reqwest::Response, ToolError> {
+        let mut req = self
+            .client
+            .post(&self.mcp_url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(
+                reqwest::header::ACCEPT,
+                "application/json, text/event-stream",
+            )
+            .header(reqwest::header::USER_AGENT, PARALLEL_MCP_USER_AGENT)
+            .json(body);
+        if let Some(session_id) = mcp_session_id.filter(|v| !v.trim().is_empty()) {
+            req = req.header("Mcp-Session-Id", session_id);
+        }
+        if let Some(version) = protocol_version.filter(|v| !v.trim().is_empty()) {
+            req = req.header("MCP-Protocol-Version", version);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Parallel MCP request failed: {e}")))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ToolError::ExecutionFailed(format!(
+                "Parallel MCP error ({status}): {text}"
+            )));
+        }
+        Ok(resp)
+    }
+}
+
+#[async_trait]
+impl WebSearchBackend for ParallelWebBackend {
+    async fn search(
+        &self,
+        query: &str,
+        num_results: usize,
+        _category: Option<&str>,
+    ) -> Result<String, ToolError> {
+        let limit = num_results.clamp(1, 100);
+        if let Some(api_key) = self.api_key.as_deref() {
+            self.search_rest(api_key, query, limit).await
+        } else {
+            self.search_mcp(query, limit).await
+        }
+    }
+}
+
+#[async_trait]
+impl WebExtractBackend for ParallelWebBackend {
+    async fn extract(&self, url: &str, _include_links: bool) -> Result<String, ToolError> {
+        validate_url_does_not_exfiltrate_secret(url)?;
+        if let Some(api_key) = self.api_key.as_deref() {
+            self.extract_rest(api_key, url).await
+        } else {
+            self.extract_mcp(url).await
+        }
+    }
+}
+
+fn parallel_search_mode_from_env() -> String {
+    match env_optional_nonempty("PARALLEL_SEARCH_MODE")
+        .unwrap_or_else(|| "advanced".to_string())
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "basic" | "fast" | "one-shot" => "basic".to_string(),
+        _ => "advanced".to_string(),
+    }
+}
+
+fn normalize_parallel_search_results(response: &Value, limit: usize) -> Vec<Value> {
+    let rows = response
+        .get("results")
+        .and_then(Value::as_array)
+        .or_else(|| response.pointer("/data/web").and_then(Value::as_array));
+    rows.map(|rows| {
+        rows.iter()
+            .take(limit)
+            .enumerate()
+            .map(|(idx, row)| {
+                let description = row
+                    .get("excerpts")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    })
+                    .filter(|v| !v.trim().is_empty())
+                    .or_else(|| {
+                        ["description", "snippet", "text", "content"]
+                            .iter()
+                            .find_map(|key| {
+                                row.get(*key).and_then(Value::as_str).map(str::to_string)
+                            })
+                    })
+                    .unwrap_or_default();
+                search_result(
+                    row.get("title").and_then(Value::as_str).unwrap_or(""),
+                    row.get("url").and_then(Value::as_str).unwrap_or(""),
+                    description,
+                    row.get("score").and_then(Value::as_f64),
+                    idx + 1,
+                )
+            })
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+fn normalize_parallel_extract_documents(response: &Value, requested_urls: &[&str]) -> Vec<Value> {
+    let mut rows = Vec::new();
+    if let Some(results) = response.get("results").and_then(Value::as_array) {
+        for item in results {
+            let url = item.get("url").and_then(Value::as_str).unwrap_or("");
+            let title = item.get("title").and_then(Value::as_str).unwrap_or("");
+            let content = item
+                .get("full_content")
+                .or_else(|| item.get("raw_content"))
+                .or_else(|| item.get("content"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| {
+                    item.get("excerpts").and_then(Value::as_array).map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .collect::<Vec<_>>()
+                            .join("\n\n")
+                    })
+                })
+                .unwrap_or_default();
+            rows.push(json!({
+                "url": url,
+                "title": title,
+                "content": content,
+                "raw_content": content,
+                "metadata": {"sourceURL": url, "title": title},
+            }));
+        }
+    }
+    if let Some(errors) = response.get("errors").and_then(Value::as_array) {
+        for item in errors {
+            let url = item.get("url").and_then(Value::as_str).unwrap_or("");
+            let error = item
+                .get("message")
+                .or_else(|| item.get("content"))
+                .or_else(|| item.get("error_type"))
+                .or_else(|| item.get("error"))
+                .and_then(Value::as_str)
+                .unwrap_or("extraction failed");
+            rows.push(json!({
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": error,
+                "metadata": {"sourceURL": url},
+            }));
+        }
+    }
+    if rows.is_empty() {
+        for url in requested_urls {
+            rows.push(json!({
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": "extraction failed (no content returned)",
+                "metadata": {"sourceURL": url},
+            }));
+        }
+    }
+    rows
+}
+
+fn parallel_extract_response(
+    url: &str,
+    documents: Vec<Value>,
+    free_mcp: bool,
+) -> Result<String, ToolError> {
+    let first_content = documents
+        .first()
+        .and_then(|d| d.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let mut response = json!({
+        "url": url,
+        "content": first_content,
+        "results": documents,
+        "provider": "parallel",
+    });
+    if free_mcp {
+        response["attribution"] = json!(PARALLEL_FREE_EXTRACT_ATTRIBUTION);
+    }
+    serde_json::to_string_pretty(&response)
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize result: {e}")))
+}
+
+fn flatten_parallel_mcp_message(payload: Value, out: &mut Vec<Value>) {
+    match payload {
+        Value::Array(items) => out.extend(items),
+        other => out.push(other),
+    }
+}
+
+fn parallel_mcp_messages(text: &str) -> Vec<Value> {
+    let body = text.trim();
+    if body.is_empty() {
+        return Vec::new();
+    }
+    if body.starts_with('{') || body.starts_with('[') {
+        let Ok(payload) = serde_json::from_str::<Value>(body) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        flatten_parallel_mcp_message(payload, &mut out);
+        return out;
+    }
+
+    let mut out = Vec::new();
+    let mut data_lines: Vec<String> = Vec::new();
+    for raw in body.lines() {
+        let line = raw.trim_end_matches('\r');
+        if let Some(data) = line.strip_prefix("data:") {
+            data_lines.push(data.trim_start().to_string());
+            continue;
+        }
+        if line.trim().is_empty() && !data_lines.is_empty() {
+            if let Ok(payload) = serde_json::from_str::<Value>(&data_lines.join("\n")) {
+                flatten_parallel_mcp_message(payload, &mut out);
+            }
+            data_lines.clear();
+        }
+    }
+    if !data_lines.is_empty() {
+        if let Ok(payload) = serde_json::from_str::<Value>(&data_lines.join("\n")) {
+            flatten_parallel_mcp_message(payload, &mut out);
+        }
+    }
+    out
+}
+
+fn parallel_mcp_response_envelope(text: &str, request_id: &str) -> Value {
+    let mut fallback = Value::Object(Default::default());
+    for msg in parallel_mcp_messages(text) {
+        let Some(obj) = msg.as_object() else {
+            continue;
+        };
+        if !(obj.contains_key("result") || obj.contains_key("error")) {
+            continue;
+        }
+        if msg.get("id").and_then(Value::as_str) == Some(request_id) {
+            return msg;
+        }
+        fallback = msg;
+    }
+    fallback
+}
+
+fn parallel_mcp_payload(envelope: &Value) -> Result<Value, ToolError> {
+    if let Some(error) = envelope.get("error") {
+        return Err(ToolError::ExecutionFailed(format!(
+            "Parallel MCP error: {}",
+            truncate_json_for_error(error)
+        )));
+    }
+    let result = envelope.get("result").cloned().unwrap_or_else(|| json!({}));
+    if result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(ToolError::ExecutionFailed(format!(
+            "Parallel MCP tool error: {}",
+            truncate_json_for_error(&result)
+        )));
+    }
+    if let Some(structured) = result.get("structuredContent").filter(|v| v.is_object()) {
+        return Ok(structured.clone());
+    }
+    if let Some(content) = result.get("content").and_then(Value::as_array) {
+        for block in content {
+            let text = block
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|v| !v.trim().is_empty());
+            if block.get("type").and_then(Value::as_str) == Some("text") {
+                if let Some(text) = text {
+                    if let Ok(parsed) = serde_json::from_str::<Value>(text) {
+                        return Ok(parsed);
+                    }
+                }
+            }
+        }
+    }
+    Err(ToolError::ExecutionFailed(format!(
+        "Parallel MCP returned no parseable content: {}",
+        truncate_json_for_error(&result)
+    )))
+}
+
+fn truncate_json_for_error(value: &Value) -> String {
+    let mut text = value.to_string();
+    if text.len() > 500 {
+        text.truncate(500);
+    }
+    text
+}
+
 /// Resolve preferred web-search backend from environment.
 ///
 /// Priority:
 /// 1. Explicit `HERMES_WEB_SEARCH_BACKEND` override, then legacy `HERMES_WEB_BACKEND`
-///    - `exa`, `tavily`, `firecrawl`, `xai`, `searxng`, `brave-free`, `ddgs`, `fallback`
+///    - `exa`, `tavily`, `parallel`, `firecrawl`, `xai`, `searxng`, `brave-free`, `ddgs`, `fallback`
 /// 2. Exa (`EXA_API_KEY`)
 /// 3. Tavily (`TAVILY_API_KEY`, optional `TAVILY_BASE_URL`)
-/// 4. Firecrawl (`FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL`, or managed gateway)
-/// 5. SearXNG (`SEARXNG_BASE_URL` or `SEARXNG_URL`)
-/// 6. Brave (`BRAVE_SEARCH_API_KEY`)
-/// 7. Keyless DDG fallback
+/// 4. Parallel REST (`PARALLEL_API_KEY`)
+/// 5. Firecrawl (`FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL`, or managed gateway)
+/// 6. SearXNG (`SEARXNG_BASE_URL` or `SEARXNG_URL`)
+/// 7. Brave (`BRAVE_SEARCH_API_KEY`)
+/// 8. Keyless Parallel Search MCP fallback
 pub fn search_backend_from_env_or_fallback() -> Box<dyn WebSearchBackend> {
     match search_backend_choice_from_env() {
         "exa" => ExaSearchBackend::from_env()
@@ -1192,6 +1754,7 @@ pub fn search_backend_from_env_or_fallback() -> Box<dyn WebSearchBackend> {
         "tavily" => TavilySearchBackend::from_env()
             .map(|b| Box::new(b) as Box<dyn WebSearchBackend>)
             .unwrap_or_else(|_| Box::new(FallbackSearchBackend::new())),
+        "parallel" => Box::new(ParallelWebBackend::from_env()),
         "firecrawl" => FirecrawlSearchBackend::from_env_or_managed()
             .map(|b| Box::new(b) as Box<dyn WebSearchBackend>)
             .unwrap_or_else(|_| Box::new(FallbackSearchBackend::new())),
@@ -1224,6 +1787,8 @@ fn search_backend_choice_from_env() -> &'static str {
         "exa"
     } else if env_present_nonempty("TAVILY_API_KEY") {
         "tavily"
+    } else if env_present_nonempty("PARALLEL_API_KEY") {
+        "parallel"
     } else if firecrawl_direct_config_present() || firecrawl_managed_config_present() {
         "firecrawl"
     } else if searxng_config_present() {
@@ -1231,7 +1796,7 @@ fn search_backend_choice_from_env() -> &'static str {
     } else if env_present_nonempty("BRAVE_SEARCH_API_KEY") {
         "brave-free"
     } else {
-        "ddgs"
+        "parallel"
     }
 }
 
@@ -1239,6 +1804,7 @@ fn normalize_search_backend_choice(choice: &str) -> Option<&'static str> {
     match choice.trim().to_ascii_lowercase().as_str() {
         "exa" => Some("exa"),
         "tavily" => Some("tavily"),
+        "parallel" => Some("parallel"),
         "firecrawl" => Some("firecrawl"),
         "xai" | "grok" => Some("xai"),
         "searxng" | "searx" => Some("searxng"),
@@ -1253,12 +1819,13 @@ fn normalize_search_backend_choice(choice: &str) -> Option<&'static str> {
 ///
 /// Priority:
 /// 1. Explicit `HERMES_WEB_EXTRACT_BACKEND` override, then legacy `HERMES_WEB_BACKEND`
-///    (`firecrawl`, `tavily`, `simple`; search-only backends return a clear error)
+///    (`parallel`, `firecrawl`, `tavily`, `simple`; search-only backends return a clear error)
 /// 2. Firecrawl direct/self-hosted/managed when configured
 /// 3. Tavily when configured
-/// 4. Simple local HTML fetch fallback
+/// 4. Parallel REST/MCP fallback
 pub fn extract_backend_from_env_or_fallback() -> Box<dyn WebExtractBackend> {
     match extract_backend_choice_from_env() {
+        "parallel" => Box::new(ParallelWebBackend::from_env()),
         "firecrawl" => FirecrawlExtractBackend::from_env_or_managed()
             .map(|b| Box::new(b) as Box<dyn WebExtractBackend>)
             .unwrap_or_else(|_| Box::new(SimpleExtractBackend::new())),
@@ -1277,6 +1844,7 @@ pub fn extract_backend_from_env_or_fallback() -> Box<dyn WebExtractBackend> {
 fn extract_backend_choice_from_env() -> &'static str {
     if let Ok(choice) = std::env::var("HERMES_WEB_EXTRACT_BACKEND") {
         match choice.trim().to_ascii_lowercase().as_str() {
+            "parallel" => return "parallel",
             "firecrawl" => return "firecrawl",
             "tavily" => return "tavily",
             "simple" | "fallback" | "local" | "none" | "off" | "disabled" => return "simple",
@@ -1287,6 +1855,7 @@ fn extract_backend_choice_from_env() -> &'static str {
         .and_then(|choice| normalize_search_backend_choice(&choice).map(str::to_string))
     {
         match choice.as_str() {
+            "parallel" => return "parallel",
             "firecrawl" => return "firecrawl",
             "tavily" => return "tavily",
             "brave-free" => return "search-only:brave-free",
@@ -1303,7 +1872,7 @@ fn extract_backend_choice_from_env() -> &'static str {
     } else if env_present_nonempty("TAVILY_API_KEY") {
         "tavily"
     } else {
-        "simple"
+        "parallel"
     }
 }
 
@@ -2065,6 +2634,10 @@ mod web_search_env_tests {
                 "TAVILY_BASE_URL",
                 "FIRECRAWL_API_KEY",
                 "FIRECRAWL_API_URL",
+                "PARALLEL_API_KEY",
+                "PARALLEL_BASE_URL",
+                "PARALLEL_MCP_URL",
+                "PARALLEL_SEARCH_MODE",
                 "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
                 "TOOL_GATEWAY_USER_TOKEN",
                 "TOOL_GATEWAY_DOMAIN",
@@ -2208,7 +2781,7 @@ mod web_search_env_tests {
     fn search_backend_choice_uses_xai_only_when_explicit() {
         let _scope = EnvScope::new();
         std::env::set_var("XAI_API_KEY", "xai-key");
-        assert_eq!(search_backend_choice_from_env(), "ddgs");
+        assert_eq!(search_backend_choice_from_env(), "parallel");
         std::env::set_var("HERMES_WEB_SEARCH_BACKEND", "xai");
         assert_eq!(search_backend_choice_from_env(), "xai");
     }
@@ -2248,9 +2821,23 @@ mod web_search_env_tests {
     }
 
     #[test]
-    fn search_backend_choice_uses_keyless_ddg_as_last_resort() {
+    fn search_backend_choice_uses_keyless_parallel_as_last_resort() {
         let _scope = EnvScope::new();
+        assert_eq!(search_backend_choice_from_env(), "parallel");
+    }
+
+    #[test]
+    fn search_backend_choice_accepts_explicit_ddg() {
+        let _scope = EnvScope::new();
+        std::env::set_var("HERMES_WEB_SEARCH_BACKEND", "ddgs");
         assert_eq!(search_backend_choice_from_env(), "ddgs");
+    }
+
+    #[test]
+    fn search_backend_choice_uses_parallel_key_when_present() {
+        let _scope = EnvScope::new();
+        std::env::set_var("PARALLEL_API_KEY", "parallel-key");
+        assert_eq!(search_backend_choice_from_env(), "parallel");
     }
 
     #[tokio::test]
@@ -2268,11 +2855,20 @@ mod web_search_env_tests {
     #[test]
     fn extract_backend_choice_prefers_firecrawl_then_tavily_then_simple() {
         let _scope = EnvScope::new();
-        assert_eq!(extract_backend_choice_from_env(), "simple");
+        assert_eq!(extract_backend_choice_from_env(), "parallel");
         std::env::set_var("TAVILY_API_KEY", "tavily-key");
         assert_eq!(extract_backend_choice_from_env(), "tavily");
         std::env::set_var("FIRECRAWL_API_KEY", "fire-key");
         assert_eq!(extract_backend_choice_from_env(), "firecrawl");
+    }
+
+    #[test]
+    fn extract_backend_choice_accepts_explicit_simple_and_parallel() {
+        let _scope = EnvScope::new();
+        std::env::set_var("HERMES_WEB_EXTRACT_BACKEND", "simple");
+        assert_eq!(extract_backend_choice_from_env(), "simple");
+        std::env::set_var("HERMES_WEB_EXTRACT_BACKEND", "parallel");
+        assert_eq!(extract_backend_choice_from_env(), "parallel");
     }
 
     #[test]
@@ -2390,6 +2986,170 @@ mod web_search_env_tests {
     }
 
     #[test]
+    fn parallel_search_mode_maps_legacy_values() {
+        let _scope = EnvScope::new();
+        std::env::set_var("PARALLEL_SEARCH_MODE", "fast");
+        assert_eq!(parallel_search_mode_from_env(), "basic");
+        std::env::set_var("PARALLEL_SEARCH_MODE", "agentic");
+        assert_eq!(parallel_search_mode_from_env(), "advanced");
+    }
+
+    #[test]
+    fn parallel_mcp_messages_parse_plain_json_and_sse() {
+        let plain = parallel_mcp_messages(
+            r#"[{"jsonrpc":"2.0","id":"a","result":{"ok":1}},{"method":"n"}]"#,
+        );
+        assert_eq!(plain.len(), 2);
+        assert_eq!(plain[0]["id"], "a");
+
+        let sse = parallel_mcp_response_envelope(
+            "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"noise\",\"result\":{\"skip\":true}}\n\n\
+             data: {\"jsonrpc\":\"2.0\",\"id\":\"target\",\"result\":{\"structuredContent\":{\"results\":[{\"url\":\"https://a.example\"}]}}}\n\n",
+            "target",
+        );
+        let payload = parallel_mcp_payload(&sse).expect("mcp payload");
+        assert_eq!(payload["results"][0]["url"], "https://a.example");
+    }
+
+    #[test]
+    fn parallel_normalizers_map_search_and_extract_shapes() {
+        let rows = normalize_parallel_search_results(
+            &json!({
+                "results": [
+                    {"url": "https://a.example", "title": "A", "excerpts": ["one", "two"]},
+                    {"url": "https://b.example", "title": "B", "description": "desc"}
+                ]
+            }),
+            1,
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["description"], "one two");
+        assert_eq!(rows[0]["position"], 1);
+
+        let docs = normalize_parallel_extract_documents(
+            &json!({
+                "results": [{"url": "https://a.example", "title": "A", "full_content": "body"}],
+                "errors": [{"url": "https://b.example", "message": "blocked"}]
+            }),
+            &["https://a.example"],
+        );
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0]["content"], "body");
+        assert_eq!(docs[1]["error"], "blocked");
+    }
+
+    #[tokio::test]
+    async fn parallel_keyless_mcp_search_uses_generic_client_identity() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/mcp"))
+            .and(header("user-agent", PARALLEL_MCP_USER_AGENT))
+            .and(body_partial_json(json!({
+                "method": "initialize",
+                "params": {"clientInfo": {"name": PARALLEL_MCP_CLIENT_NAME}},
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("mcp-session-id", "sess-1")
+                    .set_body_json(json!({
+                        "jsonrpc": "2.0",
+                        "id": "ignored-by-fallback",
+                        "result": {"protocolVersion": PARALLEL_MCP_PROTOCOL_VERSION},
+                    })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/mcp"))
+            .and(header("mcp-session-id", "sess-1"))
+            .and(header(
+                "mcp-protocol-version",
+                PARALLEL_MCP_PROTOCOL_VERSION,
+            ))
+            .and(body_partial_json(
+                json!({"method": "notifications/initialized"}),
+            ))
+            .respond_with(ResponseTemplate::new(202).set_body_string(""))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/mcp"))
+            .and(header("mcp-session-id", "sess-1"))
+            .and(body_partial_json(json!({
+                "method": "tools/call",
+                "params": {
+                    "name": "web_search",
+                    "arguments": {"objective": "rust async"},
+                },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "event: message\n\
+                 data: {\"jsonrpc\":\"2.0\",\"id\":\"fallback\",\"result\":{\"structuredContent\":{\"results\":[{\"url\":\"https://rust-lang.org\",\"title\":\"Rust\",\"excerpts\":[\"Language\"]}]}}}\n\n",
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = ParallelWebBackend::with_endpoints(
+            None,
+            PARALLEL_BASE_URL_DEFAULT.to_string(),
+            format!("{}/mcp", server.uri()),
+            "advanced".to_string(),
+        );
+        let out = backend
+            .search("rust async", 5, None)
+            .await
+            .expect("parallel keyless search");
+        let json: Value = serde_json::from_str(&out).expect("json output");
+        assert_eq!(json["provider"], "parallel");
+        assert_eq!(json["results"][0]["url"], "https://rust-lang.org");
+        assert_eq!(json["attribution"], PARALLEL_FREE_SEARCH_ATTRIBUTION);
+    }
+
+    #[tokio::test]
+    async fn parallel_keyed_rest_search_posts_v1_payload() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .and(header("authorization", "Bearer parallel-key"))
+            .and(body_partial_json(json!({
+                "search_queries": ["rust async"],
+                "objective": "rust async",
+                "mode": "basic",
+                "advanced_settings": {"max_results": 3},
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [{"url": "https://example.com", "title": "Example", "description": "desc"}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = ParallelWebBackend::with_endpoints(
+            Some("parallel-key".to_string()),
+            server.uri(),
+            PARALLEL_MCP_SEARCH_URL_DEFAULT.to_string(),
+            "basic".to_string(),
+        );
+        let out = backend
+            .search("rust async", 3, None)
+            .await
+            .expect("parallel keyed search");
+        let json: Value = serde_json::from_str(&out).expect("json output");
+        assert_eq!(json["provider"], "parallel");
+        assert_eq!(json["results"][0]["title"], "Example");
+        assert!(json.get("attribution").is_none());
+    }
+
+    #[test]
     fn xai_json_results_parse_and_renumber_valid_rows() {
         let rows = parse_xai_json_results(
             r#"prefix {"results":[{"title":"A","url":"","description":"drop"},{"title":"B","url":"https://b.example","description":"keep"}]} suffix"#,
@@ -2432,6 +3192,10 @@ mod firecrawl_managed_tests {
                 "HERMES_HOME",
                 "FIRECRAWL_API_KEY",
                 "FIRECRAWL_API_URL",
+                "PARALLEL_API_KEY",
+                "PARALLEL_BASE_URL",
+                "PARALLEL_MCP_URL",
+                "PARALLEL_SEARCH_MODE",
                 "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
                 "TOOL_GATEWAY_USER_TOKEN",
                 "TOOL_GATEWAY_DOMAIN",

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -113,6 +113,37 @@ pub const TOOLSET_RL_TRAINING: &[&str] = &[
     "rl_list_runs",
     "rl_test_inference",
 ];
+/// Lean coding posture tools.
+pub const TOOLSET_CODING: &[&str] = &[
+    "web_search",
+    "web_extract",
+    "terminal",
+    "process",
+    "read_file",
+    "write_file",
+    "patch",
+    "search_files",
+    "vision_analyze",
+    "skills_list",
+    "skill_view",
+    "skill_manage",
+    "browser_navigate",
+    "browser_snapshot",
+    "browser_click",
+    "browser_type",
+    "browser_scroll",
+    "browser_back",
+    "browser_press",
+    "browser_get_images",
+    "browser_vision",
+    "browser_console",
+    "todo",
+    "memory",
+    "session_search",
+    "clarify",
+    "execute_code",
+    "delegate_task",
+];
 
 // ---------------------------------------------------------------------------
 // Toolset
@@ -291,6 +322,10 @@ impl ToolsetManager {
             "rl_training",
             TOOLSET_RL_TRAINING.iter().map(|s| s.to_string()).collect(),
         ));
+        self.register(Toolset::new(
+            "coding",
+            TOOLSET_CODING.iter().map(|s| s.to_string()).collect(),
+        ));
 
         // Platform composite toolsets
         self.register(Toolset::with_includes(
@@ -339,6 +374,25 @@ impl ToolsetManager {
                 "cronjob",
                 "homeassistant",
                 "rl_training",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ));
+        self.register(Toolset::with_includes(
+            "hermes-acp",
+            vec![
+                "web",
+                "terminal",
+                "file",
+                "browser",
+                "vision",
+                "skills",
+                "memory",
+                "session_search",
+                "todo",
+                "code_execution",
+                "delegation",
             ]
             .into_iter()
             .map(String::from)
@@ -807,6 +861,77 @@ mod tests {
             assert!(
                 !tools.contains(&excluded.to_string()),
                 "hermes-api-server should exclude {excluded}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_coding_toolset_is_lean_pairing_surface() {
+        let manager = ToolsetManager::new(empty_registry());
+        let tools = manager.resolve_toolset_unfiltered("coding").unwrap();
+        for expected in [
+            "web_search",
+            "web_extract",
+            "terminal",
+            "process",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+            "skills_list",
+            "skill_view",
+            "skill_manage",
+            "todo",
+            "memory",
+            "session_search",
+            "clarify",
+            "execute_code",
+            "delegate_task",
+            "browser_navigate",
+            "browser_console",
+            "vision_analyze",
+        ] {
+            assert!(
+                tools.contains(&expected.to_string()),
+                "coding should include {expected}"
+            );
+        }
+        for excluded in [
+            "send_message",
+            "image_generate",
+            "video_generate",
+            "text_to_speech",
+            "spotify_playback",
+            "ha_call_service",
+            "cronjob",
+        ] {
+            assert!(
+                !tools.contains(&excluded.to_string()),
+                "coding should exclude {excluded}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_hermes_acp_toolset_is_registered() {
+        let manager = ToolsetManager::new(empty_registry());
+        let tools = manager.resolve_toolset_unfiltered("hermes-acp").unwrap();
+        for expected in [
+            "terminal",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+        ] {
+            assert!(
+                tools.contains(&expected.to_string()),
+                "hermes-acp should include {expected}"
+            );
+        }
+        for excluded in ["send_message", "text_to_speech", "cronjob"] {
+            assert!(
+                !tools.contains(&excluded.to_string()),
+                "hermes-acp should exclude {excluded}"
             );
         }
     }

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-11T00:12:34.113401+00:00`_
+_Generated from source artifacts: `2026-06-11T04:50:05.267928+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `d1383a6b1450c6c139720b1b01f8b99cc130453f`
 - Workstream snapshot generated: `2026-06-10T03:46:53-06:00`
 - Parity matrix generated: `2026-06-11T00:16:36.371426+00:00`
-- Queue snapshot generated: `2026-06-11T00:16:40.663763+00:00`
-- Proof snapshot generated: `2026-06-11T00:12:34.113401+00:00`
+- Queue snapshot generated: `2026-06-11T05:38:09.408147+00:00`
+- Proof snapshot generated: `2026-06-11T04:50:05.267928+00:00`
 
 ## Gate Status
 
@@ -23,10 +23,10 @@ _Generated from source artifacts: `2026-06-11T00:12:34.113401+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Tracked behavior rows | 384 |
-| Covered behavior rows | 384 |
+| Tracked behavior rows | 415 |
+| Covered behavior rows | 415 |
 | Tracked behavior coverage ratio | 1.0000 |
-| Rust test functions | 3423 |
+| Rust test functions | 3425 |
 | Missing Rust test refs | 0 |
 | Critical gaps | 0 |
 
@@ -45,10 +45,10 @@ _Generated from source artifacts: `2026-06-11T00:12:34.113401+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5497 |
+| Total commits in queue | 5522 |
 | Pending | 0 |
-| Ported | 249 |
-| Superseded | 5178 |
+| Ported | 262 |
+| Superseded | 5190 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-11T01:36:11.844835+00:00",
+  "generated_at_utc": "2026-06-11T05:38:20.593903+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -131,21 +131,21 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 70,
-      "ported": 249,
-      "superseded": 5178
+      "ported": 262,
+      "superseded": 5190
     },
     "by_target_ticket": {
-      "20": 2338,
+      "20": 2350,
       "21": 118,
-      "22": 837,
+      "22": 841,
       "23": 391,
       "24": 22,
       "25": 120,
-      "26": 1671
+      "26": 1680
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5497
+    "total_commits": 5522
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-11T01:36:11.844835+00:00`
+Generated: `2026-06-11T05:38:20.593903+00:00`
 
 ## Gate Status
 
@@ -58,13 +58,13 @@ Generated: `2026-06-11T01:36:11.844835+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5497`.
+- Upstream missing commits tracked: `5522`.
 - By target ticket:
-  - `#20`: `2338`
+  - `#20`: `2350`
   - `#21`: `118`
-  - `#22`: `837`
+  - `#22`: `841`
   - `#23`: `391`
   - `#24`: `22`
   - `#25`: `120`
-  - `#26`: `1671`
+  - `#26`: `1680`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1,5 +1,33 @@
 {
   "sha": {
+    "fe54960142d1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop React trigger-popover text wrapping has no matching Rust runtime file. Hermes Agent Ultra renders slash completions through the Rust Ratatui popup in crates/hermes-cli/src/tui.rs, so the TS/CSS truncation fix is superseded by the local TUI surface."
+    },
+    "3ffbdfbcc0dc": {
+      "disposition": "ported",
+      "notes": "Rust port covers the functional slash-command delta: TUI completions now use live App state for /handoff platforms and /tools enable|disable candidates, /personality completions list built-ins, and CLI slash /tools enable|disable persists tools_config plus refreshes active tool schemas. Upstream desktop registry/picker UI and Python tui_gateway context-manager changes are superseded by this Rust-only TUI/CLI/gateway architecture."
+    },
+    "e0e25717116c": {
+      "disposition": "ported",
+      "notes": "Rust web tools now support Parallel search/extract through crates/hermes-tools/src/backends/web.rs: keyed PARALLEL_API_KEY uses v1 REST /search and /extract payloads, keyless default uses the hosted Search MCP handshake, result normalization preserves local Rust tool shapes, and tests cover resolver priority, generic MCP identity, SSE/plain JSON parsing, and keyed REST payloads."
+    },
+    "0a5762c78d11": {
+      "disposition": "ported",
+      "notes": "Rust Parallel keyless Search MCP client uses the neutral mcp-web-client identity in User-Agent, clientInfo, and per-call session ids, matching upstream telemetry policy without third-party Hermes attribution."
+    },
+    "aaccaada282b": {
+      "disposition": "ported",
+      "notes": "Rust Anthropic provider now carries ordered signed thinking/tool_use content blocks in-memory on parsed responses and replays them before reconstructing from reasoning_content/tool_calls. Regression tests cover interleaved block preservation in parse_response and convert_messages."
+    },
+    "efcbbde48c38": {
+      "disposition": "ported",
+      "notes": "Rust keeps anthropic_content_blocks in-memory only on hermes_core::Message and deliberately does not persist them through SessionPersistence, matching upstream's final no-state-db-column decision while leaving fallback reconstruction for reloaded sessions."
+    },
+    "3e74f75e41ec": {
+      "disposition": "ported",
+      "notes": "Rust port implements upstream coding-context posture through crates/hermes-agent/src/coding_context.rs, AgentConfig/GatewayConfig agent.coding_context, prompt injection with workspace/verify facts, model-family edit-format guidance, prompt-only non-coding skill pruning, a lean coding toolset, ACP default toolset registration, and focus-mode platform tool collapse with live MCP inclusion. Tests cover detection, prompt gating, skill pruning, coding/hermes-acp toolsets, and platform focus behavior."
+    },
     "e9c47c70422d": {
       "disposition": "ported",
       "notes": "Rust CLI/TUI launch model overrides are represented by resolve_cli_chat_provider_model, apply_cli_chat_runtime_env, App::new startup resolution, and sync_runtime_model_env tests covering HERMES_MODEL/HERMES_INFERENCE_MODEL plus provider env synchronization."
@@ -3051,6 +3079,34 @@
     "d1383a6b1450": {
       "disposition": "ported",
       "notes": "Sibling skills touched by upstream now use HERMES_HOME-aware .env resolution or docs, while Hermes-specific skill text keeps the local Rust runtime framing."
+    },
+    "18d61bd06e06": {
+      "disposition": "ported",
+      "notes": "Upstream desktop composer draft persistence is ported into the Rust TUI as state-root backed per-session composer drafts that restore on restart, clear on submit, and stay separate from message persistence."
+    },
+    "3d14f01fd674": {
+      "disposition": "ported",
+      "notes": "Rust TUI composer drafts persist on actual input changes instead of conversation/session lifecycle, covering the upstream debounce/write-volume fix without adding a desktop React runtime."
+    },
+    "65ddc7c4a1dc": {
+      "disposition": "ported",
+      "notes": "Rust TUI composer drafts are scoped by session id and guarded from programmatic session history; this runtime has no desktop attachment composer to port."
+    },
+    "fdc0d1956636": {
+      "disposition": "ported",
+      "notes": "Rust TUI draft wiring restores at startup, clears on submit, and reloads after session-switching slash commands, matching the upstream draft lifecycle fix in the local composer surface."
+    },
+    "c710868fbca9": {
+      "disposition": "ported",
+      "notes": "Rust TUI draft storage is decoupled from App session lifecycle and message persistence; session reset/new session do not write unsent text into conversation state."
+    },
+    "292192f7d726": {
+      "disposition": "ported",
+      "notes": "Rust TUI composer draft helpers centralize load/save/clear behavior and keep best-effort IO warnings out of the typing path."
+    },
+    "d7d281fa37e4": {
+      "disposition": "ported",
+      "notes": "Strict per-thread drafts are implemented for the Rust TUI through per-session draft keys, MRU capped persistence, startup restore, submit clearing, and regression tests."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-11T00:16:40.663763+00:00`
+Generated: `2026-06-11T05:38:09.408147+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5497`.
+- Range: `main..upstream/main`; total commits tracked: `5522`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2338 |
+| #20 | GPAR-01 tests+CI parity | 2350 |
 | #21 | GPAR-02 skills parity | 118 |
-| #22 | GPAR-03 UX parity | 837 |
+| #22 | GPAR-03 UX parity | 841 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 391 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1671 |
+| #26 | GPAR-07 upstream queue backfill | 1680 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
-| ported | 249 |
-| superseded | 5178 |
+| ported | 262 |
+| superseded | 5190 |
 
 ## First 100 Pending Commits
 


### PR DESCRIPTION
## Summary
- port upstream slash registry/help wiring, Parallel web provider backend, and Anthropic ordered content block replay into the Rust runtime
- add Rust coding-context posture for CLI/TUI/ACP/desktop-style surfaces, including focus toolset behavior and ContextLattice-first coding guidance
- port the latest upstream desktop composer draft persistence intent into the Rust TUI as per-session state-root composer drafts
- regenerate parity queue/dashboard/proof with upstream/main pending count at 0

## Local verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json
- python3 scripts/generate-upstream-patch-queue.py --max-commits 0
- python3 scripts/generate-parity-dashboard.py
- python3 scripts/generate-global-parity-proof.py --check-ci --check-release
- python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --workspace
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --quiet