### PR TITLE
parity(docker): harden packaging and SOUL seeding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN cargo build --release --features "telegram,discord,slack" \
 
 # ----- Runtime stage -----
 FROM debian:bookworm-slim
+LABEL org.opencontainers.image.source="https://github.com/sheawinkler/hermes-agent-ultra" \
+      org.opencontainers.image.licenses="MIT"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates tini gosu \
@@ -20,12 +22,13 @@ RUN apt-get update \
 
 COPY --from=builder /app/target/release/hermes /usr/local/bin/hermes
 COPY docker/entrypoint.sh /usr/local/bin/hermes-entrypoint
+COPY LICENSE NOTICE /usr/share/doc/hermes-agent-ultra/
 RUN chmod +x /usr/local/bin/hermes-entrypoint \
     && groupadd -g 10000 hermes \
     && useradd -u 10000 -g 10000 -m -s /bin/sh hermes \
     && mkdir -p /data \
     && chown -R 10000:10000 /data \
-    && chmod -R a+rX /usr/local/bin
+    && chmod -R a+rX /usr/local/bin /usr/share/doc/hermes-agent-ultra
 
 ENV HERMES_HOME=/data
 VOLUME ["/data"]

--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -37,7 +37,7 @@ use crate::budget;
 use crate::code_index::CodeIndex;
 use crate::coding_context::resolve_runtime_mode;
 use crate::context::{
-    load_builtin_memory_snapshot, load_soul_md, resolve_personality, ContextManager,
+    load_builtin_memory_snapshot, load_soul_md_from_home, resolve_personality, ContextManager,
     SystemPromptBuilder,
 };
 use crate::context_files::{load_hermes_context_files, load_workspace_context};
