### PR TITLE
parity(telegram): harden rich messages and command menu

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4529,7 +4529,7 @@ fn build_telegram_config(
         parse_markdown,
         parse_html,
         disable_link_previews: extra_bool(platform_cfg, "disable_link_previews", false),
-        rich_messages: extra_bool(platform_cfg, "rich_messages", true),
+        rich_messages: extra_bool(platform_cfg, "rich_messages", false),
         poll_timeout,
         reply_to_mode: reply_to_mode_string(platform_cfg).unwrap_or_else(|| "first".to_string()),
         reactions: extra_bool(platform_cfg, "reactions", false),
@@ -4557,6 +4557,89 @@ fn build_telegram_config(
             .and_then(|v| v.as_u64())
             .unwrap_or(750),
         bot_username: None,
+        command_menu_enabled: telegram_command_menu_bool(platform_cfg, "enabled", true),
+        command_menu_max_commands: telegram_command_menu_usize(platform_cfg, "max_commands", 60),
+        command_menu_priority: telegram_command_menu_string_vec(platform_cfg, "priority"),
+        command_menu_priority_mode: telegram_command_menu_string(
+            platform_cfg,
+            "priority_mode",
+            "prepend",
+        ),
+    }
+}
+
+#[cfg(feature = "gateway-telegram")]
+fn telegram_command_menu_value<'a>(
+    platform_cfg: &'a hermes_config::platform::PlatformConfig,
+    key: &str,
+) -> Option<&'a serde_json::Value> {
+    platform_cfg
+        .extra
+        .get("command_menu")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|menu| menu.get(key))
+        .or_else(|| platform_cfg.extra.get(&format!("command_menu_{key}")))
+}
+
+#[cfg(feature = "gateway-telegram")]
+fn telegram_command_menu_bool(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+    default: bool,
+) -> bool {
+    telegram_command_menu_value(platform_cfg, key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(default)
+}
+
+#[cfg(feature = "gateway-telegram")]
+fn telegram_command_menu_usize(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+    default: usize,
+) -> usize {
+    telegram_command_menu_value(platform_cfg, key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(default)
+}
+
+#[cfg(feature = "gateway-telegram")]
+fn telegram_command_menu_string(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+    default: &str,
+) -> String {
+    telegram_command_menu_value(platform_cfg, key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_string()
+}
+
+#[cfg(feature = "gateway-telegram")]
+fn telegram_command_menu_string_vec(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+) -> Vec<String> {
+    let Some(raw) = telegram_command_menu_value(platform_cfg, key) else {
+        return Vec::new();
+    };
+    match raw {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(str::trim))
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+        serde_json::Value::String(value) => value
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -16640,6 +16723,15 @@ mod tests {
             .extra
             .insert("rich_messages".to_string(), serde_json::json!(true));
         platform.extra.insert(
+            "command_menu".to_string(),
+            serde_json::json!({
+                "enabled": false,
+                "max_commands": 12,
+                "priority": ["status", "model"],
+                "priority_mode": "replace"
+            }),
+        );
+        platform.extra.insert(
             "fallback_ips".to_string(),
             serde_json::json!("149.154.167.220,::1"),
         );
@@ -16690,6 +16782,10 @@ mod tests {
         assert!(cfg.reactions);
         assert!(cfg.disable_link_previews);
         assert!(cfg.rich_messages);
+        assert!(!cfg.command_menu_enabled);
+        assert_eq!(cfg.command_menu_max_commands, 12);
+        assert_eq!(cfg.command_menu_priority, vec!["status", "model"]);
+        assert_eq!(cfg.command_menu_priority_mode, "replace");
         assert_eq!(cfg.fallback_ips, vec!["149.154.167.220", "::1"]);
         assert!(cfg.require_mention);
         assert!(cfg.guest_mode);
@@ -16719,6 +16815,11 @@ mod tests {
 
         let cfg = build_telegram_config(&platform, "token".to_string());
         assert_eq!(cfg.reply_to_mode, "off");
+        assert!(!cfg.rich_messages);
+        assert!(cfg.command_menu_enabled);
+        assert_eq!(cfg.command_menu_max_commands, 60);
+        assert!(cfg.command_menu_priority.is_empty());
+        assert_eq!(cfg.command_menu_priority_mode, "prepend");
     }
 
     #[test]

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -5643,6 +5643,7 @@ mod tests {
         }))
         .await;
 
+        let configured_model = format!("dynamic-runtime-model-{}", std::process::id());
         let set_provider = IncomingMessage {
             platform: "test".into(),
             chat_id: "chat1".into(),
@@ -5658,7 +5659,7 @@ mod tests {
             platform: "test".into(),
             chat_id: "chat1".into(),
             user_id: "user1".into(),
-            text: "/model gpt-4o".into(),
+            text: format!("/model {configured_model}"),
             message_id: None,
             thread_id: None,
             is_dm: true,
@@ -5722,7 +5723,8 @@ mod tests {
             })
             .expect("runtime hint response should exist");
 
-        assert!(echoed.contains("model=gpt-4o"));
+        assert!(echoed.contains(&format!("model={configured_model}")));
+        assert!(!echoed.contains("gpt-4o"));
         assert!(echoed.contains("provider=openai"));
         assert!(echoed.contains("profile=prod"));
         assert!(echoed.contains("branch=feature/parity"));

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -25,6 +25,7 @@ use hermes_tools::approval::{self, ApprovalChoice, GatewayApprovalRequest};
 use crate::adapter::{
     describe_secret, platform_http_client_builder, AdapterProxyConfig, BasePlatformAdapter,
 };
+use crate::commands::all_commands;
 use crate::format::to_telegram_markdown_v2;
 
 /// Maximum message length for Telegram (4096 characters).
@@ -61,6 +62,30 @@ const MAX_CAPTION_LENGTH: usize = 1024;
 
 /// Default aggregation delay for rapid Telegram text chunks.
 const DEFAULT_TEXT_BATCH_DELAY_MS: u64 = 750;
+const TELEGRAM_BOT_COMMAND_API_MAX: usize = 100;
+const DEFAULT_TELEGRAM_COMMAND_MENU_MAX: usize = 60;
+const TELEGRAM_COMMAND_MENU_PRIORITY: &[&str] = &[
+    "start",
+    "new",
+    "help",
+    "stop",
+    "status",
+    "resume",
+    "sessions",
+    "model",
+    "update",
+    "verbose",
+    "commands",
+    "approve",
+    "deny",
+    "queue",
+    "steer",
+    "background",
+    "reasoning",
+    "usage",
+    "platform",
+    "profile",
+];
 
 // ---------------------------------------------------------------------------
 // TelegramConfig
@@ -102,9 +127,9 @@ pub struct TelegramConfig {
 
     /// Use Bot API 10.1 rich messages for eligible final text sends/edits.
     ///
-    /// Enabled by default, but only used for constructs the legacy MarkdownV2
-    /// path degrades: pipe tables, task lists, details blocks, and block math.
-    #[serde(default = "default_true")]
+    /// Opt-in because some Telegram desktop clients accept rich payloads but
+    /// still render specific scripts/layouts worse than the legacy path.
+    #[serde(default)]
     pub rich_messages: bool,
 
     /// Long-polling timeout in seconds.
@@ -174,6 +199,22 @@ pub struct TelegramConfig {
     /// Bot username (without @), used for mention filtering in groups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bot_username: Option<String>,
+
+    /// Register Telegram BotCommand menu entries on startup.
+    #[serde(default = "default_true")]
+    pub command_menu_enabled: bool,
+
+    /// Maximum BotCommand entries to register. Telegram caps this at 100.
+    #[serde(default = "default_command_menu_max_commands")]
+    pub command_menu_max_commands: usize,
+
+    /// Priority command names that should survive a capped Telegram menu.
+    #[serde(default)]
+    pub command_menu_priority: Vec<String>,
+
+    /// How configured priority interacts with defaults: prepend, append, replace.
+    #[serde(default = "default_command_menu_priority_mode")]
+    pub command_menu_priority_mode: String,
 }
 
 fn default_true() -> bool {
@@ -190,6 +231,14 @@ fn default_reply_to_mode() -> String {
 
 fn default_text_batch_delay_ms() -> u64 {
     DEFAULT_TEXT_BATCH_DELAY_MS
+}
+
+fn default_command_menu_max_commands() -> usize {
+    DEFAULT_TELEGRAM_COMMAND_MENU_MAX
+}
+
+fn default_command_menu_priority_mode() -> String {
+    "prepend".to_string()
 }
 
 /// Effective behavior for Telegram reply anchors across split chunks.
@@ -289,6 +338,9 @@ pub struct TelegramMessage {
     pub document: Option<Document>,
     #[serde(default)]
     pub reply_to_message: Option<Box<TelegramMessage>>,
+    /// Native Bot API rich-message echo for replies to rich bot messages.
+    #[serde(default)]
+    pub rich_message: Option<serde_json::Value>,
     #[serde(default)]
     pub message_thread_id: Option<i64>,
     #[serde(default)]
@@ -417,6 +469,12 @@ pub struct InlineKeyboardButton {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct TelegramBotCommand {
+    command: String,
+    description: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -898,6 +956,141 @@ impl TelegramAdapter {
         reply_to_message_id.is_some() && self.reply_to_mode().references_chunk(chunk_index)
     }
 
+    fn sanitize_bot_command_name(raw: &str) -> Option<String> {
+        let token = raw
+            .trim()
+            .trim_start_matches('/')
+            .split_whitespace()
+            .next()?
+            .split('@')
+            .next()
+            .unwrap_or_default()
+            .trim();
+        if token.is_empty() {
+            return None;
+        }
+
+        let mut out = String::new();
+        let mut last_underscore = false;
+        for ch in token.to_ascii_lowercase().replace('-', "_").chars() {
+            if ch.is_ascii_alphanumeric() {
+                out.push(ch);
+                last_underscore = false;
+            } else if ch == '_' && !last_underscore {
+                out.push('_');
+                last_underscore = true;
+            }
+            if out.len() >= 32 {
+                break;
+            }
+        }
+
+        let out = out.trim_matches('_').to_string();
+        (!out.is_empty()).then_some(out)
+    }
+
+    fn command_menu_limit(&self) -> usize {
+        self.config
+            .command_menu_max_commands
+            .clamp(1, TELEGRAM_BOT_COMMAND_API_MAX)
+    }
+
+    fn command_menu_priority(&self) -> Vec<String> {
+        let configured = self
+            .config
+            .command_menu_priority
+            .iter()
+            .filter_map(|name| Self::sanitize_bot_command_name(name))
+            .collect::<Vec<_>>();
+        let defaults = TELEGRAM_COMMAND_MENU_PRIORITY
+            .iter()
+            .filter_map(|name| Self::sanitize_bot_command_name(name))
+            .collect::<Vec<_>>();
+
+        let mut raw = match self
+            .config
+            .command_menu_priority_mode
+            .trim()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "replace" => configured,
+            "append" => defaults.into_iter().chain(configured).collect(),
+            _ => configured.into_iter().chain(defaults).collect(),
+        };
+
+        let mut seen = HashSet::new();
+        raw.retain(|name| seen.insert(name.clone()));
+        raw
+    }
+
+    fn command_menu_commands(&self) -> Vec<TelegramBotCommand> {
+        if !self.config.command_menu_enabled {
+            return Vec::new();
+        }
+
+        let priority = self
+            .command_menu_priority()
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| (name, index))
+            .collect::<HashMap<_, _>>();
+        let mut seen = HashSet::new();
+        let mut commands = all_commands()
+            .into_iter()
+            .filter_map(|info| {
+                let command = Self::sanitize_bot_command_name(info.name)?;
+                if !seen.insert(command.clone()) {
+                    return None;
+                }
+                Some(TelegramBotCommand {
+                    command,
+                    description: truncate_chars(info.description.trim(), 256),
+                })
+            })
+            .enumerate()
+            .collect::<Vec<_>>();
+
+        commands.sort_by_key(|(original_index, command)| {
+            (
+                priority
+                    .get(&command.command)
+                    .copied()
+                    .unwrap_or(usize::MAX),
+                *original_index,
+            )
+        });
+
+        commands
+            .into_iter()
+            .map(|(_, command)| command)
+            .take(self.command_menu_limit())
+            .collect()
+    }
+
+    async fn register_command_menu(&self) -> Result<usize, GatewayError> {
+        let commands = self.command_menu_commands();
+        if commands.is_empty() {
+            return Ok(0);
+        }
+
+        let url = format!("{}/setMyCommands", self.api_base);
+        for scope_type in ["default", "all_private_chats", "all_group_chats"] {
+            let body = serde_json::json!({
+                "commands": commands.clone(),
+                "scope": { "type": scope_type },
+            });
+            let resp: TelegramResponse<bool> = self.post_json(&url, &body).await?;
+            if !resp.ok {
+                return Err(GatewayError::SendFailed(resp.description.unwrap_or_else(
+                    || format!("setMyCommands failed for scope {scope_type}"),
+                )));
+            }
+        }
+
+        Ok(commands.len())
+    }
+
     fn rich_send_is_disabled(&self) -> bool {
         self.rich_send_disabled
             .lock()
@@ -936,6 +1129,20 @@ impl TelegramAdapter {
             .find_iter(content)
             .any(|block| math.is_match(block.as_str()));
         has_crash_shape
+    }
+
+    fn has_telegram_desktop_cjk_rich_garble_shape(content: &str) -> bool {
+        content.chars().any(|ch| {
+            matches!(
+                ch,
+                '\u{3040}'..='\u{30ff}'
+                    | '\u{3400}'..='\u{4dbf}'
+                    | '\u{4e00}'..='\u{9fff}'
+                    | '\u{ac00}'..='\u{d7af}'
+                    | '\u{f900}'..='\u{faff}'
+                    | '\u{20000}'..='\u{323af}'
+            )
+        })
     }
 
     fn needs_rich_rendering(content: &str) -> bool {
@@ -987,6 +1194,7 @@ impl TelegramAdapter {
             && Self::needs_rich_rendering(text)
             && Self::content_fits_rich_limits(text)
             && !Self::has_telegram_desktop_details_math_crash_shape(text)
+            && !Self::has_telegram_desktop_cjk_rich_garble_shape(text)
     }
 
     fn should_attempt_rich_text(
@@ -1004,10 +1212,11 @@ impl TelegramAdapter {
         reply_to_message_id: Option<i64>,
         message_thread_id: Option<i64>,
     ) -> serde_json::Value {
+        let markdown = Self::rich_normalize_linebreaks(text);
         let mut body = serde_json::json!({
             "chat_id": chat_id,
             "rich_message": {
-                "markdown": text,
+                "markdown": markdown,
             },
         });
         if let Some(thread_id) = message_thread_id {
@@ -1023,17 +1232,193 @@ impl TelegramAdapter {
     }
 
     fn rich_edit_body(&self, chat_id: &str, message_id: &str, text: &str) -> serde_json::Value {
+        let markdown = Self::rich_normalize_linebreaks(text);
         let mut body = serde_json::json!({
             "chat_id": chat_id,
             "message_id": message_id.parse::<i64>().unwrap_or(0),
             "rich_message": {
-                "markdown": text,
+                "markdown": markdown,
             },
         });
         if self.config.disable_link_previews {
             body["link_preview_options"] = serde_json::json!({ "is_disabled": true });
         }
         body
+    }
+
+    fn line_without_newline(line: &str) -> &str {
+        line.trim_end_matches('\n').trim_end_matches('\r')
+    }
+
+    fn rich_line_protection_mask(lines: &[&str]) -> Vec<bool> {
+        let mut protected = vec![false; lines.len()];
+
+        let mut in_fence = false;
+        for (idx, line) in lines.iter().enumerate() {
+            let trimmed = Self::line_without_newline(line).trim_start();
+            if in_fence || trimmed.starts_with("```") {
+                protected[idx] = true;
+            }
+            if trimmed.starts_with("```") {
+                in_fence = !in_fence;
+            }
+        }
+
+        let mut idx = 0;
+        while idx + 1 < lines.len() {
+            if protected[idx] || protected[idx + 1] {
+                idx += 1;
+                continue;
+            }
+
+            let header = Self::line_without_newline(lines[idx]);
+            let delimiter = Self::line_without_newline(lines[idx + 1]);
+            if header.contains('|') && Self::looks_like_markdown_table_separator(delimiter) {
+                protected[idx] = true;
+                protected[idx + 1] = true;
+
+                let mut body_idx = idx + 2;
+                while body_idx < lines.len() {
+                    let body = Self::line_without_newline(lines[body_idx]);
+                    if protected[body_idx] || body.trim().is_empty() || !body.contains('|') {
+                        break;
+                    }
+                    protected[body_idx] = true;
+                    body_idx += 1;
+                }
+
+                idx = body_idx;
+            } else {
+                idx += 1;
+            }
+        }
+
+        protected
+    }
+
+    fn rich_normalize_linebreaks(text: &str) -> String {
+        if text.is_empty() || !text.contains('\n') {
+            return text.to_string();
+        }
+
+        let lines = text.split_inclusive('\n').collect::<Vec<_>>();
+        let protected = Self::rich_line_protection_mask(&lines);
+        let mut out = String::with_capacity(text.len() + lines.len().saturating_mul(2));
+
+        for (idx, line) in lines.iter().enumerate() {
+            let Some(without_newline) = line.strip_suffix('\n') else {
+                out.push_str(line);
+                continue;
+            };
+
+            out.push_str(without_newline);
+            let current_blank = Self::line_without_newline(line).trim().is_empty();
+            let next_blank = lines
+                .get(idx + 1)
+                .map(|next| Self::line_without_newline(next).trim().is_empty())
+                .unwrap_or(false);
+
+            if idx + 1 < lines.len()
+                && !protected[idx]
+                && !protected[idx + 1]
+                && !current_blank
+                && !next_blank
+            {
+                out.push_str("  ");
+            }
+            out.push('\n');
+        }
+
+        out
+    }
+
+    fn flatten_rich_inline_text(value: &serde_json::Value) -> String {
+        match value {
+            serde_json::Value::String(text) => text.clone(),
+            serde_json::Value::Array(items) => items
+                .iter()
+                .map(Self::flatten_rich_inline_text)
+                .collect::<String>(),
+            serde_json::Value::Object(map) => map
+                .get("text")
+                .map(Self::flatten_rich_inline_text)
+                .or_else(|| map.get("children").map(Self::flatten_rich_inline_text))
+                .unwrap_or_default(),
+            _ => String::new(),
+        }
+    }
+
+    fn rich_label_text(value: &serde_json::Value) -> Option<String> {
+        match value {
+            serde_json::Value::String(text) => {
+                let trimmed = text.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            }
+            serde_json::Value::Number(_) | serde_json::Value::Bool(_) => Some(value.to_string()),
+            _ => None,
+        }
+    }
+
+    fn flatten_rich_blocks(blocks: &serde_json::Value) -> String {
+        let Some(blocks) = blocks.as_array() else {
+            return String::new();
+        };
+
+        let mut lines = Vec::new();
+        for block in blocks {
+            let Some(block) = block.as_object() else {
+                continue;
+            };
+
+            if let Some(items) = block.get("items").and_then(|value| value.as_array()) {
+                for item in items {
+                    let Some(item) = item.as_object() else {
+                        continue;
+                    };
+                    let item_text = item
+                        .get("blocks")
+                        .map(Self::flatten_rich_blocks)
+                        .unwrap_or_default();
+                    if item_text.trim().is_empty() {
+                        continue;
+                    }
+
+                    let mut item_lines = item_text.lines();
+                    let Some(first_line) = item_lines.next() else {
+                        continue;
+                    };
+                    if let Some(label) = item.get("label").and_then(Self::rich_label_text) {
+                        lines.push(format!("{label} {first_line}"));
+                    } else {
+                        lines.push(first_line.to_string());
+                    }
+                    lines.extend(item_lines.map(ToOwned::to_owned));
+                }
+                continue;
+            }
+
+            if let Some(text) = block.get("text").map(Self::flatten_rich_inline_text) {
+                lines.extend(text.lines().map(ToOwned::to_owned));
+            }
+        }
+
+        lines
+            .into_iter()
+            .map(|line| line.trim_end().to_string())
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn extract_rich_reply_text(reply_to_message: &TelegramMessage) -> Option<String> {
+        let text = reply_to_message
+            .rich_message
+            .as_ref()
+            .and_then(|rich| rich.get("blocks"))
+            .map(Self::flatten_rich_blocks)
+            .unwrap_or_default();
+        let text = text.trim();
+        (!text.is_empty()).then(|| text.to_string())
     }
 
     fn rich_capability_error(err: &GatewayError) -> bool {
@@ -1456,11 +1841,7 @@ impl TelegramAdapter {
         }
 
         let rendered_text = self.outgoing_text_for_parse_mode(text, parse_mode);
-        if rendered_text.chars().count() > MAX_MESSAGE_LENGTH {
-            return Err(GatewayError::SendFailed(format!(
-                "Telegram edit text exceeds {MAX_MESSAGE_LENGTH} characters; send as split messages instead"
-            )));
-        }
+        let rendered_text = truncate_chars(&rendered_text, MAX_MESSAGE_LENGTH);
 
         let mut body = serde_json::json!({
             "chat_id": chat_id,
@@ -1957,7 +2338,11 @@ impl TelegramAdapter {
         msg: &TelegramMessage,
         callback: Option<(&str, &str)>,
     ) -> Option<IncomingMessage> {
-        let text = msg.text.clone().or_else(|| msg.caption.clone());
+        let text = msg
+            .text
+            .clone()
+            .or_else(|| msg.caption.clone())
+            .or_else(|| Self::extract_rich_reply_text(msg));
         let reply = msg.reply_to_message.as_deref();
         let own_media = msg.voice.is_some()
             || msg.photo.is_some()
@@ -2450,6 +2835,15 @@ impl PlatformAdapter for TelegramAdapter {
             describe_secret(&self.config.token)
         );
         self.base.mark_running();
+        match self.register_command_menu().await {
+            Ok(count) if count > 0 => {
+                info!(count, "Telegram command menu registered");
+            }
+            Ok(_) => {}
+            Err(err) => {
+                warn!(error = %err, "Telegram command menu registration failed");
+            }
+        }
         Ok(())
     }
 
@@ -2717,6 +3111,10 @@ mod tests {
             observe_unmentioned_group_messages: false,
             text_batch_delay_ms: DEFAULT_TEXT_BATCH_DELAY_MS,
             bot_username: None,
+            command_menu_enabled: true,
+            command_menu_max_commands: DEFAULT_TELEGRAM_COMMAND_MENU_MAX,
+            command_menu_priority: Vec::new(),
+            command_menu_priority_mode: "prepend".into(),
         }
     }
 
@@ -2751,14 +3149,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edit_text_rejects_overflow_without_truncating() {
-        let adapter = test_adapter(test_config());
+    async fn edit_text_clips_overflow_preview_instead_of_erroring() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/editMessageText"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 456 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
         let text = "a".repeat(MAX_MESSAGE_LENGTH + 1);
-        let err = adapter
+
+        adapter
             .edit_text("123", "456", &text, None)
             .await
-            .expect_err("overflow edits must fail into caller fallback");
-        assert!(err.to_string().contains("exceeds 4096 characters"));
+            .expect("overflow edit clips to one preview message");
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        let body: Value = requests[0].body_json().expect("json body");
+        let clipped = body
+            .get("text")
+            .and_then(Value::as_str)
+            .expect("clipped text");
+        assert_eq!(clipped.chars().count(), MAX_MESSAGE_LENGTH);
+        assert!(clipped.ends_with("..."));
     }
 
     #[test]
@@ -2769,6 +3188,93 @@ mod tests {
         let chunks = split_message(&text, 4096);
         assert_eq!(chunks.len(), 2);
         assert!(chunks[0].ends_with('\n'));
+    }
+
+    #[test]
+    fn telegram_rich_normalizes_prose_linebreaks_only() {
+        let normalized = TelegramAdapter::rich_normalize_linebreaks(
+            "intro\nnext\n\n```rust\nlet x = 1;\nlet y = 2;\n```\n\n| A | B |\n|---|---|\n| 1 | 2 |\nend",
+        );
+
+        assert!(normalized.starts_with("intro  \nnext\n\n"));
+        assert!(normalized.contains("```rust\nlet x = 1;\nlet y = 2;\n```"));
+        assert!(normalized.contains("| A | B |\n|---|---|\n| 1 | 2 |"));
+    }
+
+    #[test]
+    fn telegram_rich_cjk_guard_matches_desktop_garble_scripts() {
+        assert!(TelegramAdapter::has_telegram_desktop_cjk_rich_garble_shape(
+            "table 你好"
+        ));
+        assert!(TelegramAdapter::has_telegram_desktop_cjk_rich_garble_shape(
+            "かな"
+        ));
+        assert!(TelegramAdapter::has_telegram_desktop_cjk_rich_garble_shape(
+            "한글"
+        ));
+        assert!(!TelegramAdapter::has_telegram_desktop_cjk_rich_garble_shape("plain ascii table"));
+    }
+
+    #[test]
+    fn telegram_command_menu_prioritizes_and_caps_commands() {
+        let mut cfg = test_config();
+        cfg.command_menu_max_commands = 3;
+        cfg.command_menu_priority = vec!["status".into(), "/model".into()];
+        let adapter = test_adapter(cfg);
+
+        let commands = adapter.command_menu_commands();
+        let names = commands
+            .iter()
+            .map(|command| command.command.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["status", "model", "start"]);
+    }
+
+    #[tokio::test]
+    async fn telegram_start_registers_command_menu_for_core_scopes() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/setMyCommands"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": true
+            })))
+            .expect(3)
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.command_menu_max_commands = 2;
+        cfg.command_menu_priority = vec!["status".into()];
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        adapter.start().await.expect("start");
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 3);
+        let scopes = requests
+            .iter()
+            .map(|request| {
+                let body: Value = request.body_json().expect("json body");
+                assert_eq!(
+                    body.pointer("/commands/0/command").and_then(Value::as_str),
+                    Some("status")
+                );
+                assert_eq!(
+                    body.pointer("/commands/1/command").and_then(Value::as_str),
+                    Some("start")
+                );
+                body.pointer("/scope/type")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert!(scopes.contains(&"default".to_string()));
+        assert!(scopes.contains(&"all_private_chats".to_string()));
+        assert!(scopes.contains(&"all_group_chats".to_string()));
     }
 
     #[test]
@@ -3200,7 +3706,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn telegram_rich_messages_default_on_only_for_rich_eligible_content() {
+    async fn telegram_rich_messages_stay_legacy_for_non_eligible_content() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/botfake_token_12345/sendMessage"))
@@ -3223,6 +3729,99 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ids, vec![93]);
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].url.path().ends_with("/sendMessage"));
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_messages_default_off_even_for_eligible_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "text": "| A | B |\n|---|---|\n| 1 | 2 |"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 94 }
+            })))
+            .mount(&server)
+            .await;
+
+        let cfg: TelegramConfig =
+            serde_json::from_str(r#"{"token":"fake_token_12345"}"#).expect("config");
+        assert!(!cfg.rich_messages);
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text("123", "| A | B |\n|---|---|\n| 1 | 2 |", None, None)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![94]);
+
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].url.path().ends_with("/sendMessage"));
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_message_hard_breaks_single_newlines() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendRichMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "rich_message": { "markdown": "- [ ] one  \n- [x] two" }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 95 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.rich_messages = true;
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text("123", "- [ ] one\n- [x] two", None, None)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![95]);
+    }
+
+    #[tokio::test]
+    async fn telegram_rich_message_skips_cjk_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/sendMessage"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "123",
+                "text": "| A | B |\n|---|---|\n| 你好 | 2 |"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 96 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut cfg = test_config();
+        cfg.rich_messages = true;
+        let mut adapter = test_adapter(cfg);
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let ids = adapter
+            .send_text("123", "| A | B |\n|---|---|\n| 你好 | 2 |", None, None)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec![96]);
 
         let requests = server.received_requests().await.expect("requests");
         assert_eq!(requests.len(), 1);
@@ -3487,6 +4086,7 @@ mod tests {
             sticker: None,
             document: None,
             reply_to_message: None,
+            rich_message: None,
             message_thread_id: None,
             is_topic_message: None,
         }
@@ -3539,6 +4139,7 @@ mod tests {
                 sticker: None,
                 document: None,
                 reply_to_message: None,
+                rich_message: None,
                 message_thread_id: None,
                 is_topic_message: None,
             }),
