### PR TITLE
Build: keep parity checks non-mutating

### DIFF
--- a/scripts/generate-behavioral-similarity-diff.py
+++ b/scripts/generate-behavioral-similarity-diff.py
@@ -366,13 +366,18 @@ def main() -> int:
 
     out_json = (repo_root / args.out_json).resolve()
     out_md = (repo_root / args.out_md).resolve()
+    if args.check:
+        print(f"Checked {out_json}")
+        print(f"Checked {out_md}")
+        if not payload["gate"]["pass"]:
+            return 1
+        return 0
+
     write_json(out_json, payload)
     out_md.parent.mkdir(parents=True, exist_ok=True)
     out_md.write_text(render_md(payload) + "\n", encoding="utf-8")
     print(f"Wrote {out_json}")
     print(f"Wrote {out_md}")
-    if args.check and not payload["gate"]["pass"]:
-        return 1
     return 0
 
 

--- a/scripts/generate-deep-problem-solving-diff.py
+++ b/scripts/generate-deep-problem-solving-diff.py
@@ -358,13 +358,18 @@ def main() -> int:
 
     out_json = (repo_root / args.out_json).resolve()
     out_md = (repo_root / args.out_md).resolve()
+    if args.check:
+        print(f"Checked {out_json}")
+        print(f"Checked {out_md}")
+        if not payload["gate"]["pass"]:
+            return 1
+        return 0
+
     write_json(out_json, payload)
     out_md.parent.mkdir(parents=True, exist_ok=True)
     out_md.write_text(render_md(payload) + "\n", encoding="utf-8")
     print(f"Wrote {out_json}")
     print(f"Wrote {out_md}")
-    if args.check and not payload["gate"]["pass"]:
-        return 1
     return 0
 
 

--- a/scripts/generate-global-parity-proof.py
+++ b/scripts/generate-global-parity-proof.py
@@ -505,6 +505,15 @@ def main() -> int:
 
     out_json = (repo_root / args.out_json).resolve()
     out_md = (repo_root / args.out_md).resolve()
+    if args.check_release or args.check_ci:
+        print(f"Checked {out_json}")
+        print(f"Checked {out_md}")
+        if args.check_release and not release_gate["pass"]:
+            return 1
+        if args.check_ci and not ci_gate["pass"]:
+            return 1
+        return 0
+
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
     out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -643,10 +652,6 @@ def main() -> int:
     print(f"Wrote {out_json}")
     print(f"Wrote {out_md}")
 
-    if args.check_release and not release_gate["pass"]:
-        return 1
-    if args.check_ci and not ci_gate["pass"]:
-        return 1
     return 0
 
 

--- a/scripts/generate-sota-harness-hardening.py
+++ b/scripts/generate-sota-harness-hardening.py
@@ -430,6 +430,17 @@ def main() -> int:
     replay = build_replay_index(coverage, proof, queue, sota)
     budget = build_budget(snapshot, thresholds)
 
+    if args.check:
+        print(f"Checked {repo_root / TREND_JSON}")
+        print(f"Checked {repo_root / TREND_MD}")
+        print(f"Checked {repo_root / REPLAY_JSON}")
+        print(f"Checked {repo_root / REPLAY_MD}")
+        print(f"Checked {repo_root / BUDGET_JSON}")
+        print(f"Checked {repo_root / BUDGET_MD}")
+        if not budget["gate"]["pass"]:
+            return 1
+        return 0
+
     write_json(repo_root / TREND_JSON, trend)
     (repo_root / TREND_MD).write_text(render_trend_md(trend), encoding="utf-8")
     write_json(repo_root / REPLAY_JSON, replay)
@@ -444,8 +455,6 @@ def main() -> int:
     print(f"Wrote {repo_root / BUDGET_JSON}")
     print(f"Wrote {repo_root / BUDGET_MD}")
 
-    if args.check and not budget["gate"]["pass"]:
-        return 1
     return 0
 
 


### PR DESCRIPTION
## Summary
- Make parity proof `--check` paths validate gates without rewriting tracked artifacts.
- Keep normal generator mode unchanged for intentional artifact refreshes.
- Prevent post-merge verification from dirtying `docs/parity/*` through timestamps or trend-ledger churn.

## Local verification
- `python3 scripts/generate-behavioral-similarity-diff.py --check`
- `python3 scripts/generate-deep-problem-solving-diff.py --check`
- `python3 scripts/generate-global-parity-proof.py --check-release`
- `python3 scripts/generate-sota-harness-hardening.py --check`
- `python3 -m py_compile scripts/generate-behavioral-similarity-diff.py scripts/generate-deep-problem-solving-diff.py scripts/generate-global-parity-proof.py scripts/generate-sota-harness-hardening.py`
- `git diff --check`
