### PR TITLE
Port Telegram rich messages and Hindsight scopes

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -11,6 +11,8 @@
 //!   - `HINDSIGHT_BUDGET` (default: "mid")
 //!   - `HINDSIGHT_API_URL` (default: "https://api.hindsight.vectorize.io")
 //!   - `HINDSIGHT_MODE` (default: "cloud")
+//!   - `HINDSIGHT_RETAIN_TAGS` (comma-separated tags attached to retained memories)
+//!   - `HINDSIGHT_RETAIN_OBSERVATION_SCOPES` (per_tag/combined/all_combinations or JSON scopes)
 //!   - `$HERMES_HOME/hindsight/config.json` overrides
 
 use std::collections::HashMap;
@@ -45,7 +47,12 @@ fn retain_schema() -> Value {
             "type": "object",
             "properties": {
                 "content": {"type": "string", "description": "The information to store."},
-                "context": {"type": "string", "description": "Short label (e.g. 'user preference', 'project decision')."}
+                "context": {"type": "string", "description": "Short label (e.g. 'user preference', 'project decision')."},
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional per-call tags to merge with configured default retain tags."
+                }
             },
             "required": ["content"]
         }
@@ -104,6 +111,8 @@ struct HindsightConfig {
     recall_prompt_preamble: String,
     bank_mission: String,
     retain_async: bool,
+    retain_tags: Vec<String>,
+    observation_scopes: Option<Value>,
     timeout_secs: u64,
 }
 
@@ -128,6 +137,13 @@ impl HindsightConfig {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
+            retain_tags: parse_retain_tags_value(&Value::String(
+                std::env::var("HINDSIGHT_RETAIN_TAGS").unwrap_or_default(),
+            ))
+            .unwrap_or_default(),
+            observation_scopes: parse_observation_scopes_value(&Value::String(
+                std::env::var("HINDSIGHT_RETAIN_OBSERVATION_SCOPES").unwrap_or_default(),
+            )),
             timeout_secs: std::env::var("HINDSIGHT_TIMEOUT")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
@@ -227,6 +243,15 @@ impl HindsightConfig {
                 }
                 if let Some(ra) = raw.get("retain_async").and_then(|v| v.as_bool()) {
                     config.retain_async = ra;
+                }
+                if let Some(tags) = raw.get("retain_tags").and_then(parse_retain_tags_value) {
+                    config.retain_tags = tags;
+                }
+                if let Some(scopes) = raw
+                    .get("observation_scopes")
+                    .and_then(parse_observation_scopes_value)
+                {
+                    config.observation_scopes = Some(scopes);
                 }
                 if let Some(timeout) = raw
                     .get("hindsight_timeout")
@@ -585,6 +610,11 @@ impl MemoryProviderPlugin for HindsightPlugin {
                     return json!({"error": "Missing required parameter: content"}).to_string();
                 }
                 let ctx = args.get("context").and_then(|v| v.as_str());
+                let call_tags = args
+                    .get("tags")
+                    .and_then(parse_retain_tags_value)
+                    .unwrap_or_default();
+                let retain_tags = merge_retain_tags(&cfg.retain_tags, &call_tags);
                 match hindsight_retain(
                     &client,
                     &base,
@@ -593,6 +623,8 @@ impl MemoryProviderPlugin for HindsightPlugin {
                     content,
                     ctx,
                     cfg.retain_async,
+                    &retain_tags,
+                    cfg.observation_scopes.as_ref(),
                 ) {
                     Ok(()) => json!({"result": "Memory stored successfully."}).to_string(),
                     Err(e) => json!({"error": e}).to_string(),
@@ -679,7 +711,9 @@ impl MemoryProviderPlugin for HindsightPlugin {
             {"key": "hindsight_timeout", "description": "HTTP timeout in seconds", "default": DEFAULT_TIMEOUT_SECS},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "recall_types", "description": "Fact types returned by recall", "default": DEFAULT_RECALL_TYPE},
-            {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]}
+            {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
+            {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated or list)", "default": ""},
+            {"key": "observation_scopes", "description": "Hindsight observation scoping: combined, per_tag, all_combinations, or JSON list of tag lists", "default": ""}
         ]))
     }
 
@@ -816,6 +850,97 @@ fn parse_recall_types_value(value: &Value) -> Option<Vec<String>> {
     }
 }
 