@@ -4002,7 +4002,7 @@ impl AgentLoop {
         tool_schemas: &[ToolSchema],
         model_for_prompt: &str,
     ) -> String {
-        let soul = load_soul_md();
+        let soul = load_soul_md_from_home(self.config.hermes_home.as_deref());
         let mut builder = SystemPromptBuilder::new().with_personality(soul.as_deref());
         if let Some(base) = self.config.system_prompt.as_deref() {
             builder = builder.with_system_message(base);

--- a/crates/hermes-agent/src/context.rs
+++ b/crates/hermes-agent/src/context.rs
@@ -392,6 +392,25 @@ unless otherwise directed below. Be targeted and efficient in your exploration a
 When the user asks for an actionable task, execute immediately: run the first concrete step with available tools, \
 then continue until completion. Do not stop at intent-only narration such as 'I'll proceed' without performing work.";
 
+const LEGACY_INSTALLER_SOUL_TEMPLATE: &str = "# Hermes Agent Persona\n\n<!--\nCustomize this file to control how Hermes communicates.\nThis file is loaded every message; no restart needed.\nDelete this file (or leave it empty) to use the default personality.\n-->";
+
+const LEGACY_UPSTREAM_SOUL_TEMPLATE_WITH_EXAMPLES: &str = "# Hermes Agent Persona\n\n<!--\nThis file defines the agent's personality and tone.\nThe agent will embody whatever you write here.\nEdit this to customize how Hermes communicates with you.\n\nExamples:\n  - \"You are a warm, playful assistant who uses kaomoji occasionally.\"\n  - \"You are a concise technical expert. No fluff, just facts.\"\n  - \"You speak like a friendly coworker who happens to know everything.\"\n\nThis file is loaded fresh each message -- no restart needed.\nDelete the contents (or this file) to use the default personality.\n-->";
+
+const LEGACY_UPSTREAM_SOUL_TEMPLATE: &str = "# Hermes Agent Persona\n\n<!--\nThis file defines the agent's personality and tone.\nThe agent will embody whatever you write here.\nEdit this to customize how Hermes communicates with you.\n\nThis file is loaded fresh each message -- no restart needed.\nDelete the contents (or this file) to use the default personality.\n-->";
+
+const LEGACY_SOUL_TEMPLATES: &[&str] = &[
+    LEGACY_INSTALLER_SOUL_TEMPLATE,
+    LEGACY_UPSTREAM_SOUL_TEMPLATE_WITH_EXAMPLES,
+    LEGACY_UPSTREAM_SOUL_TEMPLATE,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SoulSeedOutcome {
+    Created,
+    UpgradedLegacy,
+    Preserved,
+}
+
 const BUILTIN_PERSONALITY_CODER: &str = "You are operating in the `coder` persona.\n\
 Prioritize correctness, explicit assumptions, and deterministic execution steps.\n\
 When editing code, prefer small verifiable changes and explain trade-offs briefly.\n\
@@ -564,12 +583,50 @@ const BUILTIN_PERSONALITY_DESCRIPTIONS: &[(&str, &str)] = &[
     ),
 ];
 
-/// Load the SOUL.md personality file from `~/.hermes/SOUL.md`.
+fn normalize_soul_template(text: &str) -> String {
+    text.replace("\r\n", "\n")
+        .replace('\r', "\n")
+        .trim_start_matches('\u{feff}')
+        .trim()
+        .to_string()
+}
+
+pub fn is_legacy_template_soul(text: &str) -> bool {
+    let normalized = normalize_soul_template(text);
+    LEGACY_SOUL_TEMPLATES
+        .iter()
+        .any(|template| normalized == normalize_soul_template(template))
+}
+
+pub fn ensure_default_soul_md(hermes_home: &Path) -> std::io::Result<SoulSeedOutcome> {
+    std::fs::create_dir_all(hermes_home)?;
+    let soul_path = hermes_home.join("SOUL.md");
+    match std::fs::read_to_string(&soul_path) {
+        Ok(existing) => {
+            if is_legacy_template_soul(&existing) {
+                std::fs::write(&soul_path, DEFAULT_AGENT_IDENTITY)?;
+                Ok(SoulSeedOutcome::UpgradedLegacy)
+            } else {
+                Ok(SoulSeedOutcome::Preserved)
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::write(&soul_path, DEFAULT_AGENT_IDENTITY)?;
+            Ok(SoulSeedOutcome::Created)
+        }
+        Err(_) => Ok(SoulSeedOutcome::Preserved),
+    }
+}
+
+/// Load the SOUL.md personality file from the active Hermes home.
 ///
 /// Returns `None` if the file doesn't exist or can't be read.
 pub fn load_soul_md() -> Option<String> {
-    let home = dirs::home_dir()?;
-    let soul_path = home.join(".hermes").join("SOUL.md");
+    load_soul_md_from_home(None)
+}
+
+pub fn load_soul_md_from_home(hermes_home_override: Option<&str>) -> Option<String> {
+    let soul_path = resolve_hermes_home(hermes_home_override).join("SOUL.md");
     load_soul_md_from(&soul_path)
 }
 
@@ -577,6 +634,11 @@ fn resolve_hermes_home(hermes_home_override: Option<&str>) -> PathBuf {
     hermes_home_override
         .map(PathBuf::from)
         .or_else(|| std::env::var("HERMES_HOME").ok().map(PathBuf::from))
+        .or_else(|| {
+            std::env::var("HERMES_AGENT_ULTRA_HOME")
+                .ok()
+                .map(PathBuf::from)
+        })
         .or_else(|| dirs::home_dir().map(|h| h.join(".hermes")))
         .unwrap_or_else(|| PathBuf::from(".hermes"))
 }
@@ -638,7 +700,9 @@ pub fn resolve_personality(name: &str, hermes_home_override: Option<&str>) -> Op
 /// Load a SOUL.md file from a specific path.
 pub fn load_soul_md_from(path: &Path) -> Option<String> {
     match std::fs::read_to_string(path) {
-        Ok(content) if !content.trim().is_empty() => Some(content),
+        Ok(content) if !content.trim().is_empty() && !is_legacy_template_soul(&content) => {
+            Some(content)
+        }
         _ => None,
     }
 }
@@ -1093,6 +1157,85 @@ mod tests {
 
         let result = load_soul_md_from(&soul_path);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_load_soul_md_ignores_legacy_template() {
+        let tmp = tempfile::tempdir().unwrap();
+        let soul_path = tmp.path().join("SOUL.md");
+        std::fs::write(
+            &soul_path,
+            format!("\u{feff}{LEGACY_INSTALLER_SOUL_TEMPLATE}\r\n"),
+        )
+        .unwrap();
+
+        assert!(is_legacy_template_soul(
+            &std::fs::read_to_string(&soul_path).unwrap()
+        ));
+        assert!(load_soul_md_from(&soul_path).is_none());
+    }
+
+    #[test]
+    fn test_legacy_template_detection_preserves_custom_persona() {
+        let custom = format!("{LEGACY_INSTALLER_SOUL_TEMPLATE}\nYou are a helpful pirate.");
+
+        assert!(!is_legacy_template_soul(&custom));
+    }
+
+    #[test]
+    fn test_load_soul_md_from_home_uses_explicit_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("SOUL.md"), "Use explicit home.").unwrap();
+
+        let result = load_soul_md_from_home(Some(tmp.path().to_string_lossy().as_ref()));
+
+        assert_eq!(result.as_deref(), Some("Use explicit home."));
+    }
+
+    #[test]
+    fn test_ensure_default_soul_md_creates_default() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let outcome = ensure_default_soul_md(tmp.path()).unwrap();
+
+        assert_eq!(outcome, SoulSeedOutcome::Created);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("SOUL.md")).unwrap(),
+            DEFAULT_AGENT_IDENTITY
+        );
+    }
+
+    #[test]
+    fn test_ensure_default_soul_md_upgrades_legacy_template() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("SOUL.md"),
+            format!("{LEGACY_UPSTREAM_SOUL_TEMPLATE_WITH_EXAMPLES}\n"),
+        )
+        .unwrap();
+
+        let outcome = ensure_default_soul_md(tmp.path()).unwrap();
+
+        assert_eq!(outcome, SoulSeedOutcome::UpgradedLegacy);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("SOUL.md")).unwrap(),
+            DEFAULT_AGENT_IDENTITY
+        );
+    }
+
+    #[test]
+    fn test_ensure_default_soul_md_preserves_custom_persona() {
+        let tmp = tempfile::tempdir().unwrap();
+        let soul_path = tmp.path().join("SOUL.md");
+        std::fs::write(&soul_path, "Custom persona.").unwrap();
+
+        let outcome = ensure_default_soul_md(tmp.path()).unwrap();
+
+        assert_eq!(outcome, SoulSeedOutcome::Preserved);
+        assert_eq!(
+            std::fs::read_to_string(soul_path).unwrap(),
+            "Custom persona."
+        );
     }
 
     #[test]

