### PR TITLE
Complete upstream queue runtime parity batch

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -934,6 +934,11 @@ pub struct AgentCallbacks {
     ///
     /// Payload is a user-friendly summary string suitable for direct UI output.
     pub background_review_callback: Option<Arc<dyn Fn(&str) + Send + Sync>>,
+    /// Called when `delegate_task(background=true)` completes out-of-band.
+    ///
+    /// Payload is a self-contained summary suitable for reinjection into the
+    /// originating UI or platform conversation.
+    pub background_delegation_callback: Option<Arc<dyn Fn(&str) + Send + Sync>>,
     /// Called for lifecycle/status notices (context pressure, retries, etc.).
     pub status_callback: Option<Arc<dyn Fn(&str, &str) + Send + Sync>>,
 }
@@ -8234,6 +8239,10 @@ impl AgentLoop {
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .map(str::to_string);
+                let background = parsed
+                    .get("background")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
                 let req = crate::sub_agent_orchestrator::SubAgentRequest {
                     task,
                     context: parsed
@@ -8253,6 +8262,7 @@ impl AgentLoop {
                     child_depth: current_delegate_depth + 1,
                     max_depth: max_delegate_depth,
                     parent_budget_remaining_usd,
+                    background,
                 };
                 // Orchestrator internally runs the child on its own
                 // `tokio::spawn` task, which erases the child future and breaks

--- a/crates/hermes-agent/src/sub_agent_orchestrator.rs
+++ b/crates/hermes-agent/src/sub_agent_orchestrator.rs
@@ -111,6 +111,9 @@ pub struct SubAgentRequest {
     pub max_depth: u32,
     /// Parent budget remaining (USD) — exposed to the child for cost awareness.
     pub parent_budget_remaining_usd: Option<f64>,
+    /// Run the child detached and deliver completion through the background
+    /// delegation callback instead of blocking the parent tool turn.
+    pub background: bool,
 }
 
 /// Configuration for [`SubAgentOrchestrator`].
@@ -124,6 +127,7 @@ pub struct SubAgentOrchestratorConfig {
     pub hermes_home: PathBuf,
     pub parent_session_id: Option<String>,
     pub timeout: Duration,
+    pub background_delegation_callback: Option<Arc<dyn Fn(&str) + Send + Sync>>,
 }
 
 /// In-process executor for `delegate_task` tool calls.
@@ -152,6 +156,11 @@ impl SubAgentOrchestrator {
                 hermes_home,
                 parent_session_id: parent.config.session_id.clone(),
                 timeout: Duration::from_secs(DEFAULT_SUB_AGENT_TIMEOUT_SECS),
+                background_delegation_callback: parent
+                    .callbacks
+                    .background_delegation_callback
+                    .clone()
+                    .or_else(|| parent.callbacks.background_review_callback.clone()),
             },
         }
     }
