### PR TITLE
parity(runtime): close model and cron backlog slice

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -71,12 +71,13 @@ use crate::kanban::{
 };
 use crate::mcp_config::{load_mcp_config, load_mcp_config_if_exists, McpTransportKind};
 use crate::model_switch::{
-    cached_provider_catalog_status, curated_provider_slugs, format_stale_auxiliary_warning,
-    normalize_provider_model, provider_catalog_entries_for_config, provider_model_ids,
-    provider_model_ids_for_config, provider_slug_from_provider_model, provider_slugs_for_config,
-    DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
+    cached_provider_catalog_status, clear_provider_catalog_cache, curated_provider_slugs,
+    format_stale_auxiliary_warning, normalize_provider_model, provider_catalog_entries_for_config,
+    provider_model_ids, provider_model_ids_for_config, provider_slug_from_provider_model,
+    provider_slugs_for_config,
 };
 use crate::pairing_store::{PairingStatus, PairingStore};
+use crate::providers::canonical_provider_id;
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
 use hermes_config::{GatewayConfig, LlmProviderConfig};
 
@@ -4854,6 +4855,77 @@ async fn handle_model_harness_command(
     Ok(CommandResult::Handled)
 }
 
+fn resolve_model_refresh_provider(app: &App, args: &[&str]) -> String {
+    let raw = args.first().copied().unwrap_or_default().trim();
+    if raw.is_empty() {
+        return canonical_provider_id(provider_slug_from_provider_model(&app.current_model));
+    }
+    if let Some((provider, _)) = raw.split_once(':') {
+        return canonical_provider_id(provider.trim());
+    }
+    canonical_provider_id(raw)
+}
+
+async fn handle_model_refresh_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let provider = resolve_model_refresh_provider(app, args);
+    if provider.trim().is_empty() {
+        emit_command_output(app, "Usage: /model refresh [provider|provider:model]");
+        return Ok(CommandResult::Handled);
+    }
+
+    let known_provider = provider_slugs_for_config(&app.config)
+        .iter()
+        .any(|slug| slug.eq_ignore_ascii_case(&provider));
+    let cache_cleared = clear_provider_catalog_cache(&provider)?;
+    let models = provider_model_ids_for_config(&provider, &app.config).await;
+    let cache_status = cached_provider_catalog_status(&provider);
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Model catalog refreshed");
+    let _ = writeln!(out, "provider: {}", provider);
+    let _ = writeln!(out, "known_provider: {}", yes_no(known_provider));
+    let _ = writeln!(out, "cache_cleared: {}", yes_no(cache_cleared));
+    let _ = writeln!(out, "catalog_total: {}", models.len());
+    match cache_status {
+        Some(status) => {
+            let _ = writeln!(
+                out,
+                "catalog_cache: verified={} age_secs={}",
+                yes_no(status.verified),
+                status
+                    .age_secs
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "n/a".to_string())
+            );
+        }
+        None => {
+            let _ = writeln!(out, "catalog_cache: unavailable");
+        }
+    }
+    if models.is_empty() {
+        let _ = writeln!(out, "models_sample: (none)");
+        if !known_provider {
+            let _ = writeln!(
+                out,
+                "note: provider is not registered; configure llm_providers or use a known provider."
+            );
+        }
+    } else {
+        let sample = models
+            .iter()
+            .take(8)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(out, "models_sample: {}", sample);
+    }
+    emit_command_output(app, out.trim_end());
+    Ok(CommandResult::Handled)
+}
+
 fn handle_model_backend_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     let action = args.first().copied().unwrap_or("list").to_ascii_lowercase();
     match action.as_str() {
@@ -4948,6 +5020,9 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
         }
         if sub.eq_ignore_ascii_case("harness") {
             return handle_model_harness_command(app, &args[1..]).await;
+        }
+        if sub.eq_ignore_ascii_case("refresh") {
+            return handle_model_refresh_command(app, &args[1..]).await;
         }
         if sub.eq_ignore_ascii_case("explain") {
             return handle_model_explain_command(app, &args[1..], false).await;
@@ -13972,8 +14047,7 @@ async fn handle_provider_command(app: &mut App) -> Result<CommandResult, AgentEr
         emit_command_output(app, "No providers registered.");
         return Ok(CommandResult::Handled);
     }
