### PR TITLE
parity(mcp): refresh late tool snapshots

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -4,6 +4,7 @@
 //! and conversation message history. It coordinates input handling,
 //! slash commands, and session management.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime};
@@ -331,6 +332,20 @@ pub struct App {
     pub quorum_armed_once: bool,
     /// Animated companion pet settings.
     pub pet_settings: PetSettings,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentToolSnapshotRefresh {
+    pub before_count: usize,
+    pub after_count: usize,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+impl AgentToolSnapshotRefresh {
+    pub fn changed(&self) -> bool {
+        !self.added.is_empty() || !self.removed.is_empty()
+    }
 }
 
 impl std::fmt::Debug for App {
@@ -2701,6 +2716,26 @@ impl App {
         self.agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
     }
 
+    pub fn refresh_agent_tool_snapshot(&mut self) -> AgentToolSnapshotRefresh {
+        let before = sorted_tool_names(self.agent.tool_registry.names());
+        self.tool_schemas = hermes_tool_planning::resolve_platform_tool_schemas(
+            &self.config,
+            "cli",
+            &self.tool_registry,
+        );
+        self.rebuild_agent_for_active_session();
+        let after = sorted_tool_names(self.agent.tool_registry.names());
+        let before_set: BTreeSet<_> = before.iter().cloned().collect();
+        let after_set: BTreeSet<_> = after.iter().cloned().collect();
+
+        AgentToolSnapshotRefresh {
+            before_count: before.len(),
+            after_count: after.len(),
+            added: after_set.difference(&before_set).cloned().collect(),
+            removed: before_set.difference(&after_set).cloned().collect(),
+        }
+    }
+
     /// Switch the active personality.
     pub fn switch_personality(&mut self, name: &str) {
         self.current_personality = Some(name.to_string());
@@ -4110,6 +4145,72 @@ mod tests {
             quorum_armed_once: false,
             pet_settings: PetSettings::default(),
         }
+    }
+
+    #[test]
+    fn refresh_agent_tool_snapshot_adds_late_registered_tool() {
+        let mut app = build_minimal_test_app();
+
+        assert!(app.agent.tool_registry.get("mcp_srv_late").is_none());
+        assert!(!app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_late"));
+
+        register_test_tool(&app.tool_registry, "mcp_srv_late");
+        let refresh = app.refresh_agent_tool_snapshot();
+
+        assert_eq!(refresh.before_count, 0);
+        assert_eq!(refresh.after_count, 1);
+        assert_eq!(refresh.added, vec!["mcp_srv_late".to_string()]);
+        assert!(refresh.removed.is_empty());
+        assert!(app.agent.tool_registry.get("mcp_srv_late").is_some());
+        assert!(app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_late"));
+        assert_eq!(
+            app.agent.config.session_id.as_deref(),
+            Some(app.session_id.as_str())
+        );
+    }
+
+    #[test]
+    fn refresh_agent_tool_snapshot_detects_equal_size_replacement() {
+        let mut app = build_minimal_test_app();
+        register_test_tool(&app.tool_registry, "mcp_srv_old");
+        let first_refresh = app.refresh_agent_tool_snapshot();
+        assert_eq!(first_refresh.added, vec!["mcp_srv_old".to_string()]);
+        assert!(app.agent.tool_registry.get("mcp_srv_old").is_some());
+
+        assert!(app.tool_registry.deregister("mcp_srv_old"));
+        register_test_tool(&app.tool_registry, "mcp_srv_new");
+        let second_refresh = app.refresh_agent_tool_snapshot();
+
+        assert_eq!(second_refresh.before_count, 1);
+        assert_eq!(second_refresh.after_count, 1);
+        assert_eq!(second_refresh.added, vec!["mcp_srv_new".to_string()]);
+        assert_eq!(second_refresh.removed, vec!["mcp_srv_old".to_string()]);
+        assert!(app.agent.tool_registry.get("mcp_srv_old").is_none());
+        assert!(app.agent.tool_registry.get("mcp_srv_new").is_some());
+        assert!(app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_new"));
+        assert!(!app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_old"));
+    }
+
+    #[test]
+    fn refresh_agent_tool_snapshot_reports_no_changes_when_current() {
+        let mut app = build_minimal_test_app();
+        let refresh = app.refresh_agent_tool_snapshot();
+
+        assert_eq!(refresh.before_count, 0);
+        assert_eq!(refresh.after_count, 0);
+        assert!(!refresh.changed());
     }
 
     #[test]
@@ -5757,6 +5858,11 @@ mod tests {
 // ---------------------------------------------------------------------------
 // Helper: bridge hermes_tools::ToolRegistry → agent_loop::ToolRegistry
 // ---------------------------------------------------------------------------
+
+fn sorted_tool_names(mut names: Vec<String>) -> Vec<String> {
+    names.sort();
+    names
+}
 
 pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
     bridge_tool_registry_excluding(tools, &[])

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -15004,10 +15004,23 @@ fn handle_memory_command(app: &mut App, args: &[&str]) -> Result<CommandResult, 
 
 fn handle_reload_command(app: &mut App, cmd: &str) -> Result<CommandResult, AgentError> {
     if cmd == "/reload-mcp" {
-        emit_command_output(
-            app,
-            "MCP reload requested. Restart session/gateway for full connector renegotiation.",
+        let refresh = app.refresh_agent_tool_snapshot();
+        let mut out = format!(
+            "MCP reload complete: refreshed agent tool snapshot ({} -> {} tools).",
+            refresh.before_count, refresh.after_count
         );
+        if refresh.changed() {
+            if !refresh.added.is_empty() {
+                let _ = write!(out, "\nAdded: {}", refresh.added.join(", "));
+            }
+            if !refresh.removed.is_empty() {
+                let _ = write!(out, "\nRemoved: {}", refresh.removed.join(", "));
+            }
+        } else {
+            out.push_str("\nNo tool changes detected.");
+        }
+        out.push_str("\nConnector renegotiation still requires a process restart.");
+        emit_command_output(app, out);
     } else if cmd == "/reload-skills" {
         let config = SkillCommandResolverConfig {
             enabled: app.config.skills.enabled.clone(),
@@ -28636,6 +28649,46 @@ mod tests {
         fn schema(&self) -> hermes_core::ToolSchema {
             self.schema.clone()
         }
+    }
+
+    fn register_cli_noop_tool(registry: &hermes_tools::ToolRegistry, name: &str) {
+        let schema =
+            hermes_core::tool_schema(name, "CLI noop", hermes_core::JsonSchema::new("object"));
+        registry.register(
+            name,
+            "mcp-test",
+            schema.clone(),
+            Arc::new(CliNoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "CLI noop",
+            "mcp",
+            None,
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_mcp_refreshes_agent_snapshot_from_runtime_registry() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        assert!(app.agent.tool_registry.get("mcp_srv_ping").is_none());
+        register_cli_noop_tool(&app.tool_registry, "mcp_srv_ping");
+
+        let result = handle_reload_command(&mut app, "/reload-mcp").expect("reload mcp");
+
+        assert_eq!(result, CommandResult::Handled);
+        assert!(app.agent.tool_registry.get("mcp_srv_ping").is_some());
+        assert!(app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_ping"));
+        let out = latest_ui_assistant_text(&app);
+        assert!(out.contains("MCP reload complete"));
+        assert!(out.contains("Added: mcp_srv_ping"));
     }
 
     #[test]

--- a/crates/hermes-tool-planning/src/lib.rs
+++ b/crates/hermes-tool-planning/src/lib.rs
@@ -83,6 +83,20 @@ fn platform_has_custom_toolsets(config: &GatewayConfig, key: &str) -> bool {
     }
 }
 
+fn append_live_mcp_toolsets(requested: &mut Vec<String>, manager: &ToolsetManager) {
+    let mut live_mcp: Vec<String> = manager
+        .list_toolsets()
+        .into_iter()
+        .filter(|name| name.starts_with("mcp-"))
+        .collect();
+    live_mcp.sort();
+    for name in live_mcp {
+        if !requested.contains(&name) {
+            requested.push(name);
+        }
+    }
+}
+
 fn coding_focus_toolsets(
     config: &GatewayConfig,
     platform: &str,
@@ -95,17 +109,7 @@ fn coding_focus_toolsets(
     coding_toolset_selection(Some(&key), None, Some(&config.agent.coding_context))?;
 
     let mut requested = vec!["coding".to_string()];
-    let mut live_mcp: Vec<String> = manager
-        .list_toolsets()
-        .into_iter()
-        .filter(|name| name.starts_with("mcp-"))
-        .collect();
-    live_mcp.sort();
-    for name in live_mcp {
-        if !requested.contains(&name) {
-            requested.push(name);
-        }
-    }
+    append_live_mcp_toolsets(&mut requested, manager);
     Some(requested)
 }
 
@@ -116,8 +120,13 @@ pub fn resolve_platform_tool_names(
     registry: &Arc<ToolRegistry>,
 ) -> Vec<String> {
     let manager = ToolsetManager::new(Arc::clone(registry));
-    let requested = coding_focus_toolsets(config, platform, &manager)
+    let key = normalize_platform_key(platform);
+    let has_custom_toolsets = platform_has_custom_toolsets(config, &key);
+    let mut requested = coding_focus_toolsets(config, platform, &manager)
         .unwrap_or_else(|| configured_platform_toolsets(config, platform));
+    if !has_custom_toolsets {
+        append_live_mcp_toolsets(&mut requested, &manager);
+    }
 
     let mut names: HashSet<String> = HashSet::new();
     for token in requested {
@@ -366,7 +375,7 @@ mod tests {
         let cfg = GatewayConfig::default();
         let reg = registry_with_minimal_tools();
         let names = resolve_platform_tool_names(&cfg, "discord", &reg);
-        assert!(names.contains(&"send_message".to_string()));
+        assert!(!names.contains(&"send_message".to_string()));
         assert!(names.contains(&"terminal".to_string()));
         assert!(names.contains(&"integrations_snapshot".to_string()));
         assert!(names.contains(&"objective_snapshot".to_string()));
@@ -484,6 +493,62 @@ mod tests {
     }
 
     #[test]
+    fn default_cli_toolset_keeps_live_mcp_tools() {
+        let cfg = GatewayConfig::default();
+        let reg = registry_with_minimal_tools();
+        let schema = tool_schema(
+            "mcp_lattice_search",
+            "ContextLattice search",
+            JsonSchema::new("object"),
+        );
+        reg.register(
+            "mcp_lattice_search",
+            "mcp-lattice",
+            schema.clone(),
+            Arc::new(NoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "ContextLattice search",
+            "x",
+            None,
+        );
+
+        let names = resolve_platform_tool_names(&cfg, "cli", &reg);
+        assert!(names.contains(&"terminal".to_string()));
+        assert!(names.contains(&"mcp_lattice_search".to_string()));
+    }
+
+    #[test]
+    fn custom_cli_toolset_does_not_auto_add_live_mcp_tools() {
+        let mut cfg = GatewayConfig::default();
+        cfg.platform_toolsets
+            .insert("cli".to_string(), vec!["web".to_string()]);
+        let reg = registry_with_minimal_tools();
+        let schema = tool_schema(
+            "mcp_lattice_search",
+            "ContextLattice search",
+            JsonSchema::new("object"),
+        );
+        reg.register(
+            "mcp_lattice_search",
+            "mcp-lattice",
+            schema.clone(),
+            Arc::new(NoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "ContextLattice search",
+            "x",
+            None,
+        );
+
+        let names = resolve_platform_tool_names(&cfg, "cli", &reg);
+        assert!(names.contains(&"web_search".to_string()));
+        assert!(!names.contains(&"mcp_lattice_search".to_string()));
+    }
+
+    #[test]
     fn coding_focus_collapses_default_cli_toolset_and_keeps_live_mcp() {
         let _lock = env_test_lock();
         let tmp = tempfile::tempdir().unwrap();
@@ -537,7 +602,8 @@ mod tests {
         let mut auto_cfg = GatewayConfig::default();
         auto_cfg.agent.coding_context = "auto".to_string();
         let auto_names = resolve_platform_tool_names(&auto_cfg, "cli", &reg);
-        assert!(auto_names.contains(&"send_message".to_string()));
+        assert!(auto_names.contains(&"terminal".to_string()));
+        assert!(!auto_names.contains(&"send_message".to_string()));
         assert!(auto_names.contains(&"image_generate".to_string()));
 
         let mut custom_focus = GatewayConfig::default();

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1762,6 +1762,14 @@
       "disposition": "ported",
       "notes": "Rust ACP sessions now include client-provided MCP server toolsets through live ToolRegistry mcp-{server} toolsets and explicit aliases, so tools.list, /tools, initialize tool names, ToolsetManager resolution, and registered MCP dispatch all see the session MCP surface. Focused tests cover toolset expansion and ACP MCP tool visibility."
     },
+    "93d6e730288e": {
+      "disposition": "ported",
+      "notes": "Rust now exposes late-registered MCP tools to active agents by refreshing the CLI App agent snapshot from the live ToolRegistry, rebuilding planner schemas, and merging live mcp-* toolsets into default platform tool planning while preserving explicit custom platform filters. Tests cover added tools, equal-size replacements, /reload-mcp command refresh, default/custom MCP planning, and the McpManager discovery-to-registry contract."
+    },
+    "2f7c4858a764": {
+      "disposition": "ported",
+      "notes": "Rust /reload-mcp now performs the stale-snapshot refresh that upstream added for late TUI MCP discovery: it re-bridges the active AgentLoop registry from the live ToolRegistry, reports added/removed tools, refreshes model-visible schemas, and keeps connector renegotiation explicitly restart-bound. Focused CLI tests cover late-added MCP tools and same-count replacement visibility."
+    },
     "f81395975025": {
       "disposition": "superseded",
       "notes": "Upstream simple-terminal registration is superseded by Rust TerminalHandler and LocalBackend command execution, explicit background=true lifecycle tracking, timeout/workdir/schema contracts, and process-management tests without the Python Morph VM dependency."

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T01:15:51.624357+00:00`
+Generated: `2026-06-25T01:37:54.055598+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `6972`.
+- Range: `main..upstream/main`; total commits tracked: `6974`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -12,20 +12,19 @@ Generated: `2026-06-25T01:15:51.624357+00:00`
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 144 |
-| #26 | GPAR-07 upstream queue backfill | 2116 |
+| #26 | GPAR-07 upstream queue backfill | 2118 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
 | pending | 241 |
-| ported | 351 |
+| ported | 353 |
 | superseded | 6304 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `2f7c4858a764` | #20 | fix(tui): refresh tool snapshot when MCP discovery lands after agent build (#48403) |
 | `5ffbfed193ad` | #20 | feat(mcp-catalog): add official Unreal Engine 5.8 MCP server |
 | `73cd8622f9fc` | #22 | feat(billing): /billing terminal billing — interactive TUI + CLI client (#45449) |
 | `49596b70cb2d` | #20 | fix(gateway): resume follows the compression tip so post-compression replies render |
@@ -61,7 +60,6 @@ Generated: `2026-06-25T01:15:51.624357+00:00`
 | `553cf4f97757` | #26 | feat(desktop): restart the gateway from Cmd+K, with statusbar spinner feedback |
 | `a1639921ac44` | #26 | fix(desktop): offer a Restart gateway action on messaging save/toggle toasts |
 | `929dbf777801` | #26 | fix(desktop): make rendered logs selectable so they can be copied |
-| `93d6e730288e` | #20 | fix(mcp): expose late-connecting MCP tools to the agent (TUI/CLI/gateway) |
 | `b6e2a54a94f5` | #20 | fix(mcp): address adversarial review round 1 (cache parity, gates, races) |
 | `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
 | `ba49fb51a585` | #20 | fix(discord): hydrate channel context when replying to a message (#49212) |
@@ -125,3 +123,5 @@ Generated: `2026-06-25T01:15:51.624357+00:00`
 | `a9669323922f` | #20 | fix(telegram): exempt tables from rich newline hard-breaks |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
 | `ea056b05598c` | #20 | fix(telegram): avoid rich messages for CJK text |
+| `d0de4601d204` | #20 | fix(tui): /compress shows a before/after summary (#46686) |
+| `7bc6f1806284` | #23 | fix(hindsight): skip local_embedded daemon when running as root |


### PR DESCRIPTION
## Summary
- refresh the active CLI AgentLoop tool snapshot from the live ToolRegistry for `/reload-mcp`
- expose late-registered `mcp-*` toolsets through default platform tool planning while preserving explicit custom platform filters
- mark upstream late MCP refresh commits `2f7c4858a764` and `93d6e730288e` as ported in the parity queue

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli refresh_agent_tool_snapshot --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli reload_mcp_refreshes_agent_snapshot_from_runtime_registry --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-tool-planning --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-mcp manager_registers_discovered_mcp_tools_as_callable_registry_tools --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_hermes_cli_toolset --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_messaging_platform_presets_present --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-tool-planning -p hermes-mcp -p hermes-tools` -> `new=0 stale=0`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test --workspace`