@@ -3580,6 +4181,7 @@ mod tests {
                 sticker: None,
                 document: None,
                 reply_to_message: None,
+                rich_message: None,
                 message_thread_id: None,
                 is_topic_message: None,
             }),
@@ -3634,6 +4236,7 @@ mod tests {
                 }),
                 document: None,
                 reply_to_message: None,
+                rich_message: None,
                 message_thread_id: None,
                 is_topic_message: None,
             }),
@@ -3671,6 +4274,7 @@ mod tests {
                     file_size: Some(2048),
                 }),
                 reply_to_message: None,
+                rich_message: None,
                 message_thread_id: None,
                 is_topic_message: None,
             }),
@@ -3711,6 +4315,7 @@ mod tests {
                     sticker: None,
                     document: None,
                     reply_to_message: None,
+                    rich_message: None,
                     message_thread_id: None,
                     is_topic_message: None,
                 }),
@@ -3767,6 +4372,7 @@ mod tests {
             sticker: None,
             document: None,
             reply_to_message: None,
+            rich_message: None,
             message_thread_id: None,
             is_topic_message: None,
         };
@@ -3786,6 +4392,7 @@ mod tests {
                 sticker: None,
                 document: None,
                 reply_to_message: Some(Box::new(reply_msg)),
+                rich_message: None,
                 message_thread_id: Some(999),
                 is_topic_message: None,
             }),
