### PR TITLE
Parity: clear latest upstream drift queue

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-12T08:23:10.814450+00:00`_
+_Generated from source artifacts: `2026-06-12T10:03:48.881291+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `4474873d2caae0fdfaf1e1e57fc490fade8dc143`
-- Workstream snapshot generated: `2026-06-11T23:28:55-06:00`
-- Parity matrix generated: `2026-06-12T08:23:09.531590+00:00`
-- Queue snapshot generated: `2026-06-12T08:23:04.974268+00:00`
-- Proof snapshot generated: `2026-06-12T08:23:10.814450+00:00`
+- Upstream target: `upstream/main` @ `9c505217044cedc28f174f1b74174d00d9ea1c81`
+- Workstream snapshot generated: `2026-06-12T04:01:49-06:00`
+- Parity matrix generated: `2026-06-12T10:03:47.604638+00:00`
+- Queue snapshot generated: `2026-06-12T10:03:42.850261+00:00`
+- Proof snapshot generated: `2026-06-12T10:03:48.881291+00:00`
 
 ## Gate Status
 
@@ -17,7 +17,7 @@ _Generated from source artifacts: `2026-06-12T08:23:10.814450+00:00`_
 - Test coverage audit: **PASS**
 - SOTA harness matrix: **PASS**
 - Release gate failures: none
-- CI gate failures: max_commits_behind (actual=5875.0, limit=5500); max_upstream_patch_missing (actual=5652.0, limit=5000)
+- CI gate failures: max_commits_behind (actual=5879.0, limit=5500); max_upstream_patch_missing (actual=5656.0, limit=5000)
 
 ## Test Coverage Audit
 
@@ -45,24 +45,24 @@ _Generated from source artifacts: `2026-06-12T08:23:10.814450+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5654 |
+| Total commits in queue | 5658 |
 | Pending | 0 |
 | Ported | 266 |
-| Superseded | 5318 |
+| Superseded | 5322 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 5875 |
-| commits_ahead | 1098 |
-| upstream_patch_missing | 5652 |
+| commits_behind | 5879 |
+| commits_ahead | 1100 |
+| upstream_patch_missing | 5656 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 893 |
-| files_only_upstream | 2304 |
+| local_patch_unique | 894 |
+| files_only_upstream | 2307 |
 | files_only_local | 730 |
-| files_shared_identical | 1624 |
-| files_shared_different | 1107 |
+| files_shared_identical | 1623 |
+| files_shared_different | 1108 |
 
 ## Workstream States
 

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T08:23:05.066986+00:00",
+  "generated_at_utc": "2026-06-12T10:03:42.962304+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-06-12T08:23:05.066986+00:00`
+Generated: `2026-06-12T10:03:42.962304+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-06-12T08:23:23.274054+00:00",
+  "generated_at_utc": "2026-06-12T10:03:58.186776+00:00",
   "items": [
     {
       "errors": [],
@@ -151,7 +151,7 @@
       "errors": [],
       "id": "rust-cli-tui-primary-ux-surface",
       "last_reviewed": "2026-04-21",
-      "matched_files": 1225,
+      "matched_files": 1227,
       "matched_sample": [
         "ui-tui/.gitignore",
         "ui-tui/.prettierrc",
@@ -188,7 +188,7 @@
     "local_paths": 3461,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 5035,
+    "upstream_paths": 5040,
     "warnings": 1
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,21 +2,21 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 5875.0,
+        "actual": 5879.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 5652.0,
+        "actual": 5656.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 2304.0,
+        "actual": 2307.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "pass"
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-12T08:23:23.547695+00:00",
+  "generated_at_utc": "2026-06-12T10:03:58.454891+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -108,16 +108,16 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 5875.0,
+    "max_commits_behind": 5879.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 2304.0,
+    "max_files_only_upstream": 2307.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
     "max_test_coverage_missing_rust_refs": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 5652.0,
+    "max_upstream_patch_missing": 5656.0,
     "min_sota_harness_domain_coverage_ratio": 1.0,
     "min_test_coverage_tracked_behavior_ratio": 1.0,
     "min_test_intent_mapping_ratio": 1.0
@@ -132,20 +132,20 @@
     "by_disposition": {
       "mirrored": 70,
       "ported": 266,
-      "superseded": 5318
+      "superseded": 5322
     },
     "by_target_ticket": {
-      "20": 2413,
+      "20": 2416,
       "21": 118,
       "22": 856,
-      "23": 399,
+      "23": 400,
       "24": 22,
       "25": 120,
       "26": 1726
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5654
+    "total_commits": 5658
   },
   "release_gate": {
     "checks": [
@@ -274,7 +274,7 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 5654,
+      "queue_total": 5658,
       "rust_test_files": 308,
       "rust_test_functions": 3465,
       "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-12T08:23:23.547695+00:00`
