### PR TITLE
Move runtime reformulation policy into app runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,7 @@ dependencies = [
  "hermes-agent",
  "hermes-config",
  "hermes-core",
+ "hermes-intelligence",
  "hermes-provider-runtime",
  "serde_json",
  "tempfile",

--- a/crates/hermes-app-runtime/Cargo.toml
+++ b/crates/hermes-app-runtime/Cargo.toml
@@ -10,6 +10,7 @@ description = "Non-UI application runtime policy and agent configuration for Her
 hermes-core = { workspace = true }
 hermes-config = { workspace = true }
 hermes-agent = { workspace = true }
+hermes-intelligence = { workspace = true }
 hermes-provider-runtime = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/hermes-app-runtime/src/lib.rs
+++ b/crates/hermes-app-runtime/src/lib.rs
@@ -16,6 +16,7 @@ use hermes_agent::smart_model_routing::ApiMode;
 use hermes_agent::{AgentCallbacks, AgentConfig, AgentLoop};
 use hermes_config::{normalize_service_tier, GatewayConfig, LlmProviderConfig};
 use hermes_core::{AgentError, AgentResult, LlmProvider, Message, MessageRole, ToolSchema};
+use hermes_intelligence::future_grade_problem_solving_guidance;
 use hermes_provider_runtime::{
     active_llm_provider_config, normalize_runtime_provider_name, resolve_provider_and_model,
 };
@@ -23,6 +24,8 @@ use serde_json::Value;
 
 pub const QUERY_ALLOW_TOOLS_ENV_KEY: &str = "HERMES_QUERY_ALLOW_TOOLS";
 pub const QUERY_DISABLE_TOOLS_ENV_KEY: &str = "HERMES_QUERY_DISABLE_TOOLS";
+pub const RUNTIME_REFORMULATION_PREFIX: &str = "[HERMES_RUNTIME_REFORMULATION] ";
+pub const RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS_DEFAULT: usize = 1_600;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryModelRemediation {
@@ -35,6 +38,15 @@ pub struct NoninteractiveQueryOutcome {
     pub active_model: String,
     pub result: AgentResult,
     pub reply: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeReformulationObjective {
+    pub id: String,
+    pub behavior_mode: String,
+    pub objective_text: String,
+    pub behavior_directives: Vec<String>,
+    pub success_criteria: Vec<String>,
 }
 
 fn build_retry_config(config: &GatewayConfig) -> RetryConfig {
@@ -334,6 +346,167 @@ pub fn query_mode_tools_enabled(query_mode: bool, allow_tools_flag: bool) -> boo
         return true;
     }
     true
+}
+
+pub fn runtime_prompt_reformulation_enabled() -> bool {
+    !matches!(
+        std::env::var("HERMES_RUNTIME_PROMPT_REFORMULATION")
+            .ok()
+            .as_deref()
+            .map(|v| v.trim().to_ascii_lowercase()),
+        Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+    )
+}
+
+pub fn runtime_contradiction_self_check_enabled() -> bool {
+    !matches!(
+        std::env::var("HERMES_RUNTIME_CONTRADICTION_SELF_CHECK")
+            .ok()
+            .as_deref()
+            .map(|v| v.trim().to_ascii_lowercase()),
+        Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
+    )
+}
+
+pub fn runtime_reformulation_prompt_preview_chars() -> usize {
+    std::env::var("HERMES_RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS_DEFAULT)
+}
+
+pub fn runtime_tool_profile_mode() -> String {
+    std::env::var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE")
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "balanced".to_string())
+}
+
+pub fn runtime_contextlattice_topic_path() -> String {
+    std::env::var("CONTEXTLATTICE_TOPIC_PATH")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "runbooks/hermes".to_string())
+}
+
+pub fn preview_for_runtime_status(raw: &str, max_chars: usize) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let collapsed = trimmed.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= max_chars {
+        collapsed
+    } else {
+        let mut out: String = collapsed
+            .chars()
+            .take(max_chars.saturating_sub(1))
+            .collect();
+        out.push('…');
+        out
+    }
+}
+
+fn bullet_lines(lines: &[String], limit: usize) -> String {
+    let joined = lines
+        .iter()
+        .take(limit)
+        .map(|line| format!("- {}", line.trim()))
+        .filter(|line| line.trim() != "-")
+        .collect::<Vec<_>>()
+        .join("\n");
+    if joined.is_empty() {
+        "- (none)".to_string()
+    } else {
+        joined
+    }
+}
+
+pub fn build_runtime_reformulation_message(
+    latest_user_prompt: &str,
+    objective: Option<&RuntimeReformulationObjective>,
+) -> Option<String> {
+    if !runtime_prompt_reformulation_enabled() {
+        return None;
+    }
+    let prompt = latest_user_prompt.trim();
+    if prompt.is_empty() {
+        return None;
+    }
+    let tool_profile_mode = runtime_tool_profile_mode();
+    let contradiction_check = runtime_contradiction_self_check_enabled();
+    let context_topic = runtime_contextlattice_topic_path();
+
+    let objective_line = objective
+        .as_ref()
+        .map(|contract| {
+            format!(
+                "objective(active): {} | behavior={} | text={}",
+                contract.id,
+                contract.behavior_mode,
+                preview_for_runtime_status(&contract.objective_text, 220)
+            )
+        })
+        .unwrap_or_else(|| "objective(active): none".to_string());
+    let objective_directives = objective
+        .map(|contract| bullet_lines(&contract.behavior_directives, 6))
+        .unwrap_or_else(|| "- (none)".to_string());
+    let objective_success = objective
+        .map(|contract| bullet_lines(&contract.success_criteria, 5))
+        .unwrap_or_else(|| "- (none)".to_string());
+
+    let contradiction_line = if contradiction_check {
+        "before final response: self-audit contradictions across tool outputs, runtime facts, and claims; unresolved items must be marked UNPROVEN/CONTRADICTORY."
+    } else {
+        "before final response: consistency self-audit optional (disabled by runtime toggle)."
+    };
+
+    let mut out = String::new();
+    out.push_str(RUNTIME_REFORMULATION_PREFIX);
+    out.push_str(
+        "\nRuntime execution reformulation (internal):\n\
+         1) apply anti-scheming evidence-first discipline\n\
+         2) pull ContextLattice context first when relevant\n\
+         3) route tool usage intentionally and avoid repetitive low-signal loops\n\
+         4) match requested output shape exactly (count/format), with no template placeholders or duplicate list items\n\
+         5) for open-ended missions, execute at least one concrete action before returning status text\n\
+         6) maintain iterative objective momentum: gather evidence, test, refine, then continue with next high-value action\n",
+    );
+    out.push_str(&format!(
+        "tool-profile(mode): {}\ncontextlattice(topic): {}\n{}\n",
+        tool_profile_mode, context_topic, objective_line
+    ));
+    out.push_str("objective behavior directives:\n");
+    out.push_str(&objective_directives);
+    out.push('\n');
+    out.push_str("objective success criteria:\n");
+    out.push_str(&objective_success);
+    out.push('\n');
+    out.push_str(
+        "objective loop protocol:\n\
+         - baseline: state current objective KPI and latest known value\n\
+         - execute: perform concrete highest-leverage action now\n\
+         - verify: present measurable delta or explicit blocked evidence\n\
+         - continue: state next action with no soft deferral\n",
+    );
+    out.push_str(contradiction_line);
+    out.push('\n');
+    out.push_str(future_grade_problem_solving_guidance());
+    out.push_str("\nuser-request(routing-preview):\n");
+    let preview_cap = runtime_reformulation_prompt_preview_chars();
+    let prompt_preview = preview_for_runtime_status(prompt, preview_cap);
+    out.push_str(&prompt_preview);
+    if prompt.chars().count() > preview_cap {
+        out.push_str(
+            "\n[preview truncated; the full user request remains available as the next user message]",
+        );
+    } else {
+        out.push_str("\n[full user request remains available as the next user message]");
+    }
+    Some(out)
 }
 
 pub fn split_provider_model(provider_model: &str) -> (&str, &str) {
@@ -1132,6 +1305,81 @@ mod tests {
         assert!(query_mode_tools_enabled(true, false));
         std::env::set_var(QUERY_ALLOW_TOOLS_ENV_KEY, "1");
         assert!(query_mode_tools_enabled(true, false));
+    }
+
+    #[test]
+    fn runtime_reformulation_message_includes_objective_and_kernel_guidance() {
+        let _lock = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_RUNTIME_PROMPT_REFORMULATION",
+            "HERMES_RUNTIME_CONTRADICTION_SELF_CHECK",
+            "HERMES_REPO_REVIEW_TOOL_PROFILE_MODE",
+            "CONTEXTLATTICE_TOPIC_PATH",
+            "HERMES_RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS",
+        ]);
+        std::env::set_var("HERMES_RUNTIME_PROMPT_REFORMULATION", "1");
+        std::env::set_var("HERMES_RUNTIME_CONTRADICTION_SELF_CHECK", "1");
+        std::env::set_var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE", "focus");
+        std::env::set_var(
+            "CONTEXTLATTICE_TOPIC_PATH",
+            "runbooks/objective/test-objective",
+        );
+
+        let objective = RuntimeReformulationObjective {
+            id: "test-objective".to_string(),
+            behavior_mode: "mission".to_string(),
+            objective_text: "Grow SOL with controlled risk".to_string(),
+            behavior_directives: vec!["Act with evidence".to_string()],
+            success_criteria: vec!["Positive risk-adjusted delta".to_string()],
+        };
+        let injected = build_runtime_reformulation_message(
+            "provide 3 more ideas with contextlattice being one",
+            Some(&objective),
+        )
+        .expect("reformulation");
+
+        assert!(injected.contains(RUNTIME_REFORMULATION_PREFIX));
+        assert!(injected.contains("tool-profile(mode): focus"));
+        assert!(injected.contains("contextlattice(topic): runbooks/objective/test-objective"));
+        assert!(injected.contains("objective(active): test-objective | behavior=mission"));
+        assert!(injected.contains("- Act with evidence"));
+        assert!(injected.contains("- Positive risk-adjusted delta"));
+        assert!(injected.contains("UNPROVEN/CONTRADICTORY"));
+        assert!(injected.contains("execute at least one concrete action"));
+        assert!(injected.contains("Hermes intelligence kernel:"));
+        assert!(injected.contains("ContextLattice memory cycle:"));
+        assert!(injected.contains("user-request(routing-preview):"));
+        assert!(injected.contains("full user request remains available as the next user message"));
+    }
+
+    #[test]
+    fn runtime_reformulation_message_respects_toggle_off() {
+        let _lock = env_test_lock();
+        let _env = EnvSnapshot::capture(&["HERMES_RUNTIME_PROMPT_REFORMULATION"]);
+        std::env::set_var("HERMES_RUNTIME_PROMPT_REFORMULATION", "off");
+        assert!(build_runtime_reformulation_message("plain request", None).is_none());
+    }
+
+    #[test]
+    fn runtime_reformulation_message_truncates_preview_without_losing_user_message() {
+        let _lock = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_RUNTIME_PROMPT_REFORMULATION",
+            "HERMES_RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS",
+        ]);
+        std::env::set_var("HERMES_RUNTIME_PROMPT_REFORMULATION", "1");
+        std::env::set_var("HERMES_RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS", "48");
+
+        let long_prompt =
+            "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu".repeat(12);
+        let injected =
+            build_runtime_reformulation_message(&long_prompt, None).expect("reformulation");
+        assert!(injected.contains("user-request(routing-preview):"));
+        assert!(injected.contains("preview truncated"));
+        assert!(!injected.contains(&long_prompt));
+        assert!(
+            injected.contains("the full user request remains available as the next user message")
+        );
     }
 
     #[test]

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -17,11 +17,14 @@ use hermes_agent::plugins::HookType;
 use hermes_agent::sub_agent_orchestrator::SubAgentOrchestrator;
 use hermes_agent::{AgentCallbacks, AgentLoop, InterruptController, SessionPersistence};
 pub use hermes_app_runtime::build_agent_config;
