### PR TITLE
Parity: managed cron automations and slash surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ name = "hermes-cron"
 version = "0.18.1"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "cron",
  "directories",
@@ -1668,10 +1669,13 @@ dependencies = [
  "hermes-core",
  "hermes-skills",
  "hermes-tools",
+ "jsonwebtoken",
  "regex",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -22,7 +22,9 @@ use hermes_core::auth_gate::{
     oauth_runtime_gate_manifest_default, OAuthRuntimeGateManifest,
 };
 use hermes_core::AgentError;
-use hermes_cron::{BlueprintCommandAction, CronJob, DeliverConfig, DeliverTarget};
+use hermes_cron::{
+    BlueprintCommandAction, CronJob, DeliverConfig, DeliverTarget, SuggestionJobSpec,
+};
 use hermes_intelligence::model_metadata::{get_model_context_length, get_model_info};
 use hermes_intelligence::models_dev::default_client;
 use hermes_intelligence::{build_swarm_execution_plan, swarm_runtime_status, SwarmExecutionMode};
@@ -172,6 +174,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/profile", "Show active profile and Hermes home path"),
     ("/whoami", "Alias for /profile"),
     ("/version", "Show Hermes Agent Ultra version and build label"),
+    ("/v", "Alias for /version"),
     ("/fast", "Toggle fast-mode hints"),
     ("/skin", "Show available skin/theme options"),
     ("/skins", "Alias for /skin"),
@@ -216,6 +219,12 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "/blueprint",
         "Automation Blueprint catalog and creation (`<name> slot=value`, alias `/bp`)",
     ),
+    ("/bp", "Alias for /blueprint"),
+    (
+        "/suggestions",
+        "Review suggested automations (`accept|dismiss N`, `catalog`, `clear`)",
+    ),
+    ("/suggest", "Alias for /suggestions"),
     ("/scheduler", "Alias for /background"),
     (
         "/agents",
@@ -301,6 +310,14 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/compact", "Alias for /compress"),
     ("/clear-queue", "Clear queued background jobs"),
     ("/usage", "Show token usage statistics"),
+    (
+        "/credits",
+        "Show Nous credit balance and local usage statistics",
+    ),
+    (
+        "/billing",
+        "Show Nous billing/credits summary and local usage statistics",
+    ),
     ("/insights", "Show local usage/session insights"),
     ("/stop", "Stop current agent execution"),
     ("/busy", "Busy/processing status compatibility surface"),
@@ -3515,6 +3532,8 @@ fn canonical_command(cmd: &str) -> &str {
         "/skins" => "/skin",
         "/summary" => "/recap",
         "/whoami" => "/profile",
+        "/v" => "/version",
+        "/billing" | "/credits" => "/usage",
         "/session" => "/sessions",
         "/switch" => "/sessions",
         "/sb" => "/statusbar",
@@ -3522,6 +3541,7 @@ fn canonical_command(cmd: &str) -> &str {
         "/rb" => "/runbook",
         "/debug" => "/debug-dump",
         "/exit" => "/quit",
+        "/suggest" => "/suggestions",
         other => other,
     }
 }
@@ -3772,6 +3792,7 @@ async fn dispatch_slash_command(
         }
         "/cron" => handle_cron_command(app),
         "/blueprint" => handle_blueprint_command(app, args).await,
+        "/suggestions" => handle_suggestions_command(app, args).await,
         "/agents" => handle_agents_command(app, args),
         "/kanban" => handle_kanban_command(app, args),
         "/plan" => handle_plan_command(app, args),
@@ -15217,6 +15238,163 @@ async fn handle_blueprint_command(
             );
         }
     }
+    Ok(CommandResult::Handled)
+}
+
+fn suggestion_error(err: hermes_cron::SuggestionError) -> AgentError {
+    AgentError::Config(format!("suggestions: {err}"))
+}
+
+fn render_pending_suggestions(pending: &[hermes_cron::SuggestionRecord]) -> String {
+    if pending.is_empty() {
+        return "No suggested automations right now.\nTry `/suggestions catalog` to see the curated starter set, or install a blueprint skill to get one.".to_string();
+    }
+
+    let mut out = String::from("Suggested automations - `/suggestions accept N` or `dismiss N`:\n");
+    for (idx, suggestion) in pending.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "\n  {}. {}  [{}]  ({})",
+            idx + 1,
+            suggestion.title,
+            suggestion.job_spec.schedule,
+            suggestion.source
+        );
+        if !suggestion.description.trim().is_empty() {
+            let _ = writeln!(out, "     {}", suggestion.description.trim());
+        }
+    }
+    out
+}
+
+fn render_suggestions_usage() -> &'static str {
+    "Usage:\n  /suggestions              list pending\n  /suggestions accept N     schedule suggestion N\n  /suggestions dismiss N    dismiss suggestion N\n  /suggestions catalog      add curated starter automations\n  /suggestions clear        housekeeping"
+}
+
+fn cron_job_from_suggestion_spec(spec: &SuggestionJobSpec) -> Result<CronJob, String> {
+    let Some(deliver) = blueprint_deliver_config(&spec.deliver) else {
+        return Err(format!(
+            "unsupported deliver target `{}`",
+            spec.deliver.trim()
+        ));
+    };
+    let mut job = CronJob::new(spec.schedule.clone(), spec.prompt.clone());
+    job.name = Some(spec.name.clone());
+    job.deliver = Some(deliver);
+    if !spec.skills.is_empty() {
+        job.skills = Some(spec.skills.clone());
+    }
+    Ok(job)
+}
+
+async fn handle_suggestions_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let store = hermes_cron::SuggestionStore::default();
+    let sub = args
+        .first()
+        .map(|arg| arg.to_ascii_lowercase())
+        .unwrap_or_default();
+    let rest = args.get(1..).unwrap_or_default().join(" ");
+
+    match sub.as_str() {
+        "" => {
+            let pending = store.list_pending().map_err(suggestion_error)?;
+            emit_command_output(app, render_pending_suggestions(&pending));
+        }
+        "accept" | "add" | "schedule" => {
+            if rest.trim().is_empty() {
+                emit_command_output(app, "Usage: /suggestions accept <number|id>");
+                return Ok(CommandResult::Handled);
+            }
+            let Some(suggestion) = store.get_pending(&rest).map_err(suggestion_error)? else {
+                emit_command_output(
+                    app,
+                    format!(
+                        "No pending suggestion matches '{}'. Run /suggestions to list them.",
+                        rest.trim()
+                    ),
+                );
+                return Ok(CommandResult::Handled);
+            };
+            let job = match cron_job_from_suggestion_spec(&suggestion.job_spec) {
+                Ok(job) => job,
+                Err(err) => {
+                    emit_command_output(
+                        app,
+                        format!(
+                            "Suggestion `{}` cannot be scheduled: {err}.",
+                            suggestion.title
+                        ),
+                    );
+                    return Ok(CommandResult::Handled);
+                }
+            };
+            let job_id = app
+                .cron_scheduler
+                .create_job(job)
+                .await
+                .map_err(|e| AgentError::Config(format!("suggestion cron create: {e}")))?;
+            store
+                .mark_accepted(&suggestion.id)
+                .map_err(suggestion_error)?;
+            emit_command_output(
+                app,
+                format!(
+                    "Scheduled '{}' ({}).\nJob: {}\nManage it with /cron.",
+                    suggestion.job_spec.name, suggestion.job_spec.schedule, job_id
+                ),
+            );
+        }
+        "dismiss" | "no" | "reject" => {
+            if rest.trim().is_empty() {
+                emit_command_output(app, "Usage: /suggestions dismiss <number|id>");
+                return Ok(CommandResult::Handled);
+            }
+            let dismissed = store.dismiss_suggestion(&rest).map_err(suggestion_error)?;
+            if dismissed {
+                emit_command_output(app, "Dismissed. Won't suggest that again.");
+            } else {
+                emit_command_output(
+                    app,
+                    format!("No pending suggestion matches '{}'.", rest.trim()),
+                );
+            }
+        }
+        "catalog" => {
+            let created = store.seed_catalog_suggestions().map_err(suggestion_error)?;
+            if created.is_empty() {
+                emit_command_output(
+                    app,
+                    "No new catalog automations to add (already offered, dismissed, or your suggestion list is full). Run /suggestions to see pending.",
+                );
+            } else {
+                let added = created
+                    .iter()
+                    .map(|record| record.title.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                emit_command_output(
+                    app,
+                    format!(
+                        "Added {} suggestion(s): {}.\nRun /suggestions to review.",
+                        created.len(),
+                        added
+                    ),
+                );
+            }
+        }
+        "clear" => {
+            let removed = store.clear_resolved().map_err(suggestion_error)?;
+            emit_command_output(
+                app,
+                format!("Cleared {removed} resolved suggestion record(s)."),
+            );
+        }
+        _ => emit_command_output(app, render_suggestions_usage()),
+    }
+
     Ok(CommandResult::Handled)
 }
 
@@ -29254,6 +29432,79 @@ mod tests {
         assert_eq!(canonical_command("/goal"), "/objective");
     }
 
