### PR TITLE
parity(session): follow compression resume tips

### DIFF
--- a/crates/hermes-agent/src/session_persistence.rs
+++ b/crates/hermes-agent/src/session_persistence.rs
@@ -1026,6 +1026,42 @@ impl SessionPersistence {
         }
     }
 
+    /// Update lineage/end-state metadata for an existing session row.
+    pub fn update_session_lineage(
+        &self,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+        end_reason: Option<&str>,
+        created_at: Option<&str>,
+        ended_at: Option<&str>,
+    ) -> Result<bool, AgentError> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() || !self.db_path.exists() {
+            return Ok(false);
+        }
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+        let changed = conn
+            .execute(
+                "UPDATE sessions
+                 SET parent_session_id = ?1,
+                     end_reason = ?2,
+                     created_at = COALESCE(?3, created_at),
+                     updated_at = COALESCE(?3, updated_at),
+                     ended_at = ?4
+                 WHERE id = ?5",
+                rusqlite::params![
+                    parent_session_id,
+                    end_reason,
+                    created_at,
+                    ended_at,
+                    session_id
+                ],
+            )
+            .map_err(|e| AgentError::Io(format!("Failed to update session lineage: {e}")))?;
+        Ok(changed > 0)
+    }
+
     /// Read the persisted model metadata for a session without creating a database.
     pub fn get_session_model(&self, session_id: &str) -> Result<Option<String>, AgentError> {
         if session_id.trim().is_empty() || !self.db_path.exists() {
@@ -1053,6 +1089,70 @@ impl SessionPersistence {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(AgentError::Io(format!("Failed to read session model: {e}"))),
         }
+    }
+
+    /// Follow compression-continuation children to the live resume tip.
+    ///
+    /// Auto-compression ends the current session with `end_reason='compression'`
+    /// and forks a child. The parent can still contain flushed messages, so a
+    /// naive resume of the parent id misses turns written to the continuation.
+    pub fn get_compression_tip(&self, session_id: &str) -> Result<String, AgentError> {
+        let mut current = session_id.trim().to_string();
+        if current.is_empty() || !self.db_path.exists() {
+            return Ok(current);
+        }
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| AgentError::Io(format!("Failed to open sessions db: {e}")))?;
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..128 {
+            if !seen.insert(current.clone()) {
+                break;
+            }
+            let mut stmt = match conn.prepare(
+                "SELECT c.id
+                 FROM sessions c
+                 JOIN sessions p ON p.id = c.parent_session_id
+                 WHERE c.parent_session_id = ?1
+                   AND p.end_reason = 'compression'
+                   AND NULLIF(TRIM(p.ended_at), '') IS NOT NULL
+                   AND c.created_at >= p.ended_at
+                 ORDER BY c.created_at DESC, c.updated_at DESC, c.id DESC
+                 LIMIT 1",
+            ) {
+                Ok(stmt) => stmt,
+                Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+                    if message.contains("no such table") || message.contains("no such column") =>
+                {
+                    return Ok(current);
+                }
+                Err(e) => {
+                    return Err(AgentError::Io(format!(
+                        "Failed to prepare compression-tip query: {e}"
+                    )));
+                }
+            };
+            let next = match stmt.query_row(rusqlite::params![current.as_str()], |row| {
+                row.get::<_, String>(0)
+            }) {
+                Ok(next) => next,
+                Err(rusqlite::Error::QueryReturnedNoRows) => break,
+                Err(e) => {
+                    return Err(AgentError::Io(format!(
+                        "Failed to resolve compression tip: {e}"
+                    )));
+                }
+            };
+            if next.trim().is_empty() || next == current {
+                break;
+            }
+            current = next;
+        }
+        Ok(current)
+    }
+
+    /// Resolve a resume target through compression continuations when present.
+    pub fn resolve_resume_session_id(&self, session_id: &str) -> Result<String, AgentError> {
+        self.get_compression_tip(session_id)
     }
 
     /// Soft-delete the target user turn and all later active rows.
@@ -1456,6 +1556,34 @@ mod tests {
             params![ts, session_id],
         )
         .expect("update updated_at");