+Generated: `2026-06-12T10:03:58.454891+00:00`
 
 ## Gate Status
 
@@ -13,9 +13,9 @@ Generated: `2026-06-12T08:23:23.547695+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 5875.0 |
-| `max_upstream_patch_missing` | 5652.0 |
-| `max_files_only_upstream` | 2304.0 |
+| `max_commits_behind` | 5879.0 |
+| `max_upstream_patch_missing` | 5656.0 |
+| `max_files_only_upstream` | 2307.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
@@ -58,12 +58,12 @@ Generated: `2026-06-12T08:23:23.547695+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5654`.
+- Upstream missing commits tracked: `5658`.
 - By target ticket:
-  - `#20`: `2413`
+  - `#20`: `2416`
   - `#21`: `118`
   - `#22`: `856`
-  - `#23`: `399`
+  - `#23`: `400`
   - `#24`: `22`
   - `#25`: `120`
   - `#26`: `1726`

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T08:23:10.880935+00:00",
+  "generated_at_utc": "2026-06-12T10:03:48.946260+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",
@@ -18,10 +18,10 @@
     "by_disposition": {
       "mirrored": 63,
       "ported": 234,
-      "superseded": 3489
+      "superseded": 3493
     },
     "pass": true,
-    "total_commits": 3786,
+    "total_commits": 3790,
     "total_pending": 0
   },
   "ticket_breakdown": {
@@ -29,11 +29,11 @@
       "by_disposition": {
         "mirrored": 14,
         "ported": 101,
-        "superseded": 2298
+        "superseded": 2301
       },
       "label": "GPAR-01 tests+CI parity",
       "pending": 0,
-      "total": 2413
+      "total": 2416
     },
     "21": {
       "by_disposition": {
@@ -59,11 +59,11 @@
       "by_disposition": {
         "mirrored": 2,
         "ported": 38,
-        "superseded": 359
+        "superseded": 360
       },
       "label": "GPAR-04 gateway/plugin-memory parity",
       "pending": 0,
-      "total": 399
+      "total": 400
     }
   }
 }

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,16 +1,16 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-06-12T08:23:10.880935+00:00`
+Generated: `2026-06-12T10:03:48.946260+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
-- Total scoped commits: `3786`
+- Total scoped commits: `3790`
 - Pending scoped commits: `0`
 - Gate: `PASS`
 
 | Ticket | Label | Total | Pending | Ported | Superseded |
 | ---: | --- | ---: | ---: | ---: | ---: |
-| #20 | GPAR-01 tests+CI parity | 2413 | 0 | 101 | 2298 |
+| #20 | GPAR-01 tests+CI parity | 2416 | 0 | 101 | 2301 |
 | #21 | GPAR-02 skills parity | 118 | 0 | 62 | 30 |
 | #22 | GPAR-03 UX parity | 856 | 0 | 33 | 802 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 399 | 0 | 38 | 359 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 400 | 0 | 38 | 360 |
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-06-12T08:23:09.531590+00:00",
+  "generated_at_utc": "2026-06-12T10:03:47.604638+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "1154cb7b365e2d89d6047ba4fa48fa0a15db6ae3",
+    "local_sha": "6b6f1e617dbb703da680b6598855b25644334d32",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "4474873d2caae0fdfaf1e1e57fc490fade8dc143",
+    "upstream_sha": "88dbf95105644efb067500136c4a73277d3936d4",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 5875,
-    "commits_ahead": 1098,
-    "upstream_patch_missing": 5652,
+    "commits_behind": 5879,
+    "commits_ahead": 1100,
+    "upstream_patch_missing": 5656,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 893,
-    "files_only_upstream": 2304,
+    "local_patch_unique": 894,
+    "files_only_upstream": 2307,
     "files_only_local": 730,
