### PR TITLE
parity(agent): add tool middleware and FTS search parity

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -46,7 +46,7 @@ use crate::credential_pool::CredentialPool;
 use crate::interrupt::InterruptController;
 use crate::lsp_context::{build_lsp_context_note, LspContextConfig};
 use crate::memory_manager::{MemoryManager, StreamingContextScrubber};
-use crate::plugins::{HookResult, HookType, PluginManager};
+use crate::plugins::{HookResult, HookType, PluginManager, ToolExecutionMiddlewareContext};
 use crate::provider::{
     is_codex_chatgpt_token, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
     OPENAI_CODEX_BASE_URL,
@@ -2266,6 +2266,33 @@ impl AgentLoop {
         }
         if changed {
             *content = Some(current);
+        }
+    }
+
+    fn apply_tool_request_middleware_to_calls(&self, tool_calls: &mut [ToolCall], turn: u32) {
+        let Some(ref pm) = self.plugin_manager else {
+            return;
+        };
+        let Ok(pm) = pm.lock() else {
+            tracing::warn!("Plugin manager lock poisoned while applying tool request middleware");
+            return;
+        };
+        for tc in tool_calls {
+            let Ok(args) = serde_json::from_str::<Value>(&tc.function.arguments) else {
+                continue;
+            };
+            let result = pm.apply_tool_request_middleware(&tc.function.name, args, turn);
+            if !result.changed {
+                continue;
+            }
+            match serde_json::to_string(&result.args) {
+                Ok(serialized) => tc.function.arguments = serialized,
+                Err(err) => tracing::warn!(
+                    tool = tc.function.name,
+                    error = %err,
+                    "Plugin tool request middleware returned non-serializable arguments"
+                ),
+            }
         }
     }
 
@@ -6112,6 +6139,7 @@ impl AgentLoop {
                 continue;
             }
             invalid_json_retries = 0;
