### PR TITLE
Split noninteractive query runtime from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,12 +1546,15 @@ dependencies = [
 name = "hermes-app-runtime"
 version = "0.18.1"
 dependencies = [
+ "async-trait",
+ "futures",
  "hermes-agent",
  "hermes-config",
  "hermes-core",
  "hermes-provider-runtime",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1847,9 +1850,7 @@ name = "hermes-parity-tests"
 version = "0.18.1"
 dependencies = [
  "async-trait",
- "clap",
  "hermes-acp",
- "hermes-cli",
  "hermes-core",
  "hermes-gateway",
  "hermes-intelligence",

--- a/crates/hermes-app-runtime/Cargo.toml
+++ b/crates/hermes-app-runtime/Cargo.toml
@@ -14,4 +14,7 @@ hermes-provider-runtime = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
+futures = { workspace = true }
 tempfile = "3"
+tokio = { workspace = true }

--- a/crates/hermes-app-runtime/src/lib.rs
+++ b/crates/hermes-app-runtime/src/lib.rs
@@ -6,14 +6,16 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use hermes_agent::agent_loop::{
     CheapModelRouteConfig, RetryConfig, RuntimeProviderConfig, SmartModelRoutingConfig,
+    ToolRegistry as AgentToolRegistry,
 };
 use hermes_agent::smart_model_routing::ApiMode;
-use hermes_agent::AgentConfig;
+use hermes_agent::{AgentCallbacks, AgentConfig, AgentLoop};
 use hermes_config::{normalize_service_tier, GatewayConfig, LlmProviderConfig};
-use hermes_core::AgentError;
+use hermes_core::{AgentError, AgentResult, LlmProvider, Message, MessageRole, ToolSchema};
 use hermes_provider_runtime::{
     active_llm_provider_config, normalize_runtime_provider_name, resolve_provider_and_model,
 };
@@ -21,6 +23,19 @@ use serde_json::Value;
 
 pub const QUERY_ALLOW_TOOLS_ENV_KEY: &str = "HERMES_QUERY_ALLOW_TOOLS";
 pub const QUERY_DISABLE_TOOLS_ENV_KEY: &str = "HERMES_QUERY_DISABLE_TOOLS";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryModelRemediation {
+    pub next_model: String,
+    pub close_matches: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct NoninteractiveQueryOutcome {
+    pub active_model: String,
+    pub result: AgentResult,
+    pub reply: String,
+}
 
 fn build_retry_config(config: &GatewayConfig) -> RetryConfig {
     let mut retry_cfg = RetryConfig::default();
@@ -321,10 +336,195 @@ pub fn query_mode_tools_enabled(query_mode: bool, allow_tools_flag: bool) -> boo
     true
 }
 
+pub fn split_provider_model(provider_model: &str) -> (&str, &str) {
+    provider_model
+        .split_once(':')
+        .unwrap_or(("openai", provider_model))
+}
+
+pub fn resolve_catalog_model_candidate(
+    requested_model: &str,
+    catalog: &[String],
+) -> Option<String> {
+    if catalog.is_empty() {
+        return None;
+    }
+    let requested_trimmed = requested_model.trim();
+    if requested_trimmed.is_empty() {
+        return catalog.first().cloned();
+    }
+    if let Some(hit) = catalog
+        .iter()
+        .find(|m| m.trim().eq_ignore_ascii_case(requested_trimmed))
+    {
+        return Some(hit.clone());
+    }
+    let requested_lc = requested_trimmed.to_ascii_lowercase();
+    let slash_suffix = format!("/{requested_lc}");
+    if let Some(hit) = catalog.iter().find(|m| {
+        let lower = m.trim().to_ascii_lowercase();
+        lower.ends_with(&slash_suffix) || lower == requested_lc
+    }) {
+        return Some(hit.clone());
+    }
+    rank_catalog_model_candidates(requested_trimmed, catalog, 1)
+        .into_iter()
+        .next()
+}
+
+pub fn rank_catalog_model_candidates(
+    requested_model: &str,
+    catalog: &[String],
+    limit: usize,
+) -> Vec<String> {
+    if catalog.is_empty() || limit == 0 {
+        return Vec::new();
+    }
+    let requested = requested_model.trim().to_ascii_lowercase();
+    if requested.is_empty() {
+        return catalog.iter().take(limit).cloned().collect();
+    }
+    let requested_tail = requested.rsplit('/').next().unwrap_or(requested.as_str());
+    let requested_norm: String = requested
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect();
+
+    let mut scored: Vec<(usize, usize, String)> = catalog
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, candidate)| {
+            let cand_trimmed = candidate.trim();
+            if cand_trimmed.is_empty() {
+                return None;
+            }
+            let cand = cand_trimmed.to_ascii_lowercase();
+            let cand_tail = cand.rsplit('/').next().unwrap_or(cand.as_str());
+            let cand_norm: String = cand.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+            let mut score = 0usize;
+
+            if cand == requested {
+                score += 10_000;
+            }
+            if cand_tail == requested_tail {
+                score += 8_000;
+            }
+            if cand.ends_with(&format!("/{}", requested_tail)) {
+                score += 6_000;
+            }
+            if cand.contains(requested_tail) || requested_tail.contains(cand_tail) {
+                score += 2_000;
+            }
+
+            let shared_prefix = requested_norm
+                .chars()
+                .zip(cand_norm.chars())
+                .take_while(|(a, b)| a == b)
+                .count();
+            score += shared_prefix.saturating_mul(40);
+
+            let shared_chars = requested_norm
+                .chars()
+                .filter(|ch| cand_norm.contains(*ch))
+                .count();
+            score += shared_chars.saturating_mul(12);
+
+            let len_delta = requested_norm.len().abs_diff(cand_norm.len());
+            score = score.saturating_sub(len_delta.saturating_mul(4));
+            if score == 0 {
+                return None;
+            }
+            Some((score, idx, cand_trimmed.to_string()))
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    scored
+        .into_iter()
+        .take(limit)
+        .map(|(_, _, candidate)| candidate)
+        .collect()
+}
+
+pub fn query_mode_remediation_target_from_catalog(
+    provider_model: &str,
+    catalog: &[String],
+) -> Option<QueryModelRemediation> {
+    let (provider, model_id) = split_provider_model(provider_model);
+    let provider = provider.trim().to_ascii_lowercase();
+    if provider.is_empty() || model_id.trim().is_empty() || catalog.is_empty() {
+        return None;
+    }
+    let close_matches = rank_catalog_model_candidates(model_id.trim(), catalog, 5);
+    let selected = resolve_catalog_model_candidate(model_id.trim(), catalog)
+        .or_else(|| close_matches.first().cloned())
+        .or_else(|| catalog.first().cloned())?;
+    let next_model = format!("{}:{}", provider, selected.trim());
+    if next_model.eq_ignore_ascii_case(provider_model) {
+        return None;
+    }
+    Some(QueryModelRemediation {
+        next_model,
+        close_matches,
+    })
+}
+
+pub fn query_mode_model_not_found(err: &AgentError) -> bool {
+    let msg = err.to_string().to_ascii_lowercase();
+    (msg.contains("model") && msg.contains("not found"))
+        || msg.contains("requested model does not exist")
+        || msg.contains("openrouter catalog")
+}
+
+pub fn assistant_reply_from_result(result: &AgentResult) -> String {
+    result
+        .messages
+        .iter()
+        .rev()
+        .find_map(|m| {
+            if m.role == MessageRole::Assistant {
+                m.content.clone()
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "(no assistant reply)".to_string())
+}
+
+pub async fn run_noninteractive_query(
+    config: &GatewayConfig,
+    active_model: &str,
+    query: &str,
+    agent_tool_registry: Arc<AgentToolRegistry>,
+    tool_schemas: Vec<ToolSchema>,
+    callbacks: AgentCallbacks,
+    provider_factory: impl Fn(&GatewayConfig, &str) -> Arc<dyn LlmProvider>,
+) -> Result<NoninteractiveQueryOutcome, AgentError> {
+    let active_model = active_model.trim().to_string();
+    apply_cli_chat_runtime_env(&active_model);
+    let agent_config = build_agent_config(config, &active_model);
+    let provider = provider_factory(config, &active_model);
+    let agent =
+        AgentLoop::new(agent_config, agent_tool_registry, provider).with_callbacks(callbacks);
+    let result = agent
+        .run(vec![Message::user(query)], Some(tool_schemas))
+        .await?;
+    let reply = assistant_reply_from_result(&result);
+    Ok(NoninteractiveQueryOutcome {
+        active_model,
+        result,
+        reply,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use futures::stream::{self, BoxStream};
+    use futures::StreamExt;
     use hermes_config::LlmProviderConfig;
+    use hermes_core::{LlmResponse, StreamChunk};
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
@@ -932,5 +1132,164 @@ mod tests {
         assert!(query_mode_tools_enabled(true, false));
         std::env::set_var(QUERY_ALLOW_TOOLS_ENV_KEY, "1");
         assert!(query_mode_tools_enabled(true, false));
+    }
+
+    #[test]
+    fn resolve_catalog_model_candidate_prefers_suffix_match() {
+        let catalog = vec![
+            "nousresearch/hermes-4-405b".to_string(),
+            "moonshotai/kimi-k2.6".to_string(),
+        ];
+        let chosen = resolve_catalog_model_candidate("kimi-k2.6", &catalog).expect("candidate");
+        assert_eq!(chosen, "moonshotai/kimi-k2.6");
+    }
+
+    #[test]
+    fn resolve_catalog_model_candidate_uses_relative_match_for_near_miss() {
+        let catalog = vec![
+            "qwen/qwen3.6-plus".to_string(),
+            "qwen/qwen3.6-max-preview".to_string(),
+            "moonshotai/kimi-k2.6".to_string(),
+        ];
+        let chosen = resolve_catalog_model_candidate("qwen3.6-max", &catalog).expect("candidate");
+        assert_eq!(chosen, "qwen/qwen3.6-max-preview");
+    }
+
+    #[test]
+    fn rank_catalog_model_candidates_returns_best_first() {
+        let catalog = vec![
+            "qwen/qwen3.6-plus".to_string(),
+            "qwen/qwen3.6-max-preview".to_string(),
+            "moonshotai/kimi-k2.6".to_string(),
+        ];
+        let ranked = rank_catalog_model_candidates("qwen3.6-max", &catalog, 2);
+        assert_eq!(
+            ranked,
+            vec![
+                "qwen/qwen3.6-max-preview".to_string(),
+                "qwen/qwen3.6-plus".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn query_mode_remediation_target_from_catalog_selects_close_model() {
+        let catalog = vec![
+            "qwen/qwen3.6-plus".to_string(),
+            "qwen/qwen3.6-max-preview".to_string(),
+        ];
+        let remediation =
+            query_mode_remediation_target_from_catalog("openrouter:qwen3.6-max", &catalog)
+                .expect("remediation");
+        assert_eq!(
+            remediation.next_model,
+            "openrouter:qwen/qwen3.6-max-preview"
+        );
+        assert_eq!(
+            remediation.close_matches.first().map(String::as_str),
+            Some("qwen/qwen3.6-max-preview")
+        );
+    }
+
+    #[test]
+    fn query_mode_model_not_found_detects_provider_shapes() {
+        assert!(query_mode_model_not_found(&AgentError::LlmApi(
+            "requested model does not exist".to_string()
+        )));
+        assert!(query_mode_model_not_found(&AgentError::Config(
+            "OpenRouter catalog did not include model".to_string()
+        )));
+        assert!(!query_mode_model_not_found(&AgentError::Config(
+            "bad config".to_string()
+        )));
+    }
+
+    #[test]
+    fn assistant_reply_from_result_prefers_last_assistant_message() {
+        let result = AgentResult {
+            messages: vec![
+                Message::assistant("first"),
+                Message::user("next"),
+                Message::assistant("last"),
+            ],
+            ..AgentResult::default()
+        };
+        assert_eq!(assistant_reply_from_result(&result), "last");
+    }
+
+    struct FixedProvider {
+        reply: &'static str,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FixedProvider {
+        async fn chat_completion(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            model: Option<&str>,
+            _extra_body: Option<&serde_json::Value>,
+        ) -> Result<LlmResponse, AgentError> {
+            Ok(LlmResponse {
+                message: Message::assistant(self.reply),
+                usage: None,
+                model: model.unwrap_or("test-model").to_string(),
+                finish_reason: Some("stop".to_string()),
+            })
+        }
+
+        fn chat_completion_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            _model: Option<&str>,
+            _extra_body: Option<&serde_json::Value>,
+        ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+            stream::empty().boxed()
+        }
+    }
+
+    #[tokio::test]
+    async fn run_noninteractive_query_uses_injected_provider_factory_and_returns_reply() {
+        let _lock = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+            "HERMES_TUI_PROVIDER",
+        ]);
+        let calls = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let calls_for_factory = Arc::clone(&calls);
+        let outcome = run_noninteractive_query(
+            &GatewayConfig::default(),
+            "openai:gpt-5.5",
+            "hello",
+            Arc::new(AgentToolRegistry::new()),
+            Vec::new(),
+            AgentCallbacks::default(),
+            move |_config, model| {
+                calls_for_factory.lock().unwrap().push(model.to_string());
+                Arc::new(FixedProvider {
+                    reply: "runtime-ok",
+                })
+            },
+        )
+        .await
+        .expect("query run");
+
+        assert_eq!(outcome.active_model, "openai:gpt-5.5");
+        assert_eq!(outcome.reply, "runtime-ok");
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &["openai:gpt-5.5".to_string()]
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_PROVIDER").ok().as_deref(),
+            Some("openai")
+        );
     }
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -17,8 +17,11 @@ use bytes::Bytes;
 use hermes_agent::plugins::PluginManifest;
 use hermes_agent::{MemoryProviderPlugin, SessionPersistence};
 use hermes_app_runtime::{
-    apply_cli_chat_runtime_env, query_mode_tools_enabled, resolve_cli_chat_provider_model_with,
-    QUERY_DISABLE_TOOLS_ENV_KEY,
+    apply_cli_chat_runtime_env, query_mode_model_not_found,
+    query_mode_remediation_target_from_catalog, query_mode_tools_enabled,
+    rank_catalog_model_candidates, resolve_catalog_model_candidate,
+    resolve_cli_chat_provider_model_with, run_noninteractive_query, split_provider_model,
+    QueryModelRemediation, QUERY_DISABLE_TOOLS_ENV_KEY,
 };
 use hermes_core::auth_gate::{
     load_oauth_runtime_gate_manifest_from_path,
@@ -4294,12 +4297,6 @@ fn parse_model_switch_request<S: AsRef<str>>(
     ModelSwitchRequest::SetDirect(trimmed.to_string())
 }
 
-fn split_provider_model(provider_model: &str) -> (&str, &str) {
-    provider_model
-        .split_once(':')
-        .unwrap_or(("openai", provider_model))
-}
-
 fn model_catalog_guard_enabled() -> bool {
     !matches!(
         std::env::var("HERMES_MODEL_CATALOG_GUARD")
@@ -4308,107 +4305,6 @@ fn model_catalog_guard_enabled() -> bool {
             .map(|v| v.trim().to_ascii_lowercase()),
         Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
     )
-}
-
-fn resolve_catalog_model_candidate(requested_model: &str, catalog: &[String]) -> Option<String> {
-    if catalog.is_empty() {
-        return None;
-    }
-    let requested_trimmed = requested_model.trim();
-    if requested_trimmed.is_empty() {
-        return catalog.first().cloned();
-    }
-    if let Some(hit) = catalog
-        .iter()
-        .find(|m| m.trim().eq_ignore_ascii_case(requested_trimmed))
-    {
-        return Some(hit.clone());
-    }
-    let requested_lc = requested_trimmed.to_ascii_lowercase();
-    let slash_suffix = format!("/{requested_lc}");
-    if let Some(hit) = catalog.iter().find(|m| {
-        let lower = m.trim().to_ascii_lowercase();
-        lower.ends_with(&slash_suffix) || lower == requested_lc
-    }) {
-        return Some(hit.clone());
-    }
-    rank_catalog_model_candidates(requested_trimmed, catalog, 1)
-        .into_iter()
-        .next()
-}
-
-fn rank_catalog_model_candidates(
-    requested_model: &str,
-    catalog: &[String],
-    limit: usize,
-) -> Vec<String> {
-    if catalog.is_empty() || limit == 0 {
-        return Vec::new();
-    }
-    let requested = requested_model.trim().to_ascii_lowercase();
-    if requested.is_empty() {
-        return catalog.iter().take(limit).cloned().collect();
-    }
-    let requested_tail = requested.rsplit('/').next().unwrap_or(requested.as_str());
-    let requested_norm: String = requested
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
-        .collect();
-
-    let mut scored: Vec<(usize, usize, String)> = catalog
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, candidate)| {
-            let cand_trimmed = candidate.trim();
-            if cand_trimmed.is_empty() {
-                return None;
-            }
-            let cand = cand_trimmed.to_ascii_lowercase();
-            let cand_tail = cand.rsplit('/').next().unwrap_or(cand.as_str());
-            let cand_norm: String = cand.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
-            let mut score = 0usize;
-
-            if cand == requested {
-                score += 10_000;
-            }
-            if cand_tail == requested_tail {
-                score += 8_000;
-            }
-            if cand.ends_with(&format!("/{}", requested_tail)) {
-                score += 6_000;
-            }
-            if cand.contains(requested_tail) || requested_tail.contains(cand_tail) {
-                score += 2_000;
-            }
-
-            let shared_prefix = requested_norm
-                .chars()
-                .zip(cand_norm.chars())
-                .take_while(|(a, b)| a == b)
-                .count();
-            score += shared_prefix.saturating_mul(40);
-
-            let shared_chars = requested_norm
-                .chars()
-                .filter(|ch| cand_norm.contains(*ch))
-                .count();
-            score += shared_chars.saturating_mul(12);
-
-            let len_delta = requested_norm.len().abs_diff(cand_norm.len());
-            score = score.saturating_sub(len_delta.saturating_mul(4));
-            if score == 0 {
-                return None;
-            }
-            Some((score, idx, cand_trimmed.to_string()))
-        })
-        .collect();
-
-    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
-    scored
-        .into_iter()
-        .take(limit)
-        .map(|(_, _, candidate)| candidate)
-        .collect()
 }
 
 async fn guard_provider_model_selection_for_config(
@@ -22120,14 +22016,7 @@ fn resolve_cli_chat_provider_model(
     )
 }
 
-fn query_mode_model_not_found(err: &hermes_core::AgentError) -> bool {
-    let msg = err.to_string().to_ascii_lowercase();
-    (msg.contains("model") && msg.contains("not found"))
-        || msg.contains("requested model does not exist")
-        || msg.contains("openrouter catalog")
-}
-
-async fn query_mode_remediation_target(provider_model: &str) -> Option<(String, Vec<String>)> {
+async fn query_mode_remediation_target(provider_model: &str) -> Option<QueryModelRemediation> {
     let (provider, model_id) = split_provider_model(provider_model);
     let provider = provider.trim().to_ascii_lowercase();
     if provider.is_empty() || model_id.trim().is_empty() {
@@ -22137,15 +22026,7 @@ async fn query_mode_remediation_target(provider_model: &str) -> Option<(String, 
     if catalog.is_empty() {
         return None;
     }
-    let close = rank_catalog_model_candidates(model_id.trim(), &catalog, 5);
-    let selected = resolve_catalog_model_candidate(model_id.trim(), &catalog)
-        .or_else(|| close.first().cloned())
-        .or_else(|| catalog.first().cloned())?;
-    let next = format!("{}:{}", provider, selected.trim());
-    if next.eq_ignore_ascii_case(provider_model) {
-        return None;
-    }
-    Some((next, close))
+    query_mode_remediation_target_from_catalog(provider_model, &catalog)
 }
 
 /// Handle `hermes chat [--query ...] [--preload-skill ...] [--yolo]`.
@@ -22161,7 +22042,6 @@ pub async fn handle_cli_chat(
     use crate::terminal_backend::build_terminal_backend;
     use crate::tool_preview::{build_tool_preview_from_value, tool_emoji};
     use hermes_config::load_config;
-    use hermes_core::MessageRole;
     use hermes_skills::{FileSkillStore, SkillManager};
     use hermes_tools::ToolRegistry;
 
@@ -22224,7 +22104,7 @@ pub async fn handle_cli_chat(
     };
     let agent_tool_registry = Arc::new(crate::app::bridge_tool_registry(&tool_registry));
 
-    let build_query_agent = |provider_model: &str| {
+    let build_query_callbacks = || {
         let on_tool_start: Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> =
             Box::new(move |name: &str, args: &serde_json::Value| {
                 let emoji = tool_emoji(name);
@@ -22248,58 +22128,55 @@ pub async fn handle_cli_chat(
                     println!("┊ {emoji} {name:<16} done: {snippet}");
                 }
             });
-        let callbacks = hermes_agent::AgentCallbacks {
+        hermes_agent::AgentCallbacks {
             on_tool_start: Some(on_tool_start),
             on_tool_complete: Some(on_tool_complete),
             ..Default::default()
-        };
-        let agent_config = crate::app::build_agent_config(&config, provider_model);
-        let provider = crate::app::build_provider(&config, provider_model);
-        let base =
-            hermes_agent::AgentLoop::new(agent_config, Arc::clone(&agent_tool_registry), provider)
-                .with_callbacks(callbacks);
-        if query_mode {
-            base
-        } else {
-            hermes_agent::attach_discovered_memory(base)
         }
     };
 
     match query {
         Some(q) => {
-            let messages = vec![hermes_core::Message::user(&q)];
             let mut active_model = current_model.clone();
-            if let Some((next_model, close)) = query_mode_remediation_target(&active_model).await {
+            if let Some(remediation) = query_mode_remediation_target(&active_model).await {
                 println!(
                     "[Model remediation: {} -> {}. Close matches: {}]",
                     active_model,
-                    next_model,
-                    if close.is_empty() {
+                    remediation.next_model,
+                    if remediation.close_matches.is_empty() {
                         "(none)".to_string()
                     } else {
-                        close.join(", ")
+                        remediation.close_matches.join(", ")
                     }
                 );
-                active_model = next_model;
+                active_model = remediation.next_model;
             }
-            apply_cli_chat_runtime_env(&active_model);
-            let agent = build_query_agent(&active_model);
-            let result = match agent.run(messages, Some(tool_schemas.clone())).await {
-                Ok(result) => result,
+            let outcome = match run_noninteractive_query(
+                &config,
+                &active_model,
+                &q,
+                Arc::clone(&agent_tool_registry),
+                tool_schemas,
+                build_query_callbacks(),
+                crate::app::build_provider,
+            )
+            .await
+            {
+                Ok(outcome) => outcome,
                 Err(err) => {
                     if query_mode_model_not_found(&err) {
-                        if let Some((next_model, close)) =
+                        if let Some(remediation) =
                             query_mode_remediation_target(&active_model).await
                         {
                             return Err(hermes_core::AgentError::Config(format!(
                                 "{}\nModel remediation suggestion: {} -> {} (close matches: {})",
                                 err,
                                 active_model,
-                                next_model,
-                                if close.is_empty() {
+                                remediation.next_model,
+                                if remediation.close_matches.is_empty() {
                                     "(none)".to_string()
                                 } else {
-                                    close.join(", ")
+                                    remediation.close_matches.join(", ")
                                 }
                             )));
                         }
@@ -22307,20 +22184,7 @@ pub async fn handle_cli_chat(
                     return Err(err);
                 }
             };
-
-            let reply = result
-                .messages
-                .iter()
-                .rev()
-                .find_map(|m| {
-                    if m.role == MessageRole::Assistant {
-                        m.content.clone()
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| "(no assistant reply)".to_string());
-            println!("{}", reply);
+            println!("{}", outcome.reply);
         }
         None => {
             println!("Starting interactive chat session...");

--- a/crates/hermes-parity-tests/Cargo.toml
+++ b/crates/hermes-parity-tests/Cargo.toml
@@ -17,10 +17,8 @@ thiserror = { workspace = true }
 [dev-dependencies]
 async-trait = { workspace = true }
 hermes-acp = { workspace = true }
-hermes-cli = { workspace = true }
 hermes-gateway = { workspace = true }
 hermes-mcp = { workspace = true }
 hermes-tools = { workspace = true }
-clap = { workspace = true }
 regex = { workspace = true }
 tokio = { workspace = true }

--- a/crates/hermes-parity-tests/tests/cli_command_contract.rs
+++ b/crates/hermes-parity-tests/tests/cli_command_contract.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use clap::CommandFactory;
 use regex::Regex;
 use serde::Deserialize;
 
@@ -65,14 +64,63 @@ fn extract_actions_from_function(source: &str, fn_name: &str) -> BTreeSet<String
     out
 }
 
+fn normalize_variant_command_name(variant: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in variant.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if idx > 0 {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn extract_top_level_commands_from_cli_source(source: &str) -> BTreeSet<String> {
+    let variant_re =
+        Regex::new(r"^    ([A-Z][A-Za-z0-9_]*)(?:\s*[,{(]|,)$").expect("variant regex");
+    let command_name_re =
+        Regex::new(r#"#\[command\(name\s*=\s*"([^"]+)""#).expect("command name regex");
+    let mut in_enum = false;
+    let mut explicit_name: Option<String> = None;
+    let mut out = BTreeSet::new();
+
+    for line in source.lines() {
+        if line.trim() == "pub enum CliCommand {" {
+            in_enum = true;
+            continue;
+        }
+        if !in_enum {
+            continue;
+        }
+        if line == "}" {
+            break;
+        }
+        if let Some(cap) = command_name_re.captures(line.trim()) {
+            explicit_name = Some(cap[1].to_string());
+            continue;
+        }
+        let Some(cap) = variant_re.captures(line) else {
+            continue;
+        };
+        let variant = &cap[1];
+        let name = explicit_name
+            .take()
+            .unwrap_or_else(|| normalize_variant_command_name(variant));
+        out.insert(name);
+    }
+    out
+}
+
 #[test]
 fn cli_top_level_surface_contains_required_commands() {
     let fixture = load_fixture();
-    let command = hermes_cli::Cli::command();
-    let have: BTreeSet<String> = command
-        .get_subcommands()
-        .map(|c| c.get_name().to_string())
-        .collect();
+    let source = std::fs::read_to_string(repo_root().join("crates/hermes-cli/src/cli.rs"))
+        .expect("read cli.rs");
+    let have = extract_top_level_commands_from_cli_source(&source);
 
     for required in fixture.required_top_level {
         assert!(

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,6 +1,6 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-23T03:48:57.156213+00:00`_
+_Generated from source artifacts: `2026-06-23T06:11:33.747281+00:00`_
 
 ## Snapshot
 
@@ -8,7 +8,7 @@ _Generated from source artifacts: `2026-06-23T03:48:57.156213+00:00`_
 - Workstream snapshot generated: `2026-06-13T16:15:14-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
 - Queue snapshot generated: `2026-06-16T23:55:38.405701+00:00`
-- Proof snapshot generated: `2026-06-23T03:48:57.156213+00:00`
+- Proof snapshot generated: `2026-06-23T06:11:33.747281+00:00`
 
 ## Gate Status
 
@@ -29,7 +29,7 @@ _Generated from source artifacts: `2026-06-23T03:48:57.156213+00:00`_
 | Tracked behavior rows | 419 |
 | Covered behavior rows | 419 |
 | Tracked behavior coverage ratio | 1.0000 |
-| Rust test functions | 3614 |
+| Rust test functions | 3622 |
 | Missing Rust test refs | 0 |
 | Critical gaps | 0 |
 

--- a/docs/parity/behavioral-similarity-diff.json
+++ b/docs/parity/behavioral-similarity-diff.json
@@ -447,7 +447,7 @@
     "pass": true
   },
   "gate_failures": [],
-  "generated_at_utc": "2026-06-23T03:48:54.251551+00:00",
+  "generated_at_utc": "2026-06-23T06:11:18.168457+00:00",
   "manifest": "docs/parity/behavioral-similarity-cases.json",
   "schema_version": 1,
   "summary": {

--- a/docs/parity/behavioral-similarity-diff.md
+++ b/docs/parity/behavioral-similarity-diff.md
@@ -1,6 +1,6 @@
 # Behavioral Similarity Diff
 
-Generated: `2026-06-23T03:48:54.251551+00:00`
+Generated: `2026-06-23T06:11:18.168457+00:00`
 
 ## Gate
 

--- a/docs/parity/deep-problem-solving-diff.json
+++ b/docs/parity/deep-problem-solving-diff.json
@@ -440,7 +440,7 @@
     "pass": true
   },
   "gate_failures": [],
-  "generated_at_utc": "2026-06-23T03:48:56.725733+00:00",
+  "generated_at_utc": "2026-06-23T06:11:18.163336+00:00",
   "manifest": "docs/parity/deep-problem-solving-cases.json",
   "schema_version": 1,
   "summary": {

--- a/docs/parity/deep-problem-solving-diff.md
+++ b/docs/parity/deep-problem-solving-diff.md
@@ -1,6 +1,6 @@
 # Deep Problem-Solving Diff
 
-Generated: `2026-06-23T03:48:56.725733+00:00`
+Generated: `2026-06-23T06:11:18.163336+00:00`
 
 ## Gate
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -260,7 +260,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-23T03:48:57.156213+00:00",
+  "generated_at_utc": "2026-06-23T06:11:33.747281+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -538,7 +538,7 @@
       "queue_pending": 0,
       "queue_total": 6132,
       "rust_test_files": 313,
-      "rust_test_functions": 3614,
+      "rust_test_functions": 3622,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-23T03:48:57.156213+00:00`
+Generated: `2026-06-23T06:11:33.747281+00:00`
 
 ## Gate Status
 

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -90,7 +90,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-23T03:48:57.050995+00:00",
+  "generated_at_utc": "2026-06-23T06:11:16.079866+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -221,8 +221,9 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 25,
+      "direct_test_evidence_count": 26,
       "direct_test_evidence_sample": [
+        "crates/hermes-app-runtime/src/lib.rs",
         "crates/hermes-cli/src/alpha_runtime.rs",
         "crates/hermes-cli/src/app.rs",
         "crates/hermes-cli/src/auth.rs",
@@ -246,11 +247,11 @@
         "crates/hermes-cli/src/terminal_backend.rs",
         "crates/hermes-cli/src/theme.rs",
         "crates/hermes-cli/src/tool_preview.rs",
-        "crates/hermes-cli/src/tui.rs",
-        "crates/hermes-parity-tests/tests/cli_command_contract.rs"
+        "crates/hermes-cli/src/tui.rs"
       ],
-      "evidence_count": 40,
+      "evidence_count": 41,
       "evidence_sample": [
+        "crates/hermes-app-runtime/src/lib.rs",
         "crates/hermes-cli/src/alpha_runtime.rs",
         "crates/hermes-cli/src/app.rs",
         "crates/hermes-cli/src/auth.rs",
@@ -274,8 +275,7 @@
         "crates/hermes-cli/src/model_switch.rs",
         "crates/hermes-cli/src/pairing_store.rs",
         "crates/hermes-cli/src/platform_toolsets.rs",
-        "crates/hermes-cli/src/profiles.rs",
-        "crates/hermes-cli/src/providers.rs"
+        "crates/hermes-cli/src/profiles.rs"
       ],
       "id": "cli-command-surface",
       "mapped": true,
@@ -286,7 +286,7 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 46,
+      "direct_test_evidence_count": 47,
       "direct_test_evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -314,7 +314,7 @@
         "crates/hermes-agent/src/memory_plugins/openviking.rs",
         "crates/hermes-agent/src/memory_plugins/retaindb.rs"
       ],
-      "evidence_count": 50,
+      "evidence_count": 51,
       "evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -569,7 +569,7 @@
     "queue_pending": 0,
     "queue_total": 6132,
     "rust_test_files": 313,
-    "rust_test_functions": 3614,
+    "rust_test_functions": 3622,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-23T03:48:57.050995+00:00`
+Generated: `2026-06-23T06:11:16.079866+00:00`
 
 ## Gate
 
@@ -16,7 +16,7 @@ Generated: `2026-06-23T03:48:57.050995+00:00`
 | `covered_behavior_rows` | 419 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
 | `rust_test_files` | 313 |
-| `rust_test_functions` | 3614 |
+| `rust_test_functions` | 3622 |
 | `coverage_manifest_entries` | 409 |
 | `coverage_manifest_entries_with_valid_rust_tests` | 409 |
 | `missing_rust_test_refs` | 0 |
@@ -39,8 +39,8 @@ Generated: `2026-06-23T03:48:57.050995+00:00`
 | --- | --- | ---: | ---: |
 | `gateway-platform-behavior` | `direct_rust_test` | 25 | 22 |
 | `tool-runtime-behavior` | `direct_rust_test` | 91 | 82 |
-| `cli-command-surface` | `direct_rust_test` | 40 | 25 |
-| `agent-loop-and-runtime` | `direct_rust_test` | 50 | 46 |
+| `cli-command-surface` | `direct_rust_test` | 41 | 26 |
+| `agent-loop-and-runtime` | `direct_rust_test` | 51 | 47 |
 | `acp-protocol-and-transport` | `direct_rust_test` | 9 | 8 |
 | `skills-management-contract` | `direct_rust_test` | 10 | 9 |
 | `cron-and-scheduler-runtime` | `direct_rust_test` | 12 | 9 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-12T11:29:15.009976+00:00",
+  "generated_at_utc": "2026-06-23T06:03:55.140114+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {
@@ -75,8 +75,9 @@
       ]
     },
     {
-      "evidence_count": 40,
+      "evidence_count": 41,
       "evidence_sample": [
+        "crates/hermes-app-runtime/src/lib.rs",
         "crates/hermes-cli/src/alpha_runtime.rs",
         "crates/hermes-cli/src/app.rs",
         "crates/hermes-cli/src/auth.rs",
@@ -100,8 +101,7 @@
         "crates/hermes-cli/src/model_switch.rs",
         "crates/hermes-cli/src/pairing_store.rs",
         "crates/hermes-cli/src/platform_toolsets.rs",
-        "crates/hermes-cli/src/profiles.rs",
-        "crates/hermes-cli/src/providers.rs"
+        "crates/hermes-cli/src/profiles.rs"
       ],
       "id": "cli-command-surface",
       "mapped": true,
@@ -111,7 +111,7 @@
       ]
     },
     {
-      "evidence_count": 50,
+      "evidence_count": 51,
       "evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -188,18 +188,20 @@
       ]
     },
     {
-      "evidence_count": 10,
+      "evidence_count": 12,
       "evidence_sample": [
         "crates/hermes-cli/src/commands.rs",
         "crates/hermes-cron/src/backend.rs",
         "crates/hermes-cron/src/blueprints.rs",
+        "crates/hermes-cron/src/chronos.rs",
         "crates/hermes-cron/src/cli_support.rs",
         "crates/hermes-cron/src/completion.rs",
         "crates/hermes-cron/src/job.rs",
         "crates/hermes-cron/src/lib.rs",
         "crates/hermes-cron/src/persistence.rs",
         "crates/hermes-cron/src/runner.rs",
-        "crates/hermes-cron/src/scheduler.rs"
+        "crates/hermes-cron/src/scheduler.rs",
+        "crates/hermes-cron/src/suggestions.rs"
       ],
       "id": "cron-and-scheduler-runtime",
       "mapped": true,

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,16 +1,16 @@
 # Test Intent Mapping
 
-Generated: `2026-06-12T11:29:15.009976+00:00`
+Generated: `2026-06-23T06:03:55.140114+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |
 | `gateway-platform-behavior` | yes | 25 |
 | `tool-runtime-behavior` | yes | 91 |
-| `cli-command-surface` | yes | 40 |
-| `agent-loop-and-runtime` | yes | 50 |
+| `cli-command-surface` | yes | 41 |
+| `agent-loop-and-runtime` | yes | 51 |
 | `acp-protocol-and-transport` | yes | 9 |
 | `skills-management-contract` | yes | 10 |
-| `cron-and-scheduler-runtime` | yes | 10 |
+| `cron-and-scheduler-runtime` | yes | 12 |
 | `memory-plugin-integration` | yes | 12 |
 | `environment-lifecycle-contract` | yes | 12 |
 | `tool-call-parser-contract` | yes | 3 |

--- a/docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md
+++ b/docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md
@@ -20,9 +20,10 @@ Keep the runtime Rust-only, but split compile surfaces so targeted work can test
    - No TUI, installer, adapter, cron, or gateway feature dependencies.
 
 2. `hermes-app-runtime`
-   - Status: first split implemented.
-   - Owns agent configuration construction plus query-mode provider/model/env/tool policy.
-   - Next: move the remaining noninteractive chat runner, prompt reformulation, tool-planning handoff, memory/context policy injection, and agent-loop wiring.
+   - Status: second split implemented.
+   - Owns agent configuration construction, query-mode provider/model/env/tool policy, model-catalog remediation selection, noninteractive query agent-loop wiring, and assistant reply extraction.
+   - Keeps provider construction injected by the CLI so OpenAI OAuth/auth-state routing remains in the existing runtime path.
+   - Next: move prompt reformulation, memory/context policy injection, and any reusable tool-planning policy that is still embedded in CLI presentation code.
    - Depend on provider runtime and core agent crates, not on CLI wrappers or TUI.
 
 3. `hermes-cli-ui`
@@ -34,7 +35,9 @@ Keep the runtime Rust-only, but split compile surfaces so targeted work can test
    - Keep provider/auth and command-contract tests from compiling every gateway adapter by default.
 
 5. Parity test dependency narrowing
-   - Point behavioral/provider parity tests at `hermes-provider-runtime` and command-contract crates where possible.
+   - Status: first split implemented.
+   - Command-contract parity now reads the CLI source contract without a `hermes-cli` or `clap` dev dependency.
+   - Point behavioral/provider parity tests at `hermes-provider-runtime`, `hermes-app-runtime`, and command-contract crates where possible.
    - Keep full `hermes-cli` parity checks for end-to-end CLI behavior only.
 
 ## Gates

--- a/scripts/audit-cargo-build-surface.sh
+++ b/scripts/audit-cargo-build-surface.sh
@@ -77,9 +77,17 @@ cargo tree -p hermes-cli --edges normal --depth 1
 echo '```'
 echo
 
+echo "## cargo tree: hermes-parity-tests --edges dev --depth 1"
+echo
+echo '```text'
+cargo tree -p hermes-parity-tests --edges dev --depth 1
+echo '```'
+echo
+
 echo "## Interpretation"
 echo
 echo "- \`hermes-cli\` is currently the invalidation root for wrappers, the main runtime binary, TUI/clipboard UI dependencies, gateway adapter features, cron, ACP, MCP, tools, skills, and telemetry."
-echo "- Provider/auth routing now has a narrower home in \`hermes-provider-runtime\`; agent configuration and query-mode provider/model/env/tool policy now have a narrower home in \`hermes-app-runtime\`."
-echo "- The next high-value split is the remaining noninteractive chat runner and tool-planning handoff away from CLI/TUI and gateway adapter feature surfaces."
-echo "- Parity tests that only validate provider, auth, or command contracts should keep moving to narrower crates instead of pulling the full CLI binary surface."
+echo "- Provider/auth routing now has a narrower home in \`hermes-provider-runtime\`; agent configuration, query-mode provider/model/env/tool policy, model remediation, noninteractive agent-loop wiring, and reply extraction now have a narrower home in \`hermes-app-runtime\`."
+echo "- Command-contract parity no longer needs a \`hermes-cli\` or \`clap\` dev dependency for the top-level command surface proof."
+echo "- The next high-value split is prompt reformulation, memory/context policy injection, and reusable tool-planning policy away from CLI/TUI and gateway adapter feature surfaces."
+echo "- Parity tests that only validate provider, auth, app-runtime, or command contracts should keep moving to narrower crates instead of pulling the full CLI binary surface."

--- a/scripts/generate-test-intent-mapping.py
+++ b/scripts/generate-test-intent-mapping.py
@@ -38,6 +38,7 @@ INTENTS: list[IntentSpec] = [
         id="cli-command-surface",
         upstream_scope=["tests/hermes_cli", "tests/cli"],
         local_evidence_globs=[
+            "crates/hermes-app-runtime/src/**/*.rs",
             "crates/hermes-cli/src/**/*.rs",
             "crates/hermes-parity-tests/tests/cli_command_contract.rs",
         ],
@@ -46,6 +47,7 @@ INTENTS: list[IntentSpec] = [
         id="agent-loop-and-runtime",
         upstream_scope=["tests/run_agent", "tests/agent"],
         local_evidence_globs=[
+            "crates/hermes-app-runtime/src/**/*.rs",
             "crates/hermes-agent/src/**/*.rs",
             "crates/hermes-agent/tests/*.rs",
         ],
@@ -191,4 +193,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
## Summary
- Move noninteractive chat AgentLoop wiring, model remediation helpers, and assistant reply extraction into `hermes-app-runtime`.
- Keep provider construction injected from `hermes-cli` so OpenAI OAuth/auth-state routing stays on the existing path.
- Narrow parity command-contract tests by removing the `hermes-cli`/`clap` dev dependency and parsing the CLI source contract directly.
- Update cargo build-surface roadmap, audit output, and parity generated artifacts.

## Verification
- `cargo fmt --all`
- `cargo test -p hermes-app-runtime -- --nocapture`
- `cargo test -p hermes-cli catalog_model -- --nocapture`
- `cargo test -p hermes-parity-tests --test cli_command_contract -- --nocapture`
- `python3 scripts/generate-test-intent-mapping.py`
- `python3 scripts/generate-test-coverage-audit.py --check`
- `python3 scripts/generate-behavioral-similarity-diff.py --check`
- `python3 scripts/generate-deep-problem-solving-diff.py --check`
- `python3 scripts/generate-global-parity-proof.py --check-ci`
- `python3 scripts/generate-global-parity-proof.py --check-release`
- `python3 scripts/generate-parity-dashboard.py`
- `scripts/audit-cargo-build-surface.sh | sed -n '1,260p'`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `cargo build -p hermes-cli --bin hermes-ultra --bin hermes-agent-ultra`
- `HERMES_QUERY_DISABLE_TOOLS=1 /Volumes/wd_black/cargo-targets/debug/hermes-ultra chat --provider openai --model openai:gpt-5.5 --query 'Reply exactly: hermes-openai-ok'`
- `cargo tree -p hermes-app-runtime --edges normal --depth 3 > /tmp/hermes-app-runtime-tree.txt && rg 'hermes-(cli|tools|cron|gateway)' /tmp/hermes-app-runtime-tree.txt || true`
- `cargo tree -p hermes-parity-tests --edges dev --depth 2 > /tmp/hermes-parity-tests-tree.txt && rg 'hermes-cli|clap' /tmp/hermes-parity-tests-tree.txt || true`
