### PR TITLE
parity(memory): harden OpenViking runtime setup

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/openviking.rs
+++ b/crates/hermes-agent/src/memory_plugins/openviking.rs
@@ -2,20 +2,24 @@
 //!
 //! Mirrors Python `plugins/memory/openviking/__init__.py` (HTTP subset).
 
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use reqwest::blocking::multipart::{Form, Part};
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
+use crate::memory_plugins::config_io;
 
 const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:1933";
 const DEFAULT_AGENT: &str = "hermes";
 const DEFAULT_MEMORY_SUBDIR: &str = "preferences";
+const DEFAULT_SESSION_DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 const REMOTE_RESOURCE_PREFIXES: &[&str] = &["http://", "https://", "git@", "ssh://", "git://"];
 
 fn search_schema() -> Value {
@@ -100,6 +104,136 @@ fn add_resource_schema() -> Value {
     })
 }
 
+#[derive(Debug, Clone)]
+struct OpenVikingConfig {
+    endpoint: String,
+    api_key: String,
+    api_key_type: String,
+    account: String,
+    user: String,
+    agent: String,
+}
+
+impl OpenVikingConfig {
+    fn config_path(hermes_home: &str) -> PathBuf {
+        Path::new(hermes_home).join("openviking.json")
+    }
+
+    fn default_config_path() -> PathBuf {
+        config_io::default_hermes_home().join("openviking.json")
+    }
+
+    fn configured_at(path: &Path) -> bool {
+        let object = config_io::read_json_object(path);
+        if object
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .is_some_and(|enabled| enabled)
+        {
+            return true;
+        }
+        ["endpoint", "api_key", "root_api_key"].iter().any(|key| {
+            object
+                .get(*key)
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+        })
+    }
+
+    fn load(hermes_home: &str) -> Self {
+        let mut config = Self {
+            endpoint: std::env::var("OPENVIKING_ENDPOINT")
+                .unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string()),
+            api_key: std::env::var("OPENVIKING_API_KEY").unwrap_or_default(),
+            api_key_type: std::env::var("OPENVIKING_API_KEY_TYPE")
+                .unwrap_or_else(|_| "user".to_string()),
+            account: std::env::var("OPENVIKING_ACCOUNT").unwrap_or_else(|_| "default".into()),
+            user: std::env::var("OPENVIKING_USER").unwrap_or_else(|_| "default".into()),
+            agent: std::env::var("OPENVIKING_AGENT").unwrap_or_else(|_| DEFAULT_AGENT.into()),
+        };
+
+        let path = Self::config_path(hermes_home);
+        let raw = config_io::read_json_object(&path);
+        apply_openviking_config_map(&mut config, &raw);
+
+        config.endpoint = normalize_openviking_endpoint(&config.endpoint);
+        config.api_key_type = normalize_openviking_key_type(&config.api_key_type);
+        config.account = nonempty_or(&config.account, "default");
+        config.user = nonempty_or(&config.user, "default");
+        config.agent = nonempty_or(&config.agent, DEFAULT_AGENT);
+        config
+    }
+}
+
+fn apply_openviking_config_map(
+    config: &mut OpenVikingConfig,
+    raw: &serde_json::Map<String, Value>,
+) {
+    if let Some(endpoint) = raw
+        .get("endpoint")
+        .or(raw.get("base_url"))
+        .or(raw.get("baseUrl"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        config.endpoint = endpoint.to_string();
+    }
+    if let Some(api_key) = raw
+        .get("api_key")
+        .or(raw.get("apiKey"))
+        .or(raw.get("root_api_key"))
+        .or(raw.get("rootApiKey"))
+        .and_then(Value::as_str)
+    {
+        config.api_key = api_key.to_string();
+    }
+    if let Some(key_type) = raw
+        .get("api_key_type")
+        .or(raw.get("apiKeyType"))
+        .and_then(Value::as_str)
+    {
+        config.api_key_type = key_type.to_string();
+    }
+    if let Some(account) = raw.get("account").and_then(Value::as_str) {
+        config.account = account.to_string();
+    }
+    if let Some(user) = raw.get("user").and_then(Value::as_str) {
+        config.user = user.to_string();
+    }
+    if let Some(agent) = raw.get("agent").and_then(Value::as_str) {
+        config.agent = agent.to_string();
+    }
+}
+
+fn normalize_openviking_endpoint(raw: &str) -> String {
+    let value = raw.trim();
+    let with_scheme = if value.is_empty() {
+        DEFAULT_ENDPOINT.to_string()
+    } else if value.contains("://") {
+        value.to_string()
+    } else {
+        format!("http://{value}")
+    };
+    with_scheme.trim_end_matches('/').to_string()
+}
+
+fn normalize_openviking_key_type(raw: &str) -> String {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "root" | "root_api_key" | "root-api-key" => "root".to_string(),
+        "none" | "dev" | "local" | "no_api_key" | "no-api-key" => "none".to_string(),
+        _ => "user".to_string(),
+    }
+}
+
+fn nonempty_or(raw: &str, default: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 #[derive(Clone)]
 struct VikingState {
     client: Client,
@@ -114,7 +248,8 @@ struct VikingState {
 
 pub struct OpenVikingMemoryPlugin {
     state: Mutex<Option<VikingState>>,
-    prefetch: std::sync::Arc<Mutex<String>>,
+    prefetch: Arc<Mutex<String>>,
+    inflight_writers: Arc<Mutex<HashMap<String, Vec<JoinHandle<()>>>>>,
 }
 
 fn viking_headers(st: &VikingState) -> reqwest::header::HeaderMap {
@@ -464,12 +599,137 @@ impl ExpandUserPath for PathBuf {
     }
 }
 
+type InflightWriters = Arc<Mutex<HashMap<String, Vec<JoinHandle<()>>>>>;
+
+fn openviking_session_drain_timeout() -> Duration {
+    std::env::var("OPENVIKING_SESSION_DRAIN_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_SESSION_DRAIN_TIMEOUT)
+}
+
+fn drain_writers_for_session(
+    writers: &InflightWriters,
+    session_id: &str,
+    timeout: Duration,
+) -> bool {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return true;
+    }
+    let deadline = Instant::now() + timeout;
+    loop {
+        let finished = {
+            let mut guard = writers.lock().unwrap();
+            let mut finished = Vec::new();
+            let mut pending = Vec::new();
+            let remove_session = {
+                let Some(handles) = guard.get_mut(session_id) else {
+                    return true;
+                };
+                for handle in handles.drain(..) {
+                    if handle.is_finished() {
+                        finished.push(handle);
+                    } else {
+                        pending.push(handle);
+                    }
+                }
+                if pending.is_empty() {
+                    true
+                } else {
+                    *handles = pending;
+                    false
+                }
+            };
+            if remove_session {
+                guard.remove(session_id);
+            }
+            finished
+        };
+        for handle in finished {
+            if handle.join().is_err() {
+                tracing::warn!("OpenViking writer for {session_id} panicked");
+            }
+        }
+        if writers
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .is_none_or(|handles| handles.is_empty())
+        {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn commit_openviking_session(st: &VikingState) -> bool {
+    if st.session_id.trim().is_empty() {
+        return false;
+    }
+    let h = viking_headers(st);
+    let url = format!("{}/api/v1/sessions/{}/commit", st.endpoint, st.session_id);
+    match st.client.post(&url).headers(h).send() {
+        Ok(resp) if resp.status().is_success() => true,
+        Ok(resp) => {
+            tracing::warn!(
+                "OpenViking session commit for {} returned HTTP {}",
+                st.session_id,
+                resp.status()
+            );
+            false
+        }
+        Err(err) => {
+            tracing::warn!(
+                "OpenViking session commit for {} failed: {err}",
+                st.session_id
+            );
+            false
+        }
+    }
+}
+
+fn spawn_deferred_commit(st: VikingState, writers: InflightWriters, context: &'static str) {
+    std::thread::spawn(move || {
+        if !drain_writers_for_session(&writers, &st.session_id, openviking_session_drain_timeout())
+        {
+            tracing::warn!(
+                "OpenViking writer for {} still alive after drain during {context}; leaving session uncommitted",
+                st.session_id
+            );
+            return;
+        }
+        let _ = commit_openviking_session(&st);
+    });
+}
+
 impl OpenVikingMemoryPlugin {
     pub fn new() -> Self {
         Self {
             state: Mutex::new(None),
-            prefetch: std::sync::Arc::new(Mutex::new(String::new())),
+            prefetch: Arc::new(Mutex::new(String::new())),
+            inflight_writers: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    fn spawn_session_writer<F>(&self, session_id: String, job: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        if session_id.trim().is_empty() {
+            return;
+        }
+        let handle = std::thread::spawn(job);
+        self.inflight_writers
+            .lock()
+            .unwrap()
+            .entry(session_id)
+            .or_default()
+            .push(handle);
     }
 }
 
@@ -482,17 +742,12 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         std::env::var("OPENVIKING_ENDPOINT")
             .map(|s| !s.trim().is_empty())
             .unwrap_or(false)
+            || OpenVikingConfig::configured_at(&OpenVikingConfig::default_config_path())
     }
 
-    fn initialize(&self, session_id: &str, _hermes_home: &str) {
-        let endpoint = std::env::var("OPENVIKING_ENDPOINT")
-            .unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string())
-            .trim_end_matches('/')
-            .to_string();
-        let api_key = std::env::var("OPENVIKING_API_KEY").unwrap_or_default();
-        let account = std::env::var("OPENVIKING_ACCOUNT").unwrap_or_else(|_| "root".into());
-        let user = std::env::var("OPENVIKING_USER").unwrap_or_else(|_| "default".into());
-        let agent = std::env::var("OPENVIKING_AGENT").unwrap_or_else(|_| DEFAULT_AGENT.into());
+    fn initialize(&self, session_id: &str, hermes_home: &str) {
+        let config = OpenVikingConfig::load(hermes_home);
+        let api_key_type = config.api_key_type.clone();
         let client = match Client::builder().timeout(Duration::from_secs(45)).build() {
             Ok(c) => c,
             Err(e) => {
@@ -502,17 +757,17 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         };
         let st = VikingState {
             client,
-            endpoint,
-            api_key,
-            account,
-            user,
-            agent,
+            endpoint: config.endpoint,
+            api_key: config.api_key,
+            account: config.account,
+            user: config.user,
+            agent: config.agent,
             session_id: session_id.to_string(),
             turn_count: 0,
         };
         let health_url = format!("{}/health", st.endpoint);
         let h = viking_headers(&st);
-        if !st
+        if st
             .client
             .get(&health_url)
             .headers(h)
@@ -520,13 +775,15 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
             .map(|r| r.status().is_success())
             .unwrap_or(false)
         {
+            *self.state.lock().unwrap() = Some(st);
+            tracing::info!("OpenViking memory plugin initialized ({api_key_type} credential mode)");
+        } else {
             tracing::warn!(
-                "OpenViking health check failed for {} — tools may still work if the server is warming up",
+                "OpenViking health check failed for {}; OpenViking memory disabled for this session",
                 st.endpoint
             );
+            *self.state.lock().unwrap() = None;
         }
-        *self.state.lock().unwrap() = Some(st);
-        tracing::info!("OpenViking memory plugin initialized");
     }
 
     fn system_prompt_block(&self) -> String {
@@ -573,18 +830,30 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         });
     }
 
-    fn sync_turn(&self, user_content: &str, assistant_content: &str, _session_id: &str) {
-        let mut lock = self.state.lock().unwrap();
-        let st = match lock.as_mut() {
-            Some(s) => s,
-            None => return,
+    fn sync_turn(&self, user_content: &str, assistant_content: &str, session_id: &str) {
+        let (sid, stc) = {
+            let mut lock = self.state.lock().unwrap();
+            let st = match lock.as_mut() {
+                Some(s) => s,
+                None => return,
+            };
+            let sid = if session_id.trim().is_empty() {
+                st.session_id.clone()
+            } else {
+                session_id.trim().to_string()
+            };
+            if sid.is_empty() {
+                return;
+            }
+            st.turn_count = st.turn_count.saturating_add(1);
+            let mut stc = st.clone();
+            stc.session_id = sid.clone();
+            (sid, stc)
         };
-        st.turn_count = st.turn_count.saturating_add(1);
-        let stc = st.clone();
         let u = user_content.chars().take(4000).collect::<String>();
         let a = assistant_content.chars().take(4000).collect::<String>();
         let h = viking_headers(&stc);
-        std::thread::spawn(move || {
+        self.spawn_session_writer(sid, move || {
             let url = format!(
                 "{}/api/v1/sessions/{}/messages",
                 stc.endpoint, stc.session_id
@@ -612,9 +881,24 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         if st.turn_count == 0 {
             return;
         }
-        let h = viking_headers(&st);
-        let url = format!("{}/api/v1/sessions/{}/commit", st.endpoint, st.session_id);
-        let _ = st.client.post(&url).headers(h).send();
+        if !drain_writers_for_session(
+            &self.inflight_writers,
+            &st.session_id,
+            openviking_session_drain_timeout(),
+        ) {
+            tracing::warn!(
+                "OpenViking writer for {} still alive after drain; skipping session commit",
+                st.session_id
+            );
+            return;
+        }
+        if commit_openviking_session(&st) {
+            if let Some(current) = self.state.lock().unwrap().as_mut() {
+                if current.session_id == st.session_id {
+                    current.turn_count = 0;
+                }
+            }
+        }
     }
 
     fn on_session_switch(&self, new_session_id: &str, _parent_session_id: &str, _reset: bool) {
@@ -622,11 +906,27 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         if new_session_id.is_empty() {
             return;
         }
-        if let Some(st) = self.state.lock().unwrap().as_mut() {
+        *self.prefetch.lock().unwrap() = String::new();
+        let old_state = {
+            let mut guard = self.state.lock().unwrap();
+            let Some(st) = guard.as_mut() else {
+                return;
+            };
+            if st.session_id == new_session_id {
+                return;
+            }
+            let old = st.clone();
             st.session_id = new_session_id.to_string();
             st.turn_count = 0;
+            old
+        };
+        if old_state.turn_count > 0 {
+            spawn_deferred_commit(
+                old_state,
+                Arc::clone(&self.inflight_writers),
+                "session switch",
+            );
         }
-        *self.prefetch.lock().unwrap() = String::new();
     }
 
     fn on_memory_write(&self, action: &str, target: &str, content: &str) {
@@ -640,7 +940,7 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         let h = viking_headers(&st);
         let url = format!("{}/api/v1/content/write", st.endpoint);
         let body = content_write_body(&st, memory_subdir_for_target(target), content);
-        std::thread::spawn(move || {
+        self.spawn_session_writer(st.session_id.clone(), move || {
             let _ = st.client.post(&url).headers(h).json(&body).send();
         });
     }
@@ -800,6 +1100,15 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
     }
 
     fn shutdown(&self) {
+        let writers = Arc::clone(&self.inflight_writers);
+        let session_ids = writers.lock().unwrap().keys().cloned().collect::<Vec<_>>();
+        for session_id in session_ids {
+            let _ = drain_writers_for_session(
+                &writers,
+                &session_id,
+                openviking_session_drain_timeout(),
+            );
+        }
         *self.state.lock().unwrap() = None;
     }
 
@@ -807,8 +1116,16 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         Some(json!([
             {"key": "endpoint", "description": "OpenViking server URL", "env_var": "OPENVIKING_ENDPOINT", "default": DEFAULT_ENDPOINT},
             {"key": "api_key", "description": "API key", "secret": true, "env_var": "OPENVIKING_API_KEY"},
+            {"key": "api_key_type", "description": "Credential type: none|user|root", "default": "user", "env_var": "OPENVIKING_API_KEY_TYPE"},
+            {"key": "account", "description": "Tenant account for root/local trusted mode", "env_var": "OPENVIKING_ACCOUNT", "default": "default"},
+            {"key": "user", "description": "Tenant user for root/local trusted mode", "env_var": "OPENVIKING_USER", "default": "default"},
             {"key": "agent", "description": "OpenViking agent namespace", "env_var": "OPENVIKING_AGENT", "default": DEFAULT_AGENT}
         ]))
+    }
+
+    fn save_config(&self, config: &Value) -> Result<(), String> {
+        let path = OpenVikingConfig::default_config_path();
+        config_io::merge_and_write_owner_only(&path, config)
     }
 }
 
@@ -860,10 +1177,110 @@ impl OpenVikingPrefetch {
 mod tests {
     use super::*;
 
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn name() {
         let p = OpenVikingMemoryPlugin::new();
         assert_eq!(p.name(), "openviking");
+    }
+
+    #[test]
+    fn config_file_activates_provider_and_loads_values() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _endpoint = EnvGuard::remove("OPENVIKING_ENDPOINT");
+        let _api_key = EnvGuard::remove("OPENVIKING_API_KEY");
+        let _account = EnvGuard::remove("OPENVIKING_ACCOUNT");
+        let _user = EnvGuard::remove("OPENVIKING_USER");
+        let _agent = EnvGuard::remove("OPENVIKING_AGENT");
+        std::fs::write(
+            tmp.path().join("openviking.json"),
+            r#"{
+                "enabled": true,
+                "endpoint": "localhost:1934/",
+                "api_key": "ov-secret",
+                "api_key_type": "root",
+                "account": "acct",
+                "user": "operator",
+                "agent": "ultra"
+            }"#,
+        )
+        .expect("write config");
+
+        assert!(OpenVikingMemoryPlugin::new().is_available());
+        let config = OpenVikingConfig::load(tmp.path().to_str().expect("home"));
+        assert_eq!(config.endpoint, "http://localhost:1934");
+        assert_eq!(config.api_key, "ov-secret");
+        assert_eq!(config.api_key_type, "root");
+        assert_eq!(config.account, "acct");
+        assert_eq!(config.user, "operator");
+        assert_eq!(config.agent, "ultra");
+    }
+
+    #[test]
+    fn save_config_merges_and_writes_owner_only() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let path = tmp.path().join("openviking.json");
+        std::fs::write(&path, r#"{"agent":"existing"}"#).expect("write existing");
+
+        OpenVikingMemoryPlugin::new()
+            .save_config(&json!({
+                "enabled": true,
+                "endpoint": "https://openviking.example",
+                "api_key": "ov-secret"
+            }))
+            .expect("save config");
+
+        let parsed: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("json");
+        assert_eq!(parsed["agent"], "existing");
+        assert_eq!(parsed["enabled"], true);
+        assert_eq!(parsed["endpoint"], "https://openviking.example");
+        assert_eq!(parsed["api_key"], "ov-secret");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
     }
 
     #[test]
@@ -934,7 +1351,7 @@ mod tests {
             user: "user".to_string(),
             agent: "agent".to_string(),
             session_id: "old".to_string(),
-            turn_count: 7,
+            turn_count: 0,
         });
         *plugin.prefetch.lock().unwrap() = "stale".to_string();
 
@@ -944,6 +1361,95 @@ mod tests {
         assert_eq!(state.session_id, "new");
         assert_eq!(state.turn_count, 0);
         assert!(plugin.prefetch.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn drain_writers_waits_for_all_finished_session_writers() {
+        let plugin = OpenVikingMemoryPlugin::new();
+        plugin.spawn_session_writer("sid".to_string(), || {});
+        plugin.spawn_session_writer("sid".to_string(), || {});
+
+        assert!(drain_writers_for_session(
+            &plugin.inflight_writers,
+            "sid",
+            Duration::from_secs(1)
+        ));
+        assert!(plugin.inflight_writers.lock().unwrap().get("sid").is_none());
+    }
+
+    #[test]
+    fn session_end_skips_commit_when_writer_outlives_drain() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let _timeout = EnvGuard::set("OPENVIKING_SESSION_DRAIN_TIMEOUT_MS", "1");
+        let plugin = OpenVikingMemoryPlugin::new();
+        *plugin.state.lock().unwrap() = Some(VikingState {
+            client: Client::new(),
+            endpoint: "http://127.0.0.1:9".to_string(),
+            api_key: String::new(),
+            account: "acct".to_string(),
+            user: "user".to_string(),
+            agent: "agent".to_string(),
+            session_id: "old".to_string(),
+            turn_count: 2,
+        });
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        plugin.spawn_session_writer("old".to_string(), move || {
+            let _ = release_rx.recv();
+        });
+
+        plugin.on_session_end(&[]);
+
+        assert_eq!(
+            plugin
+                .state
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("state")
+                .turn_count,
+            2
+        );
+        release_tx.send(()).expect("release writer");
+        assert!(drain_writers_for_session(
+            &plugin.inflight_writers,
+            "old",
+            Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn session_switch_rotates_without_waiting_for_old_writer() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let _timeout = EnvGuard::set("OPENVIKING_SESSION_DRAIN_TIMEOUT_MS", "1");
+        let plugin = OpenVikingMemoryPlugin::new();
+        *plugin.state.lock().unwrap() = Some(VikingState {
+            client: Client::new(),
+            endpoint: "http://127.0.0.1:9".to_string(),
+            api_key: String::new(),
+            account: "acct".to_string(),
+            user: "user".to_string(),
+            agent: "agent".to_string(),
+            session_id: "old".to_string(),
+            turn_count: 2,
+        });
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        plugin.spawn_session_writer("old".to_string(), move || {
+            let _ = release_rx.recv();
+        });
+        let start = Instant::now();
+
+        plugin.on_session_switch("new", "old", false);
+
+        assert!(start.elapsed() < Duration::from_millis(100));
+        let state = plugin.state.lock().unwrap().clone().expect("state");
+        assert_eq!(state.session_id, "new");
+        assert_eq!(state.turn_count, 0);
+        release_tx.send(()).expect("release writer");
+        assert!(drain_writers_for_session(
+            &plugin.inflight_writers,
+            "old",
+            Duration::from_secs(1)
+        ));
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -25021,12 +25021,159 @@ fn setup_honcho_provider(yes: bool) -> Result<PathBuf, AgentError> {
     Ok(hermes_config::hermes_home().join("honcho.json"))
 }
 
+fn normalize_openviking_setup_endpoint(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let endpoint = if trimmed.is_empty() {
+        "http://127.0.0.1:1933".to_string()
+    } else if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    };
+    endpoint.trim_end_matches('/').to_string()
+}
+
+fn openviking_setup_endpoint_is_local(endpoint: &str) -> bool {
+    endpoint.starts_with("http://127.0.0.1:")
+        || endpoint.starts_with("http://localhost:")
+        || endpoint == "http://127.0.0.1"
+        || endpoint == "http://localhost"
+}
+
+fn normalize_openviking_setup_key_type(raw: &str, endpoint: &str, api_key: &str) -> String {
+    let normalized = match raw.trim().to_ascii_lowercase().as_str() {
+        "root" | "root_api_key" | "root-api-key" => "root",
+        "none" | "dev" | "local" | "no_api_key" | "no-api-key" => "none",
+        "user" | "user_api_key" | "user-api-key" => "user",
+        "" if openviking_setup_endpoint_is_local(endpoint) && api_key.trim().is_empty() => "none",
+        _ => "user",
+    };
+    normalized.to_string()
+}
+
+struct OpenVikingSetupConfigInput<'a> {
+    endpoint: &'a str,
+    api_key: &'a str,
+    api_key_type: &'a str,
+    account: &'a str,
+    user: &'a str,
+    agent: &'a str,
+}
+
+fn build_openviking_setup_config(
+    input: OpenVikingSetupConfigInput<'_>,
+) -> Result<serde_json::Value, AgentError> {
+    let endpoint = normalize_openviking_setup_endpoint(input.endpoint);
+    let api_key_type =
+        normalize_openviking_setup_key_type(input.api_key_type, &endpoint, input.api_key);
+    let api_key = input.api_key.trim();
+    if api_key_type != "none" && api_key.is_empty() {
+        return Err(AgentError::Config(format!(
+            "OpenViking {api_key_type} setup requires an API key."
+        )));
+    }
+    let account = input.account.trim();
+    let user = input.user.trim();
+    if api_key_type == "root" && (account.is_empty() || user.is_empty()) {
+        return Err(AgentError::Config(
+            "OpenViking root API key setup requires account and user.".into(),
+        ));
+    }
+    let account = if account.is_empty() {
+        "default"
+    } else {
+        account
+    };
+    let user = if user.is_empty() { "default" } else { user };
+    let agent = if input.agent.trim().is_empty() {
+        "hermes"
+    } else {
+        input.agent.trim()
+    };
+
+    Ok(serde_json::json!({
+        "enabled": true,
+        "endpoint": endpoint,
+        "api_key": api_key,
+        "api_key_type": api_key_type,
+        "account": account,
+        "user": user,
+        "agent": agent,
+        "setup_mode": "manual"
+    }))
+}
+
+fn setup_openviking_provider(yes: bool) -> Result<PathBuf, AgentError> {
+    let endpoint_default = std::env::var("OPENVIKING_ENDPOINT")
+        .unwrap_or_else(|_| "http://127.0.0.1:1933".to_string());
+    let endpoint = normalize_openviking_setup_endpoint(&prompt_memory_setup_value(
+        "OpenViking server URL",
+        Some(&endpoint_default),
+        yes,
+    )?);
+    let api_key_default = std::env::var("OPENVIKING_API_KEY").unwrap_or_default();
+    let key_type_default = std::env::var("OPENVIKING_API_KEY_TYPE").unwrap_or_else(|_| {
+        if openviking_setup_endpoint_is_local(&endpoint) && api_key_default.trim().is_empty() {
+            "none".to_string()
+        } else {
+            "user".to_string()
+        }
+    });
+    let key_type = normalize_openviking_setup_key_type(
+        &prompt_memory_setup_value(
+            "OpenViking API key type (none|user|root)",
+            Some(&key_type_default),
+            yes,
+        )?,
+        &endpoint,
+        &api_key_default,
+    );
+    let api_key = if key_type == "none" {
+        String::new()
+    } else {
+        let label = if key_type == "root" {
+            "OpenViking root API key"
+        } else {
+            "OpenViking user API key"
+        };
+        prompt_memory_setup_value(label, Some(&api_key_default), yes)?
+    };
+    let account_default = std::env::var("OPENVIKING_ACCOUNT").unwrap_or_else(|_| "default".into());
+    let user_default = std::env::var("OPENVIKING_USER").unwrap_or_else(|_| "default".into());
+    let account = if key_type == "root" || key_type == "none" {
+        prompt_memory_setup_value("OpenViking account", Some(&account_default), yes)?
+    } else {
+        account_default
+    };
+    let user = if key_type == "root" || key_type == "none" {
+        prompt_memory_setup_value("OpenViking user", Some(&user_default), yes)?
+    } else {
+        user_default
+    };
+    let agent_default = std::env::var("OPENVIKING_AGENT").unwrap_or_else(|_| "hermes".into());
+    let agent = prompt_memory_setup_value("OpenViking agent", Some(&agent_default), yes)?;
+    let config = build_openviking_setup_config(OpenVikingSetupConfigInput {
+        endpoint: &endpoint,
+        api_key: &api_key,
+        api_key_type: &key_type,
+        account: &account,
+        user: &user,
+        agent: &agent,
+    })?;
+
+    hermes_agent::memory_plugins::openviking::OpenVikingMemoryPlugin::new()
+        .save_config(&config)
+        .map_err(AgentError::Config)?;
+    Ok(hermes_config::hermes_home().join("openviking.json"))
+}
+
 fn setup_memory_provider_target(provider: &str, yes: bool) -> Result<PathBuf, AgentError> {
     match provider.trim().to_ascii_lowercase().as_str() {
         "mem0" => setup_mem0_provider(yes),
         "honcho" => setup_honcho_provider(yes),
+        "openviking" | "ov" => setup_openviking_provider(yes),
         other => Err(AgentError::Config(format!(
-            "Unsupported memory provider setup target '{other}'. Supported: honcho, mem0"
+            "Unsupported memory provider setup target '{other}'. Supported: honcho, mem0, openviking"
         ))),
     }
 }
@@ -27695,6 +27842,34 @@ mod tests {
         }
     }
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     async fn build_test_app_with_stream(home: &Path) -> App {
         let config_dir = home.join("config");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
@@ -27809,9 +27984,103 @@ mod tests {
     }
 
     #[test]
+    fn memory_openviking_setup_config_normalizes_local_no_key_mode() {
+        let cfg = build_openviking_setup_config(OpenVikingSetupConfigInput {
+            endpoint: "localhost:1933/",
+            api_key: "",
+            api_key_type: "none",
+            account: "",
+            user: "",
+            agent: "",
+        })
+        .expect("local setup config");
+
+        assert_eq!(cfg["enabled"], true);
+        assert_eq!(cfg["endpoint"], "http://localhost:1933");
+        assert_eq!(cfg["api_key"], "");
+        assert_eq!(cfg["api_key_type"], "none");
+        assert_eq!(cfg["account"], "default");
+        assert_eq!(cfg["user"], "default");
+        assert_eq!(cfg["agent"], "hermes");
+    }
+
+    #[test]
+    fn memory_openviking_setup_config_requires_root_tenant_identity() {
+        let err = build_openviking_setup_config(OpenVikingSetupConfigInput {
+            endpoint: "https://openviking.example",
+            api_key: "root-secret",
+            api_key_type: "root",
+            account: "",
+            user: "operator",
+            agent: "hermes",
+        })
+        .expect_err("missing account should fail");
+
+        assert!(err.to_string().contains("requires account and user"));
+    }
+
+    #[test]
+    fn memory_openviking_setup_config_supports_user_key_without_tenant_prompts() {
+        let cfg = build_openviking_setup_config(OpenVikingSetupConfigInput {
+            endpoint: "https://openviking.example/",
+            api_key: "user-secret",
+            api_key_type: "user",
+            account: "",
+            user: "",
+            agent: "agent",
+        })
+        .expect("user setup config");
+
+        assert_eq!(cfg["endpoint"], "https://openviking.example");
+        assert_eq!(cfg["api_key_type"], "user");
+        assert_eq!(cfg["api_key"], "user-secret");
+        assert_eq!(cfg["account"], "default");
+        assert_eq!(cfg["user"], "default");
+        assert_eq!(cfg["agent"], "agent");
+    }
+
+    #[test]
+    fn memory_openviking_setup_target_writes_owner_only_config() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home = TempHomeGuard::new(tmp.path());
+        let _endpoint = EnvVarGuard::set("OPENVIKING_ENDPOINT", "http://localhost:1933");
+        let _api_key = EnvVarGuard::remove("OPENVIKING_API_KEY");
+        let _key_type = EnvVarGuard::remove("OPENVIKING_API_KEY_TYPE");
+        let _account = EnvVarGuard::remove("OPENVIKING_ACCOUNT");
+        let _user = EnvVarGuard::remove("OPENVIKING_USER");
+        let _agent = EnvVarGuard::remove("OPENVIKING_AGENT");
+
+        let path = setup_memory_provider_target("openviking", true).expect("setup openviking");
+
+        assert_eq!(path, tmp.path().join("openviking.json"));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("json");
+        assert_eq!(parsed["enabled"], true);
+        assert_eq!(parsed["endpoint"], "http://localhost:1933");
+        assert_eq!(parsed["api_key_type"], "none");
+        assert_eq!(parsed["agent"], "hermes");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
     fn memory_setup_prompt_classifies_secret_labels() {
         assert!(memory_setup_label_is_secret("Mem0 API key"));
         assert!(memory_setup_label_is_secret("Honcho local JWT/API key"));
+        assert!(memory_setup_label_is_secret("OpenViking root API key"));
         assert!(!memory_setup_label_is_secret("Mem0 base_url"));
         assert!(!memory_setup_label_is_secret("Deployment shape"));
     }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3946,6 +3946,91 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust: display.busy_input_mode accepts interrupt/queue/steer, display.busy_ack_enabled suppresses automatic busy acknowledgements, env/config-set bridges cover HERMES_GATEWAY_BUSY_INPUT_MODE and HERMES_GATEWAY_BUSY_ACK_ENABLED, and gateway tests cover steer fallback/attachment and quiet queueing."
+    },
+    "2dace37f6b55": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking now has first-class openviking.json activation, hermes memory setup openviking, none/user/root credential modes, tenant defaults, owner-only config writes, health-gated initialization, and provider tests for setup/config behavior."
+    },
+    "b0e25c9cb295": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking save_config writes openviking.json through shared owner-only atomic config IO with 0600 permissions and regression coverage."
+    },
+    "70f53f36cb1c": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust CLI exposes hermes memory setup openviking as the manual setup path, normalizing endpoint values and writing an owner-only openviking.json that activates on later sessions."
+    },
+    "94523764fca8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking setup chooses and normalizes the credential mode before prompting for the corresponding none/user/root API key path, with CLI unit coverage for each setup shape."
+    },
+    "2b972472cee8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking setup validates manual endpoint, credential mode, API key presence, root tenant account/user requirements, agent defaults, and local no-key mode before persisting config."
+    },
+    "3c76dac4fdbf": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking config persistence fails closed through owner-only atomic config IO instead of silently ignoring chmod failures; setup tests assert final 0600 mode."
+    },
+    "2c2ca0443bba": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking setup/config activation covers the improved setup UX in the Rust CLI and provider runtime without Python startup hooks."
+    },
+    "315fdae5f8ad": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking does not autostart openviking-server from the agent runtime; local setup can use no-key config, while runtime initialization is health-gated and fail-closed."
+    },
+    "166d2457b292": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking avoids the unhealthy-local-autostart class entirely: initialization checks /health and disables the provider for the session when health is not successful."
+    },
+    "813a4e3838f6": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking implements on_session_switch, clears stale prefetch, rotates session id, resets dirty turn state for the new session, and tests the lifecycle hook."
+    },
+    "a30b40c73ab6": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking sync_turn captures the target session id before spawning the writer and on_session_end drains tracked writers before commit, preventing session-boundary races."
+    },
+    "eddbf291a415": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking session switch rotates in-memory state immediately, clears stale prefetch, and defers old-session drain/commit so late writes do not target the new session."
+    },
+    "91e9459e1006": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking tracks all background writers per session id in an inflight writer map and drains every writer for that session before commit."
+    },
+    "00c045b43f30": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking commit paths are hardened with bounded writer drains, skipped commits when writers outlive the drain budget, dirty-state preservation on skipped/failed end commits, and tests."
+    },
+    "3ac6551ba3d3": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking treats same-session switches as prefetch invalidation only and ignores empty new session ids, preventing rewound/no-op switches from corrupting session state."
+    },
+    "c835448908e7": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking does not block command/session-switch callers on old-session writer drains; old commits run through a deferred finalizer and non-blocking switch coverage asserts prompt return."
+    },
+    "5494c1e9b660": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Rust OpenViking uses repo-native openviking.json with shared atomic owner-only config IO instead of mutating ovcli profiles; dead Python ovcli constants are not part of the Rust runtime."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-24T08:45:17.529440+00:00`
+Generated: `2026-06-25T00:35:24.714987+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `6907`.
 
@@ -17,31 +17,16 @@ Generated: `2026-06-24T08:45:17.529440+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 268 |
-| ported | 321 |
-| superseded | 6242 |
+| pending | 251 |
+| ported | 335 |
+| superseded | 6245 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `2dace37f6b55` | #23 | feat(memory): improve OpenViking setup UX |
-| `b0e25c9cb295` | #23 | fix(memory): restrict OpenViking setup file permissions |
-| `70f53f36cb1c` | #23 | feat(memory): add manual OpenViking setup path |
-| `94523764fca8` | #23 | fix(memory): choose OpenViking key type before prompting |
-| `2b972472cee8` | #23 | fix(memory): validate OpenViking manual setup steps |
-| `3c76dac4fdbf` | #23 | fix(memory): log OpenViking chmod failures |
-| `2c2ca0443bba` | #20 | feat(memory): improve OpenViking setup UX |
-| `315fdae5f8ad` | #23 | fix(memory): tighten OpenViking local autostart |
-| `166d2457b292` | #23 | fix(memory): avoid setup autostart for unhealthy OpenViking |
-| `813a4e3838f6` | #23 | fix(openviking): implement on_session_switch hook (#28296) |
-| `a30b40c73ab6` | #23 | fix(openviking): close session-boundary races on sync_turn and on_session_end |
-| `eddbf291a415` | #23 | fix(openviking): close remaining session-boundary races on switch |
-| `91e9459e1006` | #23 | fix(openviking): track writers per-session so commit waits for all |
-| `00c045b43f30` | #23 | fix(openviking): harden session writes and switch commits |
 | `547a014e7eae` | #26 | fix(desktop): avoid stack overflow rendering huge fenced blocks |
 | `b82eca2bebd8` | #26 | fix(desktop): isolate message render crashes from the root boundary |
