### PR TITLE
release: cut v0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-config"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "chrono",
  "directories",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes",
  "async-trait",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "base64 0.22.1",
  "once_cell",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -4,10 +4,10 @@ _Generated from source artifacts: `2026-06-11T21:26:35.694599+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `021ed6914162416522462b009de0bec1513c73a1`
-- Workstream snapshot generated: `2026-06-11T03:07:10-06:00`
-- Parity matrix generated: `2026-06-11T21:26:25.069080+00:00`
-- Queue snapshot generated: `2026-06-11T21:25:55.720011+00:00`
+- Upstream target: `upstream/main` @ `6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`
+- Workstream snapshot generated: `2026-06-11T15:32:21-06:00`
+- Parity matrix generated: `2026-06-12T03:52:01.994370+00:00`
+- Queue snapshot generated: `2026-06-12T03:51:59.952223+00:00`
 - Proof snapshot generated: `2026-06-11T21:26:35.694599+00:00`
 
 ## Gate Status
@@ -45,24 +45,24 @@ _Generated from source artifacts: `2026-06-11T21:26:35.694599+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5593 |
+| Total commits in queue | 5613 |
 | Pending | 0 |
 | Ported | 266 |
-| Superseded | 5257 |
+| Superseded | 5277 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 5801 |
-| commits_ahead | 1092 |
-| upstream_patch_missing | 5591 |
+| commits_behind | 5827 |
+| commits_ahead | 1094 |
+| upstream_patch_missing | 5611 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 890 |
-| files_only_upstream | 2281 |
+| local_patch_unique | 891 |
+| files_only_upstream | 2288 |
 | files_only_local | 729 |
 | files_shared_identical | 1632 |
-| files_shared_different | 1098 |
+| files_shared_different | 1099 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-11T21:26:20.927079+00:00",
+  "generated_at_utc": "2026-06-12T03:51:57.928635+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-06-11T21:26:20.927079+00:00`
+Generated: `2026-06-12T03:51:57.928635+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-06-11T21:26:21.995213+00:00",
+  "generated_at_utc": "2026-06-12T03:52:30.792677+00:00",
   "items": [
     {
       "errors": [],
@@ -151,7 +151,7 @@
       "errors": [],
       "id": "rust-cli-tui-primary-ux-surface",
       "last_reviewed": "2026-04-21",
-      "matched_files": 1225,
+      "matched_files": 1224,
       "matched_sample": [
         "ui-tui/.gitignore",
         "ui-tui/.prettierrc",
@@ -185,10 +185,10 @@
   "summary": {
     "errors": 0,
     "items": 8,
-    "local_paths": 3459,
+    "local_paths": 3460,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 5011,
+    "upstream_paths": 5019,
     "warnings": 1
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,21 +2,21 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 5801.0,
+        "actual": 5827.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 5591.0,
+        "actual": 5611.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 2281.0,
+        "actual": 2288.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "pass"
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-11T21:26:35.694599+00:00",
+  "generated_at_utc": "2026-06-12T03:52:29.931840+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -108,16 +108,16 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 5801.0,
+    "max_commits_behind": 5827.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 2281.0,
+    "max_files_only_upstream": 2288.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
     "max_test_coverage_missing_rust_refs": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 5591.0,
+    "max_upstream_patch_missing": 5611.0,
     "min_sota_harness_domain_coverage_ratio": 1.0,
     "min_test_coverage_tracked_behavior_ratio": 1.0,
     "min_test_intent_mapping_ratio": 1.0
@@ -132,20 +132,20 @@
     "by_disposition": {
       "mirrored": 70,
       "ported": 266,
-      "superseded": 5257
+      "superseded": 5277
     },
     "by_target_ticket": {
-      "20": 2384,
+      "20": 2392,
       "21": 118,
-      "22": 852,
+      "22": 855,
       "23": 393,
       "24": 22,
       "25": 120,
-      "26": 1704
+      "26": 1713
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5593
+    "total_commits": 5613
   },
   "release_gate": {
     "checks": [
@@ -274,7 +274,7 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 5593,
+      "queue_total": 5613,
       "rust_test_files": 308,
       "rust_test_functions": 3465,
       "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-11T21:26:35.694599+00:00`
+Generated: `2026-06-12T03:52:29.931840+00:00`
 
 ## Gate Status
 
