### PR TITLE
docs: close v0.18.1 upstream drift

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-11T21:26:35.694599+00:00`_
+_Generated from source artifacts: `2026-06-12T05:27:11.497516+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`
-- Workstream snapshot generated: `2026-06-11T15:32:21-06:00`
-- Parity matrix generated: `2026-06-12T03:52:01.994370+00:00`
-- Queue snapshot generated: `2026-06-12T03:51:59.952223+00:00`
-- Proof snapshot generated: `2026-06-11T21:26:35.694599+00:00`
+- Upstream target: `upstream/main` @ `c57417005099b66e94bf053cd309235bdefb2704`
+- Workstream snapshot generated: `2026-06-11T23:25:17-06:00`
+- Parity matrix generated: `2026-06-12T05:27:10.272055+00:00`
+- Queue snapshot generated: `2026-06-12T05:26:40.953596+00:00`
+- Proof snapshot generated: `2026-06-12T05:27:11.497516+00:00`
 
 ## Gate Status
 
@@ -17,7 +17,7 @@ _Generated from source artifacts: `2026-06-11T21:26:35.694599+00:00`_
 - Test coverage audit: **PASS**
 - SOTA harness matrix: **PASS**
 - Release gate failures: none
-- CI gate failures: max_commits_behind (actual=5801.0, limit=5500); max_upstream_patch_missing (actual=5591.0, limit=5000)
+- CI gate failures: max_commits_behind (actual=5833.0, limit=5500); max_upstream_patch_missing (actual=5616.0, limit=5000)
 
 ## Test Coverage Audit
 
@@ -45,22 +45,22 @@ _Generated from source artifacts: `2026-06-11T21:26:35.694599+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5613 |
+| Total commits in queue | 5618 |
 | Pending | 0 |
 | Ported | 266 |
-| Superseded | 5277 |
+| Superseded | 5282 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 5827 |
-| commits_ahead | 1094 |
-| upstream_patch_missing | 5611 |
+| commits_behind | 5833 |
+| commits_ahead | 1096 |
+| upstream_patch_missing | 5616 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 891 |
-| files_only_upstream | 2288 |
-| files_only_local | 729 |
+| local_patch_unique | 892 |
+| files_only_upstream | 2292 |
+| files_only_local | 730 |
 | files_shared_identical | 1632 |
 | files_shared_different | 1099 |
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T03:51:57.928635+00:00",
+  "generated_at_utc": "2026-06-12T05:27:06.114110+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-06-12T03:51:57.928635+00:00`
+Generated: `2026-06-12T05:27:06.114110+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-06-12T03:52:30.792677+00:00",
+  "generated_at_utc": "2026-06-12T05:28:00.308831+00:00",
   "items": [
     {
       "errors": [],
@@ -185,10 +185,10 @@
   "summary": {
     "errors": 0,
     "items": 8,
-    "local_paths": 3460,
+    "local_paths": 3461,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 5019,
+    "upstream_paths": 5023,
     "warnings": 1
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,21 +2,21 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 5827.0,
+        "actual": 5833.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 5611.0,
+        "actual": 5616.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 2288.0,
+        "actual": 2292.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "pass"
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-12T03:52:29.931840+00:00",
+  "generated_at_utc": "2026-06-12T05:28:00.610260+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -108,16 +108,16 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 5827.0,
+    "max_commits_behind": 5833.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 2288.0,
+    "max_files_only_upstream": 2292.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
     "max_test_coverage_missing_rust_refs": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 5611.0,
+    "max_upstream_patch_missing": 5616.0,
     "min_sota_harness_domain_coverage_ratio": 1.0,
     "min_test_coverage_tracked_behavior_ratio": 1.0,
     "min_test_intent_mapping_ratio": 1.0
@@ -132,20 +132,20 @@
     "by_disposition": {
       "mirrored": 70,
       "ported": 266,
-      "superseded": 5277
+      "superseded": 5282
     },
     "by_target_ticket": {
       "20": 2392,
       "21": 118,
       "22": 855,
-      "23": 393,
+      "23": 395,
       "24": 22,
       "25": 120,
-      "26": 1713
+      "26": 1716
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5613
+    "total_commits": 5618
   },
   "release_gate": {
     "checks": [
@@ -274,7 +274,7 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 5613,
+      "queue_total": 5618,
       "rust_test_files": 308,
       "rust_test_functions": 3465,
       "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-12T03:52:29.931840+00:00`