+    #[test]
+    fn test_golden_upstream_surface_aliases_are_registered() {
+        for command in [
+            "/bp",
+            "/v",
+            "/credits",
+            "/billing",
+            "/suggest",
+            "/suggestions",
+        ] {
+            assert!(
+                SLASH_COMMANDS.iter().any(|(name, _)| *name == command),
+                "{command} should be registered"
+            );
+        }
+        assert_eq!(canonical_command("/bp"), "/blueprint");
+        assert_eq!(canonical_command("/v"), "/version");
+        assert_eq!(canonical_command("/credits"), "/usage");
+        assert_eq!(canonical_command("/billing"), "/usage");
+        assert_eq!(canonical_command("/suggest"), "/suggestions");
+        assert!(autocomplete("/cre").contains(&"/credits"));
+        assert!(autocomplete("/bill").contains(&"/billing"));
+        assert!(autocomplete("/sugg").contains(&"/suggestions"));
+    }
+
+    #[tokio::test]
+    async fn suggestions_catalog_accept_and_dismiss_flow() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        let empty = handle_slash_command(&mut app, "/suggestions", &[])
+            .await
+            .expect("empty suggestions");
+        assert_eq!(empty, CommandResult::Handled);
+        assert!(latest_ui_assistant_text(&app).contains("No suggested automations"));
+
+        handle_slash_command(&mut app, "/suggestions", &["catalog"])
+            .await
+            .expect("seed catalog");
+        let seeded = latest_ui_assistant_text(&app);
+        assert!(seeded.contains("Added"));
+        assert!(seeded.contains("Morning briefing"));
+
+        handle_slash_command(&mut app, "/suggest", &[])
+            .await
+            .expect("alias list suggestions");
+        let listed = latest_ui_assistant_text(&app);
+        assert!(listed.contains("Suggested automations"));
+        assert!(listed.contains("Important-mail monitor"));
+
+        handle_slash_command(&mut app, "/suggestions", &["accept", "1"])
+            .await
+            .expect("accept suggestion");
+        let accepted = latest_ui_assistant_text(&app);
+        assert!(accepted.contains("Scheduled 'Morning briefing'"));
+        let jobs = app.cron_scheduler.list_jobs().await;
+        assert!(jobs.iter().any(|job| {
+            job.name.as_deref() == Some("Morning briefing") && job.schedule == "0 8 * * *"
+        }));
+
+        handle_slash_command(&mut app, "/suggestions", &["dismiss", "1"])
+            .await
+            .expect("dismiss suggestion");
+        assert!(latest_ui_assistant_text(&app).contains("Dismissed."));
+
+        handle_slash_command(&mut app, "/suggestions", &["clear"])
+            .await
+            .expect("clear suggestions");
+        assert!(latest_ui_assistant_text(&app).contains("Cleared 1 resolved"));
+    }
+
     #[tokio::test]
     async fn objective_lifecycle_pause_resume_updates_session_injection() {
         let _guard = env_test_lock();
@@ -29859,6 +30110,10 @@ mod tests {
         assert_eq!(canonical_command("/swarms"), "/swarm");
         assert_eq!(canonical_command("/summary"), "/recap");
         assert_eq!(canonical_command("/whoami"), "/profile");
+        assert_eq!(canonical_command("/v"), "/version");
+        assert_eq!(canonical_command("/billing"), "/usage");
+        assert_eq!(canonical_command("/credits"), "/usage");
+        assert_eq!(canonical_command("/suggest"), "/suggestions");
         assert_eq!(canonical_command("/footer"), "/statusbar");
         assert_eq!(canonical_command("/indicator"), "/statusbar");
         assert_eq!(canonical_command("/tasks"), "/kanban");

--- a/crates/hermes-cron/Cargo.toml
+++ b/crates/hermes-cron/Cargo.toml
@@ -15,6 +15,7 @@ hermes-skills = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tracing = { workspace = true }
 cron = { workspace = true }
 chrono = { workspace = true }
@@ -25,6 +26,9 @@ futures = { workspace = true }
 directories = { workspace = true }
 rusqlite = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+jsonwebtoken = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/hermes-cron/src/chronos.rs
+++ b/crates/hermes-cron/src/chronos.rs
@@ -1,0 +1,538 @@
+//! Chronos managed-cron provider.
+//!
+//! Chronos is the NAS-mediated cron provider used for hosted agents that can
+//! scale to zero. The agent computes each job's next fire time, asks NAS to arm
+//! one external one-shot, and verifies the NAS callback before running the job.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::SecondsFormat;
+use hermes_config::managed_gateway::peek_nous_access_token;
+use hermes_config::read_nous_access_token;
+use jsonwebtoken::jwk::{AlgorithmParameters, Jwk, JwkSet};
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::job::{CronJob, JobStatus};
+use crate::scheduler::{CronError, ManagedCronProvider};
+
+const DEFAULT_TIMEOUT_SECONDS: u64 = 15;
+const DEFAULT_LEEWAY_SECONDS: u64 = 30;
+const PROVISION_PATH: &str = "/api/agent-cron/provision";
+const CANCEL_PATH: &str = "/api/agent-cron/cancel";
+const LIST_PATH: &str = "/api/agent-cron/list";
+const FIRE_PURPOSE: &str = "cron_fire";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChronosConfig {
+    pub provider: String,
+    pub portal_url: String,
+    pub callback_url: String,
+    pub expected_audience: String,
+    pub nas_jwks_url: String,
+    pub token_leeway_seconds: u64,
+    pub request_timeout_seconds: u64,
+}
+
+impl Default for ChronosConfig {
+    fn default() -> Self {
+        Self {
+            provider: String::new(),
+            portal_url: String::new(),
+            callback_url: String::new(),
+            expected_audience: String::new(),
+            nas_jwks_url: String::new(),
+            token_leeway_seconds: DEFAULT_LEEWAY_SECONDS,
+            request_timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
+        }
+    }
+}
+
+impl ChronosConfig {
+    pub fn load() -> Self {
+        let yaml = load_config_yaml();
+        let provider = env_or_yaml("HERMES_CRON_PROVIDER", &yaml, &["cron", "provider"]);
+        let portal_url = env_or_yaml(
+            "HERMES_CHRONOS_PORTAL_URL",
+            &yaml,
+            &["cron", "chronos", "portal_url"],
+        );
+        let callback_url = env_or_yaml(
+            "HERMES_CHRONOS_CALLBACK_URL",
+            &yaml,
+            &["cron", "chronos", "callback_url"],
+        );
+        let expected_audience = env_or_yaml(
+            "HERMES_CHRONOS_EXPECTED_AUDIENCE",
+            &yaml,
+            &["cron", "chronos", "expected_audience"],
+        );
+        let nas_jwks_url = env_or_yaml(
+            "HERMES_CHRONOS_NAS_JWKS_URL",
+            &yaml,
+            &["cron", "chronos", "nas_jwks_url"],
+        );
+
+        Self {
+            provider,
+            portal_url,
+            callback_url,
+            expected_audience,
+            nas_jwks_url,
+            token_leeway_seconds: env_or_yaml_u64(
+                "HERMES_CHRONOS_TOKEN_LEEWAY_SECONDS",
+                &yaml,
+                &["cron", "chronos", "token_leeway_seconds"],
+                DEFAULT_LEEWAY_SECONDS,
+            ),
+            request_timeout_seconds: env_or_yaml_u64(
+                "HERMES_CHRONOS_REQUEST_TIMEOUT_SECONDS",
+                &yaml,
+                &["cron", "chronos", "request_timeout_seconds"],
+                DEFAULT_TIMEOUT_SECONDS,
+            ),
+        }
+    }
+
+    pub fn provider_enabled(&self) -> bool {
+        self.provider.trim().eq_ignore_ascii_case("chronos")
+    }
+
+    pub fn can_provision(&self) -> bool {
+        self.provider_enabled()
+            && !self.portal_url.trim().is_empty()
+            && !self.callback_url.trim().is_empty()
+            && peek_nous_access_token().is_some()
+    }
+
+    pub fn can_verify_fire(&self) -> bool {
+        self.provider_enabled()
+            && !self.expected_audience.trim().is_empty()
+            && !self.nas_jwks_url.trim().is_empty()
+    }
+}
+
+fn load_config_yaml() -> Option<Value> {
+    let bytes = std::fs::read(hermes_config::config_path()).ok()?;
+    serde_yaml::from_slice::<Value>(&bytes).ok()
+}
+
+fn yaml_string(root: &Option<Value>, path: &[&str]) -> Option<String> {
+    let mut cursor = root.as_ref()?;
+    for key in path {
+        cursor = cursor.get(*key)?;
+    }
+    match cursor {
+        Value::String(value) => {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn env_or_yaml(env: &str, yaml: &Option<Value>, path: &[&str]) -> String {
+    std::env::var(env)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| yaml_string(yaml, path))
+        .unwrap_or_default()
+}
+
+fn env_or_yaml_u64(env: &str, yaml: &Option<Value>, path: &[&str], default: u64) -> u64 {
+    env_or_yaml(env, yaml, path)
+        .parse::<u64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+#[derive(Debug, Clone)]
+pub struct ChronosNasCronProvider {
+    config: ChronosConfig,
+    client: reqwest::Client,
+}
+
+impl ChronosNasCronProvider {
+    pub fn from_environment() -> Self {
+        Self::new(ChronosConfig::load())
+    }
+
+    pub fn new(config: ChronosConfig) -> Self {
+        let timeout = Duration::from_secs(config.request_timeout_seconds.max(1));
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self { config, client }
+    }
+
+    pub fn config(&self) -> &ChronosConfig {
+        &self.config
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.config.portal_url.trim_end_matches('/'), path)
+    }
+
+    fn access_token(&self) -> Result<String, CronError> {
+        read_nous_access_token(None).ok_or_else(|| {
+            CronError::Scheduler(
+                "Chronos requires a Nous Portal access token; run `hermes auth login nous`"
+                    .to_string(),
+            )
+        })
+    }
+
+    async fn provision(
+        &self,
+        job_id: &str,
+        fire_at: &str,
+        dedup_key: &str,
+    ) -> Result<(), CronError> {
+        let token = self.access_token()?;
+        let body = serde_json::json!({
+            "job_id": job_id,
+            "fire_at": fire_at,
+            "agent_callback_url": self.config.callback_url,
+            "dedup_key": dedup_key,
+        });
+        self.client
+            .post(self.endpoint(PROVISION_PATH))
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|err| CronError::Scheduler(format!("Chronos provision failed: {err}")))?
+            .error_for_status()
+            .map_err(|err| CronError::Scheduler(format!("Chronos provision rejected: {err}")))?;
+        Ok(())
+    }
+
+    async fn cancel_one(&self, job_id: &str) -> Result<(), CronError> {
+        let token = self.access_token()?;
+        self.client
+            .post(self.endpoint(CANCEL_PATH))
+            .bearer_auth(token)
+            .json(&serde_json::json!({ "job_id": job_id }))
+            .send()
+            .await
+            .map_err(|err| CronError::Scheduler(format!("Chronos cancel failed: {err}")))?
+            .error_for_status()
+            .map_err(|err| CronError::Scheduler(format!("Chronos cancel rejected: {err}")))?;
+        Ok(())
+    }
+
+    async fn list_armed(&self) -> Result<BTreeMap<String, String>, CronError> {
+        let token = self.access_token()?;
+        let response: ChronosListResponse = self
+            .client
+            .get(self.endpoint(LIST_PATH))
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|err| CronError::Scheduler(format!("Chronos list failed: {err}")))?
+            .error_for_status()
+            .map_err(|err| CronError::Scheduler(format!("Chronos list rejected: {err}")))?
+            .json()
+            .await
+            .map_err(|err| CronError::Scheduler(format!("Chronos list parse failed: {err}")))?;
+        Ok(response
+            .armed
+            .into_iter()
+            .filter_map(|item| item.job_id.map(|id| (id, item.fire_at.unwrap_or_default())))
+            .collect())
+    }
+}
+
+#[async_trait]
+impl ManagedCronProvider for ChronosNasCronProvider {
+    fn name(&self) -> &'static str {
+        "chronos"
+    }
+
+    fn is_available(&self) -> bool {
+        self.config.can_provision()
+    }
+
+    async fn reconcile(&self, jobs: Vec<CronJob>) -> Result<(), CronError> {
+        if !self.is_available() {
+            return Ok(());
+        }
+
+        let desired = jobs
+            .into_iter()
+            .filter(|job| job.status == JobStatus::Active)
+            .filter_map(|job| {
+                let fire_at = job
+                    .next_run
+                    .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Secs, false))?;
+                Some((job.id, fire_at))
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        let observed = match self.list_armed().await {
+            Ok(observed) => observed,
+            Err(err) => {
+                tracing::debug!(
+                    "Chronos list failed during reconcile; re-arming desired jobs: {err}"
+                );
+                BTreeMap::new()
+            }
+        };
+
+        for (job_id, fire_at) in &desired {
+            if observed.get(job_id) != Some(fire_at) {
+                let dedup_key = format!("{job_id}:{fire_at}");
+                self.provision(job_id, fire_at, &dedup_key).await?;
+            }
+        }
+
+        for job_id in observed.keys() {
+            if !desired.contains_key(job_id) {
+                self.cancel_one(job_id).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn cancel(&self, job_id: &str) -> Result<(), CronError> {
+        if !self.is_available() {
+            return Ok(());
+        }
+        self.cancel_one(job_id).await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChronosListResponse {
+    #[serde(default)]
+    armed: Vec<ChronosArmedJob>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChronosArmedJob {
+    #[serde(default)]
+    job_id: Option<String>,
+    #[serde(default)]
+    fire_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChronosFireClaims {
+    #[serde(default)]
+    pub purpose: Option<String>,
+    #[serde(default)]
+    pub iss: Option<String>,
+    #[serde(default)]
+    pub aud: Option<Value>,
+    #[serde(default)]
+    pub exp: Option<u64>,
+    #[serde(default)]
+    pub nbf: Option<u64>,
+}
+
+pub async fn verify_nas_fire_token(
+    token: &str,
+    config: &ChronosConfig,
+) -> Result<ChronosFireClaims, CronError> {
+    if token.trim().is_empty() {
+        return Err(CronError::Scheduler(
+            "missing Chronos bearer token".to_string(),
+        ));
+    }
+    if !config.can_verify_fire() {
+        return Err(CronError::Scheduler(
+            "Chronos fire verification is not configured".to_string(),
+        ));
+    }
+
+    let header = decode_header(token)
+        .map_err(|err| CronError::Scheduler(format!("Chronos token header invalid: {err}")))?;
+    if !matches!(
+        header.alg,
+        Algorithm::RS256
+            | Algorithm::RS384
+            | Algorithm::RS512
+            | Algorithm::ES256
+            | Algorithm::ES384
+    ) {
+        return Err(CronError::Scheduler(
+            "Chronos token uses an unsupported signing algorithm".to_string(),
+        ));
+    }
+
+    let key = decoding_key_for_token(&header.kid, &config.nas_jwks_url).await?;
+    let mut validation = Validation::new(header.alg);
+    validation.leeway = config.token_leeway_seconds;
+    validation.validate_nbf = true;
+    validation.set_audience(&[config.expected_audience.as_str()]);
+    validation.required_spec_claims.insert("aud".to_string());
+    validation.required_spec_claims.insert("exp".to_string());
+    if !config.portal_url.trim().is_empty() {
+        validation.set_issuer(&[config.portal_url.trim_end_matches('/')]);
+        validation.required_spec_claims.insert("iss".to_string());
+    }
+
+    let data = decode::<ChronosFireClaims>(token, &key, &validation)
+        .map_err(|err| CronError::Scheduler(format!("Chronos token rejected: {err}")))?;
+    if data.claims.purpose.as_deref() != Some(FIRE_PURPOSE) {
+        return Err(CronError::Scheduler(
+            "Chronos token missing cron_fire purpose".to_string(),
+        ));
+    }
+
+    Ok(data.claims)
+}
+
+async fn decoding_key_for_token(
+    kid: &Option<String>,
+    jwks_or_key: &str,
+) -> Result<DecodingKey, CronError> {
+    let source = jwks_or_key.trim();
+    if source.starts_with("http://") || source.starts_with("https://") {
+        let set: JwkSet = reqwest::Client::new()
+            .get(source)
+            .send()
+            .await
+            .map_err(|err| CronError::Scheduler(format!("Chronos JWKS fetch failed: {err}")))?
+            .error_for_status()
+            .map_err(|err| CronError::Scheduler(format!("Chronos JWKS rejected: {err}")))?
+            .json()
+            .await
+            .map_err(|err| CronError::Scheduler(format!("Chronos JWKS parse failed: {err}")))?;
+        let jwk = select_jwk(&set, kid)?;
+        return DecodingKey::from_jwk(jwk)
+            .map_err(|err| CronError::Scheduler(format!("Chronos JWKS key invalid: {err}")));
+    }
+
+    if source.starts_with('{') {
+        let value: Value = serde_json::from_str(source)
+            .map_err(|err| CronError::Scheduler(format!("Chronos inline JWKS invalid: {err}")))?;
+        if value.get("keys").is_some() {
+            let set: JwkSet = serde_json::from_value(value).map_err(|err| {
+                CronError::Scheduler(format!("Chronos inline JWKS parse failed: {err}"))
+            })?;
+            let jwk = select_jwk(&set, kid)?;
+            return DecodingKey::from_jwk(jwk)
+                .map_err(|err| CronError::Scheduler(format!("Chronos JWKS key invalid: {err}")));
+        }
+        let jwk: Jwk = serde_json::from_value(value).map_err(|err| {
+            CronError::Scheduler(format!("Chronos inline JWK parse failed: {err}"))
+        })?;
+        reject_symmetric_jwk(&jwk)?;
+        return DecodingKey::from_jwk(&jwk)
+            .map_err(|err| CronError::Scheduler(format!("Chronos JWK key invalid: {err}")));
+    }
+
+    DecodingKey::from_rsa_pem(source.as_bytes())
+        .or_else(|_| DecodingKey::from_ec_pem(source.as_bytes()))
+        .map_err(|err| CronError::Scheduler(format!("Chronos PEM key invalid: {err}")))
+}
+
+fn select_jwk<'a>(set: &'a JwkSet, kid: &Option<String>) -> Result<&'a Jwk, CronError> {
+    let jwk = if let Some(kid) = kid {
+        set.find(kid).ok_or_else(|| {
+            CronError::Scheduler(format!("Chronos JWKS did not contain kid {kid}"))
+        })?
+    } else if set.keys.len() == 1 {
+        &set.keys[0]
+    } else {
+        return Err(CronError::Scheduler(
+            "Chronos token has no kid and JWKS has multiple keys".to_string(),
+        ));
+    };
+    reject_symmetric_jwk(jwk)?;
+    Ok(jwk)
+}
+
+fn reject_symmetric_jwk(jwk: &Jwk) -> Result<(), CronError> {
+    if matches!(jwk.algorithm, AlgorithmParameters::OctetKey(_)) {
+        return Err(CronError::Scheduler(
+            "Chronos fire tokens must use asymmetric signing keys".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde_json::json;
+
+    #[test]
+    fn config_reads_upstream_chronos_yaml_shape() {
+        let root = Some(json!({
+            "cron": {
+                "provider": "chronos",
+                "chronos": {
+                    "portal_url": "https://portal.example",
+                    "callback_url": "https://agent.example",
+                    "expected_audience": "agent:abc",
+                    "nas_jwks_url": "https://portal.example/.well-known/jwks.json",
+                    "token_leeway_seconds": 42
+                }
+            }
+        }));
+        assert_eq!(
+            yaml_string(&root, &["cron", "chronos", "portal_url"]).as_deref(),
+            Some("https://portal.example")
+        );
+        assert_eq!(
+            env_or_yaml_u64(
+                "HERMES_TEST_CHRONOS_NONE",
+                &root,
+                &["cron", "chronos", "token_leeway_seconds"],
+                30
+            ),
+            42
+        );
+    }
+
+    #[tokio::test]
+    async fn fire_verifier_rejects_symmetric_jwks() {
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &json!({
+                "aud": "agent:abc",
+                "iss": "https://portal.example",
+                "exp": 4_102_444_800_u64,
+                "purpose": FIRE_PURPOSE
+            }),
+            &EncodingKey::from_secret(b"secret"),
+        )
+        .expect("encode test token");
+        let key = base64_url("secret");
+        let config = ChronosConfig {
+            provider: "chronos".to_string(),
+            portal_url: "https://portal.example".to_string(),
+            expected_audience: "agent:abc".to_string(),
+            nas_jwks_url: json!({
+                "keys": [{
+                    "kty": "oct",
+                    "alg": "HS256",
+                    "kid": "test",
+                    "k": key
+                }]
+            })
+            .to_string(),
+            ..ChronosConfig::default()
+        };
+        let err = verify_nas_fire_token(&token, &config).await.unwrap_err();
+        assert!(err.to_string().contains("unsupported signing algorithm"));
+    }
+
+    fn base64_url(raw: &str) -> String {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+        URL_SAFE_NO_PAD.encode(raw.as_bytes())
+    }
+}

--- a/crates/hermes-cron/src/lib.rs
+++ b/crates/hermes-cron/src/lib.rs
@@ -8,12 +8,14 @@
 
 pub mod backend;
 pub mod blueprints;
+pub mod chronos;
 pub mod cli_support;
 pub mod completion;
 pub mod job;
 pub mod persistence;
 pub mod runner;
 pub mod scheduler;
+pub mod suggestions;
 
 // Re-export primary types
 pub use backend::ScheduledCronjobBackend;
@@ -22,9 +24,16 @@ pub use blueprints::{
     AutomationBlueprint, BlueprintCommandAction, BlueprintFillError, BlueprintJobSpec,
     BlueprintSlot, BlueprintSlotKind,
 };
+pub use chronos::{
+    verify_nas_fire_token, ChronosConfig, ChronosFireClaims, ChronosNasCronProvider,
+};
 pub use cli_support::{cron_scheduler_for_data_dir, MinimalCronLlm};
 pub use completion::CronCompletionEvent;
 pub use job::{CronJob, DeliverConfig, DeliverTarget, JobStatus, ModelConfig};
 pub use persistence::{FileJobPersistence, JobPersistence, SqliteJobPersistence};
 pub use runner::CronRunner;
-pub use scheduler::{CronError, CronScheduler};
+pub use scheduler::{CronError, CronScheduler, ManagedCronProvider};
+pub use suggestions::{
+    SuggestionError, SuggestionJobSpec, SuggestionRecord, SuggestionStatus, SuggestionStore,
+    MAX_PENDING_SUGGESTIONS,
+};

--- a/crates/hermes-cron/src/scheduler.rs
+++ b/crates/hermes-cron/src/scheduler.rs
@@ -13,6 +13,7 @@ use hermes_core::{AgentResult, MessageRole};
 use tokio::sync::{broadcast, Mutex, Notify};
 use tokio::time::{self, Duration};
 
+use crate::chronos::ChronosNasCronProvider;
 use crate::completion::CronCompletionEvent;
 use crate::job::{CronJob, JobStatus};
 use crate::persistence::JobPersistence;
@@ -57,6 +58,14 @@ impl CronJobExecutor for CronRunner {
     ) -> Result<(), CronError> {
         CronRunner::deliver_error(self, error_text, deliver).await
     }
+}
+
+#[async_trait::async_trait]
+pub trait ManagedCronProvider: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn is_available(&self) -> bool;
+    async fn reconcile(&self, jobs: Vec<CronJob>) -> Result<(), CronError>;
+    async fn cancel(&self, job_id: &str) -> Result<(), CronError>;
 }
 
 struct ScheduledCronRun {
@@ -192,6 +201,8 @@ pub struct CronScheduler {
     /// Jobs with per-run process-global context (currently workdir) are
     /// serialized without blocking the scheduler tick.
     sequential_run_lock: Arc<Mutex<()>>,
+    /// Optional externally managed one-shot provider for hosted scale-to-zero.
+    managed_provider: Option<Arc<dyn ManagedCronProvider>>,
 }
 
 impl CronScheduler {
@@ -204,6 +215,19 @@ impl CronScheduler {
         persistence: Arc<dyn JobPersistence>,
         runner: Arc<dyn CronJobExecutor>,
     ) -> Self {
+        let chronos = ChronosNasCronProvider::from_environment();
+        let managed_provider = chronos
+            .config()
+            .provider_enabled()
+            .then(|| Arc::new(chronos) as Arc<dyn ManagedCronProvider>);
+        Self::new_with_executor_and_managed_provider(persistence, runner, managed_provider)
+    }
+
+    fn new_with_executor_and_managed_provider(
+        persistence: Arc<dyn JobPersistence>,
+        runner: Arc<dyn CronJobExecutor>,
+        managed_provider: Option<Arc<dyn ManagedCronProvider>>,
+    ) -> Self {
         Self {
             jobs: Arc::new(Mutex::new(HashMap::new())),
             persistence,
@@ -213,12 +237,52 @@ impl CronScheduler {
             running: Arc::new(Mutex::new(false)),
             running_job_ids: Arc::new(Mutex::new(HashSet::new())),
             sequential_run_lock: Arc::new(Mutex::new(())),
+            managed_provider,
         }
     }
 
     /// Receive [`CronCompletionEvent`] on every finished run (scheduled or manual).
     pub fn set_completion_broadcast(&mut self, tx: broadcast::Sender<CronCompletionEvent>) {
         self.completion_tx = Some(tx);
+    }
+
+    pub fn set_managed_provider(&mut self, provider: Arc<dyn ManagedCronProvider>) {
+        self.managed_provider = Some(provider);
+    }
+
+    fn managed_provider_if_available(&self) -> Option<Arc<dyn ManagedCronProvider>> {
+        self.managed_provider
+            .as_ref()
+            .filter(|provider| provider.is_available())
+            .cloned()
+    }
+
+    async fn reconcile_managed_provider(&self) {
+        let Some(provider) = self.managed_provider_if_available() else {
+            return;
+        };
+        let jobs = self.list_jobs().await;
+        if let Err(err) = provider.reconcile(jobs).await {
+            tracing::warn!(
+                provider = provider.name(),
+                error = %err,
+                "managed cron reconcile failed"
+            );
+        }
+    }
+
+    async fn cancel_managed_provider_job(&self, job_id: &str) {
+        let Some(provider) = self.managed_provider_if_available() else {
+            return;
+        };
+        if let Err(err) = provider.cancel(job_id).await {
+            tracing::warn!(
+                provider = provider.name(),
+                job_id,
+                error = %err,
+                "managed cron cancel failed"
+            );
+        }
     }
 
     fn emit_completion(
@@ -273,6 +337,7 @@ impl CronScheduler {
         persistence: Arc<dyn JobPersistence>,
         completion_tx: Option<broadcast::Sender<CronCompletionEvent>>,
         runner: Arc<dyn CronJobExecutor>,
+        managed_provider: Option<Arc<dyn ManagedCronProvider>>,
         mut job: CronJob,
         scheduled_at: chrono::DateTime<Utc>,
         run_result: Result<AgentResult, CronError>,
@@ -312,6 +377,17 @@ impl CronScheduler {
 
         if let Err(e) = persistence.save_job(&job).await {
             tracing::error!("Failed to persist job '{}': {}", job.id, e);
+        }
+
+        if let Some(provider) = managed_provider.filter(|provider| provider.is_available()) {
+            let snapshot = jobs.lock().await.values().cloned().collect::<Vec<_>>();
+            if let Err(err) = provider.reconcile(snapshot).await {
+                tracing::warn!(
+                    provider = provider.name(),
+                    error = %err,
+                    "managed cron re-arm failed after fire"
+                );
+            }
         }
     }
 
@@ -354,6 +430,7 @@ impl CronScheduler {
         completion_tx: Option<broadcast::Sender<CronCompletionEvent>>,
         running_job_ids: Arc<Mutex<HashSet<String>>>,
         sequential_run_lock: Arc<Mutex<()>>,
+        managed_provider: Option<Arc<dyn ManagedCronProvider>>,
     ) -> usize {
         let now = Utc::now();
         let due_jobs = Self::collect_due_runs(jobs.clone(), running_job_ids.clone(), now).await;
@@ -373,6 +450,7 @@ impl CronScheduler {
             let completion_tx = completion_tx.clone();
             let running_job_ids = running_job_ids.clone();
             let sequential_run_lock = sequential_run_lock.clone();
+            let managed_provider = managed_provider.clone();
 
             tokio::spawn(async move {
                 let job = due_run.job;
@@ -389,6 +467,7 @@ impl CronScheduler {
                     persistence,
                     completion_tx,
                     runner,
+                    managed_provider,
                     job,
                     now,
                     run_result,
@@ -449,6 +528,22 @@ impl CronScheduler {
         let running_job_ids = self.running_job_ids.clone();
         let sequential_run_lock = self.sequential_run_lock.clone();
 
+        if let Some(provider) = self.managed_provider_if_available() {
+            if let Err(err) = provider.reconcile(self.list_jobs().await).await {
+                tracing::warn!(
+                    provider = provider.name(),
+                    error = %err,
+                    "managed cron start reconcile failed"
+                );
+            } else {
+                tracing::info!(
+                    provider = provider.name(),
+                    "managed cron provider active; in-process poll loop is disabled"
+                );
+            }
+            return;
+        }
+
         tokio::spawn(async move {
             loop {
                 // Check if we should stop
@@ -474,6 +569,7 @@ impl CronScheduler {
                     completion_tx.clone(),
                     running_job_ids.clone(),
                     sequential_run_lock.clone(),
+                    None,
                 )
                 .await;
             }
@@ -495,6 +591,7 @@ impl CronScheduler {
             self.completion_tx.clone(),
             self.running_job_ids.clone(),
             self.sequential_run_lock.clone(),
+            None,
         )
         .await
     }
@@ -561,6 +658,7 @@ impl CronScheduler {
         }
 
         tracing::info!("Created cron job '{}' ({})", id, schedule);
+        self.reconcile_managed_provider().await;
         Ok(id)
     }
 
@@ -603,6 +701,8 @@ impl CronScheduler {
             .map_err(|e| CronError::Persistence(e.to_string()))?;
 
         guard.insert(id.to_string(), job);
+        drop(guard);
+        self.reconcile_managed_provider().await;
         Ok(())
     }
 
@@ -632,6 +732,7 @@ impl CronScheduler {
         }
 
         tracing::info!("Paused cron job '{}'", id);
+        self.cancel_managed_provider_job(id).await;
         Ok(())
     }
 
@@ -662,6 +763,7 @@ impl CronScheduler {
         }
 
         tracing::info!("Resumed cron job '{}'", id);
+        self.reconcile_managed_provider().await;
         Ok(())
     }
 
@@ -680,6 +782,7 @@ impl CronScheduler {
             .map_err(|e| CronError::Persistence(e.to_string()))?;
 
         tracing::info!("Removed cron job '{}'", id);
+        self.cancel_managed_provider_job(id).await;
         Ok(())
     }
 
@@ -765,6 +868,85 @@ impl CronScheduler {
         Self::clear_running(&self.running_job_ids, id).await;
         outcome
     }
+
+    /// Accept a managed-provider fire callback and dispatch the job in the
+    /// background. Returns `Ok(false)` for duplicate or stale fires that were
+    /// safely ignored.
+    pub async fn fire_managed_job(
+        &self,
+        id: &str,
+        fire_at: Option<chrono::DateTime<Utc>>,
+    ) -> Result<bool, CronError> {
+        let (job, runnable_job, scheduled_at) = {
+            let guard = self.jobs.lock().await;
+            let job = guard
+                .get(id)
+                .cloned()
+                .ok_or_else(|| CronError::JobNotFound(id.to_string()))?;
+            if job.status != JobStatus::Active {
+                return Ok(false);
+            }
+            if let Some(expected_fire_at) = fire_at {
+                if job.next_run != Some(expected_fire_at) {
+                    tracing::info!(
+                        job_id = id,
+                        expected = ?job.next_run,
+                        received = ?expected_fire_at,
+                        "ignoring stale managed cron fire"
+                    );
+                    return Ok(false);
+                }
+            }
+
+            let mut runnable_job = job.clone();
+            if let Some(ctx_prefix) = build_context_prefix_for_job(&runnable_job, &guard) {
+                runnable_job.prompt = format!("{}\n\n{}", ctx_prefix, runnable_job.prompt);
+            }
+            let scheduled_at = fire_at.or(job.next_run).unwrap_or_else(Utc::now);
+            (job, runnable_job, scheduled_at)
+        };
+
+        if !Self::mark_running_if_idle(&self.running_job_ids, id).await {
+            tracing::info!(
+                job_id = id,
+                "ignoring duplicate managed cron fire already in flight"
+            );
+            return Ok(false);
+        }
+
+        let jobs = self.jobs.clone();
+        let persistence = self.persistence.clone();
+        let completion_tx = self.completion_tx.clone();
+        let runner = self.runner.clone();
+        let running_job_ids = self.running_job_ids.clone();
+        let sequential_run_lock = self.sequential_run_lock.clone();
+        let managed_provider = self.managed_provider.clone();
+        let job_id = id.to_string();
+
+        tokio::spawn(async move {
+            let run_result = Self::execute_with_optional_sequential_guard(
+                runner.clone(),
+                sequential_run_lock,
+                runnable_job,
+            )
+            .await;
+
+            Self::finish_scheduled_job(
+                jobs,
+                persistence,
+                completion_tx,
+                runner,
+                managed_provider,
+                job,
+                scheduled_at,
+                run_result,
+            )
+            .await;
+            Self::clear_running(&running_job_ids, &job_id).await;
+        });
+
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -819,6 +1001,48 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RecordingManagedProvider {
+        reconciles: StdMutex<Vec<Vec<String>>>,
+        cancels: StdMutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ManagedCronProvider for RecordingManagedProvider {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn reconcile(&self, jobs: Vec<CronJob>) -> Result<(), CronError> {
+            let mut ids = jobs.into_iter().map(|job| job.id).collect::<Vec<_>>();
+            ids.sort();
+            self.reconciles.lock().expect("reconciles").push(ids);
+            Ok(())
+        }
+
+        async fn cancel(&self, job_id: &str) -> Result<(), CronError> {
+            self.cancels
+                .lock()
+                .expect("cancels")
+                .push(job_id.to_string());
+            Ok(())
+        }
+    }
+
+    impl RecordingManagedProvider {
+        fn reconcile_count(&self) -> usize {
+            self.reconciles.lock().expect("reconciles").len()
+        }
+
+        fn cancels(&self) -> Vec<String> {
+            self.cancels.lock().expect("cancels").clone()
+        }
+    }
+
     #[async_trait::async_trait]
     impl CronJobExecutor for BlockingTestExecutor {
         async fn run_job(&self, job: &CronJob) -> Result<AgentResult, CronError> {
@@ -854,6 +1078,22 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let persistence = Arc::new(FileJobPersistence::with_dir(dir.path().to_path_buf()));
         (CronScheduler::new_with_executor(persistence, executor), dir)
+    }
+
+    fn make_executor_scheduler_with_provider(
+        executor: Arc<BlockingTestExecutor>,
+        provider: Arc<RecordingManagedProvider>,
+    ) -> (CronScheduler, tempfile::TempDir) {
+        let dir = tempdir().expect("tempdir");
+        let persistence = Arc::new(FileJobPersistence::with_dir(dir.path().to_path_buf()));
+        (
+            CronScheduler::new_with_executor_and_managed_provider(
+                persistence,
+                executor,
+                Some(provider),
+            ),
+            dir,
+        )
     }
 
     fn due_test_job(prompt: &str) -> CronJob {
@@ -1024,6 +1264,66 @@ mod tests {
         let stored = sched.get_job(&target_id).await.expect("stored target");
         assert_eq!(stored.prompt, "summarize");
         assert!(!stored.prompt.contains("latest source output"));
+    }
+
+    #[tokio::test]
+    async fn managed_provider_reconciles_mutations_and_cancels_disabled_jobs() {
+        let executor = Arc::new(BlockingTestExecutor::default());
+        let provider = Arc::new(RecordingManagedProvider::default());
+        let (sched, _dir) = make_executor_scheduler_with_provider(executor, provider.clone());
+
+        let id = sched
+            .create_job(CronJob::new("0 * * * *", "managed"))
+            .await
+            .expect("create managed job");
+        assert_eq!(provider.reconcile_count(), 1);
+
+        sched.pause_job(&id).await.expect("pause");
+        assert_eq!(provider.cancels(), vec![id.clone()]);
+
+        sched.resume_job(&id).await.expect("resume");
+        assert_eq!(provider.reconcile_count(), 2);
+
+        sched.remove_job(&id).await.expect("remove");
+        assert_eq!(provider.cancels(), vec![id.clone(), id]);
+    }
+
+    #[tokio::test]
+    async fn managed_fire_dispatches_once_and_ignores_stale_fire_at() {
+        let executor = Arc::new(BlockingTestExecutor::default());
+        let provider = Arc::new(RecordingManagedProvider::default());
+        let (sched, _dir) = make_executor_scheduler_with_provider(executor.clone(), provider);
+        let fire_at = Utc::now() + ChronoDuration::seconds(30);
+        let mut job = CronJob::new("*/5 * * * * *", "managed fire");
+        job.next_run = Some(fire_at);
+        let id = sched.create_job(job).await.expect("create");
+
+        let stale = sched
+            .fire_managed_job(&id, Some(fire_at + ChronoDuration::seconds(1)))
+            .await
+            .expect("stale fire");
+        assert!(!stale);
+        assert_eq!(executor.started.load(Ordering::SeqCst), 0);
+
+        let accepted = sched
+            .fire_managed_job(&id, Some(fire_at))
+            .await
+            .expect("accepted fire");
+        assert!(accepted);
+        wait_for_count(&executor.started, 1).await;
+
+        let duplicate = sched
+            .fire_managed_job(&id, Some(fire_at))
+            .await
+            .expect("duplicate fire");
+        assert!(!duplicate);
+        assert_eq!(executor.started.load(Ordering::SeqCst), 1);
+
+        executor.release.add_permits(1);
+        wait_for_count(&executor.completed, 1).await;
+        let stored = sched.get_job(&id).await.expect("stored");
+        assert_ne!(stored.next_run, Some(fire_at));
+        assert_eq!(stored.run_count, 1);
     }
 
     #[test]

--- a/crates/hermes-cron/src/suggestions.rs
+++ b/crates/hermes-cron/src/suggestions.rs
@@ -1,0 +1,478 @@
+//! Consent-first suggested cron jobs.
+//!
+//! Suggestions are ready-to-run cron job specs that become real jobs only when
+//! the user accepts them. The scheduler remains the single execution engine.
+
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::blueprints::{catalog as blueprint_catalog, fill_blueprint};
+
+pub const MAX_PENDING_SUGGESTIONS: usize = 5;
+
+const VALID_SOURCES: &[&str] = &["catalog", "blueprint", "usage", "integration"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SuggestionStatus {
+    Pending,
+    Accepted,
+    Dismissed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SuggestionJobSpec {
+    pub schedule: String,
+    pub prompt: String,
+    pub name: String,
+    #[serde(default = "default_deliver")]
+    pub deliver: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+}
+
+fn default_deliver() -> String {
+    "origin".to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SuggestionRecord {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub source: String,
+    pub job_spec: SuggestionJobSpec,
+    pub dedup_key: String,
+    pub status: SuggestionStatus,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct SuggestionFile {
+    #[serde(default)]
+    suggestions: Vec<SuggestionRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SuggestionError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("Corrupted suggestions data: {0}")]
+    Corrupted(String),
+
+    #[error("Invalid suggestion: {0}")]
+    Invalid(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct SuggestionStore {
+    path: PathBuf,
+}
+
+impl SuggestionStore {
+    pub fn new() -> Self {
+        Self {
+            path: hermes_config::cron_dir().join("suggestions.json"),
+        }
+    }
+
+    pub fn with_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    pub fn load_suggestions(&self) -> Result<Vec<SuggestionRecord>, SuggestionError> {
+        with_suggestion_lock(|| self.load_suggestions_unlocked())
+    }
+
+    pub fn list_pending(&self) -> Result<Vec<SuggestionRecord>, SuggestionError> {
+        let records = self.load_suggestions()?;
+        Ok(records
+            .into_iter()
+            .filter(|record| record.status == SuggestionStatus::Pending)
+            .collect())
+    }
+
+    pub fn seed_catalog_suggestions(&self) -> Result<Vec<SuggestionRecord>, SuggestionError> {
+        with_suggestion_lock(|| {
+            let mut records = self.load_suggestions_unlocked()?;
+            let mut created = Vec::new();
+            for blueprint in blueprint_catalog() {
+                let spec = fill_blueprint(&blueprint, &BTreeMap::new()).map_err(|err| {
+                    SuggestionError::Invalid(format!(
+                        "blueprint {} default fill failed: {err}",
+                        blueprint.key
+                    ))
+                })?;
+                let input = AddSuggestionInput {
+                    title: blueprint.title.to_string(),
+                    description: blueprint.description.to_string(),
+                    source: "catalog".to_string(),
+                    job_spec: SuggestionJobSpec {
+                        schedule: spec.schedule,
+                        prompt: spec.prompt,
+                        name: spec.title,
+                        deliver: spec.deliver,
+                        skills: spec.skills,
+                    },
+                    dedup_key: format!("catalog:{}", blueprint.key),
+                };
+                if let Some(record) = add_suggestion_to_records(&mut records, input)? {
+                    created.push(record);
+                }
+            }
+            if !created.is_empty() {
+                self.save_suggestions_unlocked(&records)?;
+            }
+            Ok(created)
+        })
+    }
+
+    pub fn get_pending(
+        &self,
+        reference: &str,
+    ) -> Result<Option<SuggestionRecord>, SuggestionError> {
+        let records = self.load_suggestions()?;
+        Ok(resolve_suggestion(&records, reference)
+            .filter(|record| record.status == SuggestionStatus::Pending)
+            .cloned())
+    }
+
+    pub fn dismiss_suggestion(&self, reference: &str) -> Result<bool, SuggestionError> {
+        with_suggestion_lock(|| {
+            let mut records = self.load_suggestions_unlocked()?;
+            let Some(record) = resolve_suggestion(&records, reference) else {
+                return Ok(false);
+            };
+            if record.status != SuggestionStatus::Pending {
+                return Ok(false);
+            }
+            let id = record.id.clone();
+            let changed = set_status(&mut records, &id, SuggestionStatus::Dismissed);
+            if changed {
+                self.save_suggestions_unlocked(&records)?;
+            }
+            Ok(changed)
+        })
+    }
+
+    pub fn mark_accepted(&self, suggestion_id: &str) -> Result<bool, SuggestionError> {
+        with_suggestion_lock(|| {
+            let mut records = self.load_suggestions_unlocked()?;
+            let Some(record) = records
+                .iter()
+                .find(|record| record.id.as_str() == suggestion_id)
+            else {
+                return Ok(false);
+            };
+            if record.status != SuggestionStatus::Pending {
+                return Ok(false);
+            }
+            let changed = set_status(&mut records, suggestion_id, SuggestionStatus::Accepted);
+            if changed {
+                self.save_suggestions_unlocked(&records)?;
+            }
+            Ok(changed)
+        })
+    }
+
+    pub fn clear_resolved(&self) -> Result<usize, SuggestionError> {
+        with_suggestion_lock(|| {
+            let mut records = self.load_suggestions_unlocked()?;
+            let before = records.len();
+            records.retain(|record| record.status != SuggestionStatus::Accepted);
+            let removed = before - records.len();
+            if removed > 0 {
+                self.save_suggestions_unlocked(&records)?;
+            }
+            Ok(removed)
+        })
+    }
+
+    fn load_suggestions_unlocked(&self) -> Result<Vec<SuggestionRecord>, SuggestionError> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let raw = std::fs::read_to_string(&self.path)?;
+        if raw.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let value: serde_json::Value = serde_json::from_str(&raw)?;
+        if value.is_array() {
+            return serde_json::from_value::<Vec<SuggestionRecord>>(value)
+                .map_err(SuggestionError::Serialization);
+        }
+        let file = serde_json::from_value::<SuggestionFile>(value)?;
+        Ok(file.suggestions)
+    }
+
+    fn save_suggestions_unlocked(
+        &self,
+        records: &[SuggestionRecord],
+    ) -> Result<(), SuggestionError> {
+        let Some(parent) = self.path.parent() else {
+            return Err(SuggestionError::Corrupted(format!(
+                "suggestions path has no parent: {}",
+                self.path.display()
+            )));
+        };
+        std::fs::create_dir_all(parent)?;
+        secure_dir(parent)?;
+
+        let file = SuggestionFile {
+            suggestions: records.to_vec(),
+            updated_at: Some(Utc::now()),
+        };
+        let raw = serde_json::to_string_pretty(&file)?;
+        let tmp = parent.join(format!(
+            ".suggestions.{}.tmp",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let write_result = (|| -> Result<(), SuggestionError> {
+            let mut handle = std::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&tmp)?;
+            handle.write_all(raw.as_bytes())?;
+            handle.flush()?;
+            handle.sync_all()?;
+            secure_file(&tmp)?;
+            std::fs::rename(&tmp, &self.path)?;
+            secure_file(&self.path)?;
+            Ok(())
+        })();
+        if write_result.is_err() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+        write_result
+    }
+}
+
+impl Default for SuggestionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct AddSuggestionInput {
+    title: String,
+    description: String,
+    source: String,
+    job_spec: SuggestionJobSpec,
+    dedup_key: String,
+}
+
+fn add_suggestion_to_records(
+    records: &mut Vec<SuggestionRecord>,
+    input: AddSuggestionInput,
+) -> Result<Option<SuggestionRecord>, SuggestionError> {
+    let title = input.title.trim();
+    let source = input.source.trim();
+    let dedup_key = input.dedup_key.trim();
+    if title.is_empty() || dedup_key.is_empty() {
+        return Err(SuggestionError::Invalid(
+            "title and dedup_key are required".to_string(),
+        ));
+    }
+    if !VALID_SOURCES.contains(&source) {
+        return Err(SuggestionError::Invalid(format!(
+            "unknown suggestion source: {source}"
+        )));
+    }
+    if records
+        .iter()
+        .any(|record| record.dedup_key.as_str() == dedup_key)
+    {
+        return Ok(None);
+    }
+    let pending_count = records
+        .iter()
+        .filter(|record| record.status == SuggestionStatus::Pending)
+        .count();
+    if pending_count >= MAX_PENDING_SUGGESTIONS {
+        return Ok(None);
+    }
+
+    let record = SuggestionRecord {
+        id: uuid::Uuid::new_v4().simple().to_string()[..12].to_string(),
+        title: title.to_string(),
+        description: input.description.trim().to_string(),
+        source: source.to_string(),
+        job_spec: input.job_spec,
+        dedup_key: dedup_key.to_string(),
+        status: SuggestionStatus::Pending,
+        created_at: Utc::now(),
+        resolved_at: None,
+    };
+    records.push(record.clone());
+    Ok(Some(record))
+}
+
+fn resolve_suggestion<'a>(
+    records: &'a [SuggestionRecord],
+    reference: &str,
+) -> Option<&'a SuggestionRecord> {
+    let reference = reference.trim();
+    if reference.is_empty() {
+        return None;
+    }
+    if let Some(record) = records.iter().find(|record| record.id == reference) {
+        return Some(record);
+    }
+    if let Ok(index) = reference.parse::<usize>() {
+        if index > 0 {
+            return records
+                .iter()
+                .filter(|record| record.status == SuggestionStatus::Pending)
+                .nth(index - 1);
+        }
+    }
+    records
+        .iter()
+        .find(|record| record.title.eq_ignore_ascii_case(reference))
+}
+
+fn set_status(
+    records: &mut [SuggestionRecord],
+    suggestion_id: &str,
+    status: SuggestionStatus,
+) -> bool {
+    let Some(record) = records
+        .iter_mut()
+        .find(|record| record.id.as_str() == suggestion_id)
+    else {
+        return false;
+    };
+    if record.status == status {
+        return false;
+    }
+    record.status = status;
+    record.resolved_at = Some(Utc::now());
+    true
+}
+
+fn suggestion_lock() -> &'static Mutex<()> {
+    static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn with_suggestion_lock<T>(
+    f: impl FnOnce() -> Result<T, SuggestionError>,
+) -> Result<T, SuggestionError> {
+    let _guard = suggestion_lock()
+        .lock()
+        .map_err(|_| SuggestionError::Corrupted("suggestions lock poisoned".to_string()))?;
+    f()
+}
+
+#[cfg(unix)]
+fn secure_dir(path: &std::path::Path) -> Result<(), std::io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn secure_dir(_path: &std::path::Path) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_file(path: &std::path::Path) -> Result<(), std::io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn secure_file(_path: &std::path::Path) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (SuggestionStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = SuggestionStore::with_path(dir.path().join("cron").join("suggestions.json"));
+        (store, dir)
+    }
+
+    #[test]
+    fn catalog_seed_lists_pending_and_is_idempotent() {
+        let (store, _dir) = temp_store();
+        let created = store
+            .seed_catalog_suggestions()
+            .expect("seed catalog suggestions");
+        assert_eq!(
+            created.len(),
+            MAX_PENDING_SUGGESTIONS.min(blueprint_catalog().len())
+        );
+
+        let pending = store.list_pending().expect("pending");
+        assert_eq!(pending.len(), created.len());
+        assert!(pending.iter().any(|record| {
+            record.title == "Morning briefing" && record.job_spec.schedule == "0 8 * * *"
+        }));
+
+        let created_again = store
+            .seed_catalog_suggestions()
+            .expect("seed catalog suggestions again");
+        assert!(created_again.is_empty());
+    }
+
+    #[test]
+    fn dismiss_latches_catalog_dedup() {
+        let (store, _dir) = temp_store();
+        store
+            .seed_catalog_suggestions()
+            .expect("seed catalog suggestions");
+
+        let dismissed = store.get_pending("1").expect("pending").expect("first");
+        let dismissed_key = dismissed.dedup_key.clone();
+        assert!(store.dismiss_suggestion("1").expect("dismiss"));
+        let pending = store.list_pending().expect("pending");
+        assert_eq!(pending.len(), MAX_PENDING_SUGGESTIONS - 1);
+
+        let _created_again = store
+            .seed_catalog_suggestions()
+            .expect("seed catalog suggestions again");
+        let records = store.load_suggestions().expect("records");
+        assert!(!records.iter().any(|record| {
+            record.dedup_key == dismissed_key && record.status == SuggestionStatus::Pending
+        }));
+    }
+
+    #[test]
+    fn accepted_records_can_be_cleared_without_losing_dismissals() {
+        let (store, _dir) = temp_store();
+        let created = store
+            .seed_catalog_suggestions()
+            .expect("seed catalog suggestions");
+        let accepted_id = created[0].id.clone();
+        assert!(store.mark_accepted(&accepted_id).expect("accepted"));
+        assert!(store.dismiss_suggestion("1").expect("dismiss remaining"));
+
+        assert_eq!(store.clear_resolved().expect("clear"), 1);
+        let records = store.load_suggestions().expect("records");
+        assert!(records.iter().all(|record| record.id != accepted_id));
+        assert!(records
+            .iter()
+            .any(|record| record.status == SuggestionStatus::Dismissed));
+    }
+}

--- a/crates/hermes-gateway/src/platforms/api_server.rs
+++ b/crates/hermes-gateway/src/platforms/api_server.rs
@@ -18,7 +18,10 @@ use tracing::{debug, error, info, warn};
 
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
-use hermes_cron::{CronError, CronJob, CronScheduler, DeliverConfig, DeliverTarget, JobStatus};
+use hermes_cron::{
+    verify_nas_fire_token, ChronosConfig, CronError, CronJob, CronScheduler, DeliverConfig,
+    DeliverTarget, JobStatus,
+};
 use hermes_tools::{ToolRegistry, ToolsetManager};
 
 use crate::adapter::BasePlatformAdapter;
@@ -193,6 +196,13 @@ struct ApiCronJobCreateRequest {
     no_agent: Option<bool>,
     #[serde(default)]
     enabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiCronFireRequest {
+    job_id: String,
+    #[serde(default)]
+    fire_at: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -921,6 +931,10 @@ const HTTP_OK: HttpStatus = HttpStatus {
     code: 200,
     reason: "OK",
 };
+const HTTP_ACCEPTED: HttpStatus = HttpStatus {
+    code: 202,
+    reason: "Accepted",
+};
 const HTTP_BAD_REQUEST: HttpStatus = HttpStatus {
     code: 400,
     reason: "Bad Request",
@@ -1057,6 +1071,7 @@ fn capabilities_response_body() -> serde_json::Value {
             "jobs_pause": {"method": "POST", "path": "/api/jobs/{job_id}/pause"},
             "jobs_resume": {"method": "POST", "path": "/api/jobs/{job_id}/resume"},
             "jobs_run": {"method": "POST", "path": "/api/jobs/{job_id}/run"},
+            "cron_fire": {"method": "POST", "path": "/api/cron/fire"},
             "skills": {"method": "GET", "path": "/v1/skills"},
             "toolsets": {"method": "GET", "path": "/v1/toolsets"},
         }
@@ -2116,6 +2131,94 @@ async fn api_jobs_action_response(
     )
 }
 
+async fn api_cron_fire_response(
+    cron_scheduler: Arc<CronScheduler>,
+    auth_header: Option<&str>,
+    body_bytes: &[u8],
+) -> (HttpStatus, serde_json::Value) {
+    let Some(token) = auth_header
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return (
+            HTTP_UNAUTHORIZED,
+            api_error("Missing Chronos bearer token", "auth_error", 401),
+        );
+    };
+
+    let config = ChronosConfig::load();
+    if let Err(err) = verify_nas_fire_token(token, &config).await {
+        tracing::warn!(error = %err, "Chronos cron fire token rejected");
+        return (
+            HTTP_UNAUTHORIZED,
+            api_error("Unauthorized", "auth_error", 401),
+        );
+    }
+
+    let body_str = String::from_utf8_lossy(body_bytes);
+    let parsed: Result<ApiCronFireRequest, _> = serde_json::from_str(&body_str);
+    let req = match parsed {
+        Ok(req) => req,
+        Err(err) => {
+            return (
+                HTTP_BAD_REQUEST,
+                api_error(
+                    format!("Invalid request: {err}"),
+                    "invalid_request_error",
+                    400,
+                ),
+            );
+        }
+    };
+    let job_id = req.job_id.trim();
+    if job_id.is_empty() {
+        return (
+            HTTP_BAD_REQUEST,
+            api_error("job_id is required", "invalid_request_error", 400),
+        );
+    }
+    let fire_at = match req
+        .fire_at
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        Some(raw) => match chrono::DateTime::parse_from_rfc3339(raw) {
+            Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+            Err(err) => {
+                return (
+                    HTTP_BAD_REQUEST,
+                    api_error(
+                        format!("fire_at must be RFC3339: {err}"),
+                        "invalid_request_error",
+                        400,
+                    ),
+                );
+            }
+        },
+        None => None,
+    };
+
+    match cron_scheduler.fire_managed_job(job_id, fire_at).await {
+        Ok(accepted) => (
+            HTTP_ACCEPTED,
+            serde_json::json!({
+                "status": "accepted",
+                "job_id": job_id,
+                "dispatched": accepted,
+            }),
+        ),
+        Err(CronError::JobNotFound(_)) => {
+            (HTTP_NOT_FOUND, api_error("Job not found", "not_found", 404))
+        }
+        Err(err) => (
+            HTTP_BAD_GATEWAY,
+            api_error(err.to_string(), "internal_error", 502),
+        ),
+    }
+}
+
 async fn handle_connection(
     stream: tokio::net::TcpStream,
     _peer: SocketAddr,
@@ -2161,8 +2264,9 @@ async fn handle_connection(
         .lines()
         .find(|l| l.to_lowercase().starts_with("authorization:"))
         .map(|l| l.splitn(2, ':').nth(1).unwrap_or("").trim().to_string());
+    let chronos_fire_route = method == "POST" && path == "/api/cron/fire";
 
-    if let Some(ref expected) = auth_token {
+    if let Some(ref expected) = auth_token.filter(|_| !chronos_fire_route) {
         let valid = auth_header
             .as_deref()
             .and_then(|v| v.strip_prefix("Bearer "))
@@ -2359,6 +2463,13 @@ async fn handle_connection(
                 }),
             )
             .await;
+            let resp = json_http_response(status, &body)?;
+            writer.write_all(resp.as_bytes()).await?;
+        }
+        ("POST", "/api/cron/fire") => {
+            let (status, body) =
+                api_cron_fire_response(cron_scheduler.clone(), auth_header.as_deref(), body_bytes)
+                    .await;
             let resp = json_http_response(status, &body)?;
             writer.write_all(resp.as_bytes()).await?;
         }
@@ -3673,6 +3784,29 @@ mod tests {
             )
             .await;
         assert!(authed_response.starts_with("HTTP/1.1 200 OK"));
+    }
+
+    #[tokio::test]
+    async fn cron_fire_endpoint_uses_nas_auth_not_generic_api_token() {
+        let (tx, _rx) = mpsc::channel(1);
+        let state = ApiTestState::new(tx);
+
+        let response = state
+            .roundtrip(
+                json_request(
+                    "POST",
+                    "/api/cron/fire",
+                    serde_json::json!({"job_id": "job-1"}),
+                ),
+                Some("api-secret".to_string()),
+            )
+            .await;
+        assert!(response.starts_with("HTTP/1.1 401 Unauthorized"));
+        let body = json_body(&response);
+        assert_eq!(
+            body["error"]["message"].as_str(),
+            Some("Missing Chronos bearer token")
+        );
     }
 
     #[tokio::test]

--- a/docs/chronos-managed-cron-contract.md
+++ b/docs/chronos-managed-cron-contract.md
@@ -1,0 +1,95 @@
+# Chronos Managed Cron Contract
+
+Status: Rust runtime contract for NAS-mediated managed cron.
+
+Chronos lets a hosted Hermes Ultra gateway scale to zero while scheduled jobs
+remain armed. The Rust runtime computes each job's next `fire_at`, asks Nous
+Account Service (NAS) to arm exactly one one-shot for that time, and accepts an
+authenticated NAS callback at `/api/cron/fire`.
+
+The scheduler provider is active only when `cron.provider` is `chronos`.
+Without complete Chronos config or a Nous Portal access token, the Rust
+`CronScheduler` falls back to the built-in in-process ticker.
+
+## Config
+
+`config.yaml`:
+
+```yaml
+cron:
+  provider: chronos
+  chronos:
+    portal_url: https://portal.nousresearch.com
+    callback_url: https://agent.example.com
+    expected_audience: agent:<instance_id>
+    nas_jwks_url: https://portal.nousresearch.com/.well-known/jwks.json
+```
+
+Equivalent environment overrides:
+
+- `HERMES_CRON_PROVIDER`
+- `HERMES_CHRONOS_PORTAL_URL`
+- `HERMES_CHRONOS_CALLBACK_URL`
+- `HERMES_CHRONOS_EXPECTED_AUDIENCE`
+- `HERMES_CHRONOS_NAS_JWKS_URL`
+- `HERMES_CHRONOS_TOKEN_LEEWAY_SECONDS`
+- `HERMES_CHRONOS_REQUEST_TIMEOUT_SECONDS`
+
+## Agent To NAS
+
+For every active job with a `next_run`, Hermes POSTs:
+
+`POST {portal_url}/api/agent-cron/provision`
+
+```json
+{
+  "job_id": "job-id",
+  "fire_at": "2026-06-20T12:34:56Z",
+  "agent_callback_url": "https://agent.example.com",
+  "dedup_key": "job-id:2026-06-20T12:34:56Z"
+}
+```
+
+Auth is the existing Nous Portal bearer token from `auth.json` or
+`TOOL_GATEWAY_USER_TOKEN`. No scheduler secret is stored in the agent.
+
+Hermes also uses:
+
+- `POST /api/agent-cron/cancel` with `{"job_id":"..."}`
+- `GET /api/agent-cron/list` returning `{"armed":[{"job_id":"...","fire_at":"..."}]}`
+
+## NAS To Agent
+
+NAS calls:
+
+`POST {callback_url}/api/cron/fire`
+
+Headers:
+
+```text
+Authorization: Bearer <NAS-minted JWT>
+```
+
+Body:
+
+```json
+{
+  "job_id": "job-id",
+  "fire_at": "2026-06-20T12:34:56Z"
+}
+```
+
+The Rust verifier checks the JWT signature against `nas_jwks_url`, requires an
+asymmetric RS/ES algorithm, validates `aud`, `iss`, `exp`, optional `nbf`, and
+requires `purpose == "cron_fire"`. Invalid, expired, wrong-audience, or
+wrong-purpose tokens return `401` and do not run jobs.
+
+Valid callbacks return `202` immediately. The job runs in the background via the
+same `CronScheduler` execution path as local scheduled jobs, so completion
+persistence, repeat limits, delivery, `context_from`, workdir serialization, and
+last-output capture stay identical.
+
+Duplicate or stale fires are accepted but not dispatched. If `fire_at` is
+present and does not match the job's current `next_run`, the callback is treated
+as stale. If the job is already running, the callback is treated as a duplicate.
+

--- a/docs/parity/intentional-divergence.json
+++ b/docs/parity/intentional-divergence.json
@@ -80,6 +80,34 @@
       ]
     },
     {
+      "id": "rust-chronos-managed-cron-provider",
+      "status": "approved",
+      "workstream": "WS3",
+      "summary": "Own Chronos managed-cron behavior in the Rust cron scheduler and API server instead of vendoring the upstream Python cron plugin.",
+      "owner": "sheawinkler",
+      "ticket": 570,
+      "last_reviewed": "2026-06-20",
+      "review_date": "2026-09-20",
+      "rationale": "Hermes Ultra implements NAS-mediated Chronos provisioning, callback JWT verification, stale/duplicate fire suppression, background dispatch, and post-fire re-arm in hermes-cron plus the Rust API server. The upstream plugins/cron Python files are reference-only and must not become Rust runtime execution paths.",
+      "path_prefixes": [
+        "plugins/cron/"
+      ]
+    },
+    {
+      "id": "rust-runtime-no-raft-platform-plugin",
+      "status": "temporary",
+      "workstream": "WS3",
+      "summary": "Track the upstream Raft Python platform plugin as non-runtime until a Rust-native Raft adapter is scoped.",
+      "owner": "sheawinkler",
+      "ticket": 570,
+      "last_reviewed": "2026-06-20",
+      "review_date": "2026-07-20",
+      "rationale": "No Rust gateway Raft adapter is registered locally. Ultra preserves Rust-only runtime behavior and does not vendor the upstream Python wake-bridge adapter; this remains an explicit platform-gap item rather than an unclassified missing plugin tree.",
+      "path_prefixes": [
+        "plugins/platforms/raft/"
+      ]
+    },
+    {
       "id": "upstream-python-plugin-backend-drift-20260527",
       "status": "temporary",
       "workstream": "WS3",

--- a/docs/rca-ssl-cacert-post-git-pull.md
+++ b/docs/rca-ssl-cacert-post-git-pull.md
@@ -1,0 +1,29 @@
+# RCA: SSL CA Cert Bundle After Update
+
+Status: upstream Python RCA retained as an Ultra diagnostic reference.
+
+Upstream Hermes added a guard for corrupted Python CA bundle state after update
+or dependency refresh. Hermes Ultra's Rust runtime uses native Rust TLS stacks
+(`rustls`/webpki roots on supported HTTP clients), so normal provider, gateway,
+and web requests do not depend on Python `certifi`.
+
+The failure can still matter for reference-only Python plugin trees or local
+helper surfaces that an operator runs manually. If a Python plugin fails with a
+low-level TLS error after an update, check these variables first:
+
+- `HERMES_CA_BUNDLE`
+- `SSL_CERT_FILE`
+- `REQUESTS_CA_BUNDLE`
+- `CURL_CA_BUNDLE`
+
+Unset stale variables or point them at a real PEM bundle. For Python helper
+environments, reinstall the affected client dependencies:
+
+```bash
+python -m pip install --force-reinstall certifi requests httpx
+```
+
+This document is intentionally diagnostic only. Rust runtime TLS failures should
+be debugged through the Rust client error and certificate store, not by adding a
+Python CA-bundle guard to the runtime.
+

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -1,0 +1,29 @@
+# Relay Connector Contract
+
+Status: upstream experimental connector contract, tracked for parity.
+
+The upstream relay connector model defines an outbound WebSocket from a Hermes
+gateway to a connector service. The connector owns platform-specific sockets,
+normalizes inbound events, strips platform credentials at the edge, and sends
+sanitized `MessageEvent` frames back over the authenticated WebSocket.
+
+Hermes Ultra's current Rust runtime does not register this experimental relay
+adapter as a first-class platform. Supported messaging behavior is owned by
+Rust-native gateway adapters such as Telegram, Discord, Slack, Signal, Matrix,
+WeCom, WhatsApp, ntfy, Home Assistant, email, SMS, and API server surfaces.
+
+If the relay connector is ported, the Rust contract must preserve these
+upstream invariants:
+
+- The gateway dials out; hosted gateways do not need a public inbound port.
+- The connector returns a capability descriptor before events flow.
+- Inbound events use the same session-key discriminators as native platform
+  adapters.
+- Platform signatures, encrypted payloads, and follow-up tokens are verified or
+  vaulted by the connector, never leaked into the gateway.
+- Interrupts route by session key and cancel only the active turn for that
+  session.
+- Unknown additive descriptor fields are ignored for forward compatibility.
+
+Until a Rust relay adapter is scoped, this document is a parity reference rather
+than an active runtime API.

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@hermes-agent/photon-sidecar",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-agent/photon-sidecar",
-      "version": "0.2.0",
+      "version": "0.3.0",
+      "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "^1.18.0"
+        "spectrum-ts": "3.1.0"
       },
       "engines": {
         "node": ">=18.17"
@@ -408,6 +409,18 @@
         "@grpc/grpc-js": "^1.14.3",
         "nice-grpc": "^2.1.15",
         "nice-grpc-common": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@photon-ai/telegram-ts": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/telegram-ts/-/telegram-ts-10.0.0.tgz",
+      "integrity": "sha512-kYGj/ieKOCG+OxoD1R69xHoT7zHl9dboF52LMPUl4FnorbwA8b2pid0uFoDYF55WIfoeo+VSqwlmY84GgpSedg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=18"
@@ -1025,6 +1038,18 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -1396,9 +1421,9 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-1.18.0.tgz",
-      "integrity": "sha512-xgqGSCY4ltA737mJ2Yb2wniJDOYzZRby3YxeT9mv0iOvyWlsG2ptSp72LcXZBgkD4ejVSXAkzg7iLmSlf02buA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-3.1.0.tgz",
+      "integrity": "sha512-Dv5rsXATxGUXFnKf3VPK0VpkMPyVkf4HHUYkti0V2AKhz2m+ut3I1UPNMsvZOsiqmF+5hW8Xvrw+u/I82+XcDA==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.11.0",
@@ -1406,10 +1431,12 @@
         "@photon-ai/otel": "^0.1.1",
         "@photon-ai/proto": "^0.2.4",
         "@photon-ai/slack": "^0.2.0",
+        "@photon-ai/telegram-ts": "10.0.0",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
         "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
         "mime-types": "^3.0.1",
         "nice-grpc": "^2.1.16",
         "nice-grpc-common": "^2.0.2",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -1,18 +1,19 @@
 {
   "name": "@hermes-agent/photon-sidecar",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Spectrum-ts bridge for the Hermes Agent Photon platform plugin.",
   "type": "module",
   "main": "index.mjs",
   "scripts": {
-    "start": "node index.mjs"
+    "start": "node index.mjs",
+    "postinstall": "node patch-spectrum-mixed-attachments.mjs"
   },
   "engines": {
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "^1.18.0"
+    "spectrum-ts": "3.1.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Patch spectrum-ts' iMessage inbound mapper until upstream preserves mixed
+// text + attachment Apple events. The current spectrum-ts mapper returns only
+// buildAttachmentMessage(...) whenever attachments are present, which drops
+// event.message.content.text before Hermes can see it.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
+
+function scriptDir() {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+function replaceOnce(source, from, to, label) {
+  const count = source.split(from).length - 1;
+  if (count !== 1) {
+    throw new Error(`expected exactly one ${label} match, found ${count}`);
+  }
+  return source.replace(from, to);
+}
+
+function replaceFirst(source, from, to, label) {
+  if (!source.includes(from)) {
+    throw new Error(`expected at least one ${label} match, found 0`);
+  }
+  return source.replace(from, to);
+}
+
+function addTextChildSnippet(messageExpr) {
+  return `if (text2) {\n      items.unshift({\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      });\n    }`;
+}
+
+function patchRebuild(source) {
+  source = replaceOnce(
+    source,
+    `  const attachments = messageAttachments(message);\n  if (attachments.length === 1) {`,
+    `  const attachments = messageAttachments(message);\n  const text2 = message.content.text;\n  if (attachments.length === 1) {`,
+    "rebuild text capture"
+  );
+  source = replaceOnce(
+    source,
+    `    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);`,
+    `    const msg2 = await buildAttachmentMessage(\n      client,\n      base,\n      info,\n      text2 ? formatChildId(1, messageGuidStr) : messageGuidStr,\n      text2 ? 1 : 0,\n      text2 ? messageGuidStr : void 0\n    );\n    if (text2) {\n      const textMsg = {\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      };\n      return {\n        ...base,\n        id: messageGuidStr,\n        content: asProviderGroup([textMsg, msg2])\n      };\n    }\n    return msg2;`,
+    "rebuild single attachment"
+  );
+  source = replaceFirst(
+    source,
+    `          formatChildId(i, messageGuidStr),\n          i,\n          messageGuidStr`,
+    `          formatChildId(text2 ? i + 1 : i, messageGuidStr),\n          text2 ? i + 1 : i,\n          messageGuidStr`,
+    "rebuild multi attachment child index"
+  );
+  source = replaceFirst(
+    source,
+    `    return {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };\n  }\n  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {`,
+    `    ${addTextChildSnippet("message")}\n    return {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };\n  }\n  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {`,
+    "rebuild multi attachment text child"
+  );
+  source = replaceFirst(
+    source,
+    `  const text2 = message.content.text;\n  return {\n    ...base,`,
+    `  return {\n    ...base,`,
+    "rebuild duplicate text declaration"
+  );
+  return source;
+}
+
+function patchInbound(source) {
+  source = replaceOnce(
+    source,
+    `  const attachments = messageAttachments(event.message);\n  if (attachments.length === 1) {`,
+    `  const attachments = messageAttachments(event.message);\n  const text2 = event.message.content.text;\n  if (attachments.length === 1) {`,
+    "inbound text capture"
+  );
+  source = replaceOnce(
+    source,
+    `      messageGuidStr,\n      0\n    );\n    cacheMessage(cache, msg2);\n    return [msg2];`,
+    `      text2 ? formatChildId(1, messageGuidStr) : messageGuidStr,\n      text2 ? 1 : 0,\n      text2 ? messageGuidStr : void 0\n    );\n    if (text2) {\n      const textMsg = {\n        ...base,\n        id: formatChildId(0, messageGuidStr),\n        content: asText(text2),\n        partIndex: 0,\n        parentId: messageGuidStr\n      };\n      const parent = {\n        ...base,\n        id: messageGuidStr,\n        content: asProviderGroup([textMsg, msg2])\n      };\n      cacheMessage(cache, parent);\n      return [parent];\n    }\n    cacheMessage(cache, msg2);\n    return [msg2];`,
+    "inbound single attachment"
+  );
+  source = replaceOnce(
+    source,
+    `          formatChildId(i, messageGuidStr),\n          i,\n          messageGuidStr`,
+    `          formatChildId(text2 ? i + 1 : i, messageGuidStr),\n          text2 ? i + 1 : i,\n          messageGuidStr`,
+    "inbound multi attachment child index"
+  );
+  source = replaceOnce(
+    source,
+    `    const parent = {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };`,
+    `    ${addTextChildSnippet("event.message")}\n    const parent = {\n      ...base,\n      id: messageGuidStr,\n      content: asProviderGroup(items)\n    };`,
+    "inbound multi attachment text child"
+  );
+  source = replaceOnce(
+    source,
+    `  const text2 = event.message.content.text;\n  const msg = {`,
+    `  const msg = {`,
+    "inbound duplicate text declaration"
+  );
+  return source;
+}
+
+export function patchSpectrumTs(root = scriptDir()) {
+  const dist = path.join(root, "node_modules", "spectrum-ts", "dist");
+  if (!fs.existsSync(dist)) {
+    throw new Error(`spectrum-ts dist not found: ${dist}`);
+  }
+  const files = fs.readdirSync(dist)
+    .filter((name) => name.endsWith(".js"))
+    .map((name) => path.join(dist, name));
+
+  for (const file of files) {
+    const raw = fs.readFileSync(file, "utf8");
+    if (raw.includes(MARKER)) {
+      return { patched: false, file, reason: "already patched" };
+    }
+    // Normalize to LF for matching so the patch works regardless of the
+    // checkout's line-ending style (Windows git autocrlf produces CRLF,
+    // which would otherwise defeat the \n-based search strings). The
+    // original EOL style is restored on write.
+    const CR = String.fromCharCode(13);
+    const CRLF = CR + "\n";
+    const usedCRLF = raw.includes(CRLF);
+    const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
+    if (!original.includes("var toInboundMessages = async") ||
+        !original.includes("var rebuildFromAppleMessage = async")) {
+      continue;
+    }
+    let patched = original;
+    patched = patchRebuild(patched);
+    patched = patchInbound(patched);
+    patched = `// ${MARKER}\n${patched}`;
+    if (usedCRLF) {
+      patched = patched.split("\n").join(CRLF);
+    }
+    fs.writeFileSync(file, patched, "utf8");
+    return { patched: true, file };
+  }
+  throw new Error("could not find spectrum-ts iMessage inbound chunk to patch");
+}
+
+const _invokedDirectly =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+if (_invokedDirectly) {
+  try {
+    const root = process.argv[2] ? path.resolve(process.argv[2]) : scriptDir();
+    const result = patchSpectrumTs(root);
+    const action = result.patched ? "patched" : "ok";
+    console.error(`photon-sidecar: spectrum mixed attachment patch ${action}: ${result.file}`);
+  } catch (err) {
+    console.error(`photon-sidecar: spectrum mixed attachment patch failed: ${err?.stack || err}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- Add Rust-native Chronos managed cron provider and NAS fire callback verification.
- Add Rust-native suggested automation workflow for /suggestions and upstream-compatible slash aliases (/bp, /v, /credits, /billing, /suggest).
- Sync Photon sidecar package metadata/patch script from upstream and document intentional Rust-only divergences.

## Local verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo fmt --all
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cron -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-gateway --features api-server platforms::api_server::tests:: -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-parity-tests -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli test_golden_upstream_surface_aliases_are_registered -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli suggestions_catalog_accept_and_dismiss_flow -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo test -p hermes-cli test_upstream_compat_aliases_are_mapped -- --nocapture
- python3 scripts/run-golden-parity-harness.py --repo-root . --upstream-root /Volumes/wd_black/hermes-agent-upstream-current --report .sync-reports/golden-parity-worktree.json
- python3 scripts/run-upstream-surface-coverage-gate.py --local-mode worktree --upstream-ref upstream/main --json --report-path .sync-reports/upstream-surface-coverage-gate-worktree.json
- python3 scripts/run-behavioral-parity-suite.py --repo-root . --report .sync-reports/behavioral-parity-worktree.json
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- npm --prefix plugins/platforms/photon/sidecar ci --package-lock-only --ignore-scripts
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets cargo build -p hermes-cli --bin hermes-ultra
- /Volumes/wd_black/cargo-targets/debug/hermes-ultra --version
- /Volumes/wd_black/cargo-targets/debug/hermes-ultra --help | sed -n '1,80p'