### PR TITLE
deps: add RustSec patch refresh workflow

### DIFF
--- a/scripts/refresh-rustsec-patches.sh
+++ b/scripts/refresh-rustsec-patches.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/refresh-rustsec-patches.sh check [all|crate-name]
+  scripts/refresh-rustsec-patches.sh refresh <crate-name> [version]
+  scripts/refresh-rustsec-patches.sh list
+
+Downloads the configured crates.io crate tarball, reapplies the local RustSec
+patch file, and either checks patched files against the repository copy or
+refreshes third_party/rustsec-patches/<crate>-<version>.
+
+Resolution workflow:
+  1. Try a newer official crate version with refresh <crate> <version>.
+  2. Update Cargo.toml [patch.crates-io] to the refreshed directory if still needed.
+  3. If the official crate no longer needs the local patch, remove the patch entry
+     instead and rerun cargo audit/check/test/build gates.
+USAGE
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+patch_root() {
+  printf '%s/third_party/rustsec-patches' "$(repo_root)"
+}
+
+patch_spec() {
+  case "$1" in
+    matrix-pickle-derive)
+      printf '%s\t%s\t%s\n' \
+        "0.2.2" \
+        "matrix-pickle-derive-0.2.2" \
+        "patches/matrix-pickle-derive-0.2.2-remove-proc-macro-error2.patch"
+      ;;
+    matrix-sdk-crypto)
+      printf '%s\t%s\t%s\n' \
+        "0.18.0" \
+        "matrix-sdk-crypto-0.18.0" \
+        "patches/matrix-sdk-crypto-0.18.0-remove-doc-aquamarine.patch"
+      ;;
+    tungstenite)
+      printf '%s\t%s\t%s\n' \
+        "0.29.0" \
+        "tungstenite-0.29.0" \
+        "patches/tungstenite-0.29.0-use-getrandom.patch"
+      ;;
+    vodozemac)
+      printf '%s\t%s\t%s\n' \
+        "0.10.0" \
+        "vodozemac-0.10.0" \
+        "patches/vodozemac-0.10.0-use-rand-core-osrng.patch"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+known_crates() {
+  printf '%s\n' matrix-pickle-derive matrix-sdk-crypto tungstenite vodozemac
+}
+
+download_and_patch() {
+  local crate=$1
+  local version=$2
+  local patch_file=$3
+  local workdir=$4
+  local archive="$workdir/$crate-$version.crate"
+
+  curl \
+    -fsSL \
+    -A 'hermes-agent-ultra-rustsec-patch-refresh/1.0' \
+    -H 'Accept: application/octet-stream' \
+    "https://crates.io/api/v1/crates/$crate/$version/download" \
+    -o "$archive"
+  tar -xzf "$archive" -C "$workdir"
+  patch -p1 -d "$workdir/$crate-$version" < "$patch_file"
+}
+
+patched_files() {
+  awk '/^\+\+\+ b\// { sub(/^\+\+\+ b\//, ""); print }' "$1" | sort -u
+}
+
+check_one() {
+  local crate=$1
+  local configured_version configured_dir patch_rel
+  IFS=$'\t' read -r configured_version configured_dir patch_rel < <(patch_spec "$crate")
+
+  local patch_dir patch_file tmp
+  patch_dir=$(patch_root)
+  patch_file="$patch_dir/$patch_rel"
+  tmp=$(mktemp -d)
+
+  (
+    trap 'rm -rf "$tmp"' EXIT
+    download_and_patch "$crate" "$configured_version" "$patch_file" "$tmp"
+
+    local file
+    while IFS= read -r file; do
+      diff -u "$tmp/$crate-$configured_version/$file" "$patch_dir/$configured_dir/$file" >/dev/null
+    done < <(patched_files "$patch_file")
+  )
+
+  printf 'ok %s %s\n' "$crate" "$configured_version"
+}
+
+prune_non_runtime_artifacts() {
+  local dir=$1
+  rm -rf \
+    "$dir/.cargo-ok" \
+    "$dir/.cargo_vcs_info.json" \
+    "$dir/Cargo.lock" \
+    "$dir/Cargo.toml.orig" \
+    "$dir/.cargo" \
+    "$dir/.config" \
+    "$dir/.github" \
+    "$dir/.vscode" \
+    "$dir/afl" \
+    "$dir/benches" \
+    "$dir/examples" \
+    "$dir/contrib"
+  find "$dir" -type d -name snapshots -prune -exec rm -rf {} +
+}
+
+refresh_one() {
+  local crate=$1
+  local requested_version=${2:-}
+  local configured_version configured_dir patch_rel
+  IFS=$'\t' read -r configured_version configured_dir patch_rel < <(patch_spec "$crate")
+
+  local version=${requested_version:-$configured_version}
+  local patch_dir patch_file tmp src dest
+  patch_dir=$(patch_root)
+  patch_file="$patch_dir/$patch_rel"
+  tmp=$(mktemp -d)
+  src="$tmp/$crate-$version"
+  dest="$patch_dir/$crate-$version"
+
+  (
+    trap 'rm -rf "$tmp"' EXIT
+    download_and_patch "$crate" "$version" "$patch_file" "$tmp"
+
+    prune_non_runtime_artifacts "$src"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    cp -R "$src/." "$dest/"
+  )
+
+  printf 'refreshed %s %s -> %s\n' "$crate" "$version" "$dest"
+  if [[ "$version" != "$configured_version" ]]; then
+    printf 'note: update Cargo.toml [patch.crates-io] from %s to %s before verifying the workspace\n' \
+      "$configured_dir" "$crate-$version"
+  fi
+}
+
+main() {
+  local command=${1:-}
+  case "$command" in
+    list)
+      known_crates
+      ;;
+    check)
+      local target=${2:-all}
+      if [[ "$target" == all ]]; then
+        local crate
+        while IFS= read -r crate; do
+          check_one "$crate"
+        done < <(known_crates)
+      else
+        patch_spec "$target" >/dev/null || {
+          printf 'unknown crate: %s\n' "$target" >&2
+          exit 2
+        }
+        check_one "$target"
+      fi
+      ;;
+    refresh)
+      local crate=${2:-}
+      [[ -n "$crate" ]] || {
+        usage >&2
+        exit 2
+      }
+      patch_spec "$crate" >/dev/null || {
+        printf 'unknown crate: %s\n' "$crate" >&2
+        exit 2
+      }
+      refresh_one "$crate" "${3:-}"
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      printf 'unknown command: %s\n' "$command" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/third_party/rustsec-patches/README.md
+++ b/third_party/rustsec-patches/README.md
@@ -1,0 +1,56 @@
+# RustSec Patch Overrides
+
+This directory contains temporary local crate overrides used by the workspace
+`[patch.crates-io]` section. They exist only to keep the resolved dependency
+graph clear under `cargo audit --deny warnings` while upstream releases catch up.
+
+## Current Overrides
+
+- `matrix-pickle-derive-0.2.2`: removes `proc-macro-error2` and uses `syn::Error`.
+- `matrix-sdk-crypto-0.18.0`: removes the doc-only `aquamarine` dependency.
+- `tungstenite-0.29.0`: replaces direct `rand` usage with `getrandom`.
+- `vodozemac-0.10.0`: replaces `rand 0.8` usage with `rand_core::OsRng`.
+
+The canonical local patch files are in `patches/`. The checked-in crate trees are
+trimmed source copies used by Cargo path patches.
+
+## Refresh Flow
+
+Verify the checked-in patched files still match a fresh crates.io download plus
+our patch files:
+
+```bash
+scripts/refresh-rustsec-patches.sh check
+```
+
+Refresh one current patch directory from crates.io:
+
+```bash
+scripts/refresh-rustsec-patches.sh refresh tungstenite
+```
+
+Trial a newer upstream crate release:
+
+```bash
+scripts/refresh-rustsec-patches.sh refresh tungstenite 0.30.0
+```
+
+When trialing a new version, update the root `Cargo.toml` `[patch.crates-io]`
+path to the new directory before running verification.
+
+## Resolution Criteria
+
+A local override is resolved when the workspace passes without the override:
+
+1. Remove the matching root `Cargo.toml` `[patch.crates-io]` entry.
+2. Update the dependency to the upstream version that contains the fix.
+3. Run:
+
+```bash
+cargo audit --deny warnings
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo check --all-targets --all-features
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test --workspace --all-features --no-fail-fast -j 1
+```
+
+If those pass, delete the matching crate directory and patch file in this folder.
+If any gate fails, keep the override and refresh/rebase the local patch.