@@ -171,11 +180,50 @@ impl SubAgentOrchestrator {
     /// cycle.
     pub fn execute(self: &Arc<Self>, req: SubAgentRequest) -> BoxSendFuture<String> {
         let this = self.clone();
-        Box::pin(async move { this.execute_inner(req).await })
+        Box::pin(async move {
+            if req.background {
+                this.dispatch_background(req)
+            } else {
+                let sub_agent_id = format!("subagent-{}", uuid::Uuid::new_v4());
+                this.execute_inner(req, sub_agent_id).await
+            }
+        })
     }
 
-    async fn execute_inner(self: Arc<Self>, req: SubAgentRequest) -> String {
+    fn dispatch_background(self: Arc<Self>, req: SubAgentRequest) -> String {
         let sub_agent_id = format!("subagent-{}", uuid::Uuid::new_v4());
+        let task = req.task.clone();
+        let context = req.context.clone();
+        let toolset = req.toolset.clone();
+        let model = req.model.clone();
+        let depth = req.child_depth;
+        let max_depth = req.max_depth;
+        let callback = self.cfg.background_delegation_callback.clone();
+        let worker = self.clone();
+        let worker_sub_agent_id = sub_agent_id.clone();
+        tokio::spawn(async move {
+            let output = worker.execute_inner(req, worker_sub_agent_id).await;
+            if let Some(callback) = callback {
+                let summary = format_background_delegation_notification(&output);
+                callback(&summary);
+            }
+        });
+
+        json!({
+            "sub_agent_id": sub_agent_id,
+            "status": "dispatched",
+            "background": true,
+            "task": task,
+            "context": context,
+            "toolset": toolset,
+            "model": model,
+            "depth": depth,
+            "max_depth": max_depth,
+        })
+        .to_string()
+    }
+
+    async fn execute_inner(self: Arc<Self>, req: SubAgentRequest, sub_agent_id: String) -> String {
         let started_at = Utc::now();
 
         let mut lineage = SubAgentLineage {
@@ -223,6 +271,7 @@ impl SubAgentOrchestrator {
                 json!({
                     "sub_agent_id": sub_agent_id,
                     "status": "completed",
+                    "background": req.background,
                     "task": req.task,
                     "total_turns": result.total_turns,
                     "finished_naturally": result.finished_naturally,
@@ -251,6 +300,7 @@ impl SubAgentOrchestrator {
 
                 json!({
                     "sub_agent_id": sub_agent_id,
+                    "background": req.background,
                     "status": match status {
                         SubAgentStatus::Timeout => "timeout",
                         SubAgentStatus::Cancelled => "cancelled",
@@ -509,6 +559,48 @@ fn extract_final_assistant_text(messages: &[Message]) -> String {
         .unwrap_or_default()
 }
 
+fn format_background_delegation_notification(output: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(output) else {
+        return format!("ASYNC DELEGATION COMPLETE\n\nStatus: unknown\n\n{output}");
+    };
+    let task = value
+        .get("task")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("(unknown task)");
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let sub_agent_id = value
+        .get("sub_agent_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let mut out = format!(
+        "ASYNC DELEGATION COMPLETE\n\nTask: {task}\nSub-agent: {sub_agent_id}\nStatus: {status}"
+    );
+    if let Some(result) = value
+        .get("result")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        out.push_str("\n\nResult:\n");
+        out.push_str(result);
+    }
+    if let Some(error) = value
+        .get("error")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        out.push_str("\n\nError:\n");
+        out.push_str(error);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -609,6 +701,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("parent".into()),
             timeout: Duration::from_secs(2),
+            background_delegation_callback: None,
         }));
 
         let out = orch
@@ -681,6 +774,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("parent".into()),
             timeout: Duration::from_millis(50),
+            background_delegation_callback: None,
         }));
         let out = orch
             .execute(SubAgentRequest {
@@ -708,6 +802,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn background_request_dispatches_handle_and_emits_completion_callback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let completions = Arc::new(Mutex::new(Vec::<String>::new()));
+        let completions_cb = completions.clone();
+        let orch = Arc::new(SubAgentOrchestrator::new(SubAgentOrchestratorConfig {
+            parent_config: AgentConfig {
+                max_turns: 2,
+                ..AgentConfig::default()
+            },
+            tool_registry: Arc::new(ToolRegistry::new()),
+            llm_provider: Arc::new(NoopProvider),
+            parent_credential_pool: None,
+            parent_interrupt: InterruptController::new(),
+            hermes_home: tmp.path().to_path_buf(),
+            parent_session_id: Some("parent".into()),
+            timeout: Duration::from_secs(2),
+            background_delegation_callback: Some(Arc::new(move |text: &str| {
+                completions_cb
+                    .lock()
+                    .expect("completion lock")
+                    .push(text.to_string());
+            })),
+        }));
+
+        let out = orch
+            .execute(SubAgentRequest {
+                task: "background task".into(),
+                child_depth: 1,
+                max_depth: 4,
+                background: true,
+                ..Default::default()
+            })
+            .await;
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["status"], "dispatched");
+        assert_eq!(parsed["background"], true);
+        let sub_agent_id = parsed["sub_agent_id"].as_str().unwrap().to_string();
+
+        for _ in 0..50 {
+            if !completions.lock().expect("completion lock").is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let completion = completions
+            .lock()
+            .expect("completion lock")
+            .pop()
+            .expect("background completion callback");
+        assert!(completion.contains("ASYNC DELEGATION COMPLETE"));
+        assert!(completion.contains("background task"));
+        assert!(completion.contains("Result:\ndone"));
+        assert!(tmp
+            .path()
+            .join("subagents")
+            .join(format!("{sub_agent_id}.json"))
+            .exists());
+    }
+
+    #[tokio::test]
     async fn cancel_path_reports_cancelled() {
         let parent_ctrl = InterruptController::new();
         parent_ctrl.interrupt(Some("stop".into())); // pre-cancel before spawn
@@ -722,6 +876,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: None,
             timeout: Duration::from_secs(2),
+            background_delegation_callback: None,
         }));
         let out = orch
             .execute(SubAgentRequest {
@@ -757,6 +912,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("root".into()),
             timeout: Duration::from_secs(1),
+            background_delegation_callback: None,
         });
         let child = orch.build_child_config(
             &SubAgentRequest {
@@ -800,6 +956,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("root".into()),
             timeout: Duration::from_secs(1),
+            background_delegation_callback: None,
         });
 
         let child = orch.build_child_config(
@@ -840,6 +997,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("root".into()),
             timeout: Duration::from_secs(1),
+            background_delegation_callback: None,
         });
 
         let child = orch.build_child_config(
@@ -878,6 +1036,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("root".into()),
             timeout: Duration::from_secs(1),
+            background_delegation_callback: None,
         });
 
         let child = orch.build_child_config(
@@ -918,6 +1077,7 @@ mod tests {
             hermes_home: tmp.path().to_path_buf(),
             parent_session_id: Some("root".into()),
             timeout: Duration::from_secs(1),
+            background_delegation_callback: None,
         }));
 
         let out = orch

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -2975,6 +2975,7 @@ async fn run_gateway(
                             .await;
                         let platform_for_review = ctx.platform.clone();
                         let chat_for_review = ctx.chat_id.clone();
+                        let thread_for_review = ctx.thread_id.clone();
                         let deferred_queue = ctx.deferred_post_delivery_messages.clone();
                         let deferred_released = ctx.deferred_post_delivery_released.clone();
                         let gateway_for_review_cb = gateway_for_review.clone();
@@ -2992,9 +2993,18 @@ async fn run_gateway(
                             let gw = gateway_for_review_cb.clone();
                             let platform = platform_for_review.clone();
                             let chat_id = chat_for_review.clone();
+                            let thread_id = thread_for_review.clone();
                             let msg = text.to_string();
                             tokio::spawn(async move {
-                                let _ = gw.send_message(&platform, &chat_id, &msg, None).await;
+                                let _ = gw
+                                    .send_notify_message_threaded(
+                                        &platform,
+                                        &chat_id,
+                                        &msg,
+                                        None,
+                                        thread_id.as_deref(),
+                                    )
+                                    .await;
                             });
                         });
                         let gateway_for_status = gateway_for_review.clone();
@@ -3237,6 +3247,7 @@ async fn run_gateway(
                             .await;
                         let platform_for_review = ctx.platform.clone();
                         let chat_for_review = ctx.chat_id.clone();
+                        let thread_for_review = ctx.thread_id.clone();
                         let deferred_queue = ctx.deferred_post_delivery_messages.clone();
                         let deferred_released = ctx.deferred_post_delivery_released.clone();
                         let gateway_for_review_cb = gateway_for_review.clone();
@@ -3254,9 +3265,18 @@ async fn run_gateway(
                             let gw = gateway_for_review_cb.clone();
                             let platform = platform_for_review.clone();
                             let chat_id = chat_for_review.clone();
+                            let thread_id = thread_for_review.clone();
                             let msg = text.to_string();
                             tokio::spawn(async move {
-                                let _ = gw.send_message(&platform, &chat_id, &msg, None).await;
+                                let _ = gw
+                                    .send_notify_message_threaded(
+                                        &platform,
+                                        &chat_id,
+                                        &msg,
+                                        None,
+                                        thread_id.as_deref(),
+                                    )
+                                    .await;
                             });
                         });
                         let gateway_for_status = gateway_for_review.clone();
@@ -4354,7 +4374,7 @@ fn build_telegram_config(
         parse_markdown,
         parse_html,
         disable_link_previews: extra_bool(platform_cfg, "disable_link_previews", false),
-        rich_messages: extra_bool(platform_cfg, "rich_messages", false),
+        rich_messages: extra_bool(platform_cfg, "rich_messages", true),
         poll_timeout,
         reply_to_mode: reply_to_mode_string(platform_cfg).unwrap_or_else(|| "first".to_string()),
         reactions: extra_bool(platform_cfg, "reactions", false),
@@ -5269,6 +5289,7 @@ async fn run_api_server_inbound_loop(
             user_id: req.user_id.clone(),
             text: req.prompt.clone(),
             message_id: Some(req.request_id.clone()),
+            thread_id: None,
             is_dm: true,
         };
         if let Err(err) = gateway.route_message(&incoming).await {
@@ -5287,6 +5308,7 @@ async fn run_webhook_inbound_loop(gateway: Arc<Gateway>, mut rx: mpsc::Receiver<
                 .unwrap_or_else(|| "webhook-client".to_string()),
             text: payload.text,
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         if let Err(err) = gateway.route_message(&incoming).await {
@@ -5922,7 +5944,8 @@ fn telegram_gateway_message(msg: TelegramIncomingMessage) -> GatewayIncomingMess
         .or(msg.username)
         .unwrap_or_else(|| "unknown".to_string());
 
-    let chat_id = match telegram_routable_topic_thread(msg.message_thread_id) {
+    let thread_id = telegram_routable_topic_thread(msg.message_thread_id);
+    let chat_id = match thread_id {
         Some(thread_id) => format!("{}:{}", msg.chat_id, thread_id),
         _ => msg.chat_id.to_string(),
     };
@@ -5933,6 +5956,7 @@ fn telegram_gateway_message(msg: TelegramIncomingMessage) -> GatewayIncomingMess
         user_id,
         text,
         message_id: Some(msg.message_id.to_string()),
+        thread_id: thread_id.map(|id| id.to_string()),
         is_dm: msg.chat_id > 0,
     }
 }

--- a/crates/hermes-core/src/traits.rs
+++ b/crates/hermes-core/src/traits.rs
@@ -70,6 +70,9 @@ pub struct SendMessageOptions {
     /// True when the caller supplied the chat/topic id explicitly rather than
     /// letting the gateway choose a configured home/publish target.
     pub explicit_chat_id: bool,
+    /// True for final user-visible replies where a platform may choose a
+    /// conservative delivery fallback if a requested thread root is broken.
+    pub notify: bool,
 }
 
 impl SendMessageOptions {
@@ -77,6 +80,7 @@ impl SendMessageOptions {
         Self {
             thread_id: thread_id.map(ToOwned::to_owned),
             explicit_chat_id: false,
+            notify: false,
         }
     }
 
@@ -84,6 +88,15 @@ impl SendMessageOptions {
         Self {
             thread_id: thread_id.map(ToOwned::to_owned),
             explicit_chat_id: true,
+            notify: false,
+        }
+    }
+
+    pub fn notify_threaded(thread_id: Option<&str>) -> Self {
+        Self {
+            thread_id: thread_id.map(ToOwned::to_owned),
+            explicit_chat_id: false,
+            notify: true,
         }
     }
 }

--- a/crates/hermes-gateway/src/delivery.rs
+++ b/crates/hermes-gateway/src/delivery.rs
@@ -355,6 +355,7 @@ impl DeliveryRouter {
                 SendMessageOptions {
                     thread_id: target.thread_id.clone(),
                     explicit_chat_id: target.is_explicit,
+                    notify: false,
                 },
             )
             .await
@@ -466,6 +467,7 @@ impl DeliveryRouter {
                         SendMessageOptions {
                             thread_id: target.thread_id.clone(),
                             explicit_chat_id: target.is_explicit,
+                            notify: false,
                         },
                     )
                     .await

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -130,6 +130,8 @@ pub struct IncomingMessage {
     pub text: String,
     /// Platform-specific message ID (for reply threading).
     pub message_id: Option<String>,
+    /// Platform-native thread/topic root for replies and progress updates.
+    pub thread_id: Option<String>,
     /// Whether this is a DM (direct message) or group message.
     pub is_dm: bool,
 }
@@ -172,6 +174,7 @@ pub struct GatewayRuntimeContext {
     pub session_key: String,
     pub platform: String,
     pub chat_id: String,
+    pub thread_id: Option<String>,
     pub user_id: String,
     pub model: Option<String>,
     pub provider: Option<String>,
@@ -2106,11 +2109,19 @@ impl Gateway {
             .await;
 
         // Send response back to the platform
-        self.send_message(&incoming.platform, &incoming.chat_id, &response, None)
-            .await?;
+        let reply_thread_id = Self::reply_thread_id(incoming);
+        self.send_notify_message_threaded(
+            &incoming.platform,
+            &incoming.chat_id,
+            &response,
+            None,
+            reply_thread_id,
+        )
+        .await?;
         self.flush_post_delivery_messages(
             &incoming.platform,
             &incoming.chat_id,
+            reply_thread_id,
             deferred_messages,
             deferred_release,
         )
@@ -2168,13 +2179,21 @@ impl Gateway {
         let stream_id = stream_handle.id.clone();
 
         // Send an initial streaming anchor message.
-        self.send_message(&incoming.platform, &incoming.chat_id, "...", None)
-            .await?;
+        let reply_thread_id = Self::reply_thread_id(incoming).map(str::to_string);
+        self.send_message_threaded(
+            &incoming.platform,
+            &incoming.chat_id,
+            "...",
+            None,
+            reply_thread_id.as_deref(),
+        )
+        .await?;
 
         // Set up the chunk callback that updates the stream and edits the message
         let stream_manager = self.stream_manager.clone();
         let platform = incoming.platform.clone();
         let chat_id = incoming.chat_id.clone();
+        let thread_id = reply_thread_id.clone();
         let gateway_adapters = self.adapters.read().await.clone();
         let sid = stream_id.clone();
 
@@ -2183,6 +2202,7 @@ impl Gateway {
             let sid = sid.clone();
             let platform = platform.clone();
             let chat_id = chat_id.clone();
+            let thread_id = thread_id.clone();
             let adapters = gateway_adapters.clone();
 
             tokio::spawn(async move {
@@ -2192,7 +2212,14 @@ impl Gateway {
                             if let Some(adapter) = adapters.get(&platform) {
                                 // For streaming, we'd need the message_id from the initial send.
                                 // This is a simplified version.
-                                let _ = adapter.send_message(&chat_id, &content, None).await;
+                                let _ = adapter
+                                    .send_message_with_options(
+                                        &chat_id,
+                                        &content,
+                                        None,
+                                        SendMessageOptions::threaded(thread_id.as_deref()),
+                                    )
+                                    .await;
                             }
                         }
                     }
@@ -2240,12 +2267,19 @@ impl Gateway {
         self.bump_output_usage(session_key, response.chars().count())
             .await;
         if !response.trim().is_empty() {
-            self.send_message(&incoming.platform, &incoming.chat_id, &response, None)
-                .await?;
+            self.send_notify_message_threaded(
+                &incoming.platform,
+                &incoming.chat_id,
+                &response,
+                None,
+                reply_thread_id.as_deref(),
+            )
+            .await?;
         }
         self.flush_post_delivery_messages(
             &incoming.platform,
             &incoming.chat_id,
+            reply_thread_id.as_deref(),
             deferred_messages,
             deferred_release,
         )
@@ -2334,6 +2368,7 @@ impl Gateway {
             session_key: session_key.to_string(),
             platform: incoming.platform.clone(),
             chat_id: incoming.chat_id.clone(),
+            thread_id: incoming.thread_id.clone(),
             user_id: incoming.user_id.clone(),
             model: state.model,
             provider: state.provider,
@@ -2354,10 +2389,19 @@ impl Gateway {
         }
     }
 
+    fn reply_thread_id(incoming: &IncomingMessage) -> Option<&str> {
+        incoming
+            .thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+    }
+
     async fn flush_post_delivery_messages(
         &self,
         platform: &str,
         chat_id: &str,
+        thread_id: Option<&str>,
         pending: Arc<StdMutex<Vec<String>>>,
         released: Arc<AtomicBool>,
     ) {
@@ -2367,7 +2411,10 @@ impl Gateway {
             Err(_) => Vec::new(),
         };
         for message in queued {
-            if let Err(e) = self.send_message(platform, chat_id, &message, None).await {
+            if let Err(e) = self
+                .send_message_threaded(platform, chat_id, &message, None, thread_id)
+                .await
+            {
                 warn!(
                     platform = platform,
                     chat_id = chat_id,
@@ -2639,6 +2686,7 @@ impl Gateway {
         let adapters = self.adapters.read().await.clone();
         let platform = incoming.platform.clone();
         let chat_id = incoming.chat_id.clone();
+        let thread_id = Self::reply_thread_id(incoming).map(str::to_string);
         let notify_task_id = task_id.clone();
         // Python `GatewayRunner._run_background_task`: only `user_message=prompt` (fresh session).
         // Python `_run_btw_task`: `conversation_history` snapshot + ephemeral user turn (no tools).
@@ -2677,7 +2725,12 @@ impl Gateway {
                             format!("✅ Background task {notify_task_id} completed")
                         };
                         let _ = adapter
-                            .send_message(&chat_id, &format!("{prefix}:\n{result}"), None)
+                            .send_message_with_options(
+                                &chat_id,
+                                &format!("{prefix}:\n{result}"),
+                                None,
+                                SendMessageOptions::notify_threaded(thread_id.as_deref()),
+                            )
                             .await;
                     }
                 }
@@ -2691,7 +2744,12 @@ impl Gateway {
                             format!("❌ Background task {notify_task_id} failed")
                         };
                         let _ = adapter
-                            .send_message(&chat_id, &format!("{prefix}: {error}"), None)
+                            .send_message_with_options(
+                                &chat_id,
+                                &format!("{prefix}: {error}"),
+                                None,
+                                SendMessageOptions::notify_threaded(thread_id.as_deref()),
+                            )
                             .await;
                     }
                 }
@@ -2787,6 +2845,26 @@ impl Gateway {
             text,
             parse_mode,
             SendMessageOptions::threaded(thread_id),
+        )
+        .await
+    }
+
+    /// Send a final user-visible reply, allowing adapters to make final-answer
+    /// delivery choices distinct from operational progress/status sends.
+    pub async fn send_notify_message_threaded(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        thread_id: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        self.send_message_with_options(
+            platform,
+            chat_id,
+            text,
+            parse_mode,
+            SendMessageOptions::notify_threaded(thread_id),
         )
         .await
     }
@@ -3191,6 +3269,10 @@ mod tests {
         files: Arc<Mutex<Vec<String>>>,
     }
 
+    struct ThreadOptionTestAdapter {
+        sends: Arc<Mutex<Vec<(String, String, Option<String>, bool)>>>,
+    }
+
     struct RecordingHook {
         seen: Arc<Mutex<Vec<(String, serde_json::Value)>>>,
     }
@@ -3430,6 +3512,72 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl PlatformAdapter for ThreadOptionTestAdapter {
+        async fn start(&self) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn send_message(
+            &self,
+            chat_id: &str,
+            text: &str,
+            _parse_mode: Option<ParseMode>,
+        ) -> Result<(), GatewayError> {
+            self.sends
+                .lock()
+                .unwrap()
+                .push((chat_id.to_string(), text.to_string(), None, false));
+            Ok(())
+        }
+
+        async fn send_message_with_options(
+            &self,
+            chat_id: &str,
+            text: &str,
+            _parse_mode: Option<ParseMode>,
+            options: SendMessageOptions,
+        ) -> Result<(), GatewayError> {
+            self.sends.lock().unwrap().push((
+                chat_id.to_string(),
+                text.to_string(),
+                options.thread_id,
+                options.notify,
+            ));
+            Ok(())
+        }
+
+        async fn edit_message(
+            &self,
+            _chat_id: &str,
+            _message_id: &str,
+            _text: &str,
+        ) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        async fn send_file(
+            &self,
+            _chat_id: &str,
+            _file_path: &str,
+            _caption: Option<&str>,
+        ) -> Result<(), GatewayError> {
+            Ok(())
+        }
+
+        fn is_running(&self) -> bool {
+            true
+        }
+
+        fn platform_name(&self) -> &str {
+            "thread-option-test"
+        }
+    }
+
     #[test]
     fn gateway_prefill_loader_parses_json_message_array() {
         let dir = tempfile::tempdir().unwrap();
@@ -3582,6 +3730,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/release_captain ship it".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await
@@ -3636,6 +3785,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/reload-skills".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await
@@ -3646,6 +3796,7 @@ mod tests {
             user_id: "user1".into(),
             text: "next turn".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await
@@ -3656,6 +3807,7 @@ mod tests {
             user_id: "user1".into(),
             text: "later turn".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await
@@ -4045,6 +4197,7 @@ mod tests {
             user_id: "unknown_user".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4066,6 +4219,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4086,6 +4240,7 @@ mod tests {
             user_id: "unknown_user".into(),
             text: "hello group".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false, // Group message, no DM check
         };
 
@@ -4114,6 +4269,7 @@ mod tests {
             user_id: "other_user".into(),
             text: "hello group".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
 
@@ -4146,6 +4302,7 @@ mod tests {
             user_id: "any_user".into(),
             text: "hello group".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
 
@@ -4181,6 +4338,7 @@ mod tests {
             user_id: "123".into(),
             text: "hello group".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&legacy_chat_source).await.is_err());
@@ -4196,6 +4354,7 @@ mod tests {
             user_id: "999".into(),
             text: "hello group".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&sender_source).await.is_err());
@@ -4223,6 +4382,7 @@ mod tests {
             user_id: "15551234567@s.whatsapp.net".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4259,6 +4419,7 @@ mod tests {
             user_id: "15551234567@s.whatsapp.net".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4306,6 +4467,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&ignored).await.is_ok());
@@ -4321,6 +4483,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&not_allowed).await.is_ok());
@@ -4335,6 +4498,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&allowed).await.is_ok());
@@ -4377,6 +4541,7 @@ mod tests {
             user_id: "user1".into(),
             text: "@hermes_bot hello".into(),
             message_id: Some("m1".into()),
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&mentioned_blocked_group).await.is_ok());
@@ -4392,6 +4557,7 @@ mod tests {
             user_id: "user1".into(),
             text: "dm hello".into(),
             message_id: Some("m2".into()),
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&dm).await.is_ok());
@@ -4429,6 +4595,7 @@ mod tests {
             user_id: "random_user".into(),
             text: "/status".into(),
             message_id: Some("m1".into()),
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&denied).await.is_ok());
@@ -4444,6 +4611,7 @@ mod tests {
             user_id: "allowed_user".into(),
             text: "/status".into(),
             message_id: Some("m2".into()),
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&allowed).await.is_ok());
@@ -4474,6 +4642,7 @@ mod tests {
             user_id: "worker_bot".into(),
             text: "notion event".into(),
             message_id: Some("m1".into()),
+            thread_id: None,
             is_dm: false,
         };
 
@@ -4509,6 +4678,7 @@ mod tests {
             user_id: "worker_bot".into(),
             text: "notion event".into(),
             message_id: Some("m1".into()),
+            thread_id: None,
             is_dm: false,
         };
 
@@ -4555,6 +4725,7 @@ mod tests {
             user_id: "other_human".into(),
             text: "hello".into(),
             message_id: Some("m1".into()),
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw
@@ -4573,6 +4744,7 @@ mod tests {
             user_id: "worker_bot".into(),
             text: "hello".into(),
             message_id: Some("m2".into()),
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw
@@ -4605,6 +4777,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/status".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4662,6 +4835,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/compress".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4712,6 +4886,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/compress".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
 
@@ -4794,6 +4969,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/background ping".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&start).await.is_ok());
@@ -4820,6 +4996,7 @@ mod tests {
             user_id: "user1".into(),
             text: format!("/background status {}", task_id),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&status).await.is_ok());
@@ -4847,6 +5024,7 @@ mod tests {
             user_id: "admin1".into(),
             text: "/approve user2".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&approve).await.is_ok());
@@ -4858,6 +5036,7 @@ mod tests {
             user_id: "user2".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&authorized_dm).await.is_err());
@@ -4868,6 +5047,7 @@ mod tests {
             user_id: "admin1".into(),
             text: "/deny user2".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&deny).await.is_ok());
@@ -4879,6 +5059,7 @@ mod tests {
             user_id: "user2".into(),
             text: "hello again".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&denied_dm).await.is_ok());
@@ -4903,6 +5084,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/provider openrouter".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&provider).await.is_ok());
@@ -4913,6 +5095,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/profile prod".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&profile).await.is_ok());
@@ -4923,6 +5106,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/reload_mcp".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&reload).await.is_ok());
@@ -4933,6 +5117,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/status".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&status).await.is_ok());
@@ -4982,6 +5167,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/title Release readiness".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&title).await.is_ok());
@@ -5070,6 +5256,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/profile work".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&profile).await.is_ok());
@@ -5080,6 +5267,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/status".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&status).await.is_ok());
@@ -5128,6 +5316,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/profile scratch".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&profile).await.is_ok());
@@ -5138,6 +5327,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/status".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&status).await.is_ok());
@@ -5190,6 +5380,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/provider openai".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&set_provider).await.is_ok());
@@ -5200,6 +5391,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/model gpt-4o".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&set_model).await.is_ok());
@@ -5210,6 +5402,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/profile prod".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&set_profile).await.is_ok());
@@ -5220,6 +5413,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/branch feature/parity".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&set_branch).await.is_ok());
@@ -5230,6 +5424,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/fast".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&set_fast).await.is_ok());
@@ -5240,6 +5435,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&normal).await.is_ok());
@@ -5283,6 +5479,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/verbose".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&verbose).await.is_ok());
@@ -5358,6 +5555,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/yolo".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&yolo_chat1).await.is_ok());
@@ -5368,6 +5566,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/yolo".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&yolo_chat2).await.is_ok());
@@ -5398,6 +5597,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/new".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&reset_chat1).await.is_ok());
@@ -5456,6 +5656,7 @@ mod tests {
                 user_id: "user1".into(),
                 text: text.into(),
                 message_id: None,
+                thread_id: None,
                 is_dm: true,
             })
             .await
@@ -5528,6 +5729,7 @@ mod tests {
             user_id: "user1".into(),
             text: "topic a before reset".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         let topic_b = IncomingMessage {
@@ -5536,6 +5738,7 @@ mod tests {
             user_id: "user1".into(),
             text: "topic b remains".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         gw.route_message(&topic_a).await.expect("route topic a");
@@ -5616,6 +5819,7 @@ mod tests {
             user_id: "user1".into(),
             text: format!("/topic {}", target_key),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await
@@ -5680,6 +5884,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/yolo".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&yolo_chat1).await.is_ok());
@@ -5701,6 +5906,7 @@ mod tests {
             user_id: "user1".into(),
             text: format!("/sessions {}", target_key),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&switch).await.is_ok());
@@ -5768,6 +5974,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/approve".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&approve).await.is_ok());
@@ -5843,6 +6050,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/deny all".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&deny).await.is_ok());
@@ -5919,6 +6127,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/new".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&reset).await.is_ok());
@@ -5960,6 +6169,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: Some("1710000000.123".into()),
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6000,6 +6210,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: Some("123456789".into()),
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6050,6 +6261,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: Some("123456789".into()),
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6081,6 +6293,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: Some("456".into()),
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6136,6 +6349,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: Some("1710000000.456".into()),
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_err());
@@ -6175,6 +6389,7 @@ mod tests {
             user_id: "user1".into(),
             text: "general channel chatter".into(),
             message_id: Some("1710000000.789".into()),
+            thread_id: None,
             is_dm: false,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6228,6 +6443,7 @@ mod tests {
                 user_id: "user1".into(),
                 text: cmd.to_string(),
                 message_id: None,
+                thread_id: None,
                 is_dm: true,
             };
             assert!(gw.route_message(&incoming).await.is_ok());
@@ -6239,6 +6455,7 @@ mod tests {
             user_id: "user1".into(),
             text: "run".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&normal).await.is_ok());
@@ -6303,6 +6520,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6314,6 +6532,65 @@ mod tests {
             vec![
                 "main-response".to_string(),
                 "💾 deferred-memory-update".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_replies_and_deferred_messages_preserve_source_thread() {
+        let sends = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(ThreadOptionTestAdapter {
+            sends: sends.clone(),
+        });
+
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+        gw.register_adapter("thread-option-test", adapter).await;
+        gw.set_message_handler_with_context(Arc::new(|_messages, ctx| {
+            Box::pin(async move {
+                let pending = ctx
+                    .deferred_post_delivery_messages
+                    .expect("deferred queue should be present");
+                pending
+                    .lock()
+                    .unwrap()
+                    .push("deferred follow-up".to_string());
+                Ok("final reply".to_string())
+            })
+        }))
+        .await;
+
+        let incoming = IncomingMessage {
+            platform: "thread-option-test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "run".into(),
+            message_id: Some("post-2".into()),
+            thread_id: Some("root-1".into()),
+            is_dm: true,
+        };
+        gw.route_message(&incoming)
+            .await
+            .expect("threaded route should succeed");
+
+        let sent = sends.lock().unwrap().clone();
+        assert_eq!(
+            sent,
+            vec![
+                (
+                    "chat1".to_string(),
+                    "final reply".to_string(),
+                    Some("root-1".to_string()),
+                    true,
+                ),
+                (
+                    "chat1".to_string(),
+                    "deferred follow-up".to_string(),
+                    Some("root-1".to_string()),
+                    false,
+                ),
             ]
         );
     }
@@ -6360,6 +6637,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6418,6 +6696,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6466,6 +6745,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6548,6 +6828,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6599,6 +6880,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/status".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&incoming).await.is_ok());
@@ -6644,6 +6926,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&normal).await.is_ok());
@@ -6654,6 +6937,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/reset".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&reset).await.is_ok());
@@ -6723,6 +7007,7 @@ mod tests {
             user_id: "user1".into(),
             text: "hello".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&normal).await.is_ok());
@@ -6739,6 +7024,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/reset".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&reset).await.is_ok());
@@ -6871,6 +7157,7 @@ mod tests {
             user_id: "user1".into(),
             text: "/new".into(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         };
         assert!(gw.route_message(&reset).await.is_ok());

--- a/crates/hermes-gateway/src/platforms/dingtalk.rs
+++ b/crates/hermes-gateway/src/platforms/dingtalk.rs
@@ -362,6 +362,7 @@ impl DingTalkAdapter {
             } else {
                 Some(parsed.message_id.clone())
             },
+            thread_id: None,
             is_dm: !parsed.is_group,
         };
         if let Some(tx) = inner.inbound_tx.read().await.clone() {

--- a/crates/hermes-gateway/src/platforms/email.rs
+++ b/crates/hermes-gateway/src/platforms/email.rs
@@ -505,6 +505,7 @@ fn imap_fetch_unseen(
                     body.trim().to_string()
                 },
                 message_id: Some(mid.clone()),
+                thread_id: None,
                 is_dm: true,
             });
         }

