### PR TITLE
release: cut v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-config"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "once_cell",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-11T05:38:20.593903+00:00`_
+_Generated from source artifacts: `2026-06-11T07:59:51.939256+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `d1383a6b1450c6c139720b1b01f8b99cc130453f`
-- Workstream snapshot generated: `2026-06-10T03:46:53-06:00`
-- Parity matrix generated: `2026-06-11T00:16:36.371426+00:00`
-- Queue snapshot generated: `2026-06-11T06:28:40.849305+00:00`
-- Proof snapshot generated: `2026-06-11T05:38:20.593903+00:00`
+- Upstream target: `upstream/main` @ `c94e93a6480f3cfdabe0624aac46f06670ffae36`
+- Workstream snapshot generated: `2026-06-11T00:30:29-06:00`
+- Parity matrix generated: `2026-06-11T07:58:56.105247+00:00`
+- Queue snapshot generated: `2026-06-11T07:59:43.043695+00:00`
+- Proof snapshot generated: `2026-06-11T07:59:51.939256+00:00`
 
 ## Gate Status
 
@@ -17,7 +17,7 @@ _Generated from source artifacts: `2026-06-11T05:38:20.593903+00:00`_
 - Test coverage audit: **PASS**
 - SOTA harness matrix: **PASS**
 - Release gate failures: none
-- CI gate failures: max_commits_behind (actual=5696.0, limit=5500); max_upstream_patch_missing (actual=5495.0, limit=5000)
+- CI gate failures: max_commits_behind (actual=5737.0, limit=5500); max_upstream_patch_missing (actual=5530.0, limit=5000)
 
 ## Test Coverage Audit
 
@@ -26,7 +26,7 @@ _Generated from source artifacts: `2026-06-11T05:38:20.593903+00:00`_
 | Tracked behavior rows | 415 |
 | Covered behavior rows | 415 |
 | Tracked behavior coverage ratio | 1.0000 |
-| Rust test functions | 3425 |
+| Rust test functions | 3452 |
 | Missing Rust test refs | 0 |
 | Critical gaps | 0 |
 
@@ -45,24 +45,24 @@ _Generated from source artifacts: `2026-06-11T05:38:20.593903+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5526 |
+| Total commits in queue | 5532 |
 | Pending | 0 |
 | Ported | 262 |
-| Superseded | 5194 |
+| Superseded | 5200 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 5696 |
-| commits_ahead | 1085 |
-| upstream_patch_missing | 5495 |
+| commits_behind | 5737 |
+| commits_ahead | 1090 |
+| upstream_patch_missing | 5530 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 886 |
-| files_only_upstream | 2253 |
-| files_only_local | 719 |
-| files_shared_identical | 1583 |
-| files_shared_different | 1122 |
+| local_patch_unique | 889 |
+| files_only_upstream | 2235 |
+| files_only_local | 727 |
+| files_shared_identical | 1635 |
+| files_shared_different | 1096 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-11T00:16:37.870037+00:00",
+  "generated_at_utc": "2026-06-11T07:59:40.937291+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-06-11T00:16:37.870037+00:00`
+Generated: `2026-06-11T07:59:40.937291+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-06-11T00:16:38.789710+00:00",
+  "generated_at_utc": "2026-06-11T07:59:41.948619+00:00",
   "items": [
     {
       "errors": [],
@@ -111,7 +111,7 @@
     {
       "errors": [],
       "id": "upstream-python-plugin-backend-drift-20260527",
-      "last_reviewed": "2026-05-27",
+      "last_reviewed": "2026-06-11",
       "matched_files": 10,
       "matched_sample": [
         "plugins/dashboard_auth/nous/__init__.py",
@@ -127,7 +127,7 @@
       ],
       "overdue": false,
       "owner": "sheawinkler",
-      "review_date": "2026-06-10",
+      "review_date": "2026-07-11",
       "status": "temporary",
       "ticket": 319,
       "warnings": []
@@ -185,10 +185,10 @@
   "summary": {
     "errors": 0,
     "items": 8,
-    "local_paths": 3424,
+    "local_paths": 3458,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 4958,
+    "upstream_paths": 4966,
     "warnings": 1
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,21 +2,21 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 5696.0,
+        "actual": 5737.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 5495.0,
+        "actual": 5530.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 2253.0,
+        "actual": 2235.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "pass"
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-11T06:28:55.752916+00:00",
+  "generated_at_utc": "2026-06-11T07:59:51.939256+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -108,16 +108,16 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 5696.0,
+    "max_commits_behind": 5737.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 2253.0,
+    "max_files_only_upstream": 2235.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
     "max_test_coverage_missing_rust_refs": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 5495.0,
+    "max_upstream_patch_missing": 5530.0,
     "min_sota_harness_domain_coverage_ratio": 1.0,
     "min_test_coverage_tracked_behavior_ratio": 1.0,
     "min_test_intent_mapping_ratio": 1.0
@@ -132,20 +132,20 @@
     "by_disposition": {
       "mirrored": 70,
       "ported": 262,
-      "superseded": 5194
+      "superseded": 5200
     },
     "by_target_ticket": {
-      "20": 2352,
+      "20": 2355,
       "21": 118,
       "22": 842,
       "23": 391,
       "24": 22,
       "25": 120,
-      "26": 1681
+      "26": 1684
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5526
+    "total_commits": 5532
   },
   "release_gate": {
     "checks": [
@@ -274,9 +274,9 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 5497,
-      "rust_test_files": 306,
-      "rust_test_functions": 3425,
+      "queue_total": 5532,
+      "rust_test_files": 307,
+      "rust_test_functions": 3452,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-11T06:28:55.752916+00:00`
+Generated: `2026-06-11T07:59:51.939256+00:00`
 
 ## Gate Status
 
