### PR TITLE
Guard OpenAI OAuth backend parity

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -5215,6 +5215,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_provider_routes_chatgpt_openai_oauth_to_responses_backend() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_OPENAI_CODEX_API_KEY",
+            "OPENAI_BASE_URL",
+            "HERMES_OPENAI_CODEX_BASE_URL",
+        ]);
+        for key in [
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_OPENAI_CODEX_API_KEY",
+            "OPENAI_BASE_URL",
+            "HERMES_OPENAI_CODEX_BASE_URL",
+        ] {
+            std::env::remove_var(key);
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "openai-pro-ok"}]
+                    }
+                ],
+                "model": "gpt-5.5",
+                "status": "completed"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "openai".to_string(),
+            LlmProviderConfig {
+                api_key: Some("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ1c2VyLXh5eiIsImV4cCI6OTk5OTk5OTk5OSwiaHR0cHM6Ly9hcGkub3BlbmFpLmNvbS9hdXRoIjp7ImNoYXRncHRfYWNjb3VudF9pZCI6ImFjY3Qtb3BlbmFpLXByby1wYXJpdHkiLCJjaGF0Z3B0X3BsYW5fdHlwZSI6InBsdXMifX0.sig".to_string()),
+                base_url: Some(server.uri()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let provider = build_provider(&config, "openai:gpt-5.5");
+        let response = provider
+            .chat_completion(
+                &[hermes_core::Message::user("hello")],
+                &[],
+                None,
+                None,
+                Some("gpt-5.5"),
+                None,
+            )
+            .await
+            .expect("OpenAI ChatGPT OAuth provider should use Responses API");
+
+        assert_eq!(response.message.content.as_deref(), Some("openai-pro-ok"));
+        server.verify().await;
+    }
+
+    #[tokio::test]
     async fn runtime_cron_scheduler_uses_configured_provider_not_minimal_fallback() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,6 +1,6 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-21T09:42:53.788558+00:00`_
+_Generated from source artifacts: `2026-06-22T21:44:45.532726+00:00`_
 
 ## Snapshot
 
@@ -8,7 +8,7 @@ _Generated from source artifacts: `2026-06-21T09:42:53.788558+00:00`_
 - Workstream snapshot generated: `2026-06-13T16:15:14-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
 - Queue snapshot generated: `2026-06-16T23:55:38.405701+00:00`
-- Proof snapshot generated: `2026-06-21T09:42:53.788558+00:00`
+- Proof snapshot generated: `2026-06-22T21:44:45.532726+00:00`
 
 ## Gate Status
 
@@ -48,8 +48,8 @@ _Generated from source artifacts: `2026-06-21T09:42:53.788558+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total cases | 12 |
-| Equal or better cases | 12 |
+| Total cases | 13 |
+| Equal or better cases | 13 |
 | Superior cases | 8 |
 | Similarity ratio | 1.0000 |
 | Regressions | 0 |
@@ -63,7 +63,7 @@ _Generated from source artifacts: `2026-06-21T09:42:53.788558+00:00`_
 | --- | ---: |
 | Total cases | 10 |
 | Equal or better cases | 10 |
-| Superior cases | 9 |
+| Superior cases | 10 |
 | Deep problem-solving ratio | 1.0000 |
 | Regressions | 0 |
 | Gaps | 0 |

--- a/docs/parity/behavioral-similarity-cases.json
+++ b/docs/parity/behavioral-similarity-cases.json
@@ -168,6 +168,39 @@
       ]
     },
     {
+      "id": "openai-pro-oauth-responses-backend",
+      "domain": "model-provider-auth",
+      "classification": "equivalent",
+      "upstream_behavior": "OpenAI/Codex OAuth sessions route ChatGPT account tokens through the Codex Responses backend instead of the public OpenAI chat-completions API shape.",
+      "ultra_behavior": "Rust provider construction detects ChatGPT OAuth JWTs, uses the Codex Responses path for OpenAI gpt-5.5 selections, imports OpenAI OAuth as chatgpt auth mode, and builds the required Responses contract.",
+      "why": "This prevents broad provider-auth parity from hiding a backend-contract gap that upstream already handles.",
+      "source_artifacts": [
+        "docs/parity/upstream-provider-auth-snapshot.json",
+        "crates/hermes-cli/src/app.rs",
+        "crates/hermes-cli/src/auth.rs",
+        "crates/hermes-agent/src/api_bridge.rs",
+        "crates/hermes-agent/src/smart_model_routing.rs"
+      ],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "build_provider_routes_chatgpt_openai_oauth_to_responses_backend"
+        },
+        {
+          "file": "crates/hermes-cli/src/auth.rs",
+          "name": "discover_existing_openai_oauth_reads_env_path"
+        },
+        {
+          "file": "crates/hermes-agent/src/api_bridge.rs",
+          "name": "openai_pro_body_uses_chatgpt_codex_contract"
+        },
+        {
+          "file": "crates/hermes-agent/src/smart_model_routing.rs",
+          "name": "detects_codex_api_mode_from_exact_openai_and_xai_hosts"
+        }
+      ]
+    },
+    {
       "id": "local-openai-compatible-backends",
       "domain": "model-provider-runtime",
       "classification": "superior",

--- a/docs/parity/behavioral-similarity-diff.json
+++ b/docs/parity/behavioral-similarity-diff.json
@@ -196,6 +196,44 @@
       "why": "This keeps interactive model/provider behavior aligned with upstream while using Rust config and auth stores."
     },
     {
+      "classification": "equivalent",
+      "domain": "model-provider-auth",
+      "id": "openai-pro-oauth-responses-backend",
+      "issues": [],
+      "missing_rust_test_refs": [],
+      "missing_source_artifacts": [],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/app.rs",
+          "name": "build_provider_routes_chatgpt_openai_oauth_to_responses_backend"
+        },
+        {
+          "file": "crates/hermes-cli/src/auth.rs",
+          "name": "discover_existing_openai_oauth_reads_env_path"
+        },
+        {
+          "file": "crates/hermes-agent/src/api_bridge.rs",
+          "name": "openai_pro_body_uses_chatgpt_codex_contract"
+        },
+        {
+          "file": "crates/hermes-agent/src/smart_model_routing.rs",
+          "name": "detects_codex_api_mode_from_exact_openai_and_xai_hosts"
+        }
+      ],
+      "score": 1.0,
+      "source_artifacts": [
+        "docs/parity/upstream-provider-auth-snapshot.json",
+        "crates/hermes-cli/src/app.rs",
+        "crates/hermes-cli/src/auth.rs",
+        "crates/hermes-agent/src/api_bridge.rs",
+        "crates/hermes-agent/src/smart_model_routing.rs"
+      ],
+      "ultra_behavior": "Rust provider construction detects ChatGPT OAuth JWTs, uses the Codex Responses path for OpenAI gpt-5.5 selections, imports OpenAI OAuth as chatgpt auth mode, and builds the required Responses contract.",
+      "upstream_behavior": "OpenAI/Codex OAuth sessions route ChatGPT account tokens through the Codex Responses backend instead of the public OpenAI chat-completions API shape.",
+      "verified": true,
+      "why": "This prevents broad provider-auth parity from hiding a backend-contract gap that upstream already handles."
+    },
+    {
       "classification": "superior",
       "domain": "model-provider-runtime",
       "id": "local-openai-compatible-backends",
@@ -407,13 +445,13 @@
     "pass": true
   },
   "gate_failures": [],
-  "generated_at_utc": "2026-06-21T01:37:43.611039+00:00",
+  "generated_at_utc": "2026-06-22T21:44:42.099700+00:00",
   "manifest": "docs/parity/behavioral-similarity-cases.json",
   "schema_version": 1,
   "summary": {
     "behavioral_similarity_ratio": 1.0,
     "classification_counts": {
-      "equivalent": 4,
+      "equivalent": 5,
       "superior": 8
     },
     "domain_counts": {
@@ -422,7 +460,7 @@
       "cron-and-scheduler-runtime": 1,
       "gateway-platform-behavior": 1,
       "memory-plugin-integration": 1,
-      "model-provider-auth": 1,
+      "model-provider-auth": 2,
       "model-provider-runtime": 1,
       "protocol-and-fault-tolerance": 1,
       "repo-research-planning": 1,
@@ -430,8 +468,8 @@
       "skills-management-contract": 1,
       "tool-runtime-behavior": 1
     },
-    "equal_or_better_cases": 12,
-    "equivalent_cases": 4,
+    "equal_or_better_cases": 13,
+    "equivalent_cases": 5,
     "gaps": 0,
     "intentional_divergence_cases": 0,
     "min_superiority_cases": 5,
@@ -439,7 +477,7 @@
     "missing_source_artifacts": 0,
     "regressions": 0,
     "superior_cases": 8,
-    "total_cases": 12,
+    "total_cases": 13,
     "unverified_cases": 0
   }
 }

--- a/docs/parity/behavioral-similarity-diff.md
+++ b/docs/parity/behavioral-similarity-diff.md
@@ -1,6 +1,6 @@
 # Behavioral Similarity Diff
 
-Generated: `2026-06-21T01:37:43.611039+00:00`
+Generated: `2026-06-22T21:44:42.099700+00:00`
 
 ## Gate
 
@@ -16,10 +16,10 @@ Generated: `2026-06-21T01:37:43.611039+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `total_cases` | 12 |
-| `equal_or_better_cases` | 12 |
+| `total_cases` | 13 |
+| `equal_or_better_cases` | 13 |
 | `superior_cases` | 8 |
-| `equivalent_cases` | 4 |
+| `equivalent_cases` | 5 |
 | `intentional_divergence_cases` | 0 |
 | `regressions` | 0 |
 | `gaps` | 0 |
@@ -32,7 +32,7 @@ Generated: `2026-06-21T01:37:43.611039+00:00`
 
 | Classification | Count |
 | --- | ---: |
-| `equivalent` | 4 |
+| `equivalent` | 5 |
 | `superior` | 8 |
 
 ## Domain Counts
@@ -44,7 +44,7 @@ Generated: `2026-06-21T01:37:43.611039+00:00`
 | `cron-and-scheduler-runtime` | 1 |
 | `gateway-platform-behavior` | 1 |
 | `memory-plugin-integration` | 1 |
-| `model-provider-auth` | 1 |
+| `model-provider-auth` | 2 |
 | `model-provider-runtime` | 1 |
 | `protocol-and-fault-tolerance` | 1 |
 | `repo-research-planning` | 1 |
@@ -62,6 +62,7 @@ Generated: `2026-06-21T01:37:43.611039+00:00`
 | `repo-research-planning-contract` | `repo-research-planning` | `superior` | 1.0 |
 | `source-synthesis-quorum` | `agent-loop-and-runtime` | `superior` | 1.0 |
 | `provider-auth-repair-and-model-routing` | `model-provider-auth` | `equivalent` | 1.0 |
+| `openai-pro-oauth-responses-backend` | `model-provider-auth` | `equivalent` | 1.0 |
 | `local-openai-compatible-backends` | `model-provider-runtime` | `superior` | 1.0 |
 | `gateway-platform-authorization` | `gateway-platform-behavior` | `equivalent` | 1.0 |
 | `telegram-cron-topic-delivery` | `cron-and-scheduler-runtime` | `superior` | 1.0 |

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -13,7 +13,7 @@
     "summary": {
       "behavioral_similarity_ratio": 1.0,
       "classification_counts": {
-        "equivalent": 4,
+        "equivalent": 5,
         "superior": 8
       },
       "domain_counts": {
@@ -22,7 +22,7 @@
         "cron-and-scheduler-runtime": 1,
         "gateway-platform-behavior": 1,
         "memory-plugin-integration": 1,
-        "model-provider-auth": 1,
+        "model-provider-auth": 2,
         "model-provider-runtime": 1,
         "protocol-and-fault-tolerance": 1,
         "repo-research-planning": 1,
@@ -30,8 +30,8 @@
         "skills-management-contract": 1,
         "tool-runtime-behavior": 1
       },
-      "equal_or_better_cases": 12,
-      "equivalent_cases": 4,
+      "equal_or_better_cases": 13,
+      "equivalent_cases": 5,
       "gaps": 0,
       "intentional_divergence_cases": 0,
       "min_superiority_cases": 5,
@@ -39,7 +39,7 @@
       "missing_source_artifacts": 0,
       "regressions": 0,
       "superior_cases": 8,
-      "total_cases": 12,
+      "total_cases": 13,
       "unverified_cases": 0
     }
   },