@@ -13,9 +13,9 @@ Generated: `2026-06-11T21:26:35.694599+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 5801.0 |
-| `max_upstream_patch_missing` | 5591.0 |
-| `max_files_only_upstream` | 2281.0 |
+| `max_commits_behind` | 5827.0 |
+| `max_upstream_patch_missing` | 5611.0 |
+| `max_files_only_upstream` | 2288.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
@@ -58,13 +58,13 @@ Generated: `2026-06-11T21:26:35.694599+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5593`.
+- Upstream missing commits tracked: `5613`.
 - By target ticket:
-  - `#20`: `2384`
+  - `#20`: `2392`
   - `#21`: `118`
-  - `#22`: `852`
+  - `#22`: `855`
   - `#23`: `393`
   - `#24`: `22`
   - `#25`: `120`
-  - `#26`: `1704`
+  - `#26`: `1713`
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-11T21:26:35.679238+00:00",
+  "generated_at_utc": "2026-06-12T03:52:29.925195+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",
@@ -18,10 +18,10 @@
     "by_disposition": {
       "mirrored": 63,
       "ported": 234,
-      "superseded": 3450
+      "superseded": 3461
     },
     "pass": true,
-    "total_commits": 3747,
+    "total_commits": 3758,
     "total_pending": 0
   },
   "ticket_breakdown": {
@@ -29,11 +29,11 @@
       "by_disposition": {
         "mirrored": 14,
         "ported": 101,
-        "superseded": 2269
+        "superseded": 2277
       },
       "label": "GPAR-01 tests+CI parity",
       "pending": 0,
-      "total": 2384
+      "total": 2392
     },
     "21": {
       "by_disposition": {
@@ -49,11 +49,11 @@
       "by_disposition": {
         "mirrored": 21,
         "ported": 33,
-        "superseded": 798
+        "superseded": 801
       },
       "label": "GPAR-03 UX parity",
       "pending": 0,
-      "total": 852
+      "total": 855
     },
     "23": {
       "by_disposition": {

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,16 +1,16 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-06-11T21:26:35.679238+00:00`
+Generated: `2026-06-12T03:52:29.925195+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
-- Total scoped commits: `3747`
+- Total scoped commits: `3758`
 - Pending scoped commits: `0`
 - Gate: `PASS`
 
 | Ticket | Label | Total | Pending | Ported | Superseded |
 | ---: | --- | ---: | ---: | ---: | ---: |
-| #20 | GPAR-01 tests+CI parity | 2384 | 0 | 101 | 2269 |
+| #20 | GPAR-01 tests+CI parity | 2392 | 0 | 101 | 2277 |
 | #21 | GPAR-02 skills parity | 118 | 0 | 62 | 30 |
-| #22 | GPAR-03 UX parity | 852 | 0 | 33 | 798 |
+| #22 | GPAR-03 UX parity | 855 | 0 | 33 | 801 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 393 | 0 | 38 | 353 |
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,30 +1,30 @@
 {
-  "generated_at_utc": "2026-06-11T21:26:25.069080+00:00",
+  "generated_at_utc": "2026-06-12T03:52:01.994370+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "5c376c21db8482914452118b7636d465f137a407",
+    "local_sha": "75d5233070092eed17a4cd475cbde4d0c6b5244e",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "021ed6914162416522462b009de0bec1513c73a1",
+    "upstream_sha": "6db65e687c53c933ea8a3b8d59f261de8eb4f0ec",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 5801,
-    "commits_ahead": 1092,
-    "upstream_patch_missing": 5591,
+    "commits_behind": 5827,
+    "commits_ahead": 1094,
+    "upstream_patch_missing": 5611,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 890,
-    "files_only_upstream": 2281,
+    "local_patch_unique": 891,
+    "files_only_upstream": 2288,
     "files_only_local": 729,
     "files_shared_identical": 1632,
-    "files_shared_different": 1098,
-    "tree_files_changed": 4034,
-    "tree_insertions": 982934,
-    "tree_deletions": 549578
+    "files_shared_different": 1099,
+    "tree_files_changed": 4042,
+    "tree_insertions": 984314,
+    "tree_deletions": 551956
   },
   "top_upstream_only": [
     {
       "path": "apps/desktop",
-      "count": 487
+      "count": 493
     },
     {
       "path": "website/i18n",
@@ -32,7 +32,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 140
+      "count": 141
     },
     {
       "path": "web/src",
@@ -48,11 +48,11 @@
     },
     {
       "path": "tests/tools",
-      "count": 51
+      "count": 52
     },
     {
       "path": "website/docs",
-      "count": 49
+      "count": 48
     },
     {
       "path": "optional-skills/creative",
@@ -190,7 +190,7 @@
     },
     {
       "path": "website/docs",
-      "count": 148
+      "count": 149
     },
     {
       "path": "tests/tools",
@@ -380,7 +380,7 @@
     },
     {
       "path": "website/docs",
-      "count": 22
+      "count": 21
     },
     {
       "path": "crates/hermes-config",
@@ -407,12 +407,12 @@
       "count": 10
     },
     {
-      "path": "crates/hermes-skills",
+      "path": "crates/hermes-cron",
       "count": 10
     },
     {
-      "path": "crates/hermes-cron",
-      "count": 9
+      "path": "crates/hermes-skills",
+      "count": 10
     },
     {
       "path": "docs/implementation",
@@ -510,7 +510,7 @@
   "top_missing_from_local": [
     {
       "path": "apps/desktop",
-      "count": 487
+      "count": 493
     },
     {
       "path": "website/i18n",
@@ -518,7 +518,7 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 140
+      "count": 141
     },
     {
       "path": "web/src",
@@ -534,11 +534,11 @@
     },
     {
       "path": "tests/tools",
-      "count": 51
+      "count": 52
     },
     {
       "path": "website/docs",
-      "count": 49
+      "count": 48
     },
     {
       "path": "optional-skills/creative",
@@ -704,7 +704,7 @@
     },
     {
       "path": "website/docs",
-      "count": 22
+      "count": 21
     },
     {
       "path": "crates/hermes-config",
@@ -731,12 +731,12 @@
       "count": 10
     },
     {
-      "path": "crates/hermes-skills",
+      "path": "crates/hermes-cron",
       "count": 10
     },
     {
-      "path": "crates/hermes-cron",
-      "count": 9
+      "path": "crates/hermes-skills",
+      "count": 10
     },
     {
       "path": "docs/implementation",
@@ -836,7 +836,7 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 507,
+      "upstream_only": 509,
       "shared_different": 722,
       "local_only": 34,
       "risk": "critical",
@@ -846,9 +846,9 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 979,
+      "upstream_only": 985,
       "shared_different": 12,
-      "local_only": 213,
+      "local_only": 214,
       "risk": "high",
       "effort": "XL"
     },
@@ -856,9 +856,9 @@
       "workstream": "WS5",
       "issue": 9,
       "name": "UX parity",
-      "upstream_only": 539,
-      "shared_different": 266,
-      "local_only": 106,
+      "upstream_only": 538,
+      "shared_different": 267,
+      "local_only": 105,
       "risk": "high",
       "effort": "XL"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 5591,
+    "upstream_patch_missing": 5611,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 890,
+    "local_patch_unique": 891,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",
@@ -960,7 +960,7 @@
       "6b69de4772eac5f982c097553dc6bcfeb60350e6"
     ],
     "intentional_divergence_items": 8,
-    "intentional_divergence_covered_files": 1047
+    "intentional_divergence_covered_files": 1046
   },
   "intentional_divergence": [
     {
@@ -1075,7 +1075,7 @@
       "status": "approved",
       "workstream": "WS5",
       "summary": "Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported.",
-      "matched_files": 829,
+      "matched_files": 828,
       "matched_sample": [
         "ui-tui/README.md",
         "ui-tui/babel.compiler.config.cjs",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,42 +1,42 @@
 # Parity Matrix
 
-Generated: `2026-06-11T21:26:25.069080+00:00`
+Generated: `2026-06-12T03:52:01.994370+00:00`
 
 ## Scope
 
-- Local ref: `main` (`5c376c21db8482914452118b7636d465f137a407`)
-- Upstream ref: `upstream/main` (`021ed6914162416522462b009de0bec1513c73a1`)
+- Local ref: `main` (`75d5233070092eed17a4cd475cbde4d0c6b5244e`)
+- Upstream ref: `upstream/main` (`6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 5801 |
-| Commits ahead local (`local` ancestry only) | 1092 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5591 |
+| Commits behind local (`upstream` ancestry only) | 5827 |
+| Commits ahead local (`local` ancestry only) | 1094 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5611 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 890 |
-| Files only in upstream tree | 2281 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 891 |
+| Files only in upstream tree | 2288 |
 | Files only in local tree | 729 |
 | Shared files identical content | 1632 |
-| Shared files different content | 1098 |
-| Total files changed (`local` vs `upstream`) | 4034 |
-| Insertions (`local` vs `upstream`) | 982934 |
-| Deletions (`local` vs `upstream`) | 549578 |
+| Shared files different content | 1099 |
+| Total files changed (`local` vs `upstream`) | 4042 |
+| Insertions (`local` vs `upstream`) | 984314 |
+| Deletions (`local` vs `upstream`) | 551956 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
-| `apps/desktop` | 487 |
+| `apps/desktop` | 493 |
 | `website/i18n` | 315 |
-| `tests/hermes_cli` | 140 |
+| `tests/hermes_cli` | 141 |
 | `web/src` | 98 |
 | `tests/agent` | 80 |
 | `tests/gateway` | 72 |
-| `tests/tools` | 51 |
-| `website/docs` | 49 |
+| `tests/tools` | 52 |
+| `website/docs` | 48 |
 | `optional-skills/creative` | 44 |
 | `gateway/platforms` | 39 |
 | `hermes_cli/subcommands` | 39 |
@@ -75,7 +75,7 @@ Generated: `2026-06-11T21:26:25.069080+00:00`
 | Bucket | Files |
 | --- | ---: |
 | `tests/gateway` | 179 |
-| `website/docs` | 148 |
+| `website/docs` | 149 |
 | `tests/tools` | 147 |
 | `tests/hermes_cli` | 133 |
 | `ui-tui/src` | 73 |
@@ -127,15 +127,15 @@ Generated: `2026-06-11T21:26:25.069080+00:00`
 | `skills/creative` | 44 |
 | `crates/hermes-intelligence` | 37 |
 | `crates/hermes-parity-tests` | 23 |
-| `website/docs` | 22 |
+| `website/docs` | 21 |
 | `crates/hermes-config` | 18 |
 | `crates/hermes-core` | 17 |
 | `crates/hermes-eval` | 15 |
 | `crates/hermes-environments` | 13 |
 | `skills/mlops` | 13 |
 | `crates/hermes-acp` | 10 |
+| `crates/hermes-cron` | 10 |
 | `crates/hermes-skills` | 10 |
-| `crates/hermes-cron` | 9 |
 | `docs/implementation` | 9 |
 | `docs/releases` | 9 |
 | `skills/red-teaming` | 9 |
@@ -164,9 +164,9 @@ Generated: `2026-06-11T21:26:25.069080+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 507 | 722 | critical | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 979 | 12 | high | XL |
-| `WS5` | #9 | UX parity | 539 | 266 | high | XL |
+| `WS6` | #10 | Tests and CI parity | 509 | 722 | critical | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 985 | 12 | high | XL |
+| `WS5` | #9 | UX parity | 538 | 267 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 117 | 71 | high | L |
 | `WS4` | #8 | Skills parity | 72 | 27 | medium | M |
 | `WS2` | #6 | Core runtime parity | 67 | 0 | critical | M |
@@ -174,10 +174,10 @@ Generated: `2026-06-11T21:26:25.069080+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `5591`
+- Upstream missing by patch-id: `5611`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `890`
-- Intentional divergence tracked items: `8` (covered files: `1047`)
+- Local unique by patch-id: `891`
+- Intentional divergence tracked items: `8` (covered files: `1046`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -191,7 +191,7 @@ Generated: `2026-06-11T21:26:25.069080+00:00`
 | `rust-gateway-platform-plugin-parity` | approved | WS3 | 5 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
 | `upstream-python-plugin-backend-drift-20260527` | temporary | WS3 | 10 | Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes. |
 | `upstream-s6-plan-doc-archive` | approved | WS7 | 0 | Do not import upstream implementation-plan archive documents unless they change local runtime or release behavior. |
-| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 829 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
+| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 828 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
 
 
 ## Notes

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3168,6 +3168,62 @@
       "disposition": "ported",
       "notes": "The final upstream Automation Blueprints terminology cleanup is ported on the local website surface: guides/automation-blueprints replaces the stale automation-templates slug, the sidebar points at the new slug, and the Rust runtime/catalog already use Automation Blueprints naming. Upstream Python docstring/web-server wording is non-runtime for Hermes Agent Ultra's Rust-only implementation."
     },
+    "73969771a514": {
+      "disposition": "superseded",
+      "notes": "Upstream dashboard /api/ws MCP discovery targets Python hermes_cli/tui_gateway startup. Hermes Agent Ultra exposes MCP through the Rust hermes-mcp client/server and Rust CLI registration paths; Python dashboard websocket backend discovery is not a Rust runtime surface."
+    },
+    "d221e369b8f3": {
+      "disposition": "superseded",
+      "notes": "Upstream assistant-ui message render boundary and virtualizer recovery is Electron/React desktop UI only. Hermes Agent Ultra's owned runtime surface is Rust CLI/TUI/gateway, with no assistant-ui thread virtualizer equivalent."
+    },
+    "e96fe06e4968": {
+      "disposition": "superseded",
+      "notes": "Upstream served dashboard token adoption targets Electron child-process dashboard websocket auth. Hermes Agent Ultra does not ship that Electron backend launcher; Rust gateway/session auth is handled by typed Rust services and CLI config rather than desktop dashboard-token.cjs."
+    },
+    "7a2d498b9dd2": {
+      "disposition": "superseded",
+      "notes": "Upstream profile session read routing is desktop React hermes.ts/session-picker wiring. Hermes Agent Ultra session state is owned by Rust SessionPersistence, CLI/TUI App state, and gateway session metadata rather than Electron profile session facades."
+    },
+    "e3ed7722b5b1": {
+      "disposition": "superseded",
+      "notes": "Upstream foreign-backend token refusal is Electron dashboard-token readiness logic. The local Rust runtime has no Electron dashboard backend token adoption path; gateway sessions are explicit Rust session keys and platform adapters."
+    },
+    "9ff0ba082739": {
+      "disposition": "superseded",
+      "notes": "Upstream port-squat and pickPort self-collision protection targets Electron desktop main.cjs and port-pool.cjs. Hermes Agent Ultra does not launch Electron dashboard child processes; Rust services bind through their own listener lifecycle."
+    },
+    "81436e143ebb": {
+      "disposition": "superseded",
+      "notes": "Upstream allow_permanent propagation fixes Python/TUI/desktop prompt payloads. Hermes Agent Ultra's Rust approval manager already carries allow_permanent in ApprovalPrompt, GatewayApprovalRequest, and approval hook events, and blocks permanent approvals for Tirith warnings."
+    },
+    "cc726aad687a": {
+      "disposition": "superseded",
+      "notes": "Upstream refactors Electron served-token adoption and foreign-backend refusal into a helper. Hermes Agent Ultra has no Electron dashboard-token helper; the underlying local token adoption/refusal failure mode is absent from the Rust runtime."
+    },
+    "b097d7b03352": {
+      "disposition": "superseded",
+      "notes": "Upstream native fetch change is confined to Electron dashboard-token.cjs. Hermes Agent Ultra's Rust runtime does not consume that JavaScript helper."
+    },
+    "55a18e68600d": {
+      "disposition": "superseded",
+      "notes": "Upstream allow_permanent comment/DRY cleanup is Python, desktop React, and ui-tui TypeScript presentation polish. The Rust approval contract remains the source of truth and already exposes allow_permanent on prompts, gateway requests, and hooks."
+    },
+    "e2145a5c9cae": {
+      "disposition": "superseded",
+      "notes": "Upstream embedded dashboard chat gateway stabilization targets ui-tui TypeScript gatewayClient and Python tui_gateway transport behavior. Hermes Agent Ultra release/runtime gates are Rust-first; the local Rust gateway/CLI session path is separate from that embedded JS/Python dashboard chat transport."
+    },
+    "4ddb03390a95": {
+      "disposition": "superseded",
+      "notes": "Upstream custom OpenAI endpoint API-key collection is desktop onboarding plus Python web_server settings. Hermes Agent Ultra handles model/provider credentials through Rust config/auth/provider flows; the Electron onboarding overlay and Python dashboard endpoint are not local Rust runtime surfaces."
+    },
+    "6c00077d3838": {
+      "disposition": "superseded",
+      "notes": "Upstream RTL/bidi auto-direction is desktop React chat text rendering. Hermes Agent Ultra has no Electron assistant-ui message text component; terminal/TUI rendering follows the local Rust/terminal surfaces."
+    },
+    "09bcf5a9370e": {
+      "disposition": "superseded",
+      "notes": "Upstream tool-row copy affordance is desktop React assistant-ui layout. Hermes Agent Ultra has no Electron tool fallback row; terminal/TUI copy behavior is handled by local TUI/terminal clipboard surfaces."
+    },
     "8505e9d6691d": {
       "disposition": "superseded",
       "notes": "Upstream composer spellcheck is a desktop React/Electron input attribute fix. Hermes Agent Ultra uses the Rust Ratatui TUI/CLI composer and has no browser spellcheck attribute surface."

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -4,19 +4,19 @@
       "kind": "nonzero_tree_drift",
       "message": "max_commits_behind remains nonzero in parity matrix",
       "metric": "max_commits_behind",
-      "value": 5796.0
+      "value": 5827.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_upstream_patch_missing remains nonzero in parity matrix",
       "metric": "max_upstream_patch_missing",
-      "value": 5586.0
+      "value": 5611.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 2280.0
+      "value": 2288.0
     }
   ],
   "audit_gate": {
@@ -61,7 +61,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-11T21:26:21.505744+00:00",
+  "generated_at_utc": "2026-06-12T03:52:17.847960+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -547,7 +547,7 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 5593,
+    "queue_total": 5613,
     "rust_test_files": 308,
     "rust_test_functions": 3465,
     "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-11T21:26:21.505744+00:00`
+Generated: `2026-06-12T03:52:17.847960+00:00`
 
 ## Gate
 
@@ -21,7 +21,7 @@ Generated: `2026-06-11T21:26:21.505744+00:00`
 | `coverage_manifest_entries_with_valid_rust_tests` | 405 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 5593 |
+| `queue_total` | 5613 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-11T21:26:20.997601+00:00",
+  "generated_at_utc": "2026-06-12T03:51:57.936362+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-06-11T21:26:20.997601+00:00`
+Generated: `2026-06-12T03:51:57.936362+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-11T21:25:55.720011+00:00`
+Generated: `2026-06-12T03:51:59.952223+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5593`.
+- Range: `main..upstream/main`; total commits tracked: `5613`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2384 |
+| #20 | GPAR-01 tests+CI parity | 2392 |
 | #21 | GPAR-02 skills parity | 118 |
-| #22 | GPAR-03 UX parity | 852 |
+| #22 | GPAR-03 UX parity | 855 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 393 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1704 |
+| #26 | GPAR-07 upstream queue backfill | 1713 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
 | ported | 266 |
-| superseded | 5257 |
+| superseded | 5277 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-06-11T03:07:10-06:00",
-  "head_sha": "5c376c21db8482914452118b7636d465f137a407",
+  "generated_at_utc": "2026-06-11T15:32:21-06:00",
+  "head_sha": "75d5233070092eed17a4cd475cbde4d0c6b5244e",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "021ed6914162416522462b009de0bec1513c73a1",
+  "upstream_sha": "6db65e687c53c933ea8a3b8d59f261de8eb4f0ec",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `5c376c21db8482914452118b7636d465f137a407`
-- Upstream: `upstream/main` (`021ed6914162416522462b009de0bec1513c73a1`)
+- Local HEAD: `75d5233070092eed17a4cd475cbde4d0c6b5244e`
+- Upstream: `upstream/main` (`6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/docs/releases/v0.18.0.md
+++ b/docs/releases/v0.18.0.md
@@ -20,8 +20,8 @@ flowchart LR
 | Signal | v0.18.0 State |
 | --- | ---: |
 | First-parent commits since `v0.17.0` after release refresh | 6 |
-| Files changed since `v0.17.0` | 137 |
-| Diff since `v0.17.0` | 27,412 insertions / 3,347 deletions |
+| Files changed since `v0.17.0` | 138 |
+| Diff since `v0.17.0` | 28,129 insertions / 2,759 deletions |
 | Upstream queue total | 5,593 |
 | Queue dispositions | 266 ported / 5,257 superseded / 70 mirrored / 0 pending |
 | Test coverage audit | PASS |

--- a/docs/releases/v0.18.1.md
+++ b/docs/releases/v0.18.1.md
@@ -1,0 +1,51 @@
+# Hermes Agent Ultra v0.18.1
+
+Release date: 2026-06-12
+
+This patch release closes the unfinished v0.18.0 release item: the website TypeScript check now runs its required prebuild step and passes, and the tracked v0.18.0 release note now matches the published tag stats. It also refreshes the upstream parity queue against `upstream/main` at `6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`.
+
+## Patch Scope
+
+- Fixed `website` typecheck by running the existing `node scripts/prebuild.mjs` before `tsc`, so generated `website/src/data/skills.json` exists for the Skills Hub import.
+- Replaced the `JSX.Element` return annotation in `UserStoriesCollage` with `React.ReactElement`, matching the React 19 TypeScript surface used by the website.
+- Corrected tracked v0.18.0 release stats to the published tag facts: 138 files changed and 28,129 insertions / 2,759 deletions since `v0.17.0`.
+- Bumped the Rust workspace and lockfile package versions to `0.18.1`.
+- Classified the latest upstream desktop/Python dashboard/ui-tui rows as non-applicable or already covered by Rust-native runtime surfaces; the queue remains closed.
+
+## Parity State
+
+| Signal | v0.18.1 State |
+| --- | ---: |
+| Upstream reference | `6db65e687c53c933ea8a3b8d59f261de8eb4f0ec` |
+| Upstream queue total | 5,613 |
+| Queue dispositions | 266 ported / 5,277 superseded / 70 mirrored / 0 pending |
+| Test coverage audit | PASS |
+| Test coverage tracked behavior ratio | 1.0 |
+| Test coverage missing Rust refs | 0 |
+| Global release gate | PASS |
+| Global CI/tree-drift gate | PASS |
+| Upstream surface coverage | PASS, missing=0 checked=2,197 |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+
+## Verification
+
+```bash
+contextlattice_agent_policy_pack --agent codex_gpt5 --project hermes-agent-ultra --topic-path release/v0.18.1 --query "fix remaining website typecheck and release-note stat debt after v0.18.0, then cut patch release" --mode balanced
+python3 scripts/generate-upstream-patch-queue.py --max-commits 0
+python3 scripts/generate-parity-matrix.py
+python3 scripts/generate-workstream-status.py
+python3 scripts/generate-test-intent-mapping.py
+python3 scripts/generate-test-coverage-audit.py --check
+python3 scripts/generate-adapter-matrix.py
+python3 scripts/validate-intentional-divergence.py --check --allow-warnings
+python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release
+python3 scripts/generate-gpar-01-04-proof.py
+python3 scripts/generate-parity-dashboard.py
+python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo metadata --format-version 1 --no-deps
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo check -p hermes-cli
+npm --prefix "$scratch/website" ci --cache /Volumes/wd_black/npm-cache
+npm --prefix "$scratch/website" run typecheck
+```
+
+Hosted GitHub CI/CD remains optional. Local release gates are authoritative for this cut.

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc",
+    "typecheck": "node scripts/prebuild.mjs && tsc",
     "lint:diagrams": "ascii-guard lint --exclude-code-blocks docs"
   },
   "dependencies": {

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -143,7 +143,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.ReactElement {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 


### PR DESCRIPTION
## Summary
- Cut v0.18.1 after completing the remaining website typecheck item.
- Make website typecheck run the repo prebuild step before tsc and use React.ReactElement for the collage component return type.
- Refresh upstream parity artifacts against upstream/main at 6db65e687c53c933ea8a3b8d59f261de8eb4f0ec with zero pending queue items.
- Correct stale v0.18.0 release stats and add v0.18.1 release notes.

## Local verification
- contextlattice_agent_policy_pack --agent codex_gpt5 --project hermes-agent-ultra --topic-path release/v0.18.1 --query "fix remaining website typecheck and release-note stat debt after v0.18.0, then cut patch release" --mode balanced
- python3 scripts/generate-upstream-patch-queue.py --max-commits 0
- python3 scripts/generate-test-coverage-audit.py --check
- python3 scripts/validate-intentional-divergence.py --check --allow-warnings
- python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree
- npm --prefix <external scratch>/website ci --cache /Volumes/wd_black/npm-cache
- npm --prefix <external scratch>/website run typecheck
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json docs/parity/test-coverage-audit.json docs/parity/sota-harness-matrix.json
- python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan-v0.18.1.json
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo check -p hermes-cli
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets scripts/clippy-warning-gate.sh --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --workspace
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --quiet -j 1
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build --release -p hermes-cli
- /Volumes/wd_black/cargo-targets/release/hermes-agent-ultra --version

## Notes
- npm audit during scratch install reports existing website dependency advisories: 53 vulnerabilities (39 moderate, 13 high, 1 critical). Typecheck passed; dependency audit remediation is not included in this patch release.
- clippy warning gate has no new warnings; it still reports 8 stale allowlist entries safe to prune separately.