### PR TITLE
Tighten research focus and MCP status

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -256,6 +256,7 @@ const FINALIZER_OUTPUT_QUALITY_MAX_RETRIES: u32 = 2;
 const FINALIZER_ACTION_EXECUTION_MAX_RETRIES: u32 = 2;
 const FINALIZER_WEB_RESEARCH_MAX_RETRIES: u32 = 4;
 const FINALIZER_GOOGLE_WORKSPACE_MAX_RETRIES: u32 = 2;
+const FINALIZER_TASK_FOCUS_MAX_RETRIES: u32 = 2;
 
 // Python `AIAgent._MEMORY_REVIEW_PROMPT` / `_SKILL_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT` (v2026.4.13)
 const MEMORY_REVIEW_PROMPT: &str = "Review the conversation above and consider saving to memory if appropriate.\n\n\
@@ -5272,6 +5273,7 @@ impl AgentLoop {
         let mut finalizer_action_execution_retries: u32 = 0;
         let mut finalizer_web_research_retries: u32 = 0;
         let mut finalizer_google_workspace_retries: u32 = 0;
+        let mut finalizer_task_focus_retries: u32 = 0;
         let governor_window_limit = governor_window_size();
 
         loop {
@@ -5750,6 +5752,24 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                if finalizer_task_focus_requires_retry(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    finalizer_task_focus_retries,
+                ) {
+                    finalizer_task_focus_retries = finalizer_task_focus_retries.saturating_add(1);
+                    self.emit_status(
+                        "lifecycle",
+                        "Detected final answer drift from explicit user anchors; forcing focused rewrite.",
+                    );
+                    ctx.add_message(Message::system(
+                        "[SYSTEM] Task-focus contract: the final answer must stay anchored to the user's explicit task nouns, paths, accounts, URLs, or identifiers. If an anchor is unverified, mark it UNPROVEN or BLOCKED instead of switching topics.",
+                    ));
+                    ctx.add_message(Message::user(
+                        "Re-issue the final response now, anchored to the explicit user task and verified evidence.",
+                    ));
+                    continue;
+                }
                 if finalizer_claim_requires_evidence_retry(
                     ctx.get_messages(),
                     assistant_msg.content.as_deref().unwrap_or_default(),
@@ -5820,6 +5840,7 @@ impl AgentLoop {
                 finalizer_action_execution_retries = 0;
                 finalizer_web_research_retries = 0;
                 finalizer_google_workspace_retries = 0;
+                finalizer_task_focus_retries = 0;
                 let (objective_guard_active, requires_analytics, deep_audit_required) =
                     objective_guard_policy(ctx.get_messages());
                 if objective_guard_active {
@@ -6577,6 +6598,7 @@ impl AgentLoop {
         let mut finalizer_action_execution_retries: u32 = 0;
         let mut finalizer_web_research_retries: u32 = 0;
         let mut finalizer_google_workspace_retries: u32 = 0;
+        let mut finalizer_task_focus_retries: u32 = 0;
         let governor_window_limit = governor_window_size();
 
         loop {
@@ -7128,6 +7150,24 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                if finalizer_task_focus_requires_retry(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    finalizer_task_focus_retries,
+                ) {
+                    finalizer_task_focus_retries = finalizer_task_focus_retries.saturating_add(1);
+                    self.emit_status(
+                        "lifecycle",
+                        "Detected final answer drift from explicit user anchors; forcing focused rewrite.",
+                    );
+                    ctx.add_message(Message::system(
+                        "[SYSTEM] Task-focus contract: the final answer must stay anchored to the user's explicit task nouns, paths, accounts, URLs, or identifiers. If an anchor is unverified, mark it UNPROVEN or BLOCKED instead of switching topics.",
+                    ));
+                    ctx.add_message(Message::user(
+                        "Re-issue the final response now, anchored to the explicit user task and verified evidence.",
+                    ));
+                    continue;
+                }
                 if finalizer_claim_requires_evidence_retry(
                     ctx.get_messages(),
                     assistant_msg.content.as_deref().unwrap_or_default(),
@@ -7198,6 +7238,7 @@ impl AgentLoop {
                 finalizer_action_execution_retries = 0;
                 finalizer_web_research_retries = 0;
                 finalizer_google_workspace_retries = 0;
+                finalizer_task_focus_retries = 0;
                 let (objective_guard_active, requires_analytics, deep_audit_required) =
                     objective_guard_policy(ctx.get_messages());
                 if objective_guard_active {
@@ -8989,12 +9030,12 @@ fn web_research_system_hint(messages: &[Message], tool_schemas: &[ToolSchema]) -
         .iter()
         .any(|t| matches!(t.name.as_str(), "web_search" | "web_extract" | "web_crawl"));
     let availability = if has_web_tool {
-        "Use `web_search` first, then `web_extract` for the highest-value results when detail matters."
+        "Use `web_search` first, then `web_extract` for the highest-value primary, official, repository, or expert-community sources before final synthesis."
     } else {
         "No web tools are advertised in this session; report that exact blocker instead of inventing sources."
     };
     Some(format!(
-        "[SYSTEM] Web research contract active. {availability} Final answer requirements: include `WEB_SEARCH_USED: yes` only after a web tool succeeds, cite concrete http(s) URLs copied from web tool results, and separate observed source evidence from speculation. For web evidence use `url=<http(s) URL>` or raw URLs; do not substitute local `file=` evidence for web sources. If every web tool call fails or no web tool is available, write `WEB_SEARCH_USED: no` with the exact blocker."
+        "[SYSTEM] Web research contract active. {availability} Final answer requirements: include `WEB_SEARCH_USED: yes` only after a web tool succeeds, cite concrete http(s) URLs copied from web tool results, include `SOURCE_QUALITY: primary=<n> community=<n> secondary=<n>`, and separate observed source evidence from speculation. For web evidence use `url=<http(s) URL>` or raw URLs; do not substitute local `file=` evidence for web sources. If every web tool call fails or no web tool is available, write `WEB_SEARCH_USED: no` with the exact blocker."
     ))
 }
 
@@ -9239,6 +9280,17 @@ fn history_includes_web_tool(messages: &[Message]) -> bool {
     })
 }
 
+fn history_includes_web_extract_or_crawl(messages: &[Message]) -> bool {
+    messages.iter().any(|m| {
+        if !matches!(m.role, MessageRole::Tool) {
+            return false;
+        }
+        m.name
+            .as_deref()
+            .is_some_and(|name| matches!(name, "web_extract" | "web_crawl"))
+    })
+}
+
 fn count_http_urls(text: &str) -> usize {
     text.split_whitespace()
         .filter(|token| token.starts_with("http://") || token.starts_with("https://"))
@@ -9247,13 +9299,45 @@ fn count_http_urls(text: &str) -> usize {
         .len()
 }
 
+fn parse_source_quality_counts(text: &str) -> Option<(u32, u32, u32)> {
+    let lower = text.to_ascii_lowercase();
+    let idx = lower.find("source_quality")?;
+    let tail = &lower[idx..];
+    fn marker_count(tail: &str, marker: &str) -> u32 {
+        tail.split(marker)
+            .nth(1)
+            .and_then(|rest| {
+                rest.trim_start_matches([' ', ':', '='])
+                    .chars()
+                    .take_while(|ch| ch.is_ascii_digit())
+                    .collect::<String>()
+                    .parse::<u32>()
+                    .ok()
+            })
+            .unwrap_or(0)
+    }
+    Some((
+        marker_count(tail, "primary"),
+        marker_count(tail, "community"),
+        marker_count(tail, "secondary"),
+    ))
+}
+
+fn has_sufficient_source_quality(text: &str) -> bool {
+    let Some((primary, community, secondary)) = parse_source_quality_counts(text) else {
+        return false;
+    };
+    primary > 0 || community >= 2 || (primary + community + secondary >= 3 && community > 0)
+}
+
 fn web_research_retry_prompt() -> &'static str {
     "[SYSTEM] Web research contract failed. This request explicitly requires online research.\n\
      Requirements now:\n\
      - call `web_search` with targeted queries before answering\n\
-     - optionally call `web_extract` on the best primary/community sources\n\
+     - call `web_extract` or `web_crawl` on at least one highest-value primary, official, repository, or expert-community source\n\
      - final answer must include the exact line `WEB_SEARCH_USED: yes` after successful web tooling\n\
      - cite at least two concrete http(s) URLs copied from web tool results\n\
+     - include `SOURCE_QUALITY: primary=<n> community=<n> secondary=<n>` and prefer primary/community evidence over generic SEO summaries\n\
      - for each web finding, include `url=<http(s) URL>` or the raw URL; do not use local `file=` evidence as a substitute\n\
      - separate observed evidence from speculation\n\
      If web tooling is unavailable or errors, final answer must include `WEB_SEARCH_USED: no` and the exact tool error/blocker."
@@ -9276,8 +9360,84 @@ fn finalizer_web_research_requires_retry(
         return false;
     }
     !(history_includes_web_tool(messages)
+        && history_includes_web_extract_or_crawl(messages)
         && has_success_line
-        && count_http_urls(assistant_text) >= 2)
+        && count_http_urls(assistant_text) >= 2
+        && has_sufficient_source_quality(assistant_text))
+}
+
+fn explicit_task_anchors(messages: &[Message]) -> Vec<String> {
+    let Some(user) = latest_user_content(messages) else {
+        return Vec::new();
+    };
+    let mut anchors = Vec::new();
+    for raw in user.split_whitespace() {
+        let token = raw
+            .trim()
+            .trim_matches(|ch: char| {
+                matches!(
+                    ch,
+                    '`' | '"' | '\'' | ',' | ';' | ':' | '.' | '(' | ')' | '[' | ']' | '{' | '}'
+                )
+            })
+            .trim_start_matches('#');
+        if token.len() < 4 {
+            continue;
+        }
+        let token_lc = token.to_ascii_lowercase();
+        let explicit = token.contains('@')
+            || token.starts_with('/')
+            || token.starts_with("http://")
+            || token.starts_with("https://")
+            || token.contains(".rs")
+            || token.contains(".py")
+            || token.contains('_')
+            || token.contains('-')
+            || token.contains('/')
+            || token_lc.contains("gmail")
+            || token_lc.contains("google")
+            || token_lc.contains("solana")
+            || token_lc.contains("telegram")
+            || token_lc.contains("contextlattice")
+            || token_lc.contains("algotrader")
+            || token_lc.contains("hermes");
+        if explicit {
+            anchors.push(token_lc);
+        }
+    }
+    anchors.sort();
+    anchors.dedup();
+    anchors.truncate(12);
+    anchors
+}
+
+fn finalizer_task_focus_requires_retry(
+    messages: &[Message],
+    assistant_text: &str,
+    retry_count: u32,
+) -> bool {
+    if retry_count >= FINALIZER_TASK_FOCUS_MAX_RETRIES {
+        return false;
+    }
+    if assistant_text.trim().is_empty() {
+        return false;
+    }
+    let anchors = explicit_task_anchors(messages);
+    if anchors.is_empty() {
+        return false;
+    }
+    let lower = assistant_text.to_ascii_lowercase();
+    if lower.contains("blocked")
+        || lower.contains("unproven")
+        || lower.contains("cannot verify")
+        || lower.contains("not authenticated")
+    {
+        return false;
+    }
+    anchors
+        .iter()
+        .take(8)
+        .all(|anchor| !lower.contains(anchor.as_str()))
 }
 
 fn detect_deep_repo_audit_intent(messages: &[Message]) -> bool {
@@ -16248,8 +16408,42 @@ mod tests {
             "web_search",
             r#"{"results":[{"url":"https://docs.jito.wtf/lowlatencytxnsend/"}]}"#,
         ));
-        let answer = "WEB_SEARCH_USED: yes\nObserved:\n- https://docs.jito.wtf/lowlatencytxnsend/\n- https://www.helius.dev/blog/solana-local-fee-markets";
+        let search_only_answer = "WEB_SEARCH_USED: yes\nSOURCE_QUALITY: primary=1 community=1 secondary=0\nObserved:\n- https://docs.jito.wtf/lowlatencytxnsend/\n- https://www.helius.dev/blog/solana-local-fee-markets";
+        assert!(finalizer_web_research_requires_retry(
+            &grounded,
+            search_only_answer,
+            0
+        ));
+        grounded.push(Message::tool_result_with_name(
+            "web2",
+            "web_extract",
+            "Extracted Jito low-latency transaction send docs.",
+        ));
+        let answer = "WEB_SEARCH_USED: yes\nSOURCE_QUALITY: primary=1 community=1 secondary=0\nObserved:\n- https://docs.jito.wtf/lowlatencytxnsend/\n- https://www.helius.dev/blog/solana-local-fee-markets";
         assert!(!finalizer_web_research_requires_retry(&grounded, answer, 0));
+    }
+
+    #[test]
+    fn test_web_research_finalizer_requires_source_quality_counts() {
+        let mut msgs = vec![Message::user(
+            "Search the web for Solana trading strategies and cite concrete URLs.",
+        )];
+        msgs.push(Message::tool_result_with_name(
+            "web1",
+            "web_search",
+            r#"{"results":[{"url":"https://docs.jito.wtf/lowlatencytxnsend/"}]}"#,
+        ));
+        msgs.push(Message::tool_result_with_name(
+            "web2",
+            "web_extract",
+            "Extracted source",
+        ));
+        let missing_quality = "WEB_SEARCH_USED: yes\n- https://docs.jito.wtf/lowlatencytxnsend/\n- https://www.helius.dev/blog/solana-local-fee-markets";
+        assert!(finalizer_web_research_requires_retry(
+            &msgs,
+            missing_quality,
+            0
+        ));
     }
 
     #[test]
@@ -16265,6 +16459,24 @@ mod tests {
         let hint = web_research_system_hint(&msgs, &tools).expect("web hint");
         assert!(hint.contains("Web research contract active"));
         assert!(hint.contains("web_search"));
+        assert!(hint.contains("SOURCE_QUALITY"));
+    }
+
+    #[test]
+    fn test_task_focus_finalizer_retries_when_explicit_anchors_disappear() {
+        let msgs = vec![Message::user(
+            "Use Gmail to summarize important emails from sheawinkler@gmail.com.",
+        )];
+        assert!(finalizer_task_focus_requires_retry(
+            &msgs,
+            "Here is a generic repository analysis with no email evidence.",
+            0
+        ));
+        assert!(!finalizer_task_focus_requires_retry(
+            &msgs,
+            "Gmail is blocked: not authenticated for sheawinkler@gmail.com.",
+            0
+        ));
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -14724,31 +14724,118 @@ fn handle_disk_cleanup_command(app: &mut App, args: &[&str]) -> Result<CommandRe
     Ok(CommandResult::Handled)
 }
 
-fn handle_mcp_command(app: &mut App) -> Result<CommandResult, AgentError> {
-    if app.config.mcp_servers.is_empty() {
-        emit_command_output(app, "No MCP servers configured in `config.yaml`.");
-        return Ok(CommandResult::Handled);
+fn render_mcp_runtime_status(
+    yaml_servers: &[hermes_config::McpServerEntry],
+    json_config: Option<&crate::mcp_config::McpConfig>,
+    json_path: &Path,
+) -> String {
+    let json_servers = json_config.map(|cfg| cfg.servers.as_slice()).unwrap_or(&[]);
+    let mut names = HashSet::new();
+    for server in yaml_servers {
+        names.insert(server.name.clone());
     }
-    let mut out = String::from("Configured MCP servers:\n");
-    for server in &app.config.mcp_servers {
-        let endpoint = server
-            .url
-            .as_deref()
-            .filter(|u| !u.is_empty())
-            .unwrap_or("<stdio>");
-        let _ = writeln!(
-            out,
-            "  - {:<18} {}  [parallel_tool_calls:{}]",
-            server.name,
-            endpoint,
-            if server.supports_parallel_tool_calls {
-                "on"
-            } else {
-                "off"
-            }
+    for server in json_servers {
+        names.insert(server.name.clone());
+    }
+
+    if names.is_empty() {
+        return format!(
+            "No MCP servers configured.\n  config.yaml entries: 0\n  mcp_servers.json: {} ({})\nAdd one with `hermes mcp add <name> --url <url>` or `hermes mcp add <name> --command <cmd>`.",
+            if json_path.exists() { "present" } else { "missing" },
+            json_path.display()
         );
     }
-    emit_command_output(app, out.trim_end());
+
+    let mut out = String::new();
+    let _ = writeln!(out, "MCP runtime status");
+    let _ = writeln!(out, "  config.yaml entries: {}", yaml_servers.len());
+    let _ = writeln!(
+        out,
+        "  mcp_servers.json entries: {} ({})",
+        json_servers.len(),
+        json_path.display()
+    );
+
+    if let Some(config) = json_config {
+        for warning in config.warnings() {
+            let _ = writeln!(out, "  warning: {warning}");
+        }
+    }
+
+    let yaml_names: HashSet<_> = yaml_servers
+        .iter()
+        .map(|server| server.name.as_str())
+        .collect();
+    let json_names: HashSet<_> = json_servers
+        .iter()
+        .map(|server| server.name.as_str())
+        .collect();
+    let mut sorted: Vec<_> = names.into_iter().collect();
+    sorted.sort();
+
+    out.push_str("Configured MCP servers:\n");
+    for name in sorted {
+        if let Some(server) = yaml_servers.iter().find(|server| server.name == name) {
+            let endpoint = server
+                .url
+                .as_deref()
+                .filter(|u| !u.is_empty())
+                .or(server.command.as_deref())
+                .unwrap_or("<stdio>");
+            let _ = writeln!(
+                out,
+                "  - {:<18} {}  [source:config.yaml; parallel_tool_calls:{}]",
+                server.name,
+                endpoint,
+                if server.supports_parallel_tool_calls {
+                    "on"
+                } else {
+                    "off"
+                }
+            );
+        }
+        if let Some(server) = json_servers.iter().find(|server| server.name == name) {
+            let _ = writeln!(
+                out,
+                "  - {:<18} {}  [source:mcp_servers.json; {}; enabled:{}; parallel_tool_calls:{}]",
+                server.name,
+                server.transport_display(),
+                server.transport_kind().as_str(),
+                if server.enabled { "on" } else { "off" },
+                if server.supports_parallel_tool_calls {
+                    "on"
+                } else {
+                    "off"
+                }
+            );
+        }
+    }
+
+    let mut yaml_only: Vec<_> = yaml_names.difference(&json_names).copied().collect();
+    let mut json_only: Vec<_> = json_names.difference(&yaml_names).copied().collect();
+    yaml_only.sort();
+    json_only.sort();
+    if !yaml_only.is_empty() || !json_only.is_empty() {
+        let _ = writeln!(
+            out,
+            "Drift: config_only=[{}] json_only=[{}]",
+            yaml_only.join(","),
+            json_only.join(",")
+        );
+    }
+
+    out.trim_end().to_string()
+}
+
+fn handle_mcp_command(app: &mut App) -> Result<CommandResult, AgentError> {
+    let mcp_config_path = app.state_root.join("mcp_servers.json");
+    let json_config = load_mcp_config_if_exists(&mcp_config_path)?;
+    let out = render_mcp_runtime_status(
+        &app.config.mcp_servers,
+        json_config.as_ref(),
+        &mcp_config_path,
+    );
+    emit_command_output(app, out);
     Ok(CommandResult::Handled)
 }
 
@@ -29917,6 +30004,46 @@ mod tests {
         assert!(status.contains("Memory provider: files (MEMORY.md + USER.md)"));
         assert!(status.contains("MEMORY.md"));
         assert!(status.contains("USER.md"));
+    }
+
+    #[test]
+    fn test_render_mcp_runtime_status_includes_json_only_servers() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("mcp_servers.json");
+        std::fs::write(
+            &path,
+            r#"{"contextlattice":{"url":"http://127.0.0.1:8075/mcp","enabled":true,"supports_parallel_tool_calls":true}}"#,
+        )
+        .expect("write mcp json");
+        let cfg = crate::mcp_config::load_mcp_config(&path).expect("load mcp config");
+
+        let status = render_mcp_runtime_status(&[], Some(&cfg), &path);
+        assert!(status.contains("MCP runtime status"));
+        assert!(status.contains("contextlattice"));
+        assert!(status.contains("source:mcp_servers.json"));
+        assert!(status.contains("json_only=[contextlattice]"));
+    }
+
+    #[test]
+    fn test_render_mcp_runtime_status_reports_drift_between_yaml_and_json() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("mcp_servers.json");
+        let cfg = crate::mcp_config::parse_mcp_config_json(
+            r#"{"json-only":{"url":"https://example.com/mcp"}}"#,
+        )
+        .expect("parse mcp config");
+        let yaml = vec![hermes_config::McpServerEntry {
+            name: "yaml-only".to_string(),
+            command: Some("local-mcp".to_string()),
+            url: None,
+            supports_parallel_tool_calls: false,
+        }];
+
+        let status = render_mcp_runtime_status(&yaml, Some(&cfg), &path);
+        assert!(status.contains("yaml-only"));
+        assert!(status.contains("json-only"));
+        assert!(status.contains("config_only=[yaml-only]"));
+        assert!(status.contains("json_only=[json-only]"));
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/tools/web.rs
+++ b/crates/hermes-tools/src/tools/web.rs
@@ -81,7 +81,7 @@ impl ToolHandler for WebSearchHandler {
             "query".into(),
             json!({
                 "type": "string",
-                "description": "The search query"
+                "description": "The search query. Prefer precise queries that target official docs, source repositories, primary data, standards, papers, or high-signal expert/community threads before generic summaries."
             }),
         );
         props.insert(
@@ -100,7 +100,7 @@ impl ToolHandler for WebSearchHandler {
 
         tool_schema(
             "web_search",
-            "Search the web using the configured provider (Exa/Tavily/SearXNG). Returns relevant results with titles, URLs, and snippets.",
+            "Search the web using the configured provider (Exa/Tavily/SearXNG). Returns titles, URLs, and snippets. For research tasks, gather primary/official/repository/community sources first and follow the best results with web_extract when detail matters.",
             JsonSchema::object(props, vec!["query".into()]),
         )
     }
@@ -152,7 +152,7 @@ impl ToolHandler for WebCrawlHandler {
             "instructions".into(),
             json!({
                 "type": "string",
-                "description": "Optional natural-language crawl guidance"
+                "description": "Optional natural-language crawl guidance. Prefer instructions that keep crawl scope on official docs, repositories, standards, papers, or expert/community pages relevant to the claim being verified."
             }),
         );
         props.insert(
@@ -175,7 +175,7 @@ impl ToolHandler for WebCrawlHandler {
 
         tool_schema(
             "web_crawl",
-            "Crawl a seed URL using the configured provider. Returns normalized page documents and per-page errors.",
+            "Crawl a seed URL using the configured provider. Returns normalized page documents and per-page errors. Use for source-grounded research when one high-value source has linked subpages worth verifying.",
             JsonSchema::object(props, vec!["url".into()]),
         )
     }
@@ -218,7 +218,7 @@ impl ToolHandler for WebExtractHandler {
             "url".into(),
             json!({
                 "type": "string",
-                "description": "The URL to extract content from"
+                "description": "The URL to extract content from. Prefer the highest-value primary, official, repository, paper, or expert/community result rather than SEO summaries."
             }),
         );
         props.insert(
@@ -232,7 +232,7 @@ impl ToolHandler for WebExtractHandler {
 
         tool_schema(
             "web_extract",
-            "Extract clean content from a web page using Firecrawl. Returns the page text and optional links.",
+            "Extract clean content from a web page using Firecrawl. Returns page text and optional links; use this to verify details from primary/official/repository/community sources before final synthesis.",
             JsonSchema::object(props, vec!["url".into()]),
         )
     }
@@ -294,6 +294,7 @@ mod tests {
         let schema = handler.schema();
         assert_eq!(schema.name, "web_search");
         assert!(schema.parameters.properties.is_some());
+        assert!(schema.description.contains("primary/official"));
     }
 
     #[tokio::test]
@@ -313,6 +314,7 @@ mod tests {
         let handler = WebExtractHandler::new(Box::new(MockExtractBackend));
         let schema = handler.schema();
         assert_eq!(schema.name, "web_extract");
+        assert!(schema.description.contains("verify details"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Summary:
- require extracted/crawled source evidence and source-quality counts for explicit web research final answers
- add explicit task-anchor drift retry before final answers switch topics
- render /mcp from both config.yaml and mcp_servers.json, including drift diagnostics

Local verification:
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent finalizer
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-tools web_
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli render_mcp_runtime_status
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-cli --bin hermes-ultra --bin hermes-agent-ultra
- /Volumes/wd_black/cargo-targets/debug/hermes-ultra -z "/mcp"
- /Volumes/wd_black/cargo-targets/debug/hermes-ultra -z "/tools"