@@ -260,7 +260,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-22T09:01:40.885073+00:00",
+  "generated_at_utc": "2026-06-22T21:44:45.532726+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-22T09:01:40.885073+00:00`
+Generated: `2026-06-22T21:44:45.532726+00:00`
 
 ## Gate Status
 

--- a/docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md
+++ b/docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md
@@ -1,0 +1,49 @@
+# Cargo Build Surface Cratification
+
+Date: 2026-06-22
+
+## Local Evidence
+
+- A focused `hermes-cli` OpenAI OAuth routing test took `4m01s` to compile before running one test.
+- A focused behavioral parity gate took `2m51s` and compiled `hermes-cli` because the parity crate has a dev dependency on the full CLI crate.
+- `hermes-cli` owns three binaries: `hermes`, `hermes-ultra`, and `hermes-agent-ultra`.
+- `hermes-cli` directly depends on runtime, gateway, cron, ACP, MCP, tools, skills, auth, intelligence, telemetry, TUI, clipboard, archive, and installer dependencies.
+- `hermes-cli` currently enables the full gateway adapter feature set, so small provider/auth changes can invalidate a broad adapter/runtime build surface.
+
+## Target Shape
+
+Keep the runtime Rust-only, but split compile surfaces so targeted work can test targeted crates:
+
+1. `hermes-provider-runtime`
+   - Own `build_provider`, provider/model selection, OpenAI ChatGPT OAuth routing, local OpenAI-compatible backend routing, and provider auth repair contracts.
+   - No TUI, installer, adapter, cron, or gateway feature dependencies.
+
+2. `hermes-app-runtime`
+   - Own noninteractive chat orchestration, prompt reformulation, tool-planning handoff, memory/context policy injection, and agent-loop wiring.
+   - Depend on provider runtime and core agent crates, not on CLI wrappers or TUI.
+
+3. `hermes-cli-ui`
+   - Own terminal UI, clipboard, slash-command rendering, and completion/help presentation.
+   - Keep UI dependencies out of provider/auth tests.
+
+4. Gateway adapter feature narrowing
+   - Move broad adapter feature enablement behind explicit binary/runtime feature sets.
+   - Keep provider/auth and command-contract tests from compiling every gateway adapter by default.
+
+5. Parity test dependency narrowing
+   - Point behavioral/provider parity tests at `hermes-provider-runtime` and command-contract crates where possible.
+   - Keep full `hermes-cli` parity checks for end-to-end CLI behavior only.
+
+## Gates
+
+- `scripts/audit-cargo-build-surface.sh`
+- `cargo test -p hermes-provider-runtime`
+- `cargo test -p hermes-app-runtime`
+- `cargo test -p hermes-parity-tests test_behavioral_similarity_diff_gate_passes_and_references_real_tests -- --nocapture`
+- `cargo build -p hermes-cli --bin hermes-ultra --bin hermes-agent-ultra`
+
+## Non-Goals
+
+- Do not split crates just to reduce a dependency count if it makes runtime behavior harder to audit.
+- Do not change public CLI behavior during the build-surface split.
+- Do not move gateway adapter behavior out of Rust or behind Python fallback.