+fn push_unique_trimmed(items: &mut Vec<String>, value: &str) {
+    let trimmed = value.trim();
+    if !trimmed.is_empty() && !items.iter().any(|existing| existing == trimmed) {
+        items.push(trimmed.to_string());
+    }
+}
+
+fn parse_retain_tags_str(value: &str) -> Option<Vec<String>> {
+    let mut tags = Vec::new();
+    for item in value.split(',') {
+        push_unique_trimmed(&mut tags, item);
+    }
+    if tags.is_empty() {
+        None
+    } else {
+        Some(tags)
+    }
+}
+
+fn parse_retain_tags_value(value: &Value) -> Option<Vec<String>> {
+    if let Some(text) = value.as_str() {
+        return parse_retain_tags_str(text);
+    }
+    let items = value.as_array()?;
+    let mut tags = Vec::new();
+    for item in items.iter().filter_map(Value::as_str) {
+        push_unique_trimmed(&mut tags, item);
+    }
+    if tags.is_empty() {
+        None
+    } else {
+        Some(tags)
+    }
+}
+
+fn merge_retain_tags(default_tags: &[String], call_tags: &[String]) -> Vec<String> {
+    let mut tags = Vec::new();
+    for tag in default_tags.iter().chain(call_tags.iter()) {
+        push_unique_trimmed(&mut tags, tag);
+    }
+    tags
+}
+
+fn parse_observation_scopes_value(value: &Value) -> Option<Value> {
+    if let Some(text) = value.as_str() {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if matches!(trimmed, "per_tag" | "combined" | "all_combinations") {
+            return Some(Value::String(trimmed.to_string()));
+        }
+        if trimmed.starts_with('[') {
+            return serde_json::from_str::<Value>(trimmed)
+                .ok()
+                .and_then(|parsed| parse_observation_scopes_value(&parsed));
+        }
+        return None;
+    }
+
+    let items = value.as_array()?;
+    if items.iter().all(Value::is_string) {
+        let tags = parse_retain_tags_value(value)?;
+        return Some(json!([tags]));
+    }
+
+    let scopes = items
+        .iter()
+        .filter_map(parse_retain_tags_value)
+        .filter(|scope| !scope.is_empty())
+        .collect::<Vec<_>>();
+    if scopes.is_empty() {
+        None
+    } else {
+        Some(json!(scopes))
+    }
+}
+
+fn apply_retain_item_options(
+    item: &mut Value,
+    retain_tags: &[String],
+    observation_scopes: Option<&Value>,
+) {
+    if !retain_tags.is_empty() {
+        item["tags"] = json!(retain_tags);
+    }
+    if let Some(scopes) = observation_scopes {
+        item["observation_scopes"] = scopes.clone();
+    }
+}
+
 fn hindsight_recall_body(
     query: &str,
     budget: &str,
@@ -844,11 +969,14 @@ fn hindsight_sync_turn_body(
     async_mode: bool,
     document_id: Option<&str>,
     update_mode: Option<&str>,
+    retain_tags: &[String],
+    observation_scopes: Option<&Value>,
 ) -> Value {
     let mut item = json!({"content": content, "context": context});
     if let Some(update_mode) = update_mode {
         item["update_mode"] = json!(update_mode);
     }
+    apply_retain_item_options(&mut item, retain_tags, observation_scopes);
     let mut body = json!({
         "items": [item],
         "async": async_mode,
@@ -890,12 +1018,18 @@ fn retain_hindsight_turns(
     );
     let content = format!("[{}]", turns.join(","));
     let url = format!("{}/v1/default/banks/{}/memories", base, bank);
+    let lineage_tags = nonempty_str(session_id)
+        .map(|session_id| vec![format!("session:{session_id}")])
+        .unwrap_or_default();
+    let retain_tags = merge_retain_tags(&cfg.retain_tags, &lineage_tags);
     let body = hindsight_sync_turn_body(
         &content,
         &cfg.retain_context,
         cfg.retain_async,
         nonempty_str(&document_id),
         update_mode,
+        &retain_tags,
+        cfg.observation_scopes.as_ref(),
     );
     let mut req = client.post(&url).json(&body);
     if !cfg.api_key.is_empty() {
@@ -1102,12 +1236,15 @@ fn hindsight_retain(
     content: &str,
     context: Option<&str>,
     async_mode: bool,
+    retain_tags: &[String],
+    observation_scopes: Option<&Value>,
 ) -> Result<(), String> {
     let url = format!("{}/v1/default/banks/{}/memories", base, bank);
     let mut item = json!({ "content": content });
     if let Some(ctx) = context {
         item["context"] = json!(ctx);
     }
+    apply_retain_item_options(&mut item, retain_tags, observation_scopes);
     let body = json!({ "items": [item], "async": async_mode });
     let mut req = client.post(&url).json(&body);
     if !api_key.is_empty() {
@@ -1198,6 +1335,8 @@ mod tests {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
+            retain_tags: Vec::new(),
+            observation_scopes: None,
             timeout_secs: DEFAULT_TIMEOUT_SECS,
         });
         assert!(plugin.get_tool_schemas().is_empty());
@@ -1225,6 +1364,8 @@ mod tests {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
+            retain_tags: Vec::new(),
+            observation_scopes: None,
             timeout_secs: DEFAULT_TIMEOUT_SECS,
         };
 
@@ -1302,6 +1443,38 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_retain_tags_and_observation_scopes() {
+        assert_eq!(
+            parse_retain_tags_value(&json!("project:ultra, session:s1, project:ultra")),
+            Some(vec!["project:ultra".to_string(), "session:s1".to_string()])
+        );
+        assert_eq!(
+            parse_retain_tags_value(&json!(["alpha", " beta ", "", "alpha"])),
+            Some(vec!["alpha".to_string(), "beta".to_string()])
+        );
+        assert_eq!(
+            merge_retain_tags(
+                &["alpha".into(), "beta".into()],
+                &["beta".into(), "gamma".into()]
+            ),
+            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
+        );
+        assert_eq!(
+            parse_observation_scopes_value(&json!("per_tag")),
+            Some(json!("per_tag"))
+        );
+        assert_eq!(
+            parse_observation_scopes_value(&json!(["alpha", "beta"])),
+            Some(json!([["alpha", "beta"]]))
+        );
+        assert_eq!(
+            parse_observation_scopes_value(&json!("[[\"alpha\"],[\"alpha\",\"beta\"]]")),
+            Some(json!([["alpha"], ["alpha", "beta"]]))
+        );
+        assert_eq!(parse_observation_scopes_value(&json!("invalid")), None);
+    }
+
+    #[test]
     fn test_resolve_bank_id_template_sanitizes_and_collapses() {
         let bank = resolve_bank_id_template(
             "hermes-{profile}-{user}-{session}",
@@ -1345,15 +1518,31 @@ mod tests {
         let _bank_id = EnvGuard::remove("HINDSIGHT_BANK_ID");
         let _mode = EnvGuard::remove("HINDSIGHT_MODE");
         let _timeout = EnvGuard::remove("HINDSIGHT_TIMEOUT");
+        let _retain_tags = EnvGuard::remove("HINDSIGHT_RETAIN_TAGS");
+        let _observation_scopes = EnvGuard::remove("HINDSIGHT_RETAIN_OBSERVATION_SCOPES");
 
         let tmp = tempfile::tempdir().expect("tempdir");
         write_hindsight_config(
             tmp.path(),
-            &json!({"mode": "cloud", "api_key": "snake-secret", "timeout": 42}),
+            &json!({
+                "mode": "cloud",
+                "api_key": "snake-secret",
+                "timeout": 42,
+                "retain_tags": ["project:ultra", "session:s1", "project:ultra"],
+                "observation_scopes": [["project:ultra"], ["project:ultra", "session:s1"]]
+            }),
         );
         let cfg = HindsightConfig::load(tmp.path().to_str().expect("tmp path"));
         assert_eq!(cfg.api_key, "snake-secret");
         assert_eq!(cfg.timeout_secs, 42);
+        assert_eq!(
+            cfg.retain_tags,
+            vec!["project:ultra".to_string(), "session:s1".to_string()]
+        );
+        assert_eq!(
+            cfg.observation_scopes,
+            Some(json!([["project:ultra"], ["project:ultra", "session:s1"]]))
+        );
 
         write_hindsight_config(
             tmp.path(),
@@ -1418,12 +1607,19 @@ mod tests {
             false,
             Some("session-1-doc"),
             Some("append"),
+            &["project:ultra".to_string(), "session:session-1".to_string()],
+            Some(&json!("per_tag")),
         );
         assert_eq!(body["async"], false);
         assert_eq!(body["document_id"], "session-1-doc");
         assert_eq!(body["items"][0]["update_mode"], "append");
         assert_eq!(body["items"][0]["content"], content);
         assert_eq!(body["items"][0]["context"], "conversation");
+        assert_eq!(
+            body["items"][0]["tags"],
+            json!(["project:ultra", "session:session-1"])
+        );
+        assert_eq!(body["items"][0]["observation_scopes"], json!("per_tag"));
     }
 
     #[test]
@@ -1464,6 +1660,8 @@ mod tests {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
+            retain_tags: Vec::new(),
+            observation_scopes: None,
             timeout_secs: DEFAULT_TIMEOUT_SECS,
         });
 
@@ -1497,6 +1695,8 @@ mod tests {
             recall_prompt_preamble: String::new(),
             bank_mission: String::new(),
             retain_async: true,
+            retain_tags: Vec::new(),
+            observation_scopes: None,
             timeout_secs: DEFAULT_TIMEOUT_SECS,
         });
         *plugin.session_id.lock().unwrap() = "old-session".into();

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -30,6 +30,9 @@ use crate::format::to_telegram_markdown_v2;
 /// Maximum message length for Telegram (4096 characters).
 const MAX_MESSAGE_LENGTH: usize = 4096;
 
+/// Bot API 10.1 rich-message raw markdown character cap.
+const RICH_MESSAGE_MAX_CHARS: usize = 32_768;
+
 /// Default long-polling timeout in seconds.
 const DEFAULT_POLL_TIMEOUT: u64 = 30;
 
@@ -92,6 +95,17 @@ pub struct TelegramConfig {
     /// Whether to parse HTML in messages.
     #[serde(default)]
     pub parse_html: bool,
+
+    /// Disable link previews on outbound Telegram text/rich messages.
+    #[serde(default)]
+    pub disable_link_previews: bool,
+
+    /// Use Bot API 10.1 sendRichMessage for eligible final text sends.
+    ///
+    /// Disabled by default because some Telegram clients still render rich
+    /// messages poorly even when the Bot API accepts them.
+    #[serde(default)]
+    pub rich_messages: bool,
 
     /// Long-polling timeout in seconds.
     #[serde(default = "default_poll_timeout")]
@@ -719,6 +733,8 @@ pub struct TelegramAdapter {
     /// Inline approval callback IDs mapped to gateway session keys.
     approval_state: Mutex<HashMap<u64, String>>,
     approval_counter: AtomicU64,
+    /// Latched off after the rich endpoint is proven unavailable.
+    rich_send_disabled: Mutex<bool>,
 }
 
 #[derive(Clone, Copy)]
@@ -770,6 +786,7 @@ impl TelegramAdapter {
             status_message_ids: Mutex::new(HashMap::new()),
             approval_state: Mutex::new(HashMap::new()),
             approval_counter: AtomicU64::new(1),
+            rich_send_disabled: Mutex::new(false),
         })
     }
 
@@ -879,6 +896,112 @@ impl TelegramAdapter {
         chunk_index: usize,
     ) -> bool {
         reply_to_message_id.is_some() && self.reply_to_mode().references_chunk(chunk_index)
+    }
+
+    fn rich_send_is_disabled(&self) -> bool {
+        self.rich_send_disabled
+            .lock()
+            .map(|guard| *guard)
+            .unwrap_or(true)
+    }
+
+    fn latch_rich_send_disabled(&self) {
+        if let Ok(mut disabled) = self.rich_send_disabled.lock() {
+            *disabled = true;
+        }
+    }
+
+    fn content_fits_rich_limits(content: &str) -> bool {
+        content.chars().count() <= RICH_MESSAGE_MAX_CHARS
+    }
+
+    fn has_telegram_desktop_details_math_crash_shape(content: &str) -> bool {
+        if content.trim().is_empty() || !content.to_ascii_lowercase().contains("<details") {
+            return false;
+        }
+        let details = regex::RegexBuilder::new(r"<details\b[^>]*>.*?</details>")
+            .case_insensitive(true)
+            .dot_matches_new_line(true)
+            .build();
+        let math = regex::RegexBuilder::new(
+            r"(\$\$.*?\$\$|\\\[.*?\\\]|\\\(.*?\\\)|\\(?:sum|frac|alpha|beta|gamma|delta|theta|lambda|mu|pi|sigma|int|prod|sqrt|lim|infty|begin\{(?:equation|align|matrix|cases)\}))",
+        )
+        .case_insensitive(true)
+        .dot_matches_new_line(true)
+        .build();
+        let (Ok(details), Ok(math)) = (details, math) else {
+            return false;
+        };
+        let has_crash_shape = details
+            .find_iter(content)
+            .any(|block| math.is_match(block.as_str()));
+        has_crash_shape
+    }
+
+    fn should_attempt_rich_text(
+        &self,
+        text: &str,
+        keyboard: Option<&InlineKeyboardMarkup>,
+    ) -> bool {
+        self.config.rich_messages
+            && !self.rich_send_is_disabled()
+            && keyboard.is_none()
+            && !text.trim().is_empty()
+            && Self::content_fits_rich_limits(text)
+            && !Self::has_telegram_desktop_details_math_crash_shape(text)
+    }
+
+    fn rich_message_body(
+        &self,
+        chat_id: &str,
+        text: &str,
+        reply_to_message_id: Option<i64>,
+        message_thread_id: Option<i64>,
+    ) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "chat_id": chat_id,
+            "rich_message": {
+                "markdown": text,
+            },
+        });
+        if let Some(thread_id) = message_thread_id {
+            body["message_thread_id"] = serde_json::Value::Number(thread_id.into());
+        }
+        if let Some(reply_id) = reply_to_message_id {
+            body["reply_parameters"] = serde_json::json!({ "message_id": reply_id });
+        }
+        if self.config.disable_link_previews {
+            body["link_preview_options"] = serde_json::json!({ "is_disabled": true });
+        }
+        body
+    }
+
+    fn rich_capability_error(err: &GatewayError) -> bool {
+        let message = match err {
+            GatewayError::SendFailed(message)
+            | GatewayError::Platform(message)
+            | GatewayError::ConnectionFailed(message) => message.to_ascii_lowercase(),
+            _ => return false,
+        };
+        message.contains("no such method")
+            || message.contains("not implemented")
+            || ((message.contains("method") || message.contains("endpoint"))
+                && (message.contains("not found") || message.contains("does not exist")))
+    }
+
+    fn rich_fallback_error(err: &GatewayError) -> bool {
+        let message = match err {
+            GatewayError::SendFailed(message)
+            | GatewayError::Platform(message)
+            | GatewayError::ConnectionFailed(message) => message.to_ascii_lowercase(),
+            _ => return false,
+        };
+        message.contains("bad request")
+            || message.contains("unsupported")
+            || message.contains("not implemented")
+            || message.contains("no such method")
+            || ((message.contains("method") || message.contains("endpoint"))
+                && (message.contains("not found") || message.contains("does not exist")))
     }
 
     /// Merge media captions without using substring checks that drop distinct captions.
@@ -1135,6 +1258,16 @@ impl TelegramAdapter {
     ) -> Result<Vec<i64>, GatewayError> {
         let (chat_id, inferred_thread_id) = Self::split_gateway_chat_thread(chat_id);
         let message_thread_id = message_thread_id.or(inferred_thread_id);
+        if self.should_attempt_rich_text(text, keyboard.as_ref()) {
+            match self
+                .try_send_rich_text(chat_id, text, reply_to_message_id, message_thread_id)
+                .await?
+            {
+                Some(message_id) => return Ok(vec![message_id]),
+                None => {}
+            }
+        }
+
         let chunks = split_message(text, MAX_MESSAGE_LENGTH);
         let mut message_ids = Vec::new();
 
@@ -1147,6 +1280,10 @@ impl TelegramAdapter {
 
             if let Some(pm) = parse_mode {
                 body["parse_mode"] = serde_json::Value::String(pm.to_string());
+            }
+
+            if self.config.disable_link_previews {
+                body["disable_web_page_preview"] = serde_json::Value::Bool(true);
             }
 
             if let Some(thread_id) = message_thread_id {
@@ -1182,6 +1319,32 @@ impl TelegramAdapter {
         }
 
         Ok(message_ids)
+    }
+
+    async fn try_send_rich_text(
+        &self,
+        chat_id: &str,
+        text: &str,
+        reply_to_message_id: Option<i64>,
+        message_thread_id: Option<i64>,
+    ) -> Result<Option<i64>, GatewayError> {
+        let body = self.rich_message_body(chat_id, text, reply_to_message_id, message_thread_id);
+        let resp: TelegramResponse<SentMessage> = match self
+            .send_json_with_thread_fallback("sendRichMessage", body)
+            .await
+        {
+            Ok(resp) => resp,
+            Err(err) if Self::rich_fallback_error(&err) => {
+                if Self::rich_capability_error(&err) {
+                    self.latch_rich_send_disabled();
+                }
+                return Ok(None);
+            }
+            Err(err) => return Err(err),
+        };
+        resp.result
+            .map(|msg| Some(msg.message_id))
+            .ok_or_else(|| GatewayError::SendFailed("sendRichMessage returned no message".into()))
     }
 
     /// Edit an existing message's text.
@@ -1280,7 +1443,8 @@ impl TelegramAdapter {
         };
         let removed_thread = obj.remove("message_thread_id").is_some();
         let removed_reply = obj.remove("reply_to_message_id").is_some();
-        removed_thread || removed_reply
+        let removed_reply_parameters = obj.remove("reply_parameters").is_some();
+        removed_thread || removed_reply || removed_reply_parameters
     }
 
     fn gateway_error_thread_or_reply_missing(err: &GatewayError) -> bool {
@@ -2420,6 +2584,8 @@ mod tests {
             proxy: AdapterProxyConfig::default(),
             parse_markdown: false,
             parse_html: false,
+            disable_link_previews: false,
+            rich_messages: false,
             poll_timeout: 30,
             reply_to_mode: "first".into(),
             reactions: false,
@@ -2867,6 +3033,112 @@ mod tests {
             .and_then(|v| v.as_str())
             .unwrap()
             .contains("\\[world\\]\\_1"));
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_message_uses_bot_api_10_1_payload_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendRichMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "-1001",
+                "message_thread_id": 42,
+                "rich_message": { "markdown": "| A | B |\n|---|---|\n| 1 | 2 |" },
+                "reply_parameters": { "message_id": 55 },
+                "link_preview_options": { "is_disabled": true }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 91 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.rich_messages = true;
+        cfg.disable_link_previews = true;
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text(
+                "-1001:42",
+                "| A | B |\n|---|---|\n| 1 | 2 |",
+                Some("MarkdownV2"),
+                Some(55),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![91]);
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        let body: Value = requests[0].body_json().expect("json body");
+        assert!(body.get("text").is_none());
+        assert!(body.get("parse_mode").is_none());
+        assert!(body.get("reply_to_message_id").is_none());
+        assert_eq!(
+            body.pointer("/rich_message/markdown")
+                .and_then(|v| v.as_str()),
+            Some("| A | B |\n|---|---|\n| 1 | 2 |")
+        );
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_message_bad_request_falls_back_to_legacy_send() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendRichMessage"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": false,
+                "description": "Bad Request: rich message is invalid"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "text": "plain fallback",
+                "disable_web_page_preview": true
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 92 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.rich_messages = true;
+        cfg.disable_link_previews = true;
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text("123", "plain fallback", None, None)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![92]);
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].url.path().ends_with("/sendRichMessage"));
+        assert!(requests[1].url.path().ends_with("/sendMessage"));
+    }
+
+    #[test]
+    fn telegram_rich_skips_desktop_details_math_crash_shape() {
+        assert!(
+            TelegramAdapter::has_telegram_desktop_details_math_crash_shape(
+                "<details><summary>Math</summary>$$x^2$$</details>"
+            )
+        );
+        assert!(
+            !TelegramAdapter::has_telegram_desktop_details_math_crash_shape(
+                "<details><summary>Plain</summary>No math here</details>"
+            )
+        );
     }
 
     #[tokio::test]
@@ -3759,6 +4031,8 @@ mod tests {
         assert!(cfg.polling);
         assert!(!cfg.parse_markdown);
         assert!(!cfg.parse_html);
+        assert!(!cfg.disable_link_previews);
+        assert!(!cfg.rich_messages);
         assert_eq!(cfg.poll_timeout, DEFAULT_POLL_TIMEOUT);
         assert_eq!(cfg.reply_to_mode, "first");
         assert!(cfg.webhook_secret.is_none());
@@ -3779,11 +4053,15 @@ mod tests {
             "token": "abc",
             "webhook_secret": "secret",
             "reply_to_mode": "all",
-            "reactions": true
+            "reactions": true,
+            "disable_link_previews": true,
+            "rich_messages": true
         }"#;
         let cfg: TelegramConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.webhook_secret.as_deref(), Some("secret"));
         assert_eq!(cfg.reply_to_mode, "all");
         assert!(cfg.reactions);
+        assert!(cfg.disable_link_previews);
+        assert!(cfg.rich_messages);
     }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -74,16 +74,16 @@
         "status": "pass"
       },
       {
-        "actual": 121.0,
+        "actual": 24.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
-        "status": "fail"
+        "status": "pass"
       }
     ],
     "mode": "tree-drift",
     "pass": false
   },