+            self.apply_tool_request_middleware_to_calls(&mut tool_calls, total_turns);
 
             for tc in &tool_calls {
                 if let Ok(mut c) = self.evolution_counters.lock() {
@@ -7564,6 +7592,7 @@ impl AgentLoop {
                 continue;
             }
             invalid_json_retries = 0;
+            self.apply_tool_request_middleware_to_calls(&mut tool_calls, total_turns);
             for tc in &tool_calls {
                 if let Ok(mut c) = self.evolution_counters.lock() {
                     match tc.function.name.as_str() {
@@ -8474,6 +8503,64 @@ impl AgentLoop {
         Ok(Some(response.message))
     }
 
+    fn execute_tool_call_terminal(
+        registry: &ToolRegistry,
+        tool_call_id: &str,
+        tool_name: &str,
+        mut params: Value,
+        max_delegate_depth: u32,
+        current_delegate_depth: u32,
+        parent_budget_remaining_usd: Option<f64>,
+    ) -> ToolResult {
+        match registry.get(tool_name) {
+            Some(entry) => {
+                if tool_name == "delegate_task" {
+                    if current_delegate_depth >= max_delegate_depth {
+                        return ToolResult::err(
+                            tool_call_id,
+                            format!(
+                                "Delegation depth limit reached ({}/{}).",
+                                current_delegate_depth, max_delegate_depth
+                            ),
+                        );
+                    }
+                    if let Some(obj) = params.as_object_mut() {
+                        obj.insert(
+                            "child_depth".to_string(),
+                            Value::from(current_delegate_depth + 1),
+                        );
+                        obj.insert("max_depth".to_string(), Value::from(max_delegate_depth));
+                        if let Some(remaining) = parent_budget_remaining_usd {
+                            obj.insert(
+                                "parent_budget_remaining_usd".to_string(),
+                                Value::from(remaining),
+                            );
+                        }
+                    }
+                }
+
+                match (entry.handler)(params) {
+                    Ok(output) => {
+                        if looks_like_tool_error_output(&output) {
+                            ToolResult::err(tool_call_id, output)
+                        } else {
+                            ToolResult::ok(tool_call_id, output)
+                        }
+                    }
+                    Err(e) => ToolResult::err(tool_call_id, e.to_string()),
+                }
+            }
+            None => {
+                let available = registry.names().join(", ");
+                let error_msg = format!(
+                    "Unknown tool '{}'. Available tools: [{}]",
+                    tool_name, available
+                );
+                ToolResult::err(tool_call_id, error_msg)
+            }
+        }
+    }
+
     /// Execute a batch of tool calls in parallel using a JoinSet.
     async fn execute_tool_calls(
         &self,
@@ -8599,74 +8686,53 @@ impl AgentLoop {
             let tool_name = tc.function.name.clone();
             let raw_args = tc.function.arguments.clone();
             let registry = self.tool_registry.clone();
+            let plugin_manager = self.plugin_manager.clone();
             let max_delegate_depth = max_delegate_depth;
             let current_delegate_depth = current_delegate_depth;
             let parent_budget_remaining_usd = parent_budget_remaining_usd;
 
             join_set.spawn(async move {
-                match registry.get(&tool_name) {
-                    Some(entry) => {
-                        // Parse arguments
-                        let mut params: Value = match serde_json::from_str(&raw_args) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                let error_msg = format!(
-                                    "Invalid JSON params for tool '{}': {}. \
-                                     Please check your parameters and retry with valid JSON.",
-                                    tool_name, e
-                                );
-                                return ToolResult::err(&tool_call_id, error_msg);
-                            }
-                        };
-
-                        if tool_name == "delegate_task" {
-                            if current_delegate_depth >= max_delegate_depth {
-                                return ToolResult::err(
-                                    &tool_call_id,
-                                    format!(
-                                        "Delegation depth limit reached ({}/{}).",
-                                        current_delegate_depth, max_delegate_depth
-                                    ),
-                                );
-                            }
-                            if let Some(obj) = params.as_object_mut() {
-                                obj.insert(
-                                    "child_depth".to_string(),
-                                    Value::from(current_delegate_depth + 1),
-                                );
-                                obj.insert(
-                                    "max_depth".to_string(),
-                                    Value::from(max_delegate_depth),
-                                );
-                                if let Some(remaining) = parent_budget_remaining_usd {
-                                    obj.insert(
-                                        "parent_budget_remaining_usd".to_string(),
-                                        Value::from(remaining),
-                                    );
-                                }
-                            }
-                        }
-
-                        // Execute the handler
-                        match (entry.handler)(params) {
-                            Ok(output) => {
-                                if looks_like_tool_error_output(&output) {
-                                    ToolResult::err(&tool_call_id, output)
-                                } else {
-                                    ToolResult::ok(&tool_call_id, output)
-                                }
-                            }
-                            Err(e) => ToolResult::err(&tool_call_id, e.to_string()),
-                        }
-                    }
-                    None => {
-                        let available = registry.names().join(", ");
+                let params: Value = match serde_json::from_str(&raw_args) {
+                    Ok(v) => v,
+                    Err(e) => {
                         let error_msg = format!(
-                            "Unknown tool '{}'. Available tools: [{}]",
-                            tool_name, available
+                            "Invalid JSON params for tool '{}': {}. \
+                             Please check your parameters and retry with valid JSON.",
+                            tool_name, e
                         );
-                        ToolResult::err(&tool_call_id, error_msg)
+                        return ToolResult::err(&tool_call_id, error_msg);
                     }
+                };
+                let middleware_ctx = ToolExecutionMiddlewareContext {
+                    tool_name: tool_name.clone(),
+                    tool_call_id: tool_call_id.clone(),
+                    args: params.clone(),
+                    original_args: params.clone(),
+                    turn,
+                };
+                let terminal = |next_params: Value| {
+                    Self::execute_tool_call_terminal(
+                        &registry,
+                        &tool_call_id,
+                        &tool_name,
+                        next_params,
+                        max_delegate_depth,
+                        current_delegate_depth,
+                        parent_budget_remaining_usd,
+                    )
+                };
+                if let Some(pm) = plugin_manager {
+                    match pm.lock() {
+                        Ok(pm) => pm.run_tool_execution_middleware(middleware_ctx, terminal),
+                        Err(_) => {
+                            tracing::warn!(
+                                "Plugin manager lock poisoned while running tool execution middleware"
+                            );
+                            terminal(params)
+                        }
+                    }
+                } else {
+                    terminal(params)
                 }
             });
             if join_set.len() >= tool_concurrency {
@@ -14862,6 +14928,134 @@ mod tests {
         assert!(transcript.contains("Tool 'web_search' is not enabled in this session"));
         assert!(transcript.contains("Available tools: terminal"));
         assert!(!transcript.contains("web ran"));
+    }
+
+    #[test]
+    fn plugin_tool_middleware_runs_inside_agent_loop() {
+        use futures::stream::BoxStream;
+        use hermes_core::JsonSchema;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        struct ToolThenDoneProvider {
+            calls: Arc<AtomicU32>,
+        }
+
+        #[async_trait::async_trait]
+        impl LlmProvider for ToolThenDoneProvider {
+            async fn chat_completion(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> Result<hermes_core::LlmResponse, AgentError> {
+                let n = self.calls.fetch_add(1, Ordering::SeqCst);
+                let message = if n == 0 {
+                    Message::assistant_with_tool_calls(
+                        None,
+                        vec![ToolCall {
+                            id: "tc_echo".to_string(),
+                            function: hermes_core::FunctionCall {
+                                name: "echo".to_string(),
+                                arguments: r#"{"value":"original"}"#.to_string(),
+                            },
+                            extra_content: None,
+                        }],
+                    )
+                } else {
+                    Message::assistant("done")
+                };
+                Ok(hermes_core::LlmResponse {
+                    message,
+                    usage: None,
+                    model: "dummy".into(),
+                    finish_reason: Some("stop".into()),
+                })
+            }
+
+            fn chat_completion_stream(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSchema],
+                _max_tokens: Option<u32>,
+                _temperature: Option<f64>,
+                _model: Option<&str>,
+                _extra_body: Option<&serde_json::Value>,
+            ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+                futures::stream::empty().boxed()
+            }
+        }
+
+        struct MiddlewarePlugin;
+
+        #[async_trait::async_trait]
+        impl crate::plugins::Plugin for MiddlewarePlugin {
+            fn meta(&self) -> crate::plugins::PluginMeta {
+                crate::plugins::PluginMeta {
+                    name: "middleware_test".to_string(),
+                    version: "0.1.0".to_string(),
+                    description: "Middleware test".to_string(),
+                    author: None,
+                }
+            }
+
+            async fn initialize(&self) -> Result<(), AgentError> {
+                Ok(())
+            }
+
+            async fn shutdown(&self) -> Result<(), AgentError> {
+                Ok(())
+            }
+
+            fn register(&self, ctx: &mut crate::plugins::PluginContext) {
+                ctx.on_tool_request(Arc::new(|request| {
+                    let mut args = request.args.clone();
+                    args["value"] = Value::String("rewritten".to_string());
+                    Some(crate::plugins::ToolRequestMiddlewareUpdate::new(args))
+                }));
+                ctx.on_tool_execution(Arc::new(|_request, next_call| {
+                    let mut result = next_call(None);
+                    result.content = format!("wrapped: {}", result.content);
+                    result
+                }));
+            }
+        }
+
+        let mut registry = ToolRegistry::new();
+        registry.register(
+            "echo",
+            ToolSchema::new("echo", "Echo tool", JsonSchema::new("object")),
+            Arc::new(|args| Ok(args["value"].as_str().unwrap_or_default().to_string())),
+        );
+        let mut plugin_manager = PluginManager::new();
+        plugin_manager.register(Arc::new(MiddlewarePlugin));
+        let agent = AgentLoop::new(
+            AgentConfig {
+                max_turns: 4,
+                ..AgentConfig::default()
+            },
+            Arc::new(registry),
+            Arc::new(ToolThenDoneProvider {
+                calls: Arc::new(AtomicU32::new(0)),
+            }),
+        )
+        .with_plugins(Arc::new(std::sync::Mutex::new(plugin_manager)));
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+        let result = rt
+            .block_on(agent.run(vec![Message::user("use echo")], None))
+            .expect("agent run should succeed");
+        let transcript = result
+            .messages
+            .iter()
+            .filter_map(|msg| msg.content.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(result.finished_naturally);
+        assert!(transcript.contains("wrapped: rewritten"), "{transcript}");
     }
 
     #[test]

--- a/crates/hermes-agent/src/plugins.rs
+++ b/crates/hermes-agent/src/plugins.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use hermes_core::{AgentError, ToolHandler, ToolSchema};
+use hermes_core::{AgentError, ToolHandler, ToolResult, ToolSchema};
 
 // ---------------------------------------------------------------------------
 // HookType
@@ -83,6 +83,60 @@ pub enum HookResult {
     /// Hook encountered an error.
     Error(String),
 }
+
+#[derive(Debug, Clone)]
+pub struct ToolRequestMiddlewareContext {
+    pub tool_name: String,
+    pub args: Value,
+    pub original_args: Value,
+    pub turn: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolRequestMiddlewareUpdate {
+    pub args: Value,
+    pub source: Option<String>,
+    pub reason: Option<String>,
+}
+
+impl ToolRequestMiddlewareUpdate {
+    pub fn new(args: Value) -> Self {
+        Self {
+            args,
+            source: None,
+            reason: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolRequestMiddlewareResult {
+    pub args: Value,
+    pub original_args: Value,
+    pub changed: bool,
+    pub trace: Vec<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolExecutionMiddlewareContext {
+    pub tool_name: String,
+    pub tool_call_id: String,
+    pub args: Value,
+    pub original_args: Value,
+    pub turn: u32,
+}
+
+pub type ToolRequestMiddleware =
+    Arc<dyn Fn(&ToolRequestMiddlewareContext) -> Option<ToolRequestMiddlewareUpdate> + Send + Sync>;
+
+pub type ToolExecutionMiddleware = Arc<
+    dyn Fn(
+            &ToolExecutionMiddlewareContext,
+            &mut dyn FnMut(Option<Value>) -> ToolResult,
+        ) -> ToolResult
+        + Send
+        + Sync,
+>;
 
 // ---------------------------------------------------------------------------
 // PluginManifest
@@ -157,6 +211,8 @@ pub trait ContextEngine: Send + Sync {
 /// Plugins use this to register hooks, tools, and CLI commands.
 pub struct PluginContext {
     hooks: HashMap<HookType, Vec<Arc<dyn Fn(&Value) -> HookResult + Send + Sync>>>,
+    tool_request_middleware: Vec<ToolRequestMiddleware>,
+    tool_execution_middleware: Vec<ToolExecutionMiddleware>,
     tools: Vec<(ToolSchema, Arc<dyn ToolHandler>)>,
     cli_commands: Vec<PluginCliCommand>,
     context_engine: Option<Arc<dyn ContextEngine>>,
@@ -167,6 +223,8 @@ impl PluginContext {
     pub fn new() -> Self {
         Self {
             hooks: HashMap::new(),
+            tool_request_middleware: Vec::new(),
+            tool_execution_middleware: Vec::new(),
             tools: Vec::new(),
             cli_commands: Vec::new(),
             context_engine: None,
@@ -181,6 +239,16 @@ impl PluginContext {
         callback: Arc<dyn Fn(&Value) -> HookResult + Send + Sync>,
     ) {
         self.hooks.entry(hook).or_default().push(callback);
+    }
+
+    /// Register middleware that can rewrite tool arguments before execution.
+    pub fn on_tool_request(&mut self, callback: ToolRequestMiddleware) {
+        self.tool_request_middleware.push(callback);
+    }
+
+    /// Register middleware that can wrap or replace tool execution.
+    pub fn on_tool_execution(&mut self, callback: ToolExecutionMiddleware) {
+        self.tool_execution_middleware.push(callback);
     }
 
     /// Register a tool provided by the plugin.
@@ -330,6 +398,123 @@ impl PluginManager {
                 }
             })
             .collect()
+    }
+
+    pub fn apply_tool_request_middleware(
+        &self,
+        tool_name: &str,
+        args: Value,
+        turn: u32,
+    ) -> ToolRequestMiddlewareResult {
+        let original_args = args.clone();
+        let mut current_args = args;
+        let mut trace = Vec::new();
+
+        for callback in &self.context.tool_request_middleware {
+            let ctx = ToolRequestMiddlewareContext {
+                tool_name: tool_name.to_string(),
+                args: current_args.clone(),
+                original_args: original_args.clone(),
+                turn,
+            };
+            let Ok(result) =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback(&ctx)))
+            else {
+                tracing::warn!(tool = tool_name, "Plugin tool request middleware panicked");
+                continue;
+            };
+            let Some(update) = result else {
+                continue;
+            };
+            current_args = update.args;
+            trace.push(serde_json::json!({
+                "source": update.source.unwrap_or_else(|| "plugin".to_string()),
+                "reason": update.reason,
+            }));
+        }
+
+        ToolRequestMiddlewareResult {
+            changed: current_args != original_args,
+            args: current_args,
+            original_args,
+            trace,
+        }
+    }
+
+    pub fn run_tool_execution_middleware<F>(
+        &self,
+        ctx: ToolExecutionMiddlewareContext,
+        mut terminal_call: F,
+    ) -> ToolResult
+    where
+        F: FnMut(Value) -> ToolResult,
+    {
+        fn call_at<F>(
+            callbacks: &[ToolExecutionMiddleware],
+            index: usize,
+            base_ctx: &ToolExecutionMiddlewareContext,
+            payload: Value,
+            terminal_call: &mut F,
+        ) -> ToolResult
+        where
+            F: FnMut(Value) -> ToolResult,
+        {
+            if index >= callbacks.len() {
+                return terminal_call(payload);
+            }
+
+            let callback = callbacks[index].clone();
+            let mut call_ctx = base_ctx.clone();
+            call_ctx.args = payload.clone();
+            let mut next_called = false;
+            let mut next_result: Option<ToolResult> = None;
+            let result = {
+                let mut next_call = |next_payload: Option<Value>| -> ToolResult {
+                    if next_called {
+                        return ToolResult::err(
+                            &call_ctx.tool_call_id,
+                            "Middleware next_call may only be called once.",
+                        );
+                    }
+                    next_called = true;
+                    let result = call_at(
+                        callbacks,
+                        index + 1,
+                        base_ctx,
+                        next_payload.unwrap_or_else(|| call_ctx.args.clone()),
+                        terminal_call,
+                    );
+                    next_result = Some(result.clone());
+                    result
+                };
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    callback(&call_ctx, &mut next_call)
+                }))
+            };
+
+            match result {
+                Ok(result) => result,
+                Err(_) => {
+                    tracing::warn!(
+                        tool = call_ctx.tool_name,
+                        "Plugin tool execution middleware panicked"
+                    );
+                    if let Some(result) = next_result {
+                        result
+                    } else {
+                        call_at(callbacks, index + 1, base_ctx, payload, terminal_call)
+                    }
+                }
+            }
+        }
+
+        call_at(
+            &self.context.tool_execution_middleware,
+            0,
+            &ctx,
+            ctx.args.clone(),
+            &mut terminal_call,
+        )
     }
 
     /// Get all tools registered via plugin contexts.
@@ -598,6 +783,122 @@ mod tests {
         let results = mgr.invoke_hook(HookType::PreLlmCall, &serde_json::json!({}));
         assert_eq!(results.len(), 1);
         assert!(matches!(results[0], HookResult::InjectContext(_)));
+    }
+
+    #[test]
+    fn test_tool_request_middleware_rewrites_args_with_original_snapshot() {
+        let mut ctx = PluginContext::new();
+        ctx.on_tool_request(Arc::new(|request| {
+            assert_eq!(request.tool_name, "terminal");
+            assert_eq!(request.original_args["cmd"], "pwd");
+            let mut args = request.args.clone();
+            args["cmd"] = Value::String("ls".to_string());
+            let mut update = ToolRequestMiddlewareUpdate::new(args);
+            update.source = Some("test".to_string());
+            update.reason = Some(format!("turn {}", request.turn));
+            Some(update)
+        }));
+        let mgr = PluginManager {
+            plugins: HashMap::new(),
+            context: ctx,
+        };
+
+        let result =
+            mgr.apply_tool_request_middleware("terminal", serde_json::json!({"cmd": "pwd"}), 7);
+
+        assert!(result.changed);
+        assert_eq!(result.args["cmd"], "ls");
+        assert_eq!(result.original_args["cmd"], "pwd");
+        assert_eq!(result.trace[0]["source"], "test");
+    }
+
+    #[test]
+    fn test_tool_execution_middleware_can_wrap_next_call() {
+        let mut ctx = PluginContext::new();
+        ctx.on_tool_execution(Arc::new(|request, next_call| {
+            let mut args = request.args.clone();
+            args["cmd"] = Value::String("rewritten".to_string());
+            let mut result = next_call(Some(args));
+            result.content = format!("wrapped: {}", result.content);
+            result
+        }));
+        let mgr = PluginManager {
+            plugins: HashMap::new(),
+            context: ctx,
+        };
+        let middleware_ctx = ToolExecutionMiddlewareContext {
+            tool_name: "terminal".to_string(),
+            tool_call_id: "tc1".to_string(),
+            args: serde_json::json!({"cmd": "original"}),
+            original_args: serde_json::json!({"cmd": "original"}),
+            turn: 1,
+        };
+
+        let result = mgr.run_tool_execution_middleware(middleware_ctx, |args| {
+            ToolResult::ok("tc1", format!("ran {}", args["cmd"].as_str().unwrap()))
+        });
+
+        assert!(!result.is_error);
+        assert_eq!(result.content, "wrapped: ran rewritten");
+    }
+
+    #[test]
+    fn test_tool_execution_next_call_is_single_use() {
+        let calls = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let mut ctx = PluginContext::new();
+        ctx.on_tool_execution(Arc::new(|_request, next_call| {
+            let first = next_call(None);
+            assert_eq!(first.content, "terminal result");
+            next_call(None)
+        }));
+        let mgr = PluginManager {
+            plugins: HashMap::new(),
+            context: ctx,
+        };
+        let middleware_ctx = ToolExecutionMiddlewareContext {
+            tool_name: "terminal".to_string(),
+            tool_call_id: "tc1".to_string(),
+            args: serde_json::json!({}),
+            original_args: serde_json::json!({}),
+            turn: 1,
+        };
+        let calls_for_terminal = calls.clone();
+
+        let result = mgr.run_tool_execution_middleware(middleware_ctx, move |_args| {
+            calls_for_terminal.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            ToolResult::ok("tc1", "terminal result")
+        });
+
+        assert!(result.is_error);
+        assert!(result.content.contains("next_call may only be called once"));
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_tool_execution_middleware_preserves_downstream_failure_after_panic() {
+        let mut ctx = PluginContext::new();
+        ctx.on_tool_execution(Arc::new(|_request, next_call| {
+            let _ = next_call(None);
+            panic!("middleware post-processing failed");
+        }));
+        let mgr = PluginManager {
+            plugins: HashMap::new(),
+            context: ctx,
+        };
+        let middleware_ctx = ToolExecutionMiddlewareContext {
+            tool_name: "terminal".to_string(),
+            tool_call_id: "tc1".to_string(),
+            args: serde_json::json!({}),
+            original_args: serde_json::json!({}),
+            turn: 1,
+        };
+
+        let result = mgr.run_tool_execution_middleware(middleware_ctx, |_args| {
+            ToolResult::err("tc1", "downstream failed")
+        });
+
+        assert!(result.is_error);
+        assert_eq!(result.content, "downstream failed");
     }
 
     #[test]

--- a/crates/hermes-tools/src/backends/session_search.rs
+++ b/crates/hermes-tools/src/backends/session_search.rs
@@ -426,6 +426,16 @@ impl SqliteSessionSearchBackend {
             .replace('_', "\\_")
     }
 
+    fn sanitize_fts5_query(raw: &str) -> Option<String> {
+        let terms = raw
+            .split_whitespace()
+            .map(str::trim)
+            .filter(|term| !term.is_empty())
+            .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+            .collect::<Vec<_>>();
+        (!terms.is_empty()).then(|| terms.join(" "))
+    }
+
     fn id_match_score(needle: &str, values: &[&str]) -> u8 {
         if values
             .iter()
@@ -1122,14 +1132,16 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
 
                 let fts_available = self.fts_enabled && Self::fts_table_exists(&conn)?;
                 let mut search_degraded = None;
+                let fts_query = Self::sanitize_fts5_query(query);
                 if tasks.len() < limit && fts_available {
-                    let hidden_placeholders = HIDDEN_SESSION_SOURCES
-                        .iter()
-                        .map(|_| "?".to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    let mut sql = String::from(
-                        "SELECT m.session_id, s.created_at, s.platform, s.model,
+                    if let Some(fts_query) = fts_query {
+                        let hidden_placeholders = HIDDEN_SESSION_SOURCES
+                            .iter()
+                            .map(|_| "?".to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        let mut sql = String::from(
+                            "SELECT m.session_id, s.created_at, s.platform, s.model,
                                 s.parent_session_id, s.model_config,
                                 p.end_reason, p.ended_at,
                                 bm25(messages_fts) AS rank
@@ -1142,111 +1154,112 @@ impl SessionSearchBackend for SqliteSessionSearchBackend {
                            AND m.content != ''
                            AND m.active = 1
                            AND COALESCE(s.platform, '') NOT IN (",
-                    );
-                    sql.push_str(&hidden_placeholders);
-                    sql.push(')');
+                        );
+                        sql.push_str(&hidden_placeholders);
+                        sql.push(')');
 
-                    let mut role_values = Vec::new();
-                    if let Some(raw_roles) = role_filter {
-                        for role in raw_roles
-                            .split(',')
-                            .map(str::trim)
-                            .filter(|s| !s.is_empty())
-                        {
-                            role_values.push(role.to_string());
+                        let mut role_values = Vec::new();
+                        if let Some(raw_roles) = role_filter {
+                            for role in raw_roles
+                                .split(',')
+                                .map(str::trim)
+                                .filter(|s| !s.is_empty())
+                            {
+                                role_values.push(role.to_string());
+                            }
+                            if !role_values.is_empty() {
+                                let placeholders = (0..role_values.len())
+                                    .map(|_| "?".to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                sql.push_str(&format!(" AND m.role IN ({})", placeholders));
+                            }
                         }
-                        if !role_values.is_empty() {
-                            let placeholders = (0..role_values.len())
-                                .map(|_| "?".to_string())
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            sql.push_str(&format!(" AND m.role IN ({})", placeholders));
-                        }
-                    }
-                    sql.push_str(" ORDER BY rank LIMIT 50");
+                        sql.push_str(" ORDER BY rank LIMIT 50");
 
-                    let mut stmt = conn.prepare(&sql).map_err(|e| {
-                        ToolError::ExecutionFailed(format!(
-                            "Failed to prepare session search query: {}",
-                            e
-                        ))
-                    })?;
-
-                    let mut values: Vec<rusqlite::types::Value> =
-                        vec![rusqlite::types::Value::Text(query.to_string())];
-                    values.extend(
-                        HIDDEN_SESSION_SOURCES
-                            .iter()
-                            .map(|s| rusqlite::types::Value::Text((*s).to_string())),
-                    );
-                    values.extend(role_values.into_iter().map(rusqlite::types::Value::Text));
-                    let params = rusqlite::params_from_iter(values.iter());
-
-                    let rows = stmt
-                        .query_map(params, |row| {
-                            Ok((
-                                row.get::<_, String>(0)?,
-                                row.get::<_, Option<String>>(1)?,
-                                row.get::<_, Option<String>>(2)?
-                                    .unwrap_or_else(|| "cli".to_string()),
-                                row.get::<_, Option<String>>(3)?,
-                                row.get::<_, Option<String>>(4)?,
-                                row.get::<_, Option<String>>(5)?,
-                                row.get::<_, Option<String>>(6)?,
-                                row.get::<_, Option<String>>(7)?,
-                            ))
-                        })
-                        .map_err(|e| {
+                        let mut stmt = conn.prepare(&sql).map_err(|e| {
                             ToolError::ExecutionFailed(format!(
-                                "Session search query failed: {}",
+                                "Failed to prepare session search query: {}",
                                 e
                             ))
                         })?;
 
-                    for row in rows.flatten() {
-                        if tasks.len() >= limit {
-                            break;
-                        }
-                        let (
-                            raw_session_id,
-                            raw_started_at,
-                            _raw_source,
-                            _raw_model,
-                            parent_session_id,
-                            model_config,
-                            parent_end_reason,
-                            parent_ended_at,
-                        ) = row;
-                        let resolved_session_id = Self::visible_session_id_for_row(
-                            &conn,
-                            &raw_session_id,
-                            parent_session_id.as_deref(),
-                            model_config.as_deref(),
-                            raw_started_at.as_deref(),
-                            parent_end_reason.as_deref(),
-                            parent_ended_at.as_deref(),
+                        let mut values: Vec<rusqlite::types::Value> =
+                            vec![rusqlite::types::Value::Text(fts_query)];
+                        values.extend(
+                            HIDDEN_SESSION_SOURCES
+                                .iter()
+                                .map(|s| rusqlite::types::Value::Text((*s).to_string())),
                         );
-                        let logical_key = Self::logical_session_key_for_row(
-                            &conn,
-                            &raw_session_id,
-                            parent_session_id.as_deref(),
-                            model_config.as_deref(),
-                            raw_started_at.as_deref(),
-                            parent_end_reason.as_deref(),
-                            parent_ended_at.as_deref(),
-                        );
-                        if let Some(ref current_root) = current_lineage_root {
-                            if &logical_key == current_root {
+                        values.extend(role_values.into_iter().map(rusqlite::types::Value::Text));
+                        let params = rusqlite::params_from_iter(values.iter());
+
+                        let rows = stmt
+                            .query_map(params, |row| {
+                                Ok((
+                                    row.get::<_, String>(0)?,
+                                    row.get::<_, Option<String>>(1)?,
+                                    row.get::<_, Option<String>>(2)?
+                                        .unwrap_or_else(|| "cli".to_string()),
+                                    row.get::<_, Option<String>>(3)?,
+                                    row.get::<_, Option<String>>(4)?,
+                                    row.get::<_, Option<String>>(5)?,
+                                    row.get::<_, Option<String>>(6)?,
+                                    row.get::<_, Option<String>>(7)?,
+                                ))
+                            })
+                            .map_err(|e| {
+                                ToolError::ExecutionFailed(format!(
+                                    "Session search query failed: {}",
+                                    e
+                                ))
+                            })?;
+
+                        for row in rows.flatten() {
+                            if tasks.len() >= limit {
+                                break;
+                            }
+                            let (
+                                raw_session_id,
+                                raw_started_at,
+                                _raw_source,
+                                _raw_model,
+                                parent_session_id,
+                                model_config,
+                                parent_end_reason,
+                                parent_ended_at,
+                            ) = row;
+                            let resolved_session_id = Self::visible_session_id_for_row(
+                                &conn,
+                                &raw_session_id,
+                                parent_session_id.as_deref(),
+                                model_config.as_deref(),
+                                raw_started_at.as_deref(),
+                                parent_end_reason.as_deref(),
+                                parent_ended_at.as_deref(),
+                            );
+                            let logical_key = Self::logical_session_key_for_row(
+                                &conn,
+                                &raw_session_id,
+                                parent_session_id.as_deref(),
+                                model_config.as_deref(),
+                                raw_started_at.as_deref(),
+                                parent_end_reason.as_deref(),
+                                parent_ended_at.as_deref(),
+                            );
+                            if let Some(ref current_root) = current_lineage_root {
+                                if &logical_key == current_root {
+                                    continue;
+                                }
+                            }
+                            if !seen.insert(logical_key) {
                                 continue;
                             }
-                        }
-                        if !seen.insert(logical_key) {
-                            continue;
-                        }
-                        if let Some(task) =
-                            Self::load_summary_task(&conn, &resolved_session_id, query, false)?
-                        {
-                            tasks.push(task);
+                            if let Some(task) =
+                                Self::load_summary_task(&conn, &resolved_session_id, query, false)?
+                            {
+                                tasks.push(task);
+                            }
                         }
                     }
                 } else if !fts_available {
@@ -1679,6 +1692,35 @@ mod tests {
             ],
             "{output}"
         );
+    }
+
+    #[tokio::test]
+    async fn search_sanitizes_colon_queries_for_fts5() {
+        let (tmp, backend) = backend_with_db();
+        let conn = db_conn(&tmp);
+        insert_session(
+            &conn,
+            "colon-search-session",
+            None,
+            None,
+            None,
+            None,
+            "2026-06-03T09:02:00Z",
+        );
+        insert_message(
+            &conn,
+            "colon-search-session",
+            "user",
+            "workspace:hermes contains a literal colon token",
+        );
+
+        let output = backend
+            .search(Some("workspace:hermes"), None, 5, None)
+            .await
+            .expect("colon query should not be parsed as an FTS5 column filter");
+        let ids = result_ids(&output);
+
+        assert_eq!(ids, vec!["colon-search-session".to_string()], "{output}");
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3911,6 +3911,26 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Upstream desktop remote-artifact authenticated download is superseded by Rust gateway/media delivery boundaries; Electron artifacts UI and Python web_server files endpoint are outside the Rust-only runtime."
+    },
+    "d1771114eda9": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust session_search now sanitizes FTS5 MATCH input by quoting query terms before execution, so colon-containing queries are treated as literal search text instead of FTS column filters. Regression coverage proves workspace:hermes searches return matching sessions without error."
+    },
+    "2e0c9083db84": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust PluginManager now exposes tool_request and tool_execution middleware primitives, AgentLoop applies request rewrites before guards/hooks and wraps real tool handler execution with a single-use next_call-equivalent chain. Unit and agent-loop tests cover argument adaptation, execution wrapping, and real autonomous tool execution."
+    },
+    "5abe45674dc7": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust tool execution middleware catches middleware panics and preserves the downstream result when next_call already ran, including error ToolResult values. Regression coverage proves downstream failures survive middleware post-processing failure."
+    },
+    "c37c6eaf296a": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust already provides Home Assistant as first-class native runtime surface: REST backend, ha_list_entities/ha_get_state/ha_list_services/ha_call_service handlers, homeassistant toolset and aliases, send-message platform routing, and gateway adapter coverage. The upstream Python bundled-plugin migration is represented by Rust-native built-in registration and platform contract tests rather than a Python plugin package."
     }
   },
   "subject_patterns": [


### PR DESCRIPTION
## Summary
- add Rust-native plugin tool request middleware and tool execution middleware with a single-use next_call-equivalent chain
- wire request rewrites and execution wrappers into AgentLoop tool execution for normal and streaming paths
- sanitize SQLite FTS5 session-search queries so colon text is searched literally
- mark the targeted upstream parity rows as ported/proven in queue overrides

## Verification
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check
- git diff --check
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-tools search_sanitizes_colon_queries_for_fts5 -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent middleware -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-tools
- python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref HEAD --upstream-remote upstream --upstream-branch main --no-fetch --out-json /tmp/hermes-queue-after-20260624.json --out-md /tmp/hermes-queue-after-20260624.md

## Queue Delta
- pending: 1519 -> 1516
- ported: 365 -> 369
- targeted rows: 2e0c9083db84, 5abe45674dc7, d1771114eda9, c37c6eaf296a now ported