--- a/docs/roadmaps/CURRENT_ROADMAP_STATUS.md
+++ b/docs/roadmaps/CURRENT_ROADMAP_STATUS.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reviewed: 2026-06-16
+Last reviewed: 2026-06-22
 
 This file is the human roadmap index. The machine-readable source of truth
 remains the generated parity artifacts under `docs/parity/`.
@@ -26,6 +26,7 @@ remains the generated parity artifacts under `docs/parity/`.
 | Deep problem-solving diff | Must keep deep problem-solving ratio at 1.0 with no regressions, gaps, or unverified cases | `python3 scripts/generate-deep-problem-solving-diff.py --check` |
 | Runtime placeholder discipline | Must stay clean | `scripts/check-runtime-placeholders.sh` |
 | Rust workspace health | Must build and test locally | `cargo build --workspace`, `cargo test --workspace` |
+| Cargo build surface | Track compile invalidation roots before crate splits | `scripts/audit-cargo-build-surface.sh` |
 
 ## Current Implementation Direction
 
@@ -37,6 +38,9 @@ remains the generated parity artifacts under `docs/parity/`.
   `docs/parity/contextlattice-replay-evidence-index.json`.
 - Keep harness growth bounded and reviewable with
   `docs/parity/harness-budget.json`.
+- Reduce Rust build latency by splitting provider/auth routing, app runtime,
+  CLI UI, and broad gateway adapter feature surfaces according to
+  `docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md`.
 - Treat stale roadmap prose as non-authoritative when it conflicts with
   generated parity artifacts or closed GitHub issue state.
 

