### PR TITLE
Improve source ranking and repo research planning

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -257,6 +257,10 @@ const FINALIZER_ACTION_EXECUTION_MAX_RETRIES: u32 = 2;
 const FINALIZER_WEB_RESEARCH_MAX_RETRIES: u32 = 4;
 const FINALIZER_GOOGLE_WORKSPACE_MAX_RETRIES: u32 = 2;
 const FINALIZER_TASK_FOCUS_MAX_RETRIES: u32 = 2;
+const FINALIZER_REPO_RESEARCH_PLAN_MAX_RETRIES: u32 = 2;
+const REPO_RESEARCH_MIN_WORKSTREAMS: usize = 3;
+const REPO_RESEARCH_MIN_UNIQUE_FILES: usize = 2;
+const REPO_RESEARCH_MIN_COMMANDS: usize = 2;
 
 // Python `AIAgent._MEMORY_REVIEW_PROMPT` / `_SKILL_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT` (v2026.4.13)
 const MEMORY_REVIEW_PROMPT: &str = "Review the conversation above and consider saving to memory if appropriate.\n\n\
@@ -5274,6 +5278,7 @@ impl AgentLoop {
         let mut finalizer_web_research_retries: u32 = 0;
         let mut finalizer_google_workspace_retries: u32 = 0;
         let mut finalizer_task_focus_retries: u32 = 0;