+use hermes_app_runtime::{
+    build_runtime_reformulation_message as build_runtime_reformulation_message_for_runtime,
+    RuntimeReformulationObjective,
+};
 use hermes_config::{hermes_home as hermes_home_dir, load_config, state_dir, GatewayConfig};
 use hermes_core::ToolSchema;
 use hermes_core::{AgentError, LlmProvider, UsageStats};
 use hermes_cron::{CronRunner, CronScheduler, FileJobPersistence};
-use hermes_intelligence::future_grade_problem_solving_guidance;
 pub use hermes_provider_runtime::{
     active_llm_provider_config, allow_no_api_key, normalize_runtime_provider_name,
     provider_api_key_from_env, provider_base_url_from_env, provider_default_base_url,
@@ -53,7 +56,6 @@ const SESSION_SNAPSHOT_MIN_FREE_BYTES_DEFAULT: u64 = 128 * 1024 * 1024;
 const QUORUM_HINT_PREFIX: &str = "[QUORUM_MODE] ";
 const QUORUM_MAX_VOTER_OUTPUT_CHARS: usize = 120_000;
 const QUORUM_DEFAULT_VOTER_PASSES: usize = 6;
-const RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS: usize = 1_600;
 const QUORUM_AGENT_CONTRACT_DEFAULT_PATH: &str =
     "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/QUORUM_AGENTS.md";
 const COMPOSER_DRAFTS_FILE: &str = "composer-drafts.json";
@@ -436,7 +438,6 @@ pub struct UiTranscriptMessage {
 
 impl App {
     const SESSION_OBJECTIVE_PREFIX: &'static str = "[SESSION_OBJECTIVE] ";
-    const RUNTIME_REFORMULATION_PREFIX: &'static str = "[HERMES_RUNTIME_REFORMULATION] ";
 
     fn ensure_session_stub_snapshot(&self) {
         if let Err(err) = self.persist_session_snapshot(None) {
@@ -1324,146 +1325,23 @@ impl App {
         }
     }
 
-    fn runtime_prompt_reformulation_enabled() -> bool {
-        !matches!(
-            std::env::var("HERMES_RUNTIME_PROMPT_REFORMULATION")
-                .ok()
-                .as_deref()
-                .map(|v| v.trim().to_ascii_lowercase()),
-            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
-        )
-    }
-
-    fn runtime_contradiction_self_check_enabled() -> bool {
-        !matches!(
-            std::env::var("HERMES_RUNTIME_CONTRADICTION_SELF_CHECK")
-                .ok()
-                .as_deref()
-                .map(|v| v.trim().to_ascii_lowercase()),
-            Some(v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
-        )
-    }
-
-    fn runtime_reformulation_prompt_preview_chars() -> usize {
-        std::env::var("HERMES_RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS")
-            .ok()
-            .and_then(|v| v.trim().parse::<usize>().ok())
-            .filter(|v| *v > 0)
-            .unwrap_or(RUNTIME_REFORMULATION_PROMPT_PREVIEW_CHARS)
-    }
-
-    fn current_tool_profile_mode() -> String {
-        std::env::var("HERMES_REPO_REVIEW_TOOL_PROFILE_MODE")
-            .ok()
-            .map(|v| v.trim().to_ascii_lowercase())
-            .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| "balanced".to_string())
+    fn runtime_reformulation_objective(
+        contract: &ObjectiveContract,
+    ) -> RuntimeReformulationObjective {
+        RuntimeReformulationObjective {
+            id: contract.id.clone(),
+            behavior_mode: canonical_objective_behavior_mode(&contract.behavior_mode),
+            objective_text: contract.objective_text.clone(),
+            behavior_directives: contract.behavior_directives.clone(),
+            success_criteria: contract.success_criteria.clone(),
+        }
     }
 
     fn build_runtime_reformulation_message(&self, latest_user_prompt: &str) -> Option<String> {
-        if !Self::runtime_prompt_reformulation_enabled() {
-            return None;
-        }
-        let prompt = latest_user_prompt.trim();
-        if prompt.is_empty() {
-            return None;
-        }
-        let tool_profile_mode = Self::current_tool_profile_mode();
-        let contradiction_check = Self::runtime_contradiction_self_check_enabled();
-        let context_topic = std::env::var("CONTEXTLATTICE_TOPIC_PATH")
-            .ok()
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| "runbooks/hermes".to_string());
-
-        let objective_contract = Self::load_active_objective_contract();
-        let objective_line = objective_contract
+        let objective = Self::load_active_objective_contract()
             .as_ref()
-            .map(|contract| {
-                format!(
-                    "objective(active): {} | behavior={} | text={}",
-                    contract.id,
-                    canonical_objective_behavior_mode(&contract.behavior_mode),
-                    Self::preview_for_status(&contract.objective_text, 220)
-                )
-            })
-            .unwrap_or_else(|| "objective(active): none".to_string());
-        let objective_directives = objective_contract
-            .as_ref()
-            .map(|contract| {
-                contract
-                    .behavior_directives
-                    .iter()
-                    .take(6)
-                    .map(|line| format!("- {}", line.trim()))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            })
-            .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| "- (none)".to_string());
-        let objective_success = objective_contract
-            .as_ref()
-            .map(|contract| {
-                contract
-                    .success_criteria
-                    .iter()
-                    .take(5)
-                    .map(|line| format!("- {}", line.trim()))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            })
-            .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| "- (none)".to_string());
-
-        let contradiction_line = if contradiction_check {
-            "before final response: self-audit contradictions across tool outputs, runtime facts, and claims; unresolved items must be marked UNPROVEN/CONTRADICTORY."
-        } else {
-            "before final response: consistency self-audit optional (disabled by runtime toggle)."
-        };
-
-        let mut out = String::new();
-        out.push_str(Self::RUNTIME_REFORMULATION_PREFIX);
-        out.push_str(
-            "\nRuntime execution reformulation (internal):\n\
-             1) apply anti-scheming evidence-first discipline\n\
-             2) pull ContextLattice context first when relevant\n\
-             3) route tool usage intentionally and avoid repetitive low-signal loops\n\
-             4) match requested output shape exactly (count/format), with no template placeholders or duplicate list items\n\
-             5) for open-ended missions, execute at least one concrete action before returning status text\n\
-             6) maintain iterative objective momentum: gather evidence, test, refine, then continue with next high-value action\n",
-        );
-        out.push_str(&format!(
-            "tool-profile(mode): {}\ncontextlattice(topic): {}\n{}\n",
-            tool_profile_mode, context_topic, objective_line
-        ));
-        out.push_str("objective behavior directives:\n");
-        out.push_str(&objective_directives);
-        out.push('\n');
-        out.push_str("objective success criteria:\n");
-        out.push_str(&objective_success);
-        out.push('\n');
-        out.push_str(
-            "objective loop protocol:\n\
-             - baseline: state current objective KPI and latest known value\n\
-             - execute: perform concrete highest-leverage action now\n\
-             - verify: present measurable delta or explicit blocked evidence\n\
-             - continue: state next action with no soft deferral\n",
-        );
-        out.push_str(contradiction_line);
-        out.push('\n');
-        out.push_str(future_grade_problem_solving_guidance());
-        out.push_str("\nuser-request(routing-preview):\n");
-        let preview_cap = Self::runtime_reformulation_prompt_preview_chars();
-        let prompt_preview = Self::preview_for_status(prompt, preview_cap);
-        out.push_str(&prompt_preview);
-        if prompt.chars().count() > preview_cap {
-            out.push_str(
-                "\n[preview truncated; the full user request remains available as the next user message]",
-            );
-        } else {
-            out.push_str("\n[full user request remains available as the next user message]");
-        }
-        Some(out)
+            .map(Self::runtime_reformulation_objective);
+        build_runtime_reformulation_message_for_runtime(latest_user_prompt, objective.as_ref())
     }
 
     fn build_inference_messages(&self) -> (Vec<hermes_core::Message>, bool) {
@@ -5393,7 +5271,7 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].role, hermes_core::MessageRole::System);
         let injected_text = messages[0].content.as_deref().unwrap_or_default();
-        assert!(injected_text.contains(App::RUNTIME_REFORMULATION_PREFIX));
+        assert!(injected_text.contains(hermes_app_runtime::RUNTIME_REFORMULATION_PREFIX));
         assert!(injected_text.contains("tool-profile(mode): focus"));
         assert!(injected_text.contains("contextlattice(topic): runbooks/objective/test-objective"));
         assert!(injected_text.contains(contract.id.as_str()));

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,6 +1,6 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-23T06:58:06.213560+00:00`_
+_Generated from source artifacts: `2026-06-23T07:54:24.892144+00:00`_
 
 ## Snapshot
 
@@ -8,7 +8,7 @@ _Generated from source artifacts: `2026-06-23T06:58:06.213560+00:00`_
 - Workstream snapshot generated: `2026-06-23T00:16:02-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
 - Queue snapshot generated: `2026-06-16T23:55:38.405701+00:00`
-- Proof snapshot generated: `2026-06-23T06:58:06.213560+00:00`
+- Proof snapshot generated: `2026-06-23T07:54:24.892144+00:00`
 
 ## Gate Status
 
@@ -29,7 +29,7 @@ _Generated from source artifacts: `2026-06-23T06:58:06.213560+00:00`_
 | Tracked behavior rows | 419 |
 | Covered behavior rows | 419 |
 | Tracked behavior coverage ratio | 1.0000 |
-| Rust test functions | 3622 |
+| Rust test functions | 3625 |
 | Missing Rust test refs | 0 |
 | Critical gaps | 0 |
 

--- a/docs/parity/behavioral-similarity-diff.json
+++ b/docs/parity/behavioral-similarity-diff.json
@@ -447,7 +447,7 @@
     "pass": true
   },
   "gate_failures": [],