-| `3ac6551ba3d3` | #23 | fix(openviking): handle rewound session switches |
 | `435c706e8e5a` | #26 | fix(desktop): stop a failed turn leaking into every other thread |
 | `f4100f439430` | #26 | fix(desktop): list markers and quote border follow RTL message direction |
 | `0138282f97c9` | #26 | perf(desktop): keep oversized messages from freezing the chat |
@@ -49,7 +34,6 @@ Generated: `2026-06-24T08:45:17.529440+00:00`
 | `c2fa302e933a` | #26 | Merge pull request #47913 from xxxigm/fix/desktop-backend-skew-toast-nag |
 | `b07b7894ec55` | #26 | fix(desktop): keep streaming painting in unfocused secondary chat windows (#47919) |
 | `33b1d144590a` | #20 | fix(desktop): pin Electron below the broken native extract-zip install (#47792) |
-| `c835448908e7` | #23 | fix(openviking): don't block the command thread on session switch; lock turn state |
 | `5a00bd151896` | #20 | fix(desktop): persist /title set before the first message instead of queuing (#47987) |
 | `ee41aa0c1a0a` | #26 | feat(desktop): add dismiss control to chat error banners (#47985) |
 | `fd674af47fa6` | #20 | fix(photon): preserve text in mixed iMessage attachments (salvage #46513) (#46818) |