@@ -13,9 +13,9 @@ Generated: `2026-06-11T06:28:55.752916+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 5696.0 |
-| `max_upstream_patch_missing` | 5495.0 |
-| `max_files_only_upstream` | 2253.0 |
+| `max_commits_behind` | 5737.0 |
+| `max_upstream_patch_missing` | 5530.0 |
+| `max_files_only_upstream` | 2235.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
@@ -58,13 +58,13 @@ Generated: `2026-06-11T06:28:55.752916+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5526`.
+- Upstream missing commits tracked: `5532`.
 - By target ticket:
-  - `#20`: `2352`
+  - `#20`: `2355`
   - `#21`: `118`
   - `#22`: `842`
   - `#23`: `391`
   - `#24`: `22`
   - `#25`: `120`
-  - `#26`: `1681`
+  - `#26`: `1684`
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-11T00:16:41.787507+00:00",
+  "generated_at_utc": "2026-06-11T07:59:51.940287+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",
@@ -17,23 +17,23 @@
   "summary": {
     "by_disposition": {
       "mirrored": 63,
-      "ported": 224,
-      "superseded": 3397
+      "ported": 230,
+      "superseded": 3413
     },
     "pass": true,
-    "total_commits": 3684,
+    "total_commits": 3706,
     "total_pending": 0
   },
   "ticket_breakdown": {
     "20": {
       "by_disposition": {
         "mirrored": 14,
-        "ported": 94,
-        "superseded": 2230
+        "ported": 100,
+        "superseded": 2241
       },
       "label": "GPAR-01 tests+CI parity",
       "pending": 0,
-      "total": 2338
+      "total": 2355
     },
     "21": {
       "by_disposition": {
@@ -49,11 +49,11 @@
       "by_disposition": {
         "mirrored": 21,
         "ported": 30,
-        "superseded": 786
+        "superseded": 791
       },
       "label": "GPAR-03 UX parity",
       "pending": 0,
-      "total": 837
+      "total": 842
     },
     "23": {
       "by_disposition": {

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,16 +1,16 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-06-11T00:16:41.787507+00:00`
+Generated: `2026-06-11T07:59:51.940287+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
-- Total scoped commits: `3684`
+- Total scoped commits: `3706`
 - Pending scoped commits: `0`
 - Gate: `PASS`
 
 | Ticket | Label | Total | Pending | Ported | Superseded |
 | ---: | --- | ---: | ---: | ---: | ---: |
-| #20 | GPAR-01 tests+CI parity | 2338 | 0 | 94 | 2230 |
+| #20 | GPAR-01 tests+CI parity | 2355 | 0 | 100 | 2241 |
 | #21 | GPAR-02 skills parity | 118 | 0 | 62 | 30 |
-| #22 | GPAR-03 UX parity | 837 | 0 | 30 | 786 |
+| #22 | GPAR-03 UX parity | 842 | 0 | 30 | 791 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 391 | 0 | 38 | 351 |
 

--- a/docs/parity/intentional-divergence.json
+++ b/docs/parity/intentional-divergence.json
@@ -86,9 +86,9 @@
       "summary": "Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes.",
       "owner": "sheawinkler",
       "ticket": 319,
-      "last_reviewed": "2026-05-27",
-      "review_date": "2026-06-10",
-      "rationale": "dashboard_auth/nous, image_gen/krea, and security-guidance were added upstream after this PR branch started. Importing or porting those Python plugin trees is unrelated to the focused #292/#293/#317 fixes and should be handled in a dedicated plugin parity slice.",
+      "last_reviewed": "2026-06-11",
+      "review_date": "2026-07-11",
+      "rationale": "dashboard_auth/nous, image_gen/krea, and security-guidance remain upstream-only Python plugin trees after the v0.18.0 release review. Hermes Ultra keeps runtime behavior Rust-native; these paths stay tracked for a dedicated plugin parity slice instead of being silently vendored.",
       "path_prefixes": [
         "plugins/dashboard_auth/nous/",
         "plugins/image_gen/krea/",

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,30 +1,30 @@
 {
-  "generated_at_utc": "2026-06-11T00:16:36.371426+00:00",
+  "generated_at_utc": "2026-06-11T07:58:56.105247+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "ddd78abaf6d10e7bb43008762607955a65ae3fe9",
+    "local_sha": "3f22ae8045d7b278e8a58c9c127124dd298ac39c",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "d1383a6b1450c6c139720b1b01f8b99cc130453f",
+    "upstream_sha": "c94e93a6480f3cfdabe0624aac46f06670ffae36",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 5696,
-    "commits_ahead": 1085,
-    "upstream_patch_missing": 5495,
+    "commits_behind": 5737,
+    "commits_ahead": 1090,
+    "upstream_patch_missing": 5530,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 886,
-    "files_only_upstream": 2253,
-    "files_only_local": 719,
-    "files_shared_identical": 1583,
-    "files_shared_different": 1122,
-    "tree_files_changed": 4020,
-    "tree_insertions": 971339,
-    "tree_deletions": 537641
+    "local_patch_unique": 889,
+    "files_only_upstream": 2235,
+    "files_only_local": 727,
+    "files_shared_identical": 1635,
+    "files_shared_different": 1096,
+    "tree_files_changed": 3984,
+    "tree_insertions": 966991,
+    "tree_deletions": 548686
   },
   "top_upstream_only": [
     {
       "path": "apps/desktop",
-      "count": 475
+      "count": 476
     },
     {
       "path": "website/i18n",
@@ -32,7 +32,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 135
+      "count": 136
     },
     {
       "path": "web/src",
@@ -40,7 +40,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 76
+      "count": 80
     },
     {
       "path": "tests/gateway",
@@ -72,7 +72,7 @@
     },
     {
       "path": "tests/plugins",
-      "count": 33
+      "count": 34
     },
     {
       "path": "ui-tui/src",
@@ -88,10 +88,6 @@
     },
     {
       "path": ".github/workflows",
-      "count": 17
-    },
-    {
-      "path": "plugins/platforms",
       "count": 17
     },
     {
@@ -143,10 +139,6 @@
       "count": 7
     },
     {
-      "path": "plugins/dashboard_auth",
-      "count": 6
-    },
-    {
       "path": "plugins/security-guidance",
       "count": 6
     },
@@ -180,6 +172,14 @@
     },
     {
       "path": "optional-skills/software-development",
+      "count": 3
+    },
+    {
+      "path": "plugins/platforms",
+      "count": 3
+    },
+    {
+      "path": "tests/hermes_state",
       "count": 3
     }
   ],
@@ -253,19 +253,7 @@
       "count": 7
     },
     {
-      "path": "optional-skills/creative",
-      "count": 6
-    },
-    {
-      "path": "optional-skills/productivity",
-      "count": 6
-    },
-    {
-      "path": "skills/github",
-      "count": 6
-    },
-    {
-      "path": "skills/productivity",
+      "path": "plugins/web",
       "count": 6
     },
     {
@@ -274,10 +262,6 @@
     },
     {
       "path": "plugins/teams_pipeline",
-      "count": 5
-    },
-    {
-      "path": "plugins/web",
       "count": 5
     },
     {
@@ -325,15 +309,11 @@
       "count": 3
     },
     {
-      "path": "skills/research",
+      "path": "skills/productivity",
       "count": 3
     },
     {
-      "path": "optional-skills/blockchain",
-      "count": 2
-    },
-    {
-      "path": "optional-skills/devops",
+      "path": "optional-skills/creative",
       "count": 2
     },
     {
@@ -342,6 +322,26 @@
     },
     {
       "path": "optional-skills/mlops",
+      "count": 2
+    },
+    {
+      "path": "plugins/disk-cleanup",
+      "count": 2
+    },
+    {
+      "path": "skills/autonomous-ai-agents",
+      "count": 2
+    },
+    {
+      "path": "skills/devops",
+      "count": 2
+    },
+    {
+      "path": "skills/research",
+      "count": 2
+    },
+    {
+      "path": "tests/e2e",
       "count": 2
     }
   ],
@@ -352,7 +352,7 @@
     },
     {
       "path": "crates/hermes-agent",
-      "count": 53
+      "count": 54
     },
     {
       "path": "crates/hermes-gateway",
@@ -360,27 +360,27 @@
     },
     {
       "path": "crates/hermes-cli",
-      "count": 45
+      "count": 46
+    },
+    {
+      "path": "docs/parity",
+      "count": 44
     },
     {
       "path": "skills/creative",
       "count": 44
     },
     {
-      "path": "docs/parity",
-      "count": 42
-    },
-    {
       "path": "crates/hermes-intelligence",
       "count": 37
     },
     {
-      "path": "website/docs",
-      "count": 21
+      "path": "crates/hermes-parity-tests",
+      "count": 23
     },
     {
-      "path": "crates/hermes-parity-tests",
-      "count": 19
+      "path": "website/docs",
+      "count": 21
     },
     {
       "path": "crates/hermes-config",
@@ -510,7 +510,7 @@
   "top_missing_from_local": [
     {
       "path": "apps/desktop",
-      "count": 475
+      "count": 476
     },
     {
       "path": "website/i18n",
@@ -518,7 +518,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 135
+      "count": 136
     },
     {
       "path": "web/src",
@@ -526,7 +526,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 76
+      "count": 80
     },
     {
       "path": "tests/gateway",
@@ -558,7 +558,7 @@
     },
     {
       "path": "tests/plugins",
-      "count": 33
+      "count": 34
     },
     {
       "path": "ui-tui/src",
@@ -574,10 +574,6 @@
     },
     {
       "path": ".github/workflows",
-      "count": 17
-    },
-    {
-      "path": "plugins/platforms",
       "count": 17
     },
     {
@@ -629,10 +625,6 @@
       "count": 7
     },
     {
-      "path": "plugins/dashboard_auth",
-      "count": 6
-    },
-    {
       "path": "plugins/security-guidance",
       "count": 6
     },
@@ -667,6 +659,14 @@
     {
       "path": "optional-skills/software-development",
       "count": 3
+    },
+    {
+      "path": "plugins/platforms",
+      "count": 3
+    },
+    {
+      "path": "tests/hermes_state",
+      "count": 3
     }
   ],
   "top_unique_to_local": [
@@ -676,7 +676,7 @@
     },
     {
       "path": "crates/hermes-agent",
-      "count": 53
+      "count": 54
     },
     {
       "path": "crates/hermes-gateway",
@@ -684,27 +684,27 @@
     },
     {
       "path": "crates/hermes-cli",
-      "count": 45
+      "count": 46
+    },
+    {
+      "path": "docs/parity",
+      "count": 44
     },
     {
       "path": "skills/creative",
       "count": 44
     },
     {
-      "path": "docs/parity",
-      "count": 42
-    },
-    {
       "path": "crates/hermes-intelligence",
       "count": 37
     },
     {
-      "path": "website/docs",
-      "count": 21
+      "path": "crates/hermes-parity-tests",
+      "count": 23
     },
     {
-      "path": "crates/hermes-parity-tests",
-      "count": 19
+      "path": "website/docs",
+      "count": 21
     },
     {
       "path": "crates/hermes-config",
@@ -836,7 +836,7 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 486,
+      "upstream_only": 492,
       "shared_different": 719,
       "local_only": 34,
       "risk": "critical",
@@ -846,9 +846,9 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 959,
+      "upstream_only": 961,
       "shared_different": 12,
-      "local_only": 209,
+      "local_only": 213,
       "risk": "high",
       "effort": "XL"
     },
@@ -856,9 +856,9 @@
       "workstream": "WS5",
       "issue": 9,
       "name": "UX parity",
-      "upstream_only": 531,
+      "upstream_only": 527,
       "shared_different": 267,
-      "local_only": 102,
+      "local_only": 104,
       "risk": "high",
       "effort": "XL"
     },
@@ -866,8 +866,8 @@
       "workstream": "WS3",
       "issue": 7,
       "name": "Tools and adapters parity",
-      "upstream_only": 138,
-      "shared_different": 70,
+      "upstream_only": 116,
+      "shared_different": 71,
       "local_only": 120,
       "risk": "high",
       "effort": "L"
@@ -877,10 +877,10 @@
       "issue": 8,
       "name": "Skills parity",
       "upstream_only": 72,
-      "shared_different": 54,
+      "shared_different": 27,
       "local_only": 94,
       "risk": "medium",
-      "effort": "L"
+      "effort": "M"
     },
     {
       "workstream": "WS2",
@@ -888,7 +888,7 @@
       "name": "Core runtime parity",
       "upstream_only": 67,
       "shared_different": 0,
-      "local_only": 155,
+      "local_only": 157,
       "risk": "critical",
       "effort": "M"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 5495,
+    "upstream_patch_missing": 5530,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 886,
+    "local_patch_unique": 889,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",
@@ -960,7 +960,7 @@
       "6b69de4772eac5f982c097553dc6bcfeb60350e6"
     ],
     "intentional_divergence_items": 8,