@@ -3819,6 +4426,7 @@ mod tests {
             sticker: None,
             document: None,
             reply_to_message: None,
+            rich_message: None,
             message_thread_id: None,
             is_topic_message: None,
         };
@@ -3838,6 +4446,7 @@ mod tests {
                 sticker: None,
                 document: None,
                 reply_to_message: Some(Box::new(reply_msg)),
+                rich_message: None,
                 message_thread_id: Some(999),
                 is_topic_message: None,
             }),
@@ -3870,6 +4479,7 @@ mod tests {
             sticker: None,
             document: None,
             reply_to_message: None,
+            rich_message: None,
             message_thread_id: None,
             is_topic_message: None,
         };
@@ -3894,6 +4504,7 @@ mod tests {
                 sticker: None,
                 document: None,
                 reply_to_message: Some(Box::new(reply_msg)),
+                rich_message: None,
                 message_thread_id: None,
                 is_topic_message: None,
             }),
@@ -3928,6 +4539,7 @@ mod tests {
                 file_size: Some(TELEGRAM_MAX_DOCUMENT_SIZE_BYTES + 1),
             }),
             reply_to_message: None,
+            rich_message: None,
             message_thread_id: None,
             is_topic_message: None,
         };
@@ -3947,6 +4559,7 @@ mod tests {
                 sticker: None,
                 document: None,
                 reply_to_message: Some(Box::new(reply_msg)),
+                rich_message: None,
                 message_thread_id: None,
                 is_topic_message: None,
             }),