-    let entries =
-        provider_catalog_entries_for_config(&app.config, DEFAULT_VISIBLE_MODELS_PER_PROVIDER).await;
+    let entries = provider_catalog_entries_for_config(&app.config).await;
     if entries.is_empty() {
         emit_command_output(
             app,
@@ -31085,6 +31159,36 @@ install_command: "uv pip install -r requirements.txt"
         assert!(line.contains("backend=qdrant"));
         assert!(line.contains("model=text-embedding-3-large"));
         assert!(line.contains("dimension=3072"));
+    }
+
+    #[tokio::test]
+    async fn model_refresh_command_clears_cache_and_lists_configured_provider() {
+        let _lock = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        let mut cfg = (*app.config).clone();
+        cfg.llm_providers.insert(
+            "wide-provider".to_string(),
+            LlmProviderConfig {
+                models: vec!["model-a".to_string(), "model-b".to_string()],
+                discover_models: false,
+                ..LlmProviderConfig::default()
+            },
+        );
+        app.config = Arc::new(cfg);
+
+        handle_model_command(&mut app, &["refresh", "wide-provider"])
+            .await
+            .expect("refresh model catalog");
+
+        let out = latest_ui_assistant_text(&app);
+        assert!(out.contains("Model catalog refreshed"));
+        assert!(out.contains("provider: wide-provider"));
+        assert!(out.contains("known_provider: yes"));
+        assert!(out.contains("cache_cleared: no"));
+        assert!(out.contains("catalog_total: 2"));
+        assert!(out.contains("models_sample: model-a, model-b"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -41,7 +41,7 @@ use hermes_cli::config_env::hydrate_env_from_config;
 use hermes_cli::model_switch::{
     cached_provider_catalog_status, format_stale_auxiliary_warning, normalize_provider_model,
     provider_catalog_entries_for_config, provider_model_ids, provider_picker_description,
-    provider_slug_from_provider_model, DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
+    provider_slug_from_provider_model,
 };
 use hermes_cli::providers::provider_capability_for;
 use hermes_cli::runtime_tool_wiring::{
@@ -1809,9 +1809,7 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
             println!("Current model: {}", current);
 
             // List providers with merged models.dev-aware previews.
-            let entries =
-                provider_catalog_entries_for_config(&config, DEFAULT_VISIBLE_MODELS_PER_PROVIDER)
-                    .await;
+            let entries = provider_catalog_entries_for_config(&config).await;
             println!("\nAvailable providers:");
             if entries.is_empty() {
                 println!("  openai       — OpenAI (gpt-5.5, gpt-5.5-pro, ...)");
@@ -3043,34 +3041,38 @@ async fn run_gateway(
                         let deferred_queue = ctx.deferred_post_delivery_messages.clone();
                         let deferred_released = ctx.deferred_post_delivery_released.clone();
                         let gateway_for_review_cb = gateway_for_review.clone();
-                        let review_cb = Arc::new(move |text: &str| {
-                            if let (Some(queue), Some(released)) =
-                                (deferred_queue.as_ref(), deferred_released.as_ref())
-                            {
-                                if !released.load(Ordering::Acquire) {
-                                    if let Ok(mut guard) = queue.lock() {
-                                        guard.push(text.to_string());
-                                        return;
+                        let review_cb: Arc<dyn Fn(&str) + Send + Sync> =
+                            Arc::new(move |text: &str| {
+                                if let (Some(queue), Some(released)) =
+                                    (deferred_queue.as_ref(), deferred_released.as_ref())
+                                {
+                                    if !released.load(Ordering::Acquire) {
+                                        if let Ok(mut guard) = queue.lock() {
+                                            guard.push(text.to_string());
+                                            return;
+                                        }
                                     }
                                 }
-                            }
-                            let gw = gateway_for_review_cb.clone();
-                            let platform = platform_for_review.clone();
-                            let chat_id = chat_for_review.clone();
-                            let thread_id = thread_for_review.clone();
-                            let msg = text.to_string();
-                            tokio::spawn(async move {
-                                let _ = gw
-                                    .send_notify_message_threaded(
-                                        &platform,
-                                        &chat_id,
-                                        &msg,
-                                        None,
-                                        thread_id.as_deref(),
-                                    )
-                                    .await;
+                                let gw = gateway_for_review_cb.clone();
+                                let platform = platform_for_review.clone();
+                                let chat_id = chat_for_review.clone();
+                                let thread_id = thread_for_review.clone();
+                                let msg = text.to_string();
+                                tokio::spawn(async move {
+                                    let _ = gw
+                                        .send_notify_message_threaded(
+                                            &platform,
+                                            &chat_id,
+                                            &msg,
+                                            None,
+                                            thread_id.as_deref(),
+                                        )
+                                        .await;
+                                });
                             });
-                        });
+                        let background_review_callback =
+                            gateway_memory_notifications_enabled(config.as_ref())
+                                .then_some(review_cb);
                         let gateway_for_status = gateway_for_review.clone();
                         let gateway_for_status_hook = gateway_for_review.clone();
                         let platform_for_status = ctx.platform.clone();
@@ -3225,7 +3227,7 @@ async fn run_gateway(
                                 });
                             });
                         let callbacks = AgentCallbacks {
-                            background_review_callback: Some(review_cb),
+                            background_review_callback,
                             status_callback: Some(status_cb),
                             on_tool_start: Some(on_tool_start),
                             on_tool_complete: Some(on_tool_complete),
@@ -3322,34 +3324,38 @@ async fn run_gateway(
                         let deferred_queue = ctx.deferred_post_delivery_messages.clone();
                         let deferred_released = ctx.deferred_post_delivery_released.clone();
                         let gateway_for_review_cb = gateway_for_review.clone();
-                        let review_cb = Arc::new(move |text: &str| {
-                            if let (Some(queue), Some(released)) =
-                                (deferred_queue.as_ref(), deferred_released.as_ref())
-                            {
-                                if !released.load(Ordering::Acquire) {
-                                    if let Ok(mut guard) = queue.lock() {
-                                        guard.push(text.to_string());
-                                        return;
+                        let review_cb: Arc<dyn Fn(&str) + Send + Sync> =
+                            Arc::new(move |text: &str| {
+                                if let (Some(queue), Some(released)) =
+                                    (deferred_queue.as_ref(), deferred_released.as_ref())
+                                {
+                                    if !released.load(Ordering::Acquire) {
+                                        if let Ok(mut guard) = queue.lock() {
+                                            guard.push(text.to_string());
+                                            return;
+                                        }
                                     }
                                 }
-                            }
-                            let gw = gateway_for_review_cb.clone();
-                            let platform = platform_for_review.clone();
-                            let chat_id = chat_for_review.clone();
-                            let thread_id = thread_for_review.clone();
-                            let msg = text.to_string();
-                            tokio::spawn(async move {
-                                let _ = gw
-                                    .send_notify_message_threaded(
-                                        &platform,
-                                        &chat_id,
-                                        &msg,
-                                        None,
-                                        thread_id.as_deref(),
-                                    )
-                                    .await;
+                                let gw = gateway_for_review_cb.clone();
+                                let platform = platform_for_review.clone();
+                                let chat_id = chat_for_review.clone();
+                                let thread_id = thread_for_review.clone();
+                                let msg = text.to_string();
+                                tokio::spawn(async move {
+                                    let _ = gw
+                                        .send_notify_message_threaded(
+                                            &platform,
+                                            &chat_id,
+                                            &msg,
+                                            None,
+                                            thread_id.as_deref(),
+                                        )
+                                        .await;
+                                });
                             });
-                        });
+                        let background_review_callback =
+                            gateway_memory_notifications_enabled(config.as_ref())
+                                .then_some(review_cb);
                         let gateway_for_status = gateway_for_review.clone();
                         let gateway_for_status_hook = gateway_for_review.clone();
                         let platform_for_status = ctx.platform.clone();
@@ -3504,7 +3510,7 @@ async fn run_gateway(
                                 });
                             });
                         let callbacks = AgentCallbacks {
-                            background_review_callback: Some(review_cb),
+                            background_review_callback,
                             status_callback: Some(status_cb),
                             on_tool_start: Some(on_tool_start),
                             on_tool_complete: Some(on_tool_complete),
@@ -3780,6 +3786,10 @@ fn run_sessions_db_auto_maintenance(config: &GatewayConfig) {
             if result.vacuumed { " + vacuum" } else { "" }
         );
     }
+}
+
+fn gateway_memory_notifications_enabled(config: &GatewayConfig) -> bool {
+    config.display.memory_notifications_enabled()
 }
 
 async fn prompt_yes_no(question: &str, default_yes: bool) -> Result<bool, AgentError> {
@@ -15714,6 +15724,18 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .expect("env lock poisoned")
+    }
+
+    #[test]
+    fn gateway_memory_notifications_follow_display_config() {
+        let mut cfg = GatewayConfig::default();
+        assert!(gateway_memory_notifications_enabled(&cfg));
+
+        cfg.display.memory_notifications = Some(false);
+        assert!(!gateway_memory_notifications_enabled(&cfg));
+
+        cfg.display.memory_notifications = Some(true);
+        assert!(gateway_memory_notifications_enabled(&cfg));
     }
 
     fn cli_for_temp_state_root(temp_root: &std::path::Path) -> Cli {

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -17,7 +17,6 @@ use sha2::{Digest, Sha256};
 use crate::providers::{canonical_provider_id, provider_capability_for};
 const NOUS_DEFAULT_INFERENCE_BASE_URL: &str = "https://inference-api.nousresearch.com/v1";
 const PROVIDER_CATALOG_CACHE_VERSION: u32 = 2;
-pub const DEFAULT_VISIBLE_MODELS_PER_PROVIDER: usize = 50;
 const OLLAMA_LOCAL_DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
 const LLAMA_CPP_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080/v1";
 const VLLM_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
@@ -457,6 +456,27 @@ pub fn cached_provider_catalog_status(provider: &str) -> Option<CatalogCacheStat
     provider_catalog_cache_status(provider)
 }
 
+pub fn clear_provider_catalog_cache(provider: &str) -> Result<bool, AgentError> {
+    let mut removed = false;
+    for path in [
+        provider_catalog_cache_path(provider),
+        provider_catalog_signature_path(provider),
+    ] {
+        match std::fs::remove_file(&path) {
+            Ok(()) => removed = true,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(AgentError::Io(format!(
+                    "Failed to clear provider catalog cache {}: {}",
+                    path.display(),
+                    err
+                )));
+            }
+        }
+    }
+    Ok(removed)
+}
+
 fn load_provider_catalog_cache(provider: &str) -> Option<Vec<String>> {
     let ttl = catalog_cache_ttl_secs();
     let status = provider_catalog_cache_status(provider)?;
@@ -844,7 +864,6 @@ pub async fn provider_model_ids_for_config(provider: &str, config: &GatewayConfi
 
 pub async fn provider_catalog_entries_for_config(
     config: &GatewayConfig,
-    max_models: usize,
 ) -> Vec<ProviderCatalogEntry> {
     let providers = provider_slugs_for_config(config);
     let mut entries = Vec::new();
@@ -855,7 +874,6 @@ pub async fn provider_catalog_entries_for_config(
             continue;
         }
         let total_models = models.len();
-        let models = models.into_iter().take(max_models).collect();
         entries.push(ProviderCatalogEntry {
             provider,
             models,
@@ -1377,10 +1395,7 @@ pub async fn provider_model_ids(provider: &str) -> Vec<String> {
     provider_model_ids_with_client(provider, default_client()).await
 }
 
-pub async fn provider_catalog_entries(
-    providers: &[&str],
-    max_models: usize,
-) -> Vec<ProviderCatalogEntry> {
+pub async fn provider_catalog_entries(providers: &[&str]) -> Vec<ProviderCatalogEntry> {
     let client = default_client();
     let mut entries = Vec::new();
 
@@ -1390,7 +1405,6 @@ pub async fn provider_catalog_entries(
             continue;
         }
         let total_models = models.len();
-        let models = models.into_iter().take(max_models).collect();
         entries.push(ProviderCatalogEntry {
             provider: (*provider).to_string(),
             models,
@@ -1411,13 +1425,14 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        cached_provider_catalog_status, is_models_dev_preferred_provider,
-        load_provider_catalog_cache, merge_with_models_dev, normalize_provider_model,
-        persist_provider_catalog_cache, provider_catalog_cache_path, provider_catalog_entries,
-        provider_catalog_entries_for_config, provider_curated_models,
-        provider_model_ids_for_config, provider_model_ids_with_client, provider_picker_description,
+        cached_provider_catalog_status, clear_provider_catalog_cache,
+        is_models_dev_preferred_provider, load_provider_catalog_cache, merge_with_models_dev,
+        normalize_provider_model, persist_provider_catalog_cache, provider_catalog_cache_path,
+        provider_catalog_entries, provider_catalog_entries_for_config,
+        provider_catalog_signature_path, provider_curated_models, provider_model_ids_for_config,
+        provider_model_ids_with_client, provider_picker_description,
         provider_slug_from_provider_model, provider_slugs_for_config,
-        resolve_huggingface_catalog_endpoint_and_token, DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
+        resolve_huggingface_catalog_endpoint_and_token,
     };
 
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -1838,7 +1853,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provider_catalog_entries_truncates_but_keeps_total() {
+    async fn provider_catalog_entry_fixture_keeps_total_with_subset_preview() {
         let client = seeded_client(json!({
             "opencode-go": {
                 "models": {
@@ -1874,7 +1889,7 @@ mod tests {
     #[tokio::test]
     async fn provider_catalog_entries_uses_global_client_shape() {
         // Smoke-test the function shape with unknown providers only, avoiding network use.
-        let entries = provider_catalog_entries(&["unknown-provider"], 2).await;
+        let entries = provider_catalog_entries(&["unknown-provider"]).await;
         assert!(entries.is_empty());
     }
 
@@ -1934,17 +1949,17 @@ mod tests {
         let providers = provider_slugs_for_config(&cfg);
         assert!(providers.iter().any(|provider| provider == "baidu-coding"));
 
-        let entries = provider_catalog_entries_for_config(&cfg, 1).await;
+        let entries = provider_catalog_entries_for_config(&cfg).await;
         let entry = entries
             .iter()
             .find(|entry| entry.provider == "baidu-coding")
             .expect("custom provider entry");
-        assert_eq!(entry.models, vec!["kimi-k2.5"]);
+        assert_eq!(entry.models, vec!["kimi-k2.5", "glm-5"]);
         assert_eq!(entry.total_models, 2);
     }
 
     #[tokio::test]
-    async fn default_visible_models_per_provider_shows_first_fifty() {
+    async fn provider_catalog_entries_do_not_truncate_model_picker_results() {
         let mut cfg = hermes_config::GatewayConfig::default();
         let models = (0..60)
             .map(|idx| format!("model-{idx:02}"))
@@ -1958,17 +1973,16 @@ mod tests {
             },
         );
 
-        let entries =
-            provider_catalog_entries_for_config(&cfg, DEFAULT_VISIBLE_MODELS_PER_PROVIDER).await;
+        let entries = provider_catalog_entries_for_config(&cfg).await;
         let entry = entries
             .iter()
             .find(|entry| entry.provider == "wide-provider")
             .expect("wide provider entry");
 
         assert_eq!(entry.total_models, 60);
-        assert_eq!(entry.models.len(), 50);
+        assert_eq!(entry.models.len(), 60);
         assert_eq!(entry.models.first().map(String::as_str), Some("model-00"));
-        assert_eq!(entry.models.last().map(String::as_str), Some("model-49"));
+        assert_eq!(entry.models.last().map(String::as_str), Some("model-59"));
     }
 
     #[tokio::test]
@@ -2024,6 +2038,23 @@ mod tests {
 
         let status = cached_provider_catalog_status("openai").expect("cache status");
         assert!(status.verified);
+    }
+
+    #[test]
+    fn clearing_provider_catalog_cache_removes_payload_and_signature() {
+        let _guard = env_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = ScopedCatalogEnv::new(tmp.path());
+
+        let models = vec!["gpt-4o".to_string()];
+        persist_provider_catalog_cache("openai", &models);
+        assert!(cached_provider_catalog_status("openai").is_some());
+
+        assert!(clear_provider_catalog_cache("openai").expect("clear cache"));
+        assert!(cached_provider_catalog_status("openai").is_none());
+        assert!(!provider_catalog_cache_path("openai").exists());
+        assert!(!provider_catalog_signature_path("openai").exists());
+        assert!(!clear_provider_catalog_cache("openai").expect("idempotent clear"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -4607,11 +4607,7 @@ async fn disconnect_provider_credentials(provider: &str) -> Result<(bool, bool),
 
 async fn open_model_provider_modal(state: &mut TuiState, app: &App) {
     let providers = crate::model_switch::curated_provider_slugs();
-    let entries = crate::model_switch::provider_catalog_entries(
-        &providers,
-        crate::model_switch::DEFAULT_VISIBLE_MODELS_PER_PROVIDER,
-    )
-    .await;
+    let entries = crate::model_switch::provider_catalog_entries(&providers).await;
     let token_store_providers = load_token_store_providers().await;
     let mut items: Vec<PickerItem> = Vec::new();
     for provider in providers {

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -332,6 +332,14 @@ pub struct DisplayConfig {
     )]
     pub busy_ack_enabled: Option<bool>,
 
+    /// Whether background memory/self-improvement summaries should be sent.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_boolish",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub memory_notifications: Option<bool>,
+
     /// Per-platform display overrides keyed by normalized platform name.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub platforms: BTreeMap<String, PlatformDisplayConfig>,
@@ -368,6 +376,10 @@ impl DisplayConfig {
 
     pub fn busy_ack_enabled(&self) -> bool {
         self.busy_ack_enabled.unwrap_or(true)
+    }
+
+    pub fn memory_notifications_enabled(&self) -> bool {
+        self.memory_notifications.unwrap_or(true)
     }
 }
 
@@ -2083,6 +2095,7 @@ display:
   tool_progress: all
   busy_input_mode: steer
   busy_ack_enabled: "false"
+  memory_notifications: "false"
   platforms:
     telegram:
       tool_progress: off
@@ -2097,6 +2110,7 @@ agent:
         assert_eq!(cfg.display.platform_tool_progress("slack"), Some("all"));
         assert_eq!(cfg.display.normalized_busy_input_mode(), "steer");
         assert!(!cfg.display.busy_ack_enabled());
+        assert!(!cfg.display.memory_notifications_enabled());
         assert_eq!(
             cfg.agent.normalized_service_tier().as_deref(),
             Some("priority")

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -628,7 +628,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -805,6 +805,10 @@ fn apply_user_config_patch_dotted(
         ["display", "busy_ack_enabled"] => {
             config.display.busy_ack_enabled =
                 Some(parse_config_bool("display.busy_ack_enabled", value)?);
+        }
+        ["display", "memory_notifications"] => {
+            config.display.memory_notifications =
+                Some(parse_config_bool("display.memory_notifications", value)?);
         }
         ["sessions", "auto_prune"] => {
             let normalized = value.trim().to_ascii_lowercase();
@@ -1111,6 +1115,9 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .map(|s| s.to_string())
             .unwrap_or_else(|| "interrupt".to_string())),
         ["display", "busy_ack_enabled"] => Ok(config.display.busy_ack_enabled().to_string()),
+        ["display", "memory_notifications"] => {
+            Ok(config.display.memory_notifications_enabled().to_string())
+        }
         ["sessions", "auto_prune"] => Ok(config.sessions.auto_prune.to_string()),
         ["sessions", "retention_days"] => Ok(config.sessions.retention_days.to_string()),
         ["sessions", "vacuum_after_prune"] => Ok(config.sessions.vacuum_after_prune.to_string()),
@@ -1501,6 +1508,10 @@ pub fn display_config_env_bridge_pairs() -> &'static [(&'static str, &'static st
     &[
         ("busy_input_mode", "HERMES_GATEWAY_BUSY_INPUT_MODE"),
         ("busy_ack_enabled", "HERMES_GATEWAY_BUSY_ACK_ENABLED"),
+        (
+            "memory_notifications",
+            "HERMES_MEMORY_NOTIFICATIONS_ENABLED",
+        ),
     ]
 }
 
@@ -2001,6 +2012,9 @@ fn bridge_display_config_to_env(display: &DisplayConfig) {
     if let Some(enabled) = display.busy_ack_enabled {
         set_env_if_missing("HERMES_GATEWAY_BUSY_ACK_ENABLED", enabled.to_string());
     }
+    if let Some(enabled) = display.memory_notifications {
+        set_env_if_missing("HERMES_MEMORY_NOTIFICATIONS_ENABLED", enabled.to_string());
+    }
 }
 
 fn apply_display_env_overrides(config: &mut DisplayConfig) {
@@ -2010,6 +2024,11 @@ fn apply_display_env_overrides(config: &mut DisplayConfig) {
     if let Some(v) = env_var_nonempty("HERMES_GATEWAY_BUSY_ACK_ENABLED") {
         if let Some(parsed) = parse_bool_env("HERMES_GATEWAY_BUSY_ACK_ENABLED", &v) {
             config.busy_ack_enabled = Some(parsed);
+        }
+    }
+    if let Some(v) = env_var_nonempty("HERMES_MEMORY_NOTIFICATIONS_ENABLED") {
+        if let Some(parsed) = parse_bool_env("HERMES_MEMORY_NOTIFICATIONS_ENABLED", &v) {
+            config.memory_notifications = Some(parsed);
         }
     }
 }
@@ -2969,7 +2988,11 @@ personalities: null
             .iter()
             .map(|(key, _)| *key)
             .collect::<std::collections::HashSet<_>>();
-        for key in ["busy_input_mode", "busy_ack_enabled"] {
+        for key in [
+            "busy_input_mode",
+            "busy_ack_enabled",
+            "memory_notifications",
+        ] {
             assert!(keys.contains(key), "missing display bridge key: {key}");
             assert!(
                 display_config_env_bridge_key(&format!("display.{key}")).is_some(),
@@ -2979,7 +3002,7 @@ personalities: null
     }
 
     #[test]
-    fn set_user_config_value_bridges_display_busy_keys() {
+    fn set_user_config_value_bridges_display_runtime_keys() {
         use tempfile::tempdir;
 
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -2996,6 +3019,11 @@ personalities: null
                 "false",
                 "HERMES_GATEWAY_BUSY_ACK_ENABLED",
             ),
+            (
+                "display.memory_notifications",
+                "false",
+                "HERMES_MEMORY_NOTIFICATIONS_ENABLED",
+            ),
         ] {
             let result = set_user_config_value(dir.path(), key, value).unwrap();
             assert!(result.wrote_config(), "{key} should write config");
@@ -3005,6 +3033,7 @@ personalities: null
         let env_text = std::fs::read_to_string(dir.path().join(".env")).unwrap();
         assert!(env_text.contains("HERMES_GATEWAY_BUSY_INPUT_MODE=steer"));
         assert!(env_text.contains("HERMES_GATEWAY_BUSY_ACK_ENABLED=false"));
+        assert!(env_text.contains("HERMES_MEMORY_NOTIFICATIONS_ENABLED=false"));
         clear_display_env_bridge_vars();
     }
 

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -95,7 +95,7 @@ pub type LlmCallback = Arc<
     dyn Fn(Value) -> Pin<Box<dyn Future<Output = Result<Value, McpError>> + Send>> + Send + Sync,
 >;
 
-const DEFAULT_MCP_CALL_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_MCP_CALL_TIMEOUT_SECS: u64 = 300;
 const MAX_MCP_CALL_TIMEOUT_SECS: u64 = 900;
 const STALE_TRANSPORT_MARKERS: &[&str] = &[
     "closedresourceerror",
@@ -2340,8 +2340,9 @@ impl McpManager {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_mcp_image_block, is_stale_transport_error, validate_mcp_server_config, LlmCallback,
-        McpClient, McpManager, McpServerConfig, SamplingConfig,
+        cache_mcp_image_block, is_stale_transport_error, mcp_call_timeout_duration,
+        validate_mcp_server_config, LlmCallback, McpClient, McpManager, McpServerConfig,
+        SamplingConfig,
     };
     use crate::transport::McpTransport;
     use crate::McpError;
@@ -2397,6 +2398,19 @@ mod tests {
             self.closed.store(true, Ordering::SeqCst);
             Ok(())
         }
+    }
+
+    #[test]
+    fn mcp_call_timeout_defaults_to_upstream_long_running_budget() {
+        std::env::remove_var("HERMES_MCP_CALL_TIMEOUT_SECS");
+        assert_eq!(mcp_call_timeout_duration().as_secs(), 300);
+
+        std::env::set_var("HERMES_MCP_CALL_TIMEOUT_SECS", "120");
+        assert_eq!(mcp_call_timeout_duration().as_secs(), 120);
+
+        std::env::set_var("HERMES_MCP_CALL_TIMEOUT_SECS", "9999");
+        assert_eq!(mcp_call_timeout_duration().as_secs(), 900);
+        std::env::remove_var("HERMES_MCP_CALL_TIMEOUT_SECS");
     }
 
     #[test]

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -66,8 +66,6 @@ pub const TOOLSET_CODE_EXECUTION: &[&str] = &["execute_code"];
 pub const TOOLSET_DELEGATION: &[&str] = &["delegate_task"];
 /// Cron job management tools.
 pub const TOOLSET_CRONJOB: &[&str] = &["cronjob"];
-/// Cross-platform messaging tools.
-pub const TOOLSET_MESSAGING: &[&str] = &["send_message"];
 /// Home Assistant integration tools.
 pub const TOOLSET_HOMEASSISTANT: &[&str] = &[
     "ha_list_entities",
@@ -285,10 +283,6 @@ impl ToolsetManager {
             TOOLSET_CRONJOB.iter().map(|s| s.to_string()).collect(),
         ));
         self.register(Toolset::new(
-            "messaging",
-            TOOLSET_MESSAGING.iter().map(|s| s.to_string()).collect(),
-        ));
-        self.register(Toolset::new(
             "homeassistant",
             TOOLSET_HOMEASSISTANT
                 .iter()
@@ -327,7 +321,8 @@ impl ToolsetManager {
             TOOLSET_CODING.iter().map(|s| s.to_string()).collect(),
         ));
 
-        // Platform composite toolsets
+        // Platform composite toolsets. Outbound platform sends are explicit
+        // gateway/cron/CLI runtime actions, not model-callable defaults.
         self.register(Toolset::with_includes(
             "hermes-cli",
             vec![
@@ -347,7 +342,6 @@ impl ToolsetManager {
                 "code_execution",
                 "delegation",
                 "cronjob",
-                "messaging",
                 "homeassistant",
                 "tts",
                 "system",
@@ -796,13 +790,14 @@ mod tests {
         assert!(tools.contains(&"web_crawl".to_string()));
         assert!(tools.contains(&"terminal".to_string()));
         assert!(tools.contains(&"read_file".to_string()));
-        // Python parity core for CLI.
+        // Python parity core for CLI, excluding tools that must not be
+        // agent-callable by default.
         assert!(tools.contains(&"image_generate".to_string()));
         assert!(tools.contains(&"video_generate".to_string()));
         assert!(tools.contains(&"spotify_playback".to_string()));
         assert!(tools.contains(&"session_search".to_string()));
         assert!(tools.contains(&"text_to_speech".to_string()));
-        assert!(tools.contains(&"send_message".to_string()));
+        assert!(!tools.contains(&"send_message".to_string()));
         assert!(tools.contains(&"ha_call_service".to_string()));
         assert!(tools.contains(&"cronjob".to_string()));
         assert!(tools.contains(&"auth_snapshot".to_string()));
@@ -947,8 +942,8 @@ mod tests {
         ] {
             let tools = manager.resolve_toolset_unfiltered(preset).unwrap();
             assert!(
-                tools.contains(&"send_message".to_string()),
-                "preset {preset} should include send_message"
+                !tools.contains(&"send_message".to_string()),
+                "preset {preset} should not expose send_message as an agent-callable tool"
             );
             assert!(
                 tools.contains(&"terminal".to_string()),

--- a/crates/hermes-tools/src/toolset_distributions.rs
+++ b/crates/hermes-tools/src/toolset_distributions.rs
@@ -84,7 +84,6 @@ fn base_weights() -> HashMap<String, f64> {
     w.insert("delegation".into(), 0.3);
     w.insert("cronjob".into(), 0.2);
     w.insert("rl_training".into(), 0.2);
-    w.insert("messaging".into(), 0.1);
     w.insert("homeassistant".into(), 0.1);
     w.insert("tts".into(), 0.1);
     w.insert("voice".into(), 0.1);

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4031,6 +4031,211 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Rust OpenViking uses repo-native openviking.json with shared atomic owner-only config IO instead of mutating ovcli profiles; dead Python ovcli constants are not part of the Rust runtime."
+    },
+    "c6c8abbadb80": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: default static agent toolsets no longer expose send_message, messaging was removed from built-in toolset distributions, explicit SendMessageHandler/GatewayMessagingBackend remain for gateway/cron/CLI runtime sends, and hermes-mcp default tool-call timeout is now 300s with env override/cap coverage."
+    },
+    "5a00bd151896": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust gateway already persists /title immediately because route_message creates the session before command handling and SessionManager::set_title updates live state directly; gateway_title_command_persists_and_surfaces_session_title covers set/show/status/session-list behavior."
+    },
+    "547a014e7eae": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fix is apps/desktop React markdown preprocessing for huge fenced blocks. Ultra has no Electron desktop renderer; Rust CLI/TUI/gateway output handling and terminal/tool result surfaces own runtime rendering instead."
+    },
+    "b82eca2bebd8": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fix isolates React desktop message render crashes. Ultra does not ship apps/desktop; Rust CLI/TUI/gateway rendering paths do not use the Streamdown/root-boundary pipeline fixed upstream."
+    },
+    "435c706e8e5a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fix is React desktop session-cache error isolation. Ultra session/error state is Rust-owned by hermes-cli App and hermes-gateway session/runtime state, not the apps/desktop view cache."
+    },
+    "f4100f439430": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream RTL list-marker/blockquote fix targets desktop DOM/CSS. Ultra has no React DOM transcript; terminal/TUI text rendering is Rust-native and not affected by browser dir=auto box direction."
+    },
+    "0138282f97c9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream oversized-message freeze fix targets synchronous React/Streamdown/Shiki desktop rendering. Ultra lacks that renderer; Rust terminal/tool-result truncation and TUI viewport behavior are the applicable runtime surfaces."
+    },
+    "c2fa302e933a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Desktop backend-skew toast nag is apps/desktop update-store UX. Ultra does not run that Electron update store; Rust CLI/TUI version/status surfaces own runtime skew reporting."
+    },
+    "b07b7894ec55": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Streaming paint in unfocused secondary Electron windows is an apps/desktop BrowserWindow preference fix. Ultra has no Electron session windows; Rust TUI/gateway streaming is terminal/platform-adapter driven."
+    },
+    "33b1d144590a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Electron dependency pin and npm lockfile repair apply to upstream desktop packaging. Ultra has no apps/desktop package tree and builds/releases through the Rust workspace/install scripts."
+    },
+    "ee41aa0c1a0a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Chat error banner dismissal is React desktop local view state. Ultra handles turn errors through Rust CLI/TUI/gateway messages and does not persist the upstream desktop banner component."
+    },
+    "016bce1a09ba": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Stranded routed session-window recovery is apps/desktop route/resume hook behavior. Ultra sessions are Rust CLI/TUI/gateway sessions, not Electron pop-out windows."
+    },
+    "f8098c6b6fe5": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Static electronDist path repair is desktop/npm packaging only. Ultra does not package Electron from apps/desktop; Rust release/install verification is cargo/Homebrew/script based."
+    },
+    "c1f9eb0ec4b9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Dynamic electronDist self-heal supersedes an upstream desktop packaging failure class. Ultra has no Electron builder/runtime in this repo, so the Rust build/install path is unaffected."
+    },
+    "4b7a18600393": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Desktop self-update rebuild retry spans Electron and bootstrap-installer/Tauri paths absent from Ultra. Rust update/release behavior is owned by the CLI and repository release scripts."
+    },
+    "92e6d8c858f6": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Disposing node-pty sessions during Electron before-quit is desktop main-process cleanup. Ultra PTY/process lifecycle is Rust-owned by hermes-tools terminal/process handlers and not node-pty."
+    },
+    "4ed2f3399418": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Long user-message scrolling is a desktop React thread presentation fix. Ultra uses Rust terminal/TUI history rendering instead of apps/desktop thread components."
+    },
+    "769f307042d2": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "react-simple-icons npm lockfile noise is specific to upstream desktop/package management. Ultra has no npm desktop dependency tree in this Rust runtime repo."
+    },
+    "fd674af47fa6": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Photon/Spectrum is an upstream Python plus Node optional platform plugin. Ultra does not expose a Rust-native Photon adapter, so this iMessage attachment salvage fix is outside the Rust runtime surface."
+    },
+    "6092be413d59": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream hardens Python/s6 hosted Docker install-tree self-modification. Ultra uses a Rust multi-stage image with immutable /usr/local/bin binaries, /data as HERMES_HOME, and tini/gosu entrypoint ownership only for runtime state."
+    },
+    "ab1a42fcea4f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Relay connector contract is retained only as experimental/reference documentation; current Ultra Rust runtime does not register the upstream Python relay adapter as a first-class platform surface."
+    },
+    "5feec8b4cfcb": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream relay conformance tests target the Python gateway relay adapter. Ultra has no active Rust relay adapter for this experimental contract, so the Python conformance harness is not a Rust runtime requirement."
+    },
+    "6e20c1992ff9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Relay A2 trust-boundary rewrite applies to the experimental cross-repo relay contract. Ultra keeps the doc as reference only; active Rust gateway adapters enforce their own platform auth paths."
+    },
+    "86f2946fbe78": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Dashboard Chat tab recovery is an upstream React web surface. Ultra has no apps/desktop/web ChatPage Rust runtime; CLI/TUI/gateway session recovery is owned by Rust surfaces."
+    },
+    "c276b017adc4": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Connector-to-gateway relay channel auth, signed HTTP inbound receiver, and enroll CLI are upstream Python relay surfaces. Ultra does not expose that experimental relay adapter in Rust."
+    },
+    "ae8fa11097e1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: crates/hermes-cron loads cron.provider/cron.chronos config, constructs ChronosNasCronProvider from environment/config, and scheduler tests cover managed provider reconciliation."
+    },
+    "4440d77bf32d": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Install-method stamping and Python Docker stage2 mutation are absent from Ultra. The Rust container separates code in /usr/local/bin from writable HERMES_HOME=/data and does not chown or mutate an install tree at runtime."
+    },
+    "4c8bbe641696": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: ChronosNasCronProvider provisions/cancels/lists NAS-mediated one-shots, scheduler disables in-process polling when managed cron is active, and focused managed-provider tests pass."
+    },
+    "3fc7b624d860": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: hermes-cron verifies NAS JWT fire tokens with asymmetric keys/audience/purpose checks and hermes-gateway exposes POST /api/cron/fire behind api-server with focused route coverage."
+    },
+    "b75757d4aa85": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: scheduler mutation paths reconcile/cancel managed Chronos jobs, cron.chronos config is documented in docs/chronos-managed-cron-contract.md, and managed fire duplicate/stale tests pass."
+    },
+    "0b54a33a3467": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust-native telemetry shape: agent loop emits request/turn scoped tracing spans for LLM/tool events and Langfuse uses OTLP config without a Python process-global _TRACE_STATE map; Langfuse tests pass."
+    },
+    "e1d10ec1ed29": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust-native telemetry shape: Langfuse endpoint/header/resource config is centralized in hermes-telemetry and span scope is carried by tracing fields rather than Python trace-key prefixes; focused tests pass."
+    },
+    "f4fbaa6cda8b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust-native telemetry shape: there is no unbounded Python _TRACE_STATE dict in Ultra; spans are created/dropped per LLM/tool event and Langfuse OTLP config tests pass."
+    },
+    "2a5d51c16e94": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust OpenViking provider: current API setup/config/headers/content writes/resource uploads/session writer drain behavior are implemented in crates/hermes-agent memory_plugins/openviking with focused tests passing."
+    },
+    "0fa7d6f6609c": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: named custom providers are preserved through llm_providers, provider catalog/model guard paths, and app-runtime config mapping; tests cover named custom runtime provider behavior."
+    },
+    "51ee5b2c94d0": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in this batch: display.memory_notifications is typed config with env/config set/get bridge, and gateway background review callbacks are gated by this setting with focused tests."
+    },
+    "9705e7944ae4": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in this batch: Rust provider catalog entries no longer truncate picker models to 50; CLI/TUI/model command call sites use the full configured catalog and regression tests cover 60 entries."
+    },
+    "03d9a95a74b2": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: Hindsight is a first-class bundled memory provider discovered by memory_plugins::discover_available_providers, with config, recall, turn buffering, and owner-only config tests passing."
+    },
+    "d2c53ff5583e": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "WS-only inbound relay is part of the upstream experimental Python relay adapter. Ultra keeps native Rust platform adapters and does not expose the relay adapter as active runtime surface."
+    },
+    "c34840e22e08": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: /api/cron/fire is served by the Rust API server route with Chronos NAS auth bypassing the generic API token path only for that route; focused api-server feature test passes."
+    },
+    "620fd59b8e6f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in this batch: /model refresh [provider|provider:model] clears signed provider catalog payload/signature files and reloads through the configured provider catalog path with command and cache tests."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,76 +1,35 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T00:35:24.714987+00:00`
+Generated: `2026-06-25T01:15:51.624357+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `6907`.
+- Range: `main..upstream/main`; total commits tracked: `6972`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3078 |
+| #20 | GPAR-01 tests+CI parity | 3115 |
 | #21 | GPAR-02 skills parity | 130 |
-| #22 | GPAR-03 UX parity | 956 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 486 |
+| #22 | GPAR-03 UX parity | 957 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 144 |
-| #26 | GPAR-07 upstream queue backfill | 2091 |
+| #26 | GPAR-07 upstream queue backfill | 2116 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 251 |
-| ported | 335 |
-| superseded | 6245 |
+| pending | 241 |
+| ported | 351 |
+| superseded | 6304 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `547a014e7eae` | #26 | fix(desktop): avoid stack overflow rendering huge fenced blocks |
-| `b82eca2bebd8` | #26 | fix(desktop): isolate message render crashes from the root boundary |
-| `435c706e8e5a` | #26 | fix(desktop): stop a failed turn leaking into every other thread |
-| `f4100f439430` | #26 | fix(desktop): list markers and quote border follow RTL message direction |
-| `0138282f97c9` | #26 | perf(desktop): keep oversized messages from freezing the chat |
-| `c6c8abbadb80` | #20 | refactor: remove agent-callable send_message tool (#47856) |
-| `c2fa302e933a` | #26 | Merge pull request #47913 from xxxigm/fix/desktop-backend-skew-toast-nag |
-| `b07b7894ec55` | #26 | fix(desktop): keep streaming painting in unfocused secondary chat windows (#47919) |
-| `33b1d144590a` | #20 | fix(desktop): pin Electron below the broken native extract-zip install (#47792) |
-| `5a00bd151896` | #20 | fix(desktop): persist /title set before the first message instead of queuing (#47987) |
-| `ee41aa0c1a0a` | #26 | feat(desktop): add dismiss control to chat error banners (#47985) |
-| `fd674af47fa6` | #20 | fix(photon): preserve text in mixed iMessage attachments (salvage #46513) (#46818) |
-| `016bce1a09ba` | #26 | fix(desktop): recover stranded session windows when resume fails (#47655) |
-| `f8098c6b6fe5` | #20 | fix(desktop): resolve electronDist to the actual electron install location (#48081) |
-| `6092be413d59` | #20 | Harden hosted Docker install tree against self-modification (#47490) |
-| `ab1a42fcea4f` | #26 | docs: relay<->connector cross-repo contract (v1, experimental) |
-| `5feec8b4cfcb` | #20 | test(gateway): enforce relay contract-doc ⟷ Python conformance |
-| `6e20c1992ff9` | #26 | docs(gateway): rewrite contract §6 to the A2 trust-boundary model |
-| `c1f9eb0ec4b9` | #20 | fix(desktop): resolve electronDist dynamically + self-heal blocked installs (supersedes #48081/#48082) (#48091) |
-| `86f2946fbe78` | #22 | fix(dashboard): recover the Chat tab when the agent session ends (NS-504) (#47674) |
-| `4b7a18600393` | #26 | fix(desktop): retry the self-update rebuild once so the app relaunches (#48122) |
-| `c276b017adc4` | #20 | feat(relay): connector⇄gateway channel auth + signed-HTTP inbound receiver + enroll CLI (#48147) |
-| `ae8fa11097e1` | #20 | feat(cron): cron.provider config + plugins/cron discovery + resolver |
-| `4440d77bf32d` | #20 | fix(update): scope install-method stamp to the code tree, not $HERMES_HOME (#48188) |
-| `4c8bbe641696` | #20 | feat(cron): Chronos NAS-mediated managed-cron provider (scale-to-zero) |
-| `3fc7b624d860` | #20 | feat(cron,gateway): NAS-JWT fire verifier + /api/cron/fire webhook (Chronos) |
-| `b75757d4aa85` | #22 | feat(cron): wire on_jobs_changed, cron.chronos config, docs + agent↔NAS contract |
-| `0b54a33a3467` | #26 | fix(langfuse): scope trace state by turn/request ids |
-| `e1d10ec1ed29` | #20 | refactor(langfuse): extract _scope_prefix from _trace_key |
-| `f4fbaa6cda8b` | #20 | fix(langfuse): bound _TRACE_STATE growth from non-finalizing turns |
-| `2a5d51c16e94` | #23 | fix(openviking): adapt memory provider for current api |
 | `2f7c4858a764` | #20 | fix(tui): refresh tool snapshot when MCP discovery lands after agent build (#48403) |
-| `92e6d8c858f6` | #26 | fix(desktop): dispose open PTY sessions in before-quit handler |
 | `5ffbfed193ad` | #20 | feat(mcp-catalog): add official Unreal Engine 5.8 MCP server |
-| `0fa7d6f6609c` | #20 | fix(desktop): never persist or restore a named custom provider as bare "custom" (#48547) |
-| `51ee5b2c94d0` | #20 | fix(desktop,tui): surface self-improvement review summary + honor memory_notifications |
 | `73cd8622f9fc` | #22 | feat(billing): /billing terminal billing — interactive TUI + CLI client (#45449) |
-| `4ed2f3399418` | #26 | fix(thread): allow scrolling long user messages in chat history (#48619) |
-| `9705e7944ae4` | #20 | fix(picker): remove max_models=50 cap in interactive model pickers |
 | `49596b70cb2d` | #20 | fix(gateway): resume follows the compression tip so post-compression replies render |
-| `769f307042d2` | #26 | fix(npm): lock react-simple-icons to 13.11.1 |
-| `03d9a95a74b2` | #20 | fix(desktop): show Hindsight memory provider (#37546) |
-| `d2c53ff5583e` | #20 | feat(relay): WS-only inbound on the gateway adapter (Phase 3) (#48294) |
 | `36851fa576eb` | #20 | fix(docker): support WebUI installs from read-only sources (#48541) |
-| `c34840e22e08` | #20 | fix(cron): serve /api/cron/fire on the dashboard app (hosted-agent surface) |
-| `620fd59b8e6f` | #20 | feat(model-picker): add Refresh Models control to bust stale model cache (#48691) |
 | `cfb55de5ea49` | #21 | Update Stripe Projects skill docs (#48673) |
 | `c02192ff6ace` | #20 | feat(image-gen): add image-to-image / editing to image_generate (#48705) |
 | `c7b7f92ec14a` | #20 | fix(openviking): sync structured turns with tool parts |
@@ -125,3 +84,44 @@ Generated: `2026-06-25T00:35:24.714987+00:00`
 | `a7dd98c8609c` | #23 | fix(env): guard remaining malformed int/float env var casts with utils helpers |
 | `5600105478ff` | #20 | refactor(gateway): migrate slack/dingtalk/whatsapp/matrix/feishu/telegram/wecom/email/sms adapters to bundled plugins |
 | `404fe730b7a2` | #26 | fix: add tooltips to right sidebar header buttons |
+| `838daca9f4cf` | #26 | chore(desktop): format tooltip indentation + author map for #49697 |
+| `75b36a138f43` | #22 | feat(pets): TUI pet pane, picker + gateway RPCs |
+| `86b990fe0fac` | #26 | feat(desktop): floating pet, pop-out overlay + Cmd+K picker |
+| `6fd839ac84d0` | #22 | docs(pets): feature guide, petdex skill + catalog |
+| `491579fa05ef` | #23 | fix(whatsapp): resolve bridge dir with HERMES_HOME mirror in Docker |
+| `37fa3c58b40e` | #21 | docs(kanban-worker): document kanban_complete artifacts deliverable param (#49854) |
+| `31bdb60013c9` | #22 | docs(skills): fix himalaya CLI arg order and download flag |
+| `2b08a4295a65` | #26 | docs(README.zh-CN): update Windows install from 'not supported' to native PowerShell |
+| `9e4348f28ac1` | #25 | docs(windows): document uv.exe AV false positive |
+| `f6275a59e790` | #26 | docs(contributing): add "search first" guidance to cut duplicate PRs |
+| `4c206b972d49` | #26 | fix(gateway): correct sys.path insertion in plugins to prevent cron namespace collision (#49410) |
+| `79f297834a9b` | #26 | fix(gateway): widen cron namespace-collision fix to all migrated adapters |
+| `46cc0345ae8a` | #21 | docs(skills): add hermes-agent verification rule |
+| `5eb158e3173d` | #21 | docs(hermes-agent skill): document project context files and their discovery rules |
+| `2609bcccca30` | #25 | feat(i18n): add complete Spanish translation |
+| `df4015bbc176` | #26 | docs: session lifecycle documentation |
+| `eec9c1d84ebd` | #26 | docs(agents): clarify background delegation durability |
+| `f80088f035de` | #26 | docs: add missing Prerequisites/How to Run sections to SKILL.md template |
+| `242962e1f5a0` | #22 | docs(providers): clarify vllm qwen reasoning output |
+| `95d970a7521c` | #21 | docs: sharpen software-development skills |
+| `defeda8c559f` | #22 | docs: sync documentation with current implementation |
+| `98ecd0beeba9` | #26 | docs(mcp): fix stale ~0.75s discovery-wait reference in late-refresh docstring |
+| `b1ab5a8ae1d9` | #21 | docs(antigravity-cli): add delegation patterns + output/bounding caveats |
+| `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
+| `29e5e127c6f1` | #20 | fix(telegram): recover reply text from native rich echo |
+| `c1f11f8c69f9` | #20 | fix(telegram): index streamed rich finals via editMessageText too |
+| `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
+| `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
+| `04730f32e7e8` | #20 | fix(cli): warn when in-session model switch will preflight-compress |
+| `1ca29723f0ea` | #20 | fix(cli): log instead of swallow preflight-warning errors; consistent TUI warning field |
+| `dd042fc4dfb1` | #20 | fix(tools): preserve core tools when a platform bundle is disabled |
+| `796f618f9987` | #20 | fix(telegram): keep chunk markers outside code fences |
+| `c7e8854cb383` | #20 | fix(tui): persist session messages on force-quit / signal shutdown |
+| `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
+| `0e47f68a479a` | #26 | fix(desktop): rename branched session via session.title RPC |
+| `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
+| `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
+| `31e59fe44d18` | #20 | fix(telegram): preserve newlines in rich slash-command output (#46070) |
+| `a9669323922f` | #20 | fix(telegram): exempt tables from rich newline hard-breaks |
+| `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
+| `ea056b05598c` | #20 | fix(telegram): avoid rich messages for CJK text |


### PR DESCRIPTION
## Summary
- remove `send_message` from default/model-callable static toolsets while keeping explicit gateway-backed messaging handlers available for runtime wiring
- raise MCP tool-call default timeout to 300s with env override and cap coverage
- remove the 50-model provider picker cap and add `/model refresh [provider|provider:model]` to clear signed provider catalog caches
- add `display.memory_notifications` config/env/set/get bridge and gate gateway background-review notification callbacks on it
- update parity queue overrides and regenerate `docs/parity/upstream-missing-queue.{json,md}`; pending is now 241, with MCP late-refresh and full billing client intentionally still pending

## Verification
All Cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0`.

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p hermes-cli clearing_provider_catalog_cache_removes_payload_and_signature --lib`
- `cargo test -p hermes-cli model_refresh_command_clears_cache_and_lists_configured_provider --lib`
- `cargo test -p hermes-cli provider_catalog_entries_do_not_truncate_model_picker_results --lib`
- `cargo test -p hermes-config set_user_config_value_bridges_display_runtime_keys --lib`
- `cargo test -p hermes-mcp mcp_call_timeout_defaults_to_upstream_long_running_budget --lib`
- `cargo test -p hermes-tools toolset --lib`
- `cargo test -p hermes-cron chronos --lib`
- `cargo test -p hermes-cron managed_provider_reconciles_mutations_and_cancels_disabled_jobs --lib`
- `cargo test -p hermes-cron managed_fire_dispatches_once_and_ignores_stale_fire_at --lib`
- `cargo test -p hermes-gateway --features api-server cron_fire_endpoint_uses_nas_auth_not_generic_api_token --lib`
- `cargo test -p hermes-gateway gateway_title_command_persists_and_surfaces_session_title --lib`
- `cargo test -p hermes-cli gateway_messaging_backend_ --lib`
- `cargo test -p hermes-telemetry langfuse --lib`
- `cargo test -p hermes-agent hindsight --lib`
- `cargo test -p hermes-agent openviking --lib`
- `cargo test -p hermes-app-runtime named_custom_runtime_provider --lib`
- `cargo build --workspace`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-config -p hermes-mcp -p hermes-tools -p hermes-agent -p hermes-cron -p hermes-gateway -p hermes-telemetry -p hermes-app-runtime` (`new=0 stale=0`)