-    "files_shared_identical": 1624,
-    "files_shared_different": 1107,
-    "tree_files_changed": 4067,
-    "tree_insertions": 994020,
-    "tree_deletions": 552730
+    "files_shared_identical": 1623,
+    "files_shared_different": 1108,
+    "tree_files_changed": 4071,
+    "tree_insertions": 996952,
+    "tree_deletions": 554545
   },
   "top_upstream_only": [
     {
@@ -40,7 +40,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 81
+      "count": 82
     },
     {
       "path": "tests/gateway",
@@ -76,7 +76,7 @@
     },
     {
       "path": "ui-tui/src",
-      "count": 32
+      "count": 34
     },
     {
       "path": "tests/run_agent",
@@ -202,7 +202,7 @@
     },
     {
       "path": "ui-tui/src",
-      "count": 73
+      "count": 74
     },
     {
       "path": "tests/agent",
@@ -526,7 +526,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 81
+      "count": 82
     },
     {
       "path": "tests/gateway",
@@ -562,7 +562,7 @@
     },
     {
       "path": "ui-tui/src",
-      "count": 32
+      "count": 34
     },
     {
       "path": "tests/run_agent",
@@ -836,7 +836,7 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 518,
+      "upstream_only": 519,
       "shared_different": 723,
       "local_only": 34,
       "risk": "critical",
@@ -856,8 +856,8 @@
       "workstream": "WS5",
       "issue": 9,
       "name": "UX parity",
-      "upstream_only": 539,
-      "shared_different": 267,
+      "upstream_only": 541,
+      "shared_different": 268,
       "local_only": 106,
       "risk": "high",
       "effort": "XL"
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 5652,
+    "upstream_patch_missing": 5656,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 893,
+    "local_patch_unique": 894,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",
@@ -960,7 +960,7 @@
       "6b69de4772eac5f982c097553dc6bcfeb60350e6"
     ],
     "intentional_divergence_items": 8,
-    "intentional_divergence_covered_files": 1047
+    "intentional_divergence_covered_files": 1050
   },
   "intentional_divergence": [
     {
@@ -1075,7 +1075,7 @@
       "status": "approved",
       "workstream": "WS5",
       "summary": "Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported.",
-      "matched_files": 829,
+      "matched_files": 832,
       "matched_sample": [
         "ui-tui/README.md",
         "ui-tui/babel.compiler.config.cjs",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,29 +1,29 @@
 # Parity Matrix
 
-Generated: `2026-06-12T08:23:09.531590+00:00`
+Generated: `2026-06-12T10:03:47.604638+00:00`
 
 ## Scope
 
-- Local ref: `main` (`1154cb7b365e2d89d6047ba4fa48fa0a15db6ae3`)
-- Upstream ref: `upstream/main` (`4474873d2caae0fdfaf1e1e57fc490fade8dc143`)
+- Local ref: `main` (`6b6f1e617dbb703da680b6598855b25644334d32`)
+- Upstream ref: `upstream/main` (`88dbf95105644efb067500136c4a73277d3936d4`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 5875 |
-| Commits ahead local (`local` ancestry only) | 1098 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5652 |
+| Commits behind local (`upstream` ancestry only) | 5879 |
+| Commits ahead local (`local` ancestry only) | 1100 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5656 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 893 |
-| Files only in upstream tree | 2304 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 894 |
+| Files only in upstream tree | 2307 |
 | Files only in local tree | 730 |
-| Shared files identical content | 1624 |
-| Shared files different content | 1107 |
-| Total files changed (`local` vs `upstream`) | 4067 |
-| Insertions (`local` vs `upstream`) | 994020 |
-| Deletions (`local` vs `upstream`) | 552730 |
+| Shared files identical content | 1623 |
+| Shared files different content | 1108 |
+| Total files changed (`local` vs `upstream`) | 4071 |
+| Insertions (`local` vs `upstream`) | 996952 |
+| Deletions (`local` vs `upstream`) | 554545 |
 
 ## Top 40 upstream-only buckets
 
@@ -33,7 +33,7 @@ Generated: `2026-06-12T08:23:09.531590+00:00`
 | `website/i18n` | 315 |
 | `tests/hermes_cli` | 142 |
 | `web/src` | 98 |
-| `tests/agent` | 81 |
+| `tests/agent` | 82 |
 | `tests/gateway` | 74 |
 | `tests/tools` | 53 |
 | `website/docs` | 49 |
@@ -42,7 +42,7 @@ Generated: `2026-06-12T08:23:09.531590+00:00`
 | `hermes_cli/subcommands` | 39 |
 | `tests/plugins` | 38 |
 | `apps/bootstrap-installer` | 35 |
-| `ui-tui/src` | 32 |
+| `ui-tui/src` | 34 |
 | `tests/run_agent` | 25 |
 | `tests/cli` | 23 |
 | `.github/workflows` | 17 |
@@ -78,7 +78,7 @@ Generated: `2026-06-12T08:23:09.531590+00:00`
 | `website/docs` | 149 |
 | `tests/tools` | 147 |
 | `tests/hermes_cli` | 133 |
-| `ui-tui/src` | 73 |
+| `ui-tui/src` | 74 |
 | `tests/agent` | 63 |
 | `tests/run_agent` | 59 |
 | `tests/cli` | 31 |
@@ -164,9 +164,9 @@ Generated: `2026-06-12T08:23:09.531590+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 518 | 723 | critical | XL |
+| `WS6` | #10 | Tests and CI parity | 519 | 723 | critical | XL |
 | `WS8` | #12 | Compatibility and divergence policy | 989 | 12 | critical | XL |
-| `WS5` | #9 | UX parity | 539 | 267 | high | XL |
+| `WS5` | #9 | UX parity | 541 | 268 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 117 | 78 | high | L |
 | `WS4` | #8 | Skills parity | 72 | 27 | medium | M |
 | `WS2` | #6 | Core runtime parity | 69 | 0 | critical | M |
@@ -174,10 +174,10 @@ Generated: `2026-06-12T08:23:09.531590+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `5652`
+- Upstream missing by patch-id: `5656`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `893`
-- Intentional divergence tracked items: `8` (covered files: `1047`)
+- Local unique by patch-id: `894`
+- Intentional divergence tracked items: `8` (covered files: `1050`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -191,7 +191,7 @@ Generated: `2026-06-12T08:23:09.531590+00:00`
 | `rust-gateway-platform-plugin-parity` | approved | WS3 | 5 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
 | `upstream-python-plugin-backend-drift-20260527` | temporary | WS3 | 10 | Track newly added upstream Python plugin/backend trees separately from surgical Rust issue-triage fixes. |
 | `upstream-s6-plan-doc-archive` | approved | WS7 | 0 | Do not import upstream implementation-plan archive documents unless they change local runtime or release behavior. |
-| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 829 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
+| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 832 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
 
 
 ## Notes

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3272,6 +3272,14 @@
       "disposition": "superseded",
       "notes": "Upstream SimpleX document classification fixes a Python plugin adapter. Hermes Agent Ultra has no Rust SimpleX gateway adapter; document attachment classification is covered in supported Rust adapters such as Discord, Telegram, and Signal."
     },
+    "7ba5df0d52b9": {
+      "disposition": "superseded",
+      "notes": "Upstream /credits adds Python CLI/gateway billing views and Ink UI-TUI RPC/buttons. Hermes Agent Ultra's Rust runtime has provider auth diagnostics and usage accounting, but it does not ship the upstream Python CLI or Ink TUI money surface, so this UI-only command remains reference-only until a Rust-native billing surface is deliberately designed."
+    },
+    "0fd34e8c5a7a": {
+      "disposition": "superseded",
+      "notes": "Upstream Teams attachment classification fixes the Python Teams gateway adapter. Hermes Agent Ultra does not register a Rust Teams chat gateway adapter; its Teams code is the Rust-native meeting pipeline, while document/image/video/audio caching is already implemented for supported Rust gateway adapters."
+    },
     "8505e9d6691d": {
       "disposition": "superseded",
       "notes": "Upstream composer spellcheck is a desktop React/Electron input attribute fix. Hermes Agent Ultra uses the Rust Ratatui TUI/CLI composer and has no browser spellcheck attribute surface."

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -4,19 +4,19 @@
       "kind": "nonzero_tree_drift",
       "message": "max_commits_behind remains nonzero in parity matrix",
       "metric": "max_commits_behind",
-      "value": 5875.0
+      "value": 5879.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_upstream_patch_missing remains nonzero in parity matrix",
       "metric": "max_upstream_patch_missing",
-      "value": 5652.0
+      "value": 5656.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 2304.0
+      "value": 2307.0
     }
   ],
   "audit_gate": {
@@ -61,7 +61,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-12T08:23:11.299360+00:00",
+  "generated_at_utc": "2026-06-12T10:03:58.712167+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -547,7 +547,7 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 5654,
+    "queue_total": 5658,
     "rust_test_files": 308,
     "rust_test_functions": 3465,
     "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-12T08:23:11.299360+00:00`
+Generated: `2026-06-12T10:03:58.712167+00:00`
 
 ## Gate
 
@@ -21,7 +21,7 @@ Generated: `2026-06-12T08:23:11.299360+00:00`
 | `coverage_manifest_entries_with_valid_rust_tests` | 405 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 5654 |
+| `queue_total` | 5658 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T08:23:10.942812+00:00",
+  "generated_at_utc": "2026-06-12T10:03:49.018734+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-06-12T08:23:10.942812+00:00`
+Generated: `2026-06-12T10:03:49.018734+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,15 +1,15 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-12T08:23:04.974268+00:00`
+Generated: `2026-06-12T10:03:42.850261+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5654`.
+- Range: `main..upstream/main`; total commits tracked: `5658`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2413 |
+| #20 | GPAR-01 tests+CI parity | 2416 |
 | #21 | GPAR-02 skills parity | 118 |
 | #22 | GPAR-03 UX parity | 856 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 399 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 400 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
 | #26 | GPAR-07 upstream queue backfill | 1726 |
@@ -18,7 +18,7 @@ Generated: `2026-06-12T08:23:04.974268+00:00`
 | --- | ---: |
 | mirrored | 70 |
 | ported | 266 |
-| superseded | 5318 |
+| superseded | 5322 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-06-11T23:28:55-06:00",
-  "head_sha": "1154cb7b365e2d89d6047ba4fa48fa0a15db6ae3",
+  "generated_at_utc": "2026-06-12T04:01:49-06:00",
+  "head_sha": "6b6f1e617dbb703da680b6598855b25644334d32",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "4474873d2caae0fdfaf1e1e57fc490fade8dc143",
+  "upstream_sha": "9c505217044cedc28f174f1b74174d00d9ea1c81",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `1154cb7b365e2d89d6047ba4fa48fa0a15db6ae3`
-- Upstream: `upstream/main` (`4474873d2caae0fdfaf1e1e57fc490fade8dc143`)
+- Local HEAD: `6b6f1e617dbb703da680b6598855b25644334d32`
+- Upstream: `upstream/main` (`9c505217044cedc28f174f1b74174d00d9ea1c81`)
 
 | Workstream | Title | State |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- refresh upstream parity artifacts after `upstream/main` advanced to `88dbf9510`
- classify the new upstream `/credits` Python/Ink billing surface as Rust-runtime superseded
- classify the new Python Teams gateway attachment classification fix as Rust-runtime superseded because Hermes Ultra has no Rust Teams chat gateway adapter
- keep the upstream queue at zero pending with test coverage still fully mapped

## Local verification
- `python3 scripts/validate-intentional-divergence.py --check --allow-warnings`
- `python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release`
- `python3 scripts/generate-test-coverage-audit.py --check`
- `jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json docs/parity/test-coverage-audit.json`
- `git diff --check`