+    }
+
+    fn set_session_lineage(
+        sp: &SessionPersistence,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+        end_reason: Option<&str>,
+        created_at: &str,
+        ended_at: Option<&str>,
+    ) {
+        let conn = rusqlite::Connection::open(&sp.db_path).expect("open db");
+        conn.execute(
+            "UPDATE sessions
+             SET parent_session_id = ?1,
+                 end_reason = ?2,
+                 created_at = ?3,
+                 updated_at = ?3,
+                 ended_at = ?4
+             WHERE id = ?5",
+            params![
+                parent_session_id,
+                end_reason,
+                created_at,
+                ended_at,
+                session_id
+            ],
+        )
+        .expect("update session lineage");
     }
 
     fn grow_sessions_wal(
@@ -1878,6 +2006,157 @@ mod tests {
             )
             .unwrap();
         assert_eq!(model, "nous:hermes-4");
+    }
+
+    #[test]
+    fn resolve_resume_session_id_follows_compression_tip_with_nonempty_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        sp.persist_session(
+            "root",
+            &[Message::user("pre-compression turn")],
+            None,
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        sp.persist_session(
+            "cont",
+            &[Message::assistant("post-compression reply")],
+            None,
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        let base = Utc::now() - ChronoDuration::hours(1);
+        let root_created = base.to_rfc3339();
+        let root_ended = (base + ChronoDuration::seconds(10)).to_rfc3339();
+        let cont_created = (base + ChronoDuration::seconds(20)).to_rfc3339();
+        set_session_lineage(
+            &sp,
+            "root",
+            None,
+            Some("compression"),
+            &root_created,
+            Some(&root_ended),
+        );
+        set_session_lineage(&sp, "cont", Some("root"), None, &cont_created, None);
+
+        assert_eq!(sp.resolve_resume_session_id("root").unwrap(), "cont");
+    }
+
+    #[test]
+    fn resolve_resume_session_id_ignores_non_compression_branch_child() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        sp.persist_session(
+            "root",
+            &[Message::user("parent turn")],
+            None,
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        sp.persist_session(
+            "branch",
+            &[Message::assistant("delegated work")],
+            None,
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        let base = Utc::now() - ChronoDuration::hours(1);
+        let root_created = base.to_rfc3339();
+        let branch_created = (base + ChronoDuration::seconds(20)).to_rfc3339();
+        set_session_lineage(&sp, "root", None, None, &root_created, None);
+        set_session_lineage(&sp, "branch", Some("root"), None, &branch_created, None);
+
+        assert_eq!(sp.resolve_resume_session_id("root").unwrap(), "root");
+    }
+
+    #[test]
+    fn resolve_resume_session_id_ignores_child_created_before_parent_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        sp.persist_session(
+            "root",
+            &[Message::user("parent turn")],
+            None,
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        sp.persist_session(
+            "early",
+            &[Message::assistant("older branch")],
+            None,
+            Some("cli"),
+            None,
+            None,
+        )
+        .unwrap();
+        let base = Utc::now() - ChronoDuration::hours(1);
+        let root_created = base.to_rfc3339();
+        let root_ended = (base + ChronoDuration::seconds(30)).to_rfc3339();
+        let early_created = (base + ChronoDuration::seconds(10)).to_rfc3339();
+        set_session_lineage(
+            &sp,
+            "root",
+            None,
+            Some("compression"),
+            &root_created,
+            Some(&root_ended),
+        );
+        set_session_lineage(&sp, "early", Some("root"), None, &early_created, None);
+
+        assert_eq!(sp.resolve_resume_session_id("root").unwrap(), "root");
+    }
+
+    #[test]
+    fn resolve_resume_session_id_walks_compression_chain_to_latest_tip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sp = SessionPersistence::new(tmp.path());
+        for id in ["root", "mid", "tip"] {
+            sp.persist_session(
+                id,
+                &[Message::assistant(format!("{id} message"))],
+                None,
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+        }
+        let base = Utc::now() - ChronoDuration::hours(1);
+        let root_created = base.to_rfc3339();
+        let root_ended = (base + ChronoDuration::seconds(10)).to_rfc3339();
+        let mid_created = (base + ChronoDuration::seconds(20)).to_rfc3339();
+        let mid_ended = (base + ChronoDuration::seconds(30)).to_rfc3339();
+        let tip_created = (base + ChronoDuration::seconds(40)).to_rfc3339();
+        set_session_lineage(
+            &sp,
+            "root",
+            None,
+            Some("compression"),
+            &root_created,
+            Some(&root_ended),
+        );
+        set_session_lineage(
+            &sp,
+            "mid",
+            Some("root"),
+            Some("compression"),
+            &mid_created,
+            Some(&mid_ended),
+        );
+        set_session_lineage(&sp, "tip", Some("mid"), None, &tip_created, None);
+
+        assert_eq!(sp.resolve_resume_session_id("root").unwrap(), "tip");
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -1304,7 +1304,46 @@ fn load_resume_payload(
             }
         }
     }
+    payload = follow_resume_compression_tip(payload)?;
     Ok(payload)
+}
+
+fn follow_resume_compression_tip(
+    payload: ResumeSessionPayload,
+) -> Result<ResumeSessionPayload, AgentError> {
+    let Some(source_sessions_dir) = payload.source_path.parent() else {
+        return Ok(payload);
+    };
+    let Some(state_root) = source_sessions_dir.parent() else {
+        return Ok(payload);
+    };
+    let persistence = SessionPersistence::new(state_root);
+    let tip = match persistence.resolve_resume_session_id(&payload.session_id) {
+        Ok(tip) => tip,
+        Err(err) => {
+            tracing::debug!(
+                "resume compression-tip resolution skipped for {}: {}",
+                payload.session_id,
+                err
+            );
+            return Ok(payload);
+        }
+    };
+    if tip.trim().is_empty() || tip == payload.session_id {
+        return Ok(payload);
+    }
+    match resolve_resume_session_file(source_sessions_dir, Some(&tip)) {
+        Ok((resolved_id, source_path)) => parse_resume_payload_file(resolved_id, source_path),
+        Err(err) => {
+            tracing::debug!(
+                "resume compression tip {} resolved from {} but snapshot lookup failed: {}",
+                tip,
+                payload.session_id,
+                err
+            );
+            Ok(payload)
+        }
+    }
 }
 
 fn parse_resume_payload_file(
@@ -18982,6 +19021,80 @@ max_turns: 50
             payload.messages[2].role,
             hermes_core::MessageRole::Assistant
         ));