-  "generated_at_utc": "2026-06-23T06:57:57.260117+00:00",
+  "generated_at_utc": "2026-06-23T07:54:16.958367+00:00",
   "manifest": "docs/parity/behavioral-similarity-cases.json",
   "schema_version": 1,
   "summary": {

--- a/docs/parity/behavioral-similarity-diff.md
+++ b/docs/parity/behavioral-similarity-diff.md
@@ -1,6 +1,6 @@
 # Behavioral Similarity Diff
 
-Generated: `2026-06-23T06:57:57.260117+00:00`
+Generated: `2026-06-23T07:54:16.958367+00:00`
 
 ## Gate
 

--- a/docs/parity/deep-problem-solving-diff.json
+++ b/docs/parity/deep-problem-solving-diff.json
@@ -440,7 +440,7 @@
     "pass": true
   },
   "gate_failures": [],
-  "generated_at_utc": "2026-06-23T06:57:57.406562+00:00",
+  "generated_at_utc": "2026-06-23T07:54:16.956332+00:00",
   "manifest": "docs/parity/deep-problem-solving-cases.json",
   "schema_version": 1,
   "summary": {

--- a/docs/parity/deep-problem-solving-diff.md
+++ b/docs/parity/deep-problem-solving-diff.md
@@ -1,6 +1,6 @@
 # Deep Problem-Solving Diff
 
-Generated: `2026-06-23T06:57:57.406562+00:00`
+Generated: `2026-06-23T07:54:16.956332+00:00`
 
 ## Gate
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -260,7 +260,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-23T06:58:06.213560+00:00",
+  "generated_at_utc": "2026-06-23T07:54:24.892144+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -538,7 +538,7 @@
       "queue_pending": 0,
       "queue_total": 6132,
       "rust_test_files": 313,
-      "rust_test_functions": 3622,
+      "rust_test_functions": 3625,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-23T06:58:06.213560+00:00`
+Generated: `2026-06-23T07:54:24.892144+00:00`
 
 ## Gate Status
 

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -90,7 +90,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-23T06:57:55.142432+00:00",
+  "generated_at_utc": "2026-06-23T07:54:14.726262+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -569,7 +569,7 @@
     "queue_pending": 0,
     "queue_total": 6132,
     "rust_test_files": 313,
-    "rust_test_functions": 3622,
+    "rust_test_functions": 3625,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-06-23T06:57:55.142432+00:00`
+Generated: `2026-06-23T07:54:14.726262+00:00`
 
 ## Gate
 
@@ -16,7 +16,7 @@ Generated: `2026-06-23T06:57:55.142432+00:00`
 | `covered_behavior_rows` | 419 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
 | `rust_test_files` | 313 |
-| `rust_test_functions` | 3622 |
+| `rust_test_functions` | 3625 |
 | `coverage_manifest_entries` | 409 |
 | `coverage_manifest_entries_with_valid_rust_tests` | 409 |
 | `missing_rust_test_refs` | 0 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-23T06:57:54.817649+00:00",
+  "generated_at_utc": "2026-06-23T07:54:14.456179+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-06-23T06:57:54.817649+00:00`
+Generated: `2026-06-23T07:54:14.456179+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md
+++ b/docs/roadmaps/CARGO_BUILD_SURFACE_CRATIFICATION_2026-06-22.md
@@ -20,10 +20,10 @@ Keep the runtime Rust-only, but split compile surfaces so targeted work can test
    - No TUI, installer, adapter, cron, or gateway feature dependencies.
 
 2. `hermes-app-runtime`
-   - Status: second split implemented.
-   - Owns agent configuration construction, query-mode provider/model/env/tool policy, model-catalog remediation selection, noninteractive query agent-loop wiring, and assistant reply extraction.
+   - Status: third split implemented.
+   - Owns agent configuration construction, query-mode provider/model/env/tool policy, model-catalog remediation selection, noninteractive query agent-loop wiring, assistant reply extraction, and runtime prompt reformulation policy.
    - Keeps provider construction injected by the CLI so OpenAI OAuth/auth-state routing remains in the existing runtime path.
-   - Next: move prompt reformulation, memory/context policy injection, and any reusable tool-planning policy that is still embedded in CLI presentation code.
+   - Next: move remaining reusable memory/context policy injection and any reusable tool-planning policy that is still embedded in CLI presentation code.
    - Depend on provider runtime and core agent crates, not on CLI wrappers or TUI.
 
 3. `hermes-cli-ui`

--- a/scripts/audit-cargo-build-surface.sh
+++ b/scripts/audit-cargo-build-surface.sh
@@ -101,8 +101,8 @@ echo
 echo "## Interpretation"
 echo
 echo "- \`hermes-cli\` is currently the invalidation root for wrappers, the main runtime binary, TUI/clipboard UI dependencies, gateway adapter features, cron, ACP, MCP, tools, skills, and telemetry."
-echo "- Provider/auth routing now has a narrower home in \`hermes-provider-runtime\`; agent configuration, query-mode provider/model/env/tool policy, model remediation, noninteractive agent-loop wiring, and reply extraction now have a narrower home in \`hermes-app-runtime\`."
+echo "- Provider/auth routing now has a narrower home in \`hermes-provider-runtime\`; agent configuration, query-mode provider/model/env/tool policy, model remediation, noninteractive agent-loop wiring, reply extraction, and runtime prompt reformulation policy now have a narrower home in \`hermes-app-runtime\`."
 echo "- Source/governance parity now lives in \`hermes-source-parity-tests\`, so command-contract checks avoid \`hermes-cli\`, \`clap\`, fixture-harness runtime crates, and protocol stack crates."
 echo "- Protocol differential parity now lives in \`hermes-protocol-parity-tests\`, isolating ACP/MCP/gateway/tool dependencies to tests that need them."
-echo "- The next high-value split is prompt reformulation, memory/context policy injection, and reusable tool-planning policy away from CLI/TUI and gateway adapter feature surfaces."
+echo "- The next high-value split is remaining reusable memory/context policy injection and tool-planning policy away from CLI/TUI and gateway adapter feature surfaces."
 echo "- Parity tests that only validate provider, auth, app-runtime, or command contracts should keep moving to narrower crates instead of pulling the full CLI binary surface."


### PR DESCRIPTION
## Summary
- Move runtime prompt reformulation policy assembly from `hermes-cli/src/app.rs` into `hermes-app-runtime`.
- Keep CLI responsible only for loading the active objective contract and passing a small `RuntimeReformulationObjective` summary.
- Add app-runtime tests for objective guidance, env toggle behavior, ContextLattice topic/tool profile wiring, and long prompt preview truncation.
- Preserve existing CLI message injection behavior through the existing CLI reformulation tests.
- Update build-surface roadmap/audit text and regenerated parity count artifacts.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p hermes-app-runtime runtime_reformulation -- --nocapture`
- `cargo test -p hermes-app-runtime -- --nocapture`
- `cargo test -p hermes-cli runtime_reformulation -- --nocapture`
- `python3 scripts/generate-test-intent-mapping.py`
- `python3 scripts/generate-test-coverage-audit.py --check`
- `python3 scripts/generate-behavioral-similarity-diff.py --check`
- `python3 scripts/generate-deep-problem-solving-diff.py --check`
- `python3 scripts/generate-global-parity-proof.py --check-ci`
- `python3 scripts/generate-global-parity-proof.py --check-release`
- `python3 scripts/generate-parity-dashboard.py`
- `scripts/audit-cargo-build-surface.sh | sed -n '1,340p'`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `cargo tree -p hermes-app-runtime --edges normal --depth 3 > /tmp/hermes-app-runtime-tree.txt && rg '^[├└│ ].*hermes-(cli|tools|cron|gateway) ' /tmp/hermes-app-runtime-tree.txt || true`
- `cargo build -p hermes-cli --bin hermes-ultra --bin hermes-agent-ultra`
- `HERMES_QUERY_DISABLE_TOOLS=1 /Volumes/wd_black/cargo-targets/debug/hermes-ultra chat --provider openai --model openai:gpt-5.5 --query 'Reply exactly: hermes-openai-ok'`