@@ -4198,6 +4811,45 @@ mod tests {
         assert!(resp.parameters.is_none());
     }
 
+    #[test]
+    fn telegram_native_rich_reply_text_is_flattened() {
+        let raw = serde_json::json!({
+            "update_id": 1,
+            "message": {
+                "message_id": 8,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 7, "first_name": "User"},
+                "text": "reply",
+                "reply_to_message": {
+                    "message_id": 6,
+                    "chat": {"id": 123, "type": "private"},
+                    "from": {"id": 42, "first_name": "Hermes", "is_bot": true},
+                    "rich_message": {
+                        "blocks": [
+                            {"text": {"text": "Summary"}},
+                            {
+                                "items": [
+                                    {
+                                        "label": "1.",
+                                        "blocks": [{"text": ["First", " item"]}]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        let update: Update = serde_json::from_value(raw).expect("telegram update");
+        let msg = update.message.expect("message");
+        let reply = msg.reply_to_message.as_deref().expect("reply");
+
+        assert_eq!(
+            TelegramAdapter::extract_rich_reply_text(reply),
+            Some("Summary\n1. First item".to_string())
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Chat deserialization with optional fields
     // -----------------------------------------------------------------------
@@ -4426,12 +5078,19 @@ mod tests {
         assert!(!cfg.parse_markdown);
         assert!(!cfg.parse_html);
         assert!(!cfg.disable_link_previews);
-        assert!(cfg.rich_messages);
+        assert!(!cfg.rich_messages);
         assert_eq!(cfg.poll_timeout, DEFAULT_POLL_TIMEOUT);
         assert_eq!(cfg.reply_to_mode, "first");
         assert!(cfg.webhook_secret.is_none());
         assert!(!cfg.reactions);
         assert!(cfg.bot_username.is_none());
+        assert!(cfg.command_menu_enabled);
+        assert_eq!(
+            cfg.command_menu_max_commands,
+            DEFAULT_TELEGRAM_COMMAND_MENU_MAX
+        );
+        assert!(cfg.command_menu_priority.is_empty());
+        assert_eq!(cfg.command_menu_priority_mode, "prepend");
     }
 
     #[test]
@@ -4449,7 +5108,11 @@ mod tests {
             "reply_to_mode": "all",
             "reactions": true,
             "disable_link_previews": true,
-            "rich_messages": true
+            "rich_messages": true,
+            "command_menu_enabled": false,
+            "command_menu_max_commands": 12,
+            "command_menu_priority": ["status", "model"],
+            "command_menu_priority_mode": "replace"
         }"#;
         let cfg: TelegramConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.webhook_secret.as_deref(), Some("secret"));
@@ -4457,5 +5120,9 @@ mod tests {
         assert!(cfg.reactions);
         assert!(cfg.disable_link_previews);
         assert!(cfg.rich_messages);
+        assert!(!cfg.command_menu_enabled);
+        assert_eq!(cfg.command_menu_max_commands, 12);
+        assert_eq!(cfg.command_menu_priority, vec!["status", "model"]);
+        assert_eq!(cfg.command_menu_priority_mode, "replace");
     }
 }

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T04:46:31.400149+00:00`_
+_Generated from source artifacts: `2026-06-25T05:38:58.962851+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T04:46:31.260695+00:00`
-- Proof snapshot generated: `2026-06-25T04:46:31.400149+00:00`
+- Queue snapshot generated: `2026-06-25T05:38:58.804651+00:00`
+- Proof snapshot generated: `2026-06-25T05:38:58.962851+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T04:46:31.400149+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=233.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=233.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=222.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=222.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-25T04:46:31.400149+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 6995 |
-| Pending | 233 |
-| Ported | 365 |
-| Superseded | 6321 |
+| Total commits in queue | 6997 |
+| Pending | 222 |
+| Ported | 373 |
+| Superseded | 6326 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 233.0,
+        "actual": 222.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T04:46:31.400149+00:00",
+  "generated_at_utc": "2026-06-25T05:38:58.962851+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 233.0,
+    "max_queue_pending_commits": 222.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,22 +299,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 233,
-      "ported": 365,
-      "superseded": 6321
+      "pending": 222,
+      "ported": 373,
+      "superseded": 6326
     },
     "by_target_ticket": {
-      "20": 3131,
+      "20": 3132,
       "21": 130,
       "22": 957,
       "23": 488,
       "24": 22,
       "25": 145,
-      "26": 2122
+      "26": 2123
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 6995
+    "total_commits": 6997
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 233.0,
+        "actual": 222.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T04:46:31.400149+00:00`
+Generated: `2026-06-25T05:38:58.962851+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T04:46:31.400149+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 233.0 |
+| `max_queue_pending_commits` | 222.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-25T04:46:31.400149+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `6995`.
+- Upstream missing commits tracked: `6997`.
 - By target ticket:
-  - `#20`: `3131`
+  - `#20`: `3132`
   - `#21`: `130`
   - `#22`: `957`
   - `#23`: `488`
   - `#24`: `22`
   - `#25`: `145`
-  - `#26`: `2122`
+  - `#26`: `2123`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4318,6 +4318,66 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust OpenViking memory plugin: canonical OpenViking tool_status values and inbound alias sets are named constants; conversion emits completed/error/pending consistently and tests cover JSON error result mapping."
+    },
+    "29e5e127c6f1c35fcc67abf0281c50c237e2929f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: TelegramMessage now deserializes Bot API rich_message echoes and parse_update flattens native rich blocks into text when Telegram omits text/caption, with focused rich-reply coverage."
+    },
+    "c1f11f8c69f9721a4b5227231a6ff23a91826f76": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream indexes streamed rich finals in a Python rich_sent_store fallback. Ultra's Rust Telegram path has no rich_sent_store; rich edit/send payloads are generated from live adapter state and native rich echoes are parsed directly."
+    },
+    "796f618f9987306722c4e27fdfb757291240386b": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fixes Python chunk marker placement around Markdown fences. Ultra's Rust Telegram split_message path does not append chunk markers, so the marker-inside-fence corruption mode is absent."
+    },
+    "31e59fe44d18498ae53f624a3d3d5dbbad2d165e": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: rich send/edit payloads normalize prose single newlines into Telegram hard breaks while preserving protected Markdown regions, with slash-output newline coverage."
+    },
+    "a9669323922f6e79482536f2c05846c354571528": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: rich newline normalization protects Markdown pipe tables from hard-break injection, preserving table layout with focused regression coverage."
+    },
+    "ea056b05598cab8330555defe095988c3a7928f9": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: rich-message eligibility now rejects CJK scripts to avoid Telegram desktop garbling, with guard and legacy-payload tests."
+    },
+    "6183e8ce1b5ee79f2d808d0c17ea46fbbf128c37": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram config: Bot API 10.1 rich messages are opt-in/default-off in serde defaults and CLI config mapping, with gateway and CLI tests pinning the default."
+    },
+    "565b7c8d9d879c6423c55e9be84596936bc489ba": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream repairs lingering Python sendChatAction typing refreshes. Ultra's Rust Telegram adapter does not implement a typing-indicator refresh loop, so there is no post-final typing state to re-arm or clear."
+    },
+    "dbe14ce35d9cb087ae9fe3e3f166f6c475297e25": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: startup registers BotCommand menus for default/private/group scopes from the Rust gateway command catalog with configurable priority, mode, and cap."
+    },
+    "d4be583d986f7bcca4f8414fd21ef9e34b18c948": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram adapter: the default command-menu cap is 60 while still clamping to Telegram's 100-command API maximum, with command ordering/cap coverage."
+    },
+    "73a20a6ad62b678d69335ef3a352ccf9ab85167b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported to Rust's edit surface: oversized Telegram edit previews are clipped to the Bot API text limit instead of failing mid-stream; final sends continue through the normal send/split path."
+    },
+    "17beb55e3c9c3574bce849a75430887dec910423": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream gates Python rich draft previews separately from finals. Ultra has no Telegram sendRichMessageDraft or rich draft-preview runtime surface; rich final send/edit attempts remain controlled by rich_messages."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T04:46:31.260695+00:00`
+Generated: `2026-06-25T05:38:58.804651+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `6995`.
+- Range: `main..upstream/main`; total commits tracked: `6997`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3131 |
+| #20 | GPAR-01 tests+CI parity | 3132 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 957 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 145 |
-| #26 | GPAR-07 upstream queue backfill | 2122 |
+| #26 | GPAR-07 upstream queue backfill | 2123 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 233 |
-| ported | 365 |
-| superseded | 6321 |
+| pending | 222 |
+| ported | 373 |
+| superseded | 6326 |
 
 ## First 100 Pending Commits
 
@@ -94,34 +94,34 @@ Generated: `2026-06-25T04:46:31.260695+00:00`
 | `98ecd0beeba9` | #26 | docs(mcp): fix stale ~0.75s discovery-wait reference in late-refresh docstring |
 | `b1ab5a8ae1d9` | #21 | docs(antigravity-cli): add delegation patterns + output/bounding caveats |
 | `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