+    }
+
+    #[test]
+    fn load_resume_payload_follows_compression_tip_snapshot() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cli = cli_for_temp_state_root(tmp.path());
+        let state_root = hermes_state_root(&cli);
+        let sessions_dir = state_root.join("sessions");
+        std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+        std::fs::write(
+            sessions_dir.join("root.json"),
+            r#"{
+  "session_info": {"session_id":"root","model":"nous:openai/gpt-5.5"},
+  "messages":[{"role":"User","content":"pre-compression turn"}]
+}"#,
+        )
+        .expect("write root session");
+        std::fs::write(
+            sessions_dir.join("cont.json"),
+            r#"{
+  "session_info": {"session_id":"cont","model":"nous:openai/gpt-5.5"},
+  "messages":[{"role":"Assistant","content":"post-compression reply"}]
+}"#,
+        )
+        .expect("write continuation session");
+
+        let persistence = SessionPersistence::new(&state_root);
+        persistence
+            .persist_session(
+                "root",
+                &[hermes_core::Message::user("pre-compression turn")],
+                Some("nous:openai/gpt-5.5"),
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+        persistence
+            .persist_session(
+                "cont",
+                &[hermes_core::Message::assistant("post-compression reply")],
+                Some("nous:openai/gpt-5.5"),
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+        let base = chrono::Utc::now() - chrono::Duration::hours(1);
+        let root_created = base.to_rfc3339();
+        let root_ended = (base + chrono::Duration::seconds(10)).to_rfc3339();
+        let cont_created = (base + chrono::Duration::seconds(20)).to_rfc3339();
+        assert!(persistence
+            .update_session_lineage(
+                "root",
+                None,
+                Some("compression"),
+                Some(&root_created),
+                Some(&root_ended),
+            )
+            .expect("mark root compressed"));
+        assert!(persistence
+            .update_session_lineage("cont", Some("root"), None, Some(&cont_created), None,)
+            .expect("link continuation"));
+
+        let payload = load_resume_payload(&cli, Some("root")).expect("load payload");
+
+        assert_eq!(payload.resolved_id, "cont");
+        assert_eq!(payload.session_id, "cont");
+        assert_eq!(payload.source_path, sessions_dir.join("cont.json"));
+        assert_eq!(payload.messages.len(), 1);
+        assert_eq!(
+            payload.messages[0].content.as_deref(),
+            Some("post-compression reply")
+        );
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4244,6 +4244,16 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in this batch: /model refresh [provider|provider:model] clears signed provider catalog payload/signature files and reloads through the configured provider catalog path with command and cache tests."
+    },
+    "49596b70cb2d0d328d68645905febb074e494e77": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust: SessionPersistence resolves resume targets through compression-continuation children only when the parent ended with end_reason='compression', has ended_at set, and the child was created after that end time; CLI resume snapshot loading follows the resolved tip so parent resumes include post-compression child messages. Focused tests cover non-empty compressed parents, branch-child guardrails, chain traversal, and snapshot reload."
+    },
+    "1699525638ed4feba3fd35f0be5c6d4d2d326a49": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fixes a Python tui_gateway slash.exec -> command.dispatch fallback for pending-input commands. Ultra's Rust gateway has no split slash.exec/command.dispatch RPC path: slash input is parsed once by crates/hermes-gateway/src/commands.rs into typed GatewayCommandResult variants, and /retry, /undo, /queue, /q, and /steer are consumed directly by crates/hermes-gateway/src/gateway.rs. The fragile client-side fallback failure mode is absent; /goal and /plan are CLI-only Rust commands, not gateway pending-input RPCs."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T01:37:54.055598+00:00`
+Generated: `2026-06-25T02:06:15.775590+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `6974`.
+- Range: `main..upstream/main`; total commits tracked: `6978`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3115 |
+| #20 | GPAR-01 tests+CI parity | 3118 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 957 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
-| #25 | GPAR-06 packaging/docs/install parity | 144 |
+| #25 | GPAR-06 packaging/docs/install parity | 145 |
 | #26 | GPAR-07 upstream queue backfill | 2118 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
 | pending | 241 |
-| ported | 353 |
-| superseded | 6304 |
+| ported | 354 |
+| superseded | 6307 |
 
 ## First 100 Pending Commits
 
@@ -27,7 +27,6 @@ Generated: `2026-06-25T01:37:54.055598+00:00`
 | --- | ---: | --- |
 | `5ffbfed193ad` | #20 | feat(mcp-catalog): add official Unreal Engine 5.8 MCP server |
 | `73cd8622f9fc` | #22 | feat(billing): /billing terminal billing — interactive TUI + CLI client (#45449) |
-| `49596b70cb2d` | #20 | fix(gateway): resume follows the compression tip so post-compression replies render |
 | `36851fa576eb` | #20 | fix(docker): support WebUI installs from read-only sources (#48541) |
 | `cfb55de5ea49` | #21 | Update Stripe Projects skill docs (#48673) |
 | `c02192ff6ace` | #20 | feat(image-gen): add image-to-image / editing to image_generate (#48705) |
@@ -38,7 +37,6 @@ Generated: `2026-06-25T01:37:54.055598+00:00`
 | `27a6e188c4b4` | #23 | refactor(openviking): derive recall-tool name set from canonical schemas |
 | `2d4046c6de97` | #23 | refactor(openviking): reuse pre-scanned tool_input for pending tool calls |
 | `be2c2beb96e5` | #23 | refactor(openviking): name tool_status constants and alias sets |
-| `1699525638ed` | #20 | fix(tui): route pending-input commands via command.dispatch (#48848) |
 | `f9ffe0bc3f61` | #26 | fix(desktop): resume stored session id on notification click |
 | `069011dd0c8f` | #26 | test(desktop): cover runtime->stored notification id resolution |
 | `bce1e36b5769` | #20 | fix(discord): unwrap dict choices + soft-boundary truncate clarify buttons |
@@ -125,3 +123,5 @@ Generated: `2026-06-25T01:37:54.055598+00:00`
 | `ea056b05598c` | #20 | fix(telegram): avoid rich messages for CJK text |
 | `d0de4601d204` | #20 | fix(tui): /compress shows a before/after summary (#46686) |
 | `7bc6f1806284` | #23 | fix(hindsight): skip local_embedded daemon when running as root |
+| `93ea9b04aff2` | #20 | fix(gateway): cap inbound media download size to prevent memory exhaustion |
+| `6183e8ce1b5e` | #20 | fix(telegram): make Bot API 10.1 rich messages opt-in (default off) |


### PR DESCRIPTION
## Summary
- port Rust resume resolution through compression-continuation session tips
- reload the resolved continuation snapshot when `hermes --resume <parent>` targets a compressed parent
- classify upstream pending-input Python RPC fallback as superseded by the Rust gateway command path and regenerate the parity queue

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-agent resolve_resume_session_id --lib
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli load_resume_payload_follows_compression_tip_snapshot --bin hermes-agent-ultra
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway commands::tests::test_active_session_bypass_registry --lib
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-cli -p hermes-gateway
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test --workspace