### PR TITLE
parity(image): add image edit runtime support

### DIFF
--- a/crates/hermes-tools/src/backends/image_gen.rs
+++ b/crates/hermes-tools/src/backends/image_gen.rs
@@ -21,25 +21,55 @@ use base64::{
     Engine as _,
 };
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crate::tools::image_gen::ImageGenBackend;
+use crate::tools::image_gen::{ImageGenBackend, ImageGenCapabilities, ImageGenerateRequest};
 use hermes_config::managed_gateway::{
     resolve_managed_tool_gateway, ManagedToolGatewayConfig, ResolveOptions,
 };
 use hermes_core::ToolError;
 
-/// Default fal.ai model when running through direct mode. Same default as
-/// the Python `image_generation_tool.py`.
-const DEFAULT_FAL_MODEL_PATH: &str = "fal-ai/flux/dev";
+/// Default fal.ai model when running through direct mode. Same default as the
+/// current upstream `image_generation_tool.py`.
+const DEFAULT_FAL_MODEL_PATH: &str = "fal-ai/flux-2/klein/9b";
+const DEFAULT_FAL_ASPECT_RATIO: &str = "landscape";
 const DEFAULT_CODEX_IMAGE_MODEL: &str = "gpt-image-2-medium";
 const CODEX_IMAGE_API_MODEL: &str = "gpt-image-2";
 const DEFAULT_CODEX_IMAGE_CHAT_MODEL: &str = "gpt-5.5";
 const DEFAULT_CODEX_IMAGE_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const CODEX_IMAGE_INSTRUCTIONS: &str = "You are an assistant that must fulfill image generation requests by using the image_generation tool when provided.";
 const CODEX_CLOUDFLARE_ORIGINATOR: &str = "codex_cli_rs";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FalSizeStyle {
+    ImageSizePreset,
+    AspectRatio,
+    GptLiteral,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FalModelSpec {
+    id: &'static str,
+    display: &'static str,
+    size_style: FalSizeStyle,
+    landscape: &'static str,
+    square: &'static str,
+    portrait: &'static str,
+    supports: &'static [&'static str],
+    edit_endpoint: Option<&'static str>,
+    edit_supports: &'static [&'static str],
+    max_reference_images: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FalPreparedRequest {
+    endpoint: String,
+    body: Value,
+    modality: &'static str,
+    source_image_count: usize,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum FalTransport {
@@ -150,14 +180,15 @@ impl FalImageGenBackend {
     /// Priority: direct `FAL_KEY` → Nous-managed `fal-queue` vendor →
     /// `Err` with a hint covering both paths.
     pub fn from_env_or_managed() -> Result<Self, ToolError> {
+        let model_path = resolve_fal_model_path();
         if let Ok(key) = std::env::var("FAL_KEY") {
             let trimmed = key.trim();
             if !trimmed.is_empty() {
-                return Ok(Self::new(trimmed.to_string()));
+                return Ok(Self::new(trimmed.to_string()).with_model_path(model_path));
             }
         }
         if let Some(cfg) = resolve_managed_tool_gateway("fal-queue", ResolveOptions::default()) {
-            return Ok(Self::from_managed(&cfg));
+            return Ok(Self::from_managed(&cfg).with_model_path(model_path));
         }
         Err(ToolError::ExecutionFailed(
             "FAL_KEY not set and Nous-managed fal-queue gateway is not configured.".into(),
@@ -175,6 +206,52 @@ impl FalImageGenBackend {
 
     pub fn model_path(&self) -> &str {
         &self.model_path
+    }
+
+    fn prepare_request(
+        &self,
+        request: &ImageGenerateRequest,
+    ) -> Result<FalPreparedRequest, ToolError> {
+        if request.prompt.trim().is_empty() {
+            return Err(ToolError::InvalidParams(
+                "Prompt is required and must be a non-empty string.".into(),
+            ));
+        }
+
+        let source_images = request.source_image_urls();
+        if source_images.is_empty() {
+            return Ok(FalPreparedRequest {
+                endpoint: self.model_path.clone(),
+                body: build_fal_text_payload(&self.model_path, request),
+                modality: "text",
+                source_image_count: 0,
+            });
+        }
+
+        let spec = fal_model_spec(&self.model_path).ok_or_else(|| {
+            ToolError::InvalidParams(format!(
+                "FAL model '{}' is not declared as image-to-image capable. Omit image_url/reference_image_urls, or switch to an edit-capable model.",
+                self.model_path
+            ))
+        })?;
+        let edit_endpoint = spec.edit_endpoint.ok_or_else(|| {
+            ToolError::InvalidParams(format!(
+                "Model '{}' ({}) is not capable of image-to-image / editing. Omit image_url/reference_image_urls, or switch to an edit-capable FAL model.",
+                spec.display, spec.id
+            ))
+        })?;
+        let max_refs = spec.max_reference_images;
+        let clamped_sources: Vec<String> = if max_refs > 0 {
+            source_images.into_iter().take(max_refs).collect()
+        } else {
+            source_images
+        };
+        Ok(FalPreparedRequest {
+            endpoint: edit_endpoint.to_string(),
+            body: build_fal_edit_payload(spec, request, &clamped_sources),
+            modality: "image",
+            source_image_count: clamped_sources.len(),
+        })
     }
 }
 
@@ -309,29 +386,9 @@ impl From<OpenAICodexImageGenBackend> for ImageGenRuntimeBackend {
 
 #[async_trait]
 impl ImageGenBackend for FalImageGenBackend {
-    async fn generate(
-        &self,
-        prompt: &str,
-        size: Option<&str>,
-        _style: Option<&str>,
-        n: Option<u32>,
-    ) -> Result<String, ToolError> {
-        let (width, height) = match size {
-            Some("256x256") => (256, 256),
-            Some("512x512") => (512, 512),
-            _ => (1024, 1024),
-        };
-
-        let body = json!({
-            "prompt": prompt,
-            "image_size": {
-                "width": width,
-                "height": height,
-            },
-            "num_images": n.unwrap_or(1),
-        });
-
-        let url = self.transport.submit_url(&self.model_path);
+    async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError> {
+        let prepared = self.prepare_request(&request)?;
+        let url = self.transport.submit_url(&prepared.endpoint);
         let (auth_name, auth_value) = self.transport.auth_header();
 
         let resp = self
@@ -339,7 +396,7 @@ impl ImageGenBackend for FalImageGenBackend {
             .post(url)
             .header(auth_name, auth_value)
             .header("Content-Type", "application/json")
-            .json(&body)
+            .json(&prepared.body)
             .send()
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("fal.ai API request failed: {}", e)))?;
@@ -376,25 +433,57 @@ impl ImageGenBackend for FalImageGenBackend {
             })
             .unwrap_or_default();
 
+        let image = images
+            .first()
+            .and_then(|img| img.get("url"))
+            .and_then(Value::as_str)
+            .map(Value::from)
+            .unwrap_or(Value::Null);
+
         Ok(json!({
+            "success": true,
+            "image": image,
             "images": images,
+            "modality": prepared.modality,
             "transport": self.transport.label(),
             "model": self.model_path,
+            "endpoint": prepared.endpoint,
+            "source_images": prepared.source_image_count,
         })
         .to_string())
+    }
+
+    fn capabilities(&self) -> ImageGenCapabilities {
+        let spec = fal_model_spec(&self.model_path);
+        ImageGenCapabilities {
+            provider: Some("FAL.ai".to_string()),
+            model: Some(
+                spec.map(|spec| spec.display)
+                    .unwrap_or_else(|| self.model_path.as_str())
+                    .to_string(),
+            ),
+            modalities: if spec.and_then(|spec| spec.edit_endpoint).is_some() {
+                vec!["text".to_string(), "image".to_string()]
+            } else {
+                vec!["text".to_string()]
+            },
+            max_reference_images: spec
+                .filter(|spec| spec.edit_endpoint.is_some())
+                .map(|spec| spec.max_reference_images)
+                .unwrap_or(0),
+        }
     }
 }
 
 #[async_trait]
 impl ImageGenBackend for OpenAICodexImageGenBackend {
-    async fn generate(
-        &self,
-        prompt: &str,
-        size: Option<&str>,
-        _style: Option<&str>,
-        _n: Option<u32>,
-    ) -> Result<String, ToolError> {
-        let prompt = prompt.trim();
+    async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError> {
+        if request.has_image_inputs() {
+            return Err(ToolError::InvalidParams(
+                "OpenAI Codex image generation is text-to-image only in this Rust backend; omit image_url/reference_image_urls or switch to an edit-capable FAL model.".into(),
+            ));
+        }
+        let prompt = request.prompt.trim();
         if prompt.is_empty() {
             return Err(ToolError::InvalidParams(
                 "Prompt is required and must be a non-empty string.".into(),
@@ -411,7 +500,7 @@ impl ImageGenBackend for OpenAICodexImageGenBackend {
                     "OpenAI Codex image generation requires Codex OAuth credentials. Run `hermes auth codex` or set HERMES_OPENAI_CODEX_API_KEY.".into(),
                 )
             })?;
-        let image_size = codex_image_size_from_tool_size(size);
+        let image_size = codex_image_size_from_tool_size(request.size.as_deref());
         let body = codex_image_responses_payload(
             prompt,
             image_size,
@@ -465,23 +554,34 @@ impl ImageGenBackend for OpenAICodexImageGenBackend {
             "prompt": prompt,
             "size": image_size,
             "quality": self.config.quality,
+            "modality": "text",
         })
         .to_string())
+    }
+
+    fn capabilities(&self) -> ImageGenCapabilities {
+        ImageGenCapabilities {
+            provider: Some("openai-codex".to_string()),
+            model: Some(self.config.tier_id.clone()),
+            modalities: vec!["text".to_string()],
+            max_reference_images: 0,
+        }
     }
 }
 
 #[async_trait]
 impl ImageGenBackend for ImageGenRuntimeBackend {
-    async fn generate(
-        &self,
-        prompt: &str,
-        size: Option<&str>,
-        style: Option<&str>,
-        n: Option<u32>,
-    ) -> Result<String, ToolError> {
+    async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError> {
         match self {
-            Self::Fal(backend) => backend.generate(prompt, size, style, n).await,
-            Self::OpenAICodex(backend) => backend.generate(prompt, size, style, n).await,
+            Self::Fal(backend) => backend.generate(request).await,
+            Self::OpenAICodex(backend) => backend.generate(request).await,
+        }
+    }
+
+    fn capabilities(&self) -> ImageGenCapabilities {
+        match self {
+            Self::Fal(backend) => backend.capabilities(),
+            Self::OpenAICodex(backend) => backend.capabilities(),
         }
     }
 }
@@ -497,6 +597,499 @@ fn env_optional_nonempty(key: &str) -> Option<String> {
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
+}
+
+fn resolve_fal_model_path() -> String {
+    for key in ["FAL_IMAGE_MODEL", "HERMES_FAL_IMAGE_MODEL"] {
+        if let Some(value) =
+            env_optional_nonempty(key).and_then(|value| normalize_fal_model_path(&value))
+        {
+            return value;
+        }
+    }
+    if let Some(cfg) = load_image_gen_config() {
+        if let Some(fal_cfg) = yaml_get(&cfg, "fal") {
+            if let Some(value) = yaml_get_str(fal_cfg, "model").and_then(normalize_fal_model_path) {
+                return value;
+            }
+        }
+        if let Some(value) = yaml_get_str(&cfg, "model").and_then(normalize_fal_model_path) {
+            return value;
+        }
+    }
+    DEFAULT_FAL_MODEL_PATH.to_string()
+}
+
+fn normalize_fal_model_path(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else if fal_model_spec(value).is_some() || value.contains('/') {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}
+
+fn build_fal_text_payload(model_path: &str, request: &ImageGenerateRequest) -> Value {
+    let Some(spec) = fal_model_spec(model_path) else {
+        return build_legacy_fal_text_payload(request);
+    };
+    let mut payload = fal_model_defaults(spec.id);
+    payload.insert("prompt".to_string(), json!(request.prompt.trim()));
+    insert_fal_size(&mut payload, spec, spec.supports, request.size.as_deref());
+    insert_common_fal_overrides(&mut payload, spec.supports, request);
+    retain_supported_keys(&mut payload, spec.supports);
+    Value::Object(payload)
+}
+
+fn build_fal_edit_payload(
+    spec: FalModelSpec,
+    request: &ImageGenerateRequest,
+    source_images: &[String],
+) -> Value {
+    let mut payload = fal_model_defaults(spec.id);
+    payload.insert("prompt".to_string(), json!(request.prompt.trim()));
+    payload.insert("image_urls".to_string(), json!(source_images));
+    insert_fal_size(
+        &mut payload,
+        spec,
+        spec.edit_supports,
+        request.size.as_deref(),
+    );
+    insert_common_fal_overrides(&mut payload, spec.edit_supports, request);
+    retain_supported_keys(&mut payload, spec.edit_supports);
+    Value::Object(payload)
+}
+
+fn build_legacy_fal_text_payload(request: &ImageGenerateRequest) -> Value {
+    let (width, height) = match request.size.as_deref().map(str::trim) {
+        Some("256x256") => (256, 256),
+        Some("512x512") => (512, 512),
+        _ => (1024, 1024),
+    };
+    json!({
+        "prompt": request.prompt.trim(),
+        "image_size": {
+            "width": width,
+            "height": height,
+        },
+        "num_images": request.n.unwrap_or(1),
+    })
+}
+
+fn insert_fal_size(
+    payload: &mut Map<String, Value>,
+    spec: FalModelSpec,
+    supports: &[&str],
+    size: Option<&str>,
+) {
+    let aspect = fal_aspect_from_tool_size(size);
+    let value = match aspect {
+        "square" => spec.square,
+        "portrait" => spec.portrait,
+        _ => spec.landscape,
+    };
+    match spec.size_style {
+        FalSizeStyle::ImageSizePreset | FalSizeStyle::GptLiteral => {
+            if supports_key(supports, "image_size") {
+                payload.insert("image_size".to_string(), json!(value));
+            }
+        }
+        FalSizeStyle::AspectRatio => {
+            if supports_key(supports, "aspect_ratio") {
+                payload.insert("aspect_ratio".to_string(), json!(value));
+            }
+        }
+    }
+}
+
+fn insert_common_fal_overrides(
+    payload: &mut Map<String, Value>,
+    supports: &[&str],
+    request: &ImageGenerateRequest,
+) {
+    if let Some(n) = request.n {
+        if supports_key(supports, "num_images") {
+            payload.insert("num_images".to_string(), json!(n));
+        }
+    }
+    if let Some(style) = request
+        .style
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        if supports_key(supports, "style") {
+            payload.insert("style".to_string(), json!(style));
+        }
+    }
+}
+
+fn fal_aspect_from_tool_size(size: Option<&str>) -> &'static str {
+    match size.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("square") | Some("1:1") | Some("1024x1024") | Some("512x512") | Some("256x256") => {
+            "square"
+        }
+        Some("portrait") | Some("9:16") | Some("1024x1536") => "portrait",
+        Some("landscape") | Some("16:9") | Some("1536x1024") => "landscape",
+        _ => DEFAULT_FAL_ASPECT_RATIO,
+    }
+}
+
+fn retain_supported_keys(payload: &mut Map<String, Value>, supports: &[&str]) {
+    payload.retain(|key, _| supports_key(supports, key));
+}
+
+fn supports_key(supports: &[&str], key: &str) -> bool {
+    supports.contains(&key)
+}
+
+fn fal_model_defaults(model_path: &str) -> Map<String, Value> {
+    let mut payload = Map::new();
+    match model_path {
+        "fal-ai/flux-2/klein/9b" => {
+            payload.insert("num_inference_steps".to_string(), json!(4));
+            payload.insert("output_format".to_string(), json!("png"));
+            payload.insert("enable_safety_checker".to_string(), json!(false));
+        }
+        "fal-ai/flux-2-pro" => {
+            payload.insert("num_inference_steps".to_string(), json!(50));
+            payload.insert("guidance_scale".to_string(), json!(4.5));
+            payload.insert("num_images".to_string(), json!(1));
+            payload.insert("output_format".to_string(), json!("png"));
+            payload.insert("enable_safety_checker".to_string(), json!(false));
+            payload.insert("safety_tolerance".to_string(), json!("5"));
+            payload.insert("sync_mode".to_string(), json!(true));
+        }
+        "fal-ai/z-image/turbo" => {
+            payload.insert("num_inference_steps".to_string(), json!(8));
+            payload.insert("num_images".to_string(), json!(1));
+            payload.insert("output_format".to_string(), json!("png"));
+            payload.insert("enable_safety_checker".to_string(), json!(false));
+            payload.insert("enable_prompt_expansion".to_string(), json!(false));
+        }
+        "fal-ai/nano-banana-pro" => {
+            payload.insert("num_images".to_string(), json!(1));
+            payload.insert("output_format".to_string(), json!("png"));
+            payload.insert("safety_tolerance".to_string(), json!("5"));
+            payload.insert("resolution".to_string(), json!("1K"));
+        }
+        "fal-ai/gpt-image-1.5" | "fal-ai/gpt-image-2" => {
+            payload.insert("quality".to_string(), json!("medium"));
+            payload.insert("num_images".to_string(), json!(1));
+            payload.insert("output_format".to_string(), json!("png"));
+        }
+        "fal-ai/ideogram/v3" => {
+            payload.insert("rendering_speed".to_string(), json!("BALANCED"));
+            payload.insert("expand_prompt".to_string(), json!(true));
+            payload.insert("style".to_string(), json!("AUTO"));
+        }
+        "fal-ai/recraft/v4/pro/text-to-image" => {
+            payload.insert("enable_safety_checker".to_string(), json!(false));
+        }
+        "fal-ai/qwen-image" => {
+            payload.insert("num_inference_steps".to_string(), json!(30));
+            payload.insert("guidance_scale".to_string(), json!(2.5));
+            payload.insert("num_images".to_string(), json!(1));
+            payload.insert("output_format".to_string(), json!("png"));
+            payload.insert("acceleration".to_string(), json!("regular"));
+        }
+        "fal-ai/krea/v2/medium/text-to-image" | "fal-ai/krea/v2/large/text-to-image" => {
+            payload.insert("creativity".to_string(), json!("medium"));
+        }
+        _ => {}
+    }
+    payload
+}
+
+fn fal_model_spec(model_path: &str) -> Option<FalModelSpec> {
+    match model_path.trim() {
+        "fal-ai/flux-2/klein/9b" => Some(FalModelSpec {
+            id: "fal-ai/flux-2/klein/9b",
+            display: "FLUX 2 Klein 9B",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_16_9",
+            square: "square_hd",
+            portrait: "portrait_16_9",
+            supports: &[
+                "prompt",
+                "image_size",
+                "num_inference_steps",
+                "seed",
+                "output_format",
+                "enable_safety_checker",
+            ],
+            edit_endpoint: Some("fal-ai/flux-2/klein/9b/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "num_inference_steps",
+                "seed",
+                "output_format",
+                "enable_safety_checker",
+            ],
+            max_reference_images: 9,
+        }),
+        "fal-ai/flux-2-pro" => Some(FalModelSpec {
+            id: "fal-ai/flux-2-pro",
+            display: "FLUX 2 Pro",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_16_9",
+            square: "square_hd",
+            portrait: "portrait_16_9",
+            supports: &[
+                "prompt",
+                "image_size",
+                "num_inference_steps",
+                "guidance_scale",
+                "num_images",
+                "output_format",
+                "enable_safety_checker",
+                "safety_tolerance",
+                "sync_mode",
+                "seed",
+            ],
+            edit_endpoint: Some("fal-ai/flux-2-pro/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "num_inference_steps",
+                "guidance_scale",
+                "num_images",
+                "output_format",
+                "enable_safety_checker",
+                "safety_tolerance",
+                "sync_mode",
+                "seed",
+            ],
+            max_reference_images: 9,
+        }),
+        "fal-ai/z-image/turbo" => Some(FalModelSpec {
+            id: "fal-ai/z-image/turbo",
+            display: "Z-Image Turbo",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_16_9",
+            square: "square_hd",
+            portrait: "portrait_16_9",
+            supports: &[
+                "prompt",
+                "image_size",
+                "num_inference_steps",
+                "num_images",
+                "seed",
+                "output_format",
+                "enable_safety_checker",
+                "enable_prompt_expansion",
+            ],
+            edit_endpoint: None,
+            edit_supports: &[],
+            max_reference_images: 0,
+        }),
+        "fal-ai/nano-banana-pro" => Some(FalModelSpec {
+            id: "fal-ai/nano-banana-pro",
+            display: "Nano Banana Pro (Gemini 3 Pro Image)",
+            size_style: FalSizeStyle::AspectRatio,
+            landscape: "16:9",
+            square: "1:1",
+            portrait: "9:16",
+            supports: &[
+                "prompt",
+                "aspect_ratio",
+                "num_images",
+                "output_format",
+                "safety_tolerance",
+                "seed",
+                "sync_mode",
+                "resolution",
+                "enable_web_search",
+                "limit_generations",
+            ],
+            edit_endpoint: Some("fal-ai/nano-banana-pro/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "aspect_ratio",
+                "num_images",
+                "output_format",
+                "safety_tolerance",
+                "seed",
+                "sync_mode",
+                "resolution",
+                "enable_web_search",
+                "limit_generations",
+            ],
+            max_reference_images: 2,
+        }),
+        "fal-ai/gpt-image-1.5" => Some(FalModelSpec {
+            id: "fal-ai/gpt-image-1.5",
+            display: "GPT Image 1.5",
+            size_style: FalSizeStyle::GptLiteral,
+            landscape: "1536x1024",
+            square: "1024x1024",
+            portrait: "1024x1536",
+            supports: &[
+                "prompt",
+                "image_size",
+                "quality",
+                "num_images",
+                "output_format",
+                "background",
+                "sync_mode",
+            ],
+            edit_endpoint: Some("fal-ai/gpt-image-1.5/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "image_size",
+                "quality",
+                "num_images",
+                "output_format",
+                "sync_mode",
+            ],
+            max_reference_images: 16,
+        }),
+        "fal-ai/gpt-image-2" => Some(FalModelSpec {
+            id: "fal-ai/gpt-image-2",
+            display: "GPT Image 2",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_4_3",
+            square: "square_hd",
+            portrait: "portrait_4_3",
+            supports: &[
+                "prompt",
+                "image_size",
+                "quality",
+                "num_images",
+                "output_format",
+                "sync_mode",
+            ],
+            edit_endpoint: Some("openai/gpt-image-2/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "quality",
+                "num_images",
+                "output_format",
+                "sync_mode",
+                "mask_image_url",
+            ],
+            max_reference_images: 16,
+        }),
+        "fal-ai/ideogram/v3" => Some(FalModelSpec {
+            id: "fal-ai/ideogram/v3",
+            display: "Ideogram V3",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_16_9",
+            square: "square_hd",
+            portrait: "portrait_16_9",
+            supports: &[
+                "prompt",
+                "image_size",
+                "rendering_speed",
+                "expand_prompt",
+                "style",
+                "seed",
+            ],
+            edit_endpoint: Some("fal-ai/ideogram/v3/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "rendering_speed",
+                "expand_prompt",
+                "style",
+                "seed",
+            ],
+            max_reference_images: 1,
+        }),
+        "fal-ai/recraft/v4/pro/text-to-image" => Some(FalModelSpec {
+            id: "fal-ai/recraft/v4/pro/text-to-image",
+            display: "Recraft V4 Pro",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_16_9",
+            square: "square_hd",
+            portrait: "portrait_16_9",
+            supports: &[
+                "prompt",
+                "image_size",
+                "enable_safety_checker",
+                "colors",
+                "background_color",
+            ],
+            edit_endpoint: None,
+            edit_supports: &[],
+            max_reference_images: 0,
+        }),
+        "fal-ai/qwen-image" => Some(FalModelSpec {
+            id: "fal-ai/qwen-image",
+            display: "Qwen Image",
+            size_style: FalSizeStyle::ImageSizePreset,
+            landscape: "landscape_16_9",
+            square: "square_hd",
+            portrait: "portrait_16_9",
+            supports: &[
+                "prompt",
+                "image_size",
+                "num_inference_steps",
+                "guidance_scale",
+                "num_images",
+                "output_format",
+                "acceleration",
+                "seed",
+                "sync_mode",
+            ],
+            edit_endpoint: Some("fal-ai/qwen-image-2/pro/edit"),
+            edit_supports: &[
+                "prompt",
+                "image_urls",
+                "num_inference_steps",
+                "guidance_scale",
+                "num_images",
+                "output_format",
+                "acceleration",
+                "seed",
+                "sync_mode",
+            ],
+            max_reference_images: 3,
+        }),
+        "fal-ai/krea/v2/medium/text-to-image" => Some(FalModelSpec {
+            id: "fal-ai/krea/v2/medium/text-to-image",
+            display: "Krea 2 Medium",
+            size_style: FalSizeStyle::AspectRatio,
+            landscape: "16:9",
+            square: "1:1",
+            portrait: "9:16",
+            supports: &[
+                "prompt",
+                "aspect_ratio",
+                "creativity",
+                "seed",
+                "image_style_references",
+            ],
+            edit_endpoint: None,
+            edit_supports: &[],
+            max_reference_images: 0,
+        }),
+        "fal-ai/krea/v2/large/text-to-image" => Some(FalModelSpec {
+            id: "fal-ai/krea/v2/large/text-to-image",
+            display: "Krea 2 Large",
+            size_style: FalSizeStyle::AspectRatio,
+            landscape: "16:9",
+            square: "1:1",
+            portrait: "9:16",
+            supports: &[
+                "prompt",
+                "aspect_ratio",
+                "creativity",
+                "seed",
+                "image_style_references",
+            ],
+            edit_endpoint: None,
+            edit_supports: &[],
+            max_reference_images: 0,
+        }),
+        _ => None,
+    }
 }
 
 fn selected_image_provider() -> Option<&'static str> {
@@ -862,6 +1455,8 @@ mod fal_managed_tests {
             let keys = [
                 "HERMES_HOME",
                 "FAL_KEY",
+                "FAL_IMAGE_MODEL",
+                "HERMES_FAL_IMAGE_MODEL",
                 "OPENAI_IMAGE_MODEL",
                 "HERMES_IMAGE_GEN_PROVIDER",
                 "HERMES_IMAGE_GEN_BACKEND",
@@ -901,6 +1496,17 @@ mod fal_managed_tests {
                     None => std::env::remove_var(k),
                 }
             }
+        }
+    }
+
+    fn image_request(prompt: &str) -> ImageGenerateRequest {
+        ImageGenerateRequest {
+            prompt: prompt.to_string(),
+            size: None,
+            style: None,
+            n: None,
+            image_url: None,
+            reference_image_urls: Vec::new(),
         }
     }
 
@@ -963,6 +1569,100 @@ mod fal_managed_tests {
     fn with_model_path_overrides_default() {
         let b = FalImageGenBackend::new("k".into()).with_model_path("fal-ai/flux-pro");
         assert_eq!(b.model_path(), "fal-ai/flux-pro");
+    }
+
+    #[test]
+    fn fal_model_path_reads_env_and_config() {
+        let _g = EnvScope::new();
+        std::env::set_var("FAL_KEY", "direct-key");
+        std::env::set_var("FAL_IMAGE_MODEL", "fal-ai/gpt-image-2");
+        let b = FalImageGenBackend::from_env_or_managed().unwrap();
+        assert_eq!(b.model_path(), "fal-ai/gpt-image-2");
+
+        std::env::remove_var("FAL_IMAGE_MODEL");
+        std::fs::write(
+            hermes_config::paths::config_path(),
+            "image_gen:\n  provider: fal\n  fal:\n    model: fal-ai/nano-banana-pro\n",
+        )
+        .expect("write config");
+        let b = FalImageGenBackend::from_env_or_managed().unwrap();
+        assert_eq!(b.model_path(), "fal-ai/nano-banana-pro");
+
+        std::fs::write(
+            hermes_config::paths::config_path(),
+            "image_gen:\n  provider: fal\n  model: gpt-image-2-high\n",
+        )
+        .expect("write config");
+        let b = FalImageGenBackend::from_env_or_managed().unwrap();
+        assert_eq!(b.model_path(), DEFAULT_FAL_MODEL_PATH);
+    }
+
+    #[test]
+    fn fal_text_payload_uses_catalog_endpoint_and_supported_keys() {
+        let backend = FalImageGenBackend::new("k".into()).with_model_path("fal-ai/gpt-image-2");
+        let mut request = image_request("draw launch typography");
+        request.size = Some("landscape".to_string());
+        request.n = Some(2);
+
+        let prepared = backend.prepare_request(&request).unwrap();
+        assert_eq!(prepared.endpoint, "fal-ai/gpt-image-2");
+        assert_eq!(prepared.modality, "text");
+        assert_eq!(prepared.body["prompt"], "draw launch typography");
+        assert_eq!(prepared.body["image_size"], "landscape_4_3");
+        assert_eq!(prepared.body["quality"], "medium");
+        assert_eq!(prepared.body["num_images"], 2);
+        assert!(prepared.body.get("image_urls").is_none());
+    }
+
+    #[test]
+    fn fal_edit_payload_uses_edit_endpoint_and_clamps_references() {
+        let backend = FalImageGenBackend::new("k".into()).with_model_path("fal-ai/nano-banana-pro");
+        let mut request = image_request("replace the sign text");
+        request.size = Some("portrait".to_string());
+        request.image_url = Some("https://example.test/source.png".to_string());
+        request.reference_image_urls = vec![
+            "https://example.test/ref-a.png".to_string(),
+            "https://example.test/ref-b.png".to_string(),
+            "https://example.test/ref-c.png".to_string(),
+        ];
+
+        let prepared = backend.prepare_request(&request).unwrap();
+        assert_eq!(prepared.endpoint, "fal-ai/nano-banana-pro/edit");
+        assert_eq!(prepared.modality, "image");
+        assert_eq!(prepared.source_image_count, 2);
+        assert_eq!(prepared.body["prompt"], "replace the sign text");
+        assert_eq!(prepared.body["aspect_ratio"], "9:16");
+        assert_eq!(
+            prepared.body["image_urls"],
+            json!([
+                "https://example.test/source.png",
+                "https://example.test/ref-a.png"
+            ])
+        );
+    }
+
+    #[test]
+    fn fal_text_only_model_rejects_image_inputs() {
+        let backend = FalImageGenBackend::new("k".into()).with_model_path("fal-ai/z-image/turbo");
+        let mut request = image_request("edit source");
+        request.image_url = Some("https://example.test/source.png".to_string());
+        let err = backend.prepare_request(&request).unwrap_err();
+        assert!(err.to_string().contains("not capable of image-to-image"));
+    }
+
+    #[test]
+    fn image_capabilities_reflect_fal_edit_support() {
+        let edit_backend = FalImageGenBackend::new("k".into()).with_model_path("fal-ai/flux-2-pro");
+        let caps = edit_backend.capabilities();
+        assert_eq!(caps.provider.as_deref(), Some("FAL.ai"));
+        assert!(caps.supports_image_input());
+        assert_eq!(caps.max_reference_images, 9);
+
+        let text_backend =
+            FalImageGenBackend::new("k".into()).with_model_path("fal-ai/z-image/turbo");
+        let caps = text_backend.capabilities();
+        assert!(!caps.supports_image_input());
+        assert_eq!(caps.max_reference_images, 0);
     }
 
     #[test]
@@ -1126,7 +1826,14 @@ mod fal_managed_tests {
 
         let backend = OpenAICodexImageGenBackend::from_env_or_auth_store().unwrap();
         let output = backend
-            .generate("paint a launch", Some("landscape"), None, None)
+            .generate(ImageGenerateRequest {
+                prompt: "paint a launch".to_string(),
+                size: Some("landscape".to_string()),
+                style: None,
+                n: None,
+                image_url: None,
+                reference_image_urls: Vec::new(),
+            })
             .await
             .unwrap();
         let payload: Value = serde_json::from_str(&output).unwrap();
@@ -1137,5 +1844,16 @@ mod fal_managed_tests {
         let image = payload["image"].as_str().expect("image path");
         assert!(image.contains("cache/images/openai_codex_gpt_image_2_high_"));
         assert_eq!(std::fs::read(image).unwrap(), b"\x89PNG\r\n\x1a\n");
+    }
+
+    #[tokio::test]
+    async fn codex_image_generate_rejects_image_inputs() {
+        let mut request = image_request("edit source");
+        request.image_url = Some("https://example.test/source.png".to_string());
+        let err = OpenAICodexImageGenBackend::unconfigured()
+            .generate(request)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("text-to-image only"));
     }
 }

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -71,7 +71,9 @@ pub use tools::homeassistant::{
     HaCallServiceHandler, HaGetStateHandler, HaListEntitiesHandler, HaListServicesHandler,
     HomeAssistantBackend,
 };
-pub use tools::image_gen::{ImageGenBackend, ImageGenerateHandler};
+pub use tools::image_gen::{
+    ImageGenBackend, ImageGenCapabilities, ImageGenerateHandler, ImageGenerateRequest,
+};
 pub use tools::integrations_snapshot::IntegrationsSnapshotHandler;
 pub use tools::managed_tool_gateway::ManagedToolGatewayHandler;
 pub use tools::memory::{MemoryBackend, MemoryHandler};

--- a/crates/hermes-tools/src/tools/image_gen.rs
+++ b/crates/hermes-tools/src/tools/image_gen.rs
@@ -12,17 +12,78 @@ use std::sync::Arc;
 // ImageGenBackend trait
 // ---------------------------------------------------------------------------
 
+/// Unified image-generation request. Source-image fields are optional; when any
+/// source image is present, edit-capable backends route to image-to-image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageGenerateRequest {
+    pub prompt: String,
+    pub size: Option<String>,
+    pub style: Option<String>,
+    pub n: Option<u32>,
+    pub image_url: Option<String>,
+    pub reference_image_urls: Vec<String>,
+}
+
+impl ImageGenerateRequest {
+    pub fn has_image_inputs(&self) -> bool {
+        self.image_url.is_some() || !self.reference_image_urls.is_empty()
+    }
+
+    pub fn source_image_urls(&self) -> Vec<String> {
+        let mut urls = Vec::new();
+        if let Some(url) = self
+            .image_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            urls.push(url.to_string());
+        }
+        urls.extend(
+            self.reference_image_urls
+                .iter()
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(ToOwned::to_owned),
+        );
+        urls
+    }
+}
+
+/// Backend-reported capability metadata used to keep the tool schema honest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageGenCapabilities {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub modalities: Vec<String>,
+    pub max_reference_images: usize,
+}
+
+impl ImageGenCapabilities {
+    pub fn text_only() -> Self {
+        Self {
+            provider: None,
+            model: None,
+            modalities: vec!["text".to_string()],
+            max_reference_images: 0,
+        }
+    }
+
+    pub fn supports_image_input(&self) -> bool {
+        self.modalities.iter().any(|m| m == "image")
+    }
+}
+
 /// Backend for image generation operations.
 #[async_trait]
 pub trait ImageGenBackend: Send + Sync {
-    /// Generate an image from a prompt.
-    async fn generate(
-        &self,
-        prompt: &str,
-        size: Option<&str>,
-        style: Option<&str>,
-        n: Option<u32>,
-    ) -> Result<String, ToolError>;
+    /// Generate an image from text or edit source images.
+    async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError>;
+
+    fn capabilities(&self) -> ImageGenCapabilities {
+        ImageGenCapabilities::text_only()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -46,13 +107,30 @@ impl ToolHandler for ImageGenerateHandler {
         let prompt = params
             .get("prompt")
             .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
             .ok_or_else(|| ToolError::InvalidParams("Missing 'prompt' parameter".into()))?;
 
-        let size = params.get("size").and_then(|v| v.as_str());
-        let style = params.get("style").and_then(|v| v.as_str());
-        let n = params.get("n").and_then(|v| v.as_u64()).map(|n| n as u32);
+        let n = match params.get("n").and_then(|v| v.as_u64()) {
+            Some(value) if value <= u32::MAX as u64 => Some(value as u32),
+            Some(_) => {
+                return Err(ToolError::InvalidParams(
+                    "'n' must fit within an unsigned 32-bit integer".into(),
+                ));
+            }
+            None => None,
+        };
 
-        self.backend.generate(prompt, size, style, n).await
+        let request = ImageGenerateRequest {
+            prompt: prompt.to_string(),
+            size: optional_string_param(&params, "size"),
+            style: optional_string_param(&params, "style"),
+            n,
+            image_url: optional_string_param(&params, "image_url"),
+            reference_image_urls: parse_reference_image_urls(&params),
+        };
+
+        self.backend.generate(request).await
     }
 
     fn schema(&self) -> ToolSchema {
@@ -66,8 +144,8 @@ impl ToolHandler for ImageGenerateHandler {
         );
         props.insert("size".into(), json!({
             "type": "string",
-            "description": "Image size: '256x256', '512x512', '1024x1024' (default: '1024x1024')",
-            "enum": ["256x256", "512x512", "1024x1024"]
+            "description": "Image size or aspect: 'landscape', 'square', 'portrait', '256x256', '512x512', '1024x1024', '1536x1024', or '1024x1536'.",
+            "enum": ["landscape", "square", "portrait", "256x256", "512x512", "1024x1024", "1536x1024", "1024x1536"]
         }));
         props.insert(
             "style".into(),
@@ -84,46 +162,185 @@ impl ToolHandler for ImageGenerateHandler {
                 "default": 1
             }),
         );
+        props.insert(
+            "image_url".into(),
+            json!({
+                "type": "string",
+                "description": "Optional source image URL/path to edit or transform. Omit for text-to-image."
+            }),
+        );
+        props.insert(
+            "reference_image_urls".into(),
+            json!({
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional additional reference image URLs/paths for image-to-image editing."
+            }),
+        );
 
         tool_schema(
             "image_generate",
-            "Generate images from text descriptions using AI image generation models.",
+            image_schema_description(&self.backend.capabilities()),
             JsonSchema::object(props, vec!["prompt".into()]),
         )
     }
 }
 
+fn optional_string_param(params: &Value, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn parse_reference_image_urls(params: &Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    for key in ["reference_image_urls", "reference_images"] {
+        collect_reference_image_urls(params.get(key), &mut refs);
+    }
+    refs
+}
+
+fn collect_reference_image_urls(value: Option<&Value>, out: &mut Vec<String>) {
+    match value {
+        Some(Value::String(value)) => {
+            let value = value.trim();
+            if !value.is_empty() {
+                out.push(value.to_string());
+            }
+        }
+        Some(Value::Array(items)) => {
+            for item in items {
+                if let Some(value) = item.as_str().map(str::trim).filter(|v| !v.is_empty()) {
+                    out.push(value.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn image_schema_description(caps: &ImageGenCapabilities) -> String {
+    let mut parts = vec![
+        "Generate high-quality images from text prompts, or edit/transform existing images when the active backend supports image inputs.".to_string(),
+    ];
+
+    let mut active = String::from("Active backend");
+    if let Some(provider) = caps.provider.as_deref().filter(|v| !v.is_empty()) {
+        active.push_str(": ");
+        active.push_str(provider);
+    }
+    if let Some(model) = caps.model.as_deref().filter(|v| !v.is_empty()) {
+        active.push_str(" - model: ");
+        active.push_str(model);
+    }
+    parts.push(active);
+
+    if caps.supports_image_input() {
+        let ref_note = if caps.max_reference_images > 1 {
+            format!(
+                "; up to {} reference image(s) via reference_image_urls",
+                caps.max_reference_images
+            )
+        } else {
+            String::new()
+        };
+        parts.push(format!(
+            "- supports text-to-image and image-to-image / editing; pass image_url{ref_note}"
+        ));
+    } else {
+        parts.push(
+            "- text-to-image only; do not pass image_url or reference_image_urls because they will be rejected"
+                .to_string(),
+        );
+    }
+
+    parts.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    struct MockImageGenBackend;
+    struct MockImageGenBackend {
+        last_request: Mutex<Option<ImageGenerateRequest>>,
+        capabilities: ImageGenCapabilities,
+    }
+
+    impl MockImageGenBackend {
+        fn new(capabilities: ImageGenCapabilities) -> Self {
+            Self {
+                last_request: Mutex::new(None),
+                capabilities,
+            }
+        }
+
+        fn last_request(&self) -> ImageGenerateRequest {
+            self.last_request.lock().unwrap().clone().unwrap()
+        }
+    }
+
     #[async_trait]
     impl ImageGenBackend for MockImageGenBackend {
-        async fn generate(
-            &self,
-            prompt: &str,
-            _size: Option<&str>,
-            _style: Option<&str>,
-            _n: Option<u32>,
-        ) -> Result<String, ToolError> {
-            Ok(format!("Generated image for: {}", prompt))
+        async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError> {
+            *self.last_request.lock().unwrap() = Some(request.clone());
+            Ok(format!("Generated image for: {}", request.prompt))
+        }
+
+        fn capabilities(&self) -> ImageGenCapabilities {
+            self.capabilities.clone()
         }
     }
 
     #[tokio::test]
     async fn test_image_generate_schema() {
-        let handler = ImageGenerateHandler::new(Arc::new(MockImageGenBackend));
+        let handler =
+            ImageGenerateHandler::new(Arc::new(MockImageGenBackend::new(ImageGenCapabilities {
+                provider: Some("FAL.ai".to_string()),
+                model: Some("FLUX".to_string()),
+                modalities: vec!["text".to_string(), "image".to_string()],
+                max_reference_images: 9,
+            })));
         assert_eq!(handler.schema().name, "image_generate");
+        assert!(handler.schema().description.contains("image-to-image"));
+        let schema = handler.schema();
+        let props = schema.parameters.properties.as_ref().unwrap();
+        assert!(props.contains_key("image_url"));
+        assert!(props.contains_key("reference_image_urls"));
     }
 
     #[tokio::test]
     async fn test_image_generate_execute() {
-        let handler = ImageGenerateHandler::new(Arc::new(MockImageGenBackend));
+        let backend = Arc::new(MockImageGenBackend::new(ImageGenCapabilities::text_only()));
+        let handler = ImageGenerateHandler::new(backend.clone());
         let result = handler
-            .execute(json!({"prompt": "a sunset"}))
+            .execute(json!({
+                "prompt": " a sunset ",
+                "size": "landscape",
+                "style": "natural",
+                "n": 2,
+                "image_url": " https://example.test/source.png ",
+                "reference_image_urls": ["https://example.test/ref-a.png", "", 5],
+                "reference_images": "https://example.test/ref-b.png"
+            }))
             .await
             .unwrap();
         assert!(result.contains("sunset"));
+        let request = backend.last_request();
+        assert_eq!(request.prompt, "a sunset");
+        assert_eq!(request.size.as_deref(), Some("landscape"));
+        assert_eq!(request.style.as_deref(), Some("natural"));
+        assert_eq!(request.n, Some(2));
+        assert_eq!(
+            request.source_image_urls(),
+            vec![
+                "https://example.test/source.png",
+                "https://example.test/ref-a.png",
+                "https://example.test/ref-b.png"
+            ]
+        );
     }
 }

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4254,6 +4254,11 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Upstream fixes a Python tui_gateway slash.exec -> command.dispatch fallback for pending-input commands. Ultra's Rust gateway has no split slash.exec/command.dispatch RPC path: slash input is parsed once by crates/hermes-gateway/src/commands.rs into typed GatewayCommandResult variants, and /retry, /undo, /queue, /q, and /steer are consumed directly by crates/hermes-gateway/src/gateway.rs. The fragile client-side fallback failure mode is absent; /goal and /plan are CLI-only Rust commands, not gateway pending-input RPCs."
+    },
+    "c02192ff6ace129fc9bcc2f8907eabd6eb3f0f1d": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust image_generate: the tool request/schema now carries image_url and reference_image_urls, FAL has a typed model catalog with edit endpoints/reference caps/payload filtering plus runtime FAL_IMAGE_MODEL/config selection, OpenAI Codex remains explicit text-only, and Rust tests cover forwarding, endpoint routing, reference clamping, capabilities, and unsupported-modality errors."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T02:06:15.775590+00:00`
+Generated: `2026-06-25T02:33:07.046683+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `6978`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T02:06:15.775590+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 241 |
-| ported | 354 |
+| pending | 240 |
+| ported | 355 |
 | superseded | 6307 |
 
 ## First 100 Pending Commits
@@ -29,7 +29,6 @@ Generated: `2026-06-25T02:06:15.775590+00:00`
 | `73cd8622f9fc` | #22 | feat(billing): /billing terminal billing — interactive TUI + CLI client (#45449) |
 | `36851fa576eb` | #20 | fix(docker): support WebUI installs from read-only sources (#48541) |
 | `cfb55de5ea49` | #21 | Update Stripe Projects skill docs (#48673) |
-| `c02192ff6ace` | #20 | feat(image-gen): add image-to-image / editing to image_generate (#48705) |
 | `c7b7f92ec14a` | #20 | fix(openviking): sync structured turns with tool parts |
 | `d7cd0bc0863c` | #20 | fix(openviking): preserve structured sync attribution |
 | `9362ce2575e0` | #22 | feat(skills): add html-artifact skill, fold in sketch + architecture-diagram + concept-diagrams (#48899) |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T02:06:15.775590+00:00`
 | `7bc6f1806284` | #23 | fix(hindsight): skip local_embedded daemon when running as root |
 | `93ea9b04aff2` | #20 | fix(gateway): cap inbound media download size to prevent memory exhaustion |
 | `6183e8ce1b5e` | #20 | fix(telegram): make Bot API 10.1 rich messages opt-in (default off) |
+| `587b5b9ac223` | #23 | fix(backup): capture memory-provider state stored outside HERMES_HOME (#50325) |


### PR DESCRIPTION
## Summary
- add typed Rust image_generate requests carrying image_url and reference_image_urls
- add FAL model catalog metadata for text/image modalities, edit endpoints, payload key filtering, max reference caps, and FAL_IMAGE_MODEL/config resolution
- keep OpenAI Codex image generation explicit text-only for source-image inputs
- mark upstream c02192ff6ace image-to-image parity item ported and regenerate upstream queue

## Verification
- cargo test -p hermes-tools image_gen --lib
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- scripts/clippy-warning-gate.sh --check -- -p hermes-tools
- cargo build --workspace
- cargo test --workspace

All cargo commands used CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation and CARGO_INCREMENTAL=0 where applicable.