### PR TITLE
Harden Nous auth verification

### DIFF
--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -1047,6 +1047,43 @@ fn parse_nous_oauth_state(value: Value) -> Option<NousAuthState> {
     Some(state)
 }
 
+fn nous_auth_state_is_runtime_viable(state: &NousAuthState) -> bool {
+    if state
+        .refresh_token
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+    {
+        return true;
+    }
+    nous_invoke_jwt_status(
+        &state.access_token,
+        state.scope.as_deref(),
+        state.expires_at.as_deref(),
+        NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    )
+    .is_none()
+}
+
+pub fn read_nous_auth_state() -> Result<Option<NousAuthState>, AgentError> {
+    if let Some(raw_state) = read_provider_auth_state("nous")? {
+        if let Some(state) = parse_nous_oauth_state(raw_state) {
+            return Ok(Some(state));
+        }
+    }
+    Ok(discover_existing_nous_oauth()?.map(|imported| imported.state))
+}
+
+pub fn read_valid_nous_auth_state() -> Result<Option<NousAuthState>, AgentError> {
+    Ok(read_nous_auth_state()?.and_then(|state| {
+        if nous_auth_state_is_runtime_viable(&state) {
+            Some(state)
+        } else {
+            None
+        }
+    }))
+}
+
 fn load_nous_oauth_import_from_path(path: &Path) -> Option<NousOAuthImport> {
     let raw = std::fs::read_to_string(path).ok()?;
     let parsed: Value = serde_json::from_str(&raw).ok()?;
@@ -1399,19 +1436,9 @@ pub async fn resolve_nous_runtime_credentials(
     refresh_skew_seconds: i64,
     _min_key_ttl_seconds: u32,
 ) -> Result<NousRuntimeCredentials, AgentError> {
-    let mut state = if let Some(raw_state) = read_provider_auth_state("nous")? {
-        parse_nous_oauth_state(raw_state).ok_or_else(|| {
-            AgentError::AuthFailed(
-                "Stored Nous auth state is invalid; re-run `hermes portal`.".into(),
-            )
-        })?
-    } else if let Some(imported) = discover_existing_nous_oauth()? {
-        imported.state
-    } else {
-        return Err(AgentError::AuthFailed(
-            "Hermes is not logged into Nous Portal. Run `hermes portal`.".into(),
-        ));
-    };
+    let mut state = read_nous_auth_state()?.ok_or_else(|| {
+        AgentError::AuthFailed("Hermes is not logged into Nous Portal. Run `hermes portal`.".into())
+    })?;
 
     if state.portal_base_url.trim().is_empty() {
         state.portal_base_url = env_or_default("NOUS_PORTAL_BASE_URL", DEFAULT_NOUS_PORTAL_URL)
@@ -3784,6 +3811,243 @@ mod tests {
             "fallback-nous-access"
         );
 
+        match prev_auth_file {
+            Some(v) => std::env::set_var("HERMES_AUTH_FILE", v),
+            None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match prev_hermes_home {
+            Some(v) => std::env::set_var("HERMES_HOME", v),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn read_valid_nous_auth_state_ignores_malformed_fallback_store() {
+        let _guard = test_env_lock::lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev_home = std::env::var("HOME").ok();
+        let prev_hermes_home = std::env::var("HERMES_HOME").ok();
+        let prev_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let prev_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+
+        std::env::set_var("HOME", tmp.path());
+        std::env::remove_var("HERMES_HOME");
+
+        let primary_store = tmp.path().join("profile-auth.json");
+        let primary_raw = serde_json::json!({
+            "version": 1,
+            "providers": {
+                "openai": { "access_token": "primary-openai" }
+            }
+        });
+        std::fs::write(
+            &primary_store,
+            serde_json::to_string_pretty(&primary_raw).expect("serialize primary auth"),
+        )
+        .expect("write primary auth");
+        std::env::set_var(
+            "HERMES_AUTH_FILE",
+            primary_store.to_string_lossy().to_string(),
+        );
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+
+        let fallback_store = tmp.path().join(".hermes").join("auth.json");
+        std::fs::create_dir_all(
+            fallback_store
+                .parent()
+                .expect("fallback store should have parent"),
+        )
+        .expect("mkdir fallback parent");
+        let fallback_raw = serde_json::json!({
+            "version": 1,
+            "providers": {
+                "nous": {
+                    "client_id": DEFAULT_NOUS_CLIENT_ID,
+                    "inference_base_url": DEFAULT_NOUS_INFERENCE_URL,
+                    "last_auth_error": "unauthorized",
+                    "portal_base_url": DEFAULT_NOUS_PORTAL_URL,
+                    "scope": DEFAULT_NOUS_SCOPE,
+                    "token_type": "Bearer"
+                }
+            }
+        });
+        std::fs::write(
+            &fallback_store,
+            serde_json::to_string_pretty(&fallback_raw).expect("serialize fallback auth"),
+        )
+        .expect("write fallback auth");
+
+        assert!(
+            read_provider_auth_state("nous")
+                .expect("read raw provider auth state")
+                .is_some(),
+            "raw fallback store should still be discoverable"
+        );
+        assert!(
+            read_valid_nous_auth_state()
+                .expect("read valid nous auth state")
+                .is_none(),
+            "malformed fallback state must not count as a valid Nous login"
+        );
+
+        match prev_nous_file {
+            Some(v) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", v),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
+        match prev_auth_file {
+            Some(v) => std::env::set_var("HERMES_AUTH_FILE", v),
+            None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match prev_hermes_home {
+            Some(v) => std::env::set_var("HERMES_HOME", v),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn read_valid_nous_auth_state_rejects_profile_only_access_state_without_refresh() {
+        let _guard = test_env_lock::lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let auth_path = tmp.path().join("auth.json");
+        let prev_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let prev_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+        std::env::set_var("HERMES_AUTH_FILE", auth_path.to_string_lossy().to_string());
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+
+        let mut state = nous_test_state("profile-access-token".to_string());
+        state.scope = Some("profile".to_string());
+        state.refresh_token = None;
+        save_nous_auth_state(&state).expect("save nous state");
+
+        assert!(
+            read_valid_nous_auth_state()
+                .expect("read valid nous auth state")
+                .is_none(),
+            "profile-only access token without refresh must not count as runtime-valid"
+        );
+
+        match prev_auth_file {
+            Some(v) => std::env::set_var("HERMES_AUTH_FILE", v),
+            None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match prev_nous_file {
+            Some(v) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", v),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
+    }
+
+    #[test]
+    fn read_valid_nous_auth_state_accepts_refreshable_access_state() {
+        let _guard = test_env_lock::lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let auth_path = tmp.path().join("auth.json");
+        let prev_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let prev_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+        std::env::set_var("HERMES_AUTH_FILE", auth_path.to_string_lossy().to_string());
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+
+        let mut state = nous_test_state("profile-access-token".to_string());
+        state.scope = Some("profile".to_string());
+        state.refresh_token = Some("refresh".to_string());
+        save_nous_auth_state(&state).expect("save nous state");
+
+        let found = read_valid_nous_auth_state()
+            .expect("read valid nous auth state")
+            .expect("refreshable state should count as valid");
+        assert_eq!(found.refresh_token.as_deref(), Some("refresh"));
+
+        match prev_auth_file {
+            Some(v) => std::env::set_var("HERMES_AUTH_FILE", v),
+            None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match prev_nous_file {
+            Some(v) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", v),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_nous_runtime_credentials_ignores_malformed_fallback_store() {
+        let _guard = test_env_lock::lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev_home = std::env::var("HOME").ok();
+        let prev_hermes_home = std::env::var("HERMES_HOME").ok();
+        let prev_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let prev_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+
+        std::env::set_var("HOME", tmp.path());
+        std::env::remove_var("HERMES_HOME");
+
+        let primary_store = tmp.path().join("profile-auth.json");
+        let primary_raw = serde_json::json!({
+            "version": 1,
+            "providers": {
+                "openai": { "access_token": "primary-openai" }
+            }
+        });
+        std::fs::write(
+            &primary_store,
+            serde_json::to_string_pretty(&primary_raw).expect("serialize primary auth"),
+        )
+        .expect("write primary auth");
+        std::env::set_var(
+            "HERMES_AUTH_FILE",
+            primary_store.to_string_lossy().to_string(),
+        );
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+
+        let fallback_store = tmp.path().join(".hermes").join("auth.json");
+        std::fs::create_dir_all(
+            fallback_store
+                .parent()
+                .expect("fallback store should have parent"),
+        )
+        .expect("mkdir fallback parent");
+        let fallback_raw = serde_json::json!({
+            "version": 1,
+            "providers": {
+                "nous": {
+                    "client_id": DEFAULT_NOUS_CLIENT_ID,
+                    "inference_base_url": DEFAULT_NOUS_INFERENCE_URL,
+                    "last_auth_error": "unauthorized",
+                    "portal_base_url": DEFAULT_NOUS_PORTAL_URL,
+                    "scope": DEFAULT_NOUS_SCOPE,
+                    "token_type": "Bearer"
+                }
+            }
+        });
+        std::fs::write(
+            &fallback_store,
+            serde_json::to_string_pretty(&fallback_raw).expect("serialize fallback auth"),
+        )
+        .expect("write fallback auth");
+
+        let err = resolve_nous_runtime_credentials(
+            false,
+            true,
+            NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+            DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS,
+        )
+        .await
+        .expect_err("malformed fallback store should not resolve runtime credentials");
+        assert!(
+            err.to_string()
+                .contains("Hermes is not logged into Nous Portal"),
+            "unexpected error: {err}"
+        );
+
+        match prev_nous_file {
+            Some(v) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", v),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
         match prev_auth_file {
             Some(v) => std::env::set_var("HERMES_AUTH_FILE", v),
             None => std::env::remove_var("HERMES_AUTH_FILE"),

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -25,16 +25,16 @@ use hermes_cli::auth::{
     get_anthropic_oauth_status, get_gemini_oauth_auth_status, get_qwen_auth_status,
     login_anthropic_oauth, login_google_gemini_cli_oauth, login_nous_device_code,
     login_openai_codex_device_code, login_openai_device_code, nous_auth_state_from_runtime_token,
-    read_provider_auth_state, resolve_gemini_oauth_runtime_credentials,
-    resolve_nous_runtime_credentials, resolve_qwen_runtime_credentials, save_codex_auth_state,
-    save_nous_auth_state, save_openai_auth_state, save_provider_auth_state,
-    AnthropicOAuthLoginOptions, CodexDeviceCodeOptions, GeminiOAuthLoginOptions, NousAuthState,
-    NousDeviceCodeOptions, NousRuntimeCredentials, ANTHROPIC_OAUTH_CLIENT_ID,
-    ANTHROPIC_OAUTH_TOKEN_URL, CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_TOKEN_URL,
-    DEFAULT_CODEX_BASE_URL, DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS, DEFAULT_NOUS_CLIENT_ID,
-    DEFAULT_NOUS_INFERENCE_URL, DEFAULT_NOUS_PORTAL_URL, DEFAULT_OPENAI_BASE_URL,
-    NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
-    QWEN_OAUTH_CLIENT_ID, QWEN_OAUTH_TOKEN_URL,
+    read_nous_auth_state, read_provider_auth_state, read_valid_nous_auth_state,
+    resolve_gemini_oauth_runtime_credentials, resolve_nous_runtime_credentials,
+    resolve_qwen_runtime_credentials, save_codex_auth_state, save_nous_auth_state,
+    save_openai_auth_state, save_provider_auth_state, AnthropicOAuthLoginOptions,
+    CodexDeviceCodeOptions, GeminiOAuthLoginOptions, NousAuthState, NousDeviceCodeOptions,
+    NousRuntimeCredentials, ANTHROPIC_OAUTH_CLIENT_ID, ANTHROPIC_OAUTH_TOKEN_URL,
+    CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_TOKEN_URL, DEFAULT_CODEX_BASE_URL,
+    DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS, DEFAULT_NOUS_CLIENT_ID, DEFAULT_NOUS_INFERENCE_URL,
+    DEFAULT_NOUS_PORTAL_URL, DEFAULT_OPENAI_BASE_URL, NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, QWEN_OAUTH_CLIENT_ID, QWEN_OAUTH_TOKEN_URL,
 };
 use hermes_cli::cli::{Cli, CliCommand};
 use hermes_cli::config_env::hydrate_env_from_config;
@@ -299,6 +299,9 @@ async fn main() {
             applied_env_vars = ?route_autotune_applied,
             "Hydrated environment from route-autotune overrides"
         );
+    }
+    if let Err(err) = scrub_unusable_nous_api_key_for_oauth_state() {
+        tracing::warn!("Nous API-key scrub skipped: {}", err);
     }
 
     tracing::debug!("Hermes Agent starting");
@@ -6502,12 +6505,24 @@ async fn hydrate_provider_env_from_vault_for_cli(cli: &Cli) -> Result<(), AgentE
     hydrate_provider_env_from_vault_for_cli_with_options(cli, true).await
 }
 
+fn scrub_unusable_nous_api_key_for_oauth_state() -> Result<(), AgentError> {
+    if read_nous_auth_state()?.is_some() && read_valid_nous_auth_state()?.is_none() {
+        std::env::remove_var("NOUS_API_KEY");
+    }
+    Ok(())
+}
+
 async fn hydrate_provider_env_from_vault_for_cli_with_options(
     cli: &Cli,
     prefer_nous_runtime_credentials: bool,
 ) -> Result<(), AgentError> {
     let path = secret_vault_path_for_cli(cli);
+    let nous_oauth_state_present =
+        prefer_nous_runtime_credentials && read_nous_auth_state()?.is_some();
     if !path.exists() {
+        if nous_oauth_state_present {
+            std::env::remove_var("NOUS_API_KEY");
+        }
         return Ok(());
     }
     let store = FileTokenStore::new(path).await?;
@@ -6545,7 +6560,11 @@ async fn hydrate_provider_env_from_vault_for_cli_with_options(
             }
             Err(err) => {
                 tracing::debug!("Nous runtime credential refresh skipped: {}", err);
-                if let Some((_provider, token)) = lookup_secret_from_vault(&store, "nous").await {
+                if nous_oauth_state_present {
+                    std::env::remove_var("NOUS_API_KEY");
+                } else if let Some((_provider, token)) =
+                    lookup_secret_from_vault(&store, "nous").await
+                {
                     std::env::set_var("NOUS_API_KEY", token);
                 }
             }
@@ -6608,6 +6627,9 @@ async fn hydrate_provider_env_from_vault_for_cli_with_options(
     ];
 
     for (env_var, provider) in env_bindings {
+        if prefer_nous_runtime_credentials && provider == "nous" && nous_oauth_state_present {
+            continue;
+        }
         let env_present = std::env::var(env_var).ok().filter(|v| !v.trim().is_empty());
         if let Some(current) = env_present {
             if provider_supports_oauth(provider) {
@@ -7707,6 +7729,64 @@ async fn save_nous_runtime_credential(
         .await
 }
 
+async fn verify_nous_runtime_credentials_live(
+    resolved: &NousRuntimeCredentials,
+) -> Result<(), String> {
+    let base_url = resolved.base_url.trim().trim_end_matches('/');
+    if base_url.is_empty() {
+        return Err("live_probe_failed: missing inference base URL".to_string());
+    }
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|err| format!("live_probe_failed: build client: {err}"))?;
+    let model = std::env::var("HERMES_MODEL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "nous:openai/gpt-5.5".to_string());
+    let model = model
+        .strip_prefix("nous:")
+        .unwrap_or(model.as_str())
+        .to_string();
+    let payload = serde_json::json!({
+        "model": model,
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+        "temperature": 0
+    });
+    let response = client
+        .post(format!("{base_url}/chat/completions"))
+        .bearer_auth(resolved.api_key.trim())
+        .header(reqwest::header::ACCEPT, "application/json")
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|err| format!("live_probe_failed: request failed: {err}"))?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let body = response.text().await.unwrap_or_default();
+    let detail = serde_json::from_str::<serde_json::Value>(&body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .or_else(|| value.get("error_description"))
+                .or_else(|| value.get("error"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| body.trim().chars().take(240).collect::<String>());
+    if detail.is_empty() {
+        Err(format!("live_probe_failed: HTTP {status}"))
+    } else {
+        Err(format!("live_probe_failed: HTTP {status}: {detail}"))
+    }
+}
+
 async fn fresh_nous_login_and_save(
     manager: &AuthManager,
 ) -> Result<(NousRuntimeCredentials, std::path::PathBuf, NousAuthState), AgentError> {
@@ -7809,6 +7889,16 @@ async fn verify_single_oauth_provider(
         .await
         {
             Ok(creds) => {
+                if let Err(detail) = verify_nous_runtime_credentials_live(&creds).await {
+                    result.outcome = AuthVerifyOutcome::RefreshFailed;
+                    result.source = creds.source;
+                    result.expires_at = creds.expires_at;
+                    result.credential_present = true;
+                    result.detail = Some(detail);
+                    return Ok(result);
+                }
+                let source = creds.source.clone();
+                let expires_at = creds.expires_at.clone();
                 manager
                     .save_credential(OAuthCredential {
                         provider: "nous".to_string(),
@@ -7819,13 +7909,13 @@ async fn verify_single_oauth_provider(
                         expires_at: parse_rfc3339_utc(creds.expires_at.as_deref()),
                     })
                     .await?;
-                result.outcome = if creds.source == "portal" {
+                result.outcome = if source == "portal" {
                     AuthVerifyOutcome::ValidRefreshed
                 } else {
                     AuthVerifyOutcome::Valid
                 };
-                result.source = creds.source;
-                result.expires_at = creds.expires_at;
+                result.source = source;
+                result.expires_at = expires_at;
                 result.credential_present = true;
                 return Ok(result);
             }
@@ -7848,6 +7938,15 @@ async fn verify_single_oauth_provider(
                         )
                         .await
                         {
+                            if let Err(detail) = verify_nous_runtime_credentials_live(&creds).await
+                            {
+                                result.outcome = AuthVerifyOutcome::RefreshFailed;
+                                result.source = "vault_invoke_jwt".to_string();
+                                result.expires_at = creds.expires_at;
+                                result.credential_present = true;
+                                result.detail = Some(detail);
+                                return Ok(result);
+                            }
                             let expires_at_text = creds.expires_at.clone();
                             manager
                                 .save_credential(OAuthCredential {
@@ -9186,6 +9285,25 @@ async fn run_auth(
                     cfg_path.display(),
                     token_present,
                     enabled
+                );
+                return Ok(());
+            }
+            if provider == "nous" {
+                let env_present = provider_api_key_from_env(&provider).is_some();
+                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let auth_state_present = read_valid_nous_auth_state()?.is_some();
+                let (has_token, source) = if env_present {
+                    (true, "env")
+                } else if store_present {
+                    (true, "token_store")
+                } else if auth_state_present {
+                    (true, "auth_json")
+                } else {
+                    (false, "none")
+                };
+                println!(
+                    "Auth status: provider='{}', credential_present={}, source={}, oauth_state_present={}",
+                    provider, has_token, source, auth_state_present
                 );
                 return Ok(());
             }
@@ -15450,6 +15568,28 @@ mod tests {
         )
     }
 
+    async fn spawn_nous_live_probe_server(status: &str, body: &'static str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind probe server");
+        let addr = listener.local_addr().expect("probe server addr");
+        let status = status.to_string();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _peer)) = listener.accept().await {
+                let mut buf = [0_u8; 2048];
+                let _ = stream.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
     fn make_platform(enabled: bool, token: Option<&str>) -> PlatformConfig {
         let mut cfg = PlatformConfig {
             enabled,
@@ -17067,6 +17207,157 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hydrate_provider_env_rejects_stale_nous_vault_when_oauth_state_is_unusable() {
+        let _guard = env_lock();
+        use clap::Parser;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_dir = tmp.path().join("cfg");
+        std::fs::create_dir_all(&config_dir).expect("create cfg dir");
+        let cli = Cli::parse_from([
+            "hermes-agent-ultra",
+            "--config-dir",
+            config_dir.to_str().expect("cfg path utf8"),
+        ]);
+
+        let vault_path = secret_vault_path_for_cli(&cli);
+        let store = FileTokenStore::new(vault_path).await.expect("vault store");
+        let manager = AuthManager::new(store);
+        manager
+            .save_credential(OAuthCredential {
+                provider: "nous".to_string(),
+                access_token: "vault-stale-key".to_string(),
+                refresh_token: None,
+                token_type: "bearer".to_string(),
+                scope: None,
+                expires_at: None,
+            })
+            .await
+            .expect("save vault credential");
+
+        let previous_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let previous_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+        let previous_nous_key = std::env::var("NOUS_API_KEY").ok();
+        let auth_path = tmp.path().join("auth.json");
+        std::env::set_var("HERMES_AUTH_FILE", auth_path.to_string_lossy().to_string());
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+        std::env::set_var("NOUS_API_KEY", "env-stale-key");
+        save_nous_auth_state(&NousAuthState {
+            portal_base_url: DEFAULT_NOUS_PORTAL_URL.to_string(),
+            inference_base_url: DEFAULT_NOUS_INFERENCE_URL.to_string(),
+            client_id: DEFAULT_NOUS_CLIENT_ID.to_string(),
+            scope: Some("profile".to_string()),
+            token_type: "Bearer".to_string(),
+            access_token: "header.eyJzY29wZSI6InByb2ZpbGUiLCJleHAiOjQ3Mzk4NTYwMDB9.sig".to_string(),
+            refresh_token: None,
+            obtained_at: chrono::Utc::now().to_rfc3339(),
+            expires_at: None,
+            expires_in: None,
+            agent_key: None,
+            agent_key_id: None,
+            agent_key_expires_at: None,
+            agent_key_expires_in: None,
+            agent_key_reused: None,
+            agent_key_obtained_at: None,
+        })
+        .expect("save unusable nous oauth state");
+
+        hydrate_provider_env_from_vault_for_cli(&cli)
+            .await
+            .expect("hydrate env");
+        assert!(
+            std::env::var("NOUS_API_KEY").is_err(),
+            "stale vault/env Nous key must not hide an unusable OAuth state"
+        );
+
+        match previous_auth_file {
+            Some(value) => std::env::set_var("HERMES_AUTH_FILE", value),
+            None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match previous_nous_file {
+            Some(value) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", value),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
+        match previous_nous_key {
+            Some(value) => std::env::set_var("NOUS_API_KEY", value),
+            None => std::env::remove_var("NOUS_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn scrub_unusable_nous_api_key_removes_config_rehydrated_key() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let previous_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let previous_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+        let previous_nous_key = std::env::var("NOUS_API_KEY").ok();
+        let auth_path = tmp.path().join("auth.json");
+        std::env::set_var("HERMES_AUTH_FILE", auth_path.to_string_lossy().to_string());
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+        std::env::set_var("NOUS_API_KEY", "config-stale-key");
+        save_nous_auth_state(&NousAuthState {
+            portal_base_url: DEFAULT_NOUS_PORTAL_URL.to_string(),
+            inference_base_url: DEFAULT_NOUS_INFERENCE_URL.to_string(),
+            client_id: DEFAULT_NOUS_CLIENT_ID.to_string(),
+            scope: Some("profile".to_string()),
+            token_type: "Bearer".to_string(),
+            access_token: "header.eyJzY29wZSI6InByb2ZpbGUiLCJleHAiOjQ3Mzk4NTYwMDB9.sig".to_string(),
+            refresh_token: None,
+            obtained_at: chrono::Utc::now().to_rfc3339(),
+            expires_at: None,
+            expires_in: None,
+            agent_key: None,
+            agent_key_id: None,
+            agent_key_expires_at: None,
+            agent_key_expires_in: None,
+            agent_key_reused: None,
+            agent_key_obtained_at: None,
+        })
+        .expect("save unusable nous oauth state");
+
+        scrub_unusable_nous_api_key_for_oauth_state().expect("scrub nous api key");
+        assert!(std::env::var("NOUS_API_KEY").is_err());
+
+        match previous_auth_file {
+            Some(value) => std::env::set_var("HERMES_AUTH_FILE", value),
+            None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match previous_nous_file {
+            Some(value) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", value),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
+        match previous_nous_key {
+            Some(value) => std::env::set_var("NOUS_API_KEY", value),
+            None => std::env::remove_var("NOUS_API_KEY"),
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_nous_runtime_credentials_live_rejects_unauthorized_probe() {
+        let base_url =
+            spawn_nous_live_probe_server("401 Unauthorized", r#"{"message":"invalid or blocked"}"#)
+                .await;
+        let err = verify_nous_runtime_credentials_live(&NousRuntimeCredentials {
+            provider: "nous".to_string(),
+            base_url,
+            api_key: test_nous_invoke_jwt(900),
+            key_id: None,
+            expires_at: None,
+            expires_in: None,
+            source: "invoke_jwt".to_string(),
+            refresh_token: None,
+            token_type: "Bearer".to_string(),
+            scope: Some("inference:invoke".to_string()),
+        })
+        .await
+        .expect_err("401 probe should reject credentials");
+        assert!(
+            err.contains("HTTP 401 Unauthorized") && err.contains("invalid or blocked"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn auth_verify_nous_repairs_stale_singleton_from_vault_invoke_jwt() {
         let _guard = env_lock();
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -17089,7 +17380,13 @@ mod tests {
             .expect("save vault credential");
 
         let previous_auth_file = std::env::var("HERMES_AUTH_FILE").ok();
+        let previous_nous_file = std::env::var("HERMES_NOUS_OAUTH_FILE").ok();
+        let previous_inference_base_url = std::env::var("NOUS_INFERENCE_BASE_URL").ok();
+        let probe_base_url =
+            spawn_nous_live_probe_server("200 OK", r#"{"object":"list","data":[]}"#).await;
         std::env::set_var("HERMES_AUTH_FILE", auth_path.to_string_lossy().to_string());
+        std::env::remove_var("HERMES_NOUS_OAUTH_FILE");
+        std::env::set_var("NOUS_INFERENCE_BASE_URL", probe_base_url);
         save_nous_auth_state(&NousAuthState {
             portal_base_url: DEFAULT_NOUS_PORTAL_URL.to_string(),
             inference_base_url: DEFAULT_NOUS_INFERENCE_URL.to_string(),
@@ -17129,6 +17426,14 @@ mod tests {
         match previous_auth_file {
             Some(value) => std::env::set_var("HERMES_AUTH_FILE", value),
             None => std::env::remove_var("HERMES_AUTH_FILE"),
+        }
+        match previous_nous_file {
+            Some(value) => std::env::set_var("HERMES_NOUS_OAUTH_FILE", value),
+            None => std::env::remove_var("HERMES_NOUS_OAUTH_FILE"),
+        }
+        match previous_inference_base_url {
+            Some(value) => std::env::set_var("NOUS_INFERENCE_BASE_URL", value),
+            None => std::env::remove_var("NOUS_INFERENCE_BASE_URL"),
         }
     }
 


### PR DESCRIPTION
## Summary
- ignore malformed upstream Nous fallback auth state for Ultra status/runtime discovery
- keep precise runtime errors for parseable but unusable Nous OAuth state
- prevent stale NOUS_API_KEY vault/config hydration from hiding unusable OAuth state
- make `auth verify nous` perform a live chat-completions probe before reporting valid

## Local verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p hermes-cli nous -- --nocapture
- cargo build -p hermes-cli --bin hermes-ultra
- /Volumes/wd_black/cargo-targets/debug/hermes-ultra auth verify nous (correctly fails live against current invalid/out-of-funds Nous state)
- /Volumes/wd_black/cargo-targets/debug/hermes-ultra --provider nous -m nous:openai/gpt-5.5 chat --query "Live release-gate auth probe. Reply with exactly: HERMES_NOUS_LIVE_OK" (currently fails with Nous 401)

## Notes
- `cargo clippy -p hermes-cli --all-targets -- -D warnings` and `--no-deps` are blocked by existing unrelated lint debt in hermes-config/hermes-intelligence/hermes-cli.
