### PR TITLE
Parity: classify latest desktop PATH drift

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-12T10:03:48.881291+00:00`_
+_Generated from source artifacts: `2026-06-12T11:29:14.898323+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `9c505217044cedc28f174f1b74174d00d9ea1c81`
-- Workstream snapshot generated: `2026-06-12T04:01:49-06:00`
-- Parity matrix generated: `2026-06-12T10:03:47.604638+00:00`
-- Queue snapshot generated: `2026-06-12T10:03:42.850261+00:00`
-- Proof snapshot generated: `2026-06-12T10:03:48.881291+00:00`
+- Workstream snapshot generated: `2026-06-12T04:04:44-06:00`
+- Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
+- Queue snapshot generated: `2026-06-12T11:29:11.103206+00:00`
+- Proof snapshot generated: `2026-06-12T11:29:14.898323+00:00`
 
 ## Gate Status
 
@@ -17,7 +17,7 @@ _Generated from source artifacts: `2026-06-12T10:03:48.881291+00:00`_
 - Test coverage audit: **PASS**
 - SOTA harness matrix: **PASS**
 - Release gate failures: none
-- CI gate failures: max_commits_behind (actual=5879.0, limit=5500); max_upstream_patch_missing (actual=5656.0, limit=5000)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
 
 ## Test Coverage Audit
 
@@ -45,21 +45,21 @@ _Generated from source artifacts: `2026-06-12T10:03:48.881291+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5658 |
+| Total commits in queue | 5659 |
 | Pending | 0 |
 | Ported | 266 |
-| Superseded | 5322 |
+| Superseded | 5323 |
 
 ## Tree/Patch Drift
 
 | Metric | Value |
 | --- | ---: |
-| commits_behind | 5879 |
-| commits_ahead | 1100 |
-| upstream_patch_missing | 5656 |
+| commits_behind | 5880 |
+| commits_ahead | 1102 |
+| upstream_patch_missing | 5657 |
 | upstream_patch_represented | 2 |
-| local_patch_unique | 894 |
-| files_only_upstream | 2307 |
+| local_patch_unique | 895 |
+| files_only_upstream | 2309 |
 | files_only_local | 730 |
 | files_shared_identical | 1623 |
 | files_shared_different | 1108 |

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T10:03:42.962304+00:00",
+  "generated_at_utc": "2026-06-12T11:29:11.183274+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-06-12T10:03:42.962304+00:00`
+Generated: `2026-06-12T11:29:11.183274+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-06-12T10:03:58.186776+00:00",
+  "generated_at_utc": "2026-06-12T11:29:22.730907+00:00",
   "items": [
     {
       "errors": [],

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -2,21 +2,21 @@
   "ci_gate": {
     "checks": [
       {
-        "actual": 5879.0,
+        "actual": 5880.0,
         "limit": 5500,
         "metric": "max_commits_behind",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 5656.0,
+        "actual": 5657.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
         "special_rule": "allow_tree_drift_when_functional_clean",
         "status": "warn"
       },
       {
-        "actual": 2307.0,
+        "actual": 2309.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "pass"
@@ -95,7 +95,7 @@
       }
     ]
   },
-  "generated_at_utc": "2026-06-12T10:03:58.454891+00:00",
+  "generated_at_utc": "2026-06-12T11:29:22.950052+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -108,16 +108,16 @@
     "GPAR-09": true
   },
   "metrics": {
-    "max_commits_behind": 5879.0,
+    "max_commits_behind": 5880.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 2307.0,
+    "max_files_only_upstream": 2309.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
     "max_test_coverage_missing_rust_refs": 0.0,
     "max_unowned_divergences": 0.0,
-    "max_upstream_patch_missing": 5656.0,
+    "max_upstream_patch_missing": 5657.0,
     "min_sota_harness_domain_coverage_ratio": 1.0,
     "min_test_coverage_tracked_behavior_ratio": 1.0,
     "min_test_intent_mapping_ratio": 1.0
@@ -132,7 +132,7 @@
     "by_disposition": {
       "mirrored": 70,
       "ported": 266,
-      "superseded": 5322
+      "superseded": 5323
     },
     "by_target_ticket": {
       "20": 2416,
@@ -141,11 +141,11 @@
       "23": 400,
       "24": 22,
       "25": 120,
-      "26": 1726
+      "26": 1727
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5658
+    "total_commits": 5659
   },
   "release_gate": {
     "checks": [
@@ -274,7 +274,7 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 5658,
+      "queue_total": 5659,
       "rust_test_files": 308,
       "rust_test_functions": 3465,
       "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-12T10:03:58.454891+00:00`