+Generated: `2026-06-12T05:28:00.610260+00:00`
 
 ## Gate Status
 
@@ -13,9 +13,9 @@ Generated: `2026-06-12T03:52:29.931840+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 5827.0 |
-| `max_upstream_patch_missing` | 5611.0 |
-| `max_files_only_upstream` | 2288.0 |
+| `max_commits_behind` | 5833.0 |
+| `max_upstream_patch_missing` | 5616.0 |
+| `max_files_only_upstream` | 2292.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
@@ -58,13 +58,13 @@ Generated: `2026-06-12T03:52:29.931840+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5613`.
+- Upstream missing commits tracked: `5618`.
 - By target ticket:
   - `#20`: `2392`
   - `#21`: `118`
   - `#22`: `855`
-  - `#23`: `393`
+  - `#23`: `395`
   - `#24`: `22`
   - `#25`: `120`
-  - `#26`: `1713`
+  - `#26`: `1716`
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T03:52:29.925195+00:00",
+  "generated_at_utc": "2026-06-12T05:27:11.562261+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",
@@ -18,10 +18,10 @@
     "by_disposition": {
       "mirrored": 63,
       "ported": 234,
-      "superseded": 3461
+      "superseded": 3463
     },
     "pass": true,
-    "total_commits": 3758,
+    "total_commits": 3760,
     "total_pending": 0
   },
   "ticket_breakdown": {
@@ -59,11 +59,11 @@
       "by_disposition": {
         "mirrored": 2,
         "ported": 38,
-        "superseded": 353
+        "superseded": 355
       },
       "label": "GPAR-04 gateway/plugin-memory parity",
       "pending": 0,
-      "total": 393
+      "total": 395
     }
   }
 }

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,9 +1,9 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-06-12T03:52:29.925195+00:00`
+Generated: `2026-06-12T05:27:11.562261+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
-- Total scoped commits: `3758`
+- Total scoped commits: `3760`
 - Pending scoped commits: `0`
 - Gate: `PASS`
 
