### PR TITLE
parity(gateway): wire busy input runtime controls

### DIFF
--- a/.ci/clippy-allowlist.txt
+++ b/.ci/clippy-allowlist.txt
@@ -143,7 +143,6 @@ hermes_gateway|clippy::manual_split_once|crates/hermes-gateway/src/platforms/api
 hermes_gateway|clippy::needless_as_bytes|crates/hermes-gateway/src/platforms/weixin.rs
 hermes_gateway|clippy::needless_borrows_for_generic_args|crates/hermes-gateway/src/gateway.rs
 hermes_gateway|clippy::needless_borrows_for_generic_args|crates/hermes-gateway/src/platforms/slack.rs
-hermes_gateway|clippy::needless_borrow|crates/hermes-gateway/src/gateway.rs
 hermes_gateway|clippy::should_implement_trait|crates/hermes-gateway/src/platforms/telegram.rs
 hermes_gateway|clippy::to_string_in_format_args|crates/hermes-gateway/src/platforms/api_server.rs
 hermes_gateway|clippy::too_many_arguments|crates/hermes-gateway/src/platforms/email.rs

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -127,7 +127,9 @@ use hermes_gateway::platforms::weixin::{WeChatAdapter, WeixinConfig};
 #[cfg(feature = "gateway-whatsapp")]
 use hermes_gateway::platforms::whatsapp::{WhatsAppAdapter, WhatsAppConfig};
 use hermes_gateway::tool_backends::ClarifyDispatcher;
-use hermes_gateway::{DmManager, Gateway, GatewayRuntimeContext, SessionManager};
+use hermes_gateway::{
+    ActiveSessionControl, DmManager, Gateway, GatewayRuntimeContext, SessionManager,
+};
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_telemetry::init_telemetry_from_env;
 use hermes_tool_planning::{resolve_platform_tool_schemas, tool_definition_summary};
@@ -3233,6 +3235,13 @@ async fn run_gateway(
                         let agent =
                             build_agent_for_gateway_context(config.as_ref(), &ctx, agent_tools)
                                 .with_callbacks(callbacks);
+                        if let Some(registration) = ctx.busy_control.clone() {
+                            let _ = registration
+                                .attach(Arc::new(GatewayAgentBusyControl::new(
+                                    agent.interrupt.clone(),
+                                )))
+                                .await;
+                        }
                         let result = agent
                             .run(messages, Some(tool_schemas))
                             .await
@@ -3505,6 +3514,13 @@ async fn run_gateway(
                         let agent =
                             build_agent_for_gateway_context(config.as_ref(), &ctx, agent_tools)
                                 .with_callbacks(callbacks);
+                        if let Some(registration) = ctx.busy_control.clone() {
+                            let _ = registration
+                                .attach(Arc::new(GatewayAgentBusyControl::new(
+                                    agent.interrupt.clone(),
+                                )))
+                                .await;
+                        }
                         let emit = on_chunk.clone();
                         let ui_state = Arc::new(Mutex::new((false, false))); // (muted, needs_break)
                         let ui_state_cb = ui_state.clone();
@@ -4268,6 +4284,29 @@ fn resolve_model_for_gateway(default_model: &str, ctx: &GatewayRuntimeContext) -
     }
 
     default_model.to_string()
+}
+
+#[derive(Clone)]
+struct GatewayAgentBusyControl {
+    interrupt: hermes_agent::InterruptController,
+}
+
+impl GatewayAgentBusyControl {
+    fn new(interrupt: hermes_agent::InterruptController) -> Self {
+        Self { interrupt }
+    }
+}
+
+impl ActiveSessionControl for GatewayAgentBusyControl {
+    fn interrupt(&self, message: &str) {
+        self.interrupt.interrupt(Some(message.to_string()));
+    }
+
+    fn steer(&self, message: &str) -> bool {
+        self.interrupt
+            .interrupt(Some(hermes_agent::format_steer_marker(message)));
+        true
+    }
 }
 
 fn normalize_gateway_tool_progress_mode(raw: &str) -> Option<String> {

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -320,6 +320,18 @@ pub struct DisplayConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_progress: Option<String>,
 
+    /// Busy-session input mode for gateway surfaces: `interrupt`, `queue`, or `steer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busy_input_mode: Option<String>,
+
+    /// Whether gateway busy-session guard should acknowledge queued/interrupted messages.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_boolish",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub busy_ack_enabled: Option<bool>,
+
     /// Per-platform display overrides keyed by normalized platform name.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub platforms: BTreeMap<String, PlatformDisplayConfig>,
@@ -336,6 +348,26 @@ impl DisplayConfig {
             .get(&key)
             .and_then(|cfg| cfg.tool_progress.as_deref())
             .or(self.tool_progress.as_deref())
+    }
+
+    pub fn normalized_busy_input_mode(&self) -> &'static str {
+        match self
+            .busy_input_mode
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "queue" | "queued" => "queue",
+            "steer" | "steering" => "steer",
+            "interrupt" | "interrupted" | "replace" | "" => "interrupt",
+            _ => "interrupt",
+        }
+    }
+
+    pub fn busy_ack_enabled(&self) -> bool {
+        self.busy_ack_enabled.unwrap_or(true)
     }
 }
 
@@ -899,6 +931,38 @@ where
     }
 
     deserializer.deserialize_any(BoolishVisitor)
+}
+
+fn deserialize_option_boolish<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct OptionBoolishVisitor;
+
+    impl<'de> Visitor<'de> for OptionBoolishVisitor {
+        type Value = Option<bool>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a bool, bool-like string, or null")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D2>(self, deserializer: D2) -> Result<Self::Value, D2::Error>
+        where
+            D2: Deserializer<'de>,
+        {
+            deserialize_boolish(deserializer).map(Some)
+        }
+    }
+
+    deserializer.deserialize_option(OptionBoolishVisitor)
 }
 
 fn deserialize_string_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
@@ -2017,6 +2081,8 @@ quick_commands:
 display:
   tool_progress_command: "true"
   tool_progress: all
+  busy_input_mode: steer
+  busy_ack_enabled: "false"
   platforms:
     telegram:
       tool_progress: off
@@ -2029,6 +2095,8 @@ agent:
         assert!(cfg.display.tool_progress_command_enabled());
         assert_eq!(cfg.display.platform_tool_progress("telegram"), Some("off"));
         assert_eq!(cfg.display.platform_tool_progress("slack"), Some("all"));
+        assert_eq!(cfg.display.normalized_busy_input_mode(), "steer");
+        assert!(!cfg.display.busy_ack_enabled());
         assert_eq!(
             cfg.agent.normalized_service_tier().as_deref(),
             Some("priority")

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub use hermes_core::ConfigError;
 
 use crate::config::{
-    GatewayConfig, LlmProviderConfig, ProxyConfig, TerminalBackendType, TerminalConfig,
-    TerminalHomeMode, WebConfig,
+    DisplayConfig, GatewayConfig, LlmProviderConfig, ProxyConfig, TerminalBackendType,
+    TerminalConfig, TerminalHomeMode, WebConfig,
 };
 use crate::merge::merge_configs;
 use crate::paths;
@@ -366,6 +366,7 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
 
     bridge_terminal_config_to_env(&config.terminal);
     bridge_web_config_to_env(&config.web);
+    bridge_display_config_to_env(&config.display);
 
     // Layer 3: environment variables (highest priority)
     apply_env_overrides(&mut config);
@@ -788,6 +789,23 @@ fn apply_user_config_patch_dotted(
         ["web", "crawl_backend"] => {
             config.web.crawl_backend = value.trim().to_string();
         }
+        ["display", "busy_input_mode"] => {
+            let normalized = match value.trim().to_ascii_lowercase().as_str() {
+                "queue" | "queued" => "queue",
+                "steer" | "steering" => "steer",
+                "interrupt" | "interrupted" | "replace" | "" => "interrupt",
+                _ => {
+                    return Err(ConfigError::ValidationError(format!(
+                        "display.busy_input_mode must be one of interrupt, queue, steer: {value}"
+                    )));
+                }
+            };
+            config.display.busy_input_mode = Some(normalized.to_string());
+        }
+        ["display", "busy_ack_enabled"] => {
+            config.display.busy_ack_enabled =
+                Some(parse_config_bool("display.busy_ack_enabled", value)?);
+        }
         ["sessions", "auto_prune"] => {
             let normalized = value.trim().to_ascii_lowercase();
             let parsed = match normalized.as_str() {
@@ -1085,6 +1103,14 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
         } else {
             config.web.crawl_backend.clone()
         }),
+        ["display", "busy_input_mode"] => Ok(config
+            .display
+            .busy_input_mode
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "interrupt".to_string())),
+        ["display", "busy_ack_enabled"] => Ok(config.display.busy_ack_enabled().to_string()),
         ["sessions", "auto_prune"] => Ok(config.sessions.auto_prune.to_string()),
         ["sessions", "retention_days"] => Ok(config.sessions.retention_days.to_string()),
         ["sessions", "vacuum_after_prune"] => Ok(config.sessions.vacuum_after_prune.to_string()),
@@ -1471,9 +1497,29 @@ pub fn web_config_env_bridge_key(key: &str) -> Option<&'static str> {
         .find_map(|(config_key, env_key)| (*config_key == normalized).then_some(*env_key))
 }
 