--- a/scripts/audit-cargo-build-surface.sh
+++ b/scripts/audit-cargo-build-surface.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cli_manifest="crates/hermes-cli/Cargo.toml"
+
+echo "# Hermes Cargo Build Surface Audit"
+echo
+
+target_dir="$(
+  cargo metadata --format-version=1 --no-deps \
+    | grep -o '"target_directory":"[^"]*"' \
+    | head -n 1 \
+    | cut -d '"' -f 4
+)"
+
+echo "## Workspace"
+echo
+echo "- Root: \`$repo_root\`"
+echo "- Cargo target directory: \`$target_dir\`"
+echo
+
+echo "## hermes-cli Targets"
+echo
+awk '
+  /^\[\[bin\]\]/ { in_bin = 1; name = ""; path = ""; next }
+  in_bin && /^name = / { name = $0; sub(/^name = "/, "", name); sub(/"$/, "", name) }
+  in_bin && /^path = / {
+    path = $0;
+    sub(/^path = "/, "", path);
+    sub(/"$/, "", path);
+    printf("- `%s` -> `%s`\n", name, path);
+    in_bin = 0;
+  }
+' "$cli_manifest"
+echo
+
+echo "## hermes-cli Direct Internal Dependencies"
+echo
+awk '
+  /^\[dependencies\]/ { in_deps = 1; next }
+  /^\[/ && in_deps { exit }
+  in_deps && /^hermes-/ {
+    dep = $1;
+    printf("- `%s`\n", dep);
+  }
+' "$cli_manifest"
+echo
+
+gateway_feature_count="$(
+  awk '
+    /^hermes-gateway = / { in_gateway = 1; next }
+    in_gateway && /^\] / { in_gateway = 0 }
+    in_gateway && /^\]/ { in_gateway = 0 }
+    in_gateway && /"/ {
+      line = $0;
+      while (match(line, /"[^"]+"/)) {
+        count++;
+        line = substr(line, RSTART + RLENGTH);
+      }
+    }
+    END { print count + 0 }
+  ' "$cli_manifest"
+)"
+
+echo "## Gateway Adapter Feature Surface"
+echo
+echo "- Feature count pulled into \`hermes-cli\`: \`$gateway_feature_count\`"
+echo
+
+echo "## cargo tree: hermes-cli --edges normal --depth 1"
+echo
+echo '```text'
+cargo tree -p hermes-cli --edges normal --depth 1
+echo '```'
+echo
+
+echo "## Interpretation"
+echo
+echo "- \`hermes-cli\` is currently the invalidation root for wrappers, the main runtime binary, provider/auth routing, TUI/clipboard UI dependencies, gateway adapter features, cron, ACP, MCP, tools, skills, and telemetry."
+echo "- The first crate split should isolate provider/auth routing and noninteractive chat contracts from the CLI/TUI and gateway adapter feature surface."
+echo "- Parity tests that only validate provider, auth, or command contracts should depend on that narrower crate instead of pulling the full CLI binary surface."