+        let mut finalizer_repo_research_plan_retries: u32 = 0;
         let governor_window_limit = governor_window_size();
 
         loop {
@@ -5770,6 +5775,23 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                if finalizer_repo_research_plan_requires_retry(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    finalizer_repo_research_plan_retries,
+                ) {
+                    finalizer_repo_research_plan_retries =
+                        finalizer_repo_research_plan_retries.saturating_add(1);
+                    self.emit_status(
+                        "lifecycle",
+                        "Detected shallow repo research synthesis; forcing workstream evidence map.",
+                    );
+                    ctx.add_message(Message::system(repo_research_retry_prompt()));
+                    ctx.add_message(Message::user(
+                        "Re-issue the final response with grounded repo research workstreams now.",
+                    ));
+                    continue;
+                }
                 if finalizer_claim_requires_evidence_retry(
                     ctx.get_messages(),
                     assistant_msg.content.as_deref().unwrap_or_default(),
@@ -5841,6 +5863,7 @@ impl AgentLoop {
                 finalizer_web_research_retries = 0;
                 finalizer_google_workspace_retries = 0;
                 finalizer_task_focus_retries = 0;
+                finalizer_repo_research_plan_retries = 0;
                 let (objective_guard_active, requires_analytics, deep_audit_required) =
                     objective_guard_policy(ctx.get_messages());
                 if objective_guard_active {
@@ -6599,6 +6622,7 @@ impl AgentLoop {
         let mut finalizer_web_research_retries: u32 = 0;
         let mut finalizer_google_workspace_retries: u32 = 0;
         let mut finalizer_task_focus_retries: u32 = 0;
+        let mut finalizer_repo_research_plan_retries: u32 = 0;
         let governor_window_limit = governor_window_size();
 
         loop {
@@ -7168,6 +7192,23 @@ impl AgentLoop {
                     ));
                     continue;
                 }
+                if finalizer_repo_research_plan_requires_retry(
+                    ctx.get_messages(),
+                    assistant_msg.content.as_deref().unwrap_or_default(),
+                    finalizer_repo_research_plan_retries,
+                ) {
+                    finalizer_repo_research_plan_retries =
+                        finalizer_repo_research_plan_retries.saturating_add(1);
+                    self.emit_status(
+                        "lifecycle",
+                        "Detected shallow repo research synthesis; forcing workstream evidence map.",
+                    );
+                    ctx.add_message(Message::system(repo_research_retry_prompt()));
+                    ctx.add_message(Message::user(
+                        "Re-issue the final response with grounded repo research workstreams now.",
+                    ));
+                    continue;
+                }
                 if finalizer_claim_requires_evidence_retry(
                     ctx.get_messages(),
                     assistant_msg.content.as_deref().unwrap_or_default(),
@@ -7239,6 +7280,7 @@ impl AgentLoop {
                 finalizer_web_research_retries = 0;
                 finalizer_google_workspace_retries = 0;
                 finalizer_task_focus_retries = 0;
+                finalizer_repo_research_plan_retries = 0;
                 let (objective_guard_active, requires_analytics, deep_audit_required) =
                     objective_guard_policy(ctx.get_messages());
                 if objective_guard_active {
@@ -8954,9 +8996,9 @@ fn repo_review_tool_profile_mode() -> RepoReviewToolProfileMode {
         .unwrap_or(RepoReviewToolProfileMode::Balanced)
 }
 
-fn exploratory_problem_solving_system_hint(messages: &[Message]) -> Option<String> {
+fn detect_exploratory_repo_research_intent(messages: &[Message]) -> bool {
     if !detect_repo_review_intent(messages) {
-        return None;
+        return false;
     }
     let user = latest_user_content(messages)
         .unwrap_or_default()
@@ -8965,7 +9007,7 @@ fn exploratory_problem_solving_system_hint(messages: &[Message]) -> Option<Strin
         .unwrap_or_default()
         .to_ascii_lowercase();
     let combined = format!("{} {}", user, objective);
-    let exploratory = [
+    [
         "explore",
         "investigate",
         "understand",
@@ -8983,8 +9025,11 @@ fn exploratory_problem_solving_system_hint(messages: &[Message]) -> Option<Strin
         "why",
     ]
     .iter()
-    .any(|needle| combined.contains(needle));
-    if !exploratory {
+    .any(|needle| combined.contains(needle))
+}
+
+fn exploratory_problem_solving_system_hint(messages: &[Message]) -> Option<String> {
+    if !detect_exploratory_repo_research_intent(messages) {
         return None;
     }
     Some(
@@ -8992,7 +9037,8 @@ fn exploratory_problem_solving_system_hint(messages: &[Message]) -> Option<Strin
 1) Start by declaring workstreams (`workstream=<name>`) that cover the full problem surface. \
 2) Run focused evidence collection per workstream (`file=...`, `cmd=...`) rather than repeated broad scans. \
 3) After each evidence batch, update status per workstream (`complete|blocked|unproven`) and refine next probes. \
-4) Do not finalize until high-leverage workstreams are either complete or explicitly blocked with concrete blockers and next actions."
+4) Do not finalize until high-leverage workstreams are either complete or explicitly blocked with concrete blockers and next actions. \
+5) Final synthesis must include `REPO_RESEARCH_PLAN: complete` or `REPO_RESEARCH_PLAN: blocked`, plus `workstream=... status=... file=... cmd=...` evidence lines."
             .to_string(),
     )
 }
@@ -9030,7 +9076,7 @@ fn web_research_system_hint(messages: &[Message], tool_schemas: &[ToolSchema]) -
         .iter()
         .any(|t| matches!(t.name.as_str(), "web_search" | "web_extract" | "web_crawl"));
     let availability = if has_web_tool {
-        "Use `web_search` first, then `web_extract` for the highest-value primary, official, repository, or expert-community sources before final synthesis."
+        "Use `web_search` first, rank candidates by returned `source_quality`/`source_quality_score`, then `web_extract` for the highest-value primary, official, repository, or expert-community sources before final synthesis."
     } else {
         "No web tools are advertised in this session; report that exact blocker instead of inventing sources."
     };
@@ -9334,6 +9380,7 @@ fn web_research_retry_prompt() -> &'static str {
     "[SYSTEM] Web research contract failed. This request explicitly requires online research.\n\
      Requirements now:\n\
      - call `web_search` with targeted queries before answering\n\
+     - use returned `source_quality`/`source_quality_score` metadata to choose sources\n\
      - call `web_extract` or `web_crawl` on at least one highest-value primary, official, repository, or expert-community source\n\
      - final answer must include the exact line `WEB_SEARCH_USED: yes` after successful web tooling\n\
      - cite at least two concrete http(s) URLs copied from web tool results\n\
@@ -9438,6 +9485,88 @@ fn finalizer_task_focus_requires_retry(
         .iter()
         .take(8)
         .all(|anchor| !lower.contains(anchor.as_str()))
+}
+
+fn repo_research_retry_prompt() -> &'static str {
+    "[SYSTEM] Repo research planning contract failed. Before final synthesis, produce a grounded research map.\n\
+     Requirements now:\n\
+     - include `REPO_RESEARCH_PLAN: complete` when covered, or `REPO_RESEARCH_PLAN: blocked` with exact blockers\n\
+     - for complete research, include at least three lines shaped like `workstream=<name> status=<complete|blocked|unproven> file=<existing path> cmd=<probe>`\n\
+     - include at least two distinct `file=`/`path=` evidence markers and two distinct `cmd=`/`command=` probes\n\
+     - include `confidence=<high|medium|low>`\n\
+     - mark uncertain claims as `status=unproven` instead of presenting them as findings."
+}
+
+fn repo_research_workstream_evidence_lines(assistant_text: &str) -> usize {
+    assistant_text
+        .lines()
+        .filter(|line| {
+            let lower = line.to_ascii_lowercase();
+            lower.contains("workstream=")
+                && lower.contains("status=")
+                && (lower.contains("file=") || lower.contains("path="))
+                && (lower.contains("cmd=") || lower.contains("command="))
+        })
+        .count()
+}
+
+fn repo_research_command_count(assistant_text: &str) -> usize {
+    assistant_text
+        .lines()
+        .filter(|line| {
+            let lower = line.to_ascii_lowercase();
+            lower.contains("cmd=") || lower.contains("command=")
+        })
+        .count()
+}
+
+fn finalizer_repo_research_plan_requires_retry(
+    messages: &[Message],
+    assistant_text: &str,
+    retry_count: u32,
+) -> bool {
+    if retry_count >= FINALIZER_REPO_RESEARCH_PLAN_MAX_RETRIES
+        || !detect_exploratory_repo_research_intent(messages)
+    {
+        return false;
+    }
+    if assistant_text.trim().is_empty() {
+        return false;
+    }
+
+    let lower = assistant_text.to_ascii_lowercase();
+    let blocked_or_unproven = lower.contains("repo_research_plan: blocked")
+        || lower.contains("repo_research_plan=blocked")
+        || lower.contains("repo_research_plan: unproven")
+        || lower.contains("repo_research_plan=unproven");
+    if blocked_or_unproven {
+        return !(lower.contains("blocker")
+            && (lower.contains("cmd=")
+                || lower.contains("command=")
+                || lower.contains("file=")
+                || lower.contains("path=")));
+    }
+
+    let complete = lower.contains("repo_research_plan: complete")
+        || lower.contains("repo_research_plan=complete");
+    let has_confidence = lower.contains("confidence=high")
+        || lower.contains("confidence=medium")
+        || lower.contains("confidence=low")
+        || lower.contains("confidence:");
+    if !complete || !has_confidence {
+        return true;
+    }
+
+    if repo_research_workstream_evidence_lines(assistant_text) < REPO_RESEARCH_MIN_WORKSTREAMS {
+        return true;
+    }
+    if extract_explicit_evidence_paths(assistant_text).len() < REPO_RESEARCH_MIN_UNIQUE_FILES {
+        return true;
+    }
+    if repo_research_command_count(assistant_text) < REPO_RESEARCH_MIN_COMMANDS {
+        return true;
+    }
+    assistant_references_missing_evidence_paths(assistant_text)
 }
 
 fn detect_deep_repo_audit_intent(messages: &[Message]) -> bool {
@@ -10071,6 +10200,27 @@ fn tool_result_signal_score(content: &str, is_error: bool) -> f64 {
         || lower.contains("cargo ")
     {
         score += 0.25;
+    }
+    if lower.contains("workstream=") {
+        score += 0.15;
+    }
+    if lower.contains("status=complete")
+        || lower.contains("status=blocked")
+        || lower.contains("status=unproven")
+    {
+        score += 0.10;
+    }
+    let evidence_markers = lower.matches("file=").count()
+        + lower.matches("path=").count()
+        + lower.matches("cmd=").count()
+        + lower.matches("command=").count();
+    if evidence_markers >= 4 {
+        score += 0.15;
+    } else if evidence_markers >= 2 {
+        score += 0.08;
+    }
+    if lower.contains("contextlattice") || lower.contains("source_quality") {
+        score += 0.05;
     }
     if lower.contains("not found")
         || lower.contains("no such file")
@@ -16388,6 +16538,49 @@ mod tests {
             "confidence=high\nfile=src/missing.rs;cmd=rg -n main src/missing.rs",
             tmp.path()
         ));
+    }
+
+    #[test]
+    fn test_repo_research_plan_finalizer_requires_workstream_evidence() {
+        let msgs = vec![Message::user(
+            "Conduct read-only repo research in crates/hermes-agent/src/agent_loop.rs and report how to improve planning.",
+        )];
+        assert!(detect_exploratory_repo_research_intent(&msgs));
+
+        let shallow = "confidence=medium\nfile=Cargo.toml\ncmd=rg -n planning crates";
+        assert!(finalizer_repo_research_plan_requires_retry(
+            &msgs, shallow, 0
+        ));
+
+        let grounded = "REPO_RESEARCH_PLAN: complete\n\
+confidence=medium\n\
+- workstream=web status=complete file=Cargo.toml cmd=rg -n web Cargo.toml\n\
+- workstream=agent-loop status=complete file=src/agent_loop.rs cmd=rg -n finalizer src/agent_loop.rs\n\
+- workstream=tests status=unproven file=Cargo.toml cmd=cargo test -p hermes-agent finalizer";
+        assert!(!finalizer_repo_research_plan_requires_retry(
+            &msgs, grounded, 0
+        ));
+    }
+
+    #[test]
+    fn test_repo_research_plan_finalizer_accepts_explicit_blocker() {
+        let msgs = vec![Message::user(
+            "Research the missing repo path /tmp/does-not-exist and report blockers.",
+        )];
+        let blocked =
+            "REPO_RESEARCH_PLAN: blocked\nblocker=path missing\ncmd=rg --files /tmp/does-not-exist";
+        assert!(!finalizer_repo_research_plan_requires_retry(
+            &msgs, blocked, 0
+        ));
+    }
+
+    #[test]
+    fn test_tool_result_signal_score_rewards_workstream_evidence() {
+        let score = tool_result_signal_score(
+            "workstream=agent status=complete file=Cargo.toml path=crates/hermes-agent/src/agent_loop.rs cmd=rg -n finalizer crates command=cargo test",
+            false,
+        );
+        assert!(score > 0.75, "score={score}");
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/web.rs
+++ b/crates/hermes-tools/src/backends/web.rs
@@ -143,6 +143,225 @@ fn validate_url_does_not_exfiltrate_secret(input: &str) -> Result<(), ToolError>
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct SourceQuality {
+    label: &'static str,
+    score: f64,
+    reason: &'static str,
+}
+
+fn host_matches(host: &str, suffixes: &[&str]) -> bool {
+    suffixes.iter().any(|suffix| {
+        host == *suffix
+            || host
+                .strip_suffix(suffix)
+                .is_some_and(|prefix| prefix.ends_with('.'))
+    })
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn source_quality_for_url(raw_url: &str) -> SourceQuality {
+    let url = raw_url.trim();
+    if url.is_empty() {
+        return SourceQuality {
+            label: "secondary",
+            score: 0.20,
+            reason: "missing URL",
+        };
+    }
+
+    let parsed = Url::parse(url).or_else(|_| Url::parse(&format!("https://{url}")));
+    let Ok(parsed) = parsed else {
+        return SourceQuality {
+            label: "secondary",
+            score: 0.35,
+            reason: "unparseable URL",
+        };
+    };
+    let host = parsed.host_str().unwrap_or_default().to_ascii_lowercase();
+    let path = parsed.path().to_ascii_lowercase();
+    let host_and_path = format!("{host}{path}");
+
+    if host_matches(&host, &["github.com", "gitlab.com"])
+        && contains_any(&path, &["/issues/", "/discussions/", "/pull/"])
+    {
+        return SourceQuality {
+            label: "community",
+            score: 0.78,
+            reason: "repository discussion",
+        };
+    }
+    if host_matches(
+        &host,
+        &[
+            "reddit.com",
+            "old.reddit.com",
+            "news.ycombinator.com",
+            "stackoverflow.com",
+            "stackexchange.com",
+        ],
+    ) || host.contains("forum")
+        || host.contains("discourse")
+    {
+        return SourceQuality {
+            label: "community",
+            score: 0.74,
+            reason: "expert/community discussion",
+        };
+    }
+    if host_matches(
+        &host,
+        &[
+            "github.com",
+            "gitlab.com",
+            "bitbucket.org",
+            "docs.rs",
+            "crates.io",
+            "rfc-editor.org",
+            "ietf.org",
+            "w3.org",
+            "arxiv.org",
+            "doi.org",
+        ],
+    ) {
+        return SourceQuality {
+            label: "primary",
+            score: 0.96,
+            reason: "source repository, registry, standard, or paper",
+        };
+    }
+    if host.ends_with(".gov")
+        || host.ends_with(".mil")
+        || host.ends_with(".edu")
+        || host.starts_with("docs.")
+        || host.starts_with("doc.")
+        || host.starts_with("developer.")
+        || contains_any(
+            &host_and_path,
+            &[
+                "/docs",
+                "/documentation",
+                "/reference",
+                "/api/",
+                "/sdk",
+                "/spec",
+                "/protocol",
+                "/whitepaper",
+                "/manual",
+            ],
+        )
+    {
+        return SourceQuality {
+            label: "primary",
+            score: 0.90,
+            reason: "official documentation or institutional source",
+        };
+    }
+    if host_matches(
+        &host,
+        &[
+            "medium.com",
+            "substack.com",
+            "youtube.com",
+            "youtu.be",
+            "forbes.com",
+            "cointelegraph.com",
+            "decrypt.co",
+        ],
+    ) || contains_any(&path, &["/blog/", "/news/", "/article/", "/posts/"])
+    {
+        return SourceQuality {
+            label: "secondary",
+            score: 0.42,
+            reason: "article or summary source",
+        };
+    }
+
+    SourceQuality {
+        label: "secondary",
+        score: 0.50,
+        reason: "general web result",
+    }
+}
+
+fn enrich_source_quality(row: &mut Value, fallback_position: usize) {
+    let url = row.get("url").and_then(Value::as_str).unwrap_or_default();
+    let quality = source_quality_for_url(url);
+    let original_position = row
+        .get("position")
+        .and_then(Value::as_u64)
+        .filter(|position| *position > 0)
+        .unwrap_or(fallback_position as u64);
+    if let Some(obj) = row.as_object_mut() {
+        obj.insert("source_quality".to_string(), json!(quality.label));
+        obj.insert("source_quality_score".to_string(), json!(quality.score));
+        obj.insert("source_quality_reason".to_string(), json!(quality.reason));
+        obj.insert("original_position".to_string(), json!(original_position));
+    }
+}
+
+fn ranked_search_results(mut rows: Vec<Value>) -> Vec<Value> {
+    for (idx, row) in rows.iter_mut().enumerate() {
+        enrich_source_quality(row, idx + 1);
+    }
+    rows.sort_by(|left, right| {
+        let left_quality = left
+            .get("source_quality_score")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let right_quality = right
+            .get("source_quality_score")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let left_score = left.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+        let right_score = right.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+        let left_position = left
+            .get("original_position")
+            .and_then(Value::as_u64)
+            .unwrap_or(u64::MAX);
+        let right_position = right
+            .get("original_position")
+            .and_then(Value::as_u64)
+            .unwrap_or(u64::MAX);
+
+        right_quality
+            .partial_cmp(&left_quality)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                right_score
+                    .partial_cmp(&left_score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| left_position.cmp(&right_position))
+    });
+    for (idx, row) in rows.iter_mut().enumerate() {
+        row["position"] = json!(idx + 1);
+        row["source_rank"] = json!(idx + 1);
+    }
+    rows
+}
+
+fn source_quality_summary(rows: &[Value]) -> Value {
+    let mut primary = 0usize;
+    let mut community = 0usize;
+    let mut secondary = 0usize;
+    for row in rows {
+        match row.get("source_quality").and_then(Value::as_str) {
+            Some("primary") => primary += 1,
+            Some("community") => community += 1,
+            _ => secondary += 1,
+        }
+    }
+    json!({
+        "primary": primary,
+        "community": community,
+        "secondary": secondary,
+    })
+}
+
 fn web_secret_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
@@ -179,11 +398,15 @@ impl SearchOnlyExtractBackend {
 impl WebExtractBackend for SearchOnlyExtractBackend {
     async fn extract(&self, url: &str, _include_links: bool) -> Result<String, ToolError> {
         validate_url_does_not_exfiltrate_secret(url)?;
+        let quality = source_quality_for_url(url);
         Ok(json!({
             "success": false,
             "error": format!("{} is a search-only web backend and cannot extract URLs", self.provider),
             "url": url,
             "provider": self.provider,
+            "source_quality": quality.label,
+            "source_quality_score": quality.score,
+            "source_quality_reason": quality.reason,
         })
         .to_string())
     }
@@ -237,12 +460,16 @@ impl WebExtractBackend for SimpleExtractBackend {
 
         if bytes.len() > MAX_EXTRACT_BYTES {
             let text = String::from_utf8_lossy(&bytes[..MAX_EXTRACT_BYTES]);
+            let quality = source_quality_for_url(url);
             let result = json!({
                 "url": url,
                 "content_type": content_type,
                 "content": redact_web_content(&text),
                 "truncated": true,
                 "original_size": bytes.len(),
+                "source_quality": quality.label,
+                "source_quality_score": quality.score,
+                "source_quality_reason": quality.reason,
             });
             return serde_json::to_string_pretty(&result)
                 .map_err(|e| ToolError::ExecutionFailed(format!("Serialization error: {}", e)));
@@ -252,12 +479,16 @@ impl WebExtractBackend for SimpleExtractBackend {
 
         let content = redact_web_content(&strip_html_tags(&text));
 
+        let quality = source_quality_for_url(url);
         let result = json!({
             "url": url,
             "content_type": content_type,
             "content": content,
             "truncated": false,
             "size": bytes.len(),
+            "source_quality": quality.label,
+            "source_quality_score": quality.score,
+            "source_quality_reason": quality.reason,
         });
 
         serde_json::to_string_pretty(&result)
@@ -406,23 +637,31 @@ impl WebSearchBackend for ExaSearchBackend {
         })?;
 
         let results = data.get("results").and_then(|r| r.as_array());
-        let formatted: Vec<Value> = results
-            .map(|arr| {
-                arr.iter()
-                    .map(|r| {
-                        json!({
-                            "title": r.get("title").and_then(|v| v.as_str()).unwrap_or(""),
-                            "url": r.get("url").and_then(|v| v.as_str()).unwrap_or(""),
-                            "text": r.get("text").and_then(|v| v.as_str()).unwrap_or(""),
-                            "score": r.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        let formatted: Vec<Value> = ranked_search_results(
+            results
+                .map(|arr| {
+                    arr.iter()
+                        .enumerate()
+                        .map(|(idx, r)| {
+                            search_result(
+                                r.get("title").and_then(|v| v.as_str()).unwrap_or(""),
+                                r.get("url").and_then(|v| v.as_str()).unwrap_or(""),
+                                r.get("text").and_then(|v| v.as_str()).unwrap_or(""),
+                                r.get("score").and_then(|v| v.as_f64()),
+                                idx + 1,
+                            )
                         })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+                        .collect()
+                })
+                .unwrap_or_default(),
+        );
 
-        serde_json::to_string_pretty(&json!({ "results": formatted }))
-            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
+        let source_summary = source_quality_summary(&formatted);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "source_quality_summary": source_summary,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
     }
 }
 
@@ -516,27 +755,34 @@ impl WebSearchBackend for TavilySearchBackend {
         })?;
 
         let results = data.get("results").and_then(|r| r.as_array());
-        let formatted: Vec<Value> = results
-            .map(|arr| {
-                arr.iter()
-                    .map(|r| {
-                        json!({
-                            "title": r.get("title").and_then(|v| v.as_str()).unwrap_or(""),
-                            "url": r.get("url").and_then(|v| v.as_str()).unwrap_or(""),
-                            "text": r
-                                .get("content")
-                                .or_else(|| r.get("raw_content"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(""),
-                            "score": r.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        let formatted: Vec<Value> = ranked_search_results(
+            results
+                .map(|arr| {
+                    arr.iter()
+                        .enumerate()
+                        .map(|(idx, r)| {
+                            search_result(
+                                r.get("title").and_then(|v| v.as_str()).unwrap_or(""),
+                                r.get("url").and_then(|v| v.as_str()).unwrap_or(""),
+                                r.get("content")
+                                    .or_else(|| r.get("raw_content"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or(""),
+                                r.get("score").and_then(|v| v.as_f64()),
+                                idx + 1,
+                            )
                         })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+                        .collect()
+                })
+                .unwrap_or_default(),
+        );
 
-        serde_json::to_string_pretty(&json!({ "results": formatted }))
-            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
+        let source_summary = source_quality_summary(&formatted);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "source_quality_summary": source_summary,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
     }
 }
 
@@ -637,11 +883,13 @@ impl WebExtractBackend for TavilyExtractBackend {
             .and_then(|d| d.get("content"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        let source_summary = source_quality_summary(&documents);
         let result = json!({
             "url": url,
             "content": first_content,
             "results": documents,
             "provider": "tavily",
+            "source_quality_summary": source_summary,
         });
         serde_json::to_string_pretty(&result)
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize result: {}", e)))
@@ -728,10 +976,13 @@ impl WebCrawlBackend for TavilyCrawlBackend {
         let data: Value = serde_json::from_str(&text).map_err(|e| {
             ToolError::ExecutionFailed(format!("Failed to parse Tavily crawl response: {}", e))
         })?;
+        let documents = normalize_tavily_documents(&data, url);
+        let source_summary = source_quality_summary(&documents);
         let result = json!({
             "url": url,
-            "results": normalize_tavily_documents(&data, url),
+            "results": documents,
             "provider": "tavily",
+            "source_quality_summary": source_summary,
         });
         serde_json::to_string_pretty(&result)
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize result: {}", e)))
@@ -767,14 +1018,16 @@ fn search_result(
     let title = title.into();
     let url = url.into();
     let description = description.into();
-    json!({
+    let mut row = json!({
         "title": title,
         "url": url,
         "description": description,
         "text": description,
         "score": score.unwrap_or(0.0),
         "position": position,
-    })
+    });
+    enrich_source_quality(&mut row, position);
+    row
 }
 
 fn normalize_tavily_documents(response: &Value, fallback_url: &str) -> Vec<Value> {
@@ -796,6 +1049,9 @@ fn normalize_tavily_documents(response: &Value, fallback_url: &str) -> Vec<Value
                 "title": title,
                 "content": raw,
                 "raw_content": raw,
+                "source_quality": source_quality_for_url(url).label,
+                "source_quality_score": source_quality_for_url(url).score,
+                "source_quality_reason": source_quality_for_url(url).reason,
                 "metadata": {"sourceURL": url, "title": title},
             }));
         }
@@ -816,6 +1072,9 @@ fn normalize_tavily_documents(response: &Value, fallback_url: &str) -> Vec<Value
                 "content": "",
                 "raw_content": "",
                 "error": error,
+                "source_quality": source_quality_for_url(url).label,
+                "source_quality_score": source_quality_for_url(url).score,
+                "source_quality_reason": source_quality_for_url(url).reason,
                 "metadata": {"sourceURL": url},
             }));
         }
@@ -832,6 +1091,9 @@ fn normalize_tavily_documents(response: &Value, fallback_url: &str) -> Vec<Value
                 "content": "",
                 "raw_content": "",
                 "error": "extraction failed",
+                "source_quality": source_quality_for_url(&url).label,
+                "source_quality_score": source_quality_for_url(&url).score,
+                "source_quality_reason": source_quality_for_url(&url).reason,
                 "metadata": {"sourceURL": url},
             }));
         }
@@ -919,7 +1181,7 @@ impl WebSearchBackend for SearxngSearchBackend {
         let data: Value = serde_json::from_str(&text).map_err(|e| {
             ToolError::ExecutionFailed(format!("Failed to parse SearXNG response: {}", e))
         })?;
-        let mut rows: Vec<Value> = data
+        let rows: Vec<Value> = data
             .get("results")
             .and_then(|r| r.as_array())
             .map(|arr| {
@@ -941,20 +1203,17 @@ impl WebSearchBackend for SearxngSearchBackend {
                     .collect()
             })
             .unwrap_or_default();
-        rows.sort_by(|a, b| {
-            let left = a.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
-            let right = b.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
-            right
-                .partial_cmp(&left)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        for (idx, row) in rows.iter_mut().take(num_results).enumerate() {
-            row["position"] = json!(idx + 1);
-        }
-        let formatted: Vec<Value> = rows.into_iter().take(num_results).collect();
+        let formatted: Vec<Value> = ranked_search_results(rows)
+            .into_iter()
+            .take(num_results)
+            .collect();
 
-        serde_json::to_string_pretty(&json!({ "results": formatted }))
-            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
+        let source_summary = source_quality_summary(&formatted);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "source_quality_summary": source_summary,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
     }
 }
 
@@ -1028,19 +1287,23 @@ impl WebSearchBackend for BraveFreeSearchBackend {
             ToolError::ExecutionFailed(format!("Failed to parse Brave Search response: {e}"))
         })?;
         let formatted = normalize_brave_results(&data, num_results);
-        serde_json::to_string_pretty(&json!({ "results": formatted, "provider": "brave-free" }))
-            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
+        let source_summary = source_quality_summary(&formatted);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "provider": "brave-free",
+            "source_quality_summary": source_summary,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
     }
 }
 
 fn normalize_brave_results(response: &Value, limit: usize) -> Vec<Value> {
-    response
+    let rows: Vec<Value> = response
         .get("web")
         .and_then(|web| web.get("results"))
         .and_then(|results| results.as_array())
         .map(|rows| {
             rows.iter()
-                .take(limit)
                 .enumerate()
                 .map(|(idx, row)| {
                     search_result(
@@ -1055,7 +1318,11 @@ fn normalize_brave_results(response: &Value, limit: usize) -> Vec<Value> {
                 })
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    ranked_search_results(rows)
+        .into_iter()
+        .take(limit)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -1122,8 +1389,13 @@ impl WebSearchBackend for DuckDuckGoSearchBackend {
             ToolError::ExecutionFailed(format!("Failed to parse DuckDuckGo response: {e}"))
         })?;
         let formatted = normalize_duckduckgo_results(&data, num_results);
-        serde_json::to_string_pretty(&json!({ "results": formatted, "provider": "ddgs" }))
-            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
+        let source_summary = source_quality_summary(&formatted);
+        serde_json::to_string_pretty(&json!({
+            "results": formatted,
+            "provider": "ddgs",
+            "source_quality_summary": source_summary,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
     }
 }
 
@@ -1149,10 +1421,10 @@ fn normalize_duckduckgo_results(response: &Value, limit: usize) -> Vec<Value> {
         ));
     }
     collect_duckduckgo_related(response.get("RelatedTopics"), &mut rows);
-    for (idx, row) in rows.iter_mut().take(limit).enumerate() {
-        row["position"] = json!(idx + 1);
-    }
-    rows.into_iter().take(limit).collect()
+    ranked_search_results(rows)
+        .into_iter()
+        .take(limit)
+        .collect()
 }
 
 fn collect_duckduckgo_related(value: Option<&Value>, rows: &mut Vec<Value>) {
@@ -1239,9 +1511,11 @@ impl ParallelWebBackend {
             )
             .await?;
         let formatted = normalize_parallel_search_results(&data, limit);
+        let source_summary = source_quality_summary(&formatted);
         serde_json::to_string_pretty(&json!({
             "results": formatted,
             "provider": "parallel",
+            "source_quality_summary": source_summary,
         }))
         .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
     }
@@ -1347,41 +1621,45 @@ fn normalize_parallel_search_results(response: &Value, limit: usize) -> Vec<Valu
         .get("results")
         .and_then(Value::as_array)
         .or_else(|| response.pointer("/data/web").and_then(Value::as_array));
-    rows.map(|rows| {
-        rows.iter()
-            .take(limit)
-            .enumerate()
-            .map(|(idx, row)| {
-                let description = row
-                    .get("excerpts")
-                    .and_then(Value::as_array)
-                    .map(|items| {
-                        items
-                            .iter()
-                            .filter_map(Value::as_str)
-                            .collect::<Vec<_>>()
-                            .join(" ")
-                    })
-                    .filter(|v| !v.trim().is_empty())
-                    .or_else(|| {
-                        ["description", "snippet", "text", "content"]
-                            .iter()
-                            .find_map(|key| {
-                                row.get(*key).and_then(Value::as_str).map(str::to_string)
-                            })
-                    })
-                    .unwrap_or_default();
-                search_result(
-                    row.get("title").and_then(Value::as_str).unwrap_or(""),
-                    row.get("url").and_then(Value::as_str).unwrap_or(""),
-                    description,
-                    row.get("score").and_then(Value::as_f64),
-                    idx + 1,
-                )
-            })
-            .collect()
-    })
-    .unwrap_or_default()
+    let normalized: Vec<Value> = rows
+        .map(|rows| {
+            rows.iter()
+                .enumerate()
+                .map(|(idx, row)| {
+                    let description = row
+                        .get("excerpts")
+                        .and_then(Value::as_array)
+                        .map(|items| {
+                            items
+                                .iter()
+                                .filter_map(Value::as_str)
+                                .collect::<Vec<_>>()
+                                .join(" ")
+                        })
+                        .filter(|v| !v.trim().is_empty())
+                        .or_else(|| {
+                            ["description", "snippet", "text", "content"]
+                                .iter()
+                                .find_map(|key| {
+                                    row.get(*key).and_then(Value::as_str).map(str::to_string)
+                                })
+                        })
+                        .unwrap_or_default();
+                    search_result(
+                        row.get("title").and_then(Value::as_str).unwrap_or(""),
+                        row.get("url").and_then(Value::as_str).unwrap_or(""),
+                        description,
+                        row.get("score").and_then(Value::as_f64),
+                        idx + 1,
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    ranked_search_results(normalized)
+        .into_iter()
+        .take(limit)
+        .collect()
 }
 
 fn normalize_parallel_extract_documents(response: &Value, requested_urls: &[&str]) -> Vec<Value> {
@@ -1411,6 +1689,9 @@ fn normalize_parallel_extract_documents(response: &Value, requested_urls: &[&str
                 "title": title,
                 "content": content,
                 "raw_content": content,
+                "source_quality": source_quality_for_url(url).label,
+                "source_quality_score": source_quality_for_url(url).score,
+                "source_quality_reason": source_quality_for_url(url).reason,
                 "metadata": {"sourceURL": url, "title": title},
             }));
         }
@@ -1430,6 +1711,9 @@ fn normalize_parallel_extract_documents(response: &Value, requested_urls: &[&str
                 "title": "",
                 "content": "",
                 "error": error,
+                "source_quality": source_quality_for_url(url).label,
+                "source_quality_score": source_quality_for_url(url).score,
+                "source_quality_reason": source_quality_for_url(url).reason,
                 "metadata": {"sourceURL": url},
             }));
         }
@@ -1441,6 +1725,9 @@ fn normalize_parallel_extract_documents(response: &Value, requested_urls: &[&str
                 "title": "",
                 "content": "",
                 "error": "extraction failed (no content returned)",
+                "source_quality": source_quality_for_url(url).label,
+                "source_quality_score": source_quality_for_url(url).score,
+                "source_quality_reason": source_quality_for_url(url).reason,
                 "metadata": {"sourceURL": url},
             }));
         }
@@ -1454,11 +1741,13 @@ fn parallel_extract_response(url: &str, documents: Vec<Value>) -> Result<String,
         .and_then(|d| d.get("content"))
         .and_then(Value::as_str)
         .unwrap_or("");
+    let source_summary = source_quality_summary(&documents);
     let response = json!({
         "url": url,
         "content": first_content,
         "results": documents,
         "provider": "parallel",
+        "source_quality_summary": source_summary,
     });
     serde_json::to_string_pretty(&response)
         .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize result: {e}")))
@@ -1763,20 +2052,16 @@ Query: {query}"
             .get("citations")
             .and_then(|v| v.as_array())
             .map(|citations| {
-                citations
+                let rows: Vec<Value> = citations
                     .iter()
                     .filter_map(|v| v.as_str())
                     .filter(|url| !url.trim().is_empty())
-                    .take(limit)
                     .enumerate()
-                    .map(|(idx, url)| {
-                        json!({
-                            "title": "",
-                            "url": url,
-                            "description": "",
-                            "position": idx + 1,
-                        })
-                    })
+                    .map(|(idx, url)| search_result("", url, "", None, idx + 1))
+                    .collect();
+                ranked_search_results(rows)
+                    .into_iter()
+                    .take(limit)
                     .collect()
             })
             .unwrap_or_default()
@@ -1850,10 +2135,13 @@ impl WebSearchBackend for XaiWebSearchBackend {
             )));
         }
 
+        let formatted = Self::parse_results(&data, limit);
+        let source_summary = source_quality_summary(&formatted);
         serde_json::to_string_pretty(&json!({
-            "results": Self::parse_results(&data, limit),
+            "results": formatted,
             "provider": "xai",
             "model": &self.model,
+            "source_quality_summary": source_summary,
         }))
         .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {e}")))
     }
@@ -1924,22 +2212,32 @@ fn parse_xai_json_results(text: &str, limit: usize) -> Vec<Value> {
             continue;
         };
         let mut normalized = Vec::new();
-        for row in results.iter().take(limit) {
+        for row in results {
             let Some(url) = row.get("url").and_then(|v| v.as_str()).map(str::trim) else {
                 continue;
             };
             if url.is_empty() {
                 continue;
             }
-            normalized.push(json!({
-                "title": row.get("title").and_then(|v| v.as_str()).unwrap_or("").trim(),
-                "url": url,
-                "description": row.get("description").and_then(|v| v.as_str()).unwrap_or("").trim(),
-                "position": normalized.len() + 1,
-            }));
+            normalized.push(search_result(
+                row.get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim(),
+                url,
+                row.get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim(),
+                None,
+                normalized.len() + 1,
+            ));
         }
         if !normalized.is_empty() {
-            return normalized;
+            return ranked_search_results(normalized)
+                .into_iter()
+                .take(limit)
+                .collect();
         }
     }
     Vec::new()
@@ -1985,17 +2283,15 @@ fn xai_results_from_annotations(
             })
             .map(|s| s.chars().rev().collect::<String>().trim().to_string())
             .unwrap_or_default();
-        results.push(json!({
-            "title": "",
-            "url": url,
-            "description": description,
-            "position": results.len() + 1,
-        }));
+        results.push(search_result("", url, description, None, results.len() + 1));
         if results.len() >= limit {
             break;
         }
     }
-    results
+    ranked_search_results(results)
+        .into_iter()
+        .take(limit)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -2168,9 +2464,11 @@ impl WebSearchBackend for FirecrawlSearchBackend {
             ToolError::ExecutionFailed(format!("Failed to parse Firecrawl search response: {}", e))
         })?;
         let formatted = normalize_firecrawl_search_results(&data);
+        let source_summary = source_quality_summary(&formatted);
         serde_json::to_string_pretty(&json!({
             "results": formatted,
             "transport": self.transport.label(),
+            "source_quality_summary": source_summary,
         }))
         .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
     }
@@ -2185,14 +2483,15 @@ fn normalize_firecrawl_search_results(response: &Value) -> Vec<Value> {
         response.get("results"),
     ];
 
-    candidates
+    let rows: Vec<Value> = candidates
         .into_iter()
         .flatten()
         .find_map(|v| v.as_array())
         .map(|results| {
             results
                 .iter()
-                .map(|result| {
+                .enumerate()
+                .map(|(idx, result)| {
                     let title = result.get("title").and_then(|v| v.as_str()).unwrap_or("");
                     let url = result.get("url").and_then(|v| v.as_str()).unwrap_or("");
                     let text = result
@@ -2202,16 +2501,18 @@ fn normalize_firecrawl_search_results(response: &Value) -> Vec<Value> {
                         .or_else(|| result.get("text"))
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
-                    json!({
-                        "title": title,
-                        "url": url,
-                        "text": text,
-                        "score": result.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0),
-                    })
+                    search_result(
+                        title,
+                        url,
+                        text,
+                        result.get("score").and_then(|v| v.as_f64()),
+                        idx + 1,
+                    )
                 })
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    ranked_search_results(rows)
 }
 
 /// Real Firecrawl API extract backend.
@@ -2510,6 +2811,53 @@ mod web_search_env_tests {
     }
 
     #[test]
+    fn source_quality_classifies_primary_community_and_secondary_urls() {
+        assert_eq!(
+            source_quality_for_url("https://github.com/NousResearch/hermes-agent").label,
+            "primary"
+        );
+        assert_eq!(
+            source_quality_for_url("https://www.reddit.com/r/solana/comments/example").label,
+            "community"
+        );
+        assert_eq!(
+            source_quality_for_url("https://medium.com/example/post").label,
+            "secondary"
+        );
+    }
+
+    #[test]
+    fn ranked_search_results_prefers_primary_sources_before_provider_score() {
+        let rows = vec![
+            search_result(
+                "SEO summary",
+                "https://medium.com/example/post",
+                "summary",
+                Some(0.99),
+                1,
+            ),
+            search_result(
+                "Official docs",
+                "https://docs.solana.com/developing",
+                "docs",
+                Some(0.10),
+                2,
+            ),
+        ];
+
+        let ranked = ranked_search_results(rows);
+        assert_eq!(ranked[0]["title"], "Official docs");
+        assert_eq!(ranked[0]["source_quality"], "primary");
+        assert_eq!(ranked[0]["original_position"], 2);
+        assert_eq!(ranked[0]["position"], 1);
+        assert_eq!(ranked[0]["source_rank"], 1);
+        assert_eq!(
+            source_quality_summary(&ranked),
+            json!({"primary": 1, "community": 0, "secondary": 1})
+        );
+    }
+
+    #[test]
     fn search_backend_choice_uses_xai_only_when_explicit() {
         let _scope = EnvScope::new();
         std::env::set_var("XAI_API_KEY", "xai-key");
@@ -2689,6 +3037,7 @@ mod web_search_env_tests {
         );
         assert_eq!(docs.len(), 4);
         assert_eq!(docs[0]["content"], "body");
+        assert_eq!(docs[0]["source_quality"], "secondary");
         assert_eq!(docs[1]["error"], "blocked");
         assert_eq!(docs[2]["url"], "https://missing.example");
         assert_eq!(docs[3]["url"], "42");


### PR DESCRIPTION
## Summary
- add deterministic source-quality classification/ranking to web search/extract/crawl outputs
- make web research prompts consume returned source_quality metadata
- enforce exploratory repo research final answers with workstream/status/file/cmd evidence

## Local verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-tools web_ -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent finalizer -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent repo_review -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-agent tool_result_signal -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-cli --bin hermes-ultra
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh

## Notes
- Full clippy with -D warnings remains blocked by existing lint debt in hermes-config/hermes-agent/hermes-tools outside this patch.