@@ -68,7 +52,6 @@ Generated: `2026-06-24T08:45:17.529440+00:00`
 | `4c8bbe641696` | #20 | feat(cron): Chronos NAS-mediated managed-cron provider (scale-to-zero) |
 | `3fc7b624d860` | #20 | feat(cron,gateway): NAS-JWT fire verifier + /api/cron/fire webhook (Chronos) |
 | `b75757d4aa85` | #22 | feat(cron): wire on_jobs_changed, cron.chronos config, docs + agent↔NAS contract |
-| `5494c1e9b660` | #23 | refactor(openviking): reuse atomic_json_write for ovcli config; drop dead constants |
 | `0b54a33a3467` | #26 | fix(langfuse): scope trace state by turn/request ids |
 | `e1d10ec1ed29` | #20 | refactor(langfuse): extract _scope_prefix from _trace_key |
 | `f4fbaa6cda8b` | #20 | fix(langfuse): bound _TRACE_STATE growth from non-finalizing turns |
@@ -125,3 +108,20 @@ Generated: `2026-06-24T08:45:17.529440+00:00`
 | `ba49fb51a585` | #20 | fix(discord): hydrate channel context when replying to a message (#49212) |
 | `40722058e532` | #20 | fix(mcp): keep short-TTL HTTP sessions alive with configurable ping keepalive |
 | `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |
+| `866f1d65c4aa` | #26 | chore(desktop): sync package.json version fallback to 0.17.0 (#49236) |
+| `7a7b56d49830` | #23 | fix(windows): prefer managed node for whatsapp and desktop |
+| `d4e7dd609da6` | #23 | refactor(windows): tidy managed-node resolver helpers |
+| `a7983d5ad768` | #20 | fix(dashboard): hide sidecar sessions from history (#49269) |
+| `d799284b1554` | #21 | feat(optional-skills/creative-ideation): expand to v2.1.0 method library (#42402) |
+| `5f55f0ff85f0` | #20 | feat(teams): native send_video/send_voice/send_document attachments (#49308) |
+| `8ebe37f6ad2d` | #26 | feat(desktop): notify renderer when GPU acceleration is disabled due to remote display |
+| `8cf7df867e7d` | #20 | fix(plugins): silence raft check_fn log spam for users without raft CLI |
+| `1b7b4d138a67` | #26 | fix(desktop): handle slash exec dispatch payloads (#49358) |
+| `236f0597e562` | #26 | feat(desktop): pop the composer out into a draggable floating window |
+| `f697c97e02f0` | #26 | fix(desktop): keep floating composer radius consistent with docked |
+| `eed78d6ebb51` | #26 | fix(desktop): composer popout polish — peel-off placement, panels, chip editing |
+| `ae8db1ab531b` | #26 | fix(desktop): mute hidden link-title window so historical links don't autoplay audio |
+| `7eb9678c5470` | #26 | test(desktop): cover link-title window audio muting |
+| `a7dd98c8609c` | #23 | fix(env): guard remaining malformed int/float env var casts with utils helpers |
+| `5600105478ff` | #20 | refactor(gateway): migrate slack/dingtalk/whatsapp/matrix/feishu/telegram/wecom/email/sms adapters to bundled plugins |
+| `404fe730b7a2` | #26 | fix: add tooltips to right sidebar header buttons |


### PR DESCRIPTION
## Summary
- Add Rust-native OpenViking config activation via `openviking.json`.
- Add `hermes memory setup openviking` with local no-key, user-key, and root-key setup modes.
- Persist OpenViking setup through shared owner-only atomic config IO.
- Health-gate OpenViking runtime initialization so unhealthy servers disable the provider for the session.
- Track background OpenViking writers per session id and drain before commit.
- Defer old-session commit on session switch so command/session rotation does not block.
- Regenerate parity queue: pending OpenViking cluster is moved out of `pending`.

## Parity Delta
- `pending`: 268 -> 251
- `ported`: 321 -> 335
- `superseded`: 6242 -> 6245

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m py_compile scripts/generate-upstream-patch-queue.py`
- `scripts/check-rust-runtime-no-python.sh`
- `cargo test -p hermes-agent openviking --lib`
- `cargo test -p hermes-cli memory_openviking --lib`
- `cargo check -p hermes-cli --bin hermes-agent-ultra`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent --lib`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-cli --lib`
