### PR TITLE
parity: close shared-different backlog batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
  "uuid",
  "which",
  "zip",

--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ Ultra uses controlled sync workflows, not blind merges.
 - `origin/main` at sync: `1861c5dcfb8cad8dcddb5f15c1a5a8c34c7f1ce2`
 - `upstream/main` at sync: `95f395027f72c69f06bddcecb08da53cfd10c440`
 - Pending commits captured in report: `1512`
-- Queue summary (`docs/parity/upstream-missing-queue.json`): pending `0`, ported `63`, superseded `1387`
-- Parity gates (`docs/parity/global-parity-proof.json`): release `pass`, ci `pass`
-- Workstream snapshot (`docs/parity/workstream-status.json`): `upstream/main` @ `8163d371922768c32f43eb6036d7d36e56775605` (generated `2026-05-04T01:23:44-06:00`)
+- Queue summary (`docs/parity/upstream-missing-queue.json`): pending `121`, ported `266`, superseded `5499`
+- Parity gates (`docs/parity/global-parity-proof.json`): release `fail`, ci `fail`
+- Workstream snapshot (`docs/parity/workstream-status.json`): `upstream/main` @ `55cb4103beba5822303c06b662635e1491ae72f5` (generated `2026-06-13T16:15:14-06:00`)
 <!-- END:ULTRA_SYNC_STATUS -->
 
 Note: this repository intentionally tracks parity via queue/gate workflows because upstream and ultra history can diverge materially.

--- a/crates/hermes-agent/Cargo.toml
+++ b/crates/hermes-agent/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 thiserror = { workspace = true }
 regex = { workspace = true }
 chrono = { workspace = true }
+url = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json", "multipart"] }
 which = "7"
 eventsource-stream = { workspace = true }

--- a/crates/hermes-agent/src/memory_plugins/openviking.rs
+++ b/crates/hermes-agent/src/memory_plugins/openviking.rs
@@ -178,12 +178,11 @@ fn memory_subdir_for_target(target: &str) -> &'static str {
     }
 }
 
-fn build_memory_uri(user: &str, agent: &str, subdir: &str) -> String {
+fn build_memory_uri(user: &str, _agent: &str, subdir: &str) -> String {
     let slug = uuid::Uuid::new_v4().simple().to_string();
     format!(
-        "viking://user/{}/agent/{}/memories/{}/mem_{}.md",
+        "viking://user/{}/memories/{}/mem_{}.md",
         viking_uri_segment(user),
-        viking_uri_segment(agent),
         viking_uri_segment(subdir),
         &slug[..12]
     )
@@ -868,9 +867,9 @@ mod tests {
     }
 
     #[test]
-    fn memory_uri_includes_agent_and_sanitizes_tenant_segments() {
+    fn memory_uri_sanitizes_tenant_segments_without_agent_scope() {
         let uri = build_memory_uri("user/name", "agent one", "patterns");
-        assert!(uri.starts_with("viking://user/user_name/agent/agent_one/memories/patterns/mem_"));
+        assert!(uri.starts_with("viking://user/user_name/memories/patterns/mem_"));
         assert!(uri.ends_with(".md"));
         assert!(!uri.contains("user/name"));
         assert!(!uri.contains("agent one"));
@@ -906,7 +905,7 @@ mod tests {
     }
 
     #[test]
-    fn content_write_body_uses_agent_scoped_create_uri() {
+    fn content_write_body_uses_user_scoped_create_uri() {
         let st = VikingState {
             client: Client::new(),
             endpoint: DEFAULT_ENDPOINT.to_string(),
@@ -919,7 +918,7 @@ mod tests {
         };
         let body = content_write_body(&st, "patterns", "fact");
         let uri = body["uri"].as_str().expect("uri");
-        assert!(uri.starts_with("viking://user/she_a/agent/hermes_ultra/memories/patterns/"));
+        assert!(uri.starts_with("viking://user/she_a/memories/patterns/"));
         assert_eq!(body["content"], "fact");
         assert_eq!(body["mode"], "create");
     }

--- a/crates/hermes-agent/src/memory_plugins/supermemory.rs
+++ b/crates/hermes-agent/src/memory_plugins/supermemory.rs
@@ -19,6 +19,7 @@ use crate::memory_plugins::config_io;
 const DEFAULT_CONTAINER_TAG: &str = "hermes";
 const DEFAULT_MAX_RECALL: usize = 10;
 const DEFAULT_BASE_URL: &str = "https://api.supermemory.ai";
+const SUPERMEMORY_SOURCE: &str = "hermes";
 
 // ---------------------------------------------------------------------------
 // Tool schemas
@@ -26,7 +27,7 @@ const DEFAULT_BASE_URL: &str = "https://api.supermemory.ai";
 
 fn store_schema() -> Value {
     json!({
-        "name": "supermemory_store",
+        "name": "supermemory-save",
         "description": "Store an explicit memory for future recall.",
         "parameters": {
             "type": "object",
@@ -42,7 +43,7 @@ fn store_schema() -> Value {
 
 fn search_schema() -> Value {
     json!({
-        "name": "supermemory_search",
+        "name": "supermemory-search",
         "description": "Search long-term memory by semantic similarity.",
         "parameters": {
             "type": "object",
@@ -58,7 +59,7 @@ fn search_schema() -> Value {
 
 fn forget_schema() -> Value {
     json!({
-        "name": "supermemory_forget",
+        "name": "supermemory-forget",
         "description": "Forget a memory by exact id or by best-match query.",
         "parameters": {
             "type": "object",
@@ -73,7 +74,7 @@ fn forget_schema() -> Value {
 
 fn profile_schema() -> Value {
     json!({
-        "name": "supermemory_profile",
+        "name": "supermemory-profile",
         "description": "Retrieve persistent profile facts and recent memory context.",
         "parameters": {
             "type": "object",
@@ -292,6 +293,7 @@ impl SupermemoryMemoryPlugin {
             .request(method.clone(), &url)
             .header("Authorization", format!("Bearer {}", config.api_key))
             .header("X-API-Key", &config.api_key)
+            .header("x-sm-source", SUPERMEMORY_SOURCE)
             .header("Content-Type", "application/json");
         if let Some(body) = payload {
             req = req.json(body);
@@ -325,7 +327,7 @@ impl SupermemoryMemoryPlugin {
             "content": content,
             "container_tags": [tag],
             "container_tag": tag,
-            "metadata": metadata.unwrap_or_else(|| json!({})),
+            "metadata": with_source_metadata(metadata),
         });
         let mut last_error = String::new();
         for path in ["/v3/memories", "/v3/documents", "/v1/memories"] {
@@ -421,6 +423,7 @@ impl SupermemoryMemoryPlugin {
             "conversationId": session_id,
             "messages": messages,
             "containerTags": [config.container_tag],
+            "metadata": {"sm_source": SUPERMEMORY_SOURCE},
         });
         Self::send_json(config, Method::POST, "/v4/conversations", Some(&payload)).map(|_| ())
     }
@@ -506,8 +509,8 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
         format!(
             "# Supermemory\n\
              Active. Container: {}.\n\
-             Use supermemory_search, supermemory_store, supermemory_forget, and \
-             supermemory_profile for explicit memory operations.",
+             Use supermemory-search, supermemory-save, supermemory-forget, and \
+             supermemory-profile for explicit memory operations.",
             tag
         )
     }
@@ -604,7 +607,7 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
         let container_tag = args.get("container_tag").and_then(|v| v.as_str());
 
         match tool_name {
-            "supermemory_store" => {
+            "supermemory-save" | "supermemory_store" => {
                 let content = args
                     .get("content")
                     .and_then(|v| v.as_str())
@@ -622,7 +625,7 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
                     Err(e) => json!({"error": e}).to_string(),
                 }
             }
-            "supermemory_search" => {
+            "supermemory-search" | "supermemory_search" => {
                 let query = args
                     .get("query")
                     .and_then(|v| v.as_str())
@@ -640,7 +643,7 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
                     Err(e) => json!({"error": e}).to_string(),
                 }
             }
-            "supermemory_forget" => {
+            "supermemory-forget" | "supermemory_forget" => {
                 let id = args.get("id").and_then(|v| v.as_str()).unwrap_or("").trim();
                 let query = args
                     .get("query")
@@ -674,7 +677,7 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
                     Err(e) => json!({"error": e}).to_string(),
                 }
             }
-            "supermemory_profile" => {
+            "supermemory-profile" | "supermemory_profile" => {
                 let query = args.get("query").and_then(|v| v.as_str());
                 match Self::get_profile(&config, query, container_tag) {
                     Ok(profile) => {
@@ -780,6 +783,21 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
     }
 }
 
+fn with_source_metadata(metadata: Option<Value>) -> Value {
+    let mut map = match metadata {
+        Some(Value::Object(map)) => map,
+        Some(other) => {
+            let mut map = serde_json::Map::new();
+            map.insert("value".to_string(), other);
+            map
+        }
+        None => serde_json::Map::new(),
+    };
+    map.entry("sm_source".to_string())
+        .or_insert_with(|| Value::String(SUPERMEMORY_SOURCE.to_string()));
+    Value::Object(map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -822,7 +840,31 @@ mod tests {
     fn test_supermemory_tool_schemas() {
         let plugin = SupermemoryMemoryPlugin::new();
         let schemas = plugin.get_tool_schemas();
-        assert_eq!(schemas.len(), 4);
+        let names = schemas
+            .iter()
+            .filter_map(|schema| schema.get("name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "supermemory-save",
+                "supermemory-search",
+                "supermemory-forget",
+                "supermemory-profile",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_supermemory_source_metadata_is_stamped_without_overwriting() {
+        assert_eq!(
+            with_source_metadata(Some(json!({"kind":"note"}))),
+            json!({"kind":"note", "sm_source":"hermes"})
+        );
+        assert_eq!(
+            with_source_metadata(Some(json!({"sm_source":"custom"}))),
+            json!({"sm_source":"custom"})
+        );
     }
 
     #[test]

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -611,11 +611,19 @@ impl GenericProvider {
                 .and_then(|v| v.as_str())
                 .and_then(parse_acp_multimodal_parts)
             {
-                api_msg["content"] = if model_supports_vision {
-                    Value::Array(parts)
-                } else {
-                    Value::String(flatten_multimodal_parts_text(&parts))
-                };
+                let is_tool_message = api_msg
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .is_some_and(|role| role.eq_ignore_ascii_case("tool"));
+                let supports_tool_multimodal = profile
+                    .map(provider_profiles::supports_vision_tool_messages)
+                    .unwrap_or(true);
+                api_msg["content"] =
+                    if model_supports_vision && (!is_tool_message || supports_tool_multimodal) {
+                        Value::Array(parts)
+                    } else {
+                        Value::String(flatten_multimodal_parts_text(&parts))
+                    };
             }
             if !enabled {
                 out.push(api_msg);
@@ -748,6 +756,7 @@ impl GenericProvider {
                 profile,
                 &mut body,
                 effective_model,
+                &self.base_url,
                 extra_body,
             );
         }
@@ -3299,6 +3308,36 @@ mod tests {
         );
         assert!(or_body.get("provider_preferences").is_none());
 
+        let anthropic_mandatory = openrouter.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "anthropic/claude-sonnet-4.6",
+            extra_body: Some(&serde_json::json!({
+                "supports_reasoning": true,
+                "reasoning": {"enabled": true, "effort": "high"}
+            })),
+            stream: false,
+        });
+        assert!(anthropic_mandatory.get("reasoning").is_none());
+        assert_eq!(anthropic_mandatory["verbosity"], "high");
+
+        let anthropic_disabled = openrouter.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "anthropic/claude-sonnet-4.6",
+            extra_body: Some(&serde_json::json!({
+                "supports_reasoning": true,
+                "reasoning": {"enabled": false}
+            })),
+            stream: false,
+        });
+        assert!(anthropic_disabled.get("reasoning").is_none());
+        assert!(anthropic_disabled.get("verbosity").is_none());
+
         let nous = GenericProvider::new(
             "https://inference-api.nousresearch.com/v1",
             "key",
@@ -3337,8 +3376,58 @@ mod tests {
             extra_body: Some(&serde_json::json!({"ollama_num_ctx": 131072})),
             stream: false,
         });
+        assert_eq!(custom_body["max_tokens"], 65_536);
         assert_eq!(custom_body["options"]["num_ctx"], 131_072);
         assert!(custom_body.get("ollama_num_ctx").is_none());
+    }
+
+    #[test]
+    fn test_provider_profile_request_body_minimax_m3_openai_reasoning_contract() {
+        let messages = vec![Message::user("hello")];
+        let provider = GenericProvider::new("https://api.minimax.io/v1", "key", "MiniMax-M3")
+            .with_provider_profile("minimax");
+
+        let enabled = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "MiniMax-M3",
+            extra_body: Some(&serde_json::json!({"reasoning": {"effort": "high"}})),
+            stream: false,
+        });
+        assert_eq!(enabled["reasoning_split"], true);
+        assert_eq!(enabled["thinking"], serde_json::json!({"type": "adaptive"}));
+        assert!(enabled.get("reasoning").is_none());
+
+        let disabled = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "minimax/minimax-m3",
+            extra_body: Some(&serde_json::json!({"reasoning_config": {"enabled": false}})),
+            stream: false,
+        });
+        assert_eq!(
+            disabled["thinking"],
+            serde_json::json!({"type": "disabled"})
+        );
+
+        let anthropic_route =
+            GenericProvider::new("https://api.minimax.io/anthropic", "key", "MiniMax-M3")
+                .with_provider_profile("minimax");
+        let body = anthropic_route.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "MiniMax-M3",
+            extra_body: Some(&serde_json::json!({"reasoning": {"effort": "high"}})),
+            stream: false,
+        });
+        assert!(body.get("reasoning_split").is_none());
+        assert!(body.get("thinking").is_none());
     }
 
     #[test]
@@ -3528,6 +3617,37 @@ mod tests {
             .expect("collapsed text");
         assert!(content.contains("[Attached image]"));
         assert!(body.get("supports_vision").is_none());
+    }
+
+    #[test]
+    fn test_xiaomi_profile_flattens_multimodal_tool_messages_only() {
+        let parts = serde_json::json!([
+            {"type": "text", "text": "tool summary"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+        ]);
+        let messages = vec![
+            Message::user(format!("{ACP_MULTIMODAL_PREFIX}{parts}")),
+            Message::tool_result("tool-call-1", format!("{ACP_MULTIMODAL_PREFIX}{parts}")),
+        ];
+        let provider = GenericProvider::new("https://api.xiaomimimo.com/v1", "key", "mimo-v2-omni")
+            .with_provider_profile("xiaomi");
+
+        let body = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "mimo-v2-omni",
+            extra_body: None,
+            stream: false,
+        });
+
+        assert!(body["messages"][0]["content"].is_array());
+        assert!(body["messages"][1]["content"].is_string());
+        assert!(body["messages"][1]["content"]
+            .as_str()
+            .unwrap()
+            .contains("[Attached image]"));
     }
 
     #[test]

--- a/crates/hermes-agent/src/provider_profiles.rs
+++ b/crates/hermes-agent/src/provider_profiles.rs
@@ -57,6 +57,8 @@ pub fn canonical_provider_profile_id(provider: &str) -> Option<&'static str> {
         "kimi" | "moonshot" | "moonshot-ai" | "kimi-coding" => Some("kimi-coding"),
         "kimi-coding-cn" | "kimi-cn" | "moonshot-cn" => Some("kimi-coding-cn"),
         "openrouter" | "or" => Some("openrouter"),
+        "minimax" | "mini-max" | "minimax-cn" | "minimax_cn" | "minimax-china"
+        | "minimax-oauth" | "minimax_oauth" => Some("minimax"),
         "nous" | "nous-portal" | "nous-api" | "nous_api" | "nousapi" | "nous-portal-api" => {
             Some("nous")
         }
@@ -73,6 +75,7 @@ pub fn default_max_tokens(profile: &str) -> Option<u32> {
         "nvidia" => Some(16_384),
         "kimi-coding" | "kimi-coding-cn" => Some(32_000),
         "qwen-oauth" => Some(65_536),
+        "custom" => Some(65_536),
         _ => None,
     }
 }
@@ -91,13 +94,16 @@ pub fn supports_vision(profile: &str) -> bool {
     )
 }
 
+pub fn supports_vision_tool_messages(profile: &str) -> bool {
+    !matches!(canonical_provider_profile_id(profile), Some("xiaomi"))
+}
+
 pub fn profile_auth_type(profile: &str) -> Option<&'static str> {
     match canonical_provider_profile_id(profile)? {
         "nous" => Some("oauth_device_code"),
         "qwen-oauth" => Some("oauth_external"),
-        "nvidia" | "kimi-coding" | "kimi-coding-cn" | "openrouter" | "xiaomi" | "custom" => {
-            Some("api_key")
-        }
+        "nvidia" | "kimi-coding" | "kimi-coding-cn" | "openrouter" | "minimax" | "xiaomi"
+        | "custom" => Some("api_key"),
         _ => None,
     }
 }
@@ -108,6 +114,7 @@ pub fn profile_base_url(profile: &str) -> Option<&'static str> {
         "kimi-coding" => Some(KIMI_CODE_BASE_URL),
         "kimi-coding-cn" => Some(KIMI_CN_BASE_URL),
         "openrouter" => Some("https://openrouter.ai/api/v1"),
+        "minimax" => Some("https://api.minimax.io/anthropic"),
         "nous" => Some("https://inference-api.nousresearch.com/v1"),
         "qwen-oauth" => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         "xiaomi" => Some("https://api.xiaomimimo.com/v1"),
@@ -227,6 +234,7 @@ pub fn apply_profile_to_body(
     profile: Option<&str>,
     body: &mut Value,
     effective_model: &str,
+    base_url: &str,
     extra_body: Option<&Value>,
 ) {
     let Some(profile) = profile.and_then(canonical_provider_profile_id) else {
@@ -234,6 +242,7 @@ pub fn apply_profile_to_body(
     };
     match profile {
         "kimi-coding" | "kimi-coding-cn" => apply_kimi_profile(body, extra_body),
+        "minimax" => apply_minimax_profile(body, effective_model, base_url, extra_body),
         "openrouter" => apply_openrouter_profile(body, effective_model, extra_body),
         "nous" => apply_nous_profile(body, extra_body),
         "qwen-oauth" => apply_qwen_profile(body, extra_body),
@@ -284,6 +293,28 @@ fn apply_kimi_profile(body: &mut Value, extra_body: Option<&Value>) {
     }
 }
 
+fn apply_minimax_profile(
+    body: &mut Value,
+    effective_model: &str,
+    base_url: &str,
+    extra_body: Option<&Value>,
+) {
+    if !is_minimax_global_openai_base_url(base_url) || !is_minimax_m3(effective_model) {
+        return;
+    }
+
+    remove_key(body, "reasoning");
+    body["reasoning_split"] = Value::Bool(true);
+    let reasoning = reasoning_config(extra_body);
+    let enabled = reasoning
+        .and_then(|cfg| cfg.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    body["thinking"] = serde_json::json!({
+        "type": if enabled { "adaptive" } else { "disabled" },
+    });
+}
+
 fn apply_openrouter_profile(body: &mut Value, effective_model: &str, extra_body: Option<&Value>) {
     if let Some(preferences) = extra_body.and_then(|v| v.get("provider_preferences")) {
         body["provider"] = preferences.clone();
@@ -302,7 +333,25 @@ fn apply_openrouter_profile(body: &mut Value, effective_model: &str, extra_body:
     }
 
     let supports_reasoning = bool_field(extra_body, "supports_reasoning").unwrap_or(false);
-    if let Some(reasoning) = reasoning_config(extra_body) {
+    if openrouter_anthropic_reasoning_is_mandatory(effective_model) {
+        remove_key(body, "reasoning");
+        let reasoning = reasoning_config(extra_body);
+        let enabled = reasoning
+            .and_then(|cfg| cfg.get("enabled"))
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let effort = reasoning
+            .and_then(|cfg| cfg.get("effort"))
+            .and_then(Value::as_str)
+            .or_else(|| string_field(extra_body, "reasoning_effort"))
+            .map(str::trim)
+            .filter(|v| !v.is_empty() && *v != "none");
+        if enabled {
+            if let Some(effort) = effort {
+                body["verbosity"] = Value::String(effort.to_string());
+            }
+        }
+    } else if let Some(reasoning) = reasoning_config(extra_body) {
         body["reasoning"] = reasoning.clone();
     } else if let Some(effort) = string_field(extra_body, "reasoning_effort") {
         body["reasoning"] = serde_json::json!({"enabled": true, "effort": effort});
@@ -394,6 +443,43 @@ fn is_grok_model(model: &str) -> bool {
         || lower.contains("/grok")
 }
 
+fn is_minimax_global_openai_base_url(base_url: &str) -> bool {
+    let normalized = base_url.trim().trim_end_matches('/').to_ascii_lowercase();
+    normalized == "https://api.minimax.io/v1"
+}
+
+fn is_minimax_m3(model: &str) -> bool {
+    matches!(
+        model.trim().to_ascii_lowercase().as_str(),
+        "minimax-m3" | "minimax/minimax-m3"
+    )
+}
+
+fn openrouter_anthropic_reasoning_is_mandatory(model: &str) -> bool {
+    let m = model.trim().to_ascii_lowercase();
+    if !m.starts_with("anthropic/") && !m.starts_with("claude") && !m.contains("claude") {
+        return false;
+    }
+    const OPTIONAL_SUBSTRINGS: &[&str] = &[
+        "claude-3",
+        "claude-opus-4-0",
+        "claude-opus-4.0",
+        "claude-opus-4-1",
+        "claude-opus-4.1",
+        "claude-sonnet-4-0",
+        "claude-sonnet-4.0",
+        "claude-opus-4-2025",
+        "claude-sonnet-4-2025",
+        "claude-opus-4-5",
+        "claude-opus-4.5",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4.5",
+        "claude-haiku-4-5",
+        "claude-haiku-4.5",
+    ];
+    !OPTIONAL_SUBSTRINGS.iter().any(|needle| m.contains(needle))
+}
+
 fn is_pareto_code_model(model: &str) -> bool {
     let lower = model.trim().to_ascii_lowercase();
     lower == "openrouter/pareto-code" || lower.ends_with("/pareto-code")
@@ -421,6 +507,7 @@ mod tests {
             Some("kimi-coding-cn")
         );
         assert_eq!(canonical_provider_profile_id("or"), Some("openrouter"));
+        assert_eq!(canonical_provider_profile_id("mini-max"), Some("minimax"));
         assert_eq!(canonical_provider_profile_id("nous-portal"), Some("nous"));
         assert_eq!(canonical_provider_profile_id("nous-api"), Some("nous"));
         assert_eq!(canonical_provider_profile_id("nousapi"), Some("nous"));
@@ -439,6 +526,7 @@ mod tests {
         assert_eq!(default_max_tokens("nvidia"), Some(16_384));
         assert_eq!(default_max_tokens("kimi"), Some(32_000));
         assert_eq!(default_max_tokens("qwen-oauth"), Some(65_536));
+        assert_eq!(default_max_tokens("ollama-local"), Some(65_536));
         assert!(omit_temperature("kimi"));
         assert_eq!(profile_auth_type("nous"), Some("oauth_device_code"));
         assert_eq!(profile_auth_type("qwen-oauth"), Some("oauth_external"));
@@ -449,6 +537,7 @@ mod tests {
             .contains("moonshot.cn"));
         assert!(profile_base_url("mimo").unwrap().contains("xiaomimimo.com"));
         assert!(supports_vision("xiaomi"));
+        assert!(!supports_vision_tool_messages("xiaomi"));
         assert!(!supports_vision("kimi"));
         assert!(is_kimi_code_base_url(KIMI_CODE_BASE_URL));
         assert_eq!(

--- a/crates/hermes-agent/src/providers_extra.rs
+++ b/crates/hermes-agent/src/providers_extra.rs
@@ -218,7 +218,8 @@ pub struct MiniMaxProvider {
 impl MiniMaxProvider {
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            inner: GenericProvider::new("https://api.minimax.chat/v1", api_key, "abab6.5s-chat"),
+            inner: GenericProvider::new("https://api.minimax.chat/v1", api_key, "abab6.5s-chat")
+                .with_provider_profile("minimax"),
         }
     }
 

--- a/crates/hermes-agent/src/smart_model_routing.rs
+++ b/crates/hermes-agent/src/smart_model_routing.rs
@@ -340,14 +340,20 @@ where
     }
 }
 
-/// Heuristic from Python `_detect_api_mode_for_url` (OpenAI direct host → Codex/Responses).
+/// Heuristic from Python `_detect_api_mode_for_url`.
 pub fn detect_api_mode_for_url(base_url: &str) -> Option<ApiMode> {
-    let normalized = base_url.trim().to_lowercase();
-    if normalized.contains("bedrock-runtime.") || normalized.contains("bedrock-runtime-") {
+    let parsed = url::Url::parse(base_url.trim()).ok()?;
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    let path = parsed.path().trim_end_matches('/').to_ascii_lowercase();
+
+    if host.contains("bedrock-runtime.") || host.contains("bedrock-runtime-") {
         return Some(ApiMode::BedrockConverse);
     }
-    if normalized.contains("api.openai.com") && !normalized.contains("openrouter") {
+    if host == "api.openai.com" || host == "api.x.ai" {
         return Some(ApiMode::CodexResponses);
+    }
+    if path == "/anthropic" || path.ends_with("/anthropic") {
+        return Some(ApiMode::AnthropicMessages);
     }
     None
 }
@@ -442,6 +448,62 @@ mod tests {
             detect_api_mode_for_url("https://bedrock-runtime.us-east-1.amazonaws.com"),
             Some(ApiMode::BedrockConverse)
         );
+    }
+
+    #[test]
+    fn detects_codex_api_mode_from_exact_openai_and_xai_hosts() {
+        assert_eq!(
+            detect_api_mode_for_url("https://api.openai.com/v1"),
+            Some(ApiMode::CodexResponses)
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://api.x.ai/v1"),
+            Some(ApiMode::CodexResponses)
+        );
+    }
+
+    #[test]
+    fn detects_anthropic_messages_api_mode_from_path_suffix() {
+        assert_eq!(
+            detect_api_mode_for_url("https://api.minimax.io/anthropic"),
+            Some(ApiMode::AnthropicMessages)
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://api.minimaxi.com/anthropic/"),
+            Some(ApiMode::AnthropicMessages)
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://dashscope.aliyuncs.com/api/v2/apps/anthropic"),
+            Some(ApiMode::AnthropicMessages)
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://API.MINIMAX.IO/Anthropic"),
+            Some(ApiMode::AnthropicMessages)
+        );
+    }
+
+    #[test]
+    fn detect_api_mode_rejects_host_suffix_and_path_false_positives() {
+        assert_eq!(
+            detect_api_mode_for_url("https://openrouter.ai/api/v1"),
+            None
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://api.openai.com.example/v1"),
+            None
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://proxy.example.test/api.openai.com/v1"),
+            None
+        );
+        assert_eq!(detect_api_mode_for_url("https://api.x.ai.example/v1"), None);
+        assert_eq!(
+            detect_api_mode_for_url("https://api.example.com/anthropic/v1"),
+            None
+        );
+        assert_eq!(detect_api_mode_for_url("https://api.together.xyz/v1"), None);
+        assert_eq!(detect_api_mode_for_url(""), None);
+        assert_eq!(detect_api_mode_for_url("http://localhost:11434/v1"), None);
     }
 
     #[test]

--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -1294,6 +1294,39 @@ mod tests {
     }
 
     #[test]
+    fn cli_parse_mcp_add_command_does_not_clobber_top_level_command() {
+        let cli = Cli::try_parse_from(vec![
+            "hermes",
+            "mcp",
+            "add",
+            "filesystem",
+            "--command",
+            "npx",
+            "--parallel-tools",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(CliCommand::Mcp {
+                action,
+                name,
+                server,
+                url,
+                command,
+                parallel_tools,
+            }) => {
+                assert_eq!(action.as_deref(), Some("add"));
+                assert_eq!(name.as_deref(), Some("filesystem"));
+                assert!(server.is_none());
+                assert!(url.is_none());
+                assert_eq!(command.as_deref(), Some("npx"));
+                assert!(parallel_tools);
+            }
+            _ => panic!("Expected MCP add command"),
+        }
+    }
+
+    #[test]
     fn cli_parse_logs_default() {
         let cli = Cli::try_parse_from(vec!["hermes", "logs"]).unwrap();
         match cli.command {

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -10553,7 +10553,7 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
     },
     SetupModelOption {
         provider: "zai",
-        model: "zai:glm-5.1",
+        model: "zai:glm-5.2",
         label: "Z.AI / GLM",
     },
     SetupModelOption {

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -253,7 +253,7 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
         ],
     ),
     ("tencent-tokenhub", &["hy3-preview"]),
-    ("zai", &["glm-5.1", "glm-5.0", "glm-4.5-flash"]),
+    ("zai", &["glm-5.2", "glm-5.1", "glm-5.0", "glm-4.5-flash"]),
     ("minimax", &["MiniMax-M3", "MiniMax-M2.7"]),
     ("minimax-cn", &["MiniMax-M3", "MiniMax-M2.7"]),
     (
@@ -1507,6 +1507,7 @@ mod tests {
         assert!(provider_curated_models("arcee-ai").contains(&"trinity-mini"));
         assert!(provider_curated_models("mimo").contains(&"mimo-v2.5-pro"));
         assert!(provider_curated_models("tokenhub").contains(&"hy3-preview"));
+        assert_eq!(provider_curated_models("zai")[0], "glm-5.2");
         assert_eq!(provider_curated_models("minimax")[0], "MiniMax-M3");
         assert_eq!(provider_curated_models("minimax-cn")[0], "MiniMax-M3");
     }

--- a/crates/hermes-gateway/src/platforms/api_server.rs
+++ b/crates/hermes-gateway/src/platforms/api_server.rs
@@ -250,7 +250,62 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
+    #[serde(deserialize_with = "deserialize_chat_content")]
     pub content: String,
+}
+
+const MAX_CHAT_CONTENT_DEPTH: usize = 10;
+const MAX_CHAT_CONTENT_LIST_SIZE: usize = 1000;
+const MAX_CHAT_CONTENT_CHARS: usize = 65_536;
+
+fn truncate_chat_content(input: &str) -> String {
+    input.chars().take(MAX_CHAT_CONTENT_CHARS).collect()
+}
+
+fn normalize_chat_content_value(value: &serde_json::Value, depth: usize) -> String {
+    if depth > MAX_CHAT_CONTENT_DEPTH {
+        return String::new();
+    }
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(text) => truncate_chat_content(text),
+        serde_json::Value::Bool(value) => {
+            if *value {
+                "True".to_string()
+            } else {
+                "False".to_string()
+            }
+        }
+        serde_json::Value::Number(value) => value.to_string(),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .take(MAX_CHAT_CONTENT_LIST_SIZE)
+            .map(|item| normalize_chat_content_value(item, depth + 1))
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        serde_json::Value::Object(map) => {
+            let part_type = map
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            if matches!(part_type, "text" | "input_text" | "output_text") {
+                map.get("text")
+                    .map(|text| normalize_chat_content_value(text, depth + 1))
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            }
+        }
+    }
+}
+
+fn deserialize_chat_content<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(normalize_chat_content_value(&value, 0))
 }
 
 #[derive(Debug, Serialize)]
@@ -3210,6 +3265,48 @@ mod tests {
         }))
         .expect("quoted false all should deserialize");
         assert!(!approval.all);
+    }
+
+    #[test]
+    fn chat_message_content_arrays_normalize_to_text() {
+        let chat: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "hermes-agent",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+                    {"type": "input_text", "text": "second"},
+                    42,
+                    true
+                ]
+            }]
+        }))
+        .expect("content array should normalize");
+
+        assert_eq!(chat.messages[0].content, "first\nsecond\n42\nTrue");
+    }
+
+    #[test]
+    fn chat_message_content_normalization_is_bounded() {
+        let many = (0..2000)
+            .map(|_| serde_json::json!({"type": "text", "text": "x"}))
+            .collect::<Vec<_>>();
+        let chat: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": many}]
+        }))
+        .expect("large content array should normalize");
+
+        assert_eq!(chat.messages[0].content.matches('x').count(), 1000);
+
+        let huge = "x".repeat(100_000);
+        let chat: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": huge}]
+        }))
+        .expect("huge string should normalize");
+        assert_eq!(chat.messages[0].content.len(), MAX_CHAT_CONTENT_CHARS);
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,23 +1,23 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-12T11:29:14.898323+00:00`_
+_Generated from source artifacts: `2026-06-16T02:12:15.001297+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `9c505217044cedc28f174f1b74174d00d9ea1c81`
-- Workstream snapshot generated: `2026-06-12T04:04:44-06:00`
+- Upstream target: `upstream/main` @ `55cb4103beba5822303c06b662635e1491ae72f5`
+- Workstream snapshot generated: `2026-06-13T16:15:14-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-12T11:29:11.103206+00:00`
-- Proof snapshot generated: `2026-06-12T11:29:14.898323+00:00`
+- Queue snapshot generated: `2026-06-16T02:12:02.309717+00:00`
+- Proof snapshot generated: `2026-06-16T02:12:15.001297+00:00`
 
 ## Gate Status
 
-- Release gate: **PASS**
-- CI/tree-drift gate: **PASS**
+- Release gate: **FAIL**
+- CI/tree-drift gate: **FAIL**
 - Test coverage audit: **PASS**
 - SOTA harness matrix: **PASS**
-- Release gate failures: none
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
+- Release gate failures: max_queue_pending_commits (actual=121.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=121.0, limit=100)
 
 ## Test Coverage Audit
 
@@ -45,10 +45,10 @@ _Generated from source artifacts: `2026-06-12T11:29:14.898323+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 5659 |
-| Pending | 0 |
+| Total commits in queue | 5956 |
+| Pending | 121 |
 | Ported | 266 |
-| Superseded | 5323 |
+| Superseded | 5499 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -5,15 +5,13 @@
         "actual": 5880.0,
         "limit": 5500,
         "metric": "max_commits_behind",
-        "special_rule": "allow_tree_drift_when_functional_clean",
-        "status": "warn"
+        "status": "fail"
       },
       {
         "actual": 5657.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
-        "special_rule": "allow_tree_drift_when_functional_clean",
-        "status": "warn"
+        "status": "fail"
       },
       {
         "actual": 2309.0,
@@ -76,26 +74,16 @@
         "status": "pass"
       },
       {
-        "actual": 0.0,
+        "actual": 121.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
-        "status": "pass"
+        "status": "fail"
       }
     ],
     "mode": "tree-drift",
-    "pass": true,
-    "special_rules_applied": [
-      {
-        "metrics": [
-          "max_commits_behind",
-          "max_upstream_patch_missing"
-        ],
-        "reason": "functional parity clean; raw upstream tree drift kept as observability warning for the Rust fork",
-        "rule": "allow_tree_drift_when_functional_clean"
-      }
-    ]
+    "pass": false
   },
-  "generated_at_utc": "2026-06-12T11:29:22.950052+00:00",
+  "generated_at_utc": "2026-06-16T02:12:15.001297+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -111,7 +99,7 @@
     "max_commits_behind": 5880.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 0.0,
+    "max_queue_pending_commits": 121.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -131,21 +119,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 70,
+      "pending": 121,
       "ported": 266,
-      "superseded": 5323
+      "superseded": 5499
     },
     "by_target_ticket": {
-      "20": 2416,
-      "21": 118,
-      "22": 856,
-      "23": 400,
+      "20": 2570,
+      "21": 119,
+      "22": 877,
+      "23": 416,
       "24": 22,
-      "25": 120,
-      "26": 1727
+      "25": 128,
+      "26": 1824
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5659
+    "total_commits": 5956
   },
   "release_gate": {
     "checks": [
@@ -204,10 +193,10 @@
         "status": "pass"
       },
       {
-        "actual": 0.0,
+        "actual": 121.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
-        "status": "pass"
+        "status": "fail"
       },
       {
         "actual": {
@@ -227,7 +216,7 @@
       }
     ],
     "mode": "functional",
-    "pass": true
+    "pass": false
   },
   "sota_harness_summary": {
     "gate": {

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,12 +1,12 @@
 # Global Parity Proof
 
-Generated: `2026-06-12T11:29:22.950052+00:00`
+Generated: `2026-06-16T02:12:15.001297+00:00`
 
 ## Gate Status
 
-- CI gate: **PASS**
+- CI gate: **FAIL**
 - CI gate mode: `tree-drift`
-- Release gate: **PASS**
+- Release gate: **FAIL**
 - Release gate mode: `functional`
 
 ## Metrics
@@ -25,7 +25,7 @@ Generated: `2026-06-12T11:29:22.950052+00:00`
 | `min_sota_harness_domain_coverage_ratio` | 1.0 |
 | `max_sota_harness_critical_gaps` | 0.0 |
 | `max_sota_harness_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 0.0 |
+| `max_queue_pending_commits` | 121.0 |
 
 ## GPAR Ticket Completion
 
@@ -58,13 +58,13 @@ Generated: `2026-06-12T11:29:22.950052+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5659`.
+- Upstream missing commits tracked: `5956`.
 - By target ticket:
-  - `#20`: `2416`
-  - `#21`: `118`
-  - `#22`: `856`
-  - `#23`: `400`
+  - `#20`: `2570`
+  - `#21`: `119`
+  - `#22`: `877`
+  - `#23`: `416`
   - `#24`: `22`
-  - `#25`: `120`
-  - `#26`: `1727`
+  - `#25`: `128`
+  - `#26`: `1824`
 

--- a/docs/parity/hermes-cli-test-coverage.json
+++ b/docs/parity/hermes-cli-test-coverage.json
@@ -549,34 +549,6 @@
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
       "coverage_tags": [
-        "general_cli",
-        "plugin/plugins/skills"
-      ],
-      "path": "tests/hermes_cli/test_banner.py",
-      "rationale": "Upstream banner behavior maps to Rust Ultra banner identity plus platform toolset normalization and disabled-tool filtering contracts.",
-      "rust_tests": [
-        {
-          "file": "crates/hermes-cli/src/banner.rs",
-          "name": "startup_banner_names_ultra_runtime"
-        },
-        {
-          "file": "crates/hermes-cli/src/platform_toolsets.rs",
-          "name": "platform_toolset_tokens_strip_legacy_tools_suffix"
-        },
-        {
-          "file": "crates/hermes-cli/src/platform_toolsets.rs",
-          "name": "tools_config_disabled_removes_even_if_platform_enables"
-        },
-        {
-          "file": "crates/hermes-cli/tests/e2e_replay_suite.rs",
-          "name": "e2e_replay_suite_provider_auth_gateway_and_deterministic_manifest"
-        }
-      ],
-      "status": "covered_by_rust_contracts"
-    },
-    {
-      "coverage_kind": "rust_contract_or_documented_divergence",
-      "coverage_tags": [
         "general_cli"
       ],
       "path": "tests/hermes_cli/test_banner_git_state.py",
@@ -628,6 +600,34 @@
         {
           "file": "crates/hermes-cli/src/main.rs",
           "name": "profile_create_no_skills_strips_cloned_skill_overrides"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
+        "general_cli",
+        "plugin/plugins/skills"
+      ],
+      "path": "tests/hermes_cli/test_banner.py",
+      "rationale": "Upstream banner behavior maps to Rust Ultra banner identity plus platform toolset normalization and disabled-tool filtering contracts.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/banner.rs",
+          "name": "startup_banner_names_ultra_runtime"
+        },
+        {
+          "file": "crates/hermes-cli/src/platform_toolsets.rs",
+          "name": "platform_toolset_tokens_strip_legacy_tools_suffix"
+        },
+        {
+          "file": "crates/hermes-cli/src/platform_toolsets.rs",
+          "name": "tools_config_disabled_removes_even_if_platform_enables"
+        },
+        {
+          "file": "crates/hermes-cli/tests/e2e_replay_suite.rs",
+          "name": "e2e_replay_suite_provider_auth_gateway_and_deterministic_manifest"
         }
       ],
       "status": "covered_by_rust_contracts"
@@ -882,7 +882,7 @@
       "coverage_tags": [
         "config/aux/mcp"
       ],
-      "path": "tests/hermes_cli/test_config.py",
+      "path": "tests/hermes_cli/test_config_validation.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -917,7 +917,7 @@
       "coverage_tags": [
         "config/aux/mcp"
       ],
-      "path": "tests/hermes_cli/test_config_validation.py",
+      "path": "tests/hermes_cli/test_config.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -1283,33 +1283,25 @@
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
       "coverage_tags": [
-        "doctor/debug/logs"
+        "model/provider/api_mode"
       ],
-      "path": "tests/hermes_cli/test_doctor.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "status": "covered_by_rust_contracts",
+      "path": "tests/hermes_cli/test_detect_api_mode_for_url.py",
       "rust_tests": [
         {
-          "file": "crates/hermes-cli/src/cli.rs",
-          "name": "cli_parse_provider_and_oneshot_flags"
+          "file": "crates/hermes-agent/src/smart_model_routing.rs",
+          "name": "detects_codex_api_mode_from_exact_openai_and_xai_hosts"
         },
         {
-          "file": "crates/hermes-cli/src/app.rs",
-          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
+          "file": "crates/hermes-agent/src/smart_model_routing.rs",
+          "name": "detects_anthropic_messages_api_mode_from_path_suffix"
         },
         {
-          "file": "crates/hermes-cli/src/cli.rs",
-          "name": "cli_parse_doctor_with_flags"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "capture_debug_log_snapshot_preserves_boundary_line"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "provenance_sign_and_verify_round_trip"
+          "file": "crates/hermes-agent/src/smart_model_routing.rs",
+          "name": "detect_api_mode_rejects_host_suffix_and_path_false_positives"
         }
-      ],
-      "status": "covered_by_rust_contracts"
+      ]
     },
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
@@ -1358,6 +1350,37 @@
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
       "coverage_tags": [
+        "doctor/debug/logs"
+      ],
+      "path": "tests/hermes_cli/test_doctor.py",
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_provider_and_oneshot_flags"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
+        },
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_doctor_with_flags"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "capture_debug_log_snapshot_preserves_boundary_line"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "provenance_sign_and_verify_round_trip"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
         "general_cli"
       ],
       "path": "tests/hermes_cli/test_fallback_cmd.py",
@@ -1378,45 +1401,6 @@
         {
           "file": "crates/hermes-cli/src/cli.rs",
           "name": "cli_parse_default"
-        }
-      ],
-      "status": "covered_by_rust_contracts"
-    },
-    {
-      "coverage_kind": "rust_contract_or_documented_divergence",
-      "coverage_tags": [
-        "gateway/webhook/hooks_cli"
-      ],
-      "path": "tests/hermes_cli/test_gateway.py",
-      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
-      "rust_tests": [
-        {
-          "file": "crates/hermes-cli/src/cli.rs",
-          "name": "cli_parse_provider_and_oneshot_flags"
-        },
-        {
-          "file": "crates/hermes-cli/src/app.rs",
-          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "api_server_config_defaults_to_loopback"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "api_server_config_honors_overrides_and_token_precedence"
-        },
-        {
-          "file": "crates/hermes-gateway/src/gateway.rs",
-          "name": "gateway_register_and_list_adapters"
-        },
-        {
-          "file": "crates/hermes-gateway/src/gateway.rs",
-          "name": "gateway_reload_mcp_and_status_reflect_runtime_state"
-        },
-        {
-          "file": "crates/hermes-gateway/src/gateway.rs",
-          "name": "gateway_emits_agent_start_and_end_hooks"
         }
       ],
       "status": "covered_by_rust_contracts"
@@ -1466,6 +1450,45 @@
         "gateway/webhook/hooks_cli"
       ],
       "path": "tests/hermes_cli/test_gateway_wsl.py",
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_provider_and_oneshot_flags"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "api_server_config_defaults_to_loopback"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "api_server_config_honors_overrides_and_token_precedence"
+        },
+        {
+          "file": "crates/hermes-gateway/src/gateway.rs",
+          "name": "gateway_register_and_list_adapters"
+        },
+        {
+          "file": "crates/hermes-gateway/src/gateway.rs",
+          "name": "gateway_reload_mcp_and_status_reflect_runtime_state"
+        },
+        {
+          "file": "crates/hermes-gateway/src/gateway.rs",
+          "name": "gateway_emits_agent_start_and_end_hooks"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
+        "gateway/webhook/hooks_cli"
+      ],
+      "path": "tests/hermes_cli/test_gateway.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -1867,6 +1890,21 @@
         }
       ],
       "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
+        "config/aux/mcp"
+      ],
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "status": "covered_by_rust_contracts",
+      "path": "tests/hermes_cli/test_mcp_add_command_dest.py",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_mcp_add_command_does_not_clobber_top_level_command"
+        }
+      ]
     },
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
@@ -2460,7 +2498,7 @@
       "coverage_tags": [
         "plugin/plugins/skills"
       ],
-      "path": "tests/hermes_cli/test_plugins.py",
+      "path": "tests/hermes_cli/test_plugins_cmd.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -2491,7 +2529,7 @@
       "coverage_tags": [
         "plugin/plugins/skills"
       ],
-      "path": "tests/hermes_cli/test_plugins_cmd.py",
+      "path": "tests/hermes_cli/test_plugins.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -2855,41 +2893,6 @@
       "coverage_tags": [
         "setup/install/reconfigure"
       ],
-      "path": "tests/hermes_cli/test_setup.py",
-      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
-      "rust_tests": [
-        {
-          "file": "crates/hermes-cli/src/cli.rs",
-          "name": "cli_parse_provider_and_oneshot_flags"
-        },
-        {
-          "file": "crates/hermes-cli/src/app.rs",
-          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "setup_model_choice_supports_nous"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "setup_provider_defaults_are_unique_and_include_nous"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "setup_provider_env_keys_include_nous"
-        },
-        {
-          "file": "crates/hermes-cli/src/main.rs",
-          "name": "merge_missing_env_keys_skips_empty_values"
-        }
-      ],
-      "status": "covered_by_rust_contracts"
-    },
-    {
-      "coverage_kind": "rust_contract_or_documented_divergence",
-      "coverage_tags": [
-        "setup/install/reconfigure"
-      ],
       "path": "tests/hermes_cli/test_setup_hermes_script.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
@@ -3230,6 +3233,41 @@
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
       "coverage_tags": [
+        "setup/install/reconfigure"
+      ],
+      "path": "tests/hermes_cli/test_setup.py",
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_provider_and_oneshot_flags"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "setup_model_choice_supports_nous"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "setup_provider_defaults_are_unique_and_include_nous"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "setup_provider_env_keys_include_nous"
+        },
+        {
+          "file": "crates/hermes-cli/src/main.rs",
+          "name": "merge_missing_env_keys_skips_empty_values"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
         "config/aux/mcp",
         "plugin/plugins/skills"
       ],
@@ -3442,37 +3480,6 @@
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
       "coverage_tags": [
-        "status"
-      ],
-      "path": "tests/hermes_cli/test_status.py",
-      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
-      "rust_tests": [
-        {
-          "file": "crates/hermes-cli/src/cli.rs",
-          "name": "cli_parse_provider_and_oneshot_flags"
-        },
-        {
-          "file": "crates/hermes-cli/src/app.rs",
-          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
-        },
-        {
-          "file": "crates/hermes-cli/src/cli.rs",
-          "name": "cli_parse_status"
-        },
-        {
-          "file": "crates/hermes-gateway/src/gateway.rs",
-          "name": "gateway_executes_status_command_without_agent_handler"
-        },
-        {
-          "file": "crates/hermes-gateway/src/gateway.rs",
-          "name": "gateway_status_updates_use_platform_status_api"
-        }
-      ],
-      "status": "covered_by_rust_contracts"
-    },
-    {
-      "coverage_kind": "rust_contract_or_documented_divergence",
-      "coverage_tags": [
         "model/provider/models_dev",
         "status"
       ],
@@ -3510,6 +3517,37 @@
         {
           "file": "crates/hermes-core/src/providers.rs",
           "name": "known_provider_registry_covers_upstream_snapshot_required_ids"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
+        "status"
+      ],
+      "path": "tests/hermes_cli/test_status.py",
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_provider_and_oneshot_flags"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "test_build_agent_config_maps_runtime_provider_api_key_env"
+        },
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_status"
+        },
+        {
+          "file": "crates/hermes-gateway/src/gateway.rs",
+          "name": "gateway_executes_status_command_without_agent_handler"
+        },
+        {
+          "file": "crates/hermes-gateway/src/gateway.rs",
+          "name": "gateway_status_updates_use_platform_status_api"
         }
       ],
       "status": "covered_by_rust_contracts"
@@ -3995,7 +4033,7 @@
       "coverage_tags": [
         "web_server/web_ui/dashboard"
       ],
-      "path": "tests/hermes_cli/test_web_server.py",
+      "path": "tests/hermes_cli/test_web_server_host_header.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -4034,7 +4072,7 @@
       "coverage_tags": [
         "web_server/web_ui/dashboard"
       ],
-      "path": "tests/hermes_cli/test_web_server_host_header.py",
+      "path": "tests/hermes_cli/test_web_server.py",
       "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
       "rust_tests": [
         {
@@ -4151,7 +4189,7 @@
   "schema_version": 1,
   "source_backlog": "docs/parity/shared-diff-backlog.json",
   "summary": {
-    "covered_paths": 114,
+    "covered_paths": 116,
     "guard_test": "crates/hermes-parity-tests/tests/hermes_cli_test_coverage_contract.rs",
     "provider_api_mode_bridge_added": true,
     "required_backlog_classification_path": "tests/hermes_cli"

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -27,7 +27,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "37c31799bea6e44b517880c08d429018917d1306",
+      "upstream_blob": "54662b23edafd57881018721753c15055cf3361f",
       "workstream": "WS6"
     },
     {
@@ -42,7 +42,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "fa4d64049b7c11a9b8508a5f2e2c4f8bff485118",
+      "upstream_blob": "6d87318e35e07f7b79f45da203dc30b570724a95",
       "workstream": "WS8"
     },
     {
@@ -72,7 +72,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f77932bf1f985d805345aa878e77f4b7df28712f",
+      "upstream_blob": "1a70116548aa69eccdb0fed1dfafd5abc30398fd",
       "workstream": "WS8"
     },
     {
@@ -117,7 +117,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "b65a11baf8fad7a3d9b43fee3abe8acc601c5035",
+      "upstream_blob": "5fb4e80082b2fea75d3428bc21ca589395c89347",
       "workstream": "WS8"
     },
     {
@@ -151,17 +151,32 @@
       "workstream": "WS8"
     },
     {
-      "action": "Add classification, owner, issue, and surgical plan before implementation.",
-      "classification": "unclassified",
-      "classification_path": "",
-      "existing_coverage": "unclaimed",
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "docs/design/profile-builder.md",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "26da98ffeb0e217a2e9ca7fcfa666b7ebbfb7c79",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "docs/design/profile-builder.md",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "76649096d2c54ee83260f434c768ba3f5349a98d",
+      "workstream": "WS8"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "docs/kanban/multi-gateway.md",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "fe9362cc1044a86ce244276542e808a3bb35160f",
-      "necessity": "unknown",
-      "owner": "",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
       "path": "docs/kanban/multi-gateway.md",
-      "rust_requirement": "needs_rust_relevance_review",
-      "status": "pending_classification",
-      "ticket": "",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
       "upstream_blob": "126e39823ab998c7717f4b71d9c129cfb58cccda",
       "workstream": "WS8"
     },
@@ -213,36 +228,6 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
-      "classification_path": "optional-skills/blockchain",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "ec0671e05086539ea18ba1cf4b3e47aefa88c08d",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/blockchain/hyperliquid/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "51843bbf1b34113a06373a8a7590dd9ec5d59b92",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/blockchain",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "1079f6b6267945e26081b7dba80450b19ae3f619",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "be2a95d5f993744c5512b8b0dbc8eb884d5c10ef",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
       "classification_path": "optional-skills/creative",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c6dcd40e5c5621977060dc8dcdf166f8e738c90a",
@@ -253,66 +238,6 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "75631e98c8c961408e19aeb1cc546494b702bad3",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/creative",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "f06972abd5f78638bc312f3498668adff9f5415f",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/creative/kanban-video-orchestrator/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "c5ac2a8c96e9881de4daa267c88b31383ba69b73",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/creative",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "01d836def8dbdf523ec201142f8404b8276bc785",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/creative/kanban-video-orchestrator/assets/setup.sh.tmpl",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "3f7629d6293465bf42df2c3b51b14e1fd4da030c",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/creative",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "ab449a0b0a47908bba2674a011c6b75b3ad59b5b",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/creative/kanban-video-orchestrator/references/kanban-setup.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "53e4f26999722857c7c25bcc40fa14411dc4c629",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/creative",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "5a52d15ddd0d1c4ea6cc0c0e1d3d850fed88a17b",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/creative/kanban-video-orchestrator/references/tool-matrix.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "b5e59c31478cdd9618d365c5edede77092073e41",
       "workstream": "WS4"
     },
     {
@@ -335,7 +260,7 @@
       "classification": "intentional_divergence",
       "classification_path": "optional-skills/devops",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "628f340b4c84f90551c82f6f049599c10fd1c697",
+      "local_blob": "d911b3ca41a2a01f884b79b512b245b8613c2ce0",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "optional-skills/devops/watchers/SKILL.md",
@@ -343,21 +268,6 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7c326ae7e4b8d1fdaeaafc50ba727fe938263c69",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/devops",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "bb4a3ca6f30061a301b535b4eef2d02bdd937ad9",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/devops/watchers/scripts/watch_github.py",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "4b42d4ed3eeca338215275769fd2d69c8f85a5d5",
       "workstream": "WS4"
     },
     {
@@ -438,96 +348,6 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
-      "classification_path": "optional-skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "fbcfec5853a8804155eac167ffcd2ba0288e1bf9",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/productivity/canvas/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "68d6402e55438c5d20ac67ba1399be36c4059ba2",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "13599c575565a6aaf354c82ed1d9edc1e9d6ea83",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/productivity/canvas/scripts/canvas_api.py",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "2390d5ff513ce8b1195b60dbcb9a701328eef2c7",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "0062674069a0b7476cf33dcee5cc81a0762d67ce",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/productivity/shopify/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "4dc8dc93ad8cd442f00580126090caf91a0bc607",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "0417ba6c4c5d117e6d5d9b08d87d56bcf452c8ef",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/productivity/siyuan/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "3f1997764387b9be53ecba13bf930b6da13c2287",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "b3d1d5884eb309fbf26a7cf4f7b6cc7bff43233f",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/productivity/telephony/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "f0d286149128615486a735954298eb0668f001f4",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "c9233647f3f595dec7b2b1e284bb82dfeef1b0c4",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/productivity/telephony/scripts/telephony.py",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "291fd8629ab85e10df594e9a2060aee1f1b3aa28",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
       "classification_path": "optional-skills/research",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1a69f6528f2195865302792d6eac659d2534c607",
@@ -568,36 +388,6 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "dd304d0d4d9d9c47bcda7cb0d85ba094abd55d73",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "2a6cc8e18b0eb0cfd3e0a5f1f87116f801fd4e92",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/security/1password/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "152cd13e60ba4e5567c81342674904d0838d619a",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "optional-skills",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "78f90f2a91fe8890c8bf2b84596a209af88b00d1",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "optional-skills/software-development/rest-graphql-debug/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "64b96b3cdd3e6f37d44040612a94b24fa6fcd87b",
       "workstream": "WS4"
     },
     {
@@ -687,7 +477,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "fddb62dacb06e5e528abdd217e83ac8572f6c19d",
+      "upstream_blob": "8f70631ea84f3f98a47ea6a972ea0f23b6526eca",
       "workstream": "WS3"
     },
     {
@@ -916,16 +706,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2398f2ebd87a3d19c9985949e29f62f539acf7b1",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "3f92b5cbb2a30afa2aa0f4f85d4a07ea1f69ce20",
       "workstream": "WS3"
@@ -946,16 +736,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/hindsight/README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "aa8e79ba0bfd94232f45fff1576a41b42e86cb93",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/hindsight/README.md",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "d8f96a45e1e9a20c8cc45c309358a64d266c7276",
       "workstream": "WS3"
@@ -972,7 +762,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "dd16f44920e0d82dec4eab6967a080add93ef4af",
+      "upstream_blob": "c26e45a0e1198d6e2892dd90f0af1e26746c5a6e",
       "workstream": "WS3"
     },
     {
@@ -987,7 +777,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "3774747d05a7ba858585e9a154403bc824824a5b",
+      "upstream_blob": "cb9b720bf56a29048d4c350cd0282c441620132f",
       "workstream": "WS3"
     },
     {
@@ -1017,7 +807,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "092b7c823d3fcd08356344876e81bffe1d4c8b90",
+      "upstream_blob": "cc19711e9567457889d16e54a0f0e0e9ae716c60",
       "workstream": "WS3"
     },
     {
@@ -1066,31 +856,31 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/openviking/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "42925fa74aa04f4fe9a708e397990e871065a0e6",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/openviking/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "810f2db43e0be9a238de3b485bba46ad8abdf81a",
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/supermemory/README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "c1f41c4157061130ff64b00ee45e2bdd35a705f8",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/supermemory/README.md",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "7e7786d83a9efe8df2cbf298d7c4b764f39a4d63",
       "workstream": "WS3"
@@ -1111,16 +901,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/memory",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/supermemory/plugin.yaml",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "23321bdb52cd78eaa3cda6073f0419cae15af6d0",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/memory/supermemory/plugin.yaml",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8100b321364cf9e50996e1b1e494241be9ead1ca",
       "workstream": "WS3"
@@ -1171,16 +961,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/model-providers",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/model-providers/custom/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "65e42e1fbee08370a23417dd72dfc1bdc368b296",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/custom/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6b7b13d5bdb72eb11c51bdf2169f2f83674a73dc",
       "workstream": "WS3"
@@ -1216,18 +1006,18 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/model-providers",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/model-providers/minimax/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "f29eb1aa07e247a68a110ba23173a4d7103d8db6",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/minimax/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6d77536acee030143fdb578a898bc2d8705135fc",
+      "upstream_blob": "7dbaf4000c22cb75657d9ea36d6711bb371aae21",
       "workstream": "WS3"
     },
     {
@@ -1261,33 +1051,48 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/model-providers",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/model-providers/openrouter/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1b464b42e828b6bb7d075b217ba9cb2693f9882e",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/openrouter/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6566d604fc51230ed917044f5dc94db545ec7231",
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/model-providers",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/model-providers/xiaomi/__init__.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "aed0d8424f8dc5935b66289ba56b227273cca1d2",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/model-providers/xiaomi/__init__.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "8cd378d760977df638ade1ed3d4dac03f82bfe4c",
+      "workstream": "WS3"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/model-providers/zai/__init__.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "70aa8704d140fa3c86dd7aa270e1f4d77928ec3b",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/zai/__init__.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "9fcdb2bec7d24df4deb4ae6b62675eff48d04e99",
       "workstream": "WS3"
     },
     {
@@ -1317,7 +1122,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "46544cd1f44c5512fdd9c68814a9607a5db89469",
+      "upstream_blob": "8146ca9de107694d8d427c5e973d4ba331dd45f0",
       "workstream": "WS3"
     },
     {
@@ -1411,6 +1216,111 @@
       "workstream": "WS3"
     },
     {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "a2cd92ec4a7fc12ccff5542273c16ff3c4df94fd",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/README.md",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "1d5d89b57ad2fceb24f7430455091d0b6d737c04",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "78902234b1b5e572a2747d06ad8523557a29e622",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/adapter.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "e5dfd358ed61e6aa8aeaaf47c6ad6701871f873d",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "789746860f85b6ce9d6960c31555f32c55e0e361",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/cli.py",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "99a6c6ee728b50e52f7f8a7451ce922a1d37dc65",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "12ade17f8e582598f38b808cc14ac8ce6d3dfe95",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/plugin.yaml",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "a39193a81bf4d35f89e58b351f085470021f9569",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "d1c44d7c51bc4ea9d78e62388f0965ef9cd1993b",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/sidecar/index.mjs",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "0ca723764a5ffaa0bc0e8bc777e449214db37bad",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "8a19d1445ddf9373e3378a672c4acec6706d1154",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/sidecar/package-lock.json",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "d76e7ccdf629ddffd17ea881925b3c12fb8dcf81",
+      "workstream": "WS3"
+    },
+    {
+      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
+      "classification": "functional",
+      "classification_path": "plugins/platforms",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "522335e46b13a13ddceb7350dbd6273f0e318096",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "plugins/platforms/photon/sidecar/package.json",
+      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "d09b3c82dcf547e45ba48d3d76b9131fe736711c",
+      "workstream": "WS3"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "plugins/platforms/simplex/adapter.py",
@@ -1422,7 +1332,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "21c2f1de8c797d1c1ae2534d6fcca7dc87bab3bd",
+      "upstream_blob": "0b241d588f3152970630bc760f00c9491aa2dd04",
       "workstream": "WS3"
     },
     {
@@ -1452,7 +1362,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "975ef5b4093342364c37f105d7dbaefe97f9f95b",
+      "upstream_blob": "f8175a6a6214c3cb41c6181b8b763901e2ffb470",
       "workstream": "WS3"
     },
     {
@@ -1576,16 +1486,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/video_gen",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/video_gen/xai/plugin.yaml",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "85aa6e68f13dfa48153b675185635b4ed7a6db3a",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/video_gen/xai/plugin.yaml",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "5e3e8b1ac214fb3b995c7cd9b3363a9c02e6ca7e",
       "workstream": "WS3"
@@ -1606,16 +1516,16 @@
       "workstream": "WS3"
     },
     {
-      "action": "Inspect upstream/local behavior; implement Rust-native parity only if local coverage is missing.",
-      "classification": "functional",
-      "classification_path": "plugins/web",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/web/searxng/provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "043f6711c1b2ac9205d163d40aa09d81ad0b4bdc",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "plugins/web/searxng/provider.py",
-      "rust_requirement": "rust_native_runtime_parity_required_if_needed",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "6f747fc3f9de06218c044c4207dad5526513d741",
       "workstream": "WS3"
@@ -1677,7 +1587,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "ce34ab2aa2cc05ece5f5ee012ad7fcbc4d369811",
+      "upstream_blob": "b3b5f104e3d8944ba5ec816589956057f6bb8eb1",
       "workstream": "WS8"
     },
     {
@@ -1700,7 +1610,7 @@
       "classification": "intentional_divergence",
       "classification_path": "skills/autonomous-ai-agents",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "3a3335e837266b313976ffa9249e47249c061971",
+      "local_blob": "8b35975439461c9d258da20c1a5c5cc7fbd975e6",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "skills/autonomous-ai-agents/hermes-agent/SKILL.md",
@@ -1743,136 +1653,31 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
-      "classification_path": "skills/github",
+      "classification_path": "skills/media/youtube-content/SKILL.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "6b929a408d5b2a549f0e1c9c3e011a84dfc1cdb0",
+      "local_blob": "32828f75986bb8ebae04cf0122d06362114d8a60",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
-      "path": "skills/github/github-auth/SKILL.md",
+      "path": "skills/media/youtube-content/SKILL.md",
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "95606d36709b5332fb74f5a97047b8851af32c8c",
+      "upstream_blob": "3661acad126a5a1ccbd9f1b82b19e074a2e45945",
       "workstream": "WS4"
     },
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
-      "classification_path": "skills/github",
+      "classification_path": "skills/media/youtube-content/scripts/fetch_transcript.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "043c6b5551bdba30857b96753df0fd99afd76187",
+      "local_blob": "5ad3e5aa652be2fdea060028ba05c00bb632a51e",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
-      "path": "skills/github/github-auth/scripts/gh-env.sh",
+      "path": "skills/media/youtube-content/scripts/fetch_transcript.py",
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "47b3ff98c5c879e0ec573c8237000611133a24aa",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/github",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "3b50ac4527918fa581ef4eb073c706553a930f67",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/github/github-code-review/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "b58309235126fec4c785fb22ebef5daa53e50e48",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/github",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "338074f885c75a61308a1ed7ffbbe94e0c38b93d",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/github/github-issues/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "bded118a10a9511687b70797106cbc295247d77a",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/github",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "0b02eca3d1eb9d2e215095756c5317081daddcd0",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/github/github-pr-workflow/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "69eb21183d3d788ee09890e9ae3e174445ea5c2a",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/github",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "0ba049e2787f581a7e94af2df73969d233f5d101",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/github/github-repo-management/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "1026ce36e494bd207ca1b4a544589ed7f6c383d9",
-      "workstream": "WS4"
-    },
-    {
-      "action": "Add classification, owner, issue, and surgical plan before implementation.",
-      "classification": "unclassified",
-      "classification_path": "",
-      "existing_coverage": "unclaimed",
-      "local_blob": "1a28b8b293d10298a53c3ce8b6f380ea0122ba49",
-      "necessity": "unknown",
-      "owner": "",
-      "path": "skills/media/gif-search/SKILL.md",
-      "rust_requirement": "skill_catalog_contract_required_if_needed",
-      "status": "pending_classification",
-      "ticket": "",
-      "upstream_blob": "5416290a9d07cf766ef7889c5f92093263b7ad8b",
-      "workstream": "WS4"
-    },
-    {
-      "action": "Add classification, owner, issue, and surgical plan before implementation.",
-      "classification": "unclassified",
-      "classification_path": "",
-      "existing_coverage": "unclaimed",
-      "local_blob": "158109008898e2c77ab891d728e04fc83ca2bf3a",
-      "necessity": "unknown",
-      "owner": "",
-      "path": "skills/note-taking/obsidian/SKILL.md",
-      "rust_requirement": "skill_catalog_contract_required_if_needed",
-      "status": "pending_classification",
-      "ticket": "",
-      "upstream_blob": "e3a9872309a44451bf2cc871c71f2001152b3069",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "547e2a14b7346f3aa5c1b7efaf6cd3fa341ca257",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/productivity/airtable/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "3fa1b0ab9737e045d573f3560c4863a338303903",
+      "upstream_blob": "6160339038dd3ba8b54882703ed779d0c8f3eced",
       "workstream": "WS4"
     },
     {
@@ -1888,21 +1693,6 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "90763589ae226773ed92cf378623cb7f3a2d779a",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "83222ffd9384df3e42a70d9b13bcdf652e20d96d",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/productivity/notion/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "22010c6241d1adec39da4b5a3b08f0c5c86fdace",
       "workstream": "WS4"
     },
     {
@@ -1938,21 +1728,6 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
-      "classification_path": "skills/productivity",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "4ad37c4758a9e767da3e1c2a3f6c7dcfeb48a82e",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/productivity/teams-meeting-pipeline/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "11960aa320149fa8c401e6ce83942b9fc44a89cf",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
       "classification_path": "skills/research",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "9acd8b97ec9a6539f549bf83e92bcd89807fd725",
@@ -1963,21 +1738,6 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "0bd6b2370f447acfba22979212e4800aa18795a7",
-      "workstream": "WS4"
-    },
-    {
-      "action": "No vendoring; verify approved divergence remains current.",
-      "classification": "intentional_divergence",
-      "classification_path": "skills/research",
-      "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "839c2f682a04b392ca7ab7839b478219b2b02ca5",
-      "necessity": "approved_divergence",
-      "owner": "sheawinkler",
-      "path": "skills/research/llm-wiki/SKILL.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_intentional_divergence",
-      "ticket": 25,
-      "upstream_blob": "7dc708c9a5fce649b853f87e75ae4bbf853aa2ce",
       "workstream": "WS4"
     },
     {
@@ -2187,7 +1947,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3cfa90bb1616d08c7558bcbd25ddd5fdedc4159e",
+      "upstream_blob": "8465ce423723a92698eceef593277d0996eec956",
       "workstream": "WS6"
     },
     {
@@ -2217,7 +1977,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "79c9c286ecfb1eadcb9fcb2b1ae7190905b5bcbc",
+      "upstream_blob": "2a2f236b9a366ab166987f2241039e564a0a1027",
       "workstream": "WS6"
     },
     {
@@ -2262,7 +2022,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "86b310ac82c3c9f3bbd4dd39f02a40385a3ef2de",
+      "upstream_blob": "7770b2e8c88766e765ad43078b74ada868332bc6",
       "workstream": "WS6"
     },
     {
@@ -2292,7 +2052,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7854313293e1cadfb59b8fae08707e896edfdd8c",
+      "upstream_blob": "8913aad537f993217233691de9d4cba1e906bb91",
       "workstream": "WS6"
     },
     {
@@ -2308,6 +2068,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "afceeec02d94bd96451161beeb8bbca9f3e17ed5",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/agent/test_auxiliary_transport_autodetect.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "eccb03de0d682573ad56f38b8c67a453a1b00100",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_auxiliary_transport_autodetect.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "dcbf75d78851b420e52f2268e7b2207177073bc0",
       "workstream": "WS6"
     },
     {
@@ -2337,7 +2112,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5f98fe5cf78d18433b84f2b14615e91cf27e025a",
+      "upstream_blob": "ac2b557aeace744c8f5f1a3302c79129a31c26d2",
       "workstream": "WS6"
     },
     {
@@ -2371,6 +2146,21 @@
       "workstream": "WS6"
     },
     {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/agent/test_compress_focus.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "8b5b1d35da3b4eb249b48514344f6beb978111d3",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_compress_focus.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "662030277b4561db14b42abaa8d978b8a5361041",
+      "workstream": "WS6"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "tests/agent/test_compressor_image_tokens.py",
@@ -2397,7 +2187,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1b4242e0e017b5bf5c79fb8ab516b06e051a6bc2",
+      "upstream_blob": "7eb1e8a57b02adebc70d895f998cd96f3e0e33ab",
       "workstream": "WS6"
     },
     {
@@ -2443,6 +2233,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1afd5ee20b2d31c9a4e7a2ef1b7013e727513ac0",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/agent/test_copilot_acp_client.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "dfc336b41cec2cc8f1dfaf100a2c1190eabda6c9",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_copilot_acp_client.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "d8188d8604eedfb5f80caea59903274ad6c2a06d",
       "workstream": "WS6"
     },
     {
@@ -2547,7 +2352,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "994aae28648452d3f97d28130bfed1b1d755cfe4",
+      "upstream_blob": "2e9afd201933775f859336300b4c90cf3807e2df",
       "workstream": "WS6"
     },
     {
@@ -2652,7 +2457,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4f894c512a6160be05f738f122058eca4a8a1b16",
+      "upstream_blob": "aa9b2a38a521b0daf6c96149bf55c9fd82143f88",
       "workstream": "WS6"
     },
     {
@@ -2727,7 +2532,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e12122724ad915775d13308fe9ae2a431fddfd44",
+      "upstream_blob": "57f8f39fc7dc975d08ba99b0367986001c743848",
       "workstream": "WS6"
     },
     {
@@ -2787,7 +2592,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ba5fa30886f30a054cd22ecdd09a26de35c18385",
+      "upstream_blob": "b6c926f5a0820bbceaea565b4471bfc0f4ca5fd9",
       "workstream": "WS6"
     },
     {
@@ -2823,6 +2628,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "tests/agent/test_moonshot_schema.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "2ce2daa096ae6bdcdcd0de2662f29e854be37825",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_moonshot_schema.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "69727f9ab778864969b7fe0613a147322f21e27e",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/agent",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "1eaf0d01d2b8350d70996d81c0c7327ee928b3b7",
@@ -2847,7 +2667,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "856a047253f23750eeb4f5e80221fe3d862661c8",
+      "upstream_blob": "e6c302fdb92dd26eb65b86fb0ca1812f434e727d",
       "workstream": "WS6"
     },
     {
@@ -2892,7 +2712,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e956b2a3ab9ac6a9caeb47ab131600914c043570",
+      "upstream_blob": "472b97fb3955628b80d5c0bbf8c82ae395fc3bf2",
       "workstream": "WS6"
     },
     {
@@ -2952,7 +2772,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1338e7a5b24c7a1c8325dae7081fe2453e7019b7",
+      "upstream_blob": "db380c75bb8aad52cd86ed73422b3b4c9e43c9c5",
       "workstream": "WS6"
     },
     {
@@ -3087,7 +2907,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0b54fe470599e1e096690b0a4f93ff086fa2334c",
+      "upstream_blob": "da642e2ae17ca724201842f4637c89318890089b",
       "workstream": "WS6"
     },
     {
@@ -3102,7 +2922,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5d8aa6ba12b8839a73b860a2f8bd4113b38b63e0",
+      "upstream_blob": "e028f434446279c1525ee118a466330697bacd32",
       "workstream": "WS6"
     },
     {
@@ -3117,7 +2937,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "18b210b7c31b39bccc894e11b2962ec4c5fa6807",
+      "upstream_blob": "7be167d53cbf9b5c7b633767bc74e8095c1bd3de",
       "workstream": "WS6"
     },
     {
@@ -3162,7 +2982,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "df7c06a2d00754a282b4f31513679236539d99d1",
+      "upstream_blob": "0d58bf8f56a9e4aac9d8588af6ebca755c8d7dcb",
       "workstream": "WS6"
     },
     {
@@ -3237,7 +3057,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "34f5cefe06efc51db559aef3bf304fd20437f942",
+      "upstream_blob": "489105f2f2021a9f51ff2e503505e8ea4f6199d7",
       "workstream": "WS6"
     },
     {
@@ -3357,7 +3177,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "47a78c57044338423764050ebc82c521e8ce3cfe",
+      "upstream_blob": "36587bff72254bb06c6bac78c9c611d32b050079",
       "workstream": "WS6"
     },
     {
@@ -3612,7 +3432,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "8e1a8dfb9c0fb127bd656a200e01a82ee484e033",
+      "upstream_blob": "2da7d4a1eb4fbdcfa3ba0747e0321cb2905517fa",
       "workstream": "WS6"
     },
     {
@@ -3762,7 +3582,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "8056d3c49e2791bf5fa9b773330d06f079a28b41",
+      "upstream_blob": "fd445de8ca6acd2b5362a20e663738d4c1484e15",
       "workstream": "WS6"
     },
     {
@@ -3808,6 +3628,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c24c7292073b257d380924b01f9cc8e9ae992dbe",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/e2e/test_discord_adapter.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "891d4806821ce97665932db724eff88d4b5dc421",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/e2e/test_discord_adapter.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "412163f43cbe08ee31572e57d24725089f3a97e2",
       "workstream": "WS6"
     },
     {
@@ -3867,7 +3702,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "37f8b51a458d489d78c57d6e416ed60bd70480e8",
+      "upstream_blob": "559e1c0e96c5300e31e8890b3281e66979ac09f7",
       "workstream": "WS6"
     },
     {
@@ -3948,6 +3783,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_api_server_normalize.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "2dd2c70f72dfb69208ff94452eb676c4ea9c6019",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server_normalize.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "1f943ced01b6bd526b6845ce20e0faa4070630ab",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "tests/gateway/test_api_server_runs.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "bdb00d74a7ba2272b9747de7e33bd3dc952bbbc2",
@@ -4017,7 +3867,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "eb20abf55df5e1c0877795d4eea5c35a2e0a3448",
+      "upstream_blob": "de3b738944bc0600986f2f5f285c511522c705d1",
       "workstream": "WS6"
     },
     {
@@ -4122,7 +3972,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "18e8ae2fb09e11260dd5fe958258a4484d712360",
+      "upstream_blob": "8c32eb8f409bf79018aca927d9eb200bd935cbb4",
       "workstream": "WS6"
     },
     {
@@ -4182,7 +4032,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "267e2a20214a4f88daacd0d96ee79b58052133f3",
+      "upstream_blob": "0d5e2828a641ee7b0958b0fe7f1a432365a91e83",
       "workstream": "WS6"
     },
     {
@@ -4197,7 +4047,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "05ffee9b8d2eb6b88fd877e75f5e49d9095ef981",
+      "upstream_blob": "299b7e6b3bef19b533629225bfd9a78d01949028",
       "workstream": "WS6"
     },
     {
@@ -4377,7 +4227,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "54dc903e97130a402ec5708168a54184fce8372b",
+      "upstream_blob": "2f12138feb06191b7be9e968558161f5c0ad144f",
       "workstream": "WS6"
     },
     {
@@ -4572,7 +4422,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "8d44f77302e57c4a96fa3968559c087c483ac4b7",
+      "upstream_blob": "5ef6812f5375104baa6bc1ab446b8b36f9abe071",
       "workstream": "WS6"
     },
     {
@@ -4617,7 +4467,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "75230e5b9cd6f8103ea0affd917aee1381755a08",
+      "upstream_blob": "3f2959282880aa271766d356ad35b3adb783516a",
       "workstream": "WS6"
     },
     {
@@ -4647,7 +4497,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9043bf24d5fc02da251249ab35d1cc4e0f7caf7f",
+      "upstream_blob": "d3c01e59eb04667373eb0b6b5aa74630ce43b6e5",
       "workstream": "WS6"
     },
     {
@@ -4677,7 +4527,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "2354f9ec201511c69d36bcf6f4d6dce6b54f7a50",
+      "upstream_blob": "8cfaa22c5d32fc0ee3b8d39e3d140a671339c928",
       "workstream": "WS6"
     },
     {
@@ -4951,6 +4801,21 @@
       "workstream": "WS6"
     },
     {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/gateway",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "2cabe2f7d102c4185370f46dd1e2f034e99d0689",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_keep_typing_timeout.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "6d6a1624ca56c48cceb1532a43c18cbbee5ea659",
+      "workstream": "WS6"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "tests/gateway/test_matrix.py",
@@ -4962,7 +4827,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "00b100d5a89e0de975c285b878494d1fc1a81795",
+      "upstream_blob": "116bb62703205b02af4d22df20a2e8438e54d450",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/gateway",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "a7afe912cba5f0d0ac60180a2bf7be8349cf640f",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_matrix_exec_approval.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "f3a8eaf86ca9d7654e1ed3d78fdcb24405d24d20",
       "workstream": "WS6"
     },
     {
@@ -5007,7 +4887,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "cafe5ad68a49201730c6b9448bb8db823feb1f6a",
+      "upstream_blob": "9b174a5137a464ddd25ef5fe305031f0c5a6c134",
       "workstream": "WS6"
     },
     {
@@ -5292,7 +5172,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a48e5f737810cab5b47e1079266c956cff67c680",
+      "upstream_blob": "15b948a4f79fc8dc28f727c04f7d6f9da52b9690",
       "workstream": "WS6"
     },
     {
@@ -5337,7 +5217,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "420328639c7682539f9b2d73610ef6a04231ff99",
+      "upstream_blob": "0974b26b4ec6063dd76aad5e1e157867f95703af",
       "workstream": "WS6"
     },
     {
@@ -5352,7 +5232,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "19f96048e15bbeee692e2d6e90553fbff61b19bb",
+      "upstream_blob": "a24a8578f4936e5ceaacb4cea264bb55c6781cf8",
       "workstream": "WS6"
     },
     {
@@ -5412,7 +5292,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "646ad92976b9258c5f65ed527c0d3a6777362bdd",
+      "upstream_blob": "c91b5a0a4c9080c2e6c6169de6dad434ad946104",
       "workstream": "WS6"
     },
     {
@@ -5487,7 +5367,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9b5fff64214c98c97f47e6727ca8982a5ea447b5",
+      "upstream_blob": "239dc28c8fc6ab0c64079596906bfd84195492b1",
       "workstream": "WS6"
     },
     {
@@ -5521,16 +5401,16 @@
       "workstream": "WS6"
     },
     {
-      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
-      "classification": "functional",
-      "classification_path": "tests/gateway",
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/gateway/test_session_env.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "2b6c983a769b4e645fb6c237d6a3901c9f1d2d22",
-      "necessity": "necessary_review",
+      "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_session_env.py",
-      "rust_requirement": "rust_equivalent_or_contract_test_required",
-      "status": "pending_review",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1da1e2a3b81895d201a0fa7a1389c8ba23456165",
       "workstream": "WS6"
@@ -5682,7 +5562,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c2cf76d9f89bbb9fbdf79c5387c6c080560547d4",
+      "upstream_blob": "afaaeb843a033d6b1096f19b3c5d8e6005b57873",
       "workstream": "WS6"
     },
     {
@@ -5727,7 +5607,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "97618f4482a50279a4004c8712fc73ac6af67b17",
+      "upstream_blob": "5f8a3b62348ec8f4ee72de5a9189b5ae7b51cec3",
       "workstream": "WS6"
     },
     {
@@ -5802,7 +5682,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bbf9d95709e3e4cd6327e67714fb814e00f575fa",
+      "upstream_blob": "e8d2f57485cf4681944cbf9739b366d9d95d1af8",
       "workstream": "WS6"
     },
     {
@@ -5817,7 +5697,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0b88d271808d81a2c76565f68e5492c6bda97871",
+      "upstream_blob": "f02738b51f2c739bed42a3997abe04b8497e6837",
       "workstream": "WS6"
     },
     {
@@ -5862,7 +5742,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "af012fb69a72c524bf38785dfae4193a781a7521",
+      "upstream_blob": "eb867300640c656a5ffbcb864ff9eebae50a1b45",
       "workstream": "WS6"
     },
     {
@@ -5877,7 +5757,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "975c0ada590230d240f466cd46c29cc039a73bbb",
+      "upstream_blob": "ed9349694323ae3c62350b94743ee71837e17166",
       "workstream": "WS6"
     },
     {
@@ -5922,7 +5802,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b9f575ef9f5c5c1993d312ae178e7a8a76be0c93",
+      "upstream_blob": "1ae10593cc6abb06affc22978030dd04b0547da9",
       "workstream": "WS6"
     },
     {
@@ -6012,7 +5892,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f5fb112f136e2c1e76ff852320cf9f96d84f14d5",
+      "upstream_blob": "d43124b56369a617c186efee9960a887407c4232",
       "workstream": "WS6"
     },
     {
@@ -6222,7 +6102,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "fa223a42fbdefe9e1f5ce58282f064761ca1ab4c",
+      "upstream_blob": "5cc7f206e667f6e96f640cf50d2f46fbfb8f5c8a",
       "workstream": "WS6"
     },
     {
@@ -6312,7 +6192,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "606bd80e46e8e2751c81a39a6286bacb18ba4f22",
+      "upstream_blob": "6e5291ca472ae8487edbaefe0806031e11086604",
       "workstream": "WS6"
     },
     {
@@ -6432,7 +6312,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "04b3174cdc29462469df4bac71fc0c481bd7b0ec",
+      "upstream_blob": "dd88728865b4c9b044ef7469f58a98e3c077e54d",
       "workstream": "WS6"
     },
     {
@@ -6552,7 +6432,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6396faabd27094e393b31466fc2cc9c8269119fe",
+      "upstream_blob": "377df8079a7b28ef405f99b805f7a1af85bd3425",
       "workstream": "WS6"
     },
     {
@@ -6627,7 +6507,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "cb85cf6818ed2971392d704da8303307631ccf67",
+      "upstream_blob": "2ce2907650da9f2eea5ef107c5fe1fcc77c35fee",
       "workstream": "WS6"
     },
     {
@@ -6747,7 +6627,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "8c0f2a39874f9b1b92398a0575a88f6943051778",
+      "upstream_blob": "07a6c55466adb1990b08746c02749378b9cbf548",
       "workstream": "WS6"
     },
     {
@@ -6762,7 +6642,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f2bcddeb1d8eb9a6d2bebff6d883213bf73906c4",
+      "upstream_blob": "9afff8f5883e98f6c26d93e3f101043d4399bf1a",
       "workstream": "WS6"
     },
     {
@@ -6897,7 +6777,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6a63ebe73e5bc1da1903b67b3d56adeed45f8ad2",
+      "upstream_blob": "72d8b5e7c378e6ca9cea8a9a683772cb7dea035d",
       "workstream": "WS6"
     },
     {
@@ -7002,7 +6882,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "aa4f6b116f14cc4834b2671d3287c74369b3e701",
+      "upstream_blob": "442433f768f47b0d5ee1579fc32657ad93d8ca01",
       "workstream": "WS6"
     },
     {
@@ -7100,6 +6980,21 @@
       "classification": "intentional_divergence",
       "classification_path": "tests/hermes_cli",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "f758570ea58274f38a5f3b9e07741b222c34f66c",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_detect_api_mode_for_url.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "e9ee41dea71dfd9e71c2e1b4344be2dee1d7347f",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "34e75045eff7dda76e7450d3bfe3d32c6492afdb",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
@@ -7107,7 +7002,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c9df041d0649754c9b1bdcbb1d769acedad60747",
+      "upstream_blob": "ba2032b8efa5027d49cb1b02a13711aa6f5a4bc2",
       "workstream": "WS6"
     },
     {
@@ -7167,7 +7062,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0988f8fb64af95c507d7ae2ca2eb83706e57ca92",
+      "upstream_blob": "38a651012795564a564af0d2b7f5b54235757f87",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/hermes_cli/test_gateway_linger.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "90f8ea3d708b9850ee2d90e34d18e126033f95b1",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_gateway_linger.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "4a34f7ab1b66fae2c5e41affa3f32495f554e478",
       "workstream": "WS6"
     },
     {
@@ -7182,7 +7092,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "13f1636e4a63fa6c7f6897d41d690ec2de2c3fa6",
+      "upstream_blob": "f9cdcc1f3134198bb8238b418a2efd8f01c75226",
       "workstream": "WS6"
     },
     {
@@ -7212,7 +7122,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "61d7bc48ebb738c3dec3711c9e755e8fdd2ba393",
+      "upstream_blob": "0b56abfa9fec10a8c3c1b1a4e9739f147b03365c",
       "workstream": "WS6"
     },
     {
@@ -7400,6 +7310,21 @@
       "classification": "intentional_divergence",
       "classification_path": "tests/hermes_cli",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "09e47df95a7e54365e67a177441df72a5d9d20ac",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_mcp_add_command_dest.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "2e7a3f2de0ccb174dd1d0b68c23153d9f09fb9ed",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e136f1b3c0fc837388c0ac9514a2985b394c78c8",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
@@ -7407,7 +7332,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "58172411764f3ff067c947d4b01c7ff2169c0874",
+      "upstream_blob": "ec5f5eefe967c69aad099290703847f30d43cd29",
       "workstream": "WS6"
     },
     {
@@ -7482,7 +7407,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7e4a6d22e872f45c87533855be8ae0868520e7bd",
+      "upstream_blob": "77ece21011508b7c7217372cf05d44cd9c9ad1c2",
       "workstream": "WS6"
     },
     {
@@ -7512,7 +7437,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d3419f9d5b43bf4dd56b585fdb209fd09cc4c20f",
+      "upstream_blob": "388c82bd3e6147dbad97b37597a376a5ef41673a",
       "workstream": "WS6"
     },
     {
@@ -7527,7 +7452,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "89465b6c6c7538e5f27ddf878aab10b0bd0589d7",
+      "upstream_blob": "f5d356055c333cab87043d4d162dbbf107cdfa3a",
       "workstream": "WS6"
     },
     {
@@ -7557,7 +7482,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c760f0da39f89e58abbabd058171aa6ce82a3cb8",
+      "upstream_blob": "a9ffc8fb975b35abf9dc55a6fedaf849ffbd5584",
       "workstream": "WS6"
     },
     {
@@ -7587,7 +7512,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "152e9e064776f7f31b18dd6d74e6b8961d90bc68",
+      "upstream_blob": "9faf25965e0efcd5df3efa734f6f4b3c7341d3ad",
       "workstream": "WS6"
     },
     {
@@ -7692,7 +7617,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bb889450d00201f0c35455d731455f9e8c4d1152",
+      "upstream_blob": "effeaa0120f1eb26ee76171ba6706895c768de26",
       "workstream": "WS6"
     },
     {
@@ -7707,7 +7632,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "75a84db428d5b8192ebf6b560e802fe730e22582",
+      "upstream_blob": "8353324e9b7671ab8e224e09c5db95308a661b51",
       "workstream": "WS6"
     },
     {
@@ -7752,7 +7677,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "310a47515d08a18ff4dce29140cfee67d789b610",
+      "upstream_blob": "1ea1845d9d33bbeb5f2279baf79d0d598c275065",
       "workstream": "WS6"
     },
     {
@@ -8037,7 +7962,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7e2170a3e94b51b430e318012ba958d3756e3e7c",
+      "upstream_blob": "8fbb063f620e1cc4ead99a937b5d46c171d7c493",
       "workstream": "WS6"
     },
     {
@@ -8142,7 +8067,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6608955d4040777bf9caf780fc92c9de117198df",
+      "upstream_blob": "f6bc7553b6d6954caa5351f8c4715ea4615b1a8e",
       "workstream": "WS6"
     },
     {
@@ -8277,7 +8202,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5d52e4276c411af59cfcd4c9d5502be6b3846e50",
+      "upstream_blob": "b2f58fefacb034b64df9828dbe6b08e1a6b86453",
       "workstream": "WS6"
     },
     {
@@ -8307,7 +8232,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a6db6c669decd3445285577d9df8141f283433aa",
+      "upstream_blob": "be1a5f1acf4c0f813f58ef664afdd3b4588982e1",
       "workstream": "WS6"
     },
     {
@@ -8322,7 +8247,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "47c018cbbdb89beb4b8de0931dcb0c21afde7288",
+      "upstream_blob": "5c590bff15cfdb04d17799a1d4c881239c1c95f0",
       "workstream": "WS6"
     },
     {
@@ -8382,7 +8307,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "76cbd59efdc14df1e2822f5337bbf663364f27a4",
+      "upstream_blob": "870474327210f3f40b35b77fbe1f369146a5029c",
       "workstream": "WS6"
     },
     {
@@ -8412,7 +8337,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0783af22a138a3077d06008f5bd7af31f9f3ff96",
+      "upstream_blob": "8f94458a6acea8c1ebe2b4d7831bb9e71d3aaae3",
       "workstream": "WS6"
     },
     {
@@ -8472,7 +8397,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "74b7e1bc34e761f8f172f8d6a55fe0ca2d7d6c14",
+      "upstream_blob": "c021cdb8cfe179d8891b0405b9a7ee5100314e96",
       "workstream": "WS6"
     },
     {
@@ -8502,7 +8427,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1e72bc97d1a45218f7e0066f14fdc621543a1512",
+      "upstream_blob": "1a6e2394a8751db82df1b62f09a58f1b93c082d7",
       "workstream": "WS6"
     },
     {
@@ -8652,7 +8577,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "a7ca66f73f4d5d37b408c40fdc9c4f52ac724a89",
+      "upstream_blob": "b121a2bb20be36286255bc2e366637cc65b49a78",
       "workstream": "WS6"
     },
     {
@@ -8727,7 +8652,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "783644d3888de5c4bd8d1512c10d46f4650cd707",
+      "upstream_blob": "52afddc9c46ab115cf3dd45f077473162a3ce6b9",
       "workstream": "WS6"
     },
     {
@@ -9132,7 +9057,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e8b20487cd463eea3875cde9b1727592251a51eb",
+      "upstream_blob": "b3f42961a070131ccafd9ed286f7068abdcff077",
       "workstream": "WS6"
     },
     {
@@ -9282,7 +9207,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b707f1d9235c820cc9ece62b38ee5908e2add75f",
+      "upstream_blob": "240546ea14cad847b834b6ddea1ba80268afa063",
       "workstream": "WS6"
     },
     {
@@ -9417,7 +9342,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3a118002e2bac4d21557c88d6640c9d5fe7dafea",
+      "upstream_blob": "dd4fce3ce53fa61ffab22e7e58ff726146aadbd3",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/run_agent/test_message_sequence_repair.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "fd1db95e843628e852efd306369a3e3dd213151e",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_message_sequence_repair.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "8fba45ebeb2a7a4d1c4076ec4111d9ec4f9a5f1a",
       "workstream": "WS6"
     },
     {
@@ -9567,7 +9507,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9d97693aa7f66482fcc18d4f83e74595f4fdee72",
+      "upstream_blob": "827bc0ef690af971515e4686cd78278b47e97150",
       "workstream": "WS6"
     },
     {
@@ -9582,7 +9522,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7f899c601d19ed91b83c5599db025ddf4e8539ca",
+      "upstream_blob": "14e01d9fecd509f5015379a42843104cc197f1b8",
       "workstream": "WS6"
     },
     {
@@ -9657,7 +9597,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5af349fa859ccf46fa97390a53dd587b3ea5f215",
+      "upstream_blob": "c7897804737c86dd0c0f6e3317acb8d5cea7b8a7",
       "workstream": "WS6"
     },
     {
@@ -9718,6 +9658,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "c925a508915d827258346c29f1af50f3378d0053",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/run_agent/test_thinking_only_sanitizer.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "83cf35f6d1a197adc9763f7b8db1ad1e2a73cd84",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_thinking_only_sanitizer.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "23184d0186dbc4d4d210a1f3444d2f096b96731d",
       "workstream": "WS6"
     },
     {
@@ -9976,6 +9931,21 @@
       "workstream": "WS6"
     },
     {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/test_atomic_replace_symlinks.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "f6b8491832946b066305d6b813027946d3789676",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/test_atomic_replace_symlinks.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "594401d05654c792a74354b1a3bd6f35c53ff332",
+      "workstream": "WS6"
+    },
+    {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
       "classification_path": "tests",
@@ -10137,7 +10107,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "04334317705a4ce55089854f10dd60d4edbce9d7",
+      "upstream_blob": "f4258f2b915d2358da7e379d92fc8fc7d8a92049",
       "workstream": "WS6"
     },
     {
@@ -10407,7 +10377,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4c69c719b6e52cb6b91ae2c57b9e1e56b50e1975",
+      "upstream_blob": "67abaebeaa2408a201f346d45c22bb8c2ae0d034",
       "workstream": "WS6"
     },
     {
@@ -10527,7 +10497,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3b95b8dceb8c5332383d88defc02113cb4b3234f",
+      "upstream_blob": "da85cc26ad64926acde7000899e237d06addfb52",
       "workstream": "WS6"
     },
     {
@@ -10557,7 +10527,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "023d949b2cca9db6e761113ea1306aa398a03a10",
+      "upstream_blob": "ac35f49647d46b4f383466367510cd21eb2d7a58",
       "workstream": "WS6"
     },
     {
@@ -10602,7 +10572,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b75983807089d2b39394fe88b4a044626b4a651b",
+      "upstream_blob": "b37d57555fb94fc9de35685086ee1d4d5961a2fc",
       "workstream": "WS6"
     },
     {
@@ -10767,7 +10737,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 306,
-      "upstream_blob": "657edad2a20940ed5e98021184802de2c1063bcd",
+      "upstream_blob": "cf1197eae632d2d0834d5a78e4741d9feb40aea4",
       "workstream": "WS6"
     },
     {
@@ -10887,7 +10857,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bcb46136b7a201664b1c8074022a0ac3380c1f83",
+      "upstream_blob": "3521d19ea191841525e08a61f2704d3fd075bb74",
       "workstream": "WS6"
     },
     {
@@ -10932,7 +10902,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b9be68379718b87d26c053bf116227fdf5cbb03e",
+      "upstream_blob": "86ad13d3eb17c5b079af4100d4c476c662c71105",
       "workstream": "WS6"
     },
     {
@@ -10977,7 +10947,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ac2fb53f3a2705325d152a9b64efba46f74a13e1",
+      "upstream_blob": "ce44959585a177f04f213c3177a94ea798f02e39",
       "workstream": "WS6"
     },
     {
@@ -11172,7 +11142,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a66a818286ba86565bd57d94cb11f34d7f1d0c3b",
+      "upstream_blob": "fb8ae552a878dcfa18a234d491b50cbe79eff4c2",
       "workstream": "WS6"
     },
     {
@@ -11248,6 +11218,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "1de38ec25a85c348daa477759cc52e57c0a91cfd",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools/test_file_tools_container_config.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "54c3a60919fd3b846fb4c44a984cd752004375fe",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_tools_container_config.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "f8a79a37e4edbfda6f73903cc3d5ac06522c1360",
       "workstream": "WS6"
     },
     {
@@ -11472,7 +11457,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1bdaeeeb67a3ce6a3489d50ed7fc1fa97c9683d2",
+      "upstream_blob": "f1e4f5b04518fdbe229aed4b11e93760147d8d01",
       "workstream": "WS6"
     },
     {
@@ -11592,7 +11577,37 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e43bf0a1851dfe06f9cbf52afa585a1460f9c89a",
+      "upstream_blob": "0f9987b7ce8ec134ca1cf8fe1017290c9536a6fd",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools/test_mcp_oauth_integration.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "9e80400246fb9d72f1583a8888c808b6a03296d6",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_mcp_oauth_integration.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "2735aad0222def19f3cf1efcd51c68c5f82f79ad",
+      "workstream": "WS6"
+    },
+    {
+      "action": "Map upstream test intent to Rust/Python contract coverage; add missing regression tests.",
+      "classification": "functional",
+      "classification_path": "tests/tools/test_mcp_oauth_manager.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "2a66449cbd2eacea42139b61c3d8a1d8e7e48ddd",
+      "necessity": "necessary_review",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_mcp_oauth_manager.py",
+      "rust_requirement": "rust_equivalent_or_contract_test_required",
+      "status": "pending_review",
+      "ticket": 25,
+      "upstream_blob": "7896fe644725f2881cd0da0e9e606286b6e46c8a",
       "workstream": "WS6"
     },
     {
@@ -11607,7 +11622,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "89d4d1478d18c2d135675ea8ab90bfba6f450ed0",
+      "upstream_blob": "92656a441b30bf15202483023c8cafe8c6a2aa57",
       "workstream": "WS6"
     },
     {
@@ -11622,7 +11637,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3897a65a866b7a9912408e1e4ac356e7e22cee5c",
+      "upstream_blob": "feb0d7a5affd96e954a3f9dfcf2e22a047381416",
       "workstream": "WS6"
     },
     {
@@ -11652,7 +11667,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f7a19f4d9219e67751830160c09a7d1c2f61386b",
+      "upstream_blob": "e9654ec74f56fdb71a45ac1e0fd2b80a8fe06812",
       "workstream": "WS6"
     },
     {
@@ -11757,7 +11772,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "84bf5f1f6b5f8d30d773ca50ab4b182aeadf1eff",
+      "upstream_blob": "5c2af09441ddb3b3885738efbc5455bd3361c4bf",
       "workstream": "WS6"
     },
     {
@@ -11802,7 +11817,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6a95e46b7e187ba44271784433aec780312dc9a1",
+      "upstream_blob": "967849a194aceb2a0d1a036cc4e5b1268c132c3f",
       "workstream": "WS6"
     },
     {
@@ -11847,7 +11862,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b856440ef4088bdad6e8b99286648baa625a20aa",
+      "upstream_blob": "360457de2b2aa7c873532fefbe683dc9ff42e299",
       "workstream": "WS6"
     },
     {
@@ -11892,7 +11907,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d1afb6c46690df1b89ae821ccba53d767f40f2aa",
+      "upstream_blob": "81cee1bb1ded450f9861835843a9b17e47837b2f",
       "workstream": "WS6"
     },
     {
@@ -11997,7 +12012,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "97cf3e9d194e254d65f2f954758884b16e4451d8",
+      "upstream_blob": "245ca934757613e08669f87c432d50d1017a01a4",
       "workstream": "WS6"
     },
     {
@@ -12102,7 +12117,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "972175999fd4569aaa65657fc50bc41754f4fff8",
+      "upstream_blob": "6ac434dd207b6b44fcc3325485ea45da9dc5ed24",
       "workstream": "WS6"
     },
     {
@@ -12117,7 +12132,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6711b3bb2f65f4eb45fe8fff0683aaed18d8021b",
+      "upstream_blob": "6be3e3705e828d5e7b985a74283320b5bf1cb48a",
       "workstream": "WS6"
     },
     {
@@ -12267,7 +12282,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ea113e63c27daefc62147be4506779028bcb3bb8",
+      "upstream_blob": "84af6fc76332b1ec15767d0f858649b5e22dda52",
       "workstream": "WS6"
     },
     {
@@ -12627,7 +12642,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 306,
-      "upstream_blob": "bd3cce8754aa9c3239e9670ac034da3894743ed0",
+      "upstream_blob": "177b34ccc92caaa30ea94084482233ca216aca03",
       "workstream": "WS6"
     },
     {
@@ -12672,7 +12687,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e093532bf377ae91d666382903683ea7781c45e1",
+      "upstream_blob": "9ba407784478925279005a8c5f08f4c8d5968ccc",
       "workstream": "WS6"
     },
     {
@@ -12687,7 +12702,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 306,
-      "upstream_blob": "28323122aca0113312b1004bb3a59da9b5174524",
+      "upstream_blob": "5838ea00b7869419a3264b2bcdb012db100f024b",
       "workstream": "WS6"
     },
     {
@@ -12747,7 +12762,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6fe6c802aced90ae5b27e12dcbbb8c1fe429fb1b",
+      "upstream_blob": "f210f8575412c765b5d4881d7b506bb3481630b9",
       "workstream": "WS6"
     },
     {
@@ -12822,7 +12837,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0b147ee286ed2077ce9f19e827536d11e8d3044e",
+      "upstream_blob": "9cd5b0d5f1433c80fc0c6167e1cf27ece1750ad6",
       "workstream": "WS6"
     },
     {
@@ -12837,7 +12852,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "cb8458395a20fba1f76de85ce8ab6d9f9925579b",
+      "upstream_blob": "b4f830f881ffeeedcebdb43cbcd9ae2d48b43cc6",
       "workstream": "WS6"
     },
     {
@@ -12897,7 +12912,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3524b60d2ca5b64511485f6f79ad2e96c031077f",
+      "upstream_blob": "d0a59798fb7332829121ce221617217cde3e4dfe",
       "workstream": "WS5"
     },
     {
@@ -12913,6 +12928,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "14fc27dfc95dcfc54bb15ac920f1f24c055b0405",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "ui-tui/packages",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "8df3c02a4a501a350acafdbd1189dd89b244cc8e",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "ui-tui/packages/hermes-ink/package.json",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "ab6728a7c9fa34954cc8c34585d5d08db9ce7913",
       "workstream": "WS5"
     },
     {
@@ -13257,7 +13287,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "121b9011c7f63cfe9d097a56d80c88cf7eec1038",
+      "upstream_blob": "43be458caa0b8af7d821557c2459026df152aeef",
       "workstream": "WS5"
     },
     {
@@ -13317,7 +13347,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f1228e56fbebb363a9a112879f3ab7fb42b739f4",
+      "upstream_blob": "a872a008ddbf9ef809180976b0d85591a9f6c9b8",
       "workstream": "WS5"
     },
     {
@@ -13527,7 +13557,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7636eb6946f120e76e7e0f59b8df5c7b604c57f7",
+      "upstream_blob": "f7f4293e16d777168f85b9d8bab128fa72426287",
       "workstream": "WS5"
     },
     {
@@ -13557,7 +13587,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "30c62e03590d56b6015540da4d7cd3d2088319bc",
+      "upstream_blob": "f7297c151da3ce568bb2b53d92c7241d4be2e09a",
       "workstream": "WS5"
     },
     {
@@ -13618,6 +13648,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "b716504b35325dd2fb1011f0d8acdf1f75029149",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "ui-tui/src",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "353b0a83d1c751a2f168a0b3f6ee5670a63a52d0",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "ui-tui/src/app/slash/registry.ts",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "7f2d95195f4bc5786cc0fa1514ee772ef5161116",
       "workstream": "WS5"
     },
     {
@@ -13722,7 +13767,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3bd981b36cf4e03888cac828eec8ace0a81284fa",
+      "upstream_blob": "d11e8e08dba3e47d0e9c828d32ce456a138acbe7",
       "workstream": "WS5"
     },
     {
@@ -13797,7 +13842,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a420d815341e962581d712167b71933ded0b9b49",
+      "upstream_blob": "007fd356355122f05bc596cf99a532dc7e6c73da",
       "workstream": "WS5"
     },
     {
@@ -13812,7 +13857,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b93e2045c7e8404c09e2d6e56684e2830c7977f5",
+      "upstream_blob": "d54f5c6da90ef6dd7efd8151f45401af84c41ff3",
       "workstream": "WS5"
     },
     {
@@ -13827,7 +13872,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9ad3a5ea7fc29243d3f90233051b42b56c0d8c76",
+      "upstream_blob": "94dab304621ca78a76ec66191671ff439d3676ad",
       "workstream": "WS5"
     },
     {
@@ -13842,7 +13887,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4f2bbb5eae54a8bf571227451a4143e223a00ebf",
+      "upstream_blob": "3325a74c33d51833d14a075d046dc03325070d11",
       "workstream": "WS5"
     },
     {
@@ -13917,7 +13962,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3dfd31be8691c011bbfba0c1094949c6748727dd",
+      "upstream_blob": "3d796b2398389c9e9a9c8cb12a86403b32eade27",
       "workstream": "WS5"
     },
     {
@@ -14067,7 +14112,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4cca1a52bccd0366bf955432f29cc0fa03b07044",
+      "upstream_blob": "5dfbe880fb1bc011ba36aa396caacd969ebe085d",
       "workstream": "WS5"
     },
     {
@@ -14082,7 +14127,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "531f08feec81d6870bf0cfb7b4fc2679893c75b6",
+      "upstream_blob": "00a3b458911f94ebd3e36ec7f00c5133ef3b3b5b",
       "workstream": "WS5"
     },
     {
@@ -14292,7 +14337,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "60f0db48ef946f09472c2c1852763857ec3cdfeb",
+      "upstream_blob": "830e532ce8d4dfc1574410018284e254e18cc8c2",
       "workstream": "WS5"
     },
     {
@@ -14502,7 +14547,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c69f45263bb14a99b36e346ba6b1f15538809b7d",
+      "upstream_blob": "3661f4359f1fa0276ee69da7c13e20010d27e08c",
       "workstream": "WS5"
     },
     {
@@ -14517,7 +14562,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "50335901752e038380326bb289294616abef0c3d",
+      "upstream_blob": "25d023ed57c826d473a451b83921103e4f465d56",
       "workstream": "WS5"
     },
     {
@@ -14667,7 +14712,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "09884fa831e39a351351f496e5a450fb6ebe05bf",
+      "upstream_blob": "2cef841fe5f207be8e8a297f12e8a6011e8b0e8f",
       "workstream": "WS5"
     },
     {
@@ -14712,7 +14757,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "04a63226648ed0d118d4012330a663e127591913",
+      "upstream_blob": "630df6e2938ce44c8f06bba7d5815ee729d4df30",
       "workstream": "WS5"
     },
     {
@@ -14757,7 +14802,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "7c4a2c2eca2ca974b5e7f3f33e746a3e5ea0e435",
+      "upstream_blob": "dec05e43fd466e0554aebaf819aba1cb39f1907b",
       "workstream": "WS5"
     },
     {
@@ -14765,14 +14810,14 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "2a6a125aa97b1f6ea63a954fc470762f828d1bf9",
+      "local_blob": "b6850d472611dd06a8cac67e987e4c9caec3a039",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
-      "path": "website/docs/guides/automation-templates.md",
+      "path": "website/docs/guides/automation-blueprints.md",
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f564bf5cee9eb3f2cc7136c10863f308bbfc4254",
+      "upstream_blob": "981f2aaa8238864298022d2e5a2a3588e1cc45a2",
       "workstream": "WS5"
     },
     {
@@ -14802,7 +14847,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "1b52f56683f4fa6f0f16f9591bae14c6f2f2c7ec",
+      "upstream_blob": "a48db94ff94adc97f756c672f0396460c42e6454",
       "workstream": "WS5"
     },
     {
@@ -14832,7 +14877,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "35a3668e7fa881e5777b8ae1ef94628a0d225f50",
+      "upstream_blob": "f24e2dd3f6c66e34450d16a97333e58b3dbe81a1",
       "workstream": "WS5"
     },
     {
@@ -15132,7 +15177,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "6d99ce6a0b630be723bd31d12f374d5928ae91bb",
+      "upstream_blob": "3071ac0e5fcc8531f538086f337ad8667cd834ac",
       "workstream": "WS5"
     },
     {
@@ -15147,7 +15192,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "cfd3001e24770c5cfba936084c033abee5c3cd7c",
+      "upstream_blob": "2419846a10f8d1594788de85e9f143522d83e26b",
       "workstream": "WS5"
     },
     {
@@ -15162,7 +15207,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "36665410a49d83ce313d9556b1e966f1216a1100",
+      "upstream_blob": "75e49b2a292ddf75f3926827050298045a4b0e9d",
       "workstream": "WS5"
     },
     {
@@ -15207,7 +15252,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "5e44cba8eb4fbc75ca47fb99e620467506663e64",
+      "upstream_blob": "89a4f47fe874f298f151b6d50c7f704012b9a02e",
       "workstream": "WS5"
     },
     {
@@ -15222,7 +15267,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "922de3790cfcfcd33373dacc0b257803dc0b0e12",
+      "upstream_blob": "678e518060f2185e9af0fc49201c1b69c57bf535",
       "workstream": "WS5"
     },
     {
@@ -15252,7 +15297,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "44a9a303a6249fc461ba37aff4428ec8f4505459",
+      "upstream_blob": "a9951263d7ffc5cb47d4510400e410ca51522ae7",
       "workstream": "WS5"
     },
     {
@@ -15312,7 +15357,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "4b2d2c40e93f0549884c60a2e39cced9bcf1f858",
+      "upstream_blob": "e22d143ce30717526a29cf4f368fc945f76bf14a",
       "workstream": "WS5"
     },
     {
@@ -15342,7 +15387,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f442a204265eaa5c713365ea8d09b2c4efd63075",
+      "upstream_blob": "c40938db3932f42a6fdc9ff6658919f2620dee33",
       "workstream": "WS5"
     },
     {
@@ -15492,7 +15537,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "cbefde68a9e4612d4f839768f6a0d6ddeb144904",
+      "upstream_blob": "89357043d7053833f83c936bd9214e623c2d32f0",
       "workstream": "WS5"
     },
     {
@@ -15522,7 +15567,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "1d19c9fddce91345bbec0c95d72964c547fbd306",
+      "upstream_blob": "b76a1df3d91985f50c0e5be21f1ba85ad52da595",
       "workstream": "WS5"
     },
     {
@@ -15582,7 +15627,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b971bea272d3ea83fd74a00922b33074515a8e39",
+      "upstream_blob": "31d8391383072c9f98161fbbb1b5720b30fbb543",
       "workstream": "WS5"
     },
     {
@@ -15597,7 +15642,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "eeba346852b791511c249a28ad76dcde88413347",
+      "upstream_blob": "465f7f149de0e09870e256d1c144774b593d028d",
       "workstream": "WS5"
     },
     {
@@ -15672,7 +15717,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "43b70334da6d2735b3bc3d16af588e29bc64baea",
+      "upstream_blob": "476bd46696dd49630416ef90290b86f095d69485",
       "workstream": "WS5"
     },
     {
@@ -15687,7 +15732,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b4814d2a178fb23ff8b4ae83856b7bf7e29993d9",
+      "upstream_blob": "1f0ee16942f426e6ac9ab6a1af8063435e9c539c",
       "workstream": "WS5"
     },
     {
@@ -15762,7 +15807,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "8a5209c6944e2d32843808527164d3a752e5d6ea",
+      "upstream_blob": "6cfbafee3c3a5edb1624eda50e9971e802c5ba7f",
       "workstream": "WS5"
     },
     {
@@ -15882,7 +15927,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b7518c01b6bf414c11ef9db728c260d7f88f65b2",
+      "upstream_blob": "2b6fbcfd6533cfc64cb333a9f983d955e97591cb",
       "workstream": "WS5"
     },
     {
@@ -16017,7 +16062,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c8a6b4a70c8c87e965eabc4285d69935b3617e2c",
+      "upstream_blob": "d0129be29bb772cfd241166b7aba84c7d9545666",
       "workstream": "WS5"
     },
     {
@@ -16047,7 +16092,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "9974ff7b918ea62c1408e1387d55fa4de0112ac1",
+      "upstream_blob": "f69de76a876dbf2562342ea2a5c33e62c8d7495c",
       "workstream": "WS5"
     },
     {
@@ -16182,7 +16227,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "ae30d4a5856b61530211315d615119fe95ff7153",
+      "upstream_blob": "bc59ca342ed11dd7b128dbd01006d8e43997f06b",
       "workstream": "WS5"
     },
     {
@@ -16197,7 +16242,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "a2ac8cb584f0f2fd24991261014f588170dd62bf",
+      "upstream_blob": "e52bfac924009ffc08c4d2d0ff444000c72cb760",
       "workstream": "WS5"
     },
     {
@@ -16257,7 +16302,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "5fb5eb2aecfb7d24d4263c2a74b2c5e6bb418a0a",
+      "upstream_blob": "b447b534707b9b2367d2a85590bc83cffbab4dc8",
       "workstream": "WS5"
     },
     {
@@ -16287,7 +16332,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "494e7ec4241873def8c105ec08692d6c98258992",
+      "upstream_blob": "904d3ec3d1ee9da64e18ef9515f9eb66a25c7575",
       "workstream": "WS5"
     },
     {
@@ -16408,6 +16453,21 @@
       "status": "cleared_non_runtime",
       "ticket": 25,
       "upstream_blob": "e5cdc3277b89eba9279d76b7b1b887c04b4218ca",
+      "workstream": "WS5"
+    },
+    {
+      "action": "No runtime implementation; keep rationale current.",
+      "classification": "policy_only",
+      "classification_path": "website/docs",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "24f8871a9724975dbfabda7664752d8246702e9a",
+      "necessity": "not_runtime_required",
+      "owner": "sheawinkler",
+      "path": "website/docs/user-guide/skills/bundled/media/media-youtube-content.md",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_non_runtime",
+      "ticket": 25,
+      "upstream_blob": "2971a56f9551769332bf5f03ddfd0b0406e2fc5c",
       "workstream": "WS5"
     },
     {
@@ -16602,7 +16662,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "9e55ad2d027ac57588f692b9d1b2e677b7da68e6",
+      "upstream_blob": "6b2e35aa86454779c75f1a5f7c4b248ebc51d85e",
       "workstream": "WS5"
     },
     {
@@ -16625,14 +16685,14 @@
       "classification": "policy_only",
       "classification_path": "website",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "c16f02920dd894f05ca3f869c481f17073555d14",
+      "local_blob": "3f19847908e1c0241b2d0d7bdcd59a4ecf136424",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/package-lock.json",
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "2b762a8a40f49c04f841b662d50757519b5e3645",
+      "upstream_blob": "df0c19c69802f5123cfed8ee813d58d61d2503e8",
       "workstream": "WS5"
     },
     {
@@ -16640,14 +16700,14 @@
       "classification": "policy_only",
       "classification_path": "website",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "fc21cd60a75b2cb0dd21d1754ceea85a7fbe740a",
+      "local_blob": "e0675aaf8b30e2596a36f9123d26f27a1a8ce724",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/package.json",
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "643d583e5f574ccb917789f71774ccd1f0ae8b84",
+      "upstream_blob": "d5ef08f465ba129c29bd8060621c57bdf90994dc",
       "workstream": "WS5"
     },
     {
@@ -16707,7 +16767,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "11f5e07521e7355137de2b8861fb46efce518b3c",
+      "upstream_blob": "b873a9b208836a5460d824a83d2413c081ee24d0",
       "workstream": "WS5"
     },
     {
@@ -16715,14 +16775,14 @@
       "classification": "policy_only",
       "classification_path": "website",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "395a5ff8260bbc1493b6aca67ac972400ee538b0",
+      "local_blob": "484977e28669834e54722047b73760f1728e3217",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/sidebars.ts",
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b6eccc27a41cc05d56fd0b0175e3dfb8d2012bf7",
+      "upstream_blob": "af12e6b883067f81071b3fda14565aa3ea7d3177",
       "workstream": "WS5"
     },
     {
@@ -16730,7 +16790,7 @@
       "classification": "policy_only",
       "classification_path": "website/src",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "79e2564496b480547179e3ce8749075f442338c6",
+      "local_blob": "131b9cd1b4da6e11b85fc7e4d267c0cfba83dbe3",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/src/components/UserStoriesCollage/index.tsx",
@@ -16812,7 +16872,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "11518d7b414b0b16f3045dbb9f1e6b694b0d4c96",
+      "upstream_blob": "ff14a1ad5e4f44aab0ee68c6611b141fca838ca8",
       "workstream": "WS5"
     },
     {
@@ -16831,45 +16891,41 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-06-11T00:16:41.702827+00:00",
+  "generated_at_utc": "2026-06-16T02:58:21.710158+00:00",
   "refs": {
-    "local_ref": "main",
-    "local_sha": "ddd78abaf6d10e7bb43008762607955a65ae3fe9",
+    "local_ref": "HEAD",
+    "local_sha": "2ba91e3c1f2a5d70e17f2547d9c6638e25182bd6",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "d1383a6b1450c6c139720b1b01f8b99cc130453f"
+    "upstream_sha": "55cb4103beba5822303c06b662635e1491ae72f5"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "functional": 17,
-      "intentional_divergence": 919,
-      "policy_only": 182,
-      "unclassified": 3
+      "functional": 25,
+      "intentional_divergence": 916,
+      "policy_only": 184
     },
     "by_rust_requirement": {
-      "needs_rust_relevance_review": 1,
-      "not_required_for_runtime": 1102,
-      "rust_equivalent_or_contract_test_required": 2,
-      "rust_native_runtime_parity_required_if_needed": 15,
-      "skill_catalog_contract_required_if_needed": 2
+      "not_required_for_runtime": 1101,
+      "rust_equivalent_or_contract_test_required": 14,
+      "rust_native_runtime_parity_required_if_needed": 11
     },
     "by_status": {
-      "cleared_intentional_divergence": 919,
-      "cleared_non_runtime": 183,
-      "pending_classification": 3,
-      "pending_review": 17
+      "cleared_intentional_divergence": 916,
+      "cleared_non_runtime": 185,
+      "pending_review": 25
     },
     "by_workstream": {
-      "WS3": 70,
-      "WS4": 54,
-      "WS5": 265,
-      "WS6": 719,
-      "WS8": 14
+      "WS3": 78,
+      "WS4": 29,
+      "WS5": 268,
+      "WS6": 736,
+      "WS8": 15
     },
-    "cleared_intentional_divergence": 919,
-    "cleared_non_runtime": 183,
-    "pending_classification": 3,
-    "pending_review": 17,
-    "total_shared_different": 1122
+    "cleared_intentional_divergence": 916,
+    "cleared_non_runtime": 185,
+    "pending_classification": 0,
+    "pending_review": 25,
+    "total_shared_different": 1126
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,52 +1,55 @@
 # Shared-Different Backlog
 
-Generated: `2026-06-11T00:16:41.702827+00:00`
+Generated: `2026-06-16T02:58:21.710158+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1122`
-- Pending classification: `3`
-- Pending functional review: `17`
-- Cleared non-runtime: `183`
-- Cleared intentional divergence: `919`
+- Total shared-different paths: `1126`
+- Pending classification: `0`
+- Pending functional review: `25`
+- Cleared non-runtime: `185`
+- Cleared intentional divergence: `916`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 919 |
-| `cleared_non_runtime` | 183 |
-| `pending_classification` | 3 |
-| `pending_review` | 17 |
+| `cleared_intentional_divergence` | 916 |
+| `cleared_non_runtime` | 185 |
+| `pending_review` | 25 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 70 |
-| `WS4` | 54 |
-| `WS5` | 265 |
-| `WS6` | 719 |
-| `WS8` | 14 |
+| `WS3` | 78 |
+| `WS4` | 29 |
+| `WS5` | 268 |
+| `WS6` | 736 |
+| `WS8` | 15 |
 
 ## Pending Classification
 
 | Path | Workstream | Action |
 | --- | --- | --- |
-| `docs/kanban/multi-gateway.md` | `WS8` | Add classification, owner, issue, and surgical plan before implementation. |
-| `skills/media/gif-search/SKILL.md` | `WS4` | Add classification, owner, issue, and surgical plan before implementation. |
-| `skills/note-taking/obsidian/SKILL.md` | `WS4` | Add classification, owner, issue, and surgical plan before implementation. |
 
 ## Pending Functional Review By Prefix
 
 | Classification Path | Count |
 | --- | ---: |
-| `plugins/memory` | 5 |
-| `plugins/model-providers` | 4 |
-| `tests/gateway` | 2 |
+| `plugins/platforms` | 8 |
+| `tests/gateway` | 3 |
 | `plugins/browser` | 1 |
 | `plugins/google_meet` | 1 |
 | `plugins/image_gen` | 1 |
-| `plugins/platforms` | 1 |
-| `plugins/video_gen` | 1 |
-| `plugins/web` | 1 |
+| `tests/agent/test_auxiliary_transport_autodetect.py` | 1 |
+| `tests/agent/test_compress_focus.py` | 1 |
+| `tests/agent/test_copilot_acp_client.py` | 1 |
+| `tests/e2e/test_discord_adapter.py` | 1 |
+| `tests/hermes_cli/test_gateway_linger.py` | 1 |
+| `tests/run_agent/test_message_sequence_repair.py` | 1 |
+| `tests/run_agent/test_thinking_only_sanitizer.py` | 1 |
+| `tests/test_atomic_replace_symlinks.py` | 1 |
+| `tests/tools/test_file_tools_container_config.py` | 1 |
+| `tests/tools/test_mcp_oauth_integration.py` | 1 |
+| `tests/tools/test_mcp_oauth_manager.py` | 1 |

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -46,27 +46,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "Dockerfile",
-      "rationale": "Hermes Agent Ultra intentionally ships a Rust multi-stage container with tini/gosu and /data state instead of upstream's Python uv+s6-overlay image; Rust-native container contracts cover the retained runtime behavior.",
-      "ticket": 305
-    },
-    {
-      "classification": "policy_only",
-      "owner": "sheawinkler",
-      "path": "LICENSE",
-      "rationale": "Licensing and attribution metadata; no runtime effect.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
-      "path": "README.md",
-      "rationale": "README.md intentionally describes Ultra's Rust-first runtime, release installer, and parity workflow rather than upstream's Python product positioning; install/readme contracts cover the actionable setup guidance.",
-      "ticket": 305
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "docker-compose.yml",
       "rationale": "Compose defaults intentionally target the Ultra Rust image, /data volume, and hermes-agent-ultra naming while preserving localhost dashboard and UID/GID runtime controls.",
       "ticket": 305
@@ -77,6 +56,27 @@
       "path": "docker/entrypoint.sh",
       "rationale": "The entrypoint intentionally implements the Rust image's direct tini/gosu startup path instead of upstream's s6 stage2 hook; entrypoint contracts cover home setup, UID/GID remap, and privilege drop.",
       "ticket": 305
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "Dockerfile",
+      "rationale": "Hermes Agent Ultra intentionally ships a Rust multi-stage container with tini/gosu and /data state instead of upstream's Python uv+s6-overlay image; Rust-native container contracts cover the retained runtime behavior.",
+      "ticket": 305
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "docs/design/profile-builder.md",
+      "rationale": "Profile-builder design prose is Python/web-server documentation; Ultra keeps the Rust CLI profile create/clone/no-skills contracts in crates/hermes-cli with hermes-cli coverage, so the shared diff is not runtime code to vendor.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "docs/kanban/multi-gateway.md",
+      "rationale": "Ultra documents the Rust kanban.dispatch_in_gateway flag, HERMES_KANBAN_DISPATCH_IN_GATEWAY override, gateway propagation, and JSON-backed Kanban store; upstream SQLite/WAL wording is intentionally not applicable to the Rust store.",
+      "ticket": 25
     },
     {
       "classification": "policy_only",
@@ -91,6 +91,13 @@
       "path": "flake.nix",
       "rationale": "Nix packaging intentionally builds the Rust workspace with the Hermes Ultra release version rather than upstream's Python flake-parts packaging stack.",
       "ticket": 305
+    },
+    {
+      "classification": "policy_only",
+      "owner": "sheawinkler",
+      "path": "LICENSE",
+      "rationale": "Licensing and attribution metadata; no runtime effect.",
+      "ticket": 25
     },
     {
       "classification": "intentional_divergence",
@@ -366,6 +373,13 @@
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/__init__.py",
+      "rationale": "Upstream Python memory namespace loading is reference-only in Ultra; Rust memory provider discovery is implemented in crates/hermes-agent/src/memory_plugins/mod.rs with native ContextLattice, Hindsight, OpenViking, Supermemory, and related provider contracts.",
+      "ticket": 25
+    },
+    {
       "classification": "policy_only",
       "owner": "sheawinkler",
       "path": "plugins/memory/byterover/__init__.py",
@@ -382,9 +396,9 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "plugins/memory/honcho/README.md",
-      "rationale": "Ultra documents the Rust-native `hermes memory setup honcho` path and dot-separated profile host keys used by crates/hermes-agent/src/memory_plugins/honcho.rs; legacy Python `hermes honcho ...` command dispatch remains disabled.",
-      "ticket": 304
+      "path": "plugins/memory/hindsight/README.md",
+      "rationale": "Hindsight is implemented as a Rust MemoryProviderPlugin with retain, recall, reflect, config loading, auto-recall, auto-retain, session switching, and focused Rust tests; local docs intentionally describe Ultra's Rust local-external/cloud contract instead of Python embedded daemon management.",
+      "ticket": 25
     },
     {
       "classification": "policy_only",
@@ -410,6 +424,13 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "plugins/memory/honcho/README.md",
+      "rationale": "Ultra documents the Rust-native `hermes memory setup honcho` path and dot-separated profile host keys used by crates/hermes-agent/src/memory_plugins/honcho.rs; legacy Python `hermes honcho ...` command dispatch remains disabled.",
+      "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "plugins/memory/honcho/session.py",
       "rationale": "Ultra supersedes the upstream Python Honcho gateway identity resolver with the Rust Honcho memory provider resolver in crates/hermes-agent/src/memory_plugins/honcho.rs, including pinUserPeer, userPeerAliases, runtimePeerPrefix, and hash-escalated collision handling.",
       "ticket": 25
@@ -422,11 +443,32 @@
       "ticket": 304
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/openviking/__init__.py",
+      "rationale": "OpenViking is implemented as a Rust MemoryProviderPlugin with REST context operations, resource upload handling, session commit, session switching, and URI regression coverage; the Python provider remains reference-only.",
+      "ticket": 25
+    },
+    {
       "classification": "policy_only",
       "owner": "sheawinkler",
       "path": "plugins/memory/supermemory/__init__.py",
       "rationale": "The shared diff is behavior-equivalent tuple membership for boolean parsing, context guards, and session-role filtering.",
       "ticket": 304
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/supermemory/plugin.yaml",
+      "rationale": "Supermemory plugin metadata is reference catalog material; Rust Supermemory provider behavior and tests carry the runtime contract, including the 1.0.1 source-attribution/tool-name semantics.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/supermemory/README.md",
+      "rationale": "Supermemory runtime behavior is implemented in Rust with kebab-case tool schemas, snake_case aliases, x-sm-source headers, sm_source metadata stamping, conversation ingest, and focused Rust tests; docs were updated to match that contract.",
+      "ticket": 25
     },
     {
       "classification": "functional",
@@ -459,6 +501,13 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "plugins/model-providers/custom/__init__.py",
+      "rationale": "Custom provider defaults are handled in Rust provider_profiles, including a 65536 default max_tokens floor for custom/Ollama-compatible profiles and provider request-body tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "plugins/model-providers/gemini/__init__.py",
       "rationale": "Bundled Gemini provider parity is covered by Rust provider registry and CLI routing contracts: the manifest directory is known, Google/Gemini aliases normalize consistently, and the Rust runtime selects the Gemini provider defaults without Python plugin imports.",
       "ticket": 25
@@ -473,6 +522,13 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "plugins/model-providers/minimax/__init__.py",
+      "rationale": "MiniMax provider behavior is handled in Rust provider_profiles/providers_extra/model_switch, including aliases, M3 defaults, anthropic default base URL, OpenAI-compatible api.minimax.io/v1 reasoning_split/thinking shaping, and focused request-body tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "plugins/model-providers/nous/__init__.py",
       "rationale": "Local Nous provider keeps a static Hermes product tag because the upstream agent.portal_tags helper is not present in this Rust checkout; focused contracts cover the emitted tag.",
       "ticket": 304
@@ -482,6 +538,27 @@
       "owner": "sheawinkler",
       "path": "plugins/model-providers/opencode-zen/__init__.py",
       "rationale": "OpenCode Zen and Go provider behavior is covered by Rust provider normalization, env-key resolution, default base URLs, model catalog merge, and GenericProvider OpenCode Go reasoning controls; this legacy upstream Python provider profile is reference-only and is not used by the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/openrouter/__init__.py",
+      "rationale": "OpenRouter provider behavior is handled in Rust provider_profiles, including reasoning-mandatory Anthropic model handling, verbosity effort mapping, x-grok-conv-id extra headers, and focused request-body/header tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/xiaomi/__init__.py",
+      "rationale": "Xiaomi provider behavior is handled in Rust provider_profiles/provider serialization, including MiMo vision enablement and tool-message multimodal flattening for models that reject list-type tool content.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/model-providers/zai/__init__.py",
+      "rationale": "ZAI/GLM provider model fallback is represented in Rust model switching/setup surfaces, including glm-5.2 curated/default setup coverage and model normalization.",
       "ticket": 25
     },
     {
@@ -501,15 +578,15 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "plugins/observability/langfuse/README.md",
-      "rationale": "Local Langfuse README intentionally documents the Hermes tools credential flow while preserving the manual enable path.",
+      "path": "plugins/observability/langfuse/plugin.yaml",
+      "rationale": "Local Langfuse manifest intentionally advertises the Hermes tools enablement path in addition to manual plugin enablement.",
       "ticket": 304
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "plugins/observability/langfuse/plugin.yaml",
-      "rationale": "Local Langfuse manifest intentionally advertises the Hermes tools enablement path in addition to manual plugin enablement.",
+      "path": "plugins/observability/langfuse/README.md",
+      "rationale": "Local Langfuse README intentionally documents the Hermes tools credential flow while preserving the manual enable path.",
       "ticket": 304
     },
     {
@@ -646,6 +723,13 @@
       "ticket": 304
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/video_gen/xai/plugin.yaml",
+      "rationale": "xAI video generation is implemented in Rust XaiVideoGenBackend with direct/auth-store credentials, text/image/reference-image payload shaping, polling, error handling, model override support, and video_generate tool registration/tests.",
+      "ticket": 25
+    },
+    {
       "classification": "functional",
       "owner": "sheawinkler",
       "path": "plugins/web",
@@ -657,6 +741,13 @@
       "owner": "sheawinkler",
       "path": "plugins/web/firecrawl/provider.py",
       "rationale": "Rust-native Firecrawl search/extract backends now cover direct, self-hosted, and Nous-managed routing; the Python plugin remains reference/compatibility code in the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/searxng/provider.py",
+      "rationale": "SearXNG web search is implemented in Rust SearxngSearchBackend with SEARXNG_BASE_URL and upstream-compatible SEARXNG_URL aliases, base URL normalization, search result normalization, backend selection, and focused Rust tests.",
       "ticket": 25
     },
     {
@@ -679,6 +770,13 @@
       "path": "plugins/web/xai/provider.py",
       "rationale": "Rust-native xAI web search now routes through the Responses API server-side web_search tool with deterministic result normalization; the Python plugin remains reference/compatibility code.",
       "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "README.md",
+      "rationale": "README.md intentionally describes Ultra's Rust-first runtime, release installer, and parity workflow rather than upstream's Python product positioning; install/readme contracts cover the actionable setup guidance.",
+      "ticket": 305
     },
     {
       "classification": "intentional_divergence",
@@ -732,6 +830,20 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "skills/media/youtube-content/scripts/fetch_transcript.py",
+      "rationale": "The transcript fetcher is an allowed skill helper script, not Hermes runtime; Ultra adopted upstream uv instructions without introducing Python runtime dispatch.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/media/youtube-content/SKILL.md",
+      "rationale": "The YouTube content skill is catalog/helper material, not Rust runtime code; Ultra adopted the upstream uv-based setup/run instructions while preserving the local skill-helper contract.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "skills/productivity",
       "rationale": "Skill catalog content is curated locally while loader and execution contracts carry runtime parity.",
       "ticket": 25
@@ -746,15 +858,15 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "skills/software-development",
-      "rationale": "Software-development skill content is curated locally while Rust native skill catalog loading and execution contracts carry runtime parity.",
+      "path": "skills/social-media/xurl/SKILL.md",
+      "rationale": "xurl skill documentation is curated locally for Hermes Agent Ultra safety guidance while skill loading and execution are governed separately.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "skills/social-media/xurl/SKILL.md",
-      "rationale": "xurl skill documentation is curated locally for Hermes Agent Ultra safety guidance while skill loading and execution are governed separately.",
+      "path": "skills/software-development",
+      "rationale": "Software-development skill content is curated locally while Rust native skill catalog loading and execution contracts carry runtime parity.",
       "ticket": 25
     },
     {
@@ -877,6 +989,13 @@
       "ticket": 25
     },
     {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_auxiliary_transport_autodetect.py",
+      "rationale": "Auxiliary transport autodetect behavior needs explicit Rust relevance review against provider/runtime routing before it can be claimed covered.",
+      "ticket": 25
+    },
+    {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/agent/test_bedrock_1m_context.py",
@@ -898,17 +1017,17 @@
       "ticket": 25
     },
     {
-      "classification": "intentional_divergence",
+      "classification": "functional",
       "owner": "sheawinkler",
-      "path": "tests/agent/test_compressor_image_tokens.py",
-      "rationale": "Upstream image-aware compression-budget intent is covered by Rust hermes-intelligence context_engine contracts that charge fixed image-block budgets for OpenAI, Responses, and Anthropic image shapes without counting base64 payload bytes; the Python test file remains reference-only.",
+      "path": "tests/agent/test_compress_focus.py",
+      "rationale": "Compress-focus behavior needs explicit Rust relevance review against the Rust compression/context-focus runtime before it can be claimed covered.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/agent/test_context_compressor.py",
-      "rationale": "Upstream context compressor thresholding, summary fallback, cooldown, tool-pair sanitization, handoff-prefix, and collision-avoidance intent is covered by Rust hermes-agent ContextCompressor state-machine tests; the Python test file remains reference-only.",
+      "path": "tests/agent/test_compressor_image_tokens.py",
+      "rationale": "Upstream image-aware compression-budget intent is covered by Rust hermes-intelligence context_engine contracts that charge fixed image-block budgets for OpenAI, Responses, and Anthropic image shapes without counting base64 payload bytes; the Python test file remains reference-only.",
       "ticket": 25
     },
     {
@@ -921,8 +1040,22 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "tests/agent/test_context_compressor.py",
+      "rationale": "Upstream context compressor thresholding, summary fallback, cooldown, tool-pair sanitization, handoff-prefix, and collision-avoidance intent is covered by Rust hermes-agent ContextCompressor state-machine tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/agent/test_context_engine.py",
       "rationale": "Upstream context-engine ABC/default behavior is represented in Rust by hermes-intelligence ContextEngine trait implementations plus Default and Importance engine compression contracts; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_copilot_acp_client.py",
+      "rationale": "Copilot ACP client behavior needs explicit Rust relevance review against the Rust ACP/Copilot runtime path before it can be claimed covered.",
       "ticket": 25
     },
     {
@@ -1194,13 +1327,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/cron/test_scheduler.py",
-      "rationale": "Upstream scheduler tick/run/delivery/history intent is covered by Rust CronScheduler create/update/run/manual-trigger, context prefix, completion broadcast, delivery suppression, and runner contract tests; the Python test file remains reference-only.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/cron/test_scheduler_mcp_init.py",
       "rationale": "Upstream no_agent scheduler MCP-skip intent is covered by Rust CronRunner no_agent short-circuiting before AgentLoop construction and tool filtering tests that exclude recursive cron scheduling; the Python test file remains reference-only.",
       "ticket": 25
@@ -1208,8 +1334,22 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "tests/cron/test_scheduler.py",
+      "rationale": "Upstream scheduler tick/run/delivery/history intent is covered by Rust CronScheduler create/update/run/manual-trigger, context prefix, completion broadcast, delivery suppression, and runner contract tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/e2e",
       "rationale": "Upstream Python test-suite rows are reference-only in Ultra; Rust runtime behavior is covered by docs/parity/python-test-suite-coverage.json and enforced by crates/hermes-parity-tests/tests/python_test_suite_coverage_contract.rs.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/e2e/test_discord_adapter.py",
+      "rationale": "Discord adapter e2e mention/command behavior needs explicit Rust gateway parity review before it can be claimed covered by existing Discord contracts.",
       "ticket": 25
     },
     {
@@ -1264,13 +1404,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_api_server.py",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/gateway/test_api_server_bind_guard.py",
       "rationale": "API-server bind-address guard behavior is covered by Rust ApiServerAdapter contracts: network-accessible IPv4/IPv6 and mapped addresses require auth tokens, loopback binds remain allowed without auth, hostname resolution fails closed, and start() rejects unsafe non-loopback binds without an auth token.",
       "ticket": 303
@@ -1285,6 +1418,13 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server_normalize.py",
+      "rationale": "Upstream API-server chat-content normalization intent is covered in Rust by ChatMessage.content deserialization for strings, scalars, and bounded content arrays with focused api_server tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "tests/gateway/test_api_server_runs.py",
       "rationale": "API-server /v1/runs behavior is covered by Rust-native TCP contracts for run start/status/events/stop, explicit session IDs, inbound gateway dispatch, completion usage/output, cancellation event closure, approval-no-pending conflicts, bool-like approval parsing, invalid conversation-history rejection without allocation, and auth gating.",
       "ticket": 303
@@ -1294,6 +1434,13 @@
       "owner": "sheawinkler",
       "path": "tests/gateway/test_api_server_toolset.py",
       "rationale": "Upstream's API-server toolset contract is covered by Rust toolset and platform-toolset tests; the Python test file remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_api_server.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
     {
@@ -1390,13 +1537,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_config.py",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/gateway/test_config_cwd_bridge.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
@@ -1405,6 +1545,13 @@
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_config_env_bridge_authority.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_config.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -1656,13 +1803,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_feishu.py",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/gateway/test_feishu_approval_buttons.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
@@ -1678,6 +1818,13 @@
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_feishu_comment.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_feishu.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -1747,13 +1894,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_matrix.py",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/gateway/test_matrix_mention.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
@@ -1762,6 +1902,13 @@
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_matrix_voice.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_matrix.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -1992,13 +2139,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_session.py",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/gateway/test_session_boundary_hooks.py",
       "rationale": "Upstream gateway session-boundary lifecycle intent is covered by Rust hermes-gateway contracts for reset ordering, old logical session finalize hooks, new logical session reset hooks, hook error containment, shutdown finalization for active sessions, and idle-expiry finalization before session removal.",
       "ticket": 25
@@ -2008,6 +2148,13 @@
       "owner": "sheawinkler",
       "path": "tests/gateway/test_session_dm_thread_seeding.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_session_env.py",
+      "rationale": "Python contextvars session-env behavior is not a Rust runtime boundary; Ultra passes session identifiers explicitly through AgentConfig, gateway sessions, memory providers, session persistence, and tool/session cleanup contracts.",
       "ticket": 25
     },
     {
@@ -2069,14 +2216,14 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_shutdown_cache_cleanup.py",
+      "path": "tests/gateway/test_session.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_signal.py",
+      "path": "tests/gateway/test_shutdown_cache_cleanup.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -2097,7 +2244,7 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_slack.py",
+      "path": "tests/gateway/test_signal.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -2105,6 +2252,13 @@
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/gateway/test_slack_approval_buttons.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/gateway/test_slack.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -2132,14 +2286,14 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_status.py",
+      "path": "tests/gateway/test_status_command.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_status_command.py",
+      "path": "tests/gateway/test_status.py",
       "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
@@ -2160,15 +2314,15 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_stream_consumer.py",
-      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
+      "path": "tests/gateway/test_stream_consumer_fresh_final.py",
+      "rationale": "Upstream fresh-final streaming intent is covered by Rust StreamConfig/StreamConsumer contracts for configurable fresh_final_after_seconds, no-edit sentinel safety, stale-preview fresh-final decisions, non-final segment behavior, turn-final delivery marking, reset clearing, and Telegram delete_message support for best-effort stale preview cleanup.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_stream_consumer_fresh_final.py",
-      "rationale": "Upstream fresh-final streaming intent is covered by Rust StreamConfig/StreamConsumer contracts for configurable fresh_final_after_seconds, no-edit sentinel safety, stale-preview fresh-final decisions, non-final segment behavior, turn-final delivery marking, reset clearing, and Telegram delete_message support for best-effort stale preview cleanup.",
+      "path": "tests/gateway/test_stream_consumer.py",
+      "rationale": "Upstream Python gateway test intent is superseded by Rust-native gateway runtime contracts. Existing Rust coverage spans access policy, DM pairing/auth fallback, command handling, sessions, status/usage/compression, platform adapters, media extraction, webhooks, delivery routing, hooks, approvals, voice, and streaming consumers. This tranche adds bounded platform message-id redelivery suppression, definitive streaming final-response delivery before deferred messages, and asynchronous /background and /btw result/error notifications to the origin chat, covered by hermes-gateway unit and primary-platform contract tests.",
       "ticket": 25
     },
     {
@@ -2398,15 +2552,15 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_wecom.py",
-      "rationale": "Upstream WeCom outbound-media intent is covered by Rust WeCom adapter contracts for image URL fallback text, content-type-derived filenames, existing-extension preservation, and feature-gated adapter compilation with gateway delivery routing.",
+      "path": "tests/gateway/test_wecom_callback.py",
+      "rationale": "Upstream WeCom callback intent is covered by Rust WeCom callback contracts for signature stability, encrypted callback rejection on bad signatures, group-mention stripping, image fallback text, and remote image filename/content-type normalization.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/gateway/test_wecom_callback.py",
-      "rationale": "Upstream WeCom callback intent is covered by Rust WeCom callback contracts for signature stability, encrypted callback rejection on bad signatures, group-mention stripping, image fallback text, and remote image filename/content-type normalization.",
+      "path": "tests/gateway/test_wecom.py",
+      "rationale": "Upstream WeCom outbound-media intent is covered by Rust WeCom adapter contracts for image URL fallback text, content-type-derived filenames, existing-extension preservation, and feature-gated adapter compilation with gateway delivery routing.",
       "ticket": 25
     },
     {
@@ -2506,6 +2660,13 @@
       "path": "tests/hermes_cli/test_env_loader.py",
       "rationale": "Upstream dotenv loader precedence and sanitization intent is covered by Rust load_dotenv/load_dotenv_file tests for user-env precedence, project fallback, sanitized concatenated assignments before loading, and atomic sanitized-file rewrite.",
       "ticket": 302
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_gateway_linger.py",
+      "rationale": "Upstream covers Linux user-systemd linger auto-enable behavior. Ultra Rust gateway service installation is currently macOS launchd-only, so this remains an explicit pending Rust relevance/implementation review instead of being covered by the broad hermes_cli manifest.",
+      "ticket": 25
     },
     {
       "classification": "intentional_divergence",
@@ -2713,14 +2874,14 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_background_review.py",
+      "path": "tests/run_agent/test_background_review_toolset_restriction.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_background_review_toolset_restriction.py",
+      "path": "tests/run_agent/test_background_review.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
@@ -2734,14 +2895,14 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_compression_boundary.py",
+      "path": "tests/run_agent/test_compression_boundary_hook.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_compression_boundary_hook.py",
+      "path": "tests/run_agent/test_compression_boundary.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
@@ -2893,6 +3054,13 @@
       "ticket": 25
     },
     {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_message_sequence_repair.py",
+      "rationale": "Message sequence repair behavior needs explicit Rust agent-loop parity review before it can be claimed covered.",
+      "ticket": 25
+    },
+    {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/run_agent/test_openai_client_lifecycle.py",
@@ -2944,14 +3112,14 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_run_agent.py",
+      "path": "tests/run_agent/test_run_agent_codex_responses.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_run_agent_codex_responses.py",
+      "path": "tests/run_agent/test_run_agent.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
@@ -2986,14 +3154,14 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_streaming.py",
+      "path": "tests/run_agent/test_streaming_tool_call_repair.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/run_agent/test_streaming_tool_call_repair.py",
+      "path": "tests/run_agent/test_streaming.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
       "ticket": 25
     },
@@ -3016,6 +3184,13 @@
       "owner": "sheawinkler",
       "path": "tests/run_agent/test_switch_model_context.py",
       "rationale": "Upstream Python run_agent test intent is superseded by Rust-native run-agent runtime contracts. Existing Rust coverage spans AgentLoop retry/failover, streaming collection, compression boundaries and persistence, session persistence, interrupt handling, budget/context pressure, provider headers/cache/reasoning, strict schema sanitization, memory/background-review nudges, and tool-loop guardrails. This tranche adds Rust tool-call argument repair/normalization, object-valued tool-argument parsing, 413/generic context-overflow classification, streaming repair before the truncation retry gate, and non-vision multimodal fallback in provider request assembly.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/run_agent/test_thinking_only_sanitizer.py",
+      "rationale": "Thinking-only assistant sanitizer behavior needs explicit Rust agent-loop parity review before it can be claimed covered.",
       "ticket": 25
     },
     {
@@ -3068,6 +3243,13 @@
       "ticket": 25
     },
     {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/test_atomic_replace_symlinks.py",
+      "rationale": "Atomic replace symlink semantics need explicit Rust filesystem/config-write parity review before they can be claimed covered.",
+      "ticket": 25
+    },
+    {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/test_honcho_client_config.py",
@@ -3079,13 +3261,6 @@
       "owner": "sheawinkler",
       "path": "tests/tools",
       "rationale": "Upstream Python test-suite rows are reference-only in Ultra; Rust runtime behavior is covered by docs/parity/python-test-suite-coverage.json and enforced by crates/hermes-parity-tests/tests/python_test_suite_coverage_contract.rs.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
-      "path": "tests/tools/test_approval.py",
-      "rationale": "Upstream dangerous-command approval behavior is covered and superseded by Rust hermes-tools approval contracts for hardline denials, recoverable confirmations, session/permanent approvals, yolo and session-yolo gates, container backend bypass, multiline shell/disk/write patterns, sensitive env/config writes, SQL/delete/find/killall refinements, sudo stdin floors, unmanaged gateway-run service-manager protection, and gateway approval queues. Python LLM smart-approval and input-prompt mechanics are intentionally not ported into the Rust safety path.",
       "ticket": 25
     },
     {
@@ -3105,16 +3280,16 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/tools/test_base_environment.py",
-      "rationale": "Upstream Python base environment wrapper tests are covered by the Rust TerminalBackend contract and hermes-environments local backend tests, including command execution, cwd handling, stdin defaults, background process lifecycle, env sanitization, and file read/write behavior.",
+      "path": "tests/tools/test_approval.py",
+      "rationale": "Upstream dangerous-command approval behavior is covered and superseded by Rust hermes-tools approval contracts for hardline denials, recoverable confirmations, session/permanent approvals, yolo and session-yolo gates, container backend bypass, multiline shell/disk/write patterns, sensitive env/config writes, SQL/delete/find/killall refinements, sudo stdin floors, unmanaged gateway-run service-manager protection, and gateway approval queues. Python LLM smart-approval and input-prompt mechanics are intentionally not ported into the Rust safety path.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/tools/test_browser_camofox.py",
-      "rationale": "Ultra supersedes upstream Python Camofox HTTP facade tests with Rust browser backend contracts in crates/hermes-tools/src/backends/browser.rs and crates/hermes-tools/src/tools/browser.rs, covering Camofox env selection, CDP override precedence, named profile wiring, loopback URL rewriting, secret exfiltration guards, and handler forwarding for navigate/click/type/scroll/back/press/images/vision/console.",
-      "ticket": 306
+      "path": "tests/tools/test_base_environment.py",
+      "rationale": "Upstream Python base environment wrapper tests are covered by the Rust TerminalBackend contract and hermes-environments local backend tests, including command execution, cwd handling, stdin defaults, background process lifecycle, env sanitization, and file read/write behavior.",
+      "ticket": 25
     },
     {
       "classification": "intentional_divergence",
@@ -3128,6 +3303,13 @@
       "owner": "sheawinkler",
       "path": "tests/tools/test_browser_camofox_state.py",
       "rationale": "Ultra maps upstream Camofox state helpers to Rust camofox_state_dir_for_home and camofox_identity_for_home contracts, proving $HERMES_HOME/browser_auth/camofox pathing, deterministic identity, task/session separation, and profile separation without Python state modules.",
+      "ticket": 306
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_browser_camofox.py",
+      "rationale": "Ultra supersedes upstream Python Camofox HTTP facade tests with Rust browser backend contracts in crates/hermes-tools/src/backends/browser.rs and crates/hermes-tools/src/tools/browser.rs, covering Camofox env selection, CDP override precedence, named profile wiring, loopback URL rewriting, secret exfiltration guards, and handler forwarding for navigate/click/type/scroll/back/press/images/vision/console.",
       "ticket": 306
     },
     {
@@ -3271,6 +3453,13 @@
       "ticket": 25
     },
     {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_file_tools_container_config.py",
+      "rationale": "File-tools container_config propagation needs explicit Rust tool/environment parity review before it can be claimed covered.",
+      "ticket": 25
+    },
+    {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
       "path": "tests/tools/test_file_tools.py",
@@ -3359,6 +3548,20 @@
       "owner": "sheawinkler",
       "path": "tests/tools/test_managed_media_gateways.py",
       "rationale": "Upstream managed media gateway behavior is covered by Rust OpenAI-audio managed endpoint contracts for TTS and transcription plus FAL managed video-generation contracts; direct keys still override managed gateways where required.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_mcp_oauth_integration.py",
+      "rationale": "MCP OAuth integration behavior needs explicit Rust MCP OAuth relevance review before it can be claimed covered.",
+      "ticket": 25
+    },
+    {
+      "classification": "functional",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_mcp_oauth_manager.py",
+      "rationale": "MCP OAuth manager cache/lifecycle behavior needs explicit Rust MCP OAuth relevance review before it can be claimed covered.",
       "ticket": 25
     },
     {
@@ -3490,15 +3693,15 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/tools/test_skills_hub.py",
-      "rationale": "Upstream skills hub trust, content hashing, and remote skill integrity intent is covered by Rust SkillsHubClient search/download/upload/update contracts, Ed25519 signature verification, trusted source resolution, and scan-before-use policy; Python source-adapter breadth remains reference-only.",
+      "path": "tests/tools/test_skills_hub_clawhub.py",
+      "rationale": "Upstream ClawHub listing/detail/search repair/version/file mapping intent is covered by Rust ClawHub registry metadata parsing, exact-slug repair, hyphenated query normalization, latest-version extraction, and inline/raw file reference contracts.",
       "ticket": 25
     },
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/tools/test_skills_hub_clawhub.py",
-      "rationale": "Upstream ClawHub listing/detail/search repair/version/file mapping intent is covered by Rust ClawHub registry metadata parsing, exact-slug repair, hyphenated query normalization, latest-version extraction, and inline/raw file reference contracts.",
+      "path": "tests/tools/test_skills_hub.py",
+      "rationale": "Upstream skills hub trust, content hashing, and remote skill integrity intent is covered by Rust SkillsHubClient search/download/upload/update contracts, Ed25519 signature verification, trusted source resolution, and scan-before-use policy; Python source-adapter breadth remains reference-only.",
       "ticket": 25
     },
     {
@@ -3581,13 +3784,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/tools/test_transcription.py",
-      "rationale": "Upstream transcription behavior is covered by Rust transcription handler contracts for audio extension mapping, credential/gateway endpoint resolution, missing-path errors, and model-specific response parsing.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/tools/test_transcription_dotenv_fallback.py",
       "rationale": "Upstream transcription key fallback behavior is covered by Rust openai-audio credential resolution contracts that prefer VOICE_TOOLS_OPENAI_KEY before HERMES_OPENAI_API_KEY and legacy OPENAI_API_KEY.",
       "ticket": 25
@@ -3597,6 +3793,13 @@
       "owner": "sheawinkler",
       "path": "tests/tools/test_transcription_tools.py",
       "rationale": "Upstream STT provider semantics are covered by Rust transcription contracts for explicit OpenAI-audio routing, managed/direct credential order, extension MIME mapping, and whisper text versus GPT transcribe JSON response formats.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_transcription.py",
+      "rationale": "Upstream transcription behavior is covered by Rust transcription handler contracts for audio extension mapping, credential/gateway endpoint resolution, missing-path errors, and model-specific response parsing.",
       "ticket": 25
     },
     {
@@ -3686,13 +3889,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "tests/tools/test_web_providers.py",
-      "rationale": "Ultra supersedes upstream Python WebSearchProvider/WebExtractProvider ABC tests with Rust WebSearchBackend, WebExtractBackend, and WebCrawlBackend traits plus handler tests; Rust backend env tests prove per-capability search/extract selection over the generic web backend.",
-      "ticket": 306
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "tests/tools/test_web_providers_brave_free.py",
       "rationale": "Upstream Brave free provider intent is covered by Rust BraveFreeSearchBackend contracts for BRAVE_SEARCH_API_KEY gating, X-Subscription-Token requests, count clamping, result normalization, explicit/generic backend selection, auto-detect priority, and search-only extract/crawl error routing.",
       "ticket": 25
@@ -3710,6 +3906,13 @@
       "path": "tests/tools/test_web_providers_searxng.py",
       "rationale": "Upstream SearXNG provider intent is covered by Rust SearxngSearchBackend contracts for SEARXNG_BASE_URL and SEARXNG_URL aliases, trailing-slash normalization, score-descending sorting, limit truncation, result normalization, availability checks, and search-only extract/crawl errors.",
       "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_web_providers.py",
+      "rationale": "Ultra supersedes upstream Python WebSearchProvider/WebExtractProvider ABC tests with Rust WebSearchBackend, WebExtractBackend, and WebCrawlBackend traits plus handler tests; Rust backend env tests prove per-capability search/extract selection over the generic web backend.",
+      "ticket": 306
     },
     {
       "classification": "intentional_divergence",

--- a/docs/parity/ui-tui-source-coverage.json
+++ b/docs/parity/ui-tui-source-coverage.json
@@ -1,6 +1,6 @@
 {
   "summary": {
-    "covered_paths": 99,
+    "covered_paths": 101,
     "required_backlog_classification_paths": [
       "ui-tui",
       "ui-tui/packages",
@@ -118,6 +118,68 @@
     },
     {
       "path": "ui-tui/packages/hermes-ink/index.d.ts",
+      "status": "covered_by_rust_primary_tui_contracts",
+      "coverage_kind": "rust_primary_tui_or_documented_divergence",
+      "coverage_tags": [
+        "rust_primary_tui",
+        "package_surface",
+        "terminal_rendering"
+      ],
+      "rationale": "The upstream TypeScript/Ink TUI row is superseded by the Rust Ratatui CLI/TUI runtime; the cited Rust tests cover the equivalent input, rendering, gateway, slash/session, text, theme, or virtual-history behavior without requiring a JS runtime path.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_tui_state_default"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_input_mode_display"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_fit_status_line_pads_and_respects_display_width"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "test_default_mouse_enabled_respects_env_override"
+        },
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_default"
+        },
+        {
+          "file": "crates/hermes-cli/src/theme.rs",
+          "name": "test_parse_color_named"
+        },
+        {
+          "file": "crates/hermes-cli/src/theme.rs",
+          "name": "test_parse_color_hex"
+        },
+        {
+          "file": "crates/hermes-cli/src/theme.rs",
+          "name": "test_resolved_styles"
+        },
+        {
+          "file": "crates/hermes-cli/src/theme.rs",
+          "name": "test_status_bar_color_fields_respect_overrides"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_status_message_style_critical_for_error"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_transcript_hides_system_messages"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_transcript_placeholder_shows_when_empty"
+        }
+      ]
+    },
+    {
+      "path": "ui-tui/packages/hermes-ink/package.json",
+      "classification_path": "ui-tui/packages",
       "status": "covered_by_rust_primary_tui_contracts",
       "coverage_kind": "rust_primary_tui_or_documented_divergence",
       "coverage_tags": [
@@ -2769,6 +2831,67 @@
     },
     {
       "path": "ui-tui/src/app/slash/commands/session.ts",
+      "status": "covered_by_rust_primary_tui_contracts",
+      "coverage_kind": "rust_primary_tui_or_documented_divergence",
+      "coverage_tags": [
+        "rust_primary_tui",
+        "slash_overlay_session"
+      ],
+      "rationale": "The upstream TypeScript/Ink TUI row is superseded by the Rust Ratatui CLI/TUI runtime; the cited Rust tests cover the equivalent input, rendering, gateway, slash/session, text, theme, or virtual-history behavior without requiring a JS runtime path.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_tui_state_default"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_input_mode_display"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_fit_status_line_pads_and_respects_display_width"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "test_default_mouse_enabled_respects_env_override"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_tui_state_completions_update"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_completion_popup_hidden_when_slash_deleted"
+        },
+        {
+          "file": "crates/hermes-cli/src/tui.rs",
+          "name": "test_completion_popup_hidden_when_modal_or_processing_active"
+        },
+        {
+          "file": "crates/hermes-cli/src/commands.rs",
+          "name": "quick_alias_rewrites_to_builtin_and_passes_args"
+        },
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_status"
+        },
+        {
+          "file": "crates/hermes-cli/src/cli.rs",
+          "name": "cli_parse_resume_latest_default"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "app_new_session_invokes_session_lifecycle_hooks"
+        },
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "app_reset_session_invokes_session_lifecycle_hooks"
+        }
+      ]
+    },
+    {
+      "path": "ui-tui/src/app/slash/registry.ts",
+      "classification_path": "ui-tui/src",
       "status": "covered_by_rust_primary_tui_contracts",
       "coverage_kind": "rust_primary_tui_or_documented_divergence",
       "coverage_tags": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,27 +1,127 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-12T11:29:11.103206+00:00`
+Generated: `2026-06-16T02:12:02.309717+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `5659`.
+- Range: `HEAD..upstream/main`; total commits tracked: `5956`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2416 |
-| #21 | GPAR-02 skills parity | 118 |
-| #22 | GPAR-03 UX parity | 856 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 400 |
+| #20 | GPAR-01 tests+CI parity | 2570 |
+| #21 | GPAR-02 skills parity | 119 |
+| #22 | GPAR-03 UX parity | 877 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 416 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
-| #25 | GPAR-06 packaging/docs/install parity | 120 |
-| #26 | GPAR-07 upstream queue backfill | 1727 |
+| #25 | GPAR-06 packaging/docs/install parity | 128 |
+| #26 | GPAR-07 upstream queue backfill | 1824 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
+| pending | 121 |
 | ported | 266 |
-| superseded | 5323 |
+| superseded | 5499 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| _(none)_ | - | - |
+| `bb5cb3283898` | #23 | refactor(honcho): canonicalize identity-mapping on pinUserPeer, migrate legacy key |
+| `d7dfeed6dc42` | #23 | feat(honcho-setup): replace deployment-shape prompt with gateway-gated identity tree |
+| `99feb036077a` | #23 | docs(honcho): demote pinPeerName to deprecated alias; document gateway identity tree |
+| `2708c33c7570` | #23 | docs(honcho): anonymize example peer name to alice |
+| `1544813bfe56` | #20 | chore(honcho): replace example Telegram UID with placeholder |
+| `d62979a6f34f` | #20 | feat(desktop): composer status stack, live subagent windows, editable prompts (#44630) |
+| `79c3ed3cc91a` | #26 | fix(desktop): new chat honours the active profile instead of rubberbanding to default (#45057) |
+| `46d758bb3e07` | #26 | feat(desktop): window translucency slider in Appearance settings (#45086) |
+| `2f9d18711fb9` | #20 | fix(ci): remove pytest-timeout, use per-file timeout only |
+| `8044bf0206c1` | #25 | fix(ci): only save test durations when tests pass |
+| `1e25358a8f22` | #20 | refactor(desktop): use port 0 for ephemeral port discovery instead of PortPool reservation |
+| `c61815232abe` | #20 | Update model correctly when updating from dashboard |
+| `8c3c08c50be8` | #20 | Update implementation to make it cleaner |
+| `bc3f4ed70fa5` | #20 | Skip redundant model switch |
+| `6b4073648ece` | #20 | fix(tui): config.yaml wins over env model seed in per-turn sync |
+| `05b9c84ca4b1` | #20 | Add Telegram Bot API 10.1 rich message support |
+| `652dd9c9f248` | #20 | fix: rich messages follow-ups — reply_parameters, send latch, opt-in default |
+| `2e874ef87926` | #26 | fix(desktop): allow dismissing settled tool rows |
+| `b16e22b8f272` | #26 | fix(desktop): persist tool-row dismissal across virtualization; keep caret hittable |
+| `bbf020e709ec` | #26 | feat(desktop): follow streaming output at bottom + jump-to-bottom button (#45263) |
+| `e90672696ea7` | #26 | feat(desktop): worktree-aware sidebar grouping + composer/sidebar UX fixes |
+| `0595af0ad19b` | #26 | feat(desktop): move workspace/worktree drag handle into the leading icon |
+| `dd12a5403de9` | #26 | refactor(desktop): extract shared WorkspaceHeader for repo + worktree rows |
+| `1899c8f507c3` | #21 | fix(skills): run youtube transcript helper through uv |
+| `1a3cd3d436a1` | #26 | refactor(desktop): collapse sidebar drag-reorder into one generic ReorderableList |
+| `78ce91750ec6` | #26 | fix(desktop): crisp terminal text via opaque xterm canvas |
+| `d14f6c95632b` | #26 | fix(desktop): stop streaming autoscroll bounce; move attachments below user bubble |
+| `7c226cc57fe6` | #26 | perf(desktop): isolate streaming re-renders & cut layout thrash |
+| `edc36f3a4589` | #26 | perf(desktop): incremental markdown rendering during streams |
+| `3cf7d43262d4` | #26 | perf(desktop): faster session resume & warm AudioContext at idle |
+| `7d183f64979f` | #26 | fix(desktop): theme the image-gen placeholder instead of a white square (#45354) |
+| `bf090deed33e` | #26 | fix(desktop): stop stranding queued prompts across backend bounces |
+| `f23a4b7bb3b8` | #26 | fix(desktop): keep queued drains quiet on transient "session busy" |
+| `18916376f198` | #26 | fix(desktop): never surface "session busy" — retry every submit past it |
+| `7f302c91b240` | #26 | chore: uptick |
+| `1e755ff5568a` | #26 | fix(desktop): keep recents sorted unless manually reordered (#45404) |
+| `76b93869d8ed` | #26 | fix(desktop): rebuild thread autoscroll on use-stick-to-bottom |
+| `77687156b4b8` | #26 | fix(desktop): tighten multiline user prompt spacing |
+| `b15dc58064eb` | #26 | fix(desktop): keep generated images in the tool slot, not inline |
+| `b82d2e549fa5` | #26 | fix(desktop): keep the diffusion placeholder circular at any aspect |
+| `b6c7ebf028d8` | #20 | fix(tui): honor provider_routing config in the desktop/TUI backend (#44953) |
+| `bdd3868b577a` | #26 | fix(desktop): keep profile color picker open from the context menu (#45489) |
+| `8cf9d8689d56` | #22 | fix(desktop): keep composer usable during reconnect (#45488) |
+| `2d474e39c7ee` | #20 | fix(acp): preserve memory provider tools |
+| `266b5a19f128` | #26 | feat(desktop): expand the full command inline from the approval bar |
+| `5d6c16e97237` | #26 | test(desktop): cover the inline command expander on the approval bar |
+| `2681c5a12d8d` | #20 | fix(photon): correct gateway start command (#45566) |
+| `573b964dc780` | #25 | fix(installer): clear an unmerged git index before stashing on update |
+| `a59d5e37e8ab` | #20 | feat(telegram): make rich messages always on (#45584) |
+| `e256f4aae493` | #20 | fix(gateway): don't restore a bare billing provider as the resumed session's provider |
+| `643dc8279306` | #20 | Fix custom provider identity loss in session persistence |
+| `2667601c05cd` | #20 | fix(tui): keep reasoning-only assistant turns visible on session resume |
+| `aa53a78d6703` | #26 | fix(desktop): hand off Windows bootstrap recovery (#45594) |
+| `4373e802a1b9` | #25 | fix(docs): reuse healthy skills index during Pages deploys (#45616) |
+| `28bf8fb47d38` | #22 | feat(dashboard): clone profiles from any source |
+| `cc14b74718aa` | #22 | docs(profile): update clone-from references |
+| `425e777f54b8` | #26 | fix(desktop): polish slash command completion (space/tab/click + typed args) (#45760) |
+| `0a865e5948cb` | #26 | fix(desktop): bypass Chromium editing pipeline for large paste & select-delete (#45812) |
+| `bf8effad023b` | #20 | fix(utils): copy fallback for atomic replace across devices (#43852) |
+| `6b76284c7769` | #26 | fix(desktop): surface off-screen approvals via the jump-to-bottom control (#45853) |
+| `a218a0f1569c` | #20 | fix(agent,gateway,doctor): add SSL CA cert bundle fail-fast guard |
+| `dc90ca4e1740` | #26 | fix(ssl): run CA guard during agent initialization |
+| `7aaae7acd0d6` | #20 | fix(ssl): align guard docs and escape hatch |
+| `8d5d36d79358` | #20 | fix(dispatch): forward session_id into registry.dispatch (#28479) |
+| `12682d96b9c8` | #20 | feat(telegram): restore rich messages opt-out |
+| `e986e3fc689c` | #26 | fix: add provider account removal |
+| `1b16c481708d` | #20 | fix: guard OAuth account removal |
+| `b4ba3f5e3b37` | #26 | feat(desktop): add curated completion cue for agent turn completion (#42480) |
+| `630a4ef03c8e` | #26 | feat(desktop): native OS notifications with per-type toggles |
+| `b0288ae9b6ea` | #26 | feat(desktop): move completion-sound picker into Notifications settings |
+| `9cbb91abd3a8` | #26 | fix(desktop): clarify UX — loading, enter-to-send, radio align (#46014) |
+| `715b691723c6` | #20 | fix(desktop): show summarizing indicator during auto-compaction |
+| `49dd91d682a4` | #26 | fix(desktop): show copied checkmark on session Copy ID (#46030) |
+| `1eb13744b4ab` | #26 | fix(desktop): polish compaction indicator and preserve scrollback |
+| `d842155da1e8` | #20 | Keep resumed profile cwd scoped to profile DB |
+| `9f33d673e9e6` | #20 | fix(tui): persist resumed profile cwd updates to profile db |
+| `5e851bc6bc51` | #26 | fix(discord): cap slash commands at Discord's 100-command limit |
+| `0428945b5b07` | #20 | fix(desktop): keep profile homes out of bootstrap (#46073) |
+| `b00060ce545c` | #20 | fix(agent): expose HERMES_REAL_HOME in subprocess envs for profile isolation |
+| `723c2331bd23` | #20 | fix: make profile subprocess HOME policy explicit |
+| `a4ee1f223d5f` | #25 | fix(install): make `npm install -g` packages reachable on PATH |
+| `1db8f7ea8094` | #25 | fix(install): repair existing managed-Node global prefix on re-run |
+| `972a9885ee20` | #20 | fix(mcp): block exfil-shaped stdio server configs (#46083) |
+| `efbe1635dd2e` | #20 | fix(gateway): include replied-to media attachments (#46107) |
+| `288f7026e332` | #20 | fix(messaging): correct Weixin personal account labeling |
+| `08d89e7aba14` | #26 | fix(desktop): limit thinking shimmer to the disclosure label (#46197) |
+| `a1f51feb72b4` | #20 | fix(telegram): avoid rich final duplicate previews (#46206) |
+| `bff78a34dc44` | #20 | feat(zai): add GLM-5.2 with verified 1M context window |
+| `f3fe99863d13` | #20 | revert(web): remove keyless Parallel search fallback (#46350) |
+| `8fe334b056d4` | #26 | fix(desktop): inset hover-reveal trigger past the adjacent scrollbar (#44159) |
+| `61ee2dbfdb40` | #20 | fix(s6): make profile gateway log parent writable (#46291) |
+| `a376ca00819e` | #23 | feat(hindsight): make observation scopes configurable on retain |
+| `c1a70a543925` | #20 | 🐛 fix(disk-cleanup): prune protected cleanup walks |
+| `40699c329265` | #20 | 🐛 fix(disk-cleanup): avoid brittle sweep review issues |
+| `975b9f0a5426` | #22 | docs: recommend standard installer for development (#46646) |
+| `92a456f711eb` | #22 | fix(cli,deps): clear esbuild audit loop |
+| `49e743985aaf` | #20 | fix: route minimax m3 reasoning controls through profile |
+| `fbabf438a17c` | #26 | fix(desktop): sync $connection on profile switch so remote profiles attach images as bytes |
+| `bee13817f069` | #26 | test(desktop): cover $connection resync on profile switch |
+| `5b2604df999c` | #26 | fix(state): skip redundant trigram backfill before v11 FTS rebuild |

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-06-12T04:04:44-06:00",
-  "head_sha": "17ee23e0adf80f56c1686918dbcc26a30d0c5a8a",
+  "generated_at_utc": "2026-06-13T16:15:14-06:00",
+  "head_sha": "2ba91e3c1f2a5d70e17f2547d9c6638e25182bd6",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "9c505217044cedc28f174f1b74174d00d9ea1c81",
+  "upstream_sha": "55cb4103beba5822303c06b662635e1491ae72f5",
   "workstreams": [
     {
       "evidence": [
@@ -40,7 +40,7 @@
       "metrics": {
         "divergence_documented": true,
         "local_skill_files": 883,
-        "upstream_skill_files": 861
+        "upstream_skill_files": 864
       },
       "state": "complete",
       "title": "Skills parity",

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `17ee23e0adf80f56c1686918dbcc26a30d0c5a8a`
-- Upstream: `upstream/main` (`9c505217044cedc28f174f1b74174d00d9ea1c81`)
+- Local HEAD: `2ba91e3c1f2a5d70e17f2547d9c6638e25182bd6`
+- Upstream: `upstream/main` (`55cb4103beba5822303c06b662635e1491ae72f5`)
 
 | Workstream | Title | State |
 | --- | --- | --- |
@@ -33,7 +33,7 @@
 - State: **complete**
 - Upstream skills catalogs audited against local tree.
 - Intentional divergence documented for skills and optional-skills vendoring.
-- Metrics: `{"divergence_documented": true, "local_skill_files": 883, "upstream_skill_files": 861}`
+- Metrics: `{"divergence_documented": true, "local_skill_files": 883, "upstream_skill_files": 864}`
 
 ## WS5 — UX parity
 

--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -45,12 +45,21 @@ Config file: `$HERMES_HOME/supermemory.json`
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `supermemory_store` | Store an explicit memory |
-| `supermemory_search` | Search memories by semantic similarity |
-| `supermemory_forget` | Forget a memory by ID or best-match query |
-| `supermemory_profile` | Retrieve persistent profile and recent context |
+Kebab-case names are registered for the agent; snake_case aliases remain supported.
+
+| Tool | Alias | Description |
+|------|-------|-------------|
+| `supermemory-save` | `supermemory_store` | Store an explicit memory |
+| `supermemory-search` | `supermemory_search` | Search memories by semantic similarity |
+| `supermemory-forget` | `supermemory_forget` | Forget a memory by ID or best-match query |
+| `supermemory-profile` | `supermemory_profile` | Retrieve persistent profile and recent context |
+
+## Source Attribution
+
+All Supermemory API calls send `x-sm-source: hermes`, and document writes stamp
+`metadata.sm_source: hermes`. This groups Hermes-written memories into a
+dedicated Hermes source in Supermemory so they can be filtered and managed
+separately from other agent sources.
 
 ## Behavior
 
@@ -87,7 +96,7 @@ For advanced setups (e.g. OpenClaw-style multi-workspace), you can enable custom
 ```
 
 When enabled:
-- `supermemory_search`, `supermemory_store`, `supermemory_forget`, and `supermemory_profile` accept an optional `container_tag` parameter
+- `supermemory-search`, `supermemory-save`, `supermemory-forget`, and `supermemory-profile` accept an optional `container_tag` parameter
 - The tag must be in the whitelist: primary container + `custom_containers`
 - Automatic operations (turn sync, prefetch, memory write mirroring, session ingest) always use the **primary** container only
 - Custom container instructions are injected into the system prompt

--- a/plugins/memory/supermemory/plugin.yaml
+++ b/plugins/memory/supermemory/plugin.yaml
@@ -1,5 +1,5 @@
 name: supermemory
-version: 1.0.0
+version: 1.0.1
 description: "Supermemory semantic long-term memory with profile recall, semantic search, explicit memory tools, and session ingest."
 pip_dependencies:
   - supermemory

--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -14,8 +14,11 @@ Extract transcripts from YouTube videos and convert them into useful formats.
 
 ## Setup
 
+Use `uv` so the dependency is installed into the same Hermes-managed environment
+that runs the helper script:
+
 ```bash
-pip install youtube-transcript-api
+uv pip install youtube-transcript-api
 ```
 
 ## Helper Script
@@ -24,16 +27,16 @@ pip install youtube-transcript-api
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats
@@ -59,7 +62,7 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Workflow
 
-1. **Fetch** the transcript using the helper script with `--text-only --timestamps`.
+1. **Fetch** the transcript using the helper script with `--text-only --timestamps` via `uv run python3`.
 2. **Validate**: confirm the output is non-empty and in the expected language. If empty, retry without `--language` to get any available transcript. If still empty, tell the user the video likely has transcripts disabled.
 3. **Chunk if needed**: if the transcript exceeds ~50K characters, split into overlapping chunks (~40K with 2K overlap) and summarize each chunk before merging.
 4. **Transform** into the requested output format. If the user did not specify a format, default to a summary.
@@ -70,4 +73,4 @@ After fetching the transcript, format it based on what the user asks for:
 - **Transcript disabled**: tell the user; suggest they check if subtitles are available on the video page.
 - **Private/unavailable video**: relay the error and ask the user to verify the URL.
 - **No matching language**: retry without `--language` to fetch any available transcript, then note the actual language to the user.
-- **Dependency missing**: run `pip install youtube-transcript-api` and retry.
+- **Dependency missing**: run `uv pip install youtube-transcript-api` and retry.

--- a/skills/media/youtube-content/scripts/fetch_transcript.py
+++ b/skills/media/youtube-content/scripts/fetch_transcript.py
@@ -3,7 +3,7 @@
 Fetch a YouTube video transcript and output it as structured JSON.
 
 Usage:
-    python fetch_transcript.py <url_or_video_id> [--language en,tr] [--timestamps]
+    uv run python3 fetch_transcript.py <url_or_video_id> [--language en,tr] [--timestamps]
 
 Output (JSON):
     {
@@ -14,7 +14,7 @@ Output (JSON):
         "timestamped_text": "00:00 first line\n00:05 second line\n..."
     }
 
-Install dependency:  pip install youtube-transcript-api
+Install dependency:  uv pip install youtube-transcript-api
 """
 
 import argparse
@@ -56,7 +56,7 @@ def fetch_transcript(video_id: str, languages: list = None):
     try:
         from youtube_transcript_api import YouTubeTranscriptApi
     except ImportError:
-        print("Error: youtube-transcript-api not installed. Run: pip install youtube-transcript-api",
+        print("Error: youtube-transcript-api not installed. Run: uv pip install youtube-transcript-api",
               file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- reduce shared-different pending review to the requested threshold: 25 pending, 0 pending classification
- add Rust/API parity coverage for provider routing, MiniMax/Xiaomi/OpenRouter request shaping, Supermemory/OpenViking memory behavior, API server content normalization, and MCP CLI parsing
- refresh generated parity/backlog/proof surfaces and align Supermemory/Youtube helper docs with the current local contracts

## Local verification
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo test -p hermes-parity-tests --test ui_tui_source_coverage_contract -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo test -p hermes-parity-tests -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo check -p hermes-cli --all-targets`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo check --workspace --all-targets`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo build -p hermes-cli --bin hermes-agent-ultra`
- `/Volumes/wd_black/cargo-targets/hermes-agent-ultra/debug/hermes-agent-ultra --version`

## Notes
- First broad workspace check hit transient external target-dir E0463 dependency lookup errors; isolated CLI check and retried workspace check passed cleanly.
- Official GitHub CI is intentionally not required for this batch.