### PR TITLE
fix(cli): keep TUI stream open during auth recovery

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -3448,9 +3448,6 @@ impl App {
                         "error handling + remediation",
                         60,
                     );
-                    if let Some(handle) = &self.stream_handle {
-                        handle.send_done();
-                    }
                     if Self::is_provider_auth_or_session_error(&e) {
                         if auth_refresh_attempts < auth_refresh_retry_limit {
                             if self.force_auth_refresh_after_error().await {
@@ -3513,6 +3510,9 @@ impl App {
                             remediation_attempted = true;
                             continue;
                         }
+                    }
+                    if let Some(handle) = &self.stream_handle {
+                        handle.send_done();
                     }
                     return Err(e);
                 }


### PR DESCRIPTION
## Summary
- keep the TUI stream handle open while auth/session/transient remediation decides whether to retry
- only send the terminal stream done marker once the error is unrecovered and will be returned

## Why
Live interactive testing showed a Nous token_expired response could refresh successfully, but the TUI stream had already been marked done before the retry path continued the same turn.

## Local verification
- cargo fmt --check
- cargo test -p hermes-cli test_is_provider_auth_or_session_error_detects_auth_failures --no-default-features
- cargo build -p hermes-cli --bin hermes-agent-ultra --bin hermes-ultra --no-default-features
- manual TUI invalid-token prompt recovered in the same turn and returned AUTO_REFRESH_RECOVERED_OK