@@ -12,5 +12,5 @@ Generated: `2026-06-12T03:52:29.925195+00:00`
 | #20 | GPAR-01 tests+CI parity | 2392 | 0 | 101 | 2277 |
 | #21 | GPAR-02 skills parity | 118 | 0 | 62 | 30 |
 | #22 | GPAR-03 UX parity | 855 | 0 | 33 | 801 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 393 | 0 | 38 | 353 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 395 | 0 | 38 | 355 |
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,30 +1,30 @@
 {
-  "generated_at_utc": "2026-06-12T03:52:01.994370+00:00",
+  "generated_at_utc": "2026-06-12T05:27:10.272055+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "75d5233070092eed17a4cd475cbde4d0c6b5244e",
+    "local_sha": "b4dd2949e78635cd152169db208f3d615423090e",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "6db65e687c53c933ea8a3b8d59f261de8eb4f0ec",
+    "upstream_sha": "c57417005099b66e94bf053cd309235bdefb2704",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 5827,
-    "commits_ahead": 1094,
-    "upstream_patch_missing": 5611,
+    "commits_behind": 5833,
+    "commits_ahead": 1096,
+    "upstream_patch_missing": 5616,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 891,
-    "files_only_upstream": 2288,
-    "files_only_local": 729,
+    "local_patch_unique": 892,
+    "files_only_upstream": 2292,
+    "files_only_local": 730,
     "files_shared_identical": 1632,
     "files_shared_different": 1099,
-    "tree_files_changed": 4042,
-    "tree_insertions": 984314,
-    "tree_deletions": 551956
+    "tree_files_changed": 4047,
+    "tree_insertions": 984937,
+    "tree_deletions": 552537
   },
   "top_upstream_only": [
     {
       "path": "apps/desktop",
-      "count": 493
+      "count": 496
     },
     {
       "path": "website/i18n",
@@ -44,7 +44,7 @@
     },
     {
       "path": "tests/gateway",
-      "count": 72
+      "count": 73
     },
     {
       "path": "tests/tools",
@@ -415,11 +415,11 @@
       "count": 10
     },
     {
-      "path": "docs/implementation",
-      "count": 9
+      "path": "docs/releases",
+      "count": 10
     },
     {
-      "path": "docs/releases",
+      "path": "docs/implementation",
       "count": 9
     },
     {
@@ -510,7 +510,7 @@
   "top_missing_from_local": [
     {
       "path": "apps/desktop",
-      "count": 493
+      "count": 496
     },
     {
       "path": "website/i18n",
@@ -530,7 +530,7 @@
     },
     {
       "path": "tests/gateway",
-      "count": 72
+      "count": 73
     },
     {
       "path": "tests/tools",
@@ -739,11 +739,11 @@
       "count": 10
     },
     {
-      "path": "docs/implementation",
-      "count": 9
+      "path": "docs/releases",
+      "count": 10
     },
     {
-      "path": "docs/releases",
+      "path": "docs/implementation",
       "count": 9
     },
     {
@@ -836,7 +836,7 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 509,
+      "upstream_only": 510,
       "shared_different": 722,
       "local_only": 34,
       "risk": "critical",
@@ -846,10 +846,10 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 985,
+      "upstream_only": 988,
       "shared_different": 12,
       "local_only": 214,
-      "risk": "high",
+      "risk": "critical",
       "effort": "XL"
     },
     {
@@ -858,7 +858,7 @@
       "name": "UX parity",
       "upstream_only": 538,
       "shared_different": 267,
-      "local_only": 105,
+      "local_only": 106,
       "risk": "high",
       "effort": "XL"
     },
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 5611,
+    "upstream_patch_missing": 5616,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 891,
+    "local_patch_unique": 892,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,40 +1,40 @@
 # Parity Matrix
 
-Generated: `2026-06-12T03:52:01.994370+00:00`
+Generated: `2026-06-12T05:27:10.272055+00:00`
 
 ## Scope
 
-- Local ref: `main` (`75d5233070092eed17a4cd475cbde4d0c6b5244e`)
-- Upstream ref: `upstream/main` (`6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`)
+- Local ref: `main` (`b4dd2949e78635cd152169db208f3d615423090e`)
+- Upstream ref: `upstream/main` (`c57417005099b66e94bf053cd309235bdefb2704`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 5827 |
-| Commits ahead local (`local` ancestry only) | 1094 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5611 |
+| Commits behind local (`upstream` ancestry only) | 5833 |
+| Commits ahead local (`local` ancestry only) | 1096 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5616 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 891 |
-| Files only in upstream tree | 2288 |
-| Files only in local tree | 729 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 892 |
+| Files only in upstream tree | 2292 |
+| Files only in local tree | 730 |
 | Shared files identical content | 1632 |
 | Shared files different content | 1099 |
-| Total files changed (`local` vs `upstream`) | 4042 |
-| Insertions (`local` vs `upstream`) | 984314 |
-| Deletions (`local` vs `upstream`) | 551956 |
+| Total files changed (`local` vs `upstream`) | 4047 |
+| Insertions (`local` vs `upstream`) | 984937 |
+| Deletions (`local` vs `upstream`) | 552537 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
-| `apps/desktop` | 493 |
+| `apps/desktop` | 496 |
 | `website/i18n` | 315 |
 | `tests/hermes_cli` | 141 |
 | `web/src` | 98 |
 | `tests/agent` | 80 |
-| `tests/gateway` | 72 |
+| `tests/gateway` | 73 |
 | `tests/tools` | 52 |
 | `website/docs` | 48 |
 | `optional-skills/creative` | 44 |
@@ -136,8 +136,8 @@ Generated: `2026-06-12T03:52:01.994370+00:00`
 | `crates/hermes-acp` | 10 |
 | `crates/hermes-cron` | 10 |
 | `crates/hermes-skills` | 10 |
+| `docs/releases` | 10 |
 | `docs/implementation` | 9 |
-| `docs/releases` | 9 |
 | `skills/red-teaming` | 9 |
 | `docs/roadmaps` | 8 |
 | `crates/hermes-mcp` | 7 |
@@ -164,8 +164,8 @@ Generated: `2026-06-12T03:52:01.994370+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 509 | 722 | critical | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 985 | 12 | high | XL |
+| `WS6` | #10 | Tests and CI parity | 510 | 722 | critical | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 988 | 12 | critical | XL |
 | `WS5` | #9 | UX parity | 538 | 267 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 117 | 71 | high | L |
 | `WS4` | #8 | Skills parity | 72 | 27 | medium | M |
@@ -174,9 +174,9 @@ Generated: `2026-06-12T03:52:01.994370+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `5611`
+- Upstream missing by patch-id: `5616`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `891`
+- Local unique by patch-id: `892`
 - Intentional divergence tracked items: `8` (covered files: `1046`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3224,6 +3224,14 @@
       "disposition": "superseded",
       "notes": "Upstream tool-row copy affordance is desktop React assistant-ui layout. Hermes Agent Ultra has no Electron tool fallback row; terminal/TUI copy behavior is handled by local TUI/terminal clipboard surfaces."
     },
+    "6e41ca956bbf": {
+      "disposition": "superseded",
+      "notes": "Upstream JetBrains Mono bundling fixes xterm font metrics in the Electron desktop terminal pane. Hermes Agent Ultra has no Electron/xterm terminal pane; terminal execution and rendering are Rust CLI/TUI surfaces using host terminal fonts."
+    },
+    "24f74eb88853": {
+      "disposition": "superseded",
+      "notes": "Upstream data-selectable-text attributes target the Electron desktop file-preview DOM. Hermes Agent Ultra has no React right-rail file preview surface; file viewing/copy behavior is exposed through Rust CLI/TUI/tool output paths."
+    },
     "8505e9d6691d": {
       "disposition": "superseded",
       "notes": "Upstream composer spellcheck is a desktop React/Electron input attribute fix. Hermes Agent Ultra uses the Rust Ratatui TUI/CLI composer and has no browser spellcheck attribute surface."

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -4,19 +4,19 @@
       "kind": "nonzero_tree_drift",
       "message": "max_commits_behind remains nonzero in parity matrix",
       "metric": "max_commits_behind",
-      "value": 5827.0
+      "value": 5833.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_upstream_patch_missing remains nonzero in parity matrix",
       "metric": "max_upstream_patch_missing",
-      "value": 5611.0
+      "value": 5616.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 2288.0
+      "value": 2292.0
     }
   ],
   "audit_gate": {
@@ -61,7 +61,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-12T03:52:17.847960+00:00",
+  "generated_at_utc": "2026-06-12T05:27:59.334099+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -547,7 +547,7 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 5613,
+    "queue_total": 5618,
     "rust_test_files": 308,
     "rust_test_functions": 3465,
     "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-12T03:52:17.847960+00:00`
+Generated: `2026-06-12T05:27:59.334099+00:00`
 
 ## Gate
 
@@ -21,7 +21,7 @@ Generated: `2026-06-12T03:52:17.847960+00:00`
 | `coverage_manifest_entries_with_valid_rust_tests` | 405 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 5613 |
+| `queue_total` | 5618 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T03:51:57.936362+00:00",
+  "generated_at_utc": "2026-06-12T05:27:11.630122+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-06-12T03:51:57.936362+00:00`
+Generated: `2026-06-12T05:27:11.630122+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-12T03:51:59.952223+00:00`
+Generated: `2026-06-12T05:27:58.853753+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5613`.
+- Range: `main..upstream/main`; total commits tracked: `5618`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
 | #20 | GPAR-01 tests+CI parity | 2392 |
 | #21 | GPAR-02 skills parity | 118 |
 | #22 | GPAR-03 UX parity | 855 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 393 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 395 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1713 |
+| #26 | GPAR-07 upstream queue backfill | 1716 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
 | ported | 266 |
-| superseded | 5277 |
+| superseded | 5282 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-06-11T15:32:21-06:00",
-  "head_sha": "75d5233070092eed17a4cd475cbde4d0c6b5244e",
+  "generated_at_utc": "2026-06-11T23:25:17-06:00",
+  "head_sha": "b4dd2949e78635cd152169db208f3d615423090e",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "6db65e687c53c933ea8a3b8d59f261de8eb4f0ec",
+  "upstream_sha": "c57417005099b66e94bf053cd309235bdefb2704",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `75d5233070092eed17a4cd475cbde4d0c6b5244e`
-- Upstream: `upstream/main` (`6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`)
+- Local HEAD: `b4dd2949e78635cd152169db208f3d615423090e`
+- Upstream: `upstream/main` (`c57417005099b66e94bf053cd309235bdefb2704`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/docs/releases/v0.18.1.md
+++ b/docs/releases/v0.18.1.md
@@ -2,7 +2,7 @@
 
 Release date: 2026-06-12
 
-This patch release closes the unfinished v0.18.0 release item: the website TypeScript check now runs its required prebuild step and passes, and the tracked v0.18.0 release note now matches the published tag stats. It also refreshes the upstream parity queue against `upstream/main` at `6db65e687c53c933ea8a3b8d59f261de8eb4f0ec`.
+This patch release closes the unfinished v0.18.0 release item: the website TypeScript check now runs its required prebuild step and passes, and the tracked v0.18.0 release note now matches the published tag stats. It also refreshes the upstream parity queue against `upstream/main` at `c57417005099b66e94bf053cd309235bdefb2704`.
 
 ## Patch Scope
 
@@ -10,15 +10,15 @@ This patch release closes the unfinished v0.18.0 release item: the website TypeS
 - Replaced the `JSX.Element` return annotation in `UserStoriesCollage` with `React.ReactElement`, matching the React 19 TypeScript surface used by the website.
 - Corrected tracked v0.18.0 release stats to the published tag facts: 138 files changed and 28,129 insertions / 2,759 deletions since `v0.17.0`.
 - Bumped the Rust workspace and lockfile package versions to `0.18.1`.
-- Classified the latest upstream desktop/Python dashboard/ui-tui rows as non-applicable or already covered by Rust-native runtime surfaces; the queue remains closed.
+- Classified the latest upstream desktop/Python/plugin/packaging rows as non-applicable or already covered by Rust-native runtime surfaces; the queue remains closed.
 
 ## Parity State
 
 | Signal | v0.18.1 State |
 | --- | ---: |
-| Upstream reference | `6db65e687c53c933ea8a3b8d59f261de8eb4f0ec` |
-| Upstream queue total | 5,613 |
-| Queue dispositions | 266 ported / 5,277 superseded / 70 mirrored / 0 pending |
+| Upstream reference | `c57417005099b66e94bf053cd309235bdefb2704` |
+| Upstream queue total | 5,618 |
+| Queue dispositions | 266 ported / 5,282 superseded / 70 mirrored / 0 pending |
 | Test coverage audit | PASS |
 | Test coverage tracked behavior ratio | 1.0 |
 | Test coverage missing Rust refs | 0 |


### PR DESCRIPTION
## Summary
- Refresh parity artifacts after upstream/main advanced to c57417005099b66e94bf053cd309235bdefb2704 during the v0.18.1 release window.
- Explicitly supersede two new Electron desktop-only commits: xterm JetBrains Mono webfont bundling and desktop file-preview selectable DOM attributes.
- Update v0.18.1 release notes to the current zero-pending queue state: 5,618 tracked commits; 266 ported, 5,282 superseded, 70 mirrored, 0 pending.

## Local verification
- python3 scripts/generate-upstream-patch-queue.py --max-commits 0
- python3 scripts/generate-test-coverage-audit.py --check
- python3 scripts/validate-intentional-divergence.py --check --allow-warnings
- python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree
- python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release
- jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json docs/parity/test-coverage-audit.json
- git diff --check