-  "generated_at_utc": "2026-06-16T02:12:15.001297+00:00",
+  "generated_at_utc": "2026-06-16T07:25:59.189499+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -99,7 +99,7 @@
     "max_commits_behind": 5880.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 121.0,
+    "max_queue_pending_commits": 24.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -119,14 +119,14 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 70,
-      "pending": 121,
-      "ported": 266,
-      "superseded": 5499
+      "pending": 24,
+      "ported": 288,
+      "superseded": 5579
     },
     "by_target_ticket": {
-      "20": 2570,
+      "20": 2574,
       "21": 119,
-      "22": 877,
+      "22": 878,
       "23": 416,
       "24": 22,
       "25": 128,
@@ -134,7 +134,7 @@
     },
     "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
     "patch_equivalent_count": 2,
-    "total_commits": 5956
+    "total_commits": 5961
   },
   "release_gate": {
     "checks": [
@@ -193,7 +193,7 @@
         "status": "pass"
       },
       {
-        "actual": 121.0,
+        "actual": 24.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-16T02:12:15.001297+00:00`
+Generated: `2026-06-16T07:25:59.189499+00:00`
 
 ## Gate Status
 
@@ -25,7 +25,7 @@ Generated: `2026-06-16T02:12:15.001297+00:00`
 | `min_sota_harness_domain_coverage_ratio` | 1.0 |
 | `max_sota_harness_critical_gaps` | 0.0 |
 | `max_sota_harness_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 121.0 |
+| `max_queue_pending_commits` | 24.0 |
 
 ## GPAR Ticket Completion
 
@@ -58,11 +58,11 @@ Generated: `2026-06-16T02:12:15.001297+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5956`.
+- Upstream missing commits tracked: `5961`.
 - By target ticket:
-  - `#20`: `2570`
+  - `#20`: `2574`
   - `#21`: `119`
-  - `#22`: `877`
+  - `#22`: `878`
   - `#23`: `416`
   - `#24`: `22`
   - `#25`: `128`

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3315,6 +3315,448 @@
     "484f484c25bc": {
       "disposition": "superseded",
       "notes": "Upstream sidebar nav drag-region carving targets Electron desktop titlebar behavior in apps/desktop. Hermes Agent Ultra uses the Rust Ratatui CLI/TUI and has no Electron draggable titlebar or React sidebar rows."
+    },
+    "d62979a6f34f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "79c3ed3cc91a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "46d758bb3e07": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "2e874ef87926": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b16e22b8f272": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "bbf020e709ec": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "e90672696ea7": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "0595af0ad19b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "dd12a5403de9": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1a3cd3d436a1": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "78ce91750ec6": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "d14f6c95632b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7c226cc57fe6": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "edc36f3a4589": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "3cf7d43262d4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7d183f64979f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "bf090deed33e": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "f23a4b7bb3b8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "18916376f198": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7f302c91b240": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1e755ff5568a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "76b93869d8ed": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "77687156b4b8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b15dc58064eb": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b82d2e549fa5": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "bdd3868b577a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "266b5a19f128": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "5d6c16e97237": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "aa53a78d6703": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "425e777f54b8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "0a865e5948cb": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "6b76284c7769": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "e986e3fc689c": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b4ba3f5e3b37": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "630a4ef03c8e": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b0288ae9b6ea": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "9cbb91abd3a8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "49dd91d682a4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1eb13744b4ab": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "08d89e7aba14": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "8fe334b056d4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "fbabf438a17c": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "bee13817f069": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "eae3836eb661": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "ae433634db56": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "f3b32e9f5220": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "368fcf1ff03b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1cb75b7971a7": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "37d717054ef6": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "9d2ec8d35a2a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "98c294126baf": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "0f75e9904a8f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "67233d1c2ad5": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "05b9c84ca4b1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: crates/hermes-gateway/src/platforms/telegram.rs now supports opt-in Bot API 10.1 sendRichMessage with raw rich_message.markdown payloads, legacy fallback, link_preview_options, and feature-gated tests telegram_rich_message_uses_bot_api_10_1_payload_shape / telegram_rich_message_bad_request_falls_back_to_legacy_send."
+    },
+    "652dd9c9f248": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: rich sends use reply_parameters instead of reply_to_message_id, latch off proven endpoint capability failures, default rich_messages remains opt-in, and bad-request rich payload failures fall back to legacy sendMessage with tests."
+    },
+    "a59d5e37e8ab": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by later upstream policy and Rust final state: Telegram rich messages are deliberately opt-in via TelegramConfig.rich_messages instead of always on because client rendering remains uneven."
+    },
+    "12682d96b9c8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram config: rich_messages deserializes as an explicit opt-in flag with default false, verified by Telegram config tests and rich-message feature tests."
+    },
+    "a1f51feb72b4": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/satisfied in Rust final architecture: rich delivery is opt-in and only attempted for eligible normal text sends, not status edits; StreamConsumer has no adapter-specific rich fresh-final hook to duplicate previews, and existing stream fresh-final tests preserve final-delivery state."
+    },
+    "a376ca00819e": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Hindsight plugin: HINDSIGHT_RETAIN_TAGS and HINDSIGHT_RETAIN_OBSERVATION_SCOPES/profile config parse into retain tags and observation_scopes, auto-retain includes session lineage tags, tool-call tags merge with defaults, and Hindsight tests cover payload/config normalization."
+    },
+    "bb5cb3283898": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Honcho setup/runtime: crates/hermes-cli/src/commands.rs and hermes_agent::memory_plugins::honcho own pinUserPeer identity mapping, legacy peerName behavior, runtimePeerPrefix, and userPeerAliases; Python Honcho CLI delta has no remaining runtime target."
+    },
+    "d7dfeed6dc42": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Honcho setup: setup_honcho_provider builds the gateway-gated identity tree for single/multi/hybrid deployments with aiPeer, pinUserPeer, runtimePeerPrefix, and aliases."
+    },
+    "99feb036077a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust Honcho configuration surface: pinUserPeer is the canonical runtime field and peerName is only emitted as a non-empty compatibility label from crates/hermes-cli/src/commands.rs."
+    },
+    "2708c33c7570": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust-first Honcho docs/tests surface; no real Telegram UID or named user example is required by the Rust Honcho setup path."
+    },
+    "1544813bfe56": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust Honcho setup/tests and release secret scan: the Rust setup path does not embed upstream example Telegram UID values and uses operator-supplied peer identity instead."
+    },
+    "c7513df4f9e4": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Honcho setup semantics: pinUserPeer is only true for the single-user/operator peer shape; multi/hybrid runtime peers are modeled through runtimePeerPrefix/userPeerAliases."
+    },
+    "c61815232abe": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust TUI model picker: crates/hermes-cli/src/tui.rs constructs provider:model selections and calls App::switch_model, so dashboard-side Python model update glue is not the active runtime path."
+    },
+    "8c3c08c50be8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/superseded by the Rust TUI model/provider modal implementation in crates/hermes-cli/src/tui.rs; the Python tui_gateway cleanup target is not shipped as the runtime backend."
+    },
+    "bc3f4ed70fa5": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust TUI/App model switching: explicit provider:model selections flow through App::switch_model without the Python desktop/TUI redundant-switch backend."
+    },
+    "6b4073648ece": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust config loader precedence: crates/hermes-config/src/loader.rs loads gateway.json, then config.yaml, then cli-config.yaml, then env overrides with explicit layer order and tests."
+    },
+    "b6c7ebf028d8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported through Rust provider/profile routing: hermes-config normalizes provider config and hermes-agent provider profiles drive request-body behavior; the Python desktop/TUI backend is not the active runtime path."
+    },
+    "e256f4aae493": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust session/provider persistence boundaries: session state and provider selections are explicit Rust App/Gateway state rather than restoring a bare billing provider from Python tui_gateway state."
+    },
+    "643dc8279306": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust session/provider identity handling: custom provider identity is carried by hermes-config provider profiles and hermes-agent provider construction instead of Python runtime_provider persistence."
+    },
+    "2667601c05cd": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust message/session rendering: crates/hermes-agent session persistence stores reasoning_content and crates/hermes-cli/src/tui.rs fingerprints/renders reasoning-aware assistant messages."
+    },
+    "d842155da1e8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust session/profile scoping: hermes-config resolves effective HERMES_HOME/profile config before runtime state, and ACP/session stores cwd explicitly in Rust session models."
+    },
+    "9f33d673e9e6": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust session state persistence: ACP/session models store cwd and update_cwd contracts in Rust tests; Python tui_gateway profile-db persistence is not the shipped runtime path."
+    },
+    "ed20f5ed0605": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust explicit model switching: crates/hermes-cli/src/tui.rs provider/model modal calls App::switch_model directly, allowing operator-selected models to escape stale config defaults."
+    },
+    "2f9d18711fb9": {
+      "disposition": "superseded",
+      "owner": "local-gates",
+      "notes": "Superseded by Ultra local Rust gates: scripts/clippy-warning-gate.sh, check-runtime-placeholders, cargo tests, and parity generators define local CI; upstream pytest-timeout/GitHub workflow tuning is optional."
+    },
+    "8044bf0206c1": {
+      "disposition": "superseded",
+      "owner": "local-gates",
+      "notes": "Superseded by local deterministic gate scripts and optional GitHub CI policy; upstream test-duration upload behavior is not a Rust runtime requirement."
+    },
+    "573b964dc780": {
+      "disposition": "superseded",
+      "owner": "installer",
+      "notes": "Superseded by Ultra release installer: scripts/install.sh installs release binaries/cargo artifacts and does not use upstream in-place git stashing/update semantics."
+    },
+    "4373e802a1b9": {
+      "disposition": "superseded",
+      "owner": "local-gates",
+      "notes": "Superseded by Rust skills registry/index implementation plus local parity gates; GitHub Pages workflow cache behavior is optional for this repo."
+    },
+    "a4ee1f223d5f": {
+      "disposition": "superseded",
+      "owner": "installer",
+      "notes": "Superseded by Rust-first installer and no Node desktop runtime: scripts/install.sh manages binary PATH/install location without upstream managed-Node global npm package requirements."
+    },
+    "1db8f7ea8094": {
+      "disposition": "superseded",
+      "owner": "installer",
+      "notes": "Superseded by Ultra installer design: release binary installation does not depend on managed Node global prefix repair."
+    },
+    "30377e108ca8": {
+      "disposition": "superseded",
+      "owner": "local-gates",
+      "notes": "Superseded by Rust-first UI/runtime scope and optional GitHub CI; there is no Electron renderer build gate for the shipped Ultra runtime."
+    },
+    "9eb0bcd60fc6": {
+      "disposition": "superseded",
+      "owner": "local-gates",
+      "notes": "Superseded by local Rust build/test gates and optional official GitHub CI; upstream nix workflow removal has no Rust runtime port target."
+    },
+    "e0492aa2dca0": {
+      "disposition": "superseded",
+      "owner": "local-gates",
+      "notes": "Superseded by user policy and local gate scripts: official GitHub pull_request CI is optional, while local shell/Rust gates define the required validation before push."
+    },
+    "1899c8f507c3": {
+      "disposition": "ported",
+      "owner": "skills",
+      "notes": "Ported in skills/media/youtube-content: SKILL.md and scripts/fetch_transcript.py already use uv run / uv pip for youtube-transcript-api, matching the upstream helper execution contract."
+    },
+    "5f6be7f31bd7": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/superseded by Rust-native Microsoft Teams pipeline in crates/hermes-tools/src/teams_pipeline.rs, including Graph auth/download, meeting jobs, Teams sink writer, and tests."
+    },
+    "49e743985aaf": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust provider profiles: crates/hermes-agent/src/provider.rs has MiniMax-M3 OpenAI reasoning contract tests and crates/hermes-agent/src/auxiliary_builder.rs registers MiniMax-M3 direct providers."
+    },
+    "1e25358a8f22": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron/desktop ephemeral-port discovery is superseded by Rust gateway/TUI runtime; Ultra does not ship apps/desktop or the Python web_server dashboard backend as the primary runtime."
+    },
+    "8cf9d8689d56": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop composer reconnect UX is superseded by Rust TUI/gateway connection surfaces; Electron composer code is intentionally not part of the Rust-only runtime."
+    },
+    "28bf8fb47d38": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream dashboard profile-clone UI is superseded by Rust profile/config commands and TUI surfaces; apps/desktop/web profile UI code is not shipped in Ultra runtime."
+    },
+    "1b16c481708d": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop OAuth account-removal UI is superseded by Rust provider/auth config surfaces; Electron onboarding/settings UI is outside the Rust-only shipped runtime."
+    },
+    "715b691723c6": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop summarizing indicator is superseded by Rust TUI/gateway status surfaces; React assistant thread/desktop store code is not part of the shipped runtime."
+    },
+    "0428945b5b07": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop bootstrap profile-home behavior is superseded by Rust hermes-config home/profile resolution and installer setup; Electron bootstrap is not shipped."
+    },
+    "288f7026e332": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop/web Weixin labeling is superseded by Rust gateway platform adapters and TUI surfaces; React messaging page labels are outside the Rust runtime."
+    },
+    "92a456f711eb": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream esbuild/Node audit-loop cleanup is superseded by the Rust-first runtime and local Cargo gates; Node desktop/web package metadata is not a shipped runtime dependency."
+    },
+    "f7c1cbe66ffa": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop download-link docs are superseded by Ultra README/install docs and release installer; /desktop website routing is not a Rust runtime target."
+    },
+    "0441b7f19feb": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop remote-profile REST routing is superseded by Rust gateway/profile/auth surfaces; Electron connection-config and Python web_server endpoints are not the primary runtime."
+    },
+    "c6b0eb4de0e5": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream desktop remote-artifact authenticated download is superseded by Rust gateway/media delivery boundaries; Electron artifacts UI and Python web_server files endpoint are outside the Rust-only runtime."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,14 +1,14 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-16T02:12:02.309717+00:00`
+Generated: `2026-06-16T07:25:59.077811+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `5956`.
+- Range: `main..upstream/main`; total commits tracked: `5961`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2570 |
+| #20 | GPAR-01 tests+CI parity | 2574 |
 | #21 | GPAR-02 skills parity | 119 |
-| #22 | GPAR-03 UX parity | 877 |
+| #22 | GPAR-03 UX parity | 878 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 416 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 128 |
@@ -17,111 +17,35 @@ Generated: `2026-06-16T02:12:02.309717+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 70 |
-| pending | 121 |
-| ported | 266 |
-| superseded | 5499 |
+| pending | 24 |
+| ported | 288 |
+| superseded | 5579 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `bb5cb3283898` | #23 | refactor(honcho): canonicalize identity-mapping on pinUserPeer, migrate legacy key |
-| `d7dfeed6dc42` | #23 | feat(honcho-setup): replace deployment-shape prompt with gateway-gated identity tree |
-| `99feb036077a` | #23 | docs(honcho): demote pinPeerName to deprecated alias; document gateway identity tree |
-| `2708c33c7570` | #23 | docs(honcho): anonymize example peer name to alice |
-| `1544813bfe56` | #20 | chore(honcho): replace example Telegram UID with placeholder |
-| `d62979a6f34f` | #20 | feat(desktop): composer status stack, live subagent windows, editable prompts (#44630) |
-| `79c3ed3cc91a` | #26 | fix(desktop): new chat honours the active profile instead of rubberbanding to default (#45057) |
-| `46d758bb3e07` | #26 | feat(desktop): window translucency slider in Appearance settings (#45086) |
-| `2f9d18711fb9` | #20 | fix(ci): remove pytest-timeout, use per-file timeout only |
-| `8044bf0206c1` | #25 | fix(ci): only save test durations when tests pass |
-| `1e25358a8f22` | #20 | refactor(desktop): use port 0 for ephemeral port discovery instead of PortPool reservation |
-| `c61815232abe` | #20 | Update model correctly when updating from dashboard |
-| `8c3c08c50be8` | #20 | Update implementation to make it cleaner |
-| `bc3f4ed70fa5` | #20 | Skip redundant model switch |
-| `6b4073648ece` | #20 | fix(tui): config.yaml wins over env model seed in per-turn sync |
-| `05b9c84ca4b1` | #20 | Add Telegram Bot API 10.1 rich message support |
-| `652dd9c9f248` | #20 | fix: rich messages follow-ups — reply_parameters, send latch, opt-in default |
-| `2e874ef87926` | #26 | fix(desktop): allow dismissing settled tool rows |
-| `b16e22b8f272` | #26 | fix(desktop): persist tool-row dismissal across virtualization; keep caret hittable |
-| `bbf020e709ec` | #26 | feat(desktop): follow streaming output at bottom + jump-to-bottom button (#45263) |
-| `e90672696ea7` | #26 | feat(desktop): worktree-aware sidebar grouping + composer/sidebar UX fixes |
-| `0595af0ad19b` | #26 | feat(desktop): move workspace/worktree drag handle into the leading icon |
-| `dd12a5403de9` | #26 | refactor(desktop): extract shared WorkspaceHeader for repo + worktree rows |
-| `1899c8f507c3` | #21 | fix(skills): run youtube transcript helper through uv |
-| `1a3cd3d436a1` | #26 | refactor(desktop): collapse sidebar drag-reorder into one generic ReorderableList |
-| `78ce91750ec6` | #26 | fix(desktop): crisp terminal text via opaque xterm canvas |
-| `d14f6c95632b` | #26 | fix(desktop): stop streaming autoscroll bounce; move attachments below user bubble |
-| `7c226cc57fe6` | #26 | perf(desktop): isolate streaming re-renders & cut layout thrash |
-| `edc36f3a4589` | #26 | perf(desktop): incremental markdown rendering during streams |
-| `3cf7d43262d4` | #26 | perf(desktop): faster session resume & warm AudioContext at idle |
-| `7d183f64979f` | #26 | fix(desktop): theme the image-gen placeholder instead of a white square (#45354) |
-| `bf090deed33e` | #26 | fix(desktop): stop stranding queued prompts across backend bounces |
-| `f23a4b7bb3b8` | #26 | fix(desktop): keep queued drains quiet on transient "session busy" |
-| `18916376f198` | #26 | fix(desktop): never surface "session busy" — retry every submit past it |
-| `7f302c91b240` | #26 | chore: uptick |
-| `1e755ff5568a` | #26 | fix(desktop): keep recents sorted unless manually reordered (#45404) |
-| `76b93869d8ed` | #26 | fix(desktop): rebuild thread autoscroll on use-stick-to-bottom |
-| `77687156b4b8` | #26 | fix(desktop): tighten multiline user prompt spacing |
-| `b15dc58064eb` | #26 | fix(desktop): keep generated images in the tool slot, not inline |
-| `b82d2e549fa5` | #26 | fix(desktop): keep the diffusion placeholder circular at any aspect |
-| `b6c7ebf028d8` | #20 | fix(tui): honor provider_routing config in the desktop/TUI backend (#44953) |
-| `bdd3868b577a` | #26 | fix(desktop): keep profile color picker open from the context menu (#45489) |
-| `8cf9d8689d56` | #22 | fix(desktop): keep composer usable during reconnect (#45488) |
 | `2d474e39c7ee` | #20 | fix(acp): preserve memory provider tools |
-| `266b5a19f128` | #26 | feat(desktop): expand the full command inline from the approval bar |
-| `5d6c16e97237` | #26 | test(desktop): cover the inline command expander on the approval bar |
 | `2681c5a12d8d` | #20 | fix(photon): correct gateway start command (#45566) |
-| `573b964dc780` | #25 | fix(installer): clear an unmerged git index before stashing on update |
-| `a59d5e37e8ab` | #20 | feat(telegram): make rich messages always on (#45584) |
-| `e256f4aae493` | #20 | fix(gateway): don't restore a bare billing provider as the resumed session's provider |
-| `643dc8279306` | #20 | Fix custom provider identity loss in session persistence |
-| `2667601c05cd` | #20 | fix(tui): keep reasoning-only assistant turns visible on session resume |
-| `aa53a78d6703` | #26 | fix(desktop): hand off Windows bootstrap recovery (#45594) |
-| `4373e802a1b9` | #25 | fix(docs): reuse healthy skills index during Pages deploys (#45616) |
-| `28bf8fb47d38` | #22 | feat(dashboard): clone profiles from any source |
 | `cc14b74718aa` | #22 | docs(profile): update clone-from references |
-| `425e777f54b8` | #26 | fix(desktop): polish slash command completion (space/tab/click + typed args) (#45760) |
-| `0a865e5948cb` | #26 | fix(desktop): bypass Chromium editing pipeline for large paste & select-delete (#45812) |
 | `bf8effad023b` | #20 | fix(utils): copy fallback for atomic replace across devices (#43852) |