-    "intentional_divergence_covered_files": 1062
+    "intentional_divergence_covered_files": 1035
   },
   "intentional_divergence": [
     {
@@ -1005,11 +1005,9 @@
       "status": "approved",
       "workstream": "WS4",
       "summary": "Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring).",
-      "matched_files": 220,
+      "matched_files": 193,
       "matched_sample": [
         "optional-skills/autonomous-ai-agents/honcho/SKILL.md",
-        "optional-skills/blockchain/hyperliquid/SKILL.md",
-        "optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py",
         "optional-skills/creative/DESCRIPTION.md",
         "optional-skills/creative/baoyu-article-illustrator/references/styles.md",
         "optional-skills/creative/baoyu-comic/PORT_NOTES.md",
@@ -1026,7 +1024,9 @@
         "optional-skills/creative/baoyu-comic/references/character-template.md",
         "optional-skills/creative/baoyu-comic/references/layouts/cinematic.md",
         "optional-skills/creative/baoyu-comic/references/layouts/dense.md",
-        "optional-skills/creative/baoyu-comic/references/layouts/four-panel.md"
+        "optional-skills/creative/baoyu-comic/references/layouts/four-panel.md",
+        "optional-skills/creative/baoyu-comic/references/layouts/mixed.md",
+        "optional-skills/creative/baoyu-comic/references/layouts/splash.md"
       ]
     },
     {

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,39 +1,39 @@
 # Parity Matrix
 
-Generated: `2026-06-11T00:16:36.371426+00:00`
+Generated: `2026-06-11T07:58:56.105247+00:00`
 
 ## Scope
 
-- Local ref: `main` (`ddd78abaf6d10e7bb43008762607955a65ae3fe9`)
-- Upstream ref: `upstream/main` (`d1383a6b1450c6c139720b1b01f8b99cc130453f`)
+- Local ref: `main` (`3f22ae8045d7b278e8a58c9c127124dd298ac39c`)
+- Upstream ref: `upstream/main` (`c94e93a6480f3cfdabe0624aac46f06670ffae36`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 5696 |
-| Commits ahead local (`local` ancestry only) | 1085 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5495 |
+| Commits behind local (`upstream` ancestry only) | 5737 |
+| Commits ahead local (`local` ancestry only) | 1090 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5530 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 886 |
-| Files only in upstream tree | 2253 |
-| Files only in local tree | 719 |
-| Shared files identical content | 1583 |
-| Shared files different content | 1122 |
-| Total files changed (`local` vs `upstream`) | 4020 |
-| Insertions (`local` vs `upstream`) | 971339 |
-| Deletions (`local` vs `upstream`) | 537641 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 889 |
+| Files only in upstream tree | 2235 |
+| Files only in local tree | 727 |
+| Shared files identical content | 1635 |
+| Shared files different content | 1096 |
+| Total files changed (`local` vs `upstream`) | 3984 |
+| Insertions (`local` vs `upstream`) | 966991 |
+| Deletions (`local` vs `upstream`) | 548686 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
-| `apps/desktop` | 475 |
+| `apps/desktop` | 476 |
 | `website/i18n` | 315 |
-| `tests/hermes_cli` | 135 |
+| `tests/hermes_cli` | 136 |
 | `web/src` | 91 |
-| `tests/agent` | 76 |
+| `tests/agent` | 80 |
 | `tests/gateway` | 68 |
 | `tests/tools` | 48 |
 | `website/docs` | 47 |
@@ -41,12 +41,11 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 | `gateway/platforms` | 39 |
 | `hermes_cli/subcommands` | 39 |
 | `apps/bootstrap-installer` | 35 |
-| `tests/plugins` | 33 |
+| `tests/plugins` | 34 |
 | `ui-tui/src` | 32 |
 | `tests/run_agent` | 24 |
 | `tests/cli` | 23 |
 | `.github/workflows` | 17 |
-| `plugins/platforms` | 17 |
 | `tests/docker` | 13 |
 | `website/static` | 13 |
 | `agent/lsp` | 11 |
@@ -59,7 +58,6 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 | `docker/s6-rc.d` | 9 |
 | `optional-skills/security` | 9 |
 | `hermes_cli/proxy` | 7 |
-| `plugins/dashboard_auth` | 6 |
 | `plugins/security-guidance` | 6 |
 | `tools/computer_use` | 6 |
 | `.github/pr-screenshots` | 5 |
@@ -69,6 +67,8 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 | `tests/acp` | 4 |
 | `optional-skills/gaming` | 3 |
 | `optional-skills/software-development` | 3 |
+| `plugins/platforms` | 3 |
+| `tests/hermes_state` | 3 |
 
 ## Top 40 shared-different buckets
 
@@ -91,13 +91,9 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 | `plugins/platforms` | 10 |
 | `tests/acp` | 8 |
 | `tests/skills` | 7 |
-| `optional-skills/creative` | 6 |
-| `optional-skills/productivity` | 6 |
-| `skills/github` | 6 |
-| `skills/productivity` | 6 |
+| `plugins/web` | 6 |
 | `skills/software-development` | 6 |
 | `plugins/teams_pipeline` | 5 |
-| `plugins/web` | 5 |
 | `tests/honcho_plugin` | 5 |
 | `tests/stress` | 5 |
 | `tests/tui_gateway` | 5 |
@@ -109,25 +105,29 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 | `plugins/browser` | 3 |
 | `plugins/kanban` | 3 |
 | `plugins/video_gen` | 3 |
-| `skills/research` | 3 |
-| `optional-skills/blockchain` | 2 |
-| `optional-skills/devops` | 2 |
+| `skills/productivity` | 3 |
+| `optional-skills/creative` | 2 |
 | `optional-skills/health` | 2 |
 | `optional-skills/mlops` | 2 |
+| `plugins/disk-cleanup` | 2 |
+| `skills/autonomous-ai-agents` | 2 |
+| `skills/devops` | 2 |
+| `skills/research` | 2 |
+| `tests/e2e` | 2 |
 
 ## Top 40 local-only buckets
 
 | Bucket | Files |
 | --- | ---: |
 | `crates/hermes-tools` | 92 |
-| `crates/hermes-agent` | 53 |
+| `crates/hermes-agent` | 54 |
 | `crates/hermes-gateway` | 50 |
-| `crates/hermes-cli` | 45 |
+| `crates/hermes-cli` | 46 |
+| `docs/parity` | 44 |
 | `skills/creative` | 44 |
-| `docs/parity` | 42 |
 | `crates/hermes-intelligence` | 37 |
+| `crates/hermes-parity-tests` | 23 |
 | `website/docs` | 21 |
-| `crates/hermes-parity-tests` | 19 |
 | `crates/hermes-config` | 18 |
 | `crates/hermes-core` | 17 |
 | `crates/hermes-eval` | 15 |
@@ -164,20 +164,20 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 486 | 719 | critical | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 959 | 12 | high | XL |
-| `WS5` | #9 | UX parity | 531 | 267 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 138 | 70 | high | L |
-| `WS4` | #8 | Skills parity | 72 | 54 | medium | L |
+| `WS6` | #10 | Tests and CI parity | 492 | 719 | critical | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 961 | 12 | high | XL |
+| `WS5` | #9 | UX parity | 527 | 267 | high | XL |
+| `WS3` | #7 | Tools and adapters parity | 116 | 71 | high | L |
+| `WS4` | #8 | Skills parity | 72 | 27 | medium | M |
 | `WS2` | #6 | Core runtime parity | 67 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `5495`
+- Upstream missing by patch-id: `5530`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `886`
-- Intentional divergence tracked items: `8` (covered files: `1062`)
+- Local unique by patch-id: `889`
+- Intentional divergence tracked items: `8` (covered files: `1035`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -187,7 +187,7 @@ Generated: `2026-06-11T00:16:36.371426+00:00`
 | `ultra-contextlattice-memory-plugin` | approved | WS3 | 2 | Keep ContextLattice native memory plugin and provider discovery in the Rust agent runtime. |
 | `ultra-webhook-queue-backends` | approved | WS7 | 4 | Preserve webhook-driven sync queue worker architecture with sqlite, SQS, and Kafka support. |
 | `ultra-launchd-webhook-lifecycle` | approved | WS7 | 4 | Preserve launchd-based interactive dev lifecycle management for webhook listener and worker. |
-| `rust-skills-catalog-governance` | approved | WS4 | 220 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
+| `rust-skills-catalog-governance` | approved | WS4 | 193 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
 | `rust-gateway-platform-plugin-parity` | approved | WS3 | 5 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
 | `upstream-python-plugin-backend-drift-20260527` | temporary | WS3 | 10 | Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes. |
 | `upstream-s6-plan-doc-archive` | approved | WS7 | 0 | Do not import upstream implementation-plan archive documents unless they change local runtime or release behavior. |

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3111,6 +3111,10 @@
     "f38f7a387013": {
       "disposition": "superseded",
       "notes": "Desktop stale runtime session recovery for session.interrupt is superseded by Rust TUI/ACP interrupt architecture: active runs are in-process and keyed directly by the active session, with no desktop runtime-id versus stored-id split."
+    },
+    "04b3f195380f": {
+      "disposition": "superseded",
+      "notes": "Upstream session archive propagation targets Python hermes_state.py archived rows plus Electron sidebar archive UI. Hermes Agent Ultra has no Rust session-archive column or setSessionArchived surface; the Rust session_search backend already projects compression roots to their continuation tip, and CLI session deletion operates on saved JSON snapshots rather than soft-archiving SQLite rows."
     }
   },
   "subject_patterns": [

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -4,19 +4,19 @@
       "kind": "nonzero_tree_drift",
       "message": "max_commits_behind remains nonzero in parity matrix",
       "metric": "max_commits_behind",
-      "value": 5696.0
+      "value": 5737.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_upstream_patch_missing remains nonzero in parity matrix",
       "metric": "max_upstream_patch_missing",
-      "value": 5495.0
+      "value": 5530.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 2253.0
+      "value": 2235.0
     }
   ],
   "audit_gate": {
@@ -61,7 +61,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-11T01:36:01.212066+00:00",
+  "generated_at_utc": "2026-06-11T07:59:41.324519+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -257,7 +257,7 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 45,
+      "direct_test_evidence_count": 46,
       "direct_test_evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -265,6 +265,7 @@
         "crates/hermes-agent/src/bedrock.rs",
         "crates/hermes-agent/src/budget.rs",
         "crates/hermes-agent/src/code_index.rs",
+        "crates/hermes-agent/src/coding_context.rs",
         "crates/hermes-agent/src/compression.rs",
         "crates/hermes-agent/src/context.rs",
         "crates/hermes-agent/src/context_files.rs",
@@ -282,10 +283,9 @@
         "crates/hermes-agent/src/memory_plugins/honcho.rs",
         "crates/hermes-agent/src/memory_plugins/mem0.rs",
         "crates/hermes-agent/src/memory_plugins/openviking.rs",
-        "crates/hermes-agent/src/memory_plugins/retaindb.rs",
-        "crates/hermes-agent/src/memory_plugins/supermemory.rs"
+        "crates/hermes-agent/src/memory_plugins/retaindb.rs"
       ],
-      "evidence_count": 49,
+      "evidence_count": 50,
       "evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -293,6 +293,7 @@
         "crates/hermes-agent/src/bedrock.rs",
         "crates/hermes-agent/src/budget.rs",
         "crates/hermes-agent/src/code_index.rs",
+        "crates/hermes-agent/src/coding_context.rs",
         "crates/hermes-agent/src/compression.rs",
         "crates/hermes-agent/src/context.rs",
         "crates/hermes-agent/src/context_files.rs",
@@ -310,8 +311,7 @@
         "crates/hermes-agent/src/memory_plugins/hindsight.rs",
         "crates/hermes-agent/src/memory_plugins/holographic.rs",
         "crates/hermes-agent/src/memory_plugins/honcho.rs",
-        "crates/hermes-agent/src/memory_plugins/mem0.rs",
-        "crates/hermes-agent/src/memory_plugins/mod.rs"
+        "crates/hermes-agent/src/memory_plugins/mem0.rs"
       ],
       "id": "agent-loop-and-runtime",
       "mapped": true,
@@ -545,9 +545,9 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 5497,
-    "rust_test_files": 306,
-    "rust_test_functions": 3425,
+    "queue_total": 5532,
+    "rust_test_files": 307,
+    "rust_test_functions": 3452,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-11T01:36:01.212066+00:00`
+Generated: `2026-06-11T07:59:41.324519+00:00`
 
 ## Gate
 
@@ -15,13 +15,13 @@ Generated: `2026-06-11T01:36:01.212066+00:00`
 | `tracked_behavior_rows` | 415 |
 | `covered_behavior_rows` | 415 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
-| `rust_test_files` | 306 |
-| `rust_test_functions` | 3425 |
+| `rust_test_files` | 307 |
+| `rust_test_functions` | 3452 |
 | `coverage_manifest_entries` | 405 |
 | `coverage_manifest_entries_with_valid_rust_tests` | 405 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 5497 |
+| `queue_total` | 5532 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 
@@ -40,7 +40,7 @@ Generated: `2026-06-11T01:36:01.212066+00:00`
 | `gateway-platform-behavior` | `direct_rust_test` | 25 | 22 |
 | `tool-runtime-behavior` | `direct_rust_test` | 91 | 82 |
 | `cli-command-surface` | `direct_rust_test` | 40 | 25 |
-| `agent-loop-and-runtime` | `direct_rust_test` | 49 | 45 |
+| `agent-loop-and-runtime` | `direct_rust_test` | 50 | 46 |
 | `acp-protocol-and-transport` | `direct_rust_test` | 9 | 8 |
 | `skills-management-contract` | `direct_rust_test` | 10 | 9 |
 | `cron-and-scheduler-runtime` | `direct_rust_test` | 9 | 6 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-11T00:16:37.451744+00:00",
+  "generated_at_utc": "2026-06-11T07:59:40.943739+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {
@@ -111,7 +111,7 @@
       ]
     },
     {
-      "evidence_count": 49,
+      "evidence_count": 50,
       "evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -119,6 +119,7 @@
         "crates/hermes-agent/src/bedrock.rs",
         "crates/hermes-agent/src/budget.rs",
         "crates/hermes-agent/src/code_index.rs",
+        "crates/hermes-agent/src/coding_context.rs",
         "crates/hermes-agent/src/compression.rs",
         "crates/hermes-agent/src/context.rs",
         "crates/hermes-agent/src/context_files.rs",
@@ -136,8 +137,7 @@
         "crates/hermes-agent/src/memory_plugins/hindsight.rs",
         "crates/hermes-agent/src/memory_plugins/holographic.rs",
         "crates/hermes-agent/src/memory_plugins/honcho.rs",
-        "crates/hermes-agent/src/memory_plugins/mem0.rs",
-        "crates/hermes-agent/src/memory_plugins/mod.rs"
+        "crates/hermes-agent/src/memory_plugins/mem0.rs"
       ],
       "id": "agent-loop-and-runtime",
       "mapped": true,

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,13 +1,13 @@
 # Test Intent Mapping
 
-Generated: `2026-06-11T00:16:37.451744+00:00`
+Generated: `2026-06-11T07:59:40.943739+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |
 | `gateway-platform-behavior` | yes | 25 |
 | `tool-runtime-behavior` | yes | 91 |
 | `cli-command-surface` | yes | 40 |
-| `agent-loop-and-runtime` | yes | 49 |
+| `agent-loop-and-runtime` | yes | 50 |
 | `acp-protocol-and-transport` | yes | 9 |
 | `skills-management-contract` | yes | 10 |
 | `cron-and-scheduler-runtime` | yes | 9 |

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-11T06:28:40.849305+00:00`
+Generated: `2026-06-11T07:59:43.043695+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5526`.
+- Range: `main..upstream/main`; total commits tracked: `5532`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2352 |
+| #20 | GPAR-01 tests+CI parity | 2355 |
 | #21 | GPAR-02 skills parity | 118 |
 | #22 | GPAR-03 UX parity | 842 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 391 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1681 |
+| #26 | GPAR-07 upstream queue backfill | 1684 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
 | ported | 262 |
-| superseded | 5194 |
+| superseded | 5200 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-06-10T03:46:53-06:00",
-  "head_sha": "ddd78abaf6d10e7bb43008762607955a65ae3fe9",
+  "generated_at_utc": "2026-06-11T00:30:29-06:00",
+  "head_sha": "3f22ae8045d7b278e8a58c9c127124dd298ac39c",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "d1383a6b1450c6c139720b1b01f8b99cc130453f",
+  "upstream_sha": "c94e93a6480f3cfdabe0624aac46f06670ffae36",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `ddd78abaf6d10e7bb43008762607955a65ae3fe9`
-- Upstream: `upstream/main` (`d1383a6b1450c6c139720b1b01f8b99cc130453f`)
+- Local HEAD: `3f22ae8045d7b278e8a58c9c127124dd298ac39c`
+- Upstream: `upstream/main` (`c94e93a6480f3cfdabe0624aac46f06670ffae36`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/docs/releases/v0.18.0.md
+++ b/docs/releases/v0.18.0.md
@@ -1,0 +1,82 @@
+# Hermes Agent Ultra v0.18.0
+
+Release date: 2026-06-11
+
+This release publishes the post-`v0.17.0` parity and harness hardening slice on `main`: the upstream queue is closed again against `upstream/main` at `c94e93a6480f3cfdabe0624aac46f06670ffae36`, the release and CI/tree-drift gates pass, and the Rust runtime now owns the newly applicable upstream coding, slash/provider, content replay, and composer-draft behavior.
+
+## Release Slice
+
+```mermaid
+flowchart LR
+    A[v0.17.0 release] --> B[Test coverage audit gate]
+    B --> C[SOTA harness matrix]
+    C --> D[Coding context + provider parity]
+    D --> E[Rust TUI draft persistence]
+    E --> F[Queue regeneration + current upstream classifications]
+    F --> G[0 pending upstream queue rows]
+    G --> H[v0.18.0 release]
+```
+
+| Signal | v0.18.0 State |
+| --- | ---: |
+| Implementation first-parent commits since `v0.17.0` before release prep | 4 |
+| Files changed since `v0.17.0` | 133 |
+| Diff since `v0.17.0` | 25,278 insertions / 2,748 deletions |
+| Upstream queue total | 5,532 |
+| Queue dispositions | 262 ported / 5,200 superseded / 70 mirrored / 0 pending |
+| Test coverage audit | PASS |
+| Test coverage tracked behavior ratio | 1.0 |
+| Test coverage missing Rust refs | 0 |
+| SOTA harness matrix | PASS |
+| SOTA harness domain coverage ratio | 1.0 |
+| Global release gate | PASS |
+| Global CI/tree-drift gate | PASS |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+
+## Upstream Parity Gaps Closed
+
+- Added a release-gated test coverage audit. The audit now tracks 415 behavior rows, covers all 415, validates 405 coverage-manifest entries, and reports 3,452 Rust test functions with 0 missing Rust test references.
+- Added a release-gated SOTA harness matrix for workflow replay, protocol differential contracts, and fault-injection coverage. The matrix passes all 3 domains, covers 5 replay steps, 7 protocol cases, 6 fault scenarios, and all 7 required fault classes.
+- Ported upstream coding-context posture into Rust with workspace detection, prompt-time coding guidance, model-family edit-format hints, ContextLattice-first memory posture, prompt-only non-coding skill pruning, and `agent.coding_context=focus` toolset collapse.
+- Ported the functional slash/provider tranche: registry-driven slash command help/completions for the Rust CLI/TUI surfaces, Parallel-backed web search/extract, generic keyless Search MCP identity, and keyed Parallel REST payloads.
+- Ported Anthropic ordered content replay by carrying in-memory `anthropic_content_blocks` and replaying signed thinking/tool-use blocks in order without adding a persisted state-db column.
+- Ported upstream desktop composer-draft behavior into the Rust TUI with state-root backed per-session draft storage, startup restore, submit clearing, session-switch reload, and MRU-capped persistence that never writes unsent text to the conversation DB.
+- Closed the new upstream desktop stop-recovery delta as non-applicable to Rust. Rust TUI/ACP interrupts are in-process and keyed directly by active session id, with no desktop runtime-id versus stored-id split.
+- Closed the new upstream compressed-lineage archive delta as non-applicable to Rust. Hermes Agent Ultra has no Rust session-archive column or Electron sidebar archive UI; `session_search` already projects compression roots forward to the visible continuation tip, and CLI session deletion remains saved-JSON snapshot deletion rather than SQLite soft archive.
+
+## Ultra Differences Preserved
+
+- Ultra remains Rust-runtime-only. Python remains acceptable for repo tooling, parity generation, and release checks, but no Python runtime surface was introduced.
+- ContextLattice remains the preferred Ultra memory backbone and orchestration helper. Coding-context guidance now makes that preference explicit for interactive coding surfaces.
+- Upstream Python plugin/backend trees for `dashboard_auth/nous`, `image_gen/krea`, and `security-guidance` remain tracked as a temporary intentional divergence. They are still upstream-only and are scheduled for a dedicated plugin parity slice rather than silently vendored into the Rust runtime.
+- Desktop React-only UI polish remains classified through parity evidence when there is no Rust desktop equivalent. Rust CLI/TUI/gateway behavior is the release-owned user surface.
+
+## Verification
+
+Release-prep verification for this tag covered version metadata, parity regeneration, queue closure, test coverage and SOTA harness gates, release proof, no-placeholder/no-Python runtime checks, clippy warning gate, workspace build, workspace test, and release binary build:
+
+```bash
+python3 scripts/generate-parity-matrix.py
+python3 scripts/generate-workstream-status.py
+python3 scripts/generate-test-intent-mapping.py
+python3 scripts/generate-test-coverage-audit.py --check
+python3 scripts/generate-adapter-matrix.py
+python3 scripts/validate-intentional-divergence.py --check --allow-warnings
+python3 scripts/generate-upstream-patch-queue.py --max-commits 0
+python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release
+python3 scripts/generate-gpar-01-04-proof.py
+python3 scripts/generate-parity-dashboard.py
+python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo metadata --format-version 1 --no-deps
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
+git diff --check
+scripts/check-rust-runtime-no-python.sh
+scripts/check-runtime-placeholders.sh
+python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan-v0.18.0.json
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --workspace
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --quiet
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --release -p hermes-cli
+```
+
+The GitHub release workflow can build and attach platform artifacts for tag `v0.18.0`. Local release gates are the authoritative release check for this cut.


### PR DESCRIPTION
## Summary
- bump workspace release metadata to `0.18.0`
- add `docs/releases/v0.18.0.md` covering the post-v0.17.0 parity and harness slice
- refresh parity artifacts against `upstream/main` @ `c94e93a6480f3cfdabe0624aac46f06670ffae36`
- classify the new upstream compressed-lineage session archive delta as non-applicable to the Rust runtime
- refresh the temporary Python plugin/backend divergence review date with current upstream-only evidence

## Gate Status
- release gate: PASS
- CI/tree-drift gate: PASS
- upstream pending queue: 0
- upstream surface coverage: missing=0 checked=2193
- release binary version: `hermes-agent-ultra 0.18.0`

## Verification
```bash
python3 scripts/generate-parity-matrix.py
python3 scripts/generate-workstream-status.py
python3 scripts/generate-test-intent-mapping.py
python3 scripts/generate-test-coverage-audit.py --check
python3 scripts/generate-adapter-matrix.py
python3 scripts/validate-intentional-divergence.py --check --allow-warnings
python3 scripts/generate-upstream-patch-queue.py --max-commits 0
python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release
python3 scripts/generate-gpar-01-04-proof.py
python3 scripts/generate-parity-dashboard.py
python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree
CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo metadata --format-version 1 --no-deps
CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
git diff --check
scripts/check-rust-runtime-no-python.sh
scripts/check-runtime-placeholders.sh
jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json docs/parity/test-coverage-audit.json docs/parity/sota-harness-matrix.json
python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan-v0.18.0.json
CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check
CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --workspace
CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --quiet
CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --release -p hermes-cli
/Volumes/wd_black/cargo-targets/release/hermes-agent-ultra --version
```