+pub fn display_config_env_bridge_pairs() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("busy_input_mode", "HERMES_GATEWAY_BUSY_INPUT_MODE"),
+        ("busy_ack_enabled", "HERMES_GATEWAY_BUSY_ACK_ENABLED"),
+    ]
+}
+
+pub fn display_config_env_bridge_key(key: &str) -> Option<&'static str> {
+    let normalized = key
+        .trim()
+        .strip_prefix("display.")
+        .unwrap_or_else(|| key.trim())
+        .replace('-', "_")
+        .to_ascii_lowercase();
+    display_config_env_bridge_pairs()
+        .iter()
+        .find_map(|(config_key, env_key)| (*config_key == normalized).then_some(*env_key))
+}
+
 fn config_env_bridge_key(key: &str) -> Option<String> {
     terminal_config_env_bridge_key(key)
         .or_else(|| web_config_env_bridge_key(key))
+        .or_else(|| display_config_env_bridge_key(key))
         .map(ToString::to_string)
 }
 
@@ -1943,6 +1989,31 @@ fn apply_web_env_overrides(config: &mut WebConfig) {
     }
 }
 
+fn bridge_display_config_to_env(display: &DisplayConfig) {
+    if let Some(mode) = display
+        .busy_input_mode
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        set_env_if_missing("HERMES_GATEWAY_BUSY_INPUT_MODE", mode.to_string());
+    }
+    if let Some(enabled) = display.busy_ack_enabled {
+        set_env_if_missing("HERMES_GATEWAY_BUSY_ACK_ENABLED", enabled.to_string());
+    }
+}
+
+fn apply_display_env_overrides(config: &mut DisplayConfig) {
+    if let Some(v) = env_var_nonempty("HERMES_GATEWAY_BUSY_INPUT_MODE") {
+        config.busy_input_mode = Some(v);
+    }
+    if let Some(v) = env_var_nonempty("HERMES_GATEWAY_BUSY_ACK_ENABLED") {
+        if let Some(parsed) = parse_bool_env("HERMES_GATEWAY_BUSY_ACK_ENABLED", &v) {
+            config.busy_ack_enabled = Some(parsed);
+        }
+    }
+}
+
 fn apply_terminal_env_overrides(config: &mut TerminalConfig) {
     if let Some(v) =
         env_var_nonempty("TERMINAL_ENV").or_else(|| env_var_nonempty("TERMINAL_BACKEND"))
@@ -2092,6 +2163,7 @@ fn apply_terminal_env_overrides(config: &mut TerminalConfig) {
 pub fn apply_env_overrides(config: &mut GatewayConfig) {
     apply_terminal_env_overrides(&mut config.terminal);
     apply_web_env_overrides(&mut config.web);
+    apply_display_env_overrides(&mut config.display);
 
     if let Ok(v) = std::env::var("HERMES_MODEL") {
         config.model = Some(v);
@@ -2385,6 +2457,13 @@ mod tests {
 
     fn clear_web_env_bridge_vars() {
         for (_, env_key) in web_config_env_bridge_pairs() {
+            // SAFETY: tests serialize env mutation with ENV_LOCK.
+            unsafe { std::env::remove_var(env_key) };
+        }
+    }
+
+    fn clear_display_env_bridge_vars() {
+        for (_, env_key) in display_config_env_bridge_pairs() {
             // SAFETY: tests serialize env mutation with ENV_LOCK.
             unsafe { std::env::remove_var(env_key) };
         }
@@ -2882,6 +2961,89 @@ personalities: null
         let env_text = std::fs::read_to_string(dir.path().join(".env")).unwrap();
         assert!(env_text.contains("HERMES_WEB_SEARCH_BACKEND=brave-free"));
         clear_web_env_bridge_vars();
+    }
+
+    #[test]
+    fn display_config_bridge_map_covers_busy_runtime_keys() {
+        let keys = display_config_env_bridge_pairs()
+            .iter()
+            .map(|(key, _)| *key)
+            .collect::<std::collections::HashSet<_>>();
+        for key in ["busy_input_mode", "busy_ack_enabled"] {
+            assert!(keys.contains(key), "missing display bridge key: {key}");
+            assert!(
+                display_config_env_bridge_key(&format!("display.{key}")).is_some(),
+                "display.{key} should map to an env var"
+            );
+        }
+    }
+
+    #[test]
+    fn set_user_config_value_bridges_display_busy_keys() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_display_env_bridge_vars();
+        let dir = tempdir().unwrap();
+        for (key, value, env_key) in [
+            (
+                "display.busy_input_mode",
+                "steer",
+                "HERMES_GATEWAY_BUSY_INPUT_MODE",
+            ),
+            (
+                "display.busy_ack_enabled",
+                "false",
+                "HERMES_GATEWAY_BUSY_ACK_ENABLED",
+            ),
+        ] {
+            let result = set_user_config_value(dir.path(), key, value).unwrap();
+            assert!(result.wrote_config(), "{key} should write config");
+            assert!(result.wrote_env(), "{key} should write env");
+            assert_eq!(result.env_key.as_deref(), Some(env_key));
+        }
+        let env_text = std::fs::read_to_string(dir.path().join(".env")).unwrap();
+        assert!(env_text.contains("HERMES_GATEWAY_BUSY_INPUT_MODE=steer"));
+        assert!(env_text.contains("HERMES_GATEWAY_BUSY_ACK_ENABLED=false"));
+        clear_display_env_bridge_vars();
+    }
+
+    #[test]
+    fn load_config_bridges_display_yaml_to_env_without_overriding_existing_env() {
+        use tempfile::tempdir;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_display_env_bridge_vars();
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.yaml"),
+            r#"
+display:
+  busy_input_mode: steer
+  busy_ack_enabled: false
+"#,
+        )
+        .unwrap();
+        unsafe { std::env::set_var("HERMES_GATEWAY_BUSY_INPUT_MODE", "queue") };
+
+        let cfg =
+            load_config(Some(dir.path().to_string_lossy().as_ref())).expect("load display config");
+
+        assert_eq!(cfg.display.normalized_busy_input_mode(), "queue");
+        assert!(!cfg.display.busy_ack_enabled());
+        assert_eq!(
+            std::env::var("HERMES_GATEWAY_BUSY_INPUT_MODE")
+                .ok()
+                .as_deref(),
+            Some("queue")
+        );
+        assert_eq!(
+            std::env::var("HERMES_GATEWAY_BUSY_ACK_ENABLED")
+                .ok()
+                .as_deref(),
+            Some("false")
+        );
+        clear_display_env_bridge_vars();
     }
 
     #[test]

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -16,6 +16,10 @@ pub enum GatewayCommandResult {
     SwitchPersonality { name: String, reply: String },
     /// Stop the currently running agent task.
     StopAgent(String),
+    /// Queue a follow-up prompt for the currently active session.
+    QueuePrompt { prompt: String },
+    /// Steer the currently active session without starting a new turn.
+    SteerPrompt { prompt: String },
     /// Show usage statistics.
     ShowUsage(String),
     /// Compress the conversation context.
@@ -545,17 +549,18 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
             if args.is_empty() {
                 GatewayCommandResult::Reply("Usage: /queue <prompt>".to_string())
             } else {
-                GatewayCommandResult::Reply(format!(
-                    "🧵 Queued follow-up for the active session: {}",
-                    args
-                ))
+                GatewayCommandResult::QueuePrompt {
+                    prompt: args.clone(),
+                }
             }
         }
         "/steer" => {
             if args.is_empty() {
                 GatewayCommandResult::Reply("Usage: /steer <prompt>".to_string())
             } else {
-                GatewayCommandResult::Reply(format!("🧭 Steering instruction accepted: {}", args))
+                GatewayCommandResult::SteerPrompt {
+                    prompt: args.clone(),
+                }
             }
         }
         "/btw" => {

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -36,6 +36,10 @@ use crate::hooks::{HookEvent, HookRegistry};
 use crate::media::validate_media_delivery_path;
 use crate::platforms::helpers::{extract_inline_images, extract_media_markers};
 use crate::session::{Session, SessionManager};
+use crate::session_control::{
+    ActiveSessionControl, BusyInputMode, BusySessionCoordinator, MessageEvent, MessageType,
+    ProcessingOutcome, SessionSource,
+};
 use crate::stream::{StreamConfig, StreamManager};
 
 const DEFAULT_MESSAGE_DEDUP_CAPACITY: usize = 4096;
@@ -188,6 +192,8 @@ pub struct GatewayRuntimeContext {
     pub yolo: bool,
     pub reasoning: bool,
     pub mcp_reload_generation: u64,
+    /// Registration handle for attaching live interrupt/steer controls to a busy session.
+    pub busy_control: Option<BusyControlRegistration>,
     /// Messages queued by handlers to be delivered only after the main reply.
     pub deferred_post_delivery_messages: Option<Arc<StdMutex<Vec<String>>>>,
     /// Release flag shared with handlers for post-delivery gating.
@@ -228,6 +234,39 @@ pub type StreamingMessageHandlerWithContext = Arc<
         > + Send
         + Sync,
 >;
+
+#[derive(Clone)]
+pub struct BusyControlRegistration {
+    session_key: String,
+    coordinator: Arc<RwLock<BusySessionCoordinator>>,
+}
+
+impl std::fmt::Debug for BusyControlRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BusyControlRegistration")
+            .field("session_key", &self.session_key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BusyControlRegistration {
+    fn new(
+        session_key: impl Into<String>,
+        coordinator: Arc<RwLock<BusySessionCoordinator>>,
+    ) -> Self {
+        Self {
+            session_key: session_key.into(),
+            coordinator,
+        }
+    }
+
+    pub async fn attach(&self, control: Arc<dyn ActiveSessionControl>) -> bool {
+        self.coordinator
+            .write()
+            .await
+            .attach_control(&self.session_key, control)
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 struct UsageStats {
@@ -515,6 +554,8 @@ pub struct Gateway {
     platform_access_policies: RwLock<HashMap<String, PlatformAccessPolicy>>,
     /// Bounded duplicate guard for platform redeliveries/restarts.
     message_deduplicator: RwLock<MessageDeduplicator>,
+    /// Active gateway sessions plus queued/steered busy follow-ups.
+    busy_sessions: Arc<RwLock<BusySessionCoordinator>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -644,6 +685,7 @@ impl Gateway {
             hook_registry: RwLock::new(None),
             platform_access_policies: RwLock::new(HashMap::new()),
             message_deduplicator: RwLock::new(MessageDeduplicator::default()),
+            busy_sessions: Arc::new(RwLock::new(BusySessionCoordinator::default())),
         }
     }
 
@@ -859,6 +901,50 @@ impl Gateway {
         sessions.len()
     }
 
+    fn busy_input_mode(&self) -> BusyInputMode {
+        match self.config.display.normalized_busy_input_mode() {
+            "queue" => BusyInputMode::Queue,
+            "steer" => BusyInputMode::Steer,
+            _ => BusyInputMode::Interrupt,
+        }
+    }
+
+    fn incoming_to_busy_event(incoming: &IncomingMessage, text: impl Into<String>) -> MessageEvent {
+        let mut source = SessionSource::new(
+            &incoming.platform,
+            &incoming.chat_id,
+            if incoming.is_dm { "dm" } else { "group" },
+        )
+        .with_user(&incoming.user_id);
+        if let Some(thread_id) = incoming
+            .thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            source = source.with_thread(thread_id);
+        }
+        let mut event = MessageEvent::text(text, source);
+        event.message_id = incoming.message_id.clone();
+        event.message_type = MessageType::Text;
+        event
+    }
+
+    fn busy_event_to_incoming(event: MessageEvent) -> IncomingMessage {
+        IncomingMessage {
+            platform: event.source.platform,
+            chat_id: event.source.chat_id,
+            user_id: event
+                .source
+                .user_id
+                .unwrap_or_else(|| "unknown".to_string()),
+            text: event.text,
+            message_id: event.message_id,
+            thread_id: event.source.thread_id,
+            is_dm: event.source.chat_type.eq_ignore_ascii_case("dm"),
+        }
+    }
+
     /// Register a platform adapter under the given name.
     pub async fn register_adapter(
         &self,
@@ -926,6 +1012,33 @@ impl Gateway {
         incoming: &IncomingMessage,
         sender: IncomingSender,
     ) -> Result<(), GatewayError> {
+        let mut current = incoming.clone();
+        for drain_depth in 0..32 {
+            match self
+                .route_message_once_from_sender(&current, sender)
+                .await?
+            {
+                Some(next) => {
+                    current = next;
+                }
+                None => return Ok(()),
+            }
+            if drain_depth == 31 {
+                warn!(
+                    platform = current.platform,
+                    chat_id = current.chat_id,
+                    "busy-session drain depth reached safety cap"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn route_message_once_from_sender(
+        &self,
+        incoming: &IncomingMessage,
+        sender: IncomingSender,
+    ) -> Result<Option<IncomingMessage>, GatewayError> {
         let access_policy = self.platform_access_policy(&incoming.platform).await;
         let is_slash_command = incoming.text.trim_start().starts_with('/');
         if let Some(policy) = access_policy.as_ref() {
@@ -938,7 +1051,7 @@ impl Gateway {
                         chat_id = incoming.chat_id,
                         "Group message denied: channel is ignored by platform policy"
                     );
-                    return Ok(());
+                    return Ok(None);
                 }
                 if !policy.is_channel_allowed(&incoming.chat_id) {
                     debug!(
@@ -946,7 +1059,7 @@ impl Gateway {
                         chat_id = incoming.chat_id,
                         "Group message denied: channel not in platform allowlist"
                     );
-                    return Ok(());
+                    return Ok(None);
                 }
                 match policy.group_mode {
                     GroupAccessMode::Disabled => {
@@ -955,7 +1068,7 @@ impl Gateway {
                             user_id = incoming.user_id,
                             "Group traffic denied by platform policy"
                         );
-                        return Ok(());
+                        return Ok(None);
                     }
                     GroupAccessMode::Allowlist => {
                         if !bypasses_user_allowlist
@@ -967,7 +1080,7 @@ impl Gateway {
                                 user_id = incoming.user_id,
                                 "Group message denied: user not in allowlist"
                             );
-                            return Ok(());
+                            return Ok(None);
                         }
                     }
                     GroupAccessMode::Open => {}
@@ -984,7 +1097,7 @@ impl Gateway {
                     user_id = incoming.user_id,
                     "Slash command denied: user not in platform allowlist"
                 );
-                return Ok(());
+                return Ok(None);
             }
         }
 
@@ -1005,7 +1118,7 @@ impl Gateway {
                         self.send_message(&incoming.platform, &incoming.chat_id, &msg, None)
                             .await?;
                     }
-                    return Ok(());
+                    return Ok(None);
                 }
                 DmDecision::Deny => {
                     debug!(
@@ -1013,7 +1126,7 @@ impl Gateway {
                         platform = incoming.platform,
                         "DM denied for unauthorized user"
                     );
-                    return Ok(());
+                    return Ok(None);
                 }
             }
         }
@@ -1025,7 +1138,7 @@ impl Gateway {
                 message_id = incoming.message_id.as_deref().unwrap_or_default(),
                 "Duplicate platform message redelivery suppressed"
             );
-            return Ok(());
+            return Ok(None);
         }
 
         // 2. Get or create session
@@ -1060,13 +1173,39 @@ impl Gateway {
 
         let mut agent_text_override: Option<String> = None;
 
+        if !is_slash_command {
+            let decision = {
+                let mut busy = self.busy_sessions.write().await;
+                busy.handle_busy_message(
+                    &session_key,
+                    Self::incoming_to_busy_event(incoming, incoming.text.clone()),
+                    self.busy_input_mode(),
+                )
+            };
+            if decision.handled {
+                if self.config.display.busy_ack_enabled() {
+                    if let Some(ack) = decision.ack {
+                        self.send_message_threaded(
+                            &incoming.platform,
+                            &incoming.chat_id,
+                            &ack,
+                            None,
+                            Self::reply_thread_id(incoming),
+                        )
+                        .await?;
+                    }
+                }
+                return Ok(None);
+            }
+        }
+
         // Slash commands are executed directly by the gateway command runtime.
         // Installed skill commands are the exception: after built-ins and quick
         // commands decline them, they are converted into a normal agent turn
         // containing the resolved SKILL.md content.
         if is_slash_command {
             match self.execute_slash_command(incoming, &session_key).await? {
-                SlashCommandOutcome::Handled => return Ok(()),
+                SlashCommandOutcome::Handled => return Ok(None),
                 SlashCommandOutcome::ForwardToAgent { message } => {
                     agent_text_override = Some(message);
                 }
@@ -1115,11 +1254,14 @@ impl Gateway {
         let messages = self.session_manager.get_messages(&session_key).await;
 
         // 5. Process through agent loop (streaming or non-streaming)
+        {
+            let mut busy = self.busy_sessions.write().await;
+            busy.mark_active(&session_key, None);
+        }
         let processing_result = if self.config.streaming_enabled {
-            self.route_streaming(&incoming, messages, &session_key)
-                .await
+            self.route_streaming(incoming, messages, &session_key).await
         } else {
-            self.route_non_streaming(&incoming, messages, &session_key)
+            self.route_non_streaming(incoming, messages, &session_key)
                 .await
         };
 
@@ -1159,8 +1301,20 @@ impl Gateway {
             }
         }
 
+        let pending = {
+            let mut busy = self.busy_sessions.write().await;
+            busy.finish(
+                &session_key,
+                if processing_result.is_ok() {
+                    ProcessingOutcome::Success
+                } else {
+                    ProcessingOutcome::Failure
+                },
+            )
+            .map(Self::busy_event_to_incoming)
+        };
         processing_result?;
-        Ok(())
+        Ok(pending)
     }
 
     fn quick_command_key(raw: &str) -> String {
@@ -1262,6 +1416,12 @@ impl Gateway {
                     | GatewayCommandResult::ShowVersion(text)
                     | GatewayCommandResult::CompressContext(text)
                     | GatewayCommandResult::StopAgent(text) => Some(text),
+                    GatewayCommandResult::QueuePrompt { prompt } => Some(format!(
+                        "🧵 Queued follow-up for the active session: {prompt}"
+                    )),
+                    GatewayCommandResult::SteerPrompt { prompt } => {
+                        Some(format!("🧭 Steering instruction accepted: {prompt}"))
+                    }
                     GatewayCommandResult::SwitchModel { reply, .. }
                     | GatewayCommandResult::SwitchFast { reply, .. }
                     | GatewayCommandResult::SwitchPersonality { reply, .. }
@@ -1584,8 +1744,70 @@ impl Gateway {
                         let _ = self.background_tasks.cancel(&task_id);
                     }
                 }
+                {
+                    let mut busy = self.busy_sessions.write().await;
+                    let _ = busy.interrupt_active(
+                        session_key,
+                        "User requested /stop for the active gateway task.",
+                    );
+                }
                 self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
                     .await?;
+                Ok(true)
+            }
+            GatewayCommandResult::QueuePrompt { prompt } => {
+                let active = {
+                    let mut busy = self.busy_sessions.write().await;
+                    let active = busy.is_active(session_key);
+                    if active {
+                        busy.queue_message(
+                            session_key,
+                            Self::incoming_to_busy_event(incoming, prompt.clone()),
+                        );
+                    }
+                    active
+                };
+                let reply = if active {
+                    format!("🧵 Queued follow-up for the active session: {prompt}")
+                } else {
+                    "No active gateway turn is running. Send the prompt normally to start it."
+                        .to_string()
+                };
+                self.send_message_threaded(
+                    &incoming.platform,
+                    &incoming.chat_id,
+                    &reply,
+                    None,
+                    Self::reply_thread_id(incoming),
+                )
+                .await?;
+                Ok(true)
+            }
+            GatewayCommandResult::SteerPrompt { prompt } => {
+                let decision = {
+                    let mut busy = self.busy_sessions.write().await;
+                    busy.handle_busy_message(
+                        session_key,
+                        Self::incoming_to_busy_event(incoming, prompt.clone()),
+                        BusyInputMode::Steer,
+                    )
+                };
+                let reply = if decision.steered {
+                    format!("🧭 Steered the running task: {prompt}")
+                } else if decision.queued {
+                    format!("🧵 No live steering hook was ready; queued follow-up: {prompt}")
+                } else {
+                    "No active gateway turn is running. Use /steer while a task is in flight."
+                        .to_string()
+                };
+                self.send_message_threaded(
+                    &incoming.platform,
+                    &incoming.chat_id,
+                    &reply,
+                    None,
+                    Self::reply_thread_id(incoming),
+                )
+                .await?;
                 Ok(true)
             }
             GatewayCommandResult::ShowUsage(_) => {
@@ -2384,6 +2606,10 @@ impl Gateway {
             yolo: state.yolo,
             reasoning: state.reasoning,
             mcp_reload_generation,
+            busy_control: Some(BusyControlRegistration::new(
+                session_key,
+                self.busy_sessions.clone(),
+            )),
             deferred_post_delivery_messages: None,
             deferred_post_delivery_released: None,
         }
@@ -2569,9 +2795,13 @@ impl Gateway {
             .into_iter()
             .filter(|(_, status, _)| *status == TaskStatus::Running)
             .count();
+        let (busy_active, busy_pending) = {
+            let busy = self.busy_sessions.read().await;
+            (busy.is_active(session_key), busy.pending_len(session_key))
+        };
 
         format!(
-            "🧭 Gateway status\n- title: {}\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- service tier: {}\n- reasoning: {}\n- verbose: {}\n- tool progress: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
+            "🧭 Gateway status\n- title: {}\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- service tier: {}\n- reasoning: {}\n- verbose: {}\n- tool progress: {}\n- busy input: {}\n- busy ack: {}\n- busy active: {}\n- busy queued: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
             title.unwrap_or_else(|| "(untitled)".to_string()),
             state.model.unwrap_or_else(|| "default".to_string()),
             state.provider.unwrap_or_else(|| "default".to_string()),
@@ -2585,6 +2815,14 @@ impl Gateway {
             if state.reasoning { "ON" } else { "OFF" },
             if state.verbose { "ON" } else { "OFF" },
             state.tool_progress.unwrap_or_else(|| "default".to_string()),
+            self.config.display.normalized_busy_input_mode(),
+            if self.config.display.busy_ack_enabled() {
+                "ON"
+            } else {
+                "OFF"
+            },
+            if busy_active { "yes" } else { "no" },
+            busy_pending,
             if state.yolo { "ON" } else { "OFF" },
             state.home.unwrap_or_else(|| "(not set)".to_string()),
             messages.len(),
@@ -3281,6 +3519,12 @@ mod tests {
 
     struct FailingHook;
 
+    #[derive(Default)]
+    struct BusyControlProbe {
+        interrupts: Mutex<Vec<String>>,
+        steers: Mutex<Vec<String>>,
+    }
+
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     struct HermesHomeEnvGuard {
@@ -3320,6 +3564,18 @@ mod tests {
         }
     }
 
+    fn test_incoming(text: impl Into<String>) -> IncomingMessage {
+        IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: text.into(),
+            message_id: None,
+            thread_id: None,
+            is_dm: true,
+        }
+    }
+
     #[async_trait]
     impl HookHandler for RecordingHook {
         async fn handle(&self, event: &HookEvent) -> Result<(), String> {
@@ -3343,6 +3599,17 @@ mod tests {
 
         fn name(&self) -> &str {
             "failing-hook"
+        }
+    }
+
+    impl ActiveSessionControl for BusyControlProbe {
+        fn interrupt(&self, message: &str) {
+            self.interrupts.lock().unwrap().push(message.to_string());
+        }
+
+        fn steer(&self, message: &str) -> bool {
+            self.steers.lock().unwrap().push(message.to_string());
+            true
         }
     }
 
@@ -6764,6 +7031,295 @@ mod tests {
             .map(|(_, ctx)| ctx.clone())
             .expect("agent:end payload should exist");
         assert_eq!(end_payload["success"], serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn gateway_busy_queue_mode_drains_fifo_followups() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let mut cfg = GatewayConfig::default();
+        cfg.display.busy_input_mode = Some("queue".to_string());
+        let gw = Arc::new(Gateway::new(session_mgr, dm_manager, cfg));
+        gw.register_adapter("test", adapter).await;
+
+        let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
+        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let calls_for_handler = calls.clone();
+        let entered_for_handler = entered_tx.clone();
+        let release_for_handler = release_rx.clone();
+        gw.set_message_handler(Arc::new(move |messages| {
+            let calls = calls_for_handler.clone();
+            let entered = entered_for_handler.clone();
+            let release = release_for_handler.clone();
+            Box::pin(async move {
+                let latest = messages
+                    .iter()
+                    .rev()
+                    .find_map(|m| {
+                        (m.role == MessageRole::User)
+                            .then(|| m.content.clone())
+                            .flatten()
+                    })
+                    .unwrap_or_default();
+                calls.lock().unwrap().push(latest.clone());
+                if latest == "first" {
+                    if let Some(tx) = entered.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    if let Some(rx) = release.lock().await.take() {
+                        let _ = rx.await;
+                    }
+                }
+                Ok(format!("reply:{latest}"))
+            })
+        }))
+        .await;
+
+        let gw_first = gw.clone();
+        let first_task =
+            tokio::spawn(async move { gw_first.route_message(&test_incoming("first")).await });
+        entered_rx.await.expect("first route should enter handler");
+        gw.route_message(&test_incoming("second"))
+            .await
+            .expect("second route should queue");
+        release_tx.send(()).expect("release first route");
+        first_task
+            .await
+            .expect("first task join")
+            .expect("first route result");
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["first".to_string(), "second".to_string()]
+        );
+        let texts: Vec<String> = sent
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(_, text)| text.clone())
+            .collect();
+        assert!(texts
+            .iter()
+            .any(|text| text.contains("Queued for the next turn")));
+        assert!(texts.iter().any(|text| text == "reply:first"));
+        assert!(texts.iter().any(|text| text == "reply:second"));
+    }
+
+    #[tokio::test]
+    async fn gateway_busy_queue_ack_can_be_suppressed() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let mut cfg = GatewayConfig::default();
+        cfg.display.busy_input_mode = Some("queue".to_string());
+        cfg.display.busy_ack_enabled = Some(false);
+        let gw = Arc::new(Gateway::new(session_mgr, dm_manager, cfg));
+        gw.register_adapter("test", adapter).await;
+
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
+        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let entered_for_handler = entered_tx.clone();
+        let release_for_handler = release_rx.clone();
+        gw.set_message_handler(Arc::new(move |messages| {
+            let entered = entered_for_handler.clone();
+            let release = release_for_handler.clone();
+            Box::pin(async move {
+                let latest = messages
+                    .iter()
+                    .rev()
+                    .find_map(|m| {
+                        (m.role == MessageRole::User)
+                            .then(|| m.content.clone())
+                            .flatten()
+                    })
+                    .unwrap_or_default();
+                if latest == "first" {
+                    if let Some(tx) = entered.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    if let Some(rx) = release.lock().await.take() {
+                        let _ = rx.await;
+                    }
+                }
+                Ok(format!("reply:{latest}"))
+            })
+        }))
+        .await;
+
+        let gw_first = gw.clone();
+        let first_task =
+            tokio::spawn(async move { gw_first.route_message(&test_incoming("first")).await });
+        entered_rx.await.expect("first route should enter handler");
+        gw.route_message(&test_incoming("second"))
+            .await
+            .expect("second route should queue silently");
+        assert!(
+            sent.lock()
+                .unwrap()
+                .iter()
+                .all(|(_, text)| !text.contains("Queued for the next turn")),
+            "automatic busy ack should be suppressed"
+        );
+        release_tx.send(()).expect("release first route");
+        first_task
+            .await
+            .expect("first task join")
+            .expect("first route result");
+    }
+
+    #[tokio::test]
+    async fn gateway_queue_command_bypasses_busy_guard_and_drains() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let mut cfg = GatewayConfig::default();
+        cfg.display.busy_input_mode = Some("interrupt".to_string());
+        let gw = Arc::new(Gateway::new(session_mgr, dm_manager, cfg));
+        gw.register_adapter("test", adapter).await;
+
+        let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
+        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let calls_for_handler = calls.clone();
+        let entered_for_handler = entered_tx.clone();
+        let release_for_handler = release_rx.clone();
+        gw.set_message_handler(Arc::new(move |messages| {
+            let calls = calls_for_handler.clone();
+            let entered = entered_for_handler.clone();
+            let release = release_for_handler.clone();
+            Box::pin(async move {
+                let latest = messages
+                    .iter()
+                    .rev()
+                    .find_map(|m| {
+                        (m.role == MessageRole::User)
+                            .then(|| m.content.clone())
+                            .flatten()
+                    })
+                    .unwrap_or_default();
+                calls.lock().unwrap().push(latest.clone());
+                if latest == "first" {
+                    if let Some(tx) = entered.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    if let Some(rx) = release.lock().await.take() {
+                        let _ = rx.await;
+                    }
+                }
+                Ok(format!("reply:{latest}"))
+            })
+        }))
+        .await;
+
+        let gw_first = gw.clone();
+        let first_task =
+            tokio::spawn(async move { gw_first.route_message(&test_incoming("first")).await });
+        entered_rx.await.expect("first route should enter handler");
+        gw.route_message(&test_incoming("/queue second"))
+            .await
+            .expect("/queue should bypass and enqueue");
+        release_tx.send(()).expect("release first route");
+        first_task
+            .await
+            .expect("first task join")
+            .expect("first route result");
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["first".to_string(), "second".to_string()]
+        );
+        assert!(sent
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(_, text)| text.contains("Queued follow-up for the active session")));
+    }
+
+    #[tokio::test]
+    async fn gateway_steer_command_uses_attached_busy_control() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let gw = Arc::new(Gateway::new(
+            session_mgr,
+            dm_manager,
+            GatewayConfig::default(),
+        ));
+        gw.register_adapter("test", adapter).await;
+
+        let control = Arc::new(BusyControlProbe::default());
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
+        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let control_for_handler = control.clone();
+        let entered_for_handler = entered_tx.clone();
+        let release_for_handler = release_rx.clone();
+        gw.set_message_handler_with_context(Arc::new(move |_messages, ctx| {
+            let control = control_for_handler.clone();
+            let entered = entered_for_handler.clone();
+            let release = release_for_handler.clone();
+            Box::pin(async move {
+                if let Some(registration) = ctx.busy_control {
+                    assert!(registration.attach(control).await);
+                }
+                if let Some(tx) = entered.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+                if let Some(rx) = release.lock().await.take() {
+                    let _ = rx.await;
+                }
+                Ok("reply:first".to_string())
+            })
+        }))
+        .await;
+
+        let gw_first = gw.clone();
+        let first_task =
+            tokio::spawn(async move { gw_first.route_message(&test_incoming("first")).await });
+        entered_rx.await.expect("first route should attach control");
+        gw.route_message(&test_incoming("/steer check tests"))
+            .await
+            .expect("/steer should use attached control");
+        release_tx.send(()).expect("release first route");
+        first_task
+            .await
+            .expect("first task join")
+            .expect("first route result");
+
+        assert_eq!(
+            control.steers.lock().unwrap().as_slice(),
+            ["check tests".to_string()]
+        );
+        assert!(sent
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(_, text)| text.contains("Steered the running task")));
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -49,8 +49,9 @@ pub use agent_cache::{
     GatewayAgentCache,
 };
 pub use session_control::{
-    build_session_key, BusyInputMode, BusyMessageDecision, BusySessionCoordinator, MessageEvent,
-    MessageType, ProcessingOutcome, SessionSource,
+    build_session_key, ActiveSessionControl, AgentActivitySummary, BusyInputMode,
+    BusyMessageDecision, BusySessionCoordinator, MessageEvent, MessageType, ProcessingOutcome,
+    SessionSource,
 };
 
 // Re-export session management

--- a/crates/hermes-gateway/src/session_control.rs
+++ b/crates/hermes-gateway/src/session_control.rs
@@ -3,7 +3,7 @@
 //! These helpers model the Python gateway's active-session guard without
 //! coupling platform adapters to a concrete Rust agent implementation.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -192,7 +192,7 @@ struct ActiveSession {
 
 pub struct BusySessionCoordinator {
     active: HashMap<String, ActiveSession>,
-    pending: HashMap<String, MessageEvent>,
+    pending: HashMap<String, VecDeque<MessageEvent>>,
     busy_ack_ts: HashMap<String, Instant>,
     ack_cooldown: Duration,
 }
@@ -241,21 +241,70 @@ impl BusySessionCoordinator {
         session_key: &str,
         _outcome: ProcessingOutcome,
     ) -> Option<MessageEvent> {
-        self.reset_session(session_key)
+        self.active.remove(session_key);
+        self.busy_ack_ts.remove(session_key);
+        self.pop_pending(session_key)
     }
 
     pub fn reset_session(&mut self, session_key: &str) -> Option<MessageEvent> {
         self.active.remove(session_key);
         self.busy_ack_ts.remove(session_key);
-        self.pending.remove(session_key)
+        self.pending
+            .remove(session_key)
+            .and_then(|mut queue| queue.pop_front())
     }
 
     pub fn is_active(&self, session_key: &str) -> bool {
         self.active.contains_key(session_key)
     }
 
+    pub fn attach_control(
+        &mut self,
+        session_key: &str,
+        control: Arc<dyn ActiveSessionControl>,
+    ) -> bool {
+        let Some(active) = self.active.get_mut(session_key) else {
+            return false;
+        };
+        active.control = Some(control);
+        true
+    }
+
+    pub fn interrupt_active(&mut self, session_key: &str, message: &str) -> bool {
+        let Some(active) = self.active.get(session_key) else {
+            return false;
+        };
+        let Some(control) = active.control.as_ref() else {
+            return false;
+        };
+        control.interrupt(message);
+        true
+    }
+
     pub fn pending(&self, session_key: &str) -> Option<&MessageEvent> {
-        self.pending.get(session_key)
+        self.pending
+            .get(session_key)
+            .and_then(|queue| queue.front())
+    }
+
+    pub fn pending_len(&self, session_key: &str) -> usize {
+        self.pending
+            .get(session_key)
+            .map(VecDeque::len)
+            .unwrap_or(0)
+    }
+
+    pub fn queue_message(&mut self, session_key: &str, event: MessageEvent) {
+        self.queue_event(session_key, event);
+    }
+
+    fn pop_pending(&mut self, session_key: &str) -> Option<MessageEvent> {
+        let queue = self.pending.get_mut(session_key)?;
+        let event = queue.pop_front();
+        if queue.is_empty() {
+            self.pending.remove(session_key);
+        }
+        event
     }
 
     fn should_ack_at(&mut self, session_key: &str, now: Instant) -> bool {
@@ -271,7 +320,10 @@ impl BusySessionCoordinator {
     }
 
     fn queue_event(&mut self, session_key: &str, event: MessageEvent) {
-        self.pending.insert(session_key.to_string(), event);
+        self.pending
+            .entry(session_key.to_string())
+            .or_default()
+            .push_back(event);
     }
 
     pub fn handle_busy_message_at(
@@ -306,15 +358,27 @@ impl BusySessionCoordinator {
             BusyInputMode::Interrupt => {
                 if let Some(control) = active.control.as_ref() {
                     control.interrupt(&event.text);
-                }
-                BusyMessageDecision {
-                    handled: true,
-                    queued: false,
-                    interrupted: active.control.is_some(),
-                    steered: false,
-                    ack: self
-                        .should_ack_at(session_key, now)
-                        .then(|| interrupt_ack(active.started_at, active.control.as_deref(), now)),
+                    BusyMessageDecision {
+                        handled: true,
+                        queued: false,
+                        interrupted: true,
+                        steered: false,
+                        ack: self.should_ack_at(session_key, now).then(|| {
+                            interrupt_ack(active.started_at, active.control.as_deref(), now)
+                        }),
+                    }
+                } else {
+                    self.queue_event(session_key, event);
+                    BusyMessageDecision {
+                        handled: true,
+                        queued: true,
+                        interrupted: false,
+                        steered: false,
+                        ack: self.should_ack_at(session_key, now).then(|| {
+                            "Queued for the next turn. I will respond once the current task finishes."
+                                .to_string()
+                        }),
+                    }
                 }
             }
             BusyInputMode::Steer => {
@@ -481,7 +545,8 @@ mod tests {
             now + Duration::from_secs(1),
         );
         assert!(second.ack.is_none());
-        assert_eq!(coord.pending(&key).unwrap().text, "still there");
+        assert_eq!(coord.pending(&key).unwrap().text, "follow up");
+        assert_eq!(coord.pending_len(&key), 2);
     }
 
     #[test]
@@ -510,6 +575,36 @@ mod tests {
         assert!(ack.contains("21/60"));
         assert!(ack.contains("terminal"));
         assert!(ack.contains("10 min"));
+    }
+
+    #[test]
+    fn interrupt_without_control_queues_instead_of_dropping_message() {
+        let mut coord = BusySessionCoordinator::default();
+        let key = build_session_key(&source("10"));
+        coord.mark_active(&key, None);
+
+        let decision = coord.handle_busy_message(
+            &key,
+            event("do not drop me", "10"),
+            BusyInputMode::Interrupt,
+        );
+
+        assert!(decision.handled);
+        assert!(decision.queued);
+        assert!(!decision.interrupted);
+        assert_eq!(coord.pending(&key).unwrap().text, "do not drop me");
+    }
+
+    #[test]
+    fn attached_control_can_be_interrupted_directly() {
+        let mut coord = BusySessionCoordinator::default();
+        let key = build_session_key(&source("10"));
+        let control = Arc::new(MockControl::default());
+        coord.mark_active(&key, None);
+
+        assert!(coord.attach_control(&key, control.clone()));
+        assert!(coord.interrupt_active(&key, "stop now"));
+        assert_eq!(control.interrupts.lock().unwrap().as_slice(), ["stop now"]);
     }
 
     #[test]
@@ -566,10 +661,11 @@ mod tests {
         let key = build_session_key(&source("10"));
         coord.mark_active(&key, None);
         coord.handle_busy_message(&key, event("queued", "10"), BusyInputMode::Queue);
+        coord.handle_busy_message(&key, event("next", "10"), BusyInputMode::Queue);
         let pending = coord.finish(&key, ProcessingOutcome::Success).unwrap();
         assert_eq!(pending.text, "queued");
         assert!(!coord.is_active(&key));
-        assert!(coord.pending(&key).is_none());
+        assert_eq!(coord.pending(&key).unwrap().text, "next");
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3931,6 +3931,21 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust already provides Home Assistant as first-class native runtime surface: REST backend, ha_list_entities/ha_get_state/ha_list_services/ha_call_service handlers, homeassistant toolset and aliases, send-message platform routing, and gateway adapter coverage. The upstream Python bundled-plugin migration is represented by Rust-native built-in registration and platform contract tests rather than a Python plugin package."
+    },
+    "2d232c999115": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust gateway: display.busy_input_mode is typed/normalized and bridged through HERMES_GATEWAY_BUSY_INPUT_MODE; active-session plain text can queue instead of interrupting, explicit /queue bypasses the busy guard and enqueues a FIFO follow-up, and gateway tests cover queue drain plus ack suppression."
+    },
+    "2edebedc9eeb": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: /steer is a structured gateway command, active gateway sessions expose a BusyControlRegistration, hermes-cli attaches AgentLoop InterruptController as ActiveSessionControl, and steer sends the trusted hermes_agent::format_steer_marker into the live run with regression coverage."
+    },
+    "635253b9185f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: display.busy_input_mode accepts interrupt/queue/steer, display.busy_ack_enabled suppresses automatic busy acknowledgements, env/config-set bridges cover HERMES_GATEWAY_BUSY_INPUT_MODE and HERMES_GATEWAY_BUSY_ACK_ENABLED, and gateway tests cover steer fallback/attachment and quiet queueing."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,27 +1,127 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-16T23:55:38.405701+00:00`
+Generated: `2026-06-24T08:45:17.529440+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `6132`.
+- Range: `origin/main..upstream/main`; total commits tracked: `6907`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 2661 |
-| #21 | GPAR-02 skills parity | 121 |
-| #22 | GPAR-03 UX parity | 890 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 428 |
+| #20 | GPAR-01 tests+CI parity | 3078 |
+| #21 | GPAR-02 skills parity | 130 |
+| #22 | GPAR-03 UX parity | 956 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 486 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
-| #25 | GPAR-06 packaging/docs/install parity | 135 |
-| #26 | GPAR-07 upstream queue backfill | 1875 |
+| #25 | GPAR-06 packaging/docs/install parity | 144 |
+| #26 | GPAR-07 upstream queue backfill | 2091 |
 
 | Disposition | Commit Count |
 | --- | ---: |
-| mirrored | 74 |
-| ported | 316 |
-| superseded | 5742 |
+| mirrored | 76 |
+| pending | 268 |
+| ported | 321 |
+| superseded | 6242 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| _(none)_ | - | - |
+| `2dace37f6b55` | #23 | feat(memory): improve OpenViking setup UX |
+| `b0e25c9cb295` | #23 | fix(memory): restrict OpenViking setup file permissions |
+| `70f53f36cb1c` | #23 | feat(memory): add manual OpenViking setup path |
+| `94523764fca8` | #23 | fix(memory): choose OpenViking key type before prompting |
+| `2b972472cee8` | #23 | fix(memory): validate OpenViking manual setup steps |
+| `3c76dac4fdbf` | #23 | fix(memory): log OpenViking chmod failures |
+| `2c2ca0443bba` | #20 | feat(memory): improve OpenViking setup UX |
+| `315fdae5f8ad` | #23 | fix(memory): tighten OpenViking local autostart |
+| `166d2457b292` | #23 | fix(memory): avoid setup autostart for unhealthy OpenViking |
+| `813a4e3838f6` | #23 | fix(openviking): implement on_session_switch hook (#28296) |
+| `a30b40c73ab6` | #23 | fix(openviking): close session-boundary races on sync_turn and on_session_end |
+| `eddbf291a415` | #23 | fix(openviking): close remaining session-boundary races on switch |
+| `91e9459e1006` | #23 | fix(openviking): track writers per-session so commit waits for all |
+| `00c045b43f30` | #23 | fix(openviking): harden session writes and switch commits |
+| `547a014e7eae` | #26 | fix(desktop): avoid stack overflow rendering huge fenced blocks |
+| `b82eca2bebd8` | #26 | fix(desktop): isolate message render crashes from the root boundary |
+| `3ac6551ba3d3` | #23 | fix(openviking): handle rewound session switches |
+| `435c706e8e5a` | #26 | fix(desktop): stop a failed turn leaking into every other thread |
+| `f4100f439430` | #26 | fix(desktop): list markers and quote border follow RTL message direction |
+| `0138282f97c9` | #26 | perf(desktop): keep oversized messages from freezing the chat |
+| `c6c8abbadb80` | #20 | refactor: remove agent-callable send_message tool (#47856) |
+| `c2fa302e933a` | #26 | Merge pull request #47913 from xxxigm/fix/desktop-backend-skew-toast-nag |
+| `b07b7894ec55` | #26 | fix(desktop): keep streaming painting in unfocused secondary chat windows (#47919) |
+| `33b1d144590a` | #20 | fix(desktop): pin Electron below the broken native extract-zip install (#47792) |
+| `c835448908e7` | #23 | fix(openviking): don't block the command thread on session switch; lock turn state |
+| `5a00bd151896` | #20 | fix(desktop): persist /title set before the first message instead of queuing (#47987) |
+| `ee41aa0c1a0a` | #26 | feat(desktop): add dismiss control to chat error banners (#47985) |
+| `fd674af47fa6` | #20 | fix(photon): preserve text in mixed iMessage attachments (salvage #46513) (#46818) |
+| `016bce1a09ba` | #26 | fix(desktop): recover stranded session windows when resume fails (#47655) |
+| `f8098c6b6fe5` | #20 | fix(desktop): resolve electronDist to the actual electron install location (#48081) |
+| `6092be413d59` | #20 | Harden hosted Docker install tree against self-modification (#47490) |
+| `ab1a42fcea4f` | #26 | docs: relay<->connector cross-repo contract (v1, experimental) |
+| `5feec8b4cfcb` | #20 | test(gateway): enforce relay contract-doc ⟷ Python conformance |
+| `6e20c1992ff9` | #26 | docs(gateway): rewrite contract §6 to the A2 trust-boundary model |
+| `c1f9eb0ec4b9` | #20 | fix(desktop): resolve electronDist dynamically + self-heal blocked installs (supersedes #48081/#48082) (#48091) |
+| `86f2946fbe78` | #22 | fix(dashboard): recover the Chat tab when the agent session ends (NS-504) (#47674) |
+| `4b7a18600393` | #26 | fix(desktop): retry the self-update rebuild once so the app relaunches (#48122) |
+| `c276b017adc4` | #20 | feat(relay): connector⇄gateway channel auth + signed-HTTP inbound receiver + enroll CLI (#48147) |
+| `ae8fa11097e1` | #20 | feat(cron): cron.provider config + plugins/cron discovery + resolver |
+| `4440d77bf32d` | #20 | fix(update): scope install-method stamp to the code tree, not $HERMES_HOME (#48188) |
+| `4c8bbe641696` | #20 | feat(cron): Chronos NAS-mediated managed-cron provider (scale-to-zero) |
+| `3fc7b624d860` | #20 | feat(cron,gateway): NAS-JWT fire verifier + /api/cron/fire webhook (Chronos) |
+| `b75757d4aa85` | #22 | feat(cron): wire on_jobs_changed, cron.chronos config, docs + agent↔NAS contract |
+| `5494c1e9b660` | #23 | refactor(openviking): reuse atomic_json_write for ovcli config; drop dead constants |
+| `0b54a33a3467` | #26 | fix(langfuse): scope trace state by turn/request ids |
+| `e1d10ec1ed29` | #20 | refactor(langfuse): extract _scope_prefix from _trace_key |
+| `f4fbaa6cda8b` | #20 | fix(langfuse): bound _TRACE_STATE growth from non-finalizing turns |
+| `2a5d51c16e94` | #23 | fix(openviking): adapt memory provider for current api |
+| `2f7c4858a764` | #20 | fix(tui): refresh tool snapshot when MCP discovery lands after agent build (#48403) |
+| `92e6d8c858f6` | #26 | fix(desktop): dispose open PTY sessions in before-quit handler |
+| `5ffbfed193ad` | #20 | feat(mcp-catalog): add official Unreal Engine 5.8 MCP server |
+| `0fa7d6f6609c` | #20 | fix(desktop): never persist or restore a named custom provider as bare "custom" (#48547) |
+| `51ee5b2c94d0` | #20 | fix(desktop,tui): surface self-improvement review summary + honor memory_notifications |
+| `73cd8622f9fc` | #22 | feat(billing): /billing terminal billing — interactive TUI + CLI client (#45449) |
+| `4ed2f3399418` | #26 | fix(thread): allow scrolling long user messages in chat history (#48619) |
+| `9705e7944ae4` | #20 | fix(picker): remove max_models=50 cap in interactive model pickers |
+| `49596b70cb2d` | #20 | fix(gateway): resume follows the compression tip so post-compression replies render |
+| `769f307042d2` | #26 | fix(npm): lock react-simple-icons to 13.11.1 |
+| `03d9a95a74b2` | #20 | fix(desktop): show Hindsight memory provider (#37546) |
+| `d2c53ff5583e` | #20 | feat(relay): WS-only inbound on the gateway adapter (Phase 3) (#48294) |
+| `36851fa576eb` | #20 | fix(docker): support WebUI installs from read-only sources (#48541) |
+| `c34840e22e08` | #20 | fix(cron): serve /api/cron/fire on the dashboard app (hosted-agent surface) |
+| `620fd59b8e6f` | #20 | feat(model-picker): add Refresh Models control to bust stale model cache (#48691) |
+| `cfb55de5ea49` | #21 | Update Stripe Projects skill docs (#48673) |
+| `c02192ff6ace` | #20 | feat(image-gen): add image-to-image / editing to image_generate (#48705) |
+| `c7b7f92ec14a` | #20 | fix(openviking): sync structured turns with tool parts |
+| `d7cd0bc0863c` | #20 | fix(openviking): preserve structured sync attribution |
+| `9362ce2575e0` | #22 | feat(skills): add html-artifact skill, fold in sketch + architecture-diagram + concept-diagrams (#48899) |
+| `fcac0f94d484` | #23 | fix(openviking): guard empty tool_id in batch skip set; reuse env_var_enabled |
+| `27a6e188c4b4` | #23 | refactor(openviking): derive recall-tool name set from canonical schemas |
+| `2d4046c6de97` | #23 | refactor(openviking): reuse pre-scanned tool_input for pending tool calls |
+| `be2c2beb96e5` | #23 | refactor(openviking): name tool_status constants and alias sets |
+| `1699525638ed` | #20 | fix(tui): route pending-input commands via command.dispatch (#48848) |
+| `f9ffe0bc3f61` | #26 | fix(desktop): resume stored session id on notification click |
+| `069011dd0c8f` | #26 | test(desktop): cover runtime->stored notification id resolution |
+| `bce1e36b5769` | #20 | fix(discord): unwrap dict choices + soft-boundary truncate clarify buttons |
+| `92451151c642` | #22 | Revert "feat(skills): add html-artifact skill, fold in sketch + architecture-diagram + concept-diagrams (#48899)" |
+| `9a2f2756f7e6` | #26 | fix(desktop): allow selecting slash output and shell logs in thread (#49063) |
+| `fad4b40d9d38` | #20 | fix(model): persist /model switch by default across sessions |
+| `6cb04be779de` | #26 | feat(desktop): Keys tab groups by backend provider identity |
+| `ee0de638d719` | #26 | feat(desktop): add API-keys search; keep provider lists priority-sorted |
+| `d91b8d8368bb` | #26 | test(desktop): make keyVar a typed EnvVarInfo factory |
+| `b936f92b25b4` | #26 | fix(desktop): render send/prefill directive notices (/goal, /undo) (#49073) |
+| `caaa916289f2` | #20 | fix(gateway): don't let delayed Discord status messages partition history backfill |
+| `db744e7d1e58` | #21 | feat(simplify-code): add risk-tiered application, Chesterton's Fence, slop + silent failure detection |
+| `6c44471bfdb8` | #23 | fix(hindsight): lazy-install cloud client dependency |
+| `13d4b5fe2f45` | #23 | fix(hindsight): align client version to 0.6.1 across all sources |
+| `b0e47a98f9ed` | #20 | fix(managed-scope): honor managed scope in all standalone config loaders |
+| `9026a8c78974` | #22 | feat(gateway): add Raft bundled platform plugin with activity hooks |
+| `7d86178cf51a` | #26 | fix(raft): set stdin=DEVNULL on bridge subprocess |
+| `6308d3416ab9` | #26 | fix(desktop): rename "Restart messaging" -> "Restart gateway" |
+| `553cf4f97757` | #26 | feat(desktop): restart the gateway from Cmd+K, with statusbar spinner feedback |
+| `a1639921ac44` | #26 | fix(desktop): offer a Restart gateway action on messaging save/toggle toasts |
+| `929dbf777801` | #26 | fix(desktop): make rendered logs selectable so they can be copied |
+| `93d6e730288e` | #20 | fix(mcp): expose late-connecting MCP tools to the agent (TUI/CLI/gateway) |
+| `b6e2a54a94f5` | #20 | fix(mcp): address adversarial review round 1 (cache parity, gates, races) |
+| `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
+| `ba49fb51a585` | #20 | fix(discord): hydrate channel context when replying to a message (#49212) |
+| `40722058e532` | #20 | fix(mcp): keep short-TTL HTTP sessions alive with configurable ping keepalive |
+| `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |

--- a/scripts/generate-upstream-patch-queue.py
+++ b/scripts/generate-upstream-patch-queue.py
@@ -175,6 +175,13 @@ def fetch_remote_branch(repo_root: Path, remote: str, branch: str) -> None:
     raise RuntimeError(f"git fetch {remote} {branch} failed: {proc.stderr.strip()}")
 
 
+def repo_relative_or_absolute(path: Path, repo_root: Path) -> str:
+    try:
+        return path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(path)
+
+
 def classify_ticket(files: list[str]) -> int:
     votes: Counter[int] = Counter()
     for f in files:
@@ -665,7 +672,7 @@ def main() -> int:
             "total_commits": len(rows),
             "by_target_ticket": {str(k): v for k, v in sorted(by_ticket.items())},
             "by_disposition": dict(sorted(by_disposition.items())),
-            "overrides_path": str(overrides_path),
+            "overrides_path": repo_relative_or_absolute(overrides_path, repo_root),
             "patch_equivalent_count": len(patch_equivalent),
         },
         "commits": rows,


### PR DESCRIPTION
## Summary
- Add Rust-native gateway busy input modes: `interrupt`, `queue`, and `steer`.
- Add `display.busy_input_mode` and `display.busy_ack_enabled` config/env/set/get surfaces.
- Wire active gateway AgentLoop interrupt/steer control from the CLI runtime.
- Make busy follow-ups FIFO-drained and expose `/queue`, `/q`, and `/steer` command routing.
- Mark covered upstream parity rows in `queue-overrides.json` and regenerate the missing-patch queue.
- Remove a stale gateway clippy allowlist entry and make the queue generator emit repo-relative override paths.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m py_compile scripts/generate-upstream-patch-queue.py`
- `scripts/check-rust-runtime-no-python.sh`
- `cargo test -p hermes-gateway busy --lib`
- `cargo test -p hermes-gateway session_control --lib`
- `cargo test -p hermes-gateway commands --lib`
- `cargo test -p hermes-config display_config --lib`
- `cargo test -p hermes-config display_busy --lib`
- `cargo test -p hermes-config load_config_bridges_display_yaml_to_env_without_overriding_existing_env --lib`
- `cargo check -p hermes-cli --bin hermes-agent-ultra`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --lib`