-| `29e5e127c6f1` | #20 | fix(telegram): recover reply text from native rich echo |
-| `c1f11f8c69f9` | #20 | fix(telegram): index streamed rich finals via editMessageText too |
 | `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
 | `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
 | `04730f32e7e8` | #20 | fix(cli): warn when in-session model switch will preflight-compress |
 | `1ca29723f0ea` | #20 | fix(cli): log instead of swallow preflight-warning errors; consistent TUI warning field |
 | `dd042fc4dfb1` | #20 | fix(tools): preserve core tools when a platform bundle is disabled |
-| `796f618f9987` | #20 | fix(telegram): keep chunk markers outside code fences |
 | `c7e8854cb383` | #20 | fix(tui): persist session messages on force-quit / signal shutdown |
 | `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
 | `0e47f68a479a` | #26 | fix(desktop): rename branched session via session.title RPC |
 | `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
 | `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
-| `31e59fe44d18` | #20 | fix(telegram): preserve newlines in rich slash-command output (#46070) |
-| `a9669323922f` | #20 | fix(telegram): exempt tables from rich newline hard-breaks |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
-| `ea056b05598c` | #20 | fix(telegram): avoid rich messages for CJK text |
 | `d0de4601d204` | #20 | fix(tui): /compress shows a before/after summary (#46686) |
 | `7bc6f1806284` | #23 | fix(hindsight): skip local_embedded daemon when running as root |
 | `93ea9b04aff2` | #20 | fix(gateway): cap inbound media download size to prevent memory exhaustion |
-| `6183e8ce1b5e` | #20 | fix(telegram): make Bot API 10.1 rich messages opt-in (default off) |
 | `587b5b9ac223` | #23 | fix(backup): capture memory-provider state stored outside HERMES_HOME (#50325) |
 | `2a4542333ee1` | #26 | fix(photon): classify Envoy overflow errors as retryable; add typing cooldown |
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
 | `5e3e89cc05d3` | #23 | feat(hindsight): configurable embedded daemon health grace timeout (#50341) |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
 | `c0409a87ff05` | #23 | feat(gateway): typed send-error classification (SendResult.error_kind) (#50342) |
-| `565b7c8d9d87` | #20 | fix(telegram): stop typing indicator lingering after final reply |
 | `b6d107240819` | #20 | fix(cli): branch new worktrees from the fresh remote tip, not stale local HEAD (#50355) |
 | `5b45fb269a06` | #20 | fix(security): sanitize kanban markdown html |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
+| `a4b1554c7349` | #20 | fix(whatsapp): normalize bare phone targets to JIDs before bridge send |
+| `99f3072aa06a` | #20 | fix(model-switch): a failed in-place swap must be a no-op, not a dead session (#50375) |
+| `b7f6cb9c8ba3` | #20 | fix(email): resolve IMAP/SMTP host from config and validate before connecting |
+| `f79e0a7060d0` | #20 | fix(email): mark missing-config as non-retryable + reject blank env vars (#40715) |
+| `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
+| `7785655b4ece` | #26 | fix(desktop): keep the floating composer in-bounds so it can't be lost off-screen |
+| `37c37c9dc511` | #26 | fix(antigravity): register google-antigravity ProviderProfile + AUTHOR_MAP |
+| `16aeba17078d` | #26 | fix(desktop): clamp composer peel-off under cursor |


### PR DESCRIPTION
## Summary
- Port Telegram Bot API 10.1 rich-message hardening into the Rust gateway: opt-in/default-off rich messages, CJK guard, prose newline hard-break normalization, table/fence protection, native rich echo flattening, and oversized edit-preview clipping.
- Add Rust Telegram BotCommand menu registration on adapter startup with configurable priority/mode/cap and default cap 60.
- Replace the brittle gateway runtime-state test model assertion with a dynamic configured model value instead of a stale static `gpt-4o` expectation.
- Update parity overrides and regenerated dashboard/proof/queue artifacts; pending queue is now 222.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-gateway --features telegram telegram`
- `cargo test -p hermes-cli --features gateway-telegram build_telegram_config`
- `cargo test -p hermes-gateway --lib gateway::tests::gateway_runtime_state_is_injected_into_agent_messages -- --nocapture`
- `cargo test -p hermes-gateway --lib`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features telegram`
- `cargo build --workspace`
- `cargo test --workspace`

## Guardrails
- OAuth/sign-in guarded paths were checked clean before commit.
- Build/test artifacts used the delegated cargo target directory, not the local SSD target dir.