-| `6b76284c7769` | #26 | fix(desktop): surface off-screen approvals via the jump-to-bottom control (#45853) |
 | `a218a0f1569c` | #20 | fix(agent,gateway,doctor): add SSL CA cert bundle fail-fast guard |
 | `dc90ca4e1740` | #26 | fix(ssl): run CA guard during agent initialization |
 | `7aaae7acd0d6` | #20 | fix(ssl): align guard docs and escape hatch |
 | `8d5d36d79358` | #20 | fix(dispatch): forward session_id into registry.dispatch (#28479) |
-| `12682d96b9c8` | #20 | feat(telegram): restore rich messages opt-out |
-| `e986e3fc689c` | #26 | fix: add provider account removal |
-| `1b16c481708d` | #20 | fix: guard OAuth account removal |
-| `b4ba3f5e3b37` | #26 | feat(desktop): add curated completion cue for agent turn completion (#42480) |
-| `630a4ef03c8e` | #26 | feat(desktop): native OS notifications with per-type toggles |
-| `b0288ae9b6ea` | #26 | feat(desktop): move completion-sound picker into Notifications settings |
-| `9cbb91abd3a8` | #26 | fix(desktop): clarify UX — loading, enter-to-send, radio align (#46014) |
-| `715b691723c6` | #20 | fix(desktop): show summarizing indicator during auto-compaction |
-| `49dd91d682a4` | #26 | fix(desktop): show copied checkmark on session Copy ID (#46030) |
-| `1eb13744b4ab` | #26 | fix(desktop): polish compaction indicator and preserve scrollback |
-| `d842155da1e8` | #20 | Keep resumed profile cwd scoped to profile DB |
-| `9f33d673e9e6` | #20 | fix(tui): persist resumed profile cwd updates to profile db |
 | `5e851bc6bc51` | #26 | fix(discord): cap slash commands at Discord's 100-command limit |