### PR DESCRIPTION
## Summary
- add a focused OpenAI ChatGPT OAuth provider test proving OpenAI gpt-5.5 routes through the Responses backend contract
- add an explicit behavioral parity case so provider-auth parity cannot hide this upstream-handled surface
- add a lightweight cargo build-surface audit and roadmap for the provider/app/runtime crate split

## Verification
- cargo fmt --all -- --check
- git diff --check
- bash -n scripts/audit-cargo-build-surface.sh
- scripts/audit-cargo-build-surface.sh | sed -n '1,180p'
- cargo test -p hermes-cli build_provider_routes_chatgpt_openai_oauth_to_responses_backend -- --nocapture
- cargo test -p hermes-cli discover_existing_openai_oauth_reads_env_path -- --nocapture
- cargo test -p hermes-agent openai_pro_body_uses_chatgpt_codex_contract -- --nocapture
- cargo test -p hermes-agent detects_codex_api_mode_from_exact_openai_and_xai_hosts -- --nocapture
- python3 scripts/generate-behavioral-similarity-diff.py --check
- python3 scripts/generate-global-parity-proof.py --check-ci
- python3 scripts/generate-parity-dashboard.py
- cargo test -p hermes-parity-tests test_behavioral_similarity_diff_gate_passes_and_references_real_tests -- --nocapture