### PR TITLE
parity: classify upstream desktop stop recovery

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-11T04:50:05.267928+00:00`_
+_Generated from source artifacts: `2026-06-11T05:38:20.593903+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `d1383a6b1450c6c139720b1b01f8b99cc130453f`
 - Workstream snapshot generated: `2026-06-10T03:46:53-06:00`
 - Parity matrix generated: `2026-06-11T00:16:36.371426+00:00`
-- Queue snapshot generated: `2026-06-11T05:38:09.408147+00:00`
-- Proof snapshot generated: `2026-06-11T04:50:05.267928+00:00`
+- Queue snapshot generated: `2026-06-11T06:28:40.849305+00:00`
+- Proof snapshot generated: `2026-06-11T05:38:20.593903+00:00`
 
 ## Gate Status
 
@@ -45,10 +45,10 @@ _Generated from source artifacts: `2026-06-11T04:50:05.267928+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5522 |
+| Total commits in queue | 5526 |
 | Pending | 0 |
 | Ported | 262 |
-| Superseded | 5190 |
+| Superseded | 5194 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-11T05:38:20.593903+00:00",
+  "generated_at_utc": "2026-06-11T06:28:55.752916+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -132,20 +132,20 @@
     "by_disposition": {
       "mirrored": 70,
       "ported": 262,
-      "superseded": 5190
+      "superseded": 5194
     },
     "by_target_ticket": {
-      "20": 2350,
+      "20": 2352,
       "21": 118,
-      "22": 841,
+      "22": 842,
       "23": 391,
       "24": 22,
       "25": 120,
-      "26": 1680
+      "26": 1681
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5522
+    "total_commits": 5526
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-11T05:38:20.593903+00:00`
+Generated: `2026-06-11T06:28:55.752916+00:00`
 
 ## Gate Status
 
@@ -58,13 +58,13 @@ Generated: `2026-06-11T05:38:20.593903+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5522`.
+- Upstream missing commits tracked: `5526`.
 - By target ticket:
-  - `#20`: `2350`
+  - `#20`: `2352`
   - `#21`: `118`
-  - `#22`: `841`
+  - `#22`: `842`
   - `#23`: `391`
   - `#24`: `22`
   - `#25`: `120`
-  - `#26`: `1680`
+  - `#26`: `1681`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3107,6 +3107,10 @@
     "d7d281fa37e4": {
       "disposition": "ported",
       "notes": "Strict per-thread drafts are implemented for the Rust TUI through per-session draft keys, MRU capped persistence, startup restore, submit clearing, and regression tests."
+    },
+    "f38f7a387013": {
+      "disposition": "superseded",
+      "notes": "Desktop stale runtime session recovery for session.interrupt is superseded by Rust TUI/ACP interrupt architecture: active runs are in-process and keyed directly by the active session, with no desktop runtime-id versus stored-id split."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-11T05:38:09.408147+00:00`
+Generated: `2026-06-11T06:28:40.849305+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5522`.
+- Range: `main..upstream/main`; total commits tracked: `5526`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2350 |
+| #20 | GPAR-01 tests+CI parity | 2352 |
 | #21 | GPAR-02 skills parity | 118 |
-| #22 | GPAR-03 UX parity | 841 |
+| #22 | GPAR-03 UX parity | 842 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 391 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1680 |
+| #26 | GPAR-07 upstream queue backfill | 1681 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
 | ported | 262 |
-| superseded | 5190 |
+| superseded | 5194 |
 
 ## First 100 Pending Commits
 


### PR DESCRIPTION
## Summary
- classify upstream desktop stale-session stop recovery as superseded by Rust TUI/ACP in-process interrupt architecture
- regenerate upstream queue, dashboard, and global parity proof against latest upstream/main
- confirm upstream missing queue pending count is 0

## Local verification
- python3 scripts/generate-upstream-patch-queue.py --max-commits 0
- python3 scripts/generate-parity-dashboard.py
- python3 scripts/generate-global-parity-proof.py --check-ci --check-release
- jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json
- git diff --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree