### PR TITLE
Route OpenAI OAuth through Pro backend

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -47,7 +47,10 @@ use crate::interrupt::InterruptController;
 use crate::lsp_context::{build_lsp_context_note, LspContextConfig};
 use crate::memory_manager::{MemoryManager, StreamingContextScrubber};
 use crate::plugins::{HookResult, HookType, PluginManager};
-use crate::provider::{AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider};
+use crate::provider::{
+    is_codex_chatgpt_token, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
+    OPENAI_CODEX_BASE_URL,
+};
 use crate::providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,
 };
@@ -688,7 +691,7 @@ fn effective_max_turns(config_max_turns: u32) -> Option<u32> {
 }
 
 fn default_model() -> String {
-    "gpt-4o".to_string()
+    "gpt-5.5".to_string()
 }
 
 fn default_max_concurrent_delegates() -> u32 {
@@ -3110,7 +3113,7 @@ impl AgentLoop {
                         .filter(|s| !s.is_empty())
                         .or_else(|| Some("acp://copilot".to_string()))
                 } else if provider == "openai-codex" || provider == "codex" {
-                    Some("https://api.openai.com/v1".to_string())
+                    Some(OPENAI_CODEX_BASE_URL.to_string())
                 } else if provider == "qwen-oauth" {
                     Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string())
                 } else if provider == "google-gemini-cli" {
@@ -3719,7 +3722,13 @@ impl AgentLoop {
             base_url,
         );
         let request_timeout_seconds = self.resolve_runtime_request_timeout_seconds(provider);
-        let mode = api_mode.unwrap_or(&self.config.api_mode);
+        let use_openai_pro_backend = matches!(provider, "openai-codex" | "codex")
+            || (provider == "openai" && is_codex_chatgpt_token(&api_key));
+        let mode = if use_openai_pro_backend {
+            &ApiMode::CodexResponses
+        } else {
+            api_mode.unwrap_or(&self.config.api_mode)
+        };
         let normalized_model_name =
             crate::model_normalize::normalize_model_for_provider(model_name, provider);
         let model_name = normalized_model_name.as_str();
@@ -3727,9 +3736,12 @@ impl AgentLoop {
         let provider_obj: Arc<dyn LlmProvider> = match provider {
             "openai" | "codex" | "openai-codex" => {
                 if matches!(mode, ApiMode::CodexResponses) {
-                    let mut p = CodexProvider::new(&api_key)
-                        .with_model(model_name)
-                        .with_optional_request_timeout_seconds(request_timeout_seconds);
+                    let mut p = if use_openai_pro_backend {
+                        CodexProvider::openai_pro(&api_key, model_name)
+                    } else {
+                        CodexProvider::new(&api_key).with_model(model_name)
+                    }
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
                     if let Some(ref url) = base_url {
                         p = p.with_base_url(url.clone());
                     }

--- a/crates/hermes-agent/src/api_bridge.rs
+++ b/crates/hermes-agent/src/api_bridge.rs
@@ -17,7 +17,10 @@ use hermes_core::{
 };
 
 use crate::credential_pool::CredentialPool;
+use crate::provider::{codex_cloudflare_headers, OPENAI_CODEX_BASE_URL};
 use crate::rate_limit::RateLimitTracker;
+
+const CODEX_RESPONSES_BETA_HEADER: &str = "responses=2026-02-06";
 
 fn request_timeout_duration(seconds: Option<f64>) -> Option<Duration> {
     seconds.and_then(|value| {
@@ -46,6 +49,7 @@ pub struct CodexProvider {
     pub base_url: String,
     pub api_key: String,
     pub model: String,
+    pub headers: Vec<(String, String)>,
     client: Client,
     request_timeout: Option<Duration>,
     pub rate_limiter: Option<Arc<RateLimitTracker>>,
@@ -59,6 +63,7 @@ impl CodexProvider {
             base_url: "https://api.openai.com/v1".to_string(),
             api_key: api_key.into(),
             model: "codex-mini-latest".to_string(),
+            headers: Vec::new(),
             client: build_codex_http_client(request_timeout),
             request_timeout,
             rate_limiter: None,
@@ -73,6 +78,11 @@ impl CodexProvider {
 
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
+        self
+    }
+
+    pub fn with_headers(mut self, headers: Vec<(String, String)>) -> Self {
+        self.headers = headers;
         self
     }
 
@@ -109,6 +119,57 @@ impl CodexProvider {
         }
     }
 
+    fn uses_chatgpt_codex_backend(&self) -> bool {
+        self.base_url
+            .trim()
+            .to_ascii_lowercase()
+            .contains("chatgpt.com/backend-api/codex")
+    }
+
+    fn request_headers(&self, api_key: &str) -> Vec<(String, String)> {
+        let mut headers = self.headers.clone();
+        if self.uses_chatgpt_codex_backend() {
+            for header in codex_cloudflare_headers(Some(api_key)) {
+                if !headers
+                    .iter()
+                    .any(|(name, _)| name.eq_ignore_ascii_case(&header.0))
+                {
+                    headers.push(header);
+                }
+            }
+            if !headers
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("OpenAI-Beta"))
+            {
+                headers.push((
+                    "OpenAI-Beta".to_string(),
+                    CODEX_RESPONSES_BETA_HEADER.to_string(),
+                ));
+            }
+        }
+        headers
+    }
+
+    fn request_builder(&self, url: &str, api_key: &str, body: &Value) -> reqwest::RequestBuilder {
+        let mut request = self
+            .client
+            .post(url)
+            .header("Authorization", format!("Bearer {}", api_key))
+            .header("Content-Type", "application/json");
+        for (name, value) in self.request_headers(api_key) {
+            request = request.header(name, value);
+        }
+        request.json(body)
+    }
+
+    pub fn openai_pro(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        let api_key = api_key.into();
+        Self::new(api_key.as_str())
+            .with_model(model)
+            .with_base_url(OPENAI_CODEX_BASE_URL)
+            .with_headers(codex_cloudflare_headers(Some(api_key.as_str())))
+    }
+
     async fn check_rate_limit(&self) {
         if let Some(ref tracker) = self.rate_limiter {
             if let Some(wait_duration) = tracker.should_wait() {
@@ -124,7 +185,7 @@ impl CodexProvider {
         }
     }
 
-    /// Convert internal messages to the Responses API input format.
+    /// Convert internal non-system messages to the Responses API input format.
     ///
     /// The Responses API uses a flat `input` array with items of different types:
     /// - `{ "role": "user", "content": "..." }`
@@ -135,12 +196,7 @@ impl CodexProvider {
         let mut input = Vec::new();
         for msg in messages {
             match msg.role {
-                MessageRole::System => {
-                    input.push(serde_json::json!({
-                        "role": "system",
-                        "content": msg.content.as_deref().unwrap_or("")
-                    }));
-                }
+                MessageRole::System => {}
                 MessageRole::User => {
                     input.push(serde_json::json!({
                         "role": "user",
@@ -185,6 +241,30 @@ impl CodexProvider {
         input
     }
 
+    fn convert_instructions(messages: &[Message]) -> Option<String> {
+        let instructions = messages
+            .iter()
+            .filter(|msg| msg.role == MessageRole::System)
+            .filter_map(|msg| msg.content.as_deref())
+            .map(str::trim)
+            .filter(|content| !content.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        if instructions.is_empty() {
+            None
+        } else {
+            Some(instructions)
+        }
+    }
+
+    fn default_instructions() -> &'static str {
+        "You are Hermes Agent Ultra. Follow the user's instructions exactly."
+    }
+
+    fn should_forward_extra_body_key(key: &str) -> bool {
+        !matches!(key, "strict_api" | "strict_tool_calls" | "provider_strict")
+    }
+
     /// Convert tool schemas to Responses API function format.
     fn convert_tools(tools: &[ToolSchema]) -> Vec<Value> {
         tools
@@ -198,6 +278,52 @@ impl CodexProvider {
                 })
             })
             .collect()
+    }
+
+    fn build_body(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        max_tokens: Option<u32>,
+        temperature: Option<f64>,
+        effective_model: &str,
+        extra_body: Option<&Value>,
+        stream: bool,
+    ) -> Value {
+        let mut body = serde_json::json!({
+            "model": effective_model,
+            "instructions": Self::convert_instructions(messages)
+                .unwrap_or_else(|| Self::default_instructions().to_string()),
+            "input": Self::convert_input(messages),
+        });
+
+        if stream {
+            body["stream"] = serde_json::json!(true);
+        }
+        if let Some(mt) = max_tokens {
+            body["max_output_tokens"] = serde_json::json!(mt);
+        }
+        if let Some(temp) = temperature {
+            body["temperature"] = serde_json::json!(temp);
+        }
+        if !tools.is_empty() {
+            body["tools"] = serde_json::json!(Self::convert_tools(tools));
+        }
+        if let Some(eb) = extra_body {
+            if let Value::Object(map) = eb {
+                for (k, v) in map {
+                    if !Self::should_forward_extra_body_key(k) {
+                        continue;
+                    }
+                    body[k] = v.clone();
+                }
+            }
+        }
+        if self.uses_chatgpt_codex_backend() {
+            body["stream"] = serde_json::json!(true);
+            body["store"] = serde_json::json!(false);
+        }
+        body
     }
 
     /// Parse a Responses API response.
@@ -299,6 +425,95 @@ impl CodexProvider {
             finish_reason: stop_reason,
         })
     }
+
+    fn parse_sse_event_block(event_block: &str) -> Option<(String, Value)> {
+        let mut event_type = String::new();
+        let mut event_data = String::new();
+
+        for line in event_block.lines() {
+            let line = line.trim();
+            if let Some(et) = line.strip_prefix("event: ") {
+                event_type = et.trim().to_string();
+            } else if let Some(d) = line.strip_prefix("data: ") {
+                event_data.push_str(d.trim());
+            }
+        }
+
+        if event_data.is_empty() {
+            return None;
+        }
+
+        let json: Value = serde_json::from_str(&event_data).ok()?;
+        Some((event_type, json))
+    }
+
+    async fn collect_streaming_response(
+        &self,
+        resp: reqwest::Response,
+        effective_model: &str,
+    ) -> Result<LlmResponse, AgentError> {
+        let mut byte_stream = resp.bytes_stream();
+        let mut buffer = String::new();
+        let mut content_text = String::new();
+        let mut completed_response: Option<Value> = None;
+
+        while let Some(chunk_result) = byte_stream.next().await {
+            let chunk_bytes =
+                chunk_result.map_err(|e| AgentError::LlmApi(format!("Stream read error: {e}")))?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk_bytes));
+
+            while let Some(event_end) = buffer.find("\n\n") {
+                let event_block = buffer[..event_end].to_string();
+                buffer = buffer[event_end + 2..].to_string();
+                let Some((event_type, json)) = Self::parse_sse_event_block(&event_block) else {
+                    continue;
+                };
+
+                match event_type.as_str() {
+                    "response.output_text.delta" => {
+                        if let Some(delta) = json.get("delta").and_then(|d| d.as_str()) {
+                            content_text.push_str(delta);
+                        }
+                    }
+                    "response.completed" => {
+                        completed_response = json.get("response").cloned();
+                    }
+                    "response.failed" => {
+                        return Err(AgentError::LlmApi(format!("response failed: {json}")));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if let Some(response) = completed_response {
+            if let Ok(parsed) = Self::parse_response(&response) {
+                if parsed.message.content.is_some() || parsed.message.tool_calls.is_some() {
+                    return Ok(parsed);
+                }
+            }
+        }
+
+        Ok(LlmResponse {
+            message: Message {
+                role: MessageRole::Assistant,
+                content: if content_text.is_empty() {
+                    None
+                } else {
+                    Some(content_text)
+                },
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+                reasoning_content: None,
+                anthropic_content_blocks: None,
+                cache_control: None,
+            },
+            usage: None,
+            model: effective_model.to_string(),
+            finish_reason: Some("stop".to_string()),
+        })
+    }
 }
 
 #[async_trait]
@@ -316,36 +531,20 @@ impl LlmProvider for CodexProvider {
         let effective_model = model.unwrap_or(&self.model);
         let api_key = self.effective_api_key();
 
-        let mut body = serde_json::json!({
-            "model": effective_model,
-            "input": Self::convert_input(messages),
-        });
-
-        if let Some(mt) = max_tokens {
-            body["max_output_tokens"] = serde_json::json!(mt);
-        }
-        if let Some(temp) = temperature {
-            body["temperature"] = serde_json::json!(temp);
-        }
-        if !tools.is_empty() {
-            body["tools"] = serde_json::json!(Self::convert_tools(tools));
-        }
-        if let Some(eb) = extra_body {
-            if let Value::Object(map) = eb {
-                for (k, v) in map {
-                    body[k] = v.clone();
-                }
-            }
-        }
+        let body = self.build_body(
+            messages,
+            tools,
+            max_tokens,
+            temperature,
+            effective_model,
+            extra_body,
+            false,
+        );
 
         let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
 
         let resp = self
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&body)
+            .request_builder(&url, &api_key, &body)
             .send()
             .await
             .map_err(|e| AgentError::LlmApi(format!("HTTP request failed: {e}")))?;
@@ -361,6 +560,10 @@ impl LlmProvider for CodexProvider {
             return Err(AgentError::LlmApi(format!(
                 "API error {status}: {body_text}"
             )));
+        }
+
+        if self.uses_chatgpt_codex_backend() {
+            return self.collect_streaming_response(resp, effective_model).await;
         }
 
         let resp_json: Value = resp
@@ -391,36 +594,20 @@ impl LlmProvider for CodexProvider {
             let effective_model = model.as_deref().unwrap_or(&provider.model);
             let api_key = provider.effective_api_key();
 
-            let mut body = serde_json::json!({
-                "model": effective_model,
-                "input": CodexProvider::convert_input(&messages),
-                "stream": true,
-            });
-
-            if let Some(mt) = max_tokens {
-                body["max_output_tokens"] = serde_json::json!(mt);
-            }
-            if let Some(temp) = temperature {
-                body["temperature"] = serde_json::json!(temp);
-            }
-            if !tools.is_empty() {
-                body["tools"] = serde_json::json!(CodexProvider::convert_tools(&tools));
-            }
-            if let Some(ref eb) = extra_body {
-                if let Value::Object(map) = eb {
-                    for (k, v) in map {
-                        body[k] = v.clone();
-                    }
-                }
-            }
+            let body = provider.build_body(
+                &messages,
+                &tools,
+                max_tokens,
+                temperature,
+                effective_model,
+                extra_body.as_ref(),
+                true,
+            );
 
             let url = format!("{}/responses", provider.base_url.trim_end_matches('/'));
 
-            let resp = match provider.client
-                .post(&url)
-                .header("Authorization", format!("Bearer {}", api_key))
-                .header("Content-Type", "application/json")
-                .json(&body)
+            let resp = match provider
+                .request_builder(&url, &api_key, &body)
                 .send()
                 .await
             {
@@ -458,23 +645,8 @@ impl LlmProvider for CodexProvider {
                     let event_block = buffer[..event_end].to_string();
                     buffer = buffer[event_end + 2..].to_string();
 
-                    let mut event_type = String::new();
-                    let mut event_data = String::new();
-
-                    for line in event_block.lines() {
-                        let line = line.trim();
-                        if let Some(et) = line.strip_prefix("event: ") {
-                            event_type = et.trim().to_string();
-                        } else if let Some(d) = line.strip_prefix("data: ") {
-                            event_data = d.trim().to_string();
-                        }
-                    }
-
-                    if event_data.is_empty() { continue; }
-
-                    let json: Value = match serde_json::from_str(&event_data) {
-                        Ok(v) => v,
-                        Err(_) => continue,
+                    let Some((event_type, json)) = CodexProvider::parse_sse_event_block(&event_block) else {
+                        continue;
                     };
 
                     match event_type.as_str() {
@@ -576,14 +748,17 @@ mod tests {
             Message::assistant("Hi!"),
         ];
         let input = CodexProvider::convert_input(&messages);
-        assert_eq!(input.len(), 3);
-        assert_eq!(input[0]["role"], "system");
-        assert_eq!(input[1]["role"], "user");
-        assert_eq!(input[2]["role"], "assistant");
-        assert_eq!(input[1]["content"][0]["type"], "input_text");
-        assert_eq!(input[1]["content"][0]["text"], "Hello");
-        assert_eq!(input[2]["content"][0]["type"], "output_text");
-        assert_eq!(input[2]["content"][0]["text"], "Hi!");
+        assert_eq!(
+            CodexProvider::convert_instructions(&messages).as_deref(),
+            Some("You are helpful")
+        );
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[1]["role"], "assistant");
+        assert_eq!(input[0]["content"][0]["type"], "input_text");
+        assert_eq!(input[0]["content"][0]["text"], "Hello");
+        assert_eq!(input[1]["content"][0]["type"], "output_text");
+        assert_eq!(input[1]["content"][0]["text"], "Hi!");
     }
 
     #[test]
@@ -615,6 +790,37 @@ mod tests {
         assert_eq!(input[1]["name"], "read_file");
         assert_eq!(input[2]["type"], "function_call_output");
         assert_eq!(input[2]["call_id"], "call_1");
+    }
+
+    #[test]
+    fn openai_pro_body_uses_chatgpt_codex_contract() {
+        let provider = CodexProvider::openai_pro("token", "gpt-5.5");
+        let messages = vec![Message::system("Be exact"), Message::user("Say ok")];
+        let extra_body = serde_json::json!({
+            "strict_api": true,
+            "strict_tool_calls": true,
+            "provider_strict": true,
+            "service_tier": "fast"
+        });
+        let body = provider.build_body(
+            &messages,
+            &[],
+            None,
+            None,
+            "gpt-5.5",
+            Some(&extra_body),
+            false,
+        );
+
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["instructions"], "Be exact");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+        assert_eq!(body["service_tier"], "fast");
+        assert!(body.get("strict_api").is_none());
+        assert!(body.get("strict_tool_calls").is_none());
+        assert!(body.get("provider_strict").is_none());
+        assert_eq!(body["input"].as_array().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -128,7 +128,7 @@ fn is_codex_cloudflare_base_url(base_url: &str) -> bool {
         .contains("chatgpt.com/backend-api/codex")
 }
 
-fn codex_chatgpt_account_id(token: &str) -> Option<String> {
+pub fn codex_chatgpt_account_id(token: &str) -> Option<String> {
     let token = token.trim();
     if token.is_empty() {
         return None;
@@ -146,6 +146,10 @@ fn codex_chatgpt_account_id(token: &str) -> Option<String> {
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
+}
+
+pub fn is_codex_chatgpt_token(token: &str) -> bool {
+    codex_chatgpt_account_id(token).is_some()
 }
 
 fn parse_acp_multimodal_parts(content: &str) -> Option<Vec<Value>> {

--- a/crates/hermes-agent/src/smart_model_routing.rs
+++ b/crates/hermes-agent/src/smart_model_routing.rs
@@ -349,7 +349,10 @@ pub fn detect_api_mode_for_url(base_url: &str) -> Option<ApiMode> {
     if host.contains("bedrock-runtime.") || host.contains("bedrock-runtime-") {
         return Some(ApiMode::BedrockConverse);
     }
-    if host == "api.openai.com" || host == "api.x.ai" {
+    if host == "api.openai.com"
+        || host == "api.x.ai"
+        || (host == "chatgpt.com" && path.ends_with("/backend-api/codex"))
+    {
         return Some(ApiMode::CodexResponses);
     }
     if path == "/anthropic" || path.ends_with("/anthropic") {
@@ -458,6 +461,10 @@ mod tests {
         );
         assert_eq!(
             detect_api_mode_for_url("https://api.x.ai/v1"),
+            Some(ApiMode::CodexResponses)
+        );
+        assert_eq!(
+            detect_api_mode_for_url("https://chatgpt.com/backend-api/codex"),
             Some(ApiMode::CodexResponses)
         );
     }

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -19,8 +19,8 @@ use hermes_agent::bedrock::{
 };
 use hermes_agent::plugins::HookType;
 use hermes_agent::provider::{
-    openai_codex_provider_with_timeout, AnthropicProvider, GenericProvider, OpenAiProvider,
-    OpenRouterProvider, OPENAI_CODEX_BASE_URL,
+    is_codex_chatgpt_token, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
+    OPENAI_CODEX_BASE_URL,
 };
 use hermes_agent::provider_profiles;
 use hermes_agent::providers_extra::{
@@ -29,7 +29,7 @@ use hermes_agent::providers_extra::{
 use hermes_agent::smart_model_routing::ApiMode;
 use hermes_agent::sub_agent_orchestrator::SubAgentOrchestrator;
 use hermes_agent::{
-    AgentCallbacks, AgentConfig, AgentLoop, InterruptController, SessionPersistence,
+    AgentCallbacks, AgentConfig, AgentLoop, CodexProvider, InterruptController, SessionPersistence,
 };
 use hermes_config::{
     hermes_home as hermes_home_dir, load_config, normalize_service_tier, state_dir, GatewayConfig,
@@ -2196,7 +2196,10 @@ impl App {
             }
         }
 
-        let configured_model = config.model.clone().unwrap_or_else(|| "gpt-4o".to_string());
+        let configured_model = config
+            .model
+            .clone()
+            .unwrap_or_else(|| "gpt-5.5".to_string());
         let current_model = resolve_startup_model(&config, &configured_model);
         let current_personality = config.personality.clone();
 
@@ -7354,7 +7357,7 @@ fn resolve_provider_and_model(config: &GatewayConfig, model: &str) -> (String, S
 fn resolve_startup_model(config: &GatewayConfig, configured_model: &str) -> String {
     let raw = configured_model.trim();
     if raw.is_empty() {
-        return "gpt-4o".to_string();
+        return "gpt-5.5".to_string();
     }
     if raw.contains(':') {
         return raw.to_string();
@@ -7812,6 +7815,24 @@ pub fn provider_api_key_from_env(provider: &str) -> Option<String> {
     }
 }
 
+fn provider_oauth_token_from_auth_state(provider: &str) -> Option<String> {
+    let provider_key = match normalize_runtime_provider_name(provider).as_str() {
+        "openai" => "openai",
+        "openai-codex" | "codex" => "openai-codex",
+        _ => return None,
+    };
+    let state = crate::auth::read_provider_auth_state(provider_key)
+        .ok()
+        .flatten()?;
+    state
+        .get("tokens")
+        .and_then(|tokens| tokens.get("access_token"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_string)
+}
+
 pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvider> {
     let (provider_name, model_name) = resolve_provider_and_model(config, model);
     let runtime_provider = normalize_runtime_provider_name(provider_name.as_str());
@@ -7844,7 +7865,9 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
                 .filter(|v| !v.trim().is_empty())
         })
         .or_else(|| provider_api_key_from_env(provider_name.as_str()))
-        .or_else(|| provider_api_key_from_env(runtime_provider.as_str()));
+        .or_else(|| provider_api_key_from_env(runtime_provider.as_str()))
+        .or_else(|| provider_oauth_token_from_auth_state(provider_name.as_str()))
+        .or_else(|| provider_oauth_token_from_auth_state(runtime_provider.as_str()));
 
     let local_no_key_ok = allow_no_api_key(
         provider_name.as_str(),
@@ -7867,22 +7890,41 @@ pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvide
         }
     };
 
+    let use_openai_pro_backend = matches!(runtime_provider.as_str(), "openai-codex" | "codex")
+        || (runtime_provider == "openai" && is_codex_chatgpt_token(&api_key));
+    let base_url = if use_openai_pro_backend {
+        Some(base_url.unwrap_or_else(|| OPENAI_CODEX_BASE_URL.to_string()))
+    } else {
+        base_url
+    };
+
     match runtime_provider.as_str() {
         "openai" => {
-            let mut p = OpenAiProvider::new(&api_key)
-                .with_model(model_name.as_str())
+            if use_openai_pro_backend {
+                let mut p = CodexProvider::openai_pro(&api_key, model_name.as_str())
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
+                if let Some(url) = base_url {
+                    p = p.with_base_url(url);
+                }
+                Arc::new(p)
+            } else {
+                let mut p = OpenAiProvider::new(&api_key)
+                    .with_model(model_name.as_str())
+                    .with_optional_request_timeout_seconds(request_timeout_seconds);
+                if let Some(url) = base_url {
+                    p = p.with_base_url(url);
+                }
+                Arc::new(p)
+            }
+        }
+        "openai-codex" | "codex" => {
+            let mut p = CodexProvider::openai_pro(&api_key, model_name.as_str())
                 .with_optional_request_timeout_seconds(request_timeout_seconds);
             if let Some(url) = base_url {
                 p = p.with_base_url(url);
             }
             Arc::new(p)
         }
-        "openai-codex" | "codex" => Arc::new(openai_codex_provider_with_timeout(
-            &api_key,
-            model_name.as_str(),
-            base_url.as_deref(),
-            request_timeout_seconds,
-        )),
         "anthropic" => {
             let mut p = AnthropicProvider::new(&api_key)
                 .with_model(model_name.as_str())

--- a/crates/hermes-cli/src/auth.rs
+++ b/crates/hermes-cli/src/auth.rs
@@ -723,7 +723,7 @@ fn load_openai_oauth_import_from_path(path: &Path, base_url: &str) -> Option<Ope
 
 pub fn discover_existing_openai_oauth() -> Result<Option<OpenAiOAuthImport>, AgentError> {
     for path in openai_oauth_discovery_paths(&[]) {
-        if let Some(imported) = load_openai_oauth_import_from_path(&path, DEFAULT_OPENAI_BASE_URL) {
+        if let Some(imported) = load_openai_oauth_import_from_path(&path, DEFAULT_CODEX_BASE_URL) {
             return Ok(Some(imported));
         }
     }
@@ -3238,12 +3238,12 @@ pub async fn login_openai_device_code(
     options: CodexDeviceCodeOptions,
 ) -> Result<CodexAuthState, AgentError> {
     let mut state = login_openai_codex_device_code(options).await?;
-    state.base_url = std::env::var("HERMES_OPENAI_BASE_URL")
+    state.base_url = std::env::var("HERMES_OPENAI_OAUTH_BASE_URL")
         .ok()
         .map(|v| v.trim().trim_end_matches('/').to_string())
         .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
-    state.auth_mode = Some("openai".to_string());
+        .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string());
+    state.auth_mode = Some("chatgpt".to_string());
     state.source = Some("device_code".to_string());
     Ok(state)
 }
@@ -3548,7 +3548,7 @@ mod tests {
             imported.state.tokens.refresh_token.as_deref(),
             Some("openai-refresh")
         );
-        assert_eq!(imported.state.base_url, DEFAULT_OPENAI_BASE_URL.to_string());
+        assert_eq!(imported.state.base_url, DEFAULT_CODEX_BASE_URL.to_string());
         assert_eq!(imported.state.auth_mode.as_deref(), Some("chatgpt"));
         assert!(
             imported.state.tokens.expires_in.unwrap_or_default() > 100,

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -33,7 +33,7 @@ use hermes_cli::auth::{
     NousRuntimeCredentials, ANTHROPIC_OAUTH_CLIENT_ID, ANTHROPIC_OAUTH_TOKEN_URL,
     CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_TOKEN_URL, DEFAULT_CODEX_BASE_URL,
     DEFAULT_NOUS_AGENT_KEY_MIN_TTL_SECONDS, DEFAULT_NOUS_CLIENT_ID, DEFAULT_NOUS_INFERENCE_URL,
-    DEFAULT_NOUS_PORTAL_URL, DEFAULT_OPENAI_BASE_URL, NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    DEFAULT_NOUS_PORTAL_URL, NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, QWEN_OAUTH_CLIENT_ID, QWEN_OAUTH_TOKEN_URL,
 };
 use hermes_cli::cli::{Cli, CliCommand};
@@ -1763,7 +1763,7 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
             }
         }
         None => {
-            let current = config.model.as_deref().unwrap_or("gpt-4o");
+            let current = config.model.as_deref().unwrap_or("gpt-5.5");
             println!("Current model: {}", current);
 
             // List providers with merged models.dev-aware previews.
@@ -1772,7 +1772,7 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
                     .await;
             println!("\nAvailable providers:");
             if entries.is_empty() {
-                println!("  openai       — OpenAI (gpt-4o, gpt-4o-mini, ...)");
+                println!("  openai       — OpenAI (gpt-5.5, gpt-5.5-pro, ...)");
                 println!("  anthropic    — Anthropic (claude-3-5-sonnet, claude-3-opus, ...)");
                 println!("  openrouter   — OpenRouter (multi-provider routing)");
                 println!("  stepfun      — Step Plan / StepFun (step-3.5-flash, ...)");
@@ -2973,7 +2973,7 @@ async fn run_gateway(
                         }
                         let agent_tools = Arc::new(bridge_tool_registry(&runtime_tools));
                         let effective_model = resolve_model_for_gateway(
-                            config.model.as_deref().unwrap_or("gpt-4o"),
+                            config.model.as_deref().unwrap_or("gpt-5.5"),
                             &ctx,
                         );
                         let tool_schemas = resolve_platform_tool_schemas(
@@ -3245,7 +3245,7 @@ async fn run_gateway(
                         }
                         let agent_tools = Arc::new(bridge_tool_registry(&runtime_tools));
                         let effective_model = resolve_model_for_gateway(
-                            config.model.as_deref().unwrap_or("gpt-4o"),
+                            config.model.as_deref().unwrap_or("gpt-5.5"),
                             &ctx,
                         );
                         let tool_schemas = resolve_platform_tool_schemas(
@@ -3538,7 +3538,10 @@ async fn run_gateway(
             let cron_dir = hermes_state_root(&cli).join("cron");
             std::fs::create_dir_all(&cron_dir)
                 .map_err(|e| AgentError::Io(format!("cron dir {}: {}", cron_dir.display(), e)))?;
-            let default_model = config.model.clone().unwrap_or_else(|| "gpt-4o".to_string());
+            let default_model = config
+                .model
+                .clone()
+                .unwrap_or_else(|| "gpt-5.5".to_string());
             let cron_persistence = Arc::new(FileJobPersistence::with_dir(cron_dir.clone()));
             let cron_llm = build_provider(&config, &default_model);
             let cron_runner = Arc::new(CronRunner::new(cron_llm, agent_tools_for_cron));
@@ -4288,7 +4291,7 @@ fn build_agent_for_gateway_context(
     agent_tools: Arc<hermes_agent::agent_loop::ToolRegistry>,
 ) -> AgentLoop {
     let effective_model =
-        resolve_model_for_gateway(config.model.as_deref().unwrap_or("gpt-4o"), ctx);
+        resolve_model_for_gateway(config.model.as_deref().unwrap_or("gpt-5.5"), ctx);
     let provider = build_provider(config, &effective_model);
     let mut agent_config = build_agent_config(config, &effective_model);
     if let Some(personality) = ctx.personality.clone() {
@@ -8444,7 +8447,10 @@ async fn run_auth(
                             id: uuid::Uuid::new_v4().simple().to_string()[..6].to_string(),
                             label: label.unwrap_or(default_label),
                             auth_type: "oauth".to_string(),
-                            source: "device_code".to_string(),
+                            source: state
+                                .source
+                                .clone()
+                                .unwrap_or_else(|| "device_code".to_string()),
                             access_token: state.tokens.access_token.clone(),
                             last_status: None,
                             last_status_at: None,
@@ -9576,7 +9582,10 @@ fn cron_cli_error(e: CronError) -> AgentError {
 fn build_live_cron_scheduler(cli: &Cli, data_dir: &Path) -> Result<CronScheduler, AgentError> {
     let config =
         load_config(cli.config_dir.as_deref()).map_err(|e| AgentError::Config(e.to_string()))?;
-    let current_model = config.model.clone().unwrap_or_else(|| "gpt-4o".to_string());
+    let current_model = config
+        .model
+        .clone()
+        .unwrap_or_else(|| "gpt-5.5".to_string());
     let provider = build_provider(&config, &current_model);
 
     let tool_registry = Arc::new(ToolRegistry::new());
@@ -10727,14 +10736,14 @@ struct SetupModelOption {
 
 const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
     SetupModelOption {
-        provider: "nous",
-        model: "nous:openai/gpt-5.5-pro",
-        label: "Nous (recommended, OAuth)",
+        provider: "openai",
+        model: "openai:gpt-5.5",
+        label: "OpenAI GPT-5.5 (ChatGPT Pro OAuth)",
     },
     SetupModelOption {
-        provider: "nous-api",
-        model: "nous-api:openai/gpt-5.5-pro",
-        label: "Nous Portal API key",
+        provider: "openai",
+        model: "openai:gpt-5.5-pro",
+        label: "OpenAI GPT-5.5 Pro (ChatGPT Pro OAuth)",
     },
     SetupModelOption {
         provider: "openai",
@@ -10745,6 +10754,16 @@ const SETUP_MODEL_OPTIONS: &[SetupModelOption] = &[
         provider: "openai",
         model: "openai:gpt-4o-mini",
         label: "OpenAI gpt-4o-mini (fast & cheap)",
+    },
+    SetupModelOption {
+        provider: "nous",
+        model: "nous:openai/gpt-5.5-pro",
+        label: "Nous (OAuth)",
+    },
+    SetupModelOption {
+        provider: "nous-api",
+        model: "nous-api:openai/gpt-5.5-pro",
+        label: "Nous Portal API key",
     },
     SetupModelOption {
         provider: "anthropic",
@@ -11564,7 +11583,7 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
                         .await?;
                     selected_oauth_token_url = Some(CODEX_OAUTH_TOKEN_URL.to_string());
                     selected_oauth_client_id = Some(CODEX_OAUTH_CLIENT_ID.to_string());
-                    selected_base_url_override = Some(DEFAULT_OPENAI_BASE_URL.to_string());
+                    selected_base_url_override = Some(DEFAULT_CODEX_BASE_URL.to_string());
                     stored_provider_secret_in_vault = true;
                 }
                 "anthropic" => {
@@ -14194,7 +14213,7 @@ async fn run_status(cli: Cli) -> Result<(), AgentError> {
 
     println!(
         "Model:   {}",
-        config.model.as_deref().unwrap_or("(default: gpt-4o)")
+        config.model.as_deref().unwrap_or("(default: gpt-5.5)")
     );
     println!(
         "Personality: {}",
@@ -14615,7 +14634,7 @@ fn collect_debug_report(cli: &Cli, lines: u32) -> Result<String, AgentError> {
         report.push_str("\n## Config Summary\n");
         report.push_str(&format!(
             "- model: {}\n",
-            cfg.model.as_deref().unwrap_or("gpt-4o")
+            cfg.model.as_deref().unwrap_or("gpt-5.5")
         ));
         report.push_str(&format!(
             "- personality: {}\n",
@@ -15092,7 +15111,7 @@ async fn run_profile(
             }
             println!(
                 "  Model:       {}",
-                config.model.as_deref().unwrap_or("gpt-4o")
+                config.model.as_deref().unwrap_or("gpt-5.5")
             );
             println!(
                 "  Personality: {}",
@@ -15229,7 +15248,7 @@ async fn run_profile(
 
             out_map
                 .entry(serde_yaml::Value::String("model".to_string()))
-                .or_insert_with(|| serde_yaml::Value::String("openai:gpt-4o".to_string()));
+                .or_insert_with(|| serde_yaml::Value::String("openai:gpt-5.5".to_string()));
             out_map
                 .entry(serde_yaml::Value::String("personality".to_string()))
                 .or_insert_with(|| serde_yaml::Value::String("default".to_string()));

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -80,6 +80,8 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
     (
         "openai",
         &[
+            "gpt-5.5",
+            "gpt-5.5-pro",
             "gpt-4o",
             "gpt-4o-mini",
             "gpt-4.1",


### PR DESCRIPTION
## Summary
- route ChatGPT/OpenAI OAuth tokens through the ChatGPT Codex Responses backend
- default OpenAI runtime/model setup to openai:gpt-5.5
- adapt Responses body/header handling for the ChatGPT Codex contract and SSE collection

## Verification
- cargo fmt
- cargo test -p hermes-agent api_bridge::tests -- --nocapture
- cargo test -p hermes-agent smart_model_routing::tests::detects_codex_api_mode_from_exact_openai_and_xai_hosts -- --nocapture
- cargo test -p hermes-cli discover_existing_openai_oauth_reads_env_path -- --nocapture
- cargo test -p hermes-cli run_model_persists_default_model_to_config_yaml -- --nocapture
- cargo test -p hermes-cli setup_default -- --nocapture
- cargo build -p hermes-cli --bin hermes-agent-ultra --bin hermes-ultra
- hermes-ultra auth verify openai
- HERMES_QUERY_DISABLE_TOOLS=1 hermes-ultra chat --query 'Reply exactly: ok'