-| `0428945b5b07` | #20 | fix(desktop): keep profile homes out of bootstrap (#46073) |
 | `b00060ce545c` | #20 | fix(agent): expose HERMES_REAL_HOME in subprocess envs for profile isolation |
 | `723c2331bd23` | #20 | fix: make profile subprocess HOME policy explicit |
-| `a4ee1f223d5f` | #25 | fix(install): make `npm install -g` packages reachable on PATH |
-| `1db8f7ea8094` | #25 | fix(install): repair existing managed-Node global prefix on re-run |
 | `972a9885ee20` | #20 | fix(mcp): block exfil-shaped stdio server configs (#46083) |
 | `efbe1635dd2e` | #20 | fix(gateway): include replied-to media attachments (#46107) |
-| `288f7026e332` | #20 | fix(messaging): correct Weixin personal account labeling |
-| `08d89e7aba14` | #26 | fix(desktop): limit thinking shimmer to the disclosure label (#46197) |
-| `a1f51feb72b4` | #20 | fix(telegram): avoid rich final duplicate previews (#46206) |
 | `bff78a34dc44` | #20 | feat(zai): add GLM-5.2 with verified 1M context window |
 | `f3fe99863d13` | #20 | revert(web): remove keyless Parallel search fallback (#46350) |
-| `8fe334b056d4` | #26 | fix(desktop): inset hover-reveal trigger past the adjacent scrollbar (#44159) |
 | `61ee2dbfdb40` | #20 | fix(s6): make profile gateway log parent writable (#46291) |