--- a/crates/hermes-gateway/src/platforms/mattermost.rs
+++ b/crates/hermes-gateway/src/platforms/mattermost.rs
@@ -41,6 +41,7 @@ pub struct IncomingMattermostMessage {
     pub channel_id: String,
     pub user_id: String,
     pub message: String,
+    pub thread_id: Option<String>,
     pub is_bot: bool,
 }
 
@@ -102,7 +103,8 @@ impl MattermostAdapter {
 
     /// Send a message via Mattermost REST API.
     pub async fn send_text(&self, channel_id: &str, text: &str) -> Result<String, GatewayError> {
-        self.send_text_with_thread(channel_id, text, None).await
+        self.send_text_with_thread(channel_id, text, None, false)
+            .await
     }
 
     async fn send_text_with_thread(
@@ -110,32 +112,57 @@ impl MattermostAdapter {
         channel_id: &str,
         text: &str,
         thread_id: Option<&str>,
+        notify: bool,
     ) -> Result<String, GatewayError> {
-        let url = format!("{}/api/v4/posts", self.config.server_url);
-        let body =
-            mattermost_post_body(channel_id, text, None, self.thread_root_for_send(thread_id));
+        let root_id = self.thread_root_for_send(thread_id).await;
+        let body = mattermost_post_body(channel_id, text, None, root_id.as_deref());
 
+        match self.post_body_once(&body).await {
+            Ok(id) => Ok(id),
+            Err(err) if notify && root_id.is_some() && err.is_broken_thread_root() => {
+                let mut flat_body = mattermost_post_body(channel_id, text, None, None);
+                flat_body["message"] = serde_json::json!(format!(
+                    "Mattermost thread delivery failed; posting final reply in channel.\n\n{text}"
+                )
+                .trim());
+                self.post_body_once(&flat_body)
+                    .await
+                    .map_err(MattermostPostFailure::into_gateway_error)
+            }
+            Err(err) => Err(err.into_gateway_error()),
+        }
+    }
+
+    async fn post_body_once(
+        &self,
+        body: &serde_json::Value,
+    ) -> Result<String, MattermostPostFailure> {
+        let url = format!("{}/api/v4/posts", self.config.server_url);
         let resp = self
             .client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.config.token))
-            .json(&body)
+            .json(body)
             .send()
             .await
-            .map_err(|e| GatewayError::SendFailed(format!("Mattermost send failed: {}", e)))?;
+            .map_err(|e| MattermostPostFailure {
+                status: None,
+                body: format!("Mattermost send failed: {e}"),
+            })?;
 
         if !resp.status().is_success() {
+            let status = resp.status().as_u16();
             let text = resp.text().await.unwrap_or_default();
-            return Err(GatewayError::SendFailed(format!(
-                "Mattermost API error: {}",
-                text
-            )));
+            return Err(MattermostPostFailure {
+                status: Some(status),
+                body: text,
+            });
         }
 
-        let result: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| GatewayError::SendFailed(format!("Mattermost parse failed: {}", e)))?;
+        let result: serde_json::Value = resp.json().await.map_err(|e| MattermostPostFailure {
+            status: None,
+            body: format!("Mattermost parse failed: {e}"),
+        })?;
         Ok(result
             .get("id")
             .and_then(|v| v.as_str())
@@ -143,12 +170,44 @@ impl MattermostAdapter {
             .to_string())
     }
 
-    fn thread_root_for_send<'a>(&self, thread_id: Option<&'a str>) -> Option<&'a str> {
-        if self.config.reply_to_mode.eq_ignore_ascii_case("thread") {
-            thread_id.map(str::trim).filter(|id| !id.is_empty())
-        } else {
-            None
+    fn thread_candidate_for_send<'a>(&self, thread_id: Option<&'a str>) -> Option<&'a str> {
+        if !self.config.reply_to_mode.eq_ignore_ascii_case("thread") {
+            return None;
         }
+        thread_id.map(str::trim).filter(|id| !id.is_empty())
+    }
+
+    async fn thread_root_for_send(&self, thread_id: Option<&str>) -> Option<String> {
+        let candidate = self.thread_candidate_for_send(thread_id)?;
+        Some(self.resolve_root_id(candidate).await)
+    }
+
+    async fn resolve_root_id(&self, post_id: &str) -> String {
+        let candidate = post_id.trim();
+        let url = format!("{}/api/v4/posts/{}", self.config.server_url, candidate);
+        let Ok(resp) = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.config.token))
+            .send()
+            .await
+        else {
+            return candidate.to_string();
+        };
+
+        if !resp.status().is_success() {
+            return candidate.to_string();
+        }
+
+        let Ok(post) = resp.json::<serde_json::Value>().await else {
+            return candidate.to_string();
+        };
+        post.get("root_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .unwrap_or(candidate)
+            .to_string()
     }
 
     async fn send_file_with_thread(
@@ -157,6 +216,7 @@ impl MattermostAdapter {
         file_path: &str,
         caption: Option<&str>,
         thread_id: Option<&str>,
+        notify: bool,
     ) -> Result<(), GatewayError> {
         use crate::platforms::helpers::mime_from_extension;
 
@@ -206,36 +266,44 @@ impl MattermostAdapter {
             })
             .unwrap_or_default();
 
-        let post_url = format!("{}/api/v4/posts", self.config.server_url);
+        let root_id = self.thread_root_for_send(thread_id).await;
         let body = mattermost_post_body(
             chat_id,
             caption.unwrap_or(""),
-            Some(file_ids),
-            self.thread_root_for_send(thread_id),
+            Some(file_ids.clone()),
+            root_id.as_deref(),
         );
 
-        let resp = self
-            .client
-            .post(&post_url)
-            .header("Authorization", format!("Bearer {}", self.config.token))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| GatewayError::SendFailed(format!("Mattermost file post failed: {e}")))?;
-
-        if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            return Err(GatewayError::SendFailed(format!(
-                "Mattermost file post error: {text}"
-            )));
+        match self.post_body_once(&body).await {
+            Ok(_) => Ok(()),
+            Err(err) if notify && root_id.is_some() && err.is_broken_thread_root() => {
+                let mut flat_body =
+                    mattermost_post_body(chat_id, caption.unwrap_or(""), Some(file_ids), None);
+                flat_body["message"] = serde_json::json!(format!(
+                    "Mattermost thread delivery failed; posting final reply in channel.\n\n{}",
+                    caption.unwrap_or("")
+                )
+                .trim());
+                self.post_body_once(&flat_body)
+                    .await
+                    .map(|_| ())
+                    .map_err(MattermostPostFailure::into_gateway_error)
+            }
+            Err(err) => Err(err.into_gateway_error()),
         }