+Generated: `2026-06-12T11:29:22.950052+00:00`
 
 ## Gate Status
 
@@ -13,9 +13,9 @@ Generated: `2026-06-12T10:03:58.454891+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `max_commits_behind` | 5879.0 |
-| `max_upstream_patch_missing` | 5656.0 |
-| `max_files_only_upstream` | 2307.0 |
+| `max_commits_behind` | 5880.0 |
+| `max_upstream_patch_missing` | 5657.0 |
+| `max_files_only_upstream` | 2309.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |
@@ -58,7 +58,7 @@ Generated: `2026-06-12T10:03:58.454891+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5658`.
+- Upstream missing commits tracked: `5659`.
 - By target ticket:
   - `#20`: `2416`
   - `#21`: `118`
@@ -66,5 +66,5 @@ Generated: `2026-06-12T10:03:58.454891+00:00`
   - `#23`: `400`
   - `#24`: `22`
   - `#25`: `120`
-  - `#26`: `1726`
+  - `#26`: `1727`
 

--- a/docs/parity/gpar-01-04-proof.json
+++ b/docs/parity/gpar-01-04-proof.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T10:03:48.946260+00:00",
+  "generated_at_utc": "2026-06-12T11:29:14.952605+00:00",
   "scope": {
     "labels": {
       "20": "GPAR-01 tests+CI parity",

--- a/docs/parity/gpar-01-04-proof.md
+++ b/docs/parity/gpar-01-04-proof.md
@@ -1,6 +1,6 @@
 # GPAR-01..04 Parity Proof
 
-Generated: `2026-06-12T10:03:48.946260+00:00`
+Generated: `2026-06-12T11:29:14.952605+00:00`
 
 - Scope tickets: `20, 21, 22, 23`
 - Total scoped commits: `3790`

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,30 +1,30 @@
 {
-  "generated_at_utc": "2026-06-12T10:03:47.604638+00:00",
+  "generated_at_utc": "2026-06-12T11:29:13.798398+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "6b6f1e617dbb703da680b6598855b25644334d32",
+    "local_sha": "17ee23e0adf80f56c1686918dbcc26a30d0c5a8a",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "88dbf95105644efb067500136c4a73277d3936d4",
+    "upstream_sha": "9c505217044cedc28f174f1b74174d00d9ea1c81",
     "merge_base": null
   },
   "summary": {
-    "commits_behind": 5879,
-    "commits_ahead": 1100,
-    "upstream_patch_missing": 5656,
+    "commits_behind": 5880,
+    "commits_ahead": 1102,
+    "upstream_patch_missing": 5657,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 894,
-    "files_only_upstream": 2307,
+    "local_patch_unique": 895,
+    "files_only_upstream": 2309,
     "files_only_local": 730,
     "files_shared_identical": 1623,
     "files_shared_different": 1108,
-    "tree_files_changed": 4071,
-    "tree_insertions": 996952,
-    "tree_deletions": 554545
+    "tree_files_changed": 4073,
+    "tree_insertions": 997153,
+    "tree_deletions": 554659
   },
   "top_upstream_only": [
     {
       "path": "apps/desktop",
-      "count": 496
+      "count": 498
     },
     {
       "path": "website/i18n",
@@ -510,7 +510,7 @@
   "top_missing_from_local": [
     {
       "path": "apps/desktop",
-      "count": 496
+      "count": 498
     },
     {
       "path": "website/i18n",
@@ -846,7 +846,7 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 989,
+      "upstream_only": 991,
       "shared_different": 12,
       "local_only": 214,
       "risk": "critical",
@@ -904,9 +904,9 @@
     }
   ],
   "commit_mapping": {
-    "upstream_patch_missing": 5656,
+    "upstream_patch_missing": 5657,
     "upstream_patch_represented": 2,
-    "local_patch_unique": 894,
+    "local_patch_unique": 895,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,35 +1,35 @@
 # Parity Matrix
 
-Generated: `2026-06-12T10:03:47.604638+00:00`
+Generated: `2026-06-12T11:29:13.798398+00:00`
 
 ## Scope
 
-- Local ref: `main` (`6b6f1e617dbb703da680b6598855b25644334d32`)
-- Upstream ref: `upstream/main` (`88dbf95105644efb067500136c4a73277d3936d4`)
+- Local ref: `main` (`17ee23e0adf80f56c1686918dbcc26a30d0c5a8a`)
+- Upstream ref: `upstream/main` (`9c505217044cedc28f174f1b74174d00d9ea1c81`)
 - Merge base: `none (history divergence)`
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| Commits behind local (`upstream` ancestry only) | 5879 |
-| Commits ahead local (`local` ancestry only) | 1100 |
-| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5656 |
+| Commits behind local (`upstream` ancestry only) | 5880 |
+| Commits ahead local (`local` ancestry only) | 1102 |
+| Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 5657 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 2 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 894 |
-| Files only in upstream tree | 2307 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 895 |
+| Files only in upstream tree | 2309 |
 | Files only in local tree | 730 |
 | Shared files identical content | 1623 |
 | Shared files different content | 1108 |
-| Total files changed (`local` vs `upstream`) | 4071 |
-| Insertions (`local` vs `upstream`) | 996952 |
-| Deletions (`local` vs `upstream`) | 554545 |
+| Total files changed (`local` vs `upstream`) | 4073 |
+| Insertions (`local` vs `upstream`) | 997153 |
+| Deletions (`local` vs `upstream`) | 554659 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
-| `apps/desktop` | 496 |
+| `apps/desktop` | 498 |
 | `website/i18n` | 315 |
 | `tests/hermes_cli` | 142 |
 | `web/src` | 98 |
@@ -165,7 +165,7 @@ Generated: `2026-06-12T10:03:47.604638+00:00`
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
 | `WS6` | #10 | Tests and CI parity | 519 | 723 | critical | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 989 | 12 | critical | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 991 | 12 | critical | XL |
 | `WS5` | #9 | UX parity | 541 | 268 | high | XL |
 | `WS3` | #7 | Tools and adapters parity | 117 | 78 | high | L |
 | `WS4` | #8 | Skills parity | 72 | 27 | medium | M |
@@ -174,9 +174,9 @@ Generated: `2026-06-12T10:03:47.604638+00:00`
 
 ## Commit Mapping
 
-- Upstream missing by patch-id: `5656`
+- Upstream missing by patch-id: `5657`
 - Upstream represented by patch-id: `2`
-- Local unique by patch-id: `894`
+- Local unique by patch-id: `895`
 - Intentional divergence tracked items: `8` (covered files: `1050`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3280,6 +3280,10 @@
       "disposition": "superseded",
       "notes": "Upstream Teams attachment classification fixes the Python Teams gateway adapter. Hermes Agent Ultra does not register a Rust Teams chat gateway adapter; its Teams code is the Rust-native meeting pipeline, while document/image/video/audio caching is already implemented for supported Rust gateway adapters."
     },
+    "9c505217044c": {
+      "disposition": "superseded",
+      "notes": "Upstream Homebrew PATH repair is scoped to the Electron desktop backend environment for Python subprocesses. Hermes Agent Ultra does not ship the upstream Electron desktop backend; the Rust CLI/TUI release path uses Cargo/Homebrew install artifacts and normal shell PATH resolution."
+    },
     "8505e9d6691d": {
       "disposition": "superseded",
       "notes": "Upstream composer spellcheck is a desktop React/Electron input attribute fix. Hermes Agent Ultra uses the Rust Ratatui TUI/CLI composer and has no browser spellcheck attribute surface."

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -4,19 +4,19 @@
       "kind": "nonzero_tree_drift",
       "message": "max_commits_behind remains nonzero in parity matrix",
       "metric": "max_commits_behind",
-      "value": 5879.0
+      "value": 5880.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_upstream_patch_missing remains nonzero in parity matrix",
       "metric": "max_upstream_patch_missing",
-      "value": 5656.0
+      "value": 5657.0
     },
     {
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 2307.0
+      "value": 2309.0
     }
   ],
   "audit_gate": {
@@ -61,7 +61,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-12T10:03:58.712167+00:00",
+  "generated_at_utc": "2026-06-12T11:29:23.268813+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -547,7 +547,7 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 5658,
+    "queue_total": 5659,
     "rust_test_files": 308,
     "rust_test_functions": 3465,
     "test_intent_mapping_ratio": 1.0,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-12T10:03:58.712167+00:00`
+Generated: `2026-06-12T11:29:23.268813+00:00`
 
 ## Gate
 
@@ -21,7 +21,7 @@ Generated: `2026-06-12T10:03:58.712167+00:00`
 | `coverage_manifest_entries_with_valid_rust_tests` | 405 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 5658 |
+| `queue_total` | 5659 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T10:03:49.018734+00:00",
+  "generated_at_utc": "2026-06-12T11:29:15.009976+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-06-12T10:03:49.018734+00:00`
+Generated: `2026-06-12T11:29:15.009976+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-12T10:03:42.850261+00:00`
+Generated: `2026-06-12T11:29:11.103206+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5658`.
+- Range: `main..upstream/main`; total commits tracked: `5659`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -12,13 +12,13 @@ Generated: `2026-06-12T10:03:42.850261+00:00`
 | #23 | GPAR-04 gateway/plugin-memory parity | 400 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1726 |
+| #26 | GPAR-07 upstream queue backfill | 1727 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
 | ported | 266 |
-| superseded | 5322 |
+| superseded | 5323 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,6 +1,6 @@
 {
-  "generated_at_utc": "2026-06-12T04:01:49-06:00",
-  "head_sha": "6b6f1e617dbb703da680b6598855b25644334d32",
+  "generated_at_utc": "2026-06-12T04:04:44-06:00",
+  "head_sha": "17ee23e0adf80f56c1686918dbcc26a30d0c5a8a",
   "states": {
     "complete": 7
   },

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,6 +1,6 @@
 # Workstream Status
 
-- Local HEAD: `6b6f1e617dbb703da680b6598855b25644334d32`
+- Local HEAD: `17ee23e0adf80f56c1686918dbcc26a30d0c5a8a`
 - Upstream: `upstream/main` (`9c505217044cedc28f174f1b74174d00d9ea1c81`)
 
 | Workstream | Title | State |


### PR DESCRIPTION
## Summary
- refresh upstream parity artifacts after `upstream/main` advanced to `9c505217044c`
- classify the upstream Electron desktop backend PATH helper as Rust-runtime superseded
- keep the upstream queue at zero pending with test coverage fully mapped

## Local verification
- `python3 scripts/validate-intentional-divergence.py --check --allow-warnings`
- `python3 scripts/run-upstream-surface-coverage-gate.py --upstream-ref upstream/main --local-mode worktree`
- `python3 scripts/generate-global-parity-proof.py --repo-root . --check-ci --check-release`
- `python3 scripts/generate-test-coverage-audit.py --check`
- `jq empty docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json docs/parity/queue-overrides.json docs/parity/test-coverage-audit.json`
- `git diff --check`