-| `a376ca00819e` | #23 | feat(hindsight): make observation scopes configurable on retain |
 | `c1a70a543925` | #20 | 🐛 fix(disk-cleanup): prune protected cleanup walks |
 | `40699c329265` | #20 | 🐛 fix(disk-cleanup): avoid brittle sweep review issues |
 | `975b9f0a5426` | #22 | docs: recommend standard installer for development (#46646) |
-| `92a456f711eb` | #22 | fix(cli,deps): clear esbuild audit loop |
-| `49e743985aaf` | #20 | fix: route minimax m3 reasoning controls through profile |
-| `fbabf438a17c` | #26 | fix(desktop): sync $connection on profile switch so remote profiles attach images as bytes |
-| `bee13817f069` | #26 | test(desktop): cover $connection resync on profile switch |
 | `5b2604df999c` | #26 | fix(state): skip redundant trigram backfill before v11 FTS rebuild |
+| `3e7e9b24d40c` | #20 | fix: harden salvaged session and browser improvements |
+| `c66ecf0bc30f` | #20 | feat(delegation): async background subagents via delegate_task(background=true) (#40946) |
+| `5a0e0d35b94f` | #20 | fix(mattermost): preserve thread-local delivery hygiene |
+| `5bfed0fe071a` | #22 | feat(skills): add optional payments skills (Stripe Link, MPP, Projects) (#31343) |


### PR DESCRIPTION
## Summary
- Port Telegram Bot API 10.1 rich-message sending into the Rust Telegram adapter with opt-in config, link-preview suppression, reply_parameters, thread support, endpoint fallback, and client crash-shape guard.
- Port Hindsight retain tags and observation scopes into the Rust memory plugin, including env/profile config parsing, per-call tag merging, and session lineage tags.
- Regenerate upstream queue and global parity proof artifacts; upstream pending queue is now 24 commits.

## Local verification
- cargo fmt --all --check
- bash scripts/check-runtime-placeholders.sh
- git diff --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo test -p hermes-gateway --features telegram telegram_rich --lib
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets/hermes-agent-ultra cargo test -p hermes-agent hindsight --lib
- python3 scripts/generate-upstream-patch-queue.py --no-fetch --local-ref main --max-commits 0
- python3 scripts/generate-global-parity-proof.py

## Notes
- CI-style queue gate passes for max_queue_pending_commits=24 <= 100.
- Release gate still fails by design until max_queue_pending_commits reaches 0.