-        Ok(())
     }
 
     /// Parse a Mattermost WebSocket event into an incoming message.
     ///
     /// Only `posted` events that contain a valid post JSON are returned.
     pub fn parse_ws_event(event: &MattermostWsEvent) -> Option<IncomingMattermostMessage> {
+        Self::parse_ws_event_with_reply_mode(event, "off")
+    }
+
+    pub fn parse_ws_event_with_reply_mode(
+        event: &MattermostWsEvent,
+        reply_to_mode: &str,
+    ) -> Option<IncomingMattermostMessage> {
         if event.event != "posted" {
             return None;
         }
@@ -252,6 +320,23 @@ impl MattermostAdapter {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+        let channel_type = data
+            .get("channel_type")
+            .or_else(|| post.get("channel_type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let mut thread_id = post
+            .get("root_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string);
+        if thread_id.is_none()
+            && reply_to_mode.eq_ignore_ascii_case("thread")
+            && channel_type != "D"
+        {
+            thread_id = Some(post_id.clone());
+        }
 
         let is_bot = post
             .get("props")
@@ -265,8 +350,16 @@ impl MattermostAdapter {
             channel_id,
             user_id,
             message,
+            thread_id,
             is_bot,
         })
+    }
+
+    fn parse_ws_event_for_config(
+        &self,
+        event: &MattermostWsEvent,
+    ) -> Option<IncomingMattermostMessage> {
+        Self::parse_ws_event_with_reply_mode(event, &self.config.reply_to_mode)
     }
 
     fn map_ws_error(err: tokio_tungstenite::tungstenite::Error) -> GatewayError {
@@ -319,7 +412,7 @@ impl MattermostAdapter {
                     match frame {
                         Some(Ok(Message::Text(text))) => {
                             if let Ok(event) = serde_json::from_str::<MattermostWsEvent>(text.as_str()) {
-                                if let Some(message) = Self::parse_ws_event(&event) {
+                                if let Some(message) = self.parse_ws_event_for_config(&event) {
                                     callback(message);
                                 }
                             }
@@ -479,6 +572,36 @@ impl MattermostAdapter {
     }
 }
 
+#[derive(Debug)]
+struct MattermostPostFailure {
+    status: Option<u16>,
+    body: String,
+}
+
+impl MattermostPostFailure {
+    fn is_broken_thread_root(&self) -> bool {
+        if !matches!(self.status, Some(400 | 404)) {
+            return false;
+        }
+        let body = self.body.to_ascii_lowercase();
+        let rootish = ["root_id", "rootid", "root id", "thread", "post"]
+            .iter()
+            .any(|needle| body.contains(needle));
+        let broken = ["invalid", "not found", "does not exist", "missing"]
+            .iter()
+            .any(|needle| body.contains(needle));
+        rootish && broken
+    }
+
+    fn into_gateway_error(self) -> GatewayError {
+        let body = self.body;
+        GatewayError::SendFailed(match self.status {
+            Some(status) => format!("Mattermost API error ({status}): {body}"),
+            None => body,
+        })
+    }
+}
+
 fn normalized_image_content_type(content_type: Option<&str>) -> Option<String> {
     let normalized = content_type?
         .split(';')
@@ -599,7 +722,8 @@ impl PlatformAdapter for MattermostAdapter {
         _parse_mode: Option<ParseMode>,
         thread_id: Option<&str>,
     ) -> Result<(), GatewayError> {
-        self.send_text_with_thread(chat_id, text, thread_id).await?;
+        self.send_text_with_thread(chat_id, text, thread_id, false)
+            .await?;
         Ok(())
     }
 
@@ -610,8 +734,10 @@ impl PlatformAdapter for MattermostAdapter {
         parse_mode: Option<ParseMode>,
         options: SendMessageOptions,
     ) -> Result<(), GatewayError> {
-        self.send_message_threaded(chat_id, text, parse_mode, options.thread_id.as_deref())
+        let _ = parse_mode;
+        self.send_text_with_thread(chat_id, text, options.thread_id.as_deref(), options.notify)
             .await
+            .map(|_| ())
     }
 
     async fn edit_message(
@@ -629,7 +755,7 @@ impl PlatformAdapter for MattermostAdapter {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
-        self.send_file_with_thread(chat_id, file_path, caption, None)
+        self.send_file_with_thread(chat_id, file_path, caption, None, false)
             .await
     }
 
@@ -640,8 +766,14 @@ impl PlatformAdapter for MattermostAdapter {
         caption: Option<&str>,
         options: SendMessageOptions,
     ) -> Result<(), GatewayError> {
-        self.send_file_with_thread(chat_id, file_path, caption, options.thread_id.as_deref())
-            .await
+        self.send_file_with_thread(
+            chat_id,
+            file_path,
+            caption,
+            options.thread_id.as_deref(),
+            options.notify,
+        )
+        .await
     }
 
     async fn send_image_url(
@@ -795,15 +927,34 @@ mod tests {
     #[test]
     fn thread_root_for_send_requires_thread_reply_mode() {
         let adapter = test_adapter();
-        assert_eq!(adapter.thread_root_for_send(Some("root-post-1")), None);
+        assert_eq!(adapter.thread_candidate_for_send(Some("root-post-1")), None);
 
         let mut threaded = test_adapter();
         threaded.config.reply_to_mode = "thread".to_string();
         assert_eq!(
-            threaded.thread_root_for_send(Some(" root-post-1 ")),
+            threaded.thread_candidate_for_send(Some(" root-post-1 ")),
             Some("root-post-1")
         );
-        assert_eq!(threaded.thread_root_for_send(Some("   ")), None);
+        assert_eq!(threaded.thread_candidate_for_send(Some("   ")), None);
+    }
+
+    #[test]
+    fn broken_thread_root_detection_is_specific() {
+        assert!(MattermostPostFailure {
+            status: Some(400),
+            body: "api.context.invalid_param.app_error: invalid root_id".into(),
+        }
+        .is_broken_thread_root());
+        assert!(!MattermostPostFailure {
+            status: Some(500),
+            body: "invalid root_id".into(),
+        }
+        .is_broken_thread_root());
+        assert!(!MattermostPostFailure {
+            status: Some(400),
+            body: "Internal Server Error".into(),
+        }
+        .is_broken_thread_root());
     }
 
     #[tokio::test]
@@ -870,7 +1021,78 @@ mod tests {
         assert_eq!(msg.channel_id, "channel-1");
         assert_eq!(msg.user_id, "user-1");
         assert_eq!(msg.message, "hello");
+        assert_eq!(msg.thread_id, None);
         assert!(msg.is_bot);
+    }
+
+    #[test]
+    fn parse_ws_event_preserves_existing_thread_root() {
+        let event = MattermostWsEvent {
+            event: "posted".to_string(),
+            data: Some(serde_json::json!({
+                "channel_type": "O",
+                "post": serde_json::json!({
+                    "id": "reply-post-1",
+                    "root_id": "root-post-1",
+                    "channel_id": "channel-1",
+                    "user_id": "user-1",
+                    "message": "thread reply"
+                }).to_string()
+            })),
+            broadcast: None,
+            seq: Some(3),
+        };
+
+        let msg = MattermostAdapter::parse_ws_event_with_reply_mode(&event, "thread")
+            .expect("thread reply event");
+        assert_eq!(msg.post_id, "reply-post-1");
+        assert_eq!(msg.thread_id.as_deref(), Some("root-post-1"));
+    }
+
+    #[test]
+    fn parse_ws_event_treats_top_level_channel_post_as_thread_root_in_thread_mode() {
+        let event = MattermostWsEvent {
+            event: "posted".to_string(),
+            data: Some(serde_json::json!({
+                "channel_type": "O",
+                "post": serde_json::json!({
+                    "id": "top-post-1",
+                    "root_id": "",
+                    "channel_id": "channel-1",
+                    "user_id": "user-1",
+                    "message": "top level"
+                }).to_string()
+            })),
+            broadcast: None,
+            seq: Some(4),
+        };
+
+        let msg = MattermostAdapter::parse_ws_event_with_reply_mode(&event, "thread")
+            .expect("top-level event");
+        assert_eq!(msg.thread_id.as_deref(), Some("top-post-1"));
+    }
+
+    #[test]
+    fn parse_ws_event_does_not_seed_dm_thread_root() {
+        let event = MattermostWsEvent {
+            event: "posted".to_string(),
+            data: Some(serde_json::json!({
+                "channel_type": "D",
+                "post": serde_json::json!({
+                    "id": "dm-post-1",
+                    "root_id": "",
+                    "channel_id": "dm-channel",
+                    "user_id": "user-1",
+                    "message": "hello"
+                }).to_string()
+            })),
+            broadcast: None,
+            seq: Some(5),
+        };
+
+        let msg =
+            MattermostAdapter::parse_ws_event_with_reply_mode(&event, "thread").expect("dm event");
+        assert_eq!(msg.thread_id, None);
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/ntfy.rs
+++ b/crates/hermes-gateway/src/platforms/ntfy.rs
@@ -271,6 +271,7 @@ impl NtfyAdapter {
             user_id: topic,
             text,
             message_id: Some(message_id),
+            thread_id: None,
             is_dm: true,
         };
         if let Some(tx) = inner.inbound_tx.read().await.as_ref() {

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -100,11 +100,11 @@ pub struct TelegramConfig {
     #[serde(default)]
     pub disable_link_previews: bool,
 
-    /// Use Bot API 10.1 sendRichMessage for eligible final text sends.
+    /// Use Bot API 10.1 rich messages for eligible final text sends/edits.
     ///
-    /// Disabled by default because some Telegram clients still render rich
-    /// messages poorly even when the Bot API accepts them.
-    #[serde(default)]
+    /// Enabled by default, but only used for constructs the legacy MarkdownV2
+    /// path degrades: pipe tables, task lists, details blocks, and block math.
+    #[serde(default = "default_true")]
     pub rich_messages: bool,
 
     /// Long-polling timeout in seconds.
@@ -938,17 +938,63 @@ impl TelegramAdapter {
         has_crash_shape
     }
 
+    fn needs_rich_rendering(content: &str) -> bool {
+        if content.trim().is_empty() {
+            return false;
+        }
+        if content
+            .lines()
+            .any(|line| Self::looks_like_markdown_table_separator(line))
+        {
+            return true;
+        }
+        if regex::Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]\s+")
+            .map(|re| re.is_match(content))
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        if regex::RegexBuilder::new(r"(?m)^</?details\b|^</?summary\b")
+            .case_insensitive(true)
+            .build()
+            .map(|re| re.is_match(content))
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        content.contains("$$")
+    }
+
+    fn looks_like_markdown_table_separator(line: &str) -> bool {
+        let trimmed = line.trim();
+        if !trimmed.contains('|') || !trimmed.contains('-') {
+            return false;
+        }
+        let cells = trimmed.trim_matches('|').split('|').collect::<Vec<_>>();
+        cells.len() >= 2
+            && cells.iter().all(|cell| {
+                let cell = cell.trim();
+                cell.len() >= 3
+                    && cell.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
+                    && cell.contains('-')
+            })
+    }
+
+    fn rich_eligible_text(&self, text: &str) -> bool {
+        self.config.rich_messages
+            && !self.rich_send_is_disabled()
+            && !text.trim().is_empty()
+            && Self::needs_rich_rendering(text)
+            && Self::content_fits_rich_limits(text)
+            && !Self::has_telegram_desktop_details_math_crash_shape(text)
+    }
+
     fn should_attempt_rich_text(
         &self,
         text: &str,
         keyboard: Option<&InlineKeyboardMarkup>,
     ) -> bool {
-        self.config.rich_messages
-            && !self.rich_send_is_disabled()
-            && keyboard.is_none()
-            && !text.trim().is_empty()
-            && Self::content_fits_rich_limits(text)
-            && !Self::has_telegram_desktop_details_math_crash_shape(text)
+        keyboard.is_none() && self.rich_eligible_text(text)
     }
 
     fn rich_message_body(
@@ -970,6 +1016,20 @@ impl TelegramAdapter {
         if let Some(reply_id) = reply_to_message_id {
             body["reply_parameters"] = serde_json::json!({ "message_id": reply_id });
         }
+        if self.config.disable_link_previews {
+            body["link_preview_options"] = serde_json::json!({ "is_disabled": true });
+        }
+        body
+    }
+
+    fn rich_edit_body(&self, chat_id: &str, message_id: &str, text: &str) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "chat_id": chat_id,
+            "message_id": message_id.parse::<i64>().unwrap_or(0),
+            "rich_message": {
+                "markdown": text,
+            },
+        });
         if self.config.disable_link_previews {
             body["link_preview_options"] = serde_json::json!({ "is_disabled": true });
         }
@@ -1002,6 +1062,17 @@ impl TelegramAdapter {
             || message.contains("no such method")
             || ((message.contains("method") || message.contains("endpoint"))
                 && (message.contains("not found") || message.contains("does not exist")))
+    }
+
+    fn rich_not_modified_error(err: &GatewayError) -> bool {
+        match err {
+            GatewayError::SendFailed(message)
+            | GatewayError::Platform(message)
+            | GatewayError::ConnectionFailed(message) => {
+                message.to_ascii_lowercase().contains("not modified")
+            }
+            _ => false,
+        }
     }
 
     /// Merge media captions without using substring checks that drop distinct captions.
@@ -1347,6 +1418,29 @@ impl TelegramAdapter {
             .ok_or_else(|| GatewayError::SendFailed("sendRichMessage returned no message".into()))
     }
 
+    async fn try_edit_rich_text(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        text: &str,
+    ) -> Result<Option<()>, GatewayError> {
+        let body = self.rich_edit_body(chat_id, message_id, text);
+        match self
+            .send_json_with_thread_fallback::<serde_json::Value>("editMessageText", body)
+            .await
+        {
+            Ok(_) => Ok(Some(())),
+            Err(err) if Self::rich_not_modified_error(&err) => Ok(Some(())),
+            Err(err) if Self::rich_fallback_error(&err) => {
+                if Self::rich_capability_error(&err) {
+                    self.latch_rich_send_disabled();
+                }
+                Ok(None)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     /// Edit an existing message's text.
     pub async fn edit_text(
         &self,
@@ -1355,6 +1449,12 @@ impl TelegramAdapter {
         text: &str,
         parse_mode: Option<&str>,
     ) -> Result<(), GatewayError> {
+        if self.rich_eligible_text(text) {
+            if let Some(()) = self.try_edit_rich_text(chat_id, message_id, text).await? {
+                return Ok(());
+            }
+        }
+
         let rendered_text = self.outgoing_text_for_parse_mode(text, parse_mode);
         if rendered_text.chars().count() > MAX_MESSAGE_LENGTH {
             return Err(GatewayError::SendFailed(format!(
@@ -2600,7 +2700,7 @@ mod tests {
             parse_markdown: false,
             parse_html: false,
             disable_link_previews: false,
-            rich_messages: false,
+            rich_messages: true,
             poll_timeout: 30,
             reply_to_mode: "first".into(),
             reactions: false,
@@ -3100,6 +3200,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn telegram_rich_messages_default_on_only_for_rich_eligible_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "text": "plain **markdown**"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 93 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text("123", "plain **markdown**", None, None)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![93]);
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].url.path().ends_with("/sendMessage"));
+    }
+
+    #[tokio::test]
     async fn telegram_rich_message_bad_request_falls_back_to_legacy_send() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -3114,7 +3244,7 @@ mod tests {
             .and(path("/botfake_token_12345/sendMessage"))
             .and(body_partial_json(serde_json::json!({
                 "chat_id": "123",
-                "text": "plain fallback",
+                "text": "| A | B |\n|---|---|\n| 1 | 2 |",
                 "disable_web_page_preview": true
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -3131,7 +3261,7 @@ mod tests {
         adapter.api_base = format!("{}/botfake_token_12345", server.uri());
 
         let ids = adapter
-            .send_text("123", "plain fallback", None, None)
+            .send_text("123", "| A | B |\n|---|---|\n| 1 | 2 |", None, None)
             .await
             .unwrap();
         assert_eq!(ids, vec![92]);
@@ -3154,6 +3284,95 @@ mod tests {
                 "<details><summary>Plain</summary>No math here</details>"
             )
         );
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_edit_uses_bot_api_10_1_payload_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/editMessageText"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "message_id": 555,
+                "rich_message": { "markdown": "| A | B |\n|---|---|\n| 1 | 2 |" },
+                "link_preview_options": { "is_disabled": true }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 555 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.disable_link_previews = true;
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        adapter
+            .edit_text(
+                "123",
+                "555",
+                "| A | B |\n|---|---|\n| 1 | 2 |",
+                Some("MarkdownV2"),
+            )
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        let body: Value = requests[0].body_json().expect("json body");
+        assert!(body.get("text").is_none());
+        assert!(body.get("parse_mode").is_none());
+        assert_eq!(
+            body.pointer("/rich_message/markdown")
+                .and_then(|v| v.as_str()),
+            Some("| A | B |\n|---|---|\n| 1 | 2 |")
+        );
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_edit_bad_request_falls_back_to_legacy_edit() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/editMessageText"))
+            .and(body_partial_json(serde_json::json!({
+                "rich_message": { "markdown": "| A | B |\n|---|---|\n| 1 | 2 |" }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": false,
+                "description": "Bad Request: rich message is invalid"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/editMessageText"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "message_id": 555,
+                "text": "| A | B |\n|---|---|\n| 1 | 2 |"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 555 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        adapter
+            .edit_text("123", "555", "| A | B |\n|---|---|\n| 1 | 2 |", None)
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 2);
+        let first: Value = requests[0].body_json().expect("first json");
+        assert!(first.get("rich_message").is_some());
+        let second: Value = requests[1].body_json().expect("second json");
+        assert!(second.get("text").is_some());
     }
 
     #[tokio::test]
@@ -4207,7 +4426,7 @@ mod tests {
         assert!(!cfg.parse_markdown);
         assert!(!cfg.parse_html);
         assert!(!cfg.disable_link_previews);
-        assert!(!cfg.rich_messages);
+        assert!(cfg.rich_messages);
         assert_eq!(cfg.poll_timeout, DEFAULT_POLL_TIMEOUT);
         assert_eq!(cfg.reply_to_mode, "first");
         assert!(cfg.webhook_secret.is_none());

--- a/crates/hermes-gateway/src/platforms/wecom_callback.rs
+++ b/crates/hermes-gateway/src/platforms/wecom_callback.rs
@@ -782,6 +782,7 @@ async fn handle_callback_request(
                         user_id: from_user,
                         text,
                         message_id: Some(msg_id),
+                        thread_id: None,
                         is_dm: !is_group,
                     })
                     .await;

--- a/crates/hermes-gateway/src/platforms/weixin.rs
+++ b/crates/hermes-gateway/src/platforms/weixin.rs
@@ -991,6 +991,7 @@ impl WeChatAdapter {
             } else {
                 Some(msg_id)
             },
+            thread_id: None,
             is_dm: chat_type == "dm",
         };
         if let Some(tx) = inner.inbound_tx.read().await.clone() {

--- a/crates/hermes-gateway/tests/contract_primary_platforms.rs
+++ b/crates/hermes-gateway/tests/contract_primary_platforms.rs
@@ -94,6 +94,7 @@ fn incoming(platform: &str, user_id: &str, text: &str) -> IncomingMessage {
         user_id: user_id.to_string(),
         text: text.to_string(),
         message_id: None,
+        thread_id: None,
         is_dm: true,
     }
 }
@@ -543,6 +544,7 @@ async fn contract_request_runtime_overrides_reach_context_handler() {
             user_id: "u1".to_string(),
             text: "run request".to_string(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await

--- a/crates/hermes-gateway/tests/e2e_gateway_route.rs
+++ b/crates/hermes-gateway/tests/e2e_gateway_route.rs
@@ -86,6 +86,7 @@ async fn e2e_gateway_routes_message_and_replies() {
             user_id: "u1".to_string(),
             text: "hello".to_string(),
             message_id: None,
+            thread_id: None,
             is_dm: true,
         })
         .await

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -506,6 +506,7 @@ async fn send_message(
         user_id,
         text: req.text,
         message_id: None,
+        thread_id: None,
         is_dm: false,
     };
 
@@ -572,6 +573,7 @@ async fn exec_command(
         user_id,
         text: cmd,
         message_id: None,
+        thread_id: None,
         is_dm: false,
     };
 

--- a/crates/hermes-tools/src/backends/delegation.rs
+++ b/crates/hermes-tools/src/backends/delegation.rs
@@ -57,6 +57,7 @@ impl DelegationBackend for SignalDelegationBackend {
         child_depth: Option<u32>,
         max_depth: Option<u32>,
         parent_budget_remaining_usd: Option<f64>,
+        background: Option<bool>,
     ) -> Result<String, ToolError> {
         let effective_child_depth = child_depth.unwrap_or(self.current_depth + 1);
         let effective_max_depth = max_depth.unwrap_or(self.max_depth);
@@ -67,6 +68,7 @@ impl DelegationBackend for SignalDelegationBackend {
             )));
         }
         let sub_agent_id = format!("subagent-{}", uuid::Uuid::new_v4());
+        let background = background.unwrap_or(false);
         Ok(json!({
             "type": "delegation_request",
             "sub_agent_id": sub_agent_id,
@@ -77,7 +79,8 @@ impl DelegationBackend for SignalDelegationBackend {
             "child_depth": effective_child_depth,
             "max_depth": effective_max_depth,
             "parent_budget_remaining_usd": parent_budget_remaining_usd.or(self.parent_budget_remaining_usd),
-            "status": "pending",
+            "background": background,
+            "status": if background { "background_pending" } else { "pending" },
         })
         .to_string())
     }
@@ -109,6 +112,7 @@ impl DelegationBackend for RpcDelegationBackend {
         child_depth: Option<u32>,
         max_depth: Option<u32>,
         parent_budget_remaining_usd: Option<f64>,
+        background: Option<bool>,
     ) -> Result<String, ToolError> {
         let payload = json!({
             "task": task,
@@ -118,6 +122,7 @@ impl DelegationBackend for RpcDelegationBackend {
             "child_depth": child_depth,
             "max_depth": max_depth,
             "parent_budget_remaining_usd": parent_budget_remaining_usd,
+            "background": background.unwrap_or(false),
         });
         let resp = self
             .client
@@ -150,6 +155,7 @@ mod tests {
                 Some(99),
                 Some(99),
                 None,
+                None,
             )
             .await
             .expect("depth at configured max should be allowed");
@@ -158,18 +164,49 @@ mod tests {
         assert_eq!(value["child_depth"], 99);
         assert_eq!(value["max_depth"], 99);
         assert_eq!(value["status"], "pending");
+        assert_eq!(value["background"], false);
     }
 
     #[tokio::test]
     async fn signal_delegation_backend_rejects_only_above_configured_max_depth() {
         let backend = SignalDelegationBackend::new().with_depth(99, 99);
         let err = backend
-            .delegate("too deep", None, None, None, Some(100), Some(99), None)
+            .delegate(
+                "too deep",
+                None,
+                None,
+                None,
+                Some(100),
+                Some(99),
+                None,
+                None,
+            )
             .await
             .expect_err("child depth above configured max should be rejected");
 
         assert!(err
             .to_string()
             .contains("Delegation depth limit reached (100/99)"));
+    }
+
+    #[tokio::test]
+    async fn signal_delegation_backend_carries_background_dispatch_flag() {
+        let out = SignalDelegationBackend::new()
+            .delegate(
+                "run async",
+                None,
+                None,
+                None,
+                Some(1),
+                Some(4),
+                None,
+                Some(true),
+            )
+            .await
+            .expect("background dispatch should be allowed");
+        let value: Value = serde_json::from_str(&out).expect("delegation envelope json");
+
+        assert_eq!(value["background"], true);
+        assert_eq!(value["status"], "background_pending");
     }
 }

--- a/crates/hermes-tools/src/tools/delegation.rs
+++ b/crates/hermes-tools/src/tools/delegation.rs
@@ -25,6 +25,7 @@ pub trait DelegationBackend: Send + Sync {
         child_depth: Option<u32>,
         max_depth: Option<u32>,
         parent_budget_remaining_usd: Option<f64>,
+        background: Option<bool>,
     ) -> Result<String, ToolError>;
 }
 
@@ -65,6 +66,7 @@ impl ToolHandler for DelegateTaskHandler {
         let parent_budget_remaining_usd = params
             .get("parent_budget_remaining_usd")
             .and_then(|v| v.as_f64());
+        let background = params.get("background").and_then(|v| v.as_bool());
 
         self.backend
             .delegate(
@@ -75,6 +77,7 @@ impl ToolHandler for DelegateTaskHandler {
                 child_depth,
                 max_depth,
                 parent_budget_remaining_usd,
+                background,
             )
             .await
     }
@@ -130,6 +133,13 @@ impl ToolHandler for DelegateTaskHandler {
                 "description": "Remaining parent budget in USD to propagate to child orchestration"
             }),
         );
+        props.insert(
+            "background".into(),
+            json!({
+                "type": "boolean",
+                "description": "Run the delegated sub-agent asynchronously and return a handle immediately (default: false)"
+            }),
+        );
 
         tool_schema(
             "delegate_task",
@@ -155,6 +165,7 @@ mod tests {
             _child_depth: Option<u32>,
             _max_depth: Option<u32>,
             _parent_budget_remaining_usd: Option<f64>,
+            _background: Option<bool>,
         ) -> Result<String, ToolError> {
             Ok(format!("Delegated task: {}", task))
         }
@@ -167,6 +178,7 @@ mod tests {
         let rendered = serde_json::to_string(&handler.schema()).expect("schema json");
         assert!(rendered.contains("inherit"));
         assert!(rendered.contains("currently enabled parent tools"));
+        assert!(rendered.contains("background"));
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/tools/disk_cleanup.rs
+++ b/crates/hermes-tools/src/tools/disk_cleanup.rs
@@ -55,6 +55,14 @@ const PROTECTED_EMPTY_TOP_LEVEL: &[&str] = &[
     "profiles",
     ".worktrees",
 ];
+const EMPTY_DIR_SWEEP_PRUNE_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "venv",
+    ".venv",
+    "site-packages",
+    "__pycache__",
+];
 
 pub const ALLOWED_CATEGORIES: &[&str] = &[
     "temp",
@@ -468,7 +476,7 @@ impl DiskCleanup {
 
     fn remove_empty_dirs(&self) -> usize {
         let mut dirs = Vec::new();
-        collect_dirs_postorder(&self.hermes_home, &mut dirs);
+        collect_pruned_dirs_postorder(&self.hermes_home, &self.hermes_home, &mut dirs);
         let mut removed = 0usize;
         for dir in dirs {
             if dir == self.hermes_home {
@@ -935,16 +943,33 @@ fn remove_path(path: &Path) -> io::Result<()> {
     }
 }
 
-fn collect_dirs_postorder(root: &Path, dirs: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(root) else {
+fn collect_pruned_dirs_postorder(home: &Path, current: &Path, dirs: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(current) else {
         return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_dir() {
-            collect_dirs_postorder(&path, dirs);
-            dirs.push(path);
+        if !path.is_dir() {
+            continue;
         }
+        let Ok(rel) = path.strip_prefix(home) else {
+            continue;
+        };
+        let name = path.file_name().and_then(|v| v.to_str()).unwrap_or("");
+        if path
+            .symlink_metadata()
+            .is_ok_and(|m| m.file_type().is_symlink())
+        {
+            continue;
+        }
+        if rel.components().count() == 1 && PROTECTED_EMPTY_TOP_LEVEL.contains(&name) {
+            continue;
+        }
+        if EMPTY_DIR_SWEEP_PRUNE_DIRS.contains(&name) {
+            continue;
+        }
+        collect_pruned_dirs_postorder(home, &path, dirs);
+        dirs.push(path);
     }
 }
 
@@ -1111,6 +1136,36 @@ mod tests {
                 "{dir} should remain"
             );
         }
+    }
+
+    #[test]
+    fn quick_does_not_descend_into_protected_or_pruned_trees() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let protected_empty = cleaner
+            .hermes_home()
+            .join("hermes-agent/node_modules/pkg/empty");
+        fs::create_dir_all(&protected_empty).unwrap();
+
+        cleaner.quick();
+
+        assert!(
+            protected_empty.exists(),
+            "empty dirs under protected checkout/dependency trees must remain untouched"
+        );
+    }
+
+    #[test]
+    fn quick_removes_empty_dirs_in_managed_subtrees() {
+        let tmp = TempDir::new().unwrap();
+        let cleaner = cleaner(&tmp);
+        let managed_empty = cleaner.hermes_home().join("scratch/nested/empty");
+        fs::create_dir_all(&managed_empty).unwrap();
+
+        let summary = cleaner.quick();
+
+        assert!(summary.empty_dirs >= 3);
+        assert!(!cleaner.hermes_home().join("scratch").exists());
     }
 
     #[test]

--- a/docs/parity/batch-triage-log.md
+++ b/docs/parity/batch-triage-log.md
@@ -1290,3 +1290,43 @@
 - Outcome:
   - Queue end-state: `pending=0`, `ported=49`, `superseded=1065`.
   - Gates: CI `PASS`, release `PASS`.
+
+## 2026-06-16 runtime-threading-queue-batch (targeted upstream parity closure)
+- Scope:
+  - Continue from the refreshed `main..upstream/main` queue snapshot (`6101` tracked commits).
+  - Reduce active pending rows below the requested `<=25` threshold without broad-dispositioning unreviewed SSL, desktop, Photon, or profile rows.
+- Queue at start:
+  - `pending=32`, `ported=299`, `superseded=5696`, `mirrored=74`.
+- Rust/docs implementation ported in this pass:
+  - `c1a70a543925` and `40699c329265` (`disk-cleanup` protected empty-dir pruning):
+    - Rust cleanup walk now prunes protected top-level trees and dependency/cache dirs before recursive empty-dir deletion.
+    - Covered by `quick_does_not_descend_into_protected_or_pruned_trees` and `quick_removes_empty_dirs_in_managed_subtrees`.
+  - `c66ecf0bc30f` (`delegate_task(background=true)`):
+    - Tool schema/backends carry `background`; `AgentLoop` forwards it; `SubAgentOrchestrator` dispatches detached children and emits completion callbacks.
+  - `5a0e0d35b94f` (`mattermost` thread-local delivery hygiene):
+    - Gateway replies now preserve source `thread_id`; Mattermost resolves thread roots, parses WebSocket root IDs, and falls back flat only for final notifications with broken roots.
+  - `5bfed0fe071a` (optional payments skills):
+    - Added payments optional skills plus generated docs and catalog entries.
+  - `a6364bfa08db` (Telegram rich streamed preview edits):
+    - Telegram rich messages default on for rich-only content shapes; rich final sends/edits use Bot API 10.1 payloads with legacy fallback.
+- Superseded in this pass:
+  - `b689624aeeef`, `510df6eaf47e`, `e7cb5d4b68c3`, `dc4b0465b558`, `be89c2e4fa41`
+    - GitHub workflow-only slicing/trigger/supply-chain deltas; this repo's validation is owned by local scripts and Rust cargo gates.
+- Queue at end:
+  - `pending=21`, `ported=305`, `superseded=5701`, `mirrored=74`.
+- Verification:
+  - `cargo fmt --all --check`
+  - `cargo check -p hermes-core -p hermes-gateway -p hermes-agent -p hermes-tools -p hermes-http -p hermes-cli`
+  - `cargo test -p hermes-gateway gateway_replies_and_deferred_messages_preserve_source_thread -- --nocapture`
+  - `cargo test -p hermes-gateway --features mattermost platforms::mattermost::tests -- --nocapture`
+  - `cargo test -p hermes-gateway --features telegram telegram_rich -- --nocapture`
+  - `cargo test -p hermes-tools delegate_task -- --nocapture`
+  - `cargo test -p hermes-tools quick_ -- --nocapture`
+  - `cargo test -p hermes-tools signal_delegation_backend -- --nocapture`
+  - `cargo test -p hermes-agent background_request_dispatches_handle_and_emits_completion_callback -- --nocapture`
+  - `cargo test -p hermes-gateway gateway_deferred_post_delivery_messages_flush_after_main_reply -- --nocapture`
+  - `scripts/check-runtime-placeholders.sh`
+  - `cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture`
+  - `python3 scripts/generate-global-parity-proof.py --check-ci`
+- Verification note:
+  - All Rust/placeholder/governance checks above passed except `generate-global-parity-proof.py --check-ci`, which regenerated proof artifacts but exited non-zero on pre-existing tree-drift thresholds (`max_commits_behind=5880 > 5500`, `max_upstream_patch_missing=5657 > 5000`) and release-mode `pending=0` policy. The queue pending metric itself is under CI threshold (`21 <= 100`).

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -74,7 +74,7 @@
         "status": "pass"
       },
       {
-        "actual": 24.0,
+        "actual": 21.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -83,7 +83,7 @@
     "mode": "tree-drift",
     "pass": false
   },
-  "generated_at_utc": "2026-06-16T07:25:59.189499+00:00",
+  "generated_at_utc": "2026-06-16T16:57:42.813160+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -99,7 +99,7 @@
     "max_commits_behind": 5880.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 24.0,
+    "max_queue_pending_commits": 21.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -118,23 +118,23 @@
   },
   "queue_summary": {
     "by_disposition": {
-      "mirrored": 70,
-      "pending": 24,
-      "ported": 288,
-      "superseded": 5579
+      "mirrored": 74,
+      "pending": 21,
+      "ported": 305,
+      "superseded": 5701
     },
     "by_target_ticket": {
-      "20": 2574,
+      "20": 2645,
       "21": 119,
-      "22": 878,
-      "23": 416,
+      "22": 886,
+      "23": 427,
       "24": 22,
-      "25": 128,
-      "26": 1824
+      "25": 134,
+      "26": 1868
     },
-    "overrides_path": "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/parity/queue-overrides.json",
-    "patch_equivalent_count": 2,
-    "total_commits": 5961
+    "overrides_path": "/Volumes/wd_black/hermes-agent-ultra/repo/docs/parity/queue-overrides.json",
+    "patch_equivalent_count": 6,
+    "total_commits": 6101
   },
   "release_gate": {
     "checks": [
@@ -193,7 +193,7 @@
         "status": "pass"
       },
       {
-        "actual": 24.0,
+        "actual": 21.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-16T07:25:59.189499+00:00`
+Generated: `2026-06-16T16:57:42.813160+00:00`
 
 ## Gate Status
 
@@ -25,7 +25,7 @@ Generated: `2026-06-16T07:25:59.189499+00:00`
 | `min_sota_harness_domain_coverage_ratio` | 1.0 |
 | `max_sota_harness_critical_gaps` | 0.0 |
 | `max_sota_harness_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 24.0 |
+| `max_queue_pending_commits` | 21.0 |
 
 ## GPAR Ticket Completion
 
@@ -58,13 +58,13 @@ Generated: `2026-06-16T07:25:59.189499+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `5961`.
+- Upstream missing commits tracked: `6101`.
 - By target ticket:
-  - `#20`: `2574`
+  - `#20`: `2645`
   - `#21`: `119`
-  - `#22`: `878`
-  - `#23`: `416`
+  - `#22`: `886`
+  - `#23`: `427`
   - `#24`: `22`
-  - `#25`: `128`
-  - `#26`: `1824`
+  - `#25`: `134`
+  - `#26`: `1868`
 

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-16T10:22:05.579269+00:00`
+Generated: `2026-06-16T16:28:08.867Z`
 
-- Range: `main..upstream/main`; total commits tracked: `6077`.
+- Range: `main..upstream/main`; total commits tracked: `6101`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2633 |
+| #20 | GPAR-01 tests+CI parity | 2645 |
 | #21 | GPAR-02 skills parity | 119 |
 | #22 | GPAR-03 UX parity | 886 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 426 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 427 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 134 |
-| #26 | GPAR-07 upstream queue backfill | 1857 |
+| #26 | GPAR-07 upstream queue backfill | 1868 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 74 |
 | pending | 21 |
-| ported | 299 |
-| superseded | 5683 |
+| ported | 305 |
+| superseded | 5701 |
 
 ## First 100 Pending Commits
 
@@ -27,11 +27,6 @@ Generated: `2026-06-16T10:22:05.579269+00:00`
 | --- | ---: | --- |
 | `cc8e5ec2afbf` | #20 | refactor(gateway): migrate Discord adapter to bundled plugin (full Teams parity) |
 | `7849a3d73f2d` | #26 | fix(gateway,discord-plugin): _platform_status must respect is_connected=False, not silently fall back to check_fn |
-| `b689624aeeef` | #25 | feat(ci): 4-way matrix slicing with LPT duration-balanced distribution |
-| `510df6eaf47e` | #25 | test: 4-way slice benchmark (with cache save) |
-| `e7cb5d4b68c3` | #25 | fix: clean push triggers |
-| `dc4b0465b558` | #25 | feat(ci): use 6-way slicing based on benchmark results |
-| `be89c2e4fa41` | #25 | ci(supply-chain): anchor install-hook regex at repo root (#31744) |
 | `d8703e27f5c3` | #22 | feat(skills-hub): health checks, freshness badge, and a watchdog cron (#32345) |
 | `2681c5a12d8d` | #20 | fix(photon): correct gateway start command (#45566) |
 | `cc14b74718aa` | #22 | docs(profile): update clone-from references |
@@ -40,9 +35,14 @@ Generated: `2026-06-16T10:22:05.579269+00:00`
 | `7aaae7acd0d6` | #20 | fix(ssl): align guard docs and escape hatch |
 | `723c2331bd23` | #20 | fix: make profile subprocess HOME policy explicit |
 | `61ee2dbfdb40` | #20 | fix(s6): make profile gateway log parent writable (#46291) |
-| `c1a70a543925` | #20 | 🐛 fix(disk-cleanup): prune protected cleanup walks |
-| `40699c329265` | #20 | 🐛 fix(disk-cleanup): avoid brittle sweep review issues |
 | `975b9f0a5426` | #22 | docs: recommend standard installer for development (#46646) |
-| `c66ecf0bc30f` | #20 | feat(delegation): async background subagents via delegate_task(background=true) (#40946) |
-| `5a0e0d35b94f` | #20 | fix(mattermost): preserve thread-local delivery hygiene |
-| `5bfed0fe071a` | #22 | feat(skills): add optional payments skills (Stripe Link, MPP, Projects) (#31343) |
+| `c92a95a130cc` | #26 | feat(desktop): move model selector from statusbar to composer |
+| `989d5d0cb72a` | #26 | fix(desktop): declutter date-pinned model snapshots in the picker |
+| `0e81d2fb71c1` | #26 | feat(desktop): per-model effort/fast presets in the picker |
+| `a0ec4f52b948` | #20 | feat(desktop): disconnect external (CLI-managed) providers |
+| `dd0e3e0a052a` | #26 | fix(desktop): tighten thread content top padding |
+| `5b3fa2636632` | #20 | fix(photon): unify project identifiers and update documentation for Spectrum provisioning |
+| `a68ac0c49af1` | #26 | feat(desktop): allow /browser connect on a local gateway (#47245) |
+| `cb6b4127e795` | #20 | refactor(desktop): make composer model picker sticky session state |
+| `7d938cc5c9c7` | #20 | fix(desktop): keep live model switch metadata truthful |
+| `80e4b8985ea9` | #26 | feat(desktop): tighten composer model picker interactions |

--- a/optional-skills/payments/mpp-agent/SKILL.md
+++ b/optional-skills/payments/mpp-agent/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: mpp-agent
+description: Pay HTTP 402 APIs via Machine Payments Protocol (MPP).
+version: 0.1.0
+author: Teknium (teknium1), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Payments, MPP, HTTP-402, Tempo, Stripe]
+    related_skills: [stripe-link-cli, stripe-projects]
+---
+
+# MPP Agent Skill
+
+Wraps the Machine Payments Protocol (MPP, https://mpp.dev) clients so Hermes can pay for per-request API access against servers that respond with `HTTP 402 Payment Required`.
+
+Three client options, all distributed via npm. Pick the lightest one that solves the user's need. Gated `[linux, macos]` while the broader payments tooling matures on Windows.
+
+## When to Use
+
+- A merchant API returns `HTTP 402` with a `www-authenticate` header — and the user wants to actually pay it, not just log the response.
+- The user asks to "pay per request", "set up an agent wallet", "use Tempo / Privy / AgentCash", or wants to discover MPP-priced services.
+- A Stripe Link spend has produced a Shared Payment Token (SPT) and the agent needs to attach it to the 402 challenge — in that flow, prefer `link-cli mpp pay` (see the `stripe-link-cli` skill).
+
+## Choosing a client
+
+| Tool | When | Setup |
+|---|---|---|
+| `link-cli` | User already has Stripe Link set up, or the 402 challenge advertises `method="stripe"` | see the `stripe-link-cli` skill |
+| Tempo Wallet | MPP services with spend controls, service discovery | `tempo wallet login` |
+| Privy Agent CLI | Multi-chain wallets, browser-based funding | `privy-agent-wallets login` |
+| AgentCash | 300+ pre-priced APIs via one USDC.e balance | `npx agentcash onboard` |
+| `mppx` | Dev + debugging, smallest dep surface | `npm install -g mppx` then `mppx account create` |
+
+Default: if the user already has Stripe Link configured or the 402 challenge specifies `method="stripe"`, use `link-cli mpp pay` (the `stripe-link-cli` skill). Otherwise `mppx` for one-off paid calls and debugging, and Tempo Wallet when the user wants persistent spend controls.
+
+## Prerequisites
+
+- Node.js 20+ on `PATH`
+- A funded wallet (Tempo / Privy / AgentCash) OR an `mppx` account
+- For Tempo / Privy / AgentCash: follow their respective onboarding skills:
+  - `https://tempo.xyz/SKILL.md`
+  - `https://agents.privy.io/skill.md`
+  - `https://agentcash.dev/skill.md`
+
+Use `web_extract` to fetch any of those SKILL.md files if the user picks one.
+
+## Procedure (mppx, fastest path)
+
+Run all commands through the `terminal` tool.
+
+### 1. Install + create an account
+
+```
+npm install -g mppx
+mppx account create
+```
+
+Store the resulting account credentials wherever the CLI tells you (the CLI writes them under its own config — do not paste them into the agent transcript).
+
+### 2. Inspect the merchant's 402 challenge
+
+If the user gives you a URL, probe it first to confirm it actually speaks MPP:
+
+```
+curl -i <url>
+```
+
+A real MPP 402 looks like:
+
+```
+HTTP/1.1 402 Payment Required
+www-authenticate: tempo amount=0.1 currency=...
+```
+
+### 3. Pay the request
+
+```
+mppx <url>
+```
+
+For non-GET methods or request bodies:
+
+```
+mppx <url> --method POST --data '<json>'
+```
+
+`mppx` handles the 402 challenge/credential dance automatically and prints the merchant's actual response on success.
+
+### 4. Verify the receipt
+
+`mppx` attaches the receipt header automatically. To inspect:
+
+```
+mppx <url> -v
+```
+
+## Procedure (Tempo Wallet)
+
+The Tempo Wallet skill at https://tempo.xyz/SKILL.md is the canonical reference; fetch it with `web_extract` and follow it. Headline:
+
+```
+tempo wallet login
+tempo wallet pay <url>
+```
+
+Spend controls and service discovery live in the wallet UI at https://wallet.tempo.xyz.
+
+## Pitfalls
+
+- **`HTTP 402` without `method="stripe"` cannot be paid by Stripe Link.** If the challenge advertises only Tempo / other methods, use `mppx` (or whichever wallet matches) — Link will reject it. Conversely, if it advertises `method="stripe"`, prefer Link via the `stripe-link-cli` skill so the spend goes through the user's approved card.
+- **Multiple challenges in one header.** `www-authenticate` may list several methods (e.g. `tempo, stripe`). The Link CLI's `mpp decode` will pick the Stripe one; `mppx` will pick Tempo. There's no single "right" client — pick by which wallet the user has funded.
+- **Zero-amount challenges.** Some MPP endpoints charge `$0.00` and just want a proof credential. These work without a funded wallet. Don't refuse them as "broken."
+- **Wallet keys never enter agent context.** All four clients store keys under their own config dirs (or generate per-session ephemeral keypairs, in Privy's case). Do not `cat`/`read_file` them.
+- **Server-side MPP is a different skill.** If the user wants to ADD 402 to their own API, this skill is wrong — point them at https://mpp.dev/quickstart/server and the `mppx/nextjs` / `mppx/hono` / `mppx/express` / `mppx/elysia` middlewares. A dedicated `mpp-server` skill may land later.
+
+## Verification
+
+```
+mppx --version && mppx account list
+```
+
+Exit code 0 means installed and an account exists.

--- a/optional-skills/payments/stripe-link-cli/SKILL.md
+++ b/optional-skills/payments/stripe-link-cli/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: stripe-link-cli
+description: Agent payments via Stripe Link — cards, SPT, approvals.
+version: 0.1.0
+author: Teknium (teknium1), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Payments, Stripe, Link, Checkout, MPP]
+    related_skills: [mpp-agent, stripe-projects]
+---
+
+# Stripe Link CLI Skill
+
+Wraps [@stripe/link-cli](https://github.com/stripe/link-cli) so Hermes can complete purchases on the user's behalf using one-time-use virtual cards or Shared Payment Tokens (SPT). Every spend is gated by an in-app approval in the Link mobile/web app — Hermes cannot self-approve.
+
+US-only at the moment (Link account requirement). Windows is not supported by the upstream CLI — this skill is gated `[linux, macos]`.
+
+## When to Use
+
+Trigger phrases:
+
+- "buy X", "pay for X", "make a purchase", "complete checkout"
+- "get me a card", "I need a payment method"
+- "log in to Link", "connect my Link wallet"
+- HTTP 402 response from a merchant API with `www-authenticate: ... method="stripe"`
+
+If the user wants a paid API call (HTTP 402, no checkout form), the `card` path is wrong — use SPT via this same skill, or hand off to the `mpp-agent` skill.
+
+## Prerequisites
+
+- Node.js 20+ available on `PATH` (`node --version`)
+- US-based (Link account requirement)
+
+The Link account, payment method, and spend-approval app do NOT need to be set up before Hermes attempts to pay — the CLI walks the user through them on first run:
+
+- A Link account at https://app.link.com — created/linked during first `link-cli` auth
+- At least one payment method — added during first run at https://app.link.com/wallet
+- The Link mobile/web app — opened to approve the first spend request when it's made
+
+No env vars required — auth state is stored locally by the CLI under its own config directory.
+
+## Install
+
+Install once, globally:
+
+```
+npm install -g @stripe/link-cli
+```
+
+Or invoke ad-hoc via `npx @stripe/link-cli`. The skill below uses the installed `link-cli` form.
+
+## How to Run
+
+All commands run through the `terminal` tool. The CLI auto-detects non-TTY callers and emits compact `toon` output by default — fine for the model. Pass `--format json` if a step needs structured fields.
+
+Discover commands: `link-cli --llms-full`.
+Get a command's schema before invoking: `link-cli <command> --schema`.
+
+## Procedure
+
+### 1. Check / establish auth
+
+```
+link-cli auth status
+```
+
+If not authenticated, log in with a clear client name (this label shows in the user's Link app):
+
+```
+link-cli auth login --client-name "Hermes" --interval 5 --timeout 300
+```
+
+The `--interval`/`--timeout` form polls inline so the agent doesn't need to manage a `_next` step. Print the verification URL + phrase to the user and wait for the CLI to return.
+
+**Do not proceed past this step until `auth status` confirms login.**
+
+### 2. Evaluate the merchant before creating a spend request
+
+Decide the credential type:
+
+| Merchant surface | `--credential-type` |
+|---|---|
+| Standard web checkout form / Stripe Elements | `card` (default) |
+| Returns HTTP 402 with `method="stripe"` in `www-authenticate` | `shared_payment_token` |
+| Returns HTTP 402 without `method="stripe"` | unsupported — stop |
+
+For 402 responses, do NOT decode the challenge manually. Pass the raw header:
+
+```
+link-cli mpp decode --challenge '<full WWW-Authenticate header>'
+```
+
+This validates the challenge and extracts the network ID + decoded request body.
+
+### 3. List payment methods + shipping
+
+```
+link-cli payment-methods list
+link-cli shipping-address list
+```
+
+Use the first entry unless the user specifies otherwise. The `id` from `payment-methods list` is the `--payment-method-id` in the next step.
+
+### 4. Create the spend request
+
+Confirm the final total with the user before issuing this command. Amounts are in cents.
+
+```
+link-cli spend-request create \
+  --payment-method-id <pm_id> \
+  --merchant-name "<name>" \
+  --merchant-url "<url>" \
+  --context "<one sentence: what is being purchased and why>" \
+  --amount <cents> \
+  --line-item "name:<item>,unit_amount:<cents>,quantity:1" \
+  --total "type:total,display_text:Total,amount:<cents>" \
+  --request-approval
+```
+
+For MPP merchants add `--credential-type shared_payment_token`.
+
+`--request-approval` pings the user's Link app and polls until they approve or deny. The CLI exits non-zero on deny / timeout.
+
+### 5. Retrieve the credential — SECURELY
+
+**Do not print card details to stdout.** Use `--output-file` so the PAN never enters the agent's transcript or logs:
+
+```
+link-cli spend-request retrieve <lsrq_id> \
+  --include card \
+  --output-file /tmp/link-card.json \
+  --format json
+```
+
+The file is written with `0600` perms; stdout shows only redacted fields (brand, last4, expiry) plus a `card_output_file` path.
+
+### 6. Use the credential
+
+- For web checkout: hand the file path to the user, OR pass it to a browser-driving tool that fills the form directly from disk. Never `read_file` or `cat` the card file into the agent's reasoning context.
+- For MPP merchants:
+
+  ```
+  link-cli mpp pay <merchant-url> \
+    --spend-request-id <lsrq_id> \
+    --method POST \
+    --data '<json body>'
+  ```
+
+### 7. Clean up
+
+Delete the card file as soon as the purchase is done:
+
+```
+rm -f /tmp/link-card.json
+```
+
+## Optional: run as an MCP server instead
+
+`@stripe/link-cli --mcp` exposes the same commands as MCP tools over stdio. To register it with Hermes' native MCP:
+
+```
+hermes mcp add stripe-link --command "npx" --args "@stripe/link-cli --mcp"
+```
+
+Then `hermes mcp list` should show `stripe-link`. The same approval rules apply — MCP doesn't bypass the Link app approval step.
+
+## Pitfalls
+
+- **US-only.** Outside the US, `auth login` will fail. Tell the user, don't keep retrying.
+- **Card PAN must never enter agent context.** Use `--output-file` every time. If you've already retrieved without it, immediately `link-cli auth logout` is not enough — the card is one-time-use but rotate hygiene matters.
+- **`--request-approval` blocks until the user acts.** If the user is asleep, the CLI will hit its timeout. Set expectations.
+- **Multi-step `_next` commands.** Some commands return `_next.command` that must be executed to continue. When in doubt, prefer the inline-polling flags (`--interval`/`--timeout`).
+- **Output format defaults to `toon`** in non-TTY mode. Fine for prose, but if a downstream step needs to parse a specific field, pass `--format json`.
+- **Don't default to `card`.** The merchant-evaluation step (Section 2) exists because picking the wrong credential type fails the purchase silently or leaks more data than needed.
+
+## Verification
+
+```
+link-cli --version && link-cli auth status
+```
+
+Exit code 0 means installed and logged in.

--- a/optional-skills/payments/stripe-projects/SKILL.md
+++ b/optional-skills/payments/stripe-projects/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: stripe-projects
+description: Provision SaaS services + sync creds via Stripe Projects.
+version: 0.1.0
+author: Teknium (teknium1), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Payments, Stripe, Projects, Provisioning, Infrastructure]
+    related_skills: [stripe-link-cli, mpp-agent]
+---
+
+# Stripe Projects Skill
+
+Wraps the [Stripe Projects](https://projects.dev) CLI plugin so Hermes can provision SaaS services (Neon, Twilio, Vercel, etc.), generate and sync credentials into the user's `.env`, and manage billing across providers from one place.
+
+Gated `[linux, macos]` while the broader payments cluster matures on Windows. The Stripe CLI itself is cross-platform; this gate is a posture for the cluster, not a hard limit.
+
+## When to Use
+
+Trigger phrases:
+
+- "set up <provider>", "provision <Neon|Twilio|Vercel|...>", "create a database"
+- "give me a <Postgres|Redis|Twilio number|...> for this project"
+- "manage my stack credentials", "rotate this key", "upgrade my plan"
+- "what providers can I add?"
+
+If the user already has the service set up manually and just wants to use it, this skill is not the right entry point.
+
+## Prerequisites
+
+- Stripe CLI installed (Homebrew on macOS, package manager on Linux, or download from https://docs.stripe.com/stripe-cli/install)
+- Stripe Projects plugin installed
+- A Stripe account, logged in via `stripe login`
+
+## Install
+
+macOS:
+
+```
+brew install stripe/stripe-cli/stripe
+stripe plugin install projects
+```
+
+Linux: follow the platform-specific install at https://docs.stripe.com/stripe-cli/install, then:
+
+```
+stripe plugin install projects
+```
+
+## How to Run
+
+All commands run through the `terminal` tool from inside the user's project directory (the CLI writes `.env` and `.projects/vault/vault.json` into the CWD).
+
+## Procedure
+
+### 1. Initialize the project
+
+```
+cd <project-root>
+stripe projects init
+```
+
+This creates `.projects/vault/vault.json` (encrypted credential store) and prepares the project to receive providers.
+
+### 2. Discover available providers
+
+```
+stripe projects catalog
+```
+
+Lists every provider Stripe Projects supports — databases, hosting, auth, AI, analytics, messaging, etc.
+
+### 3. Add a service
+
+```
+stripe projects add <provider>/<service>
+```
+
+Examples:
+
+- `stripe projects add neon/postgres`
+- `stripe projects add twilio/sms`
+- `stripe projects add runloop/sandbox`
+
+The CLI provisions the service in the user's own account with the provider, generates credentials, syncs them into `.env`, and records the resource in the vault. The user may need to confirm a tier selection or pricing prompt.
+
+### 4. Verify
+
+```
+stripe projects list
+```
+
+Should show the newly added provider and its `.env` keys.
+
+### 5. Manage / upgrade / remove
+
+```
+stripe projects upgrade <provider>     # tier change
+stripe projects remove <provider>      # deprovision
+stripe projects rotate <provider>      # rotate credentials
+```
+
+## Pitfalls
+
+- **`.env` writes are real writes.** The CLI appends to whatever `.env` is in the project root. If the user's `.env` is gitignored (normal), the keys land safely; if not, this skill could be a credential-leak vector. Always check `.gitignore` first.
+- **Per-project state.** `.projects/vault/vault.json` is per-project. Provisioning the same service in two different projects creates two separate resources — and two bills.
+- **Billing happens on Stripe's side.** Tier prompts during `add`/`upgrade` are real charges; surface them to the user before confirming.
+- **Provider availability changes.** The catalog grows; if a provider the user names isn't listed, `stripe projects catalog | grep <name>` first instead of failing the `add` call.
+- **Credentials in vault are encrypted but `.env` is plaintext.** Standard `.env` hygiene applies — never commit it.
+- **Removing a service does NOT always destroy the underlying resource.** Some providers leave a paused/dormant resource behind. Check the provider's own dashboard after `remove` for high-cost services (managed databases especially).
+
+## Verification
+
+```
+stripe projects --version && stripe projects list
+```
+
+Exit code 0 inside an initialized project means the plugin is healthy.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -143,6 +143,14 @@ hermes skills uninstall <skill-name>
 | [**unsloth**](/docs/user-guide/skills/optional/mlops/mlops-training-unsloth) | Unsloth: 2-5x faster LoRA/QLoRA fine-tuning, less VRAM. |
 | [**whisper**](/docs/user-guide/skills/optional/mlops/mlops-whisper) | OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and language identification. Six model sizes from tiny (39M params) to large (1550M params). Use for speech-to-text, podcast... |
 
+## payments
+
+| Skill | Description |
+|-------|-------------|
+| [**mpp-agent**](/docs/user-guide/skills/optional/payments/payments-mpp-agent) | Pay HTTP 402 APIs via Machine Payments Protocol (MPP). |
+| [**stripe-link-cli**](/docs/user-guide/skills/optional/payments/payments-stripe-link-cli) | Agent payments via Stripe Link — cards, SPT, approvals. |
+| [**stripe-projects**](/docs/user-guide/skills/optional/payments/payments-stripe-projects) | Provision SaaS services + sync creds via Stripe Projects. |
+
 ## productivity
 
 | Skill | Description |

--- a/website/docs/user-guide/skills/optional/payments/payments-mpp-agent.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-mpp-agent.md
@@ -1,0 +1,142 @@
+---
+title: "Mpp Agent — Pay HTTP 402 APIs via Machine Payments Protocol (MPP)"
+sidebar_label: "Mpp Agent"
+description: "Pay HTTP 402 APIs via Machine Payments Protocol (MPP)"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Mpp Agent
+
+Pay HTTP 402 APIs via Machine Payments Protocol (MPP).
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/payments/mpp-agent` |
+| Path | `optional-skills/payments/mpp-agent` |
+| Version | `0.1.0` |
+| Author | Teknium (teknium1), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Payments`, `MPP`, `HTTP-402`, `Tempo`, `Stripe` |
+| Related skills | [`stripe-link-cli`](/docs/user-guide/skills/optional/payments/payments-stripe-link-cli), [`stripe-projects`](/docs/user-guide/skills/optional/payments/payments-stripe-projects) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# MPP Agent Skill
+
+Wraps the Machine Payments Protocol (MPP, https://mpp.dev) clients so Hermes can pay for per-request API access against servers that respond with `HTTP 402 Payment Required`.
+
+Three client options, all distributed via npm. Pick the lightest one that solves the user's need. Gated `[linux, macos]` while the broader payments tooling matures on Windows.
+
+## When to Use
+
+- A merchant API returns `HTTP 402` with a `www-authenticate` header — and the user wants to actually pay it, not just log the response.
+- The user asks to "pay per request", "set up an agent wallet", "use Tempo / Privy / AgentCash", or wants to discover MPP-priced services.
+- A Stripe Link spend has produced a Shared Payment Token (SPT) and the agent needs to attach it to the 402 challenge — in that flow, prefer `link-cli mpp pay` (see the `stripe-link-cli` skill).
+
+## Choosing a client
+
+| Tool | When | Setup |
+|---|---|---|
+| `link-cli` | User already has Stripe Link set up, or the 402 challenge advertises `method="stripe"` | see the `stripe-link-cli` skill |
+| Tempo Wallet | MPP services with spend controls, service discovery | `tempo wallet login` |
+| Privy Agent CLI | Multi-chain wallets, browser-based funding | `privy-agent-wallets login` |
+| AgentCash | 300+ pre-priced APIs via one USDC.e balance | `npx agentcash onboard` |
+| `mppx` | Dev + debugging, smallest dep surface | `npm install -g mppx` then `mppx account create` |
+
+Default: if the user already has Stripe Link configured or the 402 challenge specifies `method="stripe"`, use `link-cli mpp pay` (the `stripe-link-cli` skill). Otherwise `mppx` for one-off paid calls and debugging, and Tempo Wallet when the user wants persistent spend controls.
+
+## Prerequisites
+
+- Node.js 20+ on `PATH`
+- A funded wallet (Tempo / Privy / AgentCash) OR an `mppx` account
+- For Tempo / Privy / AgentCash: follow their respective onboarding skills:
+  - `https://tempo.xyz/SKILL.md`
+  - `https://agents.privy.io/skill.md`
+  - `https://agentcash.dev/skill.md`
+
+Use `web_extract` to fetch any of those SKILL.md files if the user picks one.
+
+## Procedure (mppx, fastest path)
+
+Run all commands through the `terminal` tool.
+
+### 1. Install + create an account
+
+```
+npm install -g mppx
+mppx account create
+```
+
+Store the resulting account credentials wherever the CLI tells you (the CLI writes them under its own config — do not paste them into the agent transcript).
+
+### 2. Inspect the merchant's 402 challenge
+
+If the user gives you a URL, probe it first to confirm it actually speaks MPP:
+
+```
+curl -i <url>
+```
+
+A real MPP 402 looks like:
+
+```
+HTTP/1.1 402 Payment Required
+www-authenticate: tempo amount=0.1 currency=...
+```
+
+### 3. Pay the request
+
+```
+mppx <url>
+```
+
+For non-GET methods or request bodies:
+
+```
+mppx <url> --method POST --data '<json>'
+```
+
+`mppx` handles the 402 challenge/credential dance automatically and prints the merchant's actual response on success.
+
+### 4. Verify the receipt
+
+`mppx` attaches the receipt header automatically. To inspect:
+
+```
+mppx <url> -v
+```
+
+## Procedure (Tempo Wallet)
+
+The Tempo Wallet skill at https://tempo.xyz/SKILL.md is the canonical reference; fetch it with `web_extract` and follow it. Headline:
+
+```
+tempo wallet login
+tempo wallet pay <url>
+```
+
+Spend controls and service discovery live in the wallet UI at https://wallet.tempo.xyz.
+
+## Pitfalls
+
+- **`HTTP 402` without `method="stripe"` cannot be paid by Stripe Link.** If the challenge advertises only Tempo / other methods, use `mppx` (or whichever wallet matches) — Link will reject it. Conversely, if it advertises `method="stripe"`, prefer Link via the `stripe-link-cli` skill so the spend goes through the user's approved card.
+- **Multiple challenges in one header.** `www-authenticate` may list several methods (e.g. `tempo, stripe`). The Link CLI's `mpp decode` will pick the Stripe one; `mppx` will pick Tempo. There's no single "right" client — pick by which wallet the user has funded.
+- **Zero-amount challenges.** Some MPP endpoints charge `$0.00` and just want a proof credential. These work without a funded wallet. Don't refuse them as "broken."
+- **Wallet keys never enter agent context.** All four clients store keys under their own config dirs (or generate per-session ephemeral keypairs, in Privy's case). Do not `cat`/`read_file` them.
+- **Server-side MPP is a different skill.** If the user wants to ADD 402 to their own API, this skill is wrong — point them at https://mpp.dev/quickstart/server and the `mppx/nextjs` / `mppx/hono` / `mppx/express` / `mppx/elysia` middlewares. A dedicated `mpp-server` skill may land later.
+
+## Verification
+
+```
+mppx --version && mppx account list
+```
+
+Exit code 0 means installed and an account exists.

--- a/website/docs/user-guide/skills/optional/payments/payments-stripe-link-cli.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-stripe-link-cli.md
@@ -1,0 +1,202 @@
+---
+title: "Stripe Link Cli — Agent payments via Stripe Link — cards, SPT, approvals"
+sidebar_label: "Stripe Link Cli"
+description: "Agent payments via Stripe Link — cards, SPT, approvals"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Stripe Link Cli
+
+Agent payments via Stripe Link — cards, SPT, approvals.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/payments/stripe-link-cli` |
+| Path | `optional-skills/payments/stripe-link-cli` |
+| Version | `0.1.0` |
+| Author | Teknium (teknium1), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Payments`, `Stripe`, `Link`, `Checkout`, `MPP` |
+| Related skills | [`mpp-agent`](/docs/user-guide/skills/optional/payments/payments-mpp-agent), [`stripe-projects`](/docs/user-guide/skills/optional/payments/payments-stripe-projects) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Stripe Link CLI Skill
+
+Wraps [@stripe/link-cli](https://github.com/stripe/link-cli) so Hermes can complete purchases on the user's behalf using one-time-use virtual cards or Shared Payment Tokens (SPT). Every spend is gated by an in-app approval in the Link mobile/web app — Hermes cannot self-approve.
+
+US-only at the moment (Link account requirement). Windows is not supported by the upstream CLI — this skill is gated `[linux, macos]`.
+
+## When to Use
+
+Trigger phrases:
+
+- "buy X", "pay for X", "make a purchase", "complete checkout"
+- "get me a card", "I need a payment method"
+- "log in to Link", "connect my Link wallet"
+- HTTP 402 response from a merchant API with `www-authenticate: ... method="stripe"`
+
+If the user wants a paid API call (HTTP 402, no checkout form), the `card` path is wrong — use SPT via this same skill, or hand off to the `mpp-agent` skill.
+
+## Prerequisites
+
+- Node.js 20+ available on `PATH` (`node --version`)
+- US-based (Link account requirement)
+
+The Link account, payment method, and spend-approval app do NOT need to be set up before Hermes attempts to pay — the CLI walks the user through them on first run:
+
+- A Link account at https://app.link.com — created/linked during first `link-cli` auth
+- At least one payment method — added during first run at https://app.link.com/wallet
+- The Link mobile/web app — opened to approve the first spend request when it's made
+
+No env vars required — auth state is stored locally by the CLI under its own config directory.
+
+## Install
+
+Install once, globally:
+
+```
+npm install -g @stripe/link-cli
+```
+
+Or invoke ad-hoc via `npx @stripe/link-cli`. The skill below uses the installed `link-cli` form.
+
+## How to Run
+
+All commands run through the `terminal` tool. The CLI auto-detects non-TTY callers and emits compact `toon` output by default — fine for the model. Pass `--format json` if a step needs structured fields.
+
+Discover commands: `link-cli --llms-full`.
+Get a command's schema before invoking: `link-cli <command> --schema`.
+
+## Procedure
+
+### 1. Check / establish auth
+
+```
+link-cli auth status
+```
+
+If not authenticated, log in with a clear client name (this label shows in the user's Link app):
+
+```
+link-cli auth login --client-name "Hermes" --interval 5 --timeout 300
+```
+
+The `--interval`/`--timeout` form polls inline so the agent doesn't need to manage a `_next` step. Print the verification URL + phrase to the user and wait for the CLI to return.
+
+**Do not proceed past this step until `auth status` confirms login.**
+
+### 2. Evaluate the merchant before creating a spend request
+
+Decide the credential type:
+
+| Merchant surface | `--credential-type` |
+|---|---|
+| Standard web checkout form / Stripe Elements | `card` (default) |
+| Returns HTTP 402 with `method="stripe"` in `www-authenticate` | `shared_payment_token` |
+| Returns HTTP 402 without `method="stripe"` | unsupported — stop |
+
+For 402 responses, do NOT decode the challenge manually. Pass the raw header:
+
+```
+link-cli mpp decode --challenge '<full WWW-Authenticate header>'
+```
+
+This validates the challenge and extracts the network ID + decoded request body.
+
+### 3. List payment methods + shipping
+
+```
+link-cli payment-methods list
+link-cli shipping-address list
+```
+
+Use the first entry unless the user specifies otherwise. The `id` from `payment-methods list` is the `--payment-method-id` in the next step.
+
+### 4. Create the spend request
+
+Confirm the final total with the user before issuing this command. Amounts are in cents.
+
+```
+link-cli spend-request create \
+  --payment-method-id <pm_id> \
+  --merchant-name "<name>" \
+  --merchant-url "<url>" \
+  --context "<one sentence: what is being purchased and why>" \
+  --amount <cents> \
+  --line-item "name:<item>,unit_amount:<cents>,quantity:1" \
+  --total "type:total,display_text:Total,amount:<cents>" \
+  --request-approval
+```
+
+For MPP merchants add `--credential-type shared_payment_token`.
+
+`--request-approval` pings the user's Link app and polls until they approve or deny. The CLI exits non-zero on deny / timeout.
+
+### 5. Retrieve the credential — SECURELY
+
+**Do not print card details to stdout.** Use `--output-file` so the PAN never enters the agent's transcript or logs:
+
+```
+link-cli spend-request retrieve <lsrq_id> \
+  --include card \
+  --output-file /tmp/link-card.json \
+  --format json
+```
+
+The file is written with `0600` perms; stdout shows only redacted fields (brand, last4, expiry) plus a `card_output_file` path.
+
+### 6. Use the credential
+
+- For web checkout: hand the file path to the user, OR pass it to a browser-driving tool that fills the form directly from disk. Never `read_file` or `cat` the card file into the agent's reasoning context.
+- For MPP merchants:
+
+  ```
+  link-cli mpp pay <merchant-url> \
+    --spend-request-id <lsrq_id> \
+    --method POST \
+    --data '<json body>'
+  ```
+
+### 7. Clean up
+
+Delete the card file as soon as the purchase is done:
+
+```
+rm -f /tmp/link-card.json
+```
+
+## Optional: run as an MCP server instead
+
+`@stripe/link-cli --mcp` exposes the same commands as MCP tools over stdio. To register it with Hermes' native MCP:
+
+```
+hermes mcp add stripe-link --command "npx" --args "@stripe/link-cli --mcp"
+```
+
+Then `hermes mcp list` should show `stripe-link`. The same approval rules apply — MCP doesn't bypass the Link app approval step.
+
+## Pitfalls
+
+- **US-only.** Outside the US, `auth login` will fail. Tell the user, don't keep retrying.
+- **Card PAN must never enter agent context.** Use `--output-file` every time. If you've already retrieved without it, immediately `link-cli auth logout` is not enough — the card is one-time-use but rotate hygiene matters.
+- **`--request-approval` blocks until the user acts.** If the user is asleep, the CLI will hit its timeout. Set expectations.
+- **Multi-step `_next` commands.** Some commands return `_next.command` that must be executed to continue. When in doubt, prefer the inline-polling flags (`--interval`/`--timeout`).
+- **Output format defaults to `toon`** in non-TTY mode. Fine for prose, but if a downstream step needs to parse a specific field, pass `--format json`.
+- **Don't default to `card`.** The merchant-evaluation step (Section 2) exists because picking the wrong credential type fails the purchase silently or leaks more data than needed.
+
+## Verification
+
+```
+link-cli --version && link-cli auth status
+```
+
+Exit code 0 means installed and logged in.

--- a/website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-stripe-projects.md
@@ -1,0 +1,138 @@
+---
+title: "Stripe Projects — Provision SaaS services + sync creds via Stripe Projects"
+sidebar_label: "Stripe Projects"
+description: "Provision SaaS services + sync creds via Stripe Projects"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Stripe Projects
+
+Provision SaaS services + sync creds via Stripe Projects.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/payments/stripe-projects` |
+| Path | `optional-skills/payments/stripe-projects` |
+| Version | `0.1.0` |
+| Author | Teknium (teknium1), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Payments`, `Stripe`, `Projects`, `Provisioning`, `Infrastructure` |
+| Related skills | [`stripe-link-cli`](/docs/user-guide/skills/optional/payments/payments-stripe-link-cli), [`mpp-agent`](/docs/user-guide/skills/optional/payments/payments-mpp-agent) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Stripe Projects Skill
+
+Wraps the [Stripe Projects](https://projects.dev) CLI plugin so Hermes can provision SaaS services (Neon, Twilio, Vercel, etc.), generate and sync credentials into the user's `.env`, and manage billing across providers from one place.
+
+Gated `[linux, macos]` while the broader payments cluster matures on Windows. The Stripe CLI itself is cross-platform; this gate is a posture for the cluster, not a hard limit.
+
+## When to Use
+
+Trigger phrases:
+
+- "set up &lt;provider>", "provision &lt;Neon|Twilio|Vercel|...>", "create a database"
+- "give me a &lt;Postgres|Redis|Twilio number|...> for this project"
+- "manage my stack credentials", "rotate this key", "upgrade my plan"
+- "what providers can I add?"
+
+If the user already has the service set up manually and just wants to use it, this skill is not the right entry point.
+
+## Prerequisites
+
+- Stripe CLI installed (Homebrew on macOS, package manager on Linux, or download from https://docs.stripe.com/stripe-cli/install)
+- Stripe Projects plugin installed
+- A Stripe account, logged in via `stripe login`
+
+## Install
+
+macOS:
+
+```
+brew install stripe/stripe-cli/stripe
+stripe plugin install projects
+```
+
+Linux: follow the platform-specific install at https://docs.stripe.com/stripe-cli/install, then:
+
+```
+stripe plugin install projects
+```
+
+## How to Run
+
+All commands run through the `terminal` tool from inside the user's project directory (the CLI writes `.env` and `.projects/vault/vault.json` into the CWD).
+
+## Procedure
+
+### 1. Initialize the project
+
+```
+cd <project-root>
+stripe projects init
+```
+
+This creates `.projects/vault/vault.json` (encrypted credential store) and prepares the project to receive providers.
+
+### 2. Discover available providers
+
+```
+stripe projects catalog
+```
+
+Lists every provider Stripe Projects supports — databases, hosting, auth, AI, analytics, messaging, etc.
+
+### 3. Add a service
+
+```
+stripe projects add <provider>/<service>
+```
+
+Examples:
+
+- `stripe projects add neon/postgres`
+- `stripe projects add twilio/sms`
+- `stripe projects add runloop/sandbox`
+
+The CLI provisions the service in the user's own account with the provider, generates credentials, syncs them into `.env`, and records the resource in the vault. The user may need to confirm a tier selection or pricing prompt.
+
+### 4. Verify
+
+```
+stripe projects list
+```
+
+Should show the newly added provider and its `.env` keys.
+
+### 5. Manage / upgrade / remove
+
+```
+stripe projects upgrade <provider>     # tier change
+stripe projects remove <provider>      # deprovision
+stripe projects rotate <provider>      # rotate credentials
+```
+
+## Pitfalls
+
+- **`.env` writes are real writes.** The CLI appends to whatever `.env` is in the project root. If the user's `.env` is gitignored (normal), the keys land safely; if not, this skill could be a credential-leak vector. Always check `.gitignore` first.
+- **Per-project state.** `.projects/vault/vault.json` is per-project. Provisioning the same service in two different projects creates two separate resources — and two bills.
+- **Billing happens on Stripe's side.** Tier prompts during `add`/`upgrade` are real charges; surface them to the user before confirming.
+- **Provider availability changes.** The catalog grows; if a provider the user names isn't listed, `stripe projects catalog | grep <name>` first instead of failing the `add` call.
+- **Credentials in vault are encrypted but `.env` is plaintext.** Standard `.env` hygiene applies — never commit it.
+- **Removing a service does NOT always destroy the underlying resource.** Some providers leave a paused/dormant resource behind. Check the provider's own dashboard after `remove` for high-cost services (managed databases especially).
+
+## Verification
+
+```
+stripe projects --version && stripe projects list
+```
+
+Exit code 0 inside an initialized project means the plugin is healthy.


### PR DESCRIPTION
## Summary
- add optional payments skills and generated docs/catalog entries
- preserve source threads across gateway replies/deferred messages, Mattermost thread roots, and Telegram rich final/edit delivery
- add async delegate_task(background=true) dispatch and disk cleanup protected-tree pruning
- update upstream queue artifacts from pending=32 to pending=21 with batch triage notes

## Local verification
- cargo fmt --all --check
- cargo check -p hermes-core -p hermes-gateway -p hermes-agent -p hermes-tools -p hermes-http -p hermes-cli
- cargo test -p hermes-gateway gateway_replies_and_deferred_messages_preserve_source_thread -- --nocapture
- cargo test -p hermes-gateway --features mattermost platforms::mattermost::tests -- --nocapture
- cargo test -p hermes-gateway --features telegram telegram_rich -- --nocapture
- cargo test -p hermes-tools delegate_task -- --nocapture
- cargo test -p hermes-tools quick_ -- --nocapture
- cargo test -p hermes-tools signal_delegation_backend -- --nocapture
- cargo test -p hermes-agent background_request_dispatches_handle_and_emits_completion_callback -- --nocapture
- cargo test -p hermes-gateway gateway_deferred_post_delivery_messages_flush_after_main_reply -- --nocapture
- scripts/check-runtime-placeholders.sh
- cargo test -p hermes-parity-tests --test global_parity_governance -- --nocapture

## Known local gate note
- python3 scripts/generate-global-parity-proof.py --check-ci regenerated proof artifacts but exits non-zero on existing tree-drift thresholds: max_commits_behind=5880 > 5500 and max_upstream_patch_missing=5657 > 5000. Queue pending is under CI threshold: 21 <= 100.