### PR TITLE
fix(nous): preserve strict replay controls

### DIFF
--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -3535,6 +3535,55 @@ mod tests {
     }
 
     #[test]
+    fn test_nous_profile_strict_controls_sanitize_tool_replay_without_leaking_controls() {
+        let provider = GenericProvider::new(
+            "https://inference-api.nousresearch.com/v1",
+            "key",
+            "openai/gpt-5.5",
+        )
+        .with_provider_profile("nous");
+        let messages = vec![
+            Message::assistant_with_tool_calls(
+                None,
+                vec![ToolCall {
+                    id: "call_read".to_string(),
+                    function: FunctionCall {
+                        name: "read_file".to_string(),
+                        arguments: "{\"path\":\"a.txt\"}".to_string(),
+                    },
+                    extra_content: None,
+                }],
+            ),
+            Message::tool_result_with_name("call_read", "read_file", "{\"result\":\"ok\"}"),
+        ];
+
+        let body = provider.chat_request_body(ChatRequestParams {
+            messages: &messages,
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: "openai/gpt-5.5",
+            extra_body: Some(&serde_json::json!({
+                "strict_api": true,
+                "provider_strict": true
+            })),
+            stream: false,
+        });
+
+        assert!(body.get("strict_api").is_none());
+        assert!(body.get("provider_strict").is_none());
+        let tc = &body["messages"][0]["tool_calls"][0];
+        assert_eq!(tc["id"], "call_read");
+        assert_eq!(tc["type"], "function");
+        assert_eq!(tc["function"]["name"], "read_file");
+        assert_eq!(tc["function"]["arguments"], "{\"path\":\"a.txt\"}");
+        assert!(tc.get("name").is_none());
+        assert!(tc.get("arguments").is_none());
+        assert_eq!(body["messages"][1]["role"], "tool");
+        assert_eq!(body["messages"][1]["tool_call_id"], "call_read");
+    }
+
+    #[test]
     fn test_sanitize_messages_for_api_decodes_acp_multimodal_user_parts_for_vision_models() {
         let parts = serde_json::json!([
             {"type": "text", "text": "inspect"},

--- a/crates/hermes-agent/src/providers_extra.rs
+++ b/crates/hermes-agent/src/providers_extra.rs
@@ -21,9 +21,6 @@ fn openrouter_compatible_extra_body(extra_body: Option<&Value>) -> Option<Value>
     };
 
     let mut cleaned = map.clone();
-    cleaned.remove("strict_tool_calls");
-    cleaned.remove("strict_api");
-    cleaned.remove("provider_strict");
 
     // Nous' inference API is OpenRouter-compatible. Use the documented
     // cross-provider reasoning object instead of leaking provider-specific or
@@ -497,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn nous_extra_body_uses_openrouter_reasoning_shape_and_strips_local_controls() {
+    fn nous_extra_body_uses_openrouter_reasoning_shape_and_preserves_local_controls() {
         let extra = serde_json::json!({
             "strict_api": true,
             "provider_strict": true,
@@ -505,8 +502,8 @@ mod tests {
             "temperature": 0.1
         });
         let cleaned = openrouter_compatible_extra_body(Some(&extra)).expect("cleaned body");
-        assert!(cleaned.get("strict_api").is_none());
-        assert!(cleaned.get("provider_strict").is_none());
+        assert_eq!(cleaned["strict_api"], true);
+        assert_eq!(cleaned["provider_strict"], true);
         assert!(cleaned.get("reasoning_effort").is_none());
         assert_eq!(cleaned["reasoning"]["effort"], "xhigh");
         assert_eq!(cleaned["temperature"], 0.1);


### PR DESCRIPTION
## Summary
- Preserve local strict replay controls through Nous extra-body normalization so GenericProvider can sanitize assistant tool calls for OpenAI-compatible APIs.
- Keep strict/provider control keys out of the final HTTP body while replaying tool calls in standard Chat Completions shape.
- Add regression coverage for Nous tool-call replay and the extra-body wrapper contract.

## Local verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-cli --bin hermes-ultra --bin hermes-agent-ultra
- upstream live: hermes -z sentinel read_file prompt -> HERMES_BEHAVIOR_SENTINEL_2026_06_19
- ultra live: hermes-ultra -z sentinel read_file prompt -> HERMES_BEHAVIOR_SENTINEL_2026_06_19