--- a/crates/hermes-agent/src/lib.rs
+++ b/crates/hermes-agent/src/lib.rs
@@ -49,8 +49,10 @@ pub use agent_loop::{
 // Re-export context management
 pub use compression::summarize_messages_with_llm;
 pub use context::{
-    builtin_personality_descriptions, builtin_personality_names, load_context_files, load_soul_md,
-    load_soul_md_from, switch_personality, ContextManager, SystemPromptBuilder,
+    builtin_personality_descriptions, builtin_personality_names, ensure_default_soul_md,
+    is_legacy_template_soul, load_context_files, load_soul_md, load_soul_md_from,
+    load_soul_md_from_home, switch_personality, ContextManager, SoulSeedOutcome,
+    SystemPromptBuilder,
 };
 
 // Re-export budget enforcement

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -12185,13 +12185,16 @@ async fn run_setup(cli: Cli) -> Result<(), AgentError> {
         println!("  ✓ Created default profile");
     }
 
-    // 7. Ensure SOUL.md exists so users can customize persona immediately.
-    let soul_path = config_dir.join("SOUL.md");
-    if !soul_path.exists() {
-        let soul_template = "# Hermes Agent Persona\n\n<!--\nCustomize this file to control how Hermes communicates.\nThis file is loaded every message; no restart needed.\nDelete this file (or leave it empty) to use the default personality.\n-->\n";
-        std::fs::write(&soul_path, soul_template)
-            .map_err(|e| AgentError::Io(format!("Failed to write SOUL.md: {}", e)))?;
-        println!("  ✓ Created SOUL.md");
+    // 7. Ensure SOUL.md contains a real default persona. Exact legacy
+    // comment-only scaffolds are safe to upgrade; customized files are kept.
+    match hermes_agent::ensure_default_soul_md(&config_dir)
+        .map_err(|e| AgentError::Io(format!("Failed to initialize SOUL.md: {}", e)))?
+    {
+        hermes_agent::SoulSeedOutcome::Created => println!("  ✓ Created SOUL.md"),
+        hermes_agent::SoulSeedOutcome::UpgradedLegacy => {
+            println!("  ✓ Upgraded legacy SOUL.md template")
+        }
+        hermes_agent::SoulSeedOutcome::Preserved => {}
     }
 
     if full_setup && prompt_yes_no("\nConfigure optional setup sections now?", true).await? {

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,26 +1,26 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-23T11:49:00.474768+00:00`_
+_Generated from source artifacts: `2026-06-25T04:22:02.326832+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-16T23:55:38.405701+00:00`
-- Proof snapshot generated: `2026-06-23T11:49:00.474768+00:00`
+- Queue snapshot generated: `2026-06-25T04:12:55.364845+00:00`
+- Proof snapshot generated: `2026-06-25T04:22:02.326832+00:00`
 
 ## Gate Status
 
-- Release gate: **PASS**
-- CI/tree-drift gate: **PASS**
+- Release gate: **FAIL**
+- CI/tree-drift gate: **FAIL**
 - Test coverage audit: **PASS**
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: none
-- CI gate failures: none
-- CI gate warnings: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
+- Release gate failures: max_queue_pending_commits (actual=234.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=234.0, limit=100)
+- CI gate warnings: none
 
 ## Test Coverage Audit
 
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-23T11:49:00.474768+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 6132 |
-| Pending | 0 |
-| Ported | 316 |
-| Superseded | 5742 |
+| Total commits in queue | 6978 |
+| Pending | 234 |
+| Ported | 359 |
+| Superseded | 6309 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -49,15 +49,13 @@
         "actual": 5880.0,
         "limit": 5500,
         "metric": "max_commits_behind",
-        "special_rule": "allow_tree_drift_when_functional_clean",
-        "status": "warn"
+        "status": "fail"
       },
       {
         "actual": 5657.0,
         "limit": 5000,
         "metric": "max_upstream_patch_missing",
-        "special_rule": "allow_tree_drift_when_functional_clean",
-        "status": "warn"
+        "status": "fail"
       },
       {
         "actual": 2309.0,
@@ -198,24 +196,14 @@
         "status": "pass"
       },
       {
-        "actual": 0.0,
+        "actual": 234.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
-        "status": "pass"
+        "status": "fail"
       }
     ],
     "mode": "tree-drift",
-    "pass": true,
-    "special_rules_applied": [
-      {
-        "metrics": [
-          "max_commits_behind",
-          "max_upstream_patch_missing"
-        ],
-        "reason": "functional parity clean; raw upstream tree drift kept as observability warning for the Rust fork",
-        "rule": "allow_tree_drift_when_functional_clean"
-      }
-    ]
+    "pass": false
   },
   "deep_problem_solving_summary": {
     "gate": {
@@ -260,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-24T00:21:32.551260+00:00",
+  "generated_at_utc": "2026-06-25T04:22:02.326832+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -286,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 0.0,
+    "max_queue_pending_commits": 234.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -310,22 +298,23 @@
   },
   "queue_summary": {
     "by_disposition": {
-      "mirrored": 74,
-      "ported": 316,
-      "superseded": 5742
+      "mirrored": 76,
+      "pending": 234,
+      "ported": 359,
+      "superseded": 6309
     },
     "by_target_ticket": {
-      "20": 2661,
-      "21": 121,
-      "22": 890,
-      "23": 428,
+      "20": 3118,
+      "21": 130,
+      "22": 957,
+      "23": 488,
       "24": 22,
-      "25": 135,
-      "26": 1875
+      "25": 145,
+      "26": 2118
     },
-    "overrides_path": "/Volumes/wd_black/hermes-agent-ultra/repo/docs/parity/queue-overrides.json",
+    "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 6132
+    "total_commits": 6978
   },
   "release_gate": {
     "checks": [
@@ -462,10 +451,10 @@
         "status": "pass"
       },
       {
-        "actual": 0.0,
+        "actual": 234.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
-        "status": "pass"
+        "status": "fail"
       },
       {
         "actual": {
@@ -487,7 +476,7 @@
       }
     ],
     "mode": "functional",
-    "pass": true
+    "pass": false
   },
   "sota_harness_summary": {
     "gate": {

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,12 +1,12 @@
 # Global Parity Proof
 
-Generated: `2026-06-24T00:21:32.551260+00:00`
+Generated: `2026-06-25T04:22:02.326832+00:00`
 
 ## Gate Status
 
-- CI gate: **PASS**
+- CI gate: **FAIL**
 - CI gate mode: `tree-drift`
-- Release gate: **PASS**
+- Release gate: **FAIL**
 - Release gate mode: `functional`
 
 ## Metrics
@@ -38,7 +38,7 @@ Generated: `2026-06-24T00:21:32.551260+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 0.0 |
+| `max_queue_pending_commits` | 234.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-24T00:21:32.551260+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `6132`.
+- Upstream missing commits tracked: `6978`.
 - By target ticket:
-  - `#20`: `2661`
-  - `#21`: `121`
-  - `#22`: `890`
-  - `#23`: `428`
+  - `#20`: `3118`
+  - `#21`: `130`
+  - `#22`: `957`
+  - `#23`: `488`
   - `#24`: `22`
-  - `#25`: `135`
-  - `#26`: `1875`
+  - `#25`: `145`
+  - `#26`: `2118`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4268,6 +4268,26 @@
     "73cd8622f9fcd5e368060d1a1678e08bd3d0a794": {
       "disposition": "ported",
       "notes": "Ported as a Rust-native terminal billing surface: `hermes billing` and `/billing` now render Nous billing state fail-open from the auth store and billing API, support scoped `billing:manage` device-code step-up, explicit-confirmation charge and auto-reload actions with idempotency-key handling and typed error mapping, charge status polling, deterministic portal URL normalization, decimal-string money formatting, and focused Rust tests for state parsing, scope detection, client contracts, CLI parsing, slash behavior, auth isolation, and confirmation gating."
+    },
+    "36851fa576eb4079f0397010f418cafa15a4ab26": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Python setup.py/WebUI read-only-source workaround is structurally absent in Ultra: there is no top-level setup.py or Python WebUI install path. This batch pins the Rust Docker image contract instead: LICENSE/NOTICE are shipped in the image, .dockerignore cannot exclude them, and tests assert immutable /usr/local/bin code with writable HERMES_HOME=/data."
+    },
+    "eb51c180e6484ec15809d04c25a8115e6e48dc3c": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported to Ultra Docker/Rust dashboard contract: docker-compose runs dashboard on 127.0.0.1 by default, docs remove the stale HERMES_DASHBOARD side-process/insecure escape hatch, and Rust API server bind guards still require API_SERVER_KEY for network-accessible binds even when dashboard --insecure acknowledges non-localhost binding."
+    },
+    "cbd6ba1bdd916d8342f6c741cb290b62dd89dbc4": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream durable lazy Python install target is superseded by Ultra Rust packaging: the container ships a compiled /usr/local/bin/hermes binary, has no top-level setup.py/pip install surface, keeps runtime state under /data, and now has Dockerfile contracts proving code immutability plus license packaging."
+    },
+    "411faf08bd678fe3e49b22afcef1e9fd2d7f5592": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust/setup/install: hermes-agent now exposes DEFAULT_AGENT_IDENTITY-backed SOUL.md seeding, ignores exact legacy comment-only templates at prompt load, upgrades those templates during setup, preserves customized SOUL.md files, respects explicit/HERMES_HOME resolution, and install.sh seeds the real default persona instead of an empty scaffold."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T03:33:51.999047+00:00`
+Generated: `2026-06-25T04:12:55.364845+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `6978`.
+- Range: `origin/main..upstream/main`; total commits tracked: `6978`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -17,15 +17,14 @@ Generated: `2026-06-25T03:33:51.999047+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 238 |
-| ported | 357 |
-| superseded | 6307 |
+| pending | 234 |
+| ported | 359 |
+| superseded | 6309 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `36851fa576eb` | #20 | fix(docker): support WebUI installs from read-only sources (#48541) |
 | `cfb55de5ea49` | #21 | Update Stripe Projects skill docs (#48673) |
 | `c7b7f92ec14a` | #20 | fix(openviking): sync structured turns with tool parts |
 | `d7cd0bc0863c` | #20 | fix(openviking): preserve structured sync attribution |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T03:33:51.999047+00:00`
 | `587b5b9ac223` | #23 | fix(backup): capture memory-provider state stored outside HERMES_HOME (#50325) |
 | `2a4542333ee1` | #26 | fix(photon): classify Envoy overflow errors as retryable; add typing cooldown |
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
+| `5e3e89cc05d3` | #23 | feat(hindsight): configurable embedded daemon health grace timeout (#50341) |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,6 +54,7 @@ RUN_SETUP_MODE="${RUN_SETUP_MODE:-auto}" # auto|always|never
 ROOT_FHS_LAYOUT=false
 PATH_GUARD_APPLIED=false
 POSITIONAL_VERSION=""
+DEFAULT_SOUL_MD="You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations. When the user asks for an actionable task, execute immediately: run the first concrete step with available tools, then continue until completion. Do not stop at intent-only narration such as 'I'll proceed' without performing work."
 if [[ -t 0 ]]; then
   IS_INTERACTIVE=true
 else
@@ -424,15 +425,7 @@ fi
 
 mkdir -p "${HERMES_HOME}"
 if [[ ! -f "${HERMES_HOME}/SOUL.md" ]]; then
-  cat > "${HERMES_HOME}/SOUL.md" <<'SOUL_EOF'
-# Hermes Agent Persona
-
-<!--
-Customize this file to control how Hermes communicates.
-This file is loaded every message; no restart needed.
-Delete this file (or leave it empty) to use the default personality.
--->
-SOUL_EOF
+  printf '%s' "${DEFAULT_SOUL_MD}" > "${HERMES_HOME}/SOUL.md"
   echo "Created ${HERMES_HOME}/SOUL.md (edit to customize personality)."
 fi
 

--- a/tests/test_dockerfile_packaging_contract.py
+++ b/tests/test_dockerfile_packaging_contract.py
@@ -1,0 +1,61 @@
+"""Contracts for the Rust Docker image packaging surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+DOCKER_DOC = REPO_ROOT / "website" / "docs" / "user-guide" / "docker.md"
+
+
+def test_docker_image_carries_license_metadata_and_files() -> None:
+    text = DOCKERFILE.read_text()
+
+    assert 'org.opencontainers.image.licenses="MIT"' in text
+    assert "COPY LICENSE NOTICE /usr/share/doc/hermes-agent-ultra/" in text
+    assert "chmod -R a+rX /usr/local/bin /usr/share/doc/hermes-agent-ultra" in text
+
+
+def test_docker_context_does_not_exclude_license_file() -> None:
+    dockerignore = REPO_ROOT / ".dockerignore"
+    if not dockerignore.exists():
+        return
+
+    active_lines = [
+        line.strip()
+        for line in dockerignore.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert "LICENSE" not in active_lines
+    assert "NOTICE" not in active_lines
+
+
+def test_docker_image_has_no_python_setup_install_surface() -> None:
+    text = DOCKERFILE.read_text()
+
+    assert not (REPO_ROOT / "setup.py").exists()
+    assert "pip install" not in text
+    assert "uv pip install" not in text
+    assert "setup.py" not in text
+
+
+def test_docker_image_keeps_code_immutable_and_state_on_data_volume() -> None:
+    text = DOCKERFILE.read_text()
+
+    assert "COPY --from=builder /app/target/release/hermes /usr/local/bin/hermes" in text
+    assert "ENV HERMES_HOME=/data" in text
+    assert 'VOLUME ["/data"]' in text
+    assert "chown -R 10000:10000 /data" in text
+    assert "chown -R 10000:10000 /usr/local" not in text
+
+
+def test_docker_docs_match_ultra_image_and_data_volume() -> None:
+    text = DOCKER_DOC.read_text()
+
+    assert "hermes-agent-ultra" in text
+    assert "nousresearch/hermes-agent" not in text
+    assert "/opt/data" not in text
+    assert "HERMES_DASHBOARD=1" not in text

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -67,3 +67,12 @@ def test_installer_keeps_legacy_hermes_alias_opt_in() -> None:
     assert 'INSTALL_LEGACY_ALIAS="${INSTALL_LEGACY_ALIAS:-false}"' in text
     legacy_link = 'ln -sfn "${CANONICAL_BIN_NAME}" "${INSTALL_DIR}/${LEGACY_BIN_NAME}"'
     assert text.index('truthy_env "${INSTALL_LEGACY_ALIAS}"') < text.index(legacy_link)
+
+
+def test_installer_seeds_real_default_soul_not_empty_template() -> None:
+    text = INSTALL_SH.read_text()
+
+    assert 'DEFAULT_SOUL_MD="You are Hermes Agent' in text
+    assert 'printf \'%s\' "${DEFAULT_SOUL_MD}" > "${HERMES_HOME}/SOUL.md"' in text
+    assert "# Hermes Agent Persona" not in text
+    assert "Customize this file to control how Hermes communicates" not in text

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -11,20 +11,21 @@ There are two distinct ways Docker intersects with Hermes Agent:
 1. **Running Hermes IN Docker** — the agent itself runs inside a container (this page's primary focus)
 2. **Docker as a terminal backend** — the agent runs on your host but executes every command inside a single, persistent Docker sandbox container that survives across tool calls, `/new`, and subagents for the life of the Hermes process (see [Configuration → Docker Backend](./configuration.md#docker-backend))
 
-This page covers option 1. The container stores all user data (config, API keys, sessions, skills, memories) in a single directory mounted from the host at `/opt/data`. The image itself is stateless and can be upgraded by pulling a new version without losing any configuration.
+This page covers option 1. The Ultra container stores all user data (config, API keys, sessions, skills, memories) in a single directory mounted from the host at `/data`. The image itself is stateless and can be rebuilt or upgraded without losing any configuration.
 
 ## Quick start
 
-If this is your first time running Hermes Agent, create a data directory on the host and start the container interactively to run the setup wizard:
+Build the local Rust image, then create a data directory on the host and start the container interactively to run the setup wizard:
 
 ```sh
-mkdir -p ~/.hermes
+docker build -t hermes-agent-ultra .
+mkdir -p ~/.hermes-agent-ultra
 docker run -it --rm \
-  -v ~/.hermes:/opt/data \
-  nousresearch/hermes-agent setup
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra setup
 ```
 
-This drops you into the setup wizard, which will prompt you for your API keys and write them to `~/.hermes/.env`. You only need to do this once. It is highly recommended to set up a chat system for the gateway to work with at this point.
+This drops you into the setup wizard, which will prompt you for your provider credentials and write them under `~/.hermes-agent-ultra`. You only need to do this once. It is highly recommended to set up a chat system for the gateway to work with at this point.
 
 ## Running in gateway mode
 
@@ -32,11 +33,13 @@ Once configured, run the container in the background as a persistent gateway (Te
 
 ```sh
 docker run -d \
-  --name hermes \
+  --name hermes-agent-ultra \
   --restart unless-stopped \
-  -v ~/.hermes:/opt/data \
-  -p 8642:8642 \
-  nousresearch/hermes-agent gateway run
+  --network host \
+  -v ~/.hermes-agent-ultra:/data \
+  -e HERMES_UID="$(id -u)" \
+  -e HERMES_GID="$(id -g)" \
+  hermes-agent-ultra gateway run
 ```
 
 Port 8642 exposes the gateway's [OpenAI-compatible API server](./features/api-server.md) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
@@ -45,47 +48,38 @@ Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond 
 
 ```sh
 docker run -d \
-  --name hermes \
+  --name hermes-agent-ultra \
   --restart unless-stopped \
-  -v ~/.hermes:/opt/data \
-  -p 8642:8642 \
+  --network host \
+  -v ~/.hermes-agent-ultra:/data \
   -e API_SERVER_ENABLED=true \
   -e API_SERVER_HOST=0.0.0.0 \
   -e API_SERVER_KEY=your_api_key_here \
   -e API_SERVER_CORS_ORIGINS='*' \
-  nousresearch/hermes-agent gateway run
+  hermes-agent-ultra gateway run
 ```
 
 Opening any port on an internet facing machine is a security risk. You should not do it unless you understand the risks.
 
 ## Running the dashboard
 
-The built-in web dashboard runs as an optional side-process inside the same container as the gateway. Set `HERMES_DASHBOARD=1` and expose port `9119` alongside the gateway's `8642`:
+Ultra runs the dashboard through the Rust `hermes dashboard` command. Keep the default loopback bind for local use:
 
 ```sh
-docker run -d \
-  --name hermes \
-  --restart unless-stopped \
-  -v ~/.hermes:/opt/data \
-  -p 8642:8642 \
-  -p 9119:9119 \
-  -e HERMES_DASHBOARD=1 \
-  nousresearch/hermes-agent gateway run
+docker run -it --rm \
+  --network host \
+  -v ~/.hermes-agent-ultra:/data \
+  -e HERMES_UID="$(id -u)" \
+  -e HERMES_GID="$(id -g)" \
+  hermes-agent-ultra dashboard --host 127.0.0.1 --no-open
 ```
 
-The entrypoint starts `hermes dashboard` in the background (running as the non-root `hermes` user) before `exec`-ing the main command. Dashboard output is prefixed with `[dashboard]` in `docker logs` so it's easy to separate from gateway logs.
+For persistent deployments, run the dashboard as the separate service shown in this repository's `docker-compose.yml`. The compose service shares the same `/data` volume and host network namespace as the gateway, and binds the dashboard to `127.0.0.1` by default.
 
-| Environment variable | Description | Default |
-|---------------------|-------------|---------|
-| `HERMES_DASHBOARD` | Set to `1` (or `true` / `yes`) to launch the dashboard alongside the main command | *(unset — dashboard not started)* |
-| `HERMES_DASHBOARD_HOST` | Bind address for the dashboard HTTP server | `0.0.0.0` |
-| `HERMES_DASHBOARD_PORT` | Port for the dashboard HTTP server | `9119` |
-| `HERMES_DASHBOARD_TUI` | Set to `1` to expose the in-browser Chat tab (embedded `hermes --tui` via PTY/WebSocket) | *(unset)* |
-
-The default `HERMES_DASHBOARD_HOST=0.0.0.0` is required for the host to reach the dashboard through the published port; the entrypoint automatically passes `--insecure` to `hermes dashboard` in that case. Override to `127.0.0.1` if you want to restrict the dashboard to in-container access only (e.g. behind a reverse proxy in a sidecar).
+Binding the dashboard/API surface to `0.0.0.0` requires an explicit `--insecure` acknowledgement on `hermes dashboard`, but that flag does **not** disable API authentication. The Rust API server still refuses network-accessible binds without `API_SERVER_KEY`.
 
 :::note
-The dashboard side-process is **not supervised** — if it crashes, it stays down until the container restarts. Running it as a separate container is not supported: the dashboard's gateway-liveness detection requires a shared PID namespace with the gateway process.
+There is no `HERMES_DASHBOARD_INSECURE` Docker escape hatch in Ultra's Rust/tini entrypoint. Use loopback, SSH/Tailscale, or a real `API_SERVER_KEY` for any network-accessible bind.
 :::
 
 ## Running interactively (CLI chat)
@@ -94,19 +88,19 @@ To open an interactive chat session against a running data directory:
 
 ```sh
 docker run -it --rm \
-  -v ~/.hermes:/opt/data \
-  nousresearch/hermes-agent
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra
 ```
 
-Or if you have already opened a terminal in your running container (via Docker Desktop for instance), just run:
+Or if you have already opened a terminal in your running container, just run:
 
 ```sh
-/opt/hermes/.venv/bin/hermes
+hermes
 ```
 
 ## Persistent volumes
 
-The `/opt/data` volume is the single source of truth for all Hermes state. It maps to your host's `~/.hermes/` directory and contains:
+The `/data` volume is the single source of truth for all Hermes state. It maps to your host's `~/.hermes-agent-ultra/` directory in the examples above and contains:
 
 | Path | Contents |
 |------|----------|
@@ -127,105 +121,118 @@ Never run two Hermes **gateway** containers against the same data directory simu
 
 ## Multi-profile support
 
-Hermes supports [multiple profiles](../reference/profile-commands.md) — separate `~/.hermes/` directories that let you run independent agents (different SOUL, skills, memory, sessions, credentials) from a single installation. **When running under Docker, using Hermes' built-in multi-profile feature is not recommended.**
+Hermes supports [multiple profiles](../reference/profile-commands.md) — separate Hermes home directories that let you run independent agents (different SOUL, skills, memory, sessions, credentials) from a single installation. **When running under Docker, using Hermes' built-in multi-profile feature is not recommended.**
 
-Instead, the recommended pattern is **one container per profile**, with each container bind-mounting its own host directory as `/opt/data`:
+Instead, the recommended pattern is **one container per profile**, with each container bind-mounting its own host directory as `/data`:
 
 ```sh
 # Work profile
 docker run -d \
-  --name hermes-work \
+  --name hermes-ultra-work \
   --restart unless-stopped \
-  -v ~/.hermes-work:/opt/data \
-  -p 8642:8642 \
-  nousresearch/hermes-agent gateway run
+  --network host \
+  -v ~/.hermes-ultra-work:/data \
+  -e HERMES_UID="$(id -u)" \
+  -e HERMES_GID="$(id -g)" \
+  hermes-agent-ultra gateway run
 
 # Personal profile
 docker run -d \
-  --name hermes-personal \
+  --name hermes-ultra-personal \
   --restart unless-stopped \
-  -v ~/.hermes-personal:/opt/data \
-  -p 8643:8642 \
-  nousresearch/hermes-agent gateway run
+  --network host \
+  -v ~/.hermes-ultra-personal:/data \
+  -e HERMES_UID="$(id -u)" \
+  -e HERMES_GID="$(id -g)" \
+  hermes-agent-ultra gateway run
 ```
 
 Why separate containers over profiles in Docker:
 
 - **Isolation** — each container has its own filesystem, process table, and resource limits. A crash, dependency change, or runaway session in one profile can't affect another.
-- **Independent lifecycle** — upgrade, restart, pause, or roll back each agent separately (`docker restart hermes-work` leaves `hermes-personal` untouched).
+- **Independent lifecycle** — upgrade, restart, pause, or roll back each agent separately (`docker restart hermes-ultra-work` leaves `hermes-ultra-personal` untouched).
 - **Clean port and network separation** — each gateway binds its own host port; there's no risk of cross-talk between chat platforms or API servers.
 - **Simpler mental model** — the container *is* the profile. Backups, migrations, and permissions all follow the bind-mounted directory, with no extra `--profile` flags to remember.
 - **Avoids concurrent-write risk** — the warning above about never running two gateways against the same data directory still applies to profiles within a single container.
 
-In Docker Compose, this just means declaring one service per profile with distinct `container_name`, `volumes`, and `ports`:
+In Docker Compose, this just means declaring one service per profile with distinct `container_name`, `volumes`, and any explicit API-server ports/keys you choose to expose:
 
 ```yaml
 services:
   hermes-work:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes-work
+    image: hermes-agent-ultra
+    container_name: hermes-ultra-work
     restart: unless-stopped
-    command: gateway run
-    ports:
-      - "8642:8642"
+    network_mode: host
     volumes:
-      - ~/.hermes-work:/opt/data
+      - ~/.hermes-ultra-work:/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    command: ["gateway", "run"]
 
   hermes-personal:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes-personal
+    image: hermes-agent-ultra
+    container_name: hermes-ultra-personal
     restart: unless-stopped
-    command: gateway run
-    ports:
-      - "8643:8642"
+    network_mode: host
     volumes:
-      - ~/.hermes-personal:/opt/data
+      - ~/.hermes-ultra-personal:/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    command: ["gateway", "run"]
 ```
 
 ## Environment variable forwarding
 
-API keys are read from `/opt/data/.env` inside the container. You can also pass environment variables directly:
+API keys are read from `/data/.env` inside the container. You can also pass environment variables directly:
 
 ```sh
 docker run -it --rm \
-  -v ~/.hermes:/opt/data \
+  -v ~/.hermes-agent-ultra:/data \
   -e ANTHROPIC_API_KEY="sk-ant-..." \
   -e OPENAI_API_KEY="sk-..." \
-  nousresearch/hermes-agent
+  hermes-agent-ultra
 ```
 
 Direct `-e` flags override values from `.env`. This is useful for CI/CD or secrets-manager integrations where you don't want keys on disk.
 
 ## Docker Compose example
 
-For persistent deployment with both the gateway and dashboard, a `docker-compose.yaml` is convenient:
+For persistent deployment with both the gateway and dashboard, this repository's `docker-compose.yml` uses two services over the same image and data volume:
 
 ```yaml
 services:
-  hermes:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes
+  gateway:
+    build: .
+    image: hermes-agent-ultra
+    container_name: hermes-agent-ultra
     restart: unless-stopped
-    command: gateway run
-    ports:
-      - "8642:8642"   # gateway API
-      - "9119:9119"   # dashboard (only reached when HERMES_DASHBOARD=1)
+    network_mode: host
     volumes:
-      - ~/.hermes:/opt/data
+      - ~/.hermes-agent-ultra:/data
     environment:
-      - HERMES_DASHBOARD=1
-      # Uncomment to forward specific env vars instead of using .env file:
-      # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      # - OPENAI_API_KEY=${OPENAI_API_KEY}
-      # - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-          cpus: "2.0"
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    command: ["gateway", "run"]
+
+  dashboard:
+    image: hermes-agent-ultra
+    container_name: hermes-agent-ultra-dashboard
+    restart: unless-stopped
+    network_mode: host
+    depends_on:
+      - gateway
+    volumes:
+      - ~/.hermes-agent-ultra:/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    command: ["dashboard", "--host", "127.0.0.1", "--no-open"]
 ```
 
-Start with `docker compose up -d` and view logs with `docker compose logs -f`. Dashboard output is prefixed with `[dashboard]` so it's easy to filter from gateway logs.
+Start with `HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d` and view logs with `docker compose logs -f`.
 
 ## Resource limits
 
@@ -243,50 +250,48 @@ Set limits in Docker:
 
 ```sh
 docker run -d \
-  --name hermes \
+  --name hermes-agent-ultra \
   --restart unless-stopped \
   --memory=4g --cpus=2 \
-  -v ~/.hermes:/opt/data \
-  nousresearch/hermes-agent gateway run
+  --network host \
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra gateway run
 ```
 
 ## What the Dockerfile does
 
-The official image is based on `debian:13.4` and includes:
+The Ultra image uses a Rust multi-stage build and a slim Debian runtime. It includes:
 
-- Python 3 with all Hermes dependencies (`uv pip install -e ".[all]"`)
-- Node.js + npm (for browser automation and WhatsApp bridge)
-- Playwright with Chromium (`npx playwright install --with-deps chromium --only-shell`)
-- ripgrep, ffmpeg, git, and tini as system utilities
-- **`docker-cli`** — so agents running inside the container can drive the host's Docker daemon (bind-mount `/var/run/docker.sock` to opt in) for `docker build`, `docker run`, container inspection, etc.
-- **`openssh-client`** — enables the [SSH terminal backend](/docs/user-guide/configuration#ssh-backend) from inside the container. The SSH backend shells out to the system `ssh` binary; without this, it failed silently in containerized installs.
-- The WhatsApp bridge (`scripts/whatsapp-bridge/`)
+- The compiled Rust `hermes` binary under `/usr/local/bin`.
+- `tini` as PID 1 for signal handling and child reaping.
+- `gosu` for dropping root to the configured runtime UID/GID.
+- `ca-certificates` for HTTPS provider/API calls.
+- MIT license metadata plus `LICENSE` and `NOTICE` under `/usr/share/doc/hermes-agent-ultra`.
 
-The entrypoint script (`docker/entrypoint.sh`) bootstraps the data volume on first run:
-- Creates the directory structure (`sessions/`, `memories/`, `skills/`, etc.)
-- Copies `.env.example` → `.env` if no `.env` exists
-- Copies default `config.yaml` if missing
-- Copies default `SOUL.md` if missing
-- Syncs bundled skills using a manifest-based approach (preserves user edits)
-- Optionally launches `hermes dashboard` as a background side-process when `HERMES_DASHBOARD=1` (see [Running the dashboard](#running-the-dashboard))
-- Then runs `hermes` with whatever arguments you pass
+The entrypoint script (`docker/entrypoint.sh`) keeps runtime state separated from the immutable Rust image:
+- Resolves `HERMES_HOME` to `/data` by default.
+- Creates the data directory if it is missing.
+- Remaps the `hermes` user/group to `HERMES_UID` / `HERMES_GID` when the container starts as root.
+- Recursively repairs ownership only for the mounted data directory when needed.
+- Drops privileges with `gosu` before running the requested `hermes` command.
 
 :::warning
-Do not override the image entrypoint unless you keep `/opt/hermes/docker/entrypoint.sh` in the command chain. The entrypoint drops root privileges to the `hermes` user before gateway state files are created. Starting `hermes gateway run` as root inside the official image is refused by default because it can leave root-owned files in `/opt/data` and break later dashboard or gateway starts. Set `HERMES_ALLOW_ROOT_GATEWAY=1` only when you intentionally accept that risk.
+Do not override the image entrypoint unless you keep `/usr/local/bin/hermes-entrypoint` in the command chain. The entrypoint drops root privileges to the `hermes` user before gateway state files are created. Starting `hermes gateway run` as root can leave root-owned files in `/data` and break later dashboard or gateway starts.
 :::
 
 ## Upgrading
 
-Pull the latest image and recreate the container. Your data directory is untouched.
+Rebuild or pull the updated image and recreate the container. Your data directory is untouched.
 
 ```sh
-docker pull nousresearch/hermes-agent:latest
-docker rm -f hermes
+docker build -t hermes-agent-ultra .
+docker rm -f hermes-agent-ultra
 docker run -d \
-  --name hermes \
+  --name hermes-agent-ultra \
   --restart unless-stopped \
-  -v ~/.hermes:/opt/data \
-  nousresearch/hermes-agent gateway run
+  --network host \
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra gateway run
 ```
 
 Or with Docker Compose:
@@ -331,23 +336,21 @@ services:
             - capabilities: [gpu]
 
   hermes:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes
+    image: hermes-agent-ultra
+    container_name: hermes-agent-ultra
     restart: unless-stopped
-    command: gateway run
-    ports:
-      - "8642:8642"
     volumes:
-      - ~/.hermes:/opt/data
+      - ~/.hermes-agent-ultra:/data
     networks:
       - hermes-net
+    command: ["gateway", "run"]
 
 networks:
   hermes-net:
     driver: bridge
 ```
 
-Then in your `~/.hermes/config.yaml`, use the **container name** as the hostname:
+Then in your `~/.hermes-agent-ultra/config.yaml`, use the **container name** as the hostname:
 
 ```yaml
 model:
@@ -372,10 +375,9 @@ If your inference server runs directly on the host (not in Docker), use `host.do
 
 ```sh
 docker run -d \
-  --name hermes \
-  -v ~/.hermes:/opt/data \
-  -p 8642:8642 \
-  nousresearch/hermes-agent gateway run
+  --name hermes-agent-ultra \
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra gateway run
 ```
 
 ```yaml
@@ -391,10 +393,10 @@ model:
 
 ```sh
 docker run -d \
-  --name hermes \
+  --name hermes-agent-ultra \
   --network host \
-  -v ~/.hermes:/opt/data \
-  nousresearch/hermes-agent gateway run
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra gateway run
 ```
 
 ```yaml
@@ -414,7 +416,7 @@ model:
 From inside the Hermes container, confirm the inference server is reachable:
 
 ```sh
-docker exec hermes curl -s http://vllm:8000/v1/models
+docker exec hermes-agent-ultra curl -s http://vllm:8000/v1/models
 ```
 
 You should see a JSON response listing your served model. If this fails, check:
@@ -439,28 +441,28 @@ model:
 
 ### Container exits immediately
 
-Check logs: `docker logs hermes`. Common causes:
+Check logs: `docker logs hermes-agent-ultra`. Common causes:
 - Missing or invalid `.env` file — run interactively first to complete setup
 - Port conflicts if running with exposed ports
 
 ### "Permission denied" errors
 
-The container's entrypoint drops privileges to the non-root `hermes` user (UID 10000) via `gosu`. If your host `~/.hermes/` is owned by a different UID, set `HERMES_UID`/`HERMES_GID` to match your host user, or ensure the data directory is writable:
+The container's entrypoint drops privileges to the non-root `hermes` user (UID 10000 by default) via `gosu`. If your host data directory is owned by your user, set `HERMES_UID`/`HERMES_GID` to match instead of recursively changing permissions:
 
 ```sh
-chmod -R 755 ~/.hermes
+HERMES_UID="$(id -u)" HERMES_GID="$(id -g)" docker compose up -d
 ```
 
 ### Browser tools not working
 
-Playwright needs shared memory. Add `--shm-size=1g` to your Docker run command:
+If you add browser tooling to a custom image, Chromium/Playwright typically needs shared memory. Add `--shm-size=1g` to that custom Docker run command:
 
 ```sh
 docker run -d \
-  --name hermes \
+  --name hermes-agent-ultra \
   --shm-size=1g \
-  -v ~/.hermes:/opt/data \
-  nousresearch/hermes-agent gateway run
+  -v ~/.hermes-agent-ultra:/data \
+  hermes-agent-ultra gateway run
 ```
 
 ### Gateway not reconnecting after network issues
@@ -468,13 +470,13 @@ docker run -d \
 The `--restart unless-stopped` flag handles most transient failures. If the gateway is stuck, restart the container:
 
 ```sh
-docker restart hermes
+docker restart hermes-agent-ultra
 ```
 
 ### Checking container health
 
 ```sh
-docker logs --tail 50 hermes          # Recent logs
-docker run -it --rm nousresearch/hermes-agent:latest version     # Verify version
-docker stats hermes                    # Resource usage
+docker logs --tail 50 hermes-agent-ultra       # Recent logs
+docker run -it --rm hermes-agent-ultra version # Verify version
+docker stats hermes-agent-ultra                # Resource usage
 ```


### PR DESCRIPTION
## Summary
- Port/supersede four Docker/dashboard/SOUL parity queue items with Rust-native behavior and contracts.
- Seed `SOUL.md` with the real runtime default persona, upgrade only exact legacy comment-only templates, preserve customized personas, and load SOUL from the active Hermes home.
- Harden Docker packaging/docs around the Ultra Rust image: immutable binary path, `/data` state volume, license metadata/files, no Python setup install surface, localhost dashboard default, and no `HERMES_DASHBOARD` side-process escape hatch.
- Update parity ledgers/proof/dashboard: pending is now `234`.

## Auth / Sign-In Guard
- No changes under `crates/hermes-cli/src/auth.rs`, `crates/hermes-auth`, `crates/hermes-agent/src/oauth.rs`, `crates/hermes-core/src/auth_gate.rs`, or `crates/hermes-tools/src/tools/auth_snapshot.rs`.
- Full workspace tests exercised auth/OAuth coverage successfully.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `/opt/homebrew/bin/pytest tests/test_install_sh_pythonpath_sanitization.py tests/test_dockerfile_packaging_contract.py tests/test_docker_compose_contract.py tests/test_docker_entrypoint_contract.py -q`
- `cargo test -p hermes-agent soul`
- `cargo test -p hermes-tools dashboard_control`
- `cargo test -p hermes-cli setup`
- `cargo test -p hermes-gateway --features api-server bind_guard_requires_token_only_for_network_accessible_hosts`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-cli -p hermes-tools -p hermes-gateway`
- `cargo build --workspace`
- `cargo test --workspace`

Note: `scripts/generate-readme-sync-status.py` was intentionally not applicable in this checkout because `.sync-reports` has no upstream-sync reports.