--- a/third_party/rustsec-patches/patches/matrix-pickle-derive-0.2.2-remove-proc-macro-error2.patch
+++ b/third_party/rustsec-patches/patches/matrix-pickle-derive-0.2.2-remove-proc-macro-error2.patch
@@ -1,0 +1,119 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -34,10 +34,6 @@
+ version = "3.4.0"
+ default-features = false
+ 
+-[dependencies.proc-macro-error2]
+-version = "2.0.1"
+-default-features = false
+-
+ [dependencies.proc-macro2]
+ version = "1.0.103"
+ default-features = false
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -32,7 +32,6 @@
+ use proc_macro::TokenStream;
+ use proc_macro2::TokenStream as TokenStream2;
+ use proc_macro_crate::{crate_name, FoundCrate};
+-use proc_macro_error2::{abort_call_site, proc_macro_error};
+ use quote::{format_ident, quote};
+ use syn::{
+     parse_macro_input, parse_quote, punctuated::Punctuated, token::Comma, Data, DataEnum,
+@@ -49,7 +48,6 @@
+ }
+ 
+ /// Derive an `Encode` implementation for a struct or enum.
+-#[proc_macro_error]
+ #[proc_macro_derive(Encode)]
+ pub fn derive_encode(input: TokenStream) -> TokenStream {
+     let mut input = parse_macro_input!(input as DeriveInput);
+@@ -125,30 +123,43 @@
+             }
+         }
+ 
+-        _ => abort_call_site!("`#[derive(Encode)` only supports non-tuple structs"),
++        _ => {
++            return syn::Error::new_spanned(
++                name,
++                "`#[derive(Encode)]` only supports structs and enums",
++            )
++            .to_compile_error()
++            .into()
++        }
+     }.into()
+ }
+ 
+-fn check_if_boxed(fields: &Punctuated<Field, Comma>) {
++fn check_if_boxed(fields: &Punctuated<Field, Comma>) -> syn::Result<()> {
+     for field in fields {
+         for attribute in &field.attrs {
+             if attribute.path().is_ident("secret") {
+                 match &field.ty {
+-                    Type::Array(_) => abort_call_site!(
+-                        "Arrays need to be boxed to avoid unintended copies of the secret"
+-                    ),
++                    Type::Array(_) => {
++                        return Err(syn::Error::new_spanned(
++                            field,
++                            "Arrays need to be boxed to avoid unintended copies of the secret",
++                        ))
++                    }
+                     Type::Path(_) => {}
+                     _ => {
+-                        abort_call_site!("Type {} does not support being decoded as a secret value")
++                        return Err(syn::Error::new_spanned(
++                            field,
++                            "Type does not support being decoded as a secret value",
++                        ))
+                     }
+                 }
+             }
+         }
+     }
++    Ok(())
+ }
+ 
+ /// Derive an `Decode` implementation for a struct or enum.
+-#[proc_macro_error]
+ #[proc_macro_derive(Decode, attributes(secret))]
+ pub fn derive_decode(input: TokenStream) -> TokenStream {
+     let mut input = parse_macro_input!(input as DeriveInput);
+@@ -170,7 +181,9 @@
+             fields: Fields::Named(FieldsNamed { named, .. }),
+             ..
+         }) => {
+-            check_if_boxed(&named);
++            if let Err(err) = check_if_boxed(&named) {
++                return err.to_compile_error().into();
++            }
+ 
+             let names = named.iter().map(|f| &f.ident);
+             let field_types = named.iter().map(|f| &f.ty);
+@@ -189,7 +202,9 @@
+             fields: Fields::Unnamed(FieldsUnnamed { unnamed, .. }),
+             ..
+         }) => {
+-            check_if_boxed(&unnamed);
++            if let Err(err) = check_if_boxed(&unnamed) {
++                return err.to_compile_error().into();
++            }
+ 
+             let field_types = unnamed.iter().map(|f| &f.ty);
+ 
+@@ -224,6 +239,13 @@
+                 }
+             }
+         }
+-        _ => abort_call_site!("`#[derive(Encode)` only supports non-tuple structs"),
++        _ => {
++            return syn::Error::new_spanned(
++                name,
++                "`#[derive(Decode)]` only supports structs and enums",
++            )
++            .to_compile_error()
++            .into()
++        }
+     }.into()
+ }

--- a/third_party/rustsec-patches/patches/matrix-sdk-crypto-0.18.0-remove-doc-aquamarine.patch
+++ b/third_party/rustsec-patches/patches/matrix-sdk-crypto-0.18.0-remove-doc-aquamarine.patch
@@ -1,0 +1,23 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -68,10 +68,6 @@
+ 
+ [dependencies.aes]
+ version = "0.8.4"
+-default-features = false
+-
+-[dependencies.aquamarine]
+-version = "0.6.0"
+ default-features = false
+ 
+ [dependencies.as_variant]
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -160,7 +160,6 @@
+     UnableToDecrypt(UnableToDecryptInfo),
+ }
+ 
+-#[cfg_attr(doc, aquamarine::aquamarine)]
+ /// A step by step guide that explains how to include [end-to-end-encryption]
+ /// support in a [Matrix] client library.
+ ///

--- a/third_party/rustsec-patches/patches/tungstenite-0.29.0-use-getrandom.patch
+++ b/third_party/rustsec-patches/patches/tungstenite-0.29.0-use-getrandom.patch
@@ -1,0 +1,50 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -156,8 +156,8 @@
+ optional = true
+ package = "native-tls"
+ 
+-[dependencies.rand]
+-version = "0.9.0"
++[dependencies.getrandom]
++version = "0.3"
+ 
+ [dependencies.rustls]
+ version = "0.23.0"
+@@ -197,9 +197,6 @@
+ [dev-dependencies.input_buffer]
+ version = "0.5.0"
+ 
+-[dev-dependencies.rand]
+-version = "0.9.0"
+-
+ [dev-dependencies.socket2]
+ version = "0.6.0"
+ 
+--- a/src/protocol/frame/mask.rs
++++ b/src/protocol/frame/mask.rs
+@@ -1,7 +1,9 @@
+ /// Generate a random frame mask.
+ #[inline]
+ pub fn generate_mask() -> [u8; 4] {
+-    rand::random()
++    let mut mask = [0u8; 4];
++    getrandom::fill(&mut mask).expect("websocket mask generation requires system randomness");
++    mask
+ }
+ 
+ /// Mask/unmask a frame.
+--- a/src/handshake/client.rs
++++ b/src/handshake/client.rs
+@@ -329,8 +329,9 @@
+ pub fn generate_key() -> String {
+     // a base64-encoded (see Section 4 of [RFC4648]) value that,
+     // when decoded, is 16 bytes in length (RFC 6455)
+-    let r: [u8; 16] = rand::random();
+-    data_encoding::BASE64.encode(&r)
++    let mut key = [0u8; 16];
++    getrandom::fill(&mut key).expect("websocket handshake key requires system randomness");
++    data_encoding::BASE64.encode(&key)
+ }
+ 
+ #[cfg(test)]

--- a/third_party/rustsec-patches/patches/vodozemac-0.10.0-use-rand-core-osrng.patch
+++ b/third_party/rustsec-patches/patches/vodozemac-0.10.0-use-rand-core-osrng.patch
@@ -1,0 +1,143 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -121,8 +121,9 @@
+ [dependencies.prost]
+ version = "0.14.3"
+ 
+-[dependencies.rand]
+-version = "0.8.5"
++[dependencies.rand_core]
++version = "0.6"
++features = ["getrandom"]
+ 
+ [dependencies.serde]
+ version = "1.0.219"
+--- a/src/types/curve25519.rs
++++ b/src/types/curve25519.rs
+@@ -16,7 +16,7 @@
+ 
+ use base64::decoded_len_estimate;
+ use matrix_pickle::{Decode, DecodeError};
+-use rand::thread_rng;
++use rand_core::OsRng;
+ use serde::{Deserialize, Serialize};
+ use x25519_dalek::{EphemeralSecret, PublicKey, ReusableSecret, SharedSecret, StaticSecret};
+ use zeroize::Zeroize;
+@@ -32,7 +32,7 @@
+ impl Curve25519SecretKey {
+     /// Generate a new, random, Curve25519SecretKey.
+     pub fn new() -> Self {
+-        let rng = thread_rng();
++        let rng = OsRng;
+ 
+         Self(Box::new(StaticSecret::random_from_rng(rng)))
+     }
+--- a/src/types/ed25519.rs
++++ b/src/types/ed25519.rs
+@@ -20,7 +20,7 @@
+ use ed25519_dalek::{
+     PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH, Signature, Signer, SigningKey, VerifyingKey,
+ };
+-use rand::thread_rng;
++use rand_core::OsRng;
+ use serde::{Deserialize, Deserializer, Serialize, Serializer};
+ use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
+ use sha2::Sha512;
+@@ -127,7 +127,7 @@
+ impl Ed25519Keypair {
+     /// Create a new, random, `Ed25519Keypair`.
+     pub fn new() -> Self {
+-        let mut rng = thread_rng();
++        let mut rng = OsRng;
+         let signing_key = SigningKey::generate(&mut rng);
+ 
+         Self {
+@@ -206,7 +206,7 @@
+ 
+     /// Create a new random `Ed25519SecretKey`.
+     pub fn new() -> Self {
+-        let mut rng = thread_rng();
++        let mut rng = OsRng;
+         let signing_key = SigningKey::generate(&mut rng);
+         let key = Box::new(signing_key);
+ 
+--- a/src/ecies/mod.rs
++++ b/src/ecies/mod.rs
+@@ -85,7 +85,7 @@
+ 
+ use chacha20poly1305::{ChaCha20Poly1305, Key as Chacha20Key, KeyInit, Nonce, aead::Aead};
+ use hkdf::Hkdf;
+-use rand::thread_rng;
++use rand_core::OsRng;
+ use sha2::Sha512;
+ use thiserror::Error;
+ use x25519_dalek::{EphemeralSecret, SharedSecret};
+@@ -244,7 +244,7 @@
+     /// The application info will be used to derive the various secrets and
+     /// provide domain separation.
+     pub fn with_info(info: &str) -> Self {
+-        let rng = thread_rng();
++        let rng = OsRng;
+         let secret_key = EphemeralSecret::random_from_rng(rng);
+         let application_info_prefix = info.to_owned();
+ 
+--- a/src/sas.rs
++++ b/src/sas.rs
+@@ -53,7 +53,7 @@
+ 
+ use hkdf::Hkdf;
+ use hmac::{Hmac, Mac as _, digest::MacError};
+-use rand::thread_rng;
++use rand_core::OsRng;
+ use sha2::Sha256;
+ use thiserror::Error;
+ use x25519_dalek::{EphemeralSecret, SharedSecret};
+@@ -221,7 +221,7 @@
+     /// This creates an ephemeral curve25519 keypair that can be used to
+     /// establish a shared secret.
+     pub fn new() -> Self {
+-        let rng = thread_rng();
++        let rng = OsRng;
+ 
+         let secret_key = EphemeralSecret::random_from_rng(rng);
+         let public_key = Curve25519PublicKey::from(&secret_key);
+--- a/src/olm/account/mod.rs
++++ b/src/olm/account/mod.rs
+@@ -21,7 +21,7 @@
+     ChaCha20Poly1305,
+     aead::{Aead, AeadCore, KeyInit},
+ };
+-use rand::thread_rng;
++use rand_core::OsRng;
+ use serde::{Deserialize, Serialize};
+ use thiserror::Error;
+ use zeroize::Zeroize;
+@@ -520,7 +520,7 @@
+             .map_err(|e| DehydratedDeviceError::LibolmPickle(LibolmPickleError::Encode(e)))?;
+ 
+         let cipher = ChaCha20Poly1305::new(key.into());
+-        let rng = thread_rng();
++        let rng = OsRng;
+         let nonce = ChaCha20Poly1305::generate_nonce(rng);
+         let ciphertext = cipher.encrypt(&nonce, encoded.as_slice());
+ 
+--- a/src/megolm/ratchet.rs
++++ b/src/megolm/ratchet.rs
+@@ -14,7 +14,7 @@
+ // limitations under the License.
+ 
+ use hmac::{Hmac, Mac as _};
+-use rand::{RngCore, thread_rng};
++use rand_core::{OsRng, RngCore};
+ use serde::{Deserialize, Deserializer, Serialize, Serializer};
+ use sha2::{Sha256, digest::CtOutput};
+ use subtle::{Choice, ConstantTimeEq};
+@@ -139,7 +139,7 @@
+     const LAST_RATCHET_INDEX: usize = Self::RATCHET_PART_COUNT - 1;
+ 
+     pub fn new() -> Self {
+-        let mut rng = thread_rng();
++        let mut rng = OsRng;
+ 
+         let mut ratchet =
+             Self { inner: RatchetBytes(Box::new([0u8; Self::RATCHET_LENGTH])), counter: 0 };


### PR DESCRIPTION
## Summary
- Add a crate-specific refresh/check helper for local RustSec patch overrides.
- Add canonical patch files for matrix-pickle-derive, matrix-sdk-crypto, tungstenite, and vodozemac.
- Document how to refresh from crates.io, trial newer official releases, and remove an override once upstream resolves it.

## Verification
- `scripts/refresh-rustsec-patches.sh check`
- `bash -n scripts/refresh-rustsec-patches.sh`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo audit --deny warnings`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo check --all-targets --all-features`
