### PR TITLE
parity(model): persist runtime switches and warn on compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "hermes-config",
  "hermes-core",
  "hermes-cron",
+ "hermes-intelligence",
  "hermes-tools",
  "hmac",
  "matrix-sdk-crypto",

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -26,6 +26,7 @@ use hermes_config::{hermes_home as hermes_home_dir, load_config, state_dir, Gate
 use hermes_core::ToolSchema;
 use hermes_core::{AgentError, LlmProvider, UsageStats};
 use hermes_cron::{CronRunner, CronScheduler, FileJobPersistence};
+use hermes_intelligence::{build_model_switch_preflight_warning, estimate_messages_tokens_rough};
 pub use hermes_provider_runtime::{
     active_llm_provider_config, allow_no_api_key, normalize_runtime_provider_name,
     provider_api_key_from_env, provider_base_url_from_env, provider_default_base_url,
@@ -288,7 +289,7 @@ pub struct App {
     /// Whether the application loop is still running.
     pub running: bool,
 
-    /// Currently active model identifier (e.g. "openai:gpt-4o").
+    /// Currently active model identifier (for example, "dynamic" or "provider:model").
     pub current_model: String,
 
     /// Actual provider-reported usage for the most recently applied agent run.
@@ -2697,6 +2698,18 @@ impl App {
         tracing::info!("Switched model to: {}", provider_model);
     }
 
+    /// Warn before a user-initiated model switch if the current transcript is
+    /// likely to trigger preflight compression under the new context window.
+    pub fn model_switch_preflight_warning(&self, provider_model: &str) -> Option<String> {
+        let values = self
+            .messages
+            .iter()
+            .filter_map(|message| serde_json::to_value(message).ok())
+            .collect::<Vec<_>>();
+        let estimate = estimate_messages_tokens_rough(&values);
+        build_model_switch_preflight_warning(Some(&self.current_model), provider_model, estimate)
+    }
+
     fn rebuild_agent_for_active_session(&mut self) {
         let provider = build_provider(&self.config, &self.current_model);
         let mut agent_config = build_agent_config(&self.config, &self.current_model);
@@ -3994,7 +4007,7 @@ fn apply_cli_runtime_overrides(config: &mut GatewayConfig, cli: &Cli) {
         .filter(|v| !v.is_empty())
     {
         let provider = normalize_runtime_provider_name(provider);
-        let existing_model = config.model.as_deref().unwrap_or("gpt-4o").trim();
+        let existing_model = config.model.as_deref().unwrap_or("dynamic").trim();
         let model_name = existing_model
             .split_once(':')
             .map(|(_, name)| name.trim())
@@ -4092,16 +4105,16 @@ mod tests {
         std::fs::create_dir_all(&cron_dir).expect("create cron test dir");
         let cron_scheduler = Arc::new(build_runtime_cron_scheduler(
             config.as_ref(),
-            "openai:gpt-4o",
+            "dynamic",
             cron_dir,
             &tool_registry,
         ));
         let agent_tool_registry = Arc::new(bridge_tool_registry(&tool_registry));
         let session_id = "test-session".to_string();
-        let mut agent_config = build_agent_config(config.as_ref(), "openai:gpt-4o");
+        let mut agent_config = build_agent_config(config.as_ref(), "dynamic");
         agent_config.session_id = Some(session_id.clone());
         let provider: Arc<dyn LlmProvider> = Arc::new(hermes_provider_runtime::NoBackendProvider {
-            model: "openai:gpt-4o".to_string(),
+            model: "dynamic".to_string(),
         });
         let agent_inner = hermes_agent::attach_discovered_memory(AgentLoop::new(
             agent_config,
@@ -4126,7 +4139,7 @@ mod tests {
             ui_messages: Vec::new(),
             session_id,
             running: true,
-            current_model: "openai:gpt-4o".to_string(),
+            current_model: "dynamic".to_string(),
             last_usage: None,
             session_usage: None,
             session_cost_usd: 0.0,
@@ -4258,6 +4271,29 @@ mod tests {
                 None => std::env::remove_var(key),
             }
         }
+    }
+
+    #[test]
+    fn model_switch_preflight_warning_is_ui_only_and_keeps_messages_clean() {
+        let mut app = build_minimal_test_app();
+        app.current_model = "anthropic:claude-sonnet-4-6".to_string();
+        app.messages = vec![hermes_core::Message::user("abcd".repeat(90_000))];
+
+        let warning = app
+            .model_switch_preflight_warning("deepseek-chat")
+            .expect("large transcript should warn");
+
+        assert!(warning.contains("Context warning"));
+        assert!(warning.contains("preflight compression"));
+        assert_eq!(
+            app.messages.len(),
+            1,
+            "warning must not mutate model context"
+        );
+        assert!(
+            app.ui_messages.is_empty(),
+            "warning calculation must not add UI transcript rows"
+        );
     }
 
     #[test]
@@ -4509,7 +4545,7 @@ mod tests {
     fn test_session_info_serialization() {
         let info = SessionInfo {
             session_id: "test-123".to_string(),
-            model: "gpt-4o".to_string(),
+            model: "dynamic".to_string(),
             personality: Some("helpful".to_string()),
             message_count: 5,
             created_at: "2025-01-01T00:00:00Z".to_string(),
@@ -4517,7 +4553,7 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         let back: SessionInfo = serde_json::from_str(&json).unwrap();
         assert_eq!(back.session_id, "test-123");
-        assert_eq!(back.model, "gpt-4o");
+        assert_eq!(back.model, "dynamic");
     }
 
     #[test]
@@ -5008,7 +5044,7 @@ mod tests {
     #[test]
     fn test_apply_cli_runtime_overrides_applies_provider_to_prefixed_model() {
         let mut cfg = GatewayConfig::default();
-        cfg.model = Some("openai:gpt-4o".to_string());
+        cfg.model = Some("openai:dynamic".to_string());
         let cli = Cli {
             command: None,
             verbose: false,
@@ -5023,7 +5059,7 @@ mod tests {
         };
 
         apply_cli_runtime_overrides(&mut cfg, &cli);
-        assert_eq!(cfg.model.as_deref(), Some("nous:gpt-4o"));
+        assert_eq!(cfg.model.as_deref(), Some("nous:dynamic"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -4374,6 +4374,7 @@ async fn pick_model_for_provider(
     let provider_model = format!("{}:{}", provider, filtered_models[pick.index].trim());
     let (guarded, note) =
         guard_provider_model_selection_for_config(&provider_model, &app.config).await?;
+    let warning = app.model_switch_preflight_warning(&guarded);
     app.switch_model(&guarded);
     let mut msg = format!("Model switched to: {}", guarded);
     if let Some(n) = note {
@@ -4382,6 +4383,10 @@ async fn pick_model_for_provider(
     }
     msg.push_str("\n");
     msg.push_str(&format_model_persistence_note(app));
+    if let Some(warning) = warning {
+        msg.push_str("\n");
+        msg.push_str(&warning);
+    }
     emit_command_output(app, msg);
     Ok(true)
 }
@@ -5070,6 +5075,7 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
                     )));
                 }
             }
+            let warning = app.model_switch_preflight_warning(&guarded);
             app.switch_model(&guarded);
             let mut msg = format!("Model switched to: {}", guarded);
             if let Some(n) = note {
@@ -5085,6 +5091,10 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
             }
             msg.push_str("\n");
             msg.push_str(&format_model_persistence_note(app));
+            if let Some(warning) = warning {
+                msg.push_str("\n");
+                msg.push_str(&warning);
+            }
             emit_command_output(app, msg);
         }
         ModelSwitchRequest::PickModelFromProvider(provider) => {
@@ -27665,7 +27675,7 @@ impl hermes_acp::AcpPromptExecutor for CliAcpPromptExecutor {
             .model
             .clone()
             .or_else(|| self.config.model.clone())
-            .unwrap_or_else(|| "gpt-4o".to_string());
+            .unwrap_or_else(|| "dynamic".to_string());
 
         let provider = crate::app::build_provider(&self.config, &model);
         let mut agent_config = crate::app::build_agent_config(&self.config, &model);
@@ -27793,7 +27803,10 @@ pub async fn handle_cli_acp(
             let config = hermes_config::load_config(None)
                 .map_err(|e| hermes_core::AgentError::Config(e.to_string()))?;
 
-            let model = config.model.clone().unwrap_or_else(|| "gpt-4o".to_string());
+            let model = config
+                .model
+                .clone()
+                .unwrap_or_else(|| "dynamic".to_string());
             let max_turns = config.max_turns as usize;
 
             println!(
@@ -29955,7 +29968,7 @@ mod tests {
         let mut app = build_test_app_with_stream(tmp.path()).await;
         std::fs::write(
             app.state_root.join("config.yaml"),
-            "model:\n  provider: openai\n  default: gpt-4o\n  openai_runtime: codex_app_server\n",
+            "model:\n  provider: openai\n  default: dynamic\n  openai_runtime: codex_app_server\n",
         )
         .expect("write config");
 
@@ -31448,6 +31461,44 @@ install_command: "uv pip install -r requirements.txt"
         assert!(out.contains("models_sample: model-a, model-b"));
     }
 
+    #[tokio::test]
+    async fn model_switch_command_emits_preflight_warning_for_large_transcript() {
+        let _lock = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        let mut cfg = (*app.config).clone();
+        cfg.model = Some("anthropic:claude-sonnet-4-6".to_string());
+        cfg.llm_providers.insert(
+            "compact-provider".to_string(),
+            LlmProviderConfig {
+                models: vec!["deepseek-chat".to_string()],
+                discover_models: false,
+                ..LlmProviderConfig::default()
+            },
+        );
+        app.config = Arc::new(cfg);
+        app.current_model = "anthropic:claude-sonnet-4-6".to_string();
+        app.messages = vec![hermes_core::Message::user("abcd".repeat(90_000))];
+
+        handle_model_command(
+            &mut app,
+            &["deepseek-chat", "--provider", "compact-provider"],
+        )
+        .await
+        .expect("model switch");
+
+        let out = latest_ui_assistant_text(&app);
+        assert!(out.contains("Model switched to: compact-provider:deepseek-chat"));
+        assert!(out.contains("Context warning"));
+        assert!(out.contains("preflight compression"));
+        assert_eq!(
+            app.messages.len(),
+            1,
+            "warning must not append model context"
+        );
+    }
+
     #[test]
     fn parse_model_command_args_extracts_capability_flags() {
         let (positional, requirements, provider_override) = parse_model_command_args(&[
@@ -31469,9 +31520,9 @@ install_command: "uv pip install -r requirements.txt"
     #[test]
     fn parse_model_command_args_supports_boolean_capability_switches() {
         let (positional, requirements, provider_override) =
-            parse_model_command_args(&["openai:gpt-4o", "--tools", "--long-context"])
+            parse_model_command_args(&["nous:openai/gpt-5.5-pro", "--tools", "--long-context"])
                 .expect("parse");
-        assert_eq!(positional, vec!["openai:gpt-4o".to_string()]);
+        assert_eq!(positional, vec!["nous:openai/gpt-5.5-pro".to_string()]);
         assert!(requirements.require_tools);
         assert!(requirements.require_long_context);
         assert_eq!(
@@ -31484,9 +31535,9 @@ install_command: "uv pip install -r requirements.txt"
     #[test]
     fn parse_model_command_args_extracts_provider_override() {
         let (positional, _requirements, provider_override) =
-            parse_model_command_args(&["gpt-4o", "--provider", "openai"]).expect("parse");
-        assert_eq!(positional, vec!["gpt-4o".to_string()]);
-        assert_eq!(provider_override.as_deref(), Some("openai"));
+            parse_model_command_args(&["dynamic", "--provider", "nous"]).expect("parse");
+        assert_eq!(positional, vec!["dynamic".to_string()]);
+        assert_eq!(provider_override.as_deref(), Some("nous"));
     }
 
     #[test]
@@ -31630,18 +31681,18 @@ install_command: "uv pip install -r requirements.txt"
     #[test]
     fn parse_model_switch_request_accepts_direct_provider_model() {
         let providers = vec!["openai", "nous", "anthropic"];
-        let req = parse_model_switch_request(&["openai:gpt-4o"], &providers);
+        let req = parse_model_switch_request(&["nous:openai/gpt-5.5-pro"], &providers);
         assert_eq!(
             req,
-            ModelSwitchRequest::SetDirect("openai:gpt-4o".to_string())
+            ModelSwitchRequest::SetDirect("nous:openai/gpt-5.5-pro".to_string())
         );
     }
 
     #[test]
     fn parse_model_switch_request_keeps_bare_model_as_direct() {
         let providers = vec!["openai", "nous", "anthropic"];
-        let req = parse_model_switch_request(&["gpt-4o"], &providers);
-        assert_eq!(req, ModelSwitchRequest::SetDirect("gpt-4o".to_string()));
+        let req = parse_model_switch_request(&["dynamic"], &providers);
+        assert_eq!(req, ModelSwitchRequest::SetDirect("dynamic".to_string()));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -2983,6 +2983,14 @@ async fn run_gateway(
 
             // Build gateway runtime and context-aware message handler.
             let runtime_gateway_config = RuntimeGatewayConfig {
+                model: config.model.clone(),
+                model_switch_persist_by_default: config.model_switch.persist_switch_by_default,
+                model_switch_config_path: Some(
+                    hermes_state_root(&cli)
+                        .join("config.yaml")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
                 streaming_enabled: config.streaming.enabled,
                 display: config.display.clone(),
                 service_tier: config.agent.normalized_service_tier(),

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -4801,10 +4801,17 @@ async fn process_modal_confirm(state: &mut TuiState, app: &mut App) -> Result<()
         }
         PickerKind::ModelForProvider { provider } => {
             let provider_model = format!("{provider}:{}", item.value.trim());
+            let warning = app.model_switch_preflight_warning(&provider_model);
             app.switch_model(&provider_model);
-            app.push_ui_assistant(format!("Model switched to: {}", provider_model));
+            let mut notice = format!("Model switched to: {}", provider_model);
+            if let Some(warning) = warning.as_deref() {
+                notice.push('\n');
+                notice.push_str(warning);
+            }
+            app.push_ui_assistant(notice);
             state.close_modal();
-            state.status_message = format!("Switched model to {}", provider_model);
+            state.status_message =
+                warning.unwrap_or_else(|| format!("Switched model to {}", provider_model));
         }
         PickerKind::Personality => {
             app.switch_personality(item.value.as_str());

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -18,9 +18,13 @@ use crate::streaming::StreamingConfig;
 /// Top-level configuration for the hermes gateway.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GatewayConfig {
-    /// Default LLM model identifier (e.g. "gpt-4o", "claude-3-opus").
+    /// Default LLM model identifier (for example `nous:nousresearch/hermes-4-70b`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+
+    /// Model-switch persistence controls.
+    #[serde(default)]
+    pub model_switch: ModelSwitchConfig,
 
     /// Personality / persona name to load.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -171,6 +175,7 @@ impl Default for GatewayConfig {
     fn default() -> Self {
         Self {
             model: None,
+            model_switch: ModelSwitchConfig::default(),
             personality: None,
             max_turns: default_max_turns(),
             system_prompt: None,
@@ -204,6 +209,25 @@ impl Default for GatewayConfig {
             profile: ProfileConfig::default(),
             agent: AgentLoopBehaviorConfig::default(),
             home_dir: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSwitchConfig {
+    /// Persist plain `/model <name>` switches to config by default.
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_boolish",
+        skip_serializing_if = "is_true"
+    )]
+    pub persist_switch_by_default: bool,
+}
+
+impl Default for ModelSwitchConfig {
+    fn default() -> Self {
+        Self {
+            persist_switch_by_default: true,
         }
     }
 }

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -22,11 +22,11 @@ pub mod streaming;
 pub use config::{
     default_auxiliary_task_configs, normalize_service_tier, AgentLoopBehaviorConfig,
     ApprovalConfig, AuxiliaryTaskConfig, CheapModelRouteConfig, DelegationConfig, DisplayConfig,
-    GatewayConfig, LlmProviderConfig, McpServerEntry, PlatformDisplayConfig, ProfileConfig,
-    ProxyConfig, QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig, SkillsSettings,
-    SmartModelRoutingConfig, StaleAuxiliaryAssignment, TerminalBackendType, TerminalConfig,
-    TerminalHomeMode, ToolOutputConfig, ToolsSettings, WebConfig, WebsiteBlocklistConfig,
-    DEFAULT_TOOL_OUTPUT_MAX_BYTES, DEFAULT_TOOL_OUTPUT_MAX_LINES,
+    GatewayConfig, LlmProviderConfig, McpServerEntry, ModelSwitchConfig, PlatformDisplayConfig,
+    ProfileConfig, ProxyConfig, QuickCommandConfig, SecurityConfig, SessionsMaintenanceConfig,
+    SkillsSettings, SmartModelRoutingConfig, StaleAuxiliaryAssignment, TerminalBackendType,
+    TerminalConfig, TerminalHomeMode, ToolOutputConfig, ToolsSettings, WebConfig,
+    WebsiteBlocklistConfig, DEFAULT_TOOL_OUTPUT_MAX_BYTES, DEFAULT_TOOL_OUTPUT_MAX_LINES,
     DEFAULT_TOOL_OUTPUT_MAX_LINE_LENGTH,
 };
 pub use loader::{

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -628,7 +628,7 @@ fn normalize_provider_secrets(config: &mut GatewayConfig) {
     });
 }
 
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, model_switch.persist_switch_by_default, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -857,6 +857,10 @@ fn apply_user_config_patch_dotted(
         ["kanban", "dispatch_in_gateway"] => {
             config.kanban.dispatch_in_gateway =
                 parse_config_bool("kanban.dispatch_in_gateway", value)?;
+        }
+        ["model_switch", "persist_switch_by_default"] | ["model", "persist_switch_by_default"] => {
+            config.model_switch.persist_switch_by_default =
+                parse_config_bool("model_switch.persist_switch_by_default", value)?;
         }
         ["agent", "api_max_retries"] | ["agent", "apiMaxRetries"] => {
             config.agent.api_max_retries = Some(value.parse().map_err(|_| {
@@ -1123,6 +1127,9 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
         ["sessions", "vacuum_after_prune"] => Ok(config.sessions.vacuum_after_prune.to_string()),
         ["sessions", "min_interval_hours"] => Ok(config.sessions.min_interval_hours.to_string()),
         ["kanban", "dispatch_in_gateway"] => Ok(config.kanban.dispatch_in_gateway.to_string()),
+        ["model_switch", "persist_switch_by_default"] | ["model", "persist_switch_by_default"] => {
+            Ok(config.model_switch.persist_switch_by_default.to_string())
+        }
         ["agent", "api_max_retries"] | ["agent", "apiMaxRetries"] => Ok(config
             .agent
             .api_max_retries

--- a/crates/hermes-config/src/python_yaml_compat.rs
+++ b/crates/hermes-config/src/python_yaml_compat.rs
@@ -110,6 +110,20 @@ fn normalize_model_block(map: &mut Mapping) {
             map.insert(model_key, Value::String(s));
         }
         Value::Mapping(m) => {
+            if let Some(persist) = m.get(&key("persist_switch_by_default")).cloned() {
+                let switch_key = key("model_switch");
+                let mut switch_map = match map.remove(&switch_key) {
+                    Some(Value::Mapping(existing)) => existing,
+                    Some(other) => {
+                        let mut existing = Mapping::new();
+                        existing.insert(key("value"), other);
+                        existing
+                    }
+                    None => Mapping::new(),
+                };
+                switch_map.insert(key("persist_switch_by_default"), persist);
+                map.insert(switch_key, Value::Mapping(switch_map));
+            }
             let default = m
                 .get(&key("default"))
                 .and_then(as_str)
@@ -586,9 +600,28 @@ max_turns: 99
         normalize_config_yaml_root(m);
         let cfg: crate::config::GatewayConfig = serde_yaml::from_value(root).unwrap();
         assert_eq!(cfg.model.as_deref(), Some("openrouter:z-ai/glm-5.1"));
+        assert!(cfg.model_switch.persist_switch_by_default);
         assert_eq!(cfg.max_turns, 99);
         let or = cfg.llm_providers.get("openrouter").expect("openrouter");
         assert_eq!(or.base_url.as_deref(), Some("https://openrouter.ai/api/v1"));
+    }
+
+    #[test]
+    fn python_model_block_lifts_persist_default_flag() {
+        let raw = r#"
+model:
+  default: zai/glm-5.2
+  provider: openrouter
+  persist_switch_by_default: "false"
+"#;
+        let mut root: Value = serde_yaml::from_str(raw).unwrap();
+        let Value::Mapping(ref mut m) = root else {
+            panic!();
+        };
+        normalize_config_yaml_root(m);
+        let cfg: crate::config::GatewayConfig = serde_yaml::from_value(root).unwrap();
+        assert_eq!(cfg.model.as_deref(), Some("openrouter:zai/glm-5.2"));
+        assert!(!cfg.model_switch.persist_switch_by_default);
     }
 
     #[test]

--- a/crates/hermes-config/tests/prop_config_roundtrip.rs
+++ b/crates/hermes-config/tests/prop_config_roundtrip.rs
@@ -150,6 +150,7 @@ fn gateway_config(
 ) -> GatewayConfig {
     GatewayConfig {
         model: model.map(str::to_string),
+        model_switch: Default::default(),
         personality: personality.map(str::to_string),
         max_turns,
         system_prompt: None,

--- a/crates/hermes-gateway/Cargo.toml
+++ b/crates/hermes-gateway/Cargo.toml
@@ -32,6 +32,7 @@ webhook = []
 [dependencies]
 hermes-core = { workspace = true }
 hermes-config = { workspace = true }
+hermes-intelligence = { workspace = true }
 hermes-tools = { workspace = true }
 hermes-cron = { workspace = true }
 tokio = { workspace = true }

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -11,7 +11,7 @@ pub enum GatewayCommandResult {
     /// Reset the session and send a reply.
     ResetSession(String),
     /// Switch the model and send a reply.
-    SwitchModel { model: String, reply: String },
+    SwitchModel { request: ModelSwitchRequest },
     /// Switch the personality and send a reply.
     SwitchPersonality { name: String, reply: String },
     /// Stop the currently running agent task.
@@ -98,6 +98,26 @@ pub enum GatewayCommandResult {
     Noop,
 }
 
+/// Requested persistence behavior for `/model`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelSwitchScope {
+    /// Defer to config (`model_switch.persist_switch_by_default`, default true).
+    Default,
+    /// Persist the model switch as the gateway default.
+    Global,
+    /// Apply only to the current gateway session.
+    Session,
+}
+
+/// Parsed `/model` command payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelSwitchRequest {
+    pub model: String,
+    pub provider: Option<String>,
+    pub scope: ModelSwitchScope,
+    pub force_refresh: bool,
+}
+
 /// Metadata about a slash command.
 pub struct CommandInfo {
     pub name: &'static str,
@@ -137,7 +157,7 @@ pub fn all_commands() -> Vec<CommandInfo> {
             name: "/model",
             aliases: &[],
             description: "Show or switch the LLM model",
-            usage: "/model [name]",
+            usage: "/model [name] [--session|--global] [--provider provider]",
         },
         CommandInfo {
             name: "/personality",
@@ -353,9 +373,106 @@ pub fn all_commands() -> Vec<CommandInfo> {
 }
 
 fn normalize_command_args(args: &str) -> String {
-    args.replace("\u{2014}\u{2014}", "--")
+    let mut normalized = args.to_string();
+    for flag in ["provider", "global", "session", "refresh"] {
+        for dash in ['\u{2012}', '\u{2013}', '\u{2014}', '\u{2015}'] {
+            normalized = normalized.replace(&format!("{dash}{flag}"), &format!("--{flag}"));
+        }
+    }
+    normalized
+        .replace("\u{2014}\u{2014}", "--")
         .replace('\u{2014}', "--")
         .replace('\u{2013}', "-")
+}
+
+fn parse_model_switch_args(args: &str) -> Result<ModelSwitchRequest, String> {
+    let mut is_global = false;
+    let mut is_session = false;
+    let mut provider: Option<String> = None;
+    let mut force_refresh = false;
+    let mut model_parts = Vec::new();
+
+    let tokens = args.split_whitespace().collect::<Vec<_>>();
+    let mut i = 0;
+    while i < tokens.len() {
+        match tokens[i].to_ascii_lowercase().as_str() {
+            "--global" => {
+                is_global = true;
+                i += 1;
+            }
+            "--session" => {
+                is_session = true;
+                i += 1;
+            }
+            "--refresh" => {
+                force_refresh = true;
+                i += 1;
+            }
+            "--provider" => {
+                let Some(value) = tokens
+                    .get(i + 1)
+                    .map(|v| v.trim())
+                    .filter(|v| !v.is_empty())
+                else {
+                    return Err(
+                        "Usage: /model <name> [--provider provider] [--session|--global]"
+                            .to_string(),
+                    );
+                };
+                provider = Some((*value).to_string());
+                i += 2;
+            }
+            other if other.starts_with("--provider=") => {
+                let value = tokens[i]
+                    .split_once('=')
+                    .map(|(_, value)| value.trim())
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        "Usage: /model <name> [--provider provider] [--session|--global]"
+                            .to_string()
+                    })?;
+                provider = Some(value.to_string());
+                i += 1;
+            }
+            _ => {
+                model_parts.push(tokens[i]);
+                i += 1;
+            }
+        }
+    }
+
+    let raw_model = model_parts.join(" ");
+    let model = raw_model.trim();
+    if model.is_empty() {
+        if force_refresh {
+            return Err(
+                "Gateway model catalog refresh requires a model value. Use `/model <name> --refresh`."
+                    .to_string(),
+            );
+        }
+        return Err("Usage: /model <name> [--session|--global] [--provider provider]".to_string());
+    }
+
+    let model = if model.contains(':') || provider.is_none() {
+        model.to_string()
+    } else {
+        format!("{}:{}", provider.as_deref().unwrap_or_default(), model)
+    };
+
+    let scope = if is_session {
+        ModelSwitchScope::Session
+    } else if is_global {
+        ModelSwitchScope::Global
+    } else {
+        ModelSwitchScope::Default
+    };
+
+    Ok(ModelSwitchRequest {
+        model,
+        provider,
+        scope,
+        force_refresh,
+    })
 }
 
 fn parse_fast_service_tier(args: &str) -> Result<Option<String>, String> {
@@ -459,12 +576,12 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
         "/model" => {
             if args.is_empty() {
                 GatewayCommandResult::Reply(
-                    "Current model shown in status. Use /model <name> to switch.".to_string(),
+                    "Current model shown in status. Use /model <name> to switch, or /model <name> --session for a one-off switch.".to_string(),
                 )
             } else {
-                GatewayCommandResult::SwitchModel {
-                    model: args.clone(),
-                    reply: format!("🔀 Model switched to: {}", args),
+                match parse_model_switch_args(&args) {
+                    Ok(request) => GatewayCommandResult::SwitchModel { request },
+                    Err(msg) => GatewayCommandResult::Reply(msg),
                 }
             }
         }
@@ -757,33 +874,48 @@ mod tests {
 
     #[test]
     fn test_model_switch() {
-        match handle_command("/model gpt-4o") {
-            GatewayCommandResult::SwitchModel { model, .. } => {
-                assert_eq!(model, "gpt-4o");
+        match handle_command("/model nousresearch/hermes-4-70b") {
+            GatewayCommandResult::SwitchModel { request } => {
+                assert_eq!(request.model, "nousresearch/hermes-4-70b");
+                assert_eq!(request.scope, ModelSwitchScope::Default);
+                assert!(request.provider.is_none());
             }
             other => panic!("Expected SwitchModel, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_model_switch_normalizes_ios_unicode_dashes() {
+    fn test_model_switch_parses_scope_provider_and_unicode_dashes() {
         let em_dash = '\u{2014}';
         let en_dash = '\u{2013}';
 
-        let em_input = format!("/model glm-4.7 {}provider zai", em_dash);
+        let em_input = format!("/model glm-5.2 {}provider zai {}session", em_dash, em_dash);
         match handle_command(&em_input) {
-            GatewayCommandResult::SwitchModel { model, .. } => {
-                assert_eq!(model, "glm-4.7 --provider zai");
+            GatewayCommandResult::SwitchModel { request } => {
+                assert_eq!(request.model, "zai:glm-5.2");
+                assert_eq!(request.provider.as_deref(), Some("zai"));
+                assert_eq!(request.scope, ModelSwitchScope::Session);
             }
             other => panic!("Expected SwitchModel for em dash input, got {:?}", other),
         }
 
-        let en_input = format!("/model glm-4.7 {}provider zai", en_dash);
+        let en_input = format!("/model zai/glm-5.2 {}global", en_dash);
         match handle_command(&en_input) {
-            GatewayCommandResult::SwitchModel { model, .. } => {
-                assert_eq!(model, "glm-4.7 -provider zai");
+            GatewayCommandResult::SwitchModel { request } => {
+                assert_eq!(request.model, "zai/glm-5.2");
+                assert_eq!(request.scope, ModelSwitchScope::Global);
             }
             other => panic!("Expected SwitchModel for en dash input, got {:?}", other),
+        }
+
+        match handle_command("/model zai/glm-5.2 --global --session") {
+            GatewayCommandResult::SwitchModel { request } => {
+                assert_eq!(request.scope, ModelSwitchScope::Session);
+            }
+            other => panic!(
+                "Expected SwitchModel with session precedence, got {:?}",
+                other
+            ),
         }
     }
 

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -19,10 +19,17 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
-use hermes_config::{normalize_service_tier, DisplayConfig, QuickCommandConfig};
+use hermes_config::{
+    load_user_config_file, normalize_service_tier, save_config_yaml, DisplayConfig,
+    QuickCommandConfig,
+};
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 use hermes_core::types::{Message, MessageRole};
+use hermes_intelligence::{
+    build_model_switch_preflight_warning as format_model_switch_preflight_warning,
+    estimate_messages_tokens_rough,
+};
 use hermes_tools::skill_commands::{
     build_skill_reload_system_note, installed_skill_slash_command_snapshot,
     render_skill_slash_command_snapshot, resolve_installed_skill_slash_command,
@@ -30,7 +37,7 @@ use hermes_tools::skill_commands::{
 };
 
 use crate::background::{BackgroundTaskManager, TaskStatus};
-use crate::commands::{handle_command, GatewayCommandResult};
+use crate::commands::{handle_command, GatewayCommandResult, ModelSwitchRequest, ModelSwitchScope};
 use crate::dm::{DmDecision, DmManager};
 use crate::hooks::{HookEvent, HookRegistry};
 use crate::media::validate_media_delivery_path;
@@ -51,6 +58,22 @@ const DEFAULT_MESSAGE_DEDUP_CAPACITY: usize = 4096;
 /// Configuration for the Gateway orchestrator.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GatewayConfig {
+    /// Default model used when a gateway session has no explicit `/model` override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Persist plain `/model <name>` switches by default unless `--session` is used.
+    #[serde(default = "default_true")]
+    pub model_switch_persist_by_default: bool,
+
+    /// Optional config.yaml path for durable gateway `/model` writes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_switch_config_path: Option<String>,
+
+    /// Warn when the current transcript is likely to preflight-compress after a switch.
+    #[serde(default = "default_true")]
+    pub model_switch_preflight_warning: bool,
+
     /// Enable SSRF protection on outbound URLs (default: true).
     #[serde(default = "default_true")]
     pub ssrf_protection: bool,
@@ -91,6 +114,10 @@ pub struct GatewayConfig {
 impl Default for GatewayConfig {
     fn default() -> Self {
         Self {
+            model: None,
+            model_switch_persist_by_default: true,
+            model_switch_config_path: None,
+            model_switch_preflight_warning: true,
             ssrf_protection: true,
             media_cache_dir: None,
             media_cache_max_bytes: 0,
@@ -541,6 +568,8 @@ pub struct Gateway {
     streaming_handler_with_context: RwLock<Option<StreamingMessageHandlerWithContext>>,
     /// Runtime command state for each session.
     runtime_state: RwLock<HashMap<String, SessionRuntimeState>>,
+    /// Process-wide gateway default model updated by persistent `/model` switches.
+    default_model: RwLock<Option<String>>,
     tool_progress_modes: RwLock<BTreeMap<String, String>>,
     /// Basic usage counters for each session.
     usage_stats: RwLock<HashMap<String, UsageStats>>,
@@ -666,6 +695,7 @@ impl Gateway {
         config: GatewayConfig,
     ) -> Self {
         let stream_manager = Arc::new(StreamManager::new(config.streaming.clone()));
+        let default_model = config.model.clone();
 
         Self {
             adapters: RwLock::new(HashMap::new()),
@@ -678,6 +708,7 @@ impl Gateway {
             streaming_handler: RwLock::new(None),
             streaming_handler_with_context: RwLock::new(None),
             runtime_state: RwLock::new(HashMap::new()),
+            default_model: RwLock::new(default_model),
             tool_progress_modes: RwLock::new(BTreeMap::new()),
             usage_stats: RwLock::new(HashMap::new()),
             background_tasks: Arc::new(BackgroundTaskManager::new(8)),
@@ -1422,8 +1453,10 @@ impl Gateway {
                     GatewayCommandResult::SteerPrompt { prompt } => {
                         Some(format!("🧭 Steering instruction accepted: {prompt}"))
                     }
-                    GatewayCommandResult::SwitchModel { reply, .. }
-                    | GatewayCommandResult::SwitchFast { reply, .. }
+                    GatewayCommandResult::SwitchModel { request } => {
+                        Some(format!("🔀 Model switch alias parsed: {}", request.model))
+                    }
+                    GatewayCommandResult::SwitchFast { reply, .. }
                     | GatewayCommandResult::SwitchPersonality { reply, .. }
                     | GatewayCommandResult::SetTitle { reply, .. }
                     | GatewayCommandResult::SetHome { reply, .. } => Some(reply),
@@ -1611,6 +1644,135 @@ impl Gateway {
         .await
     }
 
+    fn estimate_gateway_messages_tokens(messages: &[Message]) -> u64 {
+        let values = messages
+            .iter()
+            .filter_map(|message| serde_json::to_value(message).ok())
+            .collect::<Vec<_>>();
+        estimate_messages_tokens_rough(&values)
+    }
+
+    async fn effective_session_model(&self, session_key: &str) -> Option<String> {
+        let state_model = self
+            .runtime_state
+            .read()
+            .await
+            .get(session_key)
+            .and_then(|state| state.model.clone());
+        if state_model.is_some() {
+            state_model
+        } else {
+            self.default_model.read().await.clone()
+        }
+    }
+
+    async fn build_model_switch_preflight_warning(
+        &self,
+        session_key: &str,
+        new_model: &str,
+    ) -> Option<String> {
+        if !self.config.model_switch_preflight_warning {
+            return None;
+        }
+
+        let messages = self.session_manager.get_messages(session_key).await;
+        let estimate = Self::estimate_gateway_messages_tokens(&messages);
+        let current_model = self.effective_session_model(session_key).await;
+        format_model_switch_preflight_warning(current_model.as_deref(), new_model, estimate)
+            .map(|warning| format!("⚠️ {warning}"))
+    }
+
+    fn persist_gateway_default_model_to_config(
+        &self,
+        model: &str,
+    ) -> Result<Option<PathBuf>, String> {
+        let Some(path) = self
+            .config
+            .model_switch_config_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        else {
+            return Ok(None);
+        };
+        let path = PathBuf::from(path);
+        let mut disk = load_user_config_file(&path)
+            .map_err(|err| format!("load {}: {err}", path.display()))?;
+        disk.model = Some(model.to_string());
+        save_config_yaml(&path, &disk).map_err(|err| format!("save {}: {err}", path.display()))?;
+        Ok(Some(path))
+    }
+
+    async fn apply_model_switch_command(
+        &self,
+        incoming: &IncomingMessage,
+        session_key: &str,
+        request: ModelSwitchRequest,
+    ) -> Result<(), GatewayError> {
+        let warning = self
+            .build_model_switch_preflight_warning(session_key, &request.model)
+            .await;
+        let persist = match request.scope {
+            ModelSwitchScope::Session => false,
+            ModelSwitchScope::Global => true,
+            ModelSwitchScope::Default => self.config.model_switch_persist_by_default,
+        };
+
+        {
+            let mut states = self.runtime_state.write().await;
+            let state = states.entry(session_key.to_string()).or_default();
+            state.model = Some(request.model.clone());
+            if let Some(provider) = request.provider.clone() {
+                state.provider = Some(provider);
+            } else if request.model.contains(':') {
+                state.provider = None;
+            }
+        }
+
+        let mut lines = vec![format!("🔀 Model switched to: {}", request.model)];
+        if let Some(provider) = request.provider.as_deref() {
+            lines.push(format!("Provider: {provider}"));
+        }
+
+        if persist {
+            *self.default_model.write().await = Some(request.model.clone());
+            match self.persist_gateway_default_model_to_config(&request.model) {
+                Ok(Some(path)) => lines.push(format!("Saved to {}.", path.display())),
+                Ok(None) => lines.push(
+                    "Saved as the gateway default for this process; no config path was configured."
+                        .to_string(),
+                ),
+                Err(err) => {
+                    warn!(error = %err, "Failed to persist gateway model switch");
+                    lines.push(format!(
+                        "⚠️ Config save failed: {err}. The switch remains active for this gateway process."
+                    ));
+                }
+            }
+        } else {
+            lines.push("Session only. Use `/model <name> --global` to persist.".to_string());
+        }
+
+        if request.force_refresh {
+            lines.push(
+                "Refresh flag accepted; this Rust gateway has no separate in-process model catalog cache to clear."
+                    .to_string(),
+            );
+        }
+        if let Some(warning) = warning {
+            lines.push(warning);
+        }
+
+        self.send_message(
+            &incoming.platform,
+            &incoming.chat_id,
+            &lines.join("\n"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
     async fn apply_command_result(
         &self,
         incoming: &IncomingMessage,
@@ -1671,11 +1833,8 @@ impl Gateway {
                     .await?;
                 Ok(true)
             }
-            GatewayCommandResult::SwitchModel { model, reply } => {
-                let mut states = self.runtime_state.write().await;
-                states.entry(session_key.to_string()).or_default().model = Some(model);
-                drop(states);
-                self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
+            GatewayCommandResult::SwitchModel { request } => {
+                self.apply_model_switch_command(incoming, session_key, request)
                     .await?;
                 Ok(true)
             }
@@ -2528,6 +2687,7 @@ impl Gateway {
         session_key: &str,
         messages: Vec<Message>,
     ) -> Vec<Message> {
+        let default_model = self.default_model.read().await.clone();
         let (state, pending_system_notes) = {
             let mut states = self.runtime_state.write().await;
             let state = states.entry(session_key.to_string()).or_default();
@@ -2536,7 +2696,7 @@ impl Gateway {
         };
 
         let mut hints = Vec::new();
-        if let Some(model) = state.model {
+        if let Some(model) = state.model.or(default_model) {
             hints.push(format!("model={}", model));
         }
         if let Some(provider) = state.provider {
@@ -2577,6 +2737,7 @@ impl Gateway {
         incoming: &IncomingMessage,
         session_key: &str,
     ) -> GatewayRuntimeContext {
+        let default_model = self.default_model.read().await.clone();
         let state = self
             .runtime_state
             .read()
@@ -2592,7 +2753,7 @@ impl Gateway {
             chat_id: incoming.chat_id.clone(),
             thread_id: incoming.thread_id.clone(),
             user_id: incoming.user_id.clone(),
-            model: state.model,
+            model: state.model.or(default_model),
             provider: state.provider,
             profile: state.profile,
             branch: state.branch,
@@ -2773,6 +2934,7 @@ impl Gateway {
     }
 
     async fn build_status_text(&self, session_key: &str) -> String {
+        let default_model = self.default_model.read().await.clone();
         let state = self
             .runtime_state
             .read()
@@ -2803,7 +2965,10 @@ impl Gateway {
         format!(
             "🧭 Gateway status\n- title: {}\n- model: {}\n- provider: {}\n- profile: {}\n- branch: {}\n- personality: {}\n- service tier: {}\n- reasoning: {}\n- verbose: {}\n- tool progress: {}\n- busy input: {}\n- busy ack: {}\n- busy active: {}\n- busy queued: {}\n- yolo: {}\n- home: {}\n- messages in session: {}\n- running background tasks: {}\n- mcp generation: {}\n- input/output chars: {}/{}",
             title.unwrap_or_else(|| "(untitled)".to_string()),
-            state.model.unwrap_or_else(|| "default".to_string()),
+            state
+                .model
+                .or(default_model)
+                .unwrap_or_else(|| "default".to_string()),
             state.provider.unwrap_or_else(|| "default".to_string()),
             state.profile.unwrap_or_else(|| "default".to_string()),
             state.branch.unwrap_or_else(|| "main".to_string()),
@@ -3406,17 +3571,17 @@ impl Gateway {
 
     /// Resolve model routing candidate for a message (static heuristics only; no adaptive policy store).
     pub fn load_smart_model_routing(&self, text: &str) -> Option<String> {
-        Self::heuristic_model_hint(text)
+        Self::message_requests_smart_model_route(text)
+            .then(|| self.config.model.clone())
+            .flatten()
     }
 
-    fn heuristic_model_hint(text: &str) -> Option<String> {
-        if text.len() > 2000 || text.contains("analyze") || text.contains("refactor") {
-            Some("openai:gpt-4o".to_string())
-        } else if text.contains("quick") || text.contains("summary") {
-            Some("openai:gpt-4o-mini".to_string())
-        } else {
-            None
-        }
+    fn message_requests_smart_model_route(text: &str) -> bool {
+        text.len() > 2000
+            || text.contains("analyze")
+            || text.contains("refactor")
+            || text.contains("quick")
+            || text.contains("summary")
     }
 
     /// Authorize user based on DM manager and platform context.
@@ -3469,7 +3634,12 @@ impl Gateway {
         if has_model {
             return;
         }
-        if let Some(model) = Self::heuristic_model_hint(text) {
+        if Self::message_requests_smart_model_route(text) {
+            let model = self.default_model.read().await.clone();
+            let model = model.or_else(|| self.config.model.clone());
+            let Some(model) = model else {
+                return;
+            };
             let mut states = self.runtime_state.write().await;
             states.entry(session_key.to_string()).or_default().model = Some(model);
         }
@@ -5732,6 +5902,128 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_model_switch_persists_default_and_applies_to_new_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &config_path,
+            "model: nous:nousresearch/hermes-4-70b\nmodel_switch:\n  persist_switch_by_default: true\n",
+        )
+        .unwrap();
+
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        dm_manager.authorize_user("user2");
+        let cfg = GatewayConfig {
+            model: Some("nous:nousresearch/hermes-4-70b".to_string()),
+            model_switch_config_path: Some(config_path.to_string_lossy().to_string()),
+            ..GatewayConfig::default()
+        };
+        let gw = Gateway::new(session_mgr, dm_manager, cfg);
+        gw.register_adapter("test", adapter).await;
+        gw.set_message_handler_with_context(Arc::new(|_messages, ctx| {
+            Box::pin(async move { Ok(format!("ctx model={:?}", ctx.model)) })
+        }))
+        .await;
+
+        let switch = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/model openrouter:zai/glm-5.2".into(),
+            message_id: None,
+            thread_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&switch).await.is_ok());
+        let disk = hermes_config::load_user_config_file(&config_path).unwrap();
+        assert_eq!(disk.model.as_deref(), Some("openrouter:zai/glm-5.2"));
+
+        let new_session_message = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat2".into(),
+            user_id: "user2".into(),
+            text: "hello from a fresh gateway session".into(),
+            message_id: None,
+            thread_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&new_session_message).await.is_ok());
+
+        let msgs = sent.lock().unwrap();
+        assert!(msgs.iter().any(|(_, text)| text.contains("Saved to")));
+        assert!(msgs
+            .iter()
+            .any(|(_, text)| text.contains("ctx model=Some(\"openrouter:zai/glm-5.2\")")));
+    }
+
+    #[tokio::test]
+    async fn gateway_model_switch_session_scope_does_not_persist_and_warns_on_large_context() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &config_path,
+            "model: nous:nousresearch/hermes-4-70b\nmodel_switch:\n  persist_switch_by_default: true\n",
+        )
+        .unwrap();
+
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let session_key = session_mgr.compose_session_key("test", "chat1", "user1");
+        session_mgr
+            .get_or_create_session("test", "chat1", "user1")
+            .await;
+        session_mgr
+            .add_message(&session_key, Message::user("large-context ".repeat(40_000)))
+            .await;
+        let mut dm_manager = DmManager::with_pair_behavior();
+        dm_manager.authorize_user("user1");
+        let cfg = GatewayConfig {
+            model: Some("nous:nousresearch/hermes-4-70b".to_string()),
+            model_switch_config_path: Some(config_path.to_string_lossy().to_string()),
+            ..GatewayConfig::default()
+        };
+        let gw = Gateway::new(session_mgr, dm_manager, cfg);
+        gw.register_adapter("test", adapter).await;
+
+        let switch = IncomingMessage {
+            platform: "test".into(),
+            chat_id: "chat1".into(),
+            user_id: "user1".into(),
+            text: "/model compact-runtime-model --global --session".into(),
+            message_id: None,
+            thread_id: None,
+            is_dm: true,
+        };
+        assert!(gw.route_message(&switch).await.is_ok());
+
+        let disk = hermes_config::load_user_config_file(&config_path).unwrap();
+        assert_eq!(
+            disk.model.as_deref(),
+            Some("nous:nousresearch/hermes-4-70b")
+        );
+        let msgs = sent.lock().unwrap();
+        let reply = msgs
+            .iter()
+            .find_map(|(_, text)| {
+                text.contains("compact-runtime-model")
+                    .then_some(text.clone())
+            })
+            .expect("model switch reply should exist");
+        assert!(reply.contains("Session only"));
+        assert!(reply.contains("Context warning"));
+        assert!(reply.contains("preflight compression"));
+    }
+
+    #[tokio::test]
     async fn gateway_verbose_command_is_config_gated_and_cycles_tool_progress() {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let adapter = Arc::new(TestAdapter {
@@ -6703,7 +6995,7 @@ mod tests {
 
         let setup_cmds = vec![
             "/provider openai",
-            "/model gpt-4o-mini",
+            "/model dynamic-structured-context-model",
             "/profile prod",
             "/branch feat-123",
         ];
@@ -6743,7 +7035,7 @@ mod tests {
                 }
             })
             .expect("context response should exist");
-        assert!(echoed.contains("Some(\"gpt-4o-mini\")"));
+        assert!(echoed.contains("Some(\"dynamic-structured-context-model\")"));
         assert!(echoed.contains("Some(\"openai\")"));
         assert!(echoed.contains("Some(\"prod\")"));
         assert!(echoed.contains("Some(\"feat-123\")"));

--- a/crates/hermes-intelligence/src/lib.rs
+++ b/crates/hermes-intelligence/src/lib.rs
@@ -67,10 +67,10 @@ pub use display::{
     format_tool_result, format_usage_stats, get_cute_tool_message, render_inline_unified_diff,
 };
 pub use model_metadata::{
-    estimate_messages_tokens_rough, estimate_request_tokens_rough, estimate_tokens_rough,
-    get_model_context_length, get_model_info, get_next_probe_tier, infer_provider_from_url,
-    is_local_endpoint, known_models, max_output_tokens, supports_tools, supports_vision,
-    ModelMetadataEntry,
+    build_model_switch_preflight_warning, estimate_messages_tokens_rough,
+    estimate_request_tokens_rough, estimate_tokens_rough, get_model_context_length, get_model_info,
+    get_next_probe_tier, infer_provider_from_url, is_local_endpoint, known_models,
+    max_output_tokens, supports_tools, supports_vision, ModelMetadataEntry,
 };
 pub use usage_pricing::{
     calculate_cost, format_token_count_compact, get_pricing, get_pricing_entry, has_known_pricing,

--- a/crates/hermes-intelligence/src/model_metadata.rs
+++ b/crates/hermes-intelligence/src/model_metadata.rs
@@ -8,6 +8,8 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use serde::{Deserialize, Serialize};
 
+use crate::usage_pricing::format_token_count_compact;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -471,6 +473,53 @@ pub fn estimate_request_tokens_rough(
     ((total_chars as u64) + 3) / 4
 }
 
+/// Build a user-facing warning when a model switch will likely require
+/// preflight context compression on the next request.
+pub fn build_model_switch_preflight_warning(
+    current_model: Option<&str>,
+    new_model: &str,
+    estimated_tokens: u64,
+) -> Option<String> {
+    if estimated_tokens == 0 {
+        return None;
+    }
+
+    let new_model = new_model.trim();
+    if new_model.is_empty() {
+        return None;
+    }
+
+    let new_context = get_model_context_length(new_model);
+    let threshold = (((new_context as f64) * 0.5) as u64).max(MINIMUM_CONTEXT_LENGTH);
+    if estimated_tokens < threshold {
+        return None;
+    }
+
+    let shrink = current_model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(|old_model| (old_model, get_model_context_length(old_model)))
+        .filter(|(_, old_context)| *old_context > new_context)
+        .map(|(old_model, old_context)| {
+            format!(
+                " Context window shrinks from {} ({}) to {} ({}).",
+                old_model,
+                format_token_count_compact(old_context),
+                new_model,
+                format_token_count_compact(new_context)
+            )
+        })
+        .unwrap_or_default();
+
+    Some(format!(
+        "Context warning:{} Current session is about {} tokens; {} auto-compresses at about {} tokens. The next message may run preflight compression before the model replies.",
+        shrink,
+        format_token_count_compact(estimated_tokens),
+        new_model,
+        format_token_count_compact(threshold)
+    ))
+}
+
 fn estimate_message_tokens_rough(message: &serde_json::Value) -> u64 {
     let Some(content) = message.get("content") else {
         return estimate_tokens_rough(&message.to_string());
@@ -736,6 +785,29 @@ mod tests {
         assert!(
             estimate < 5_000,
             "image payload bytes should not dominate token estimate"
+        );
+    }
+
+    #[test]
+    fn test_model_switch_preflight_warning_reports_shrink_and_threshold() {
+        let warning = build_model_switch_preflight_warning(
+            Some("anthropic:claude-sonnet-4-6"),
+            "deepseek-chat",
+            100_000,
+        )
+        .expect("warning");
+
+        assert!(warning.contains("Context warning"));
+        assert!(warning.contains("Context window shrinks"));
+        assert!(warning.contains("100"));
+        assert!(warning.contains("tokens"));
+        assert!(warning.contains("preflight compression"));
+    }
+
+    #[test]
+    fn test_model_switch_preflight_warning_ignores_small_contexts() {
+        assert!(
+            build_model_switch_preflight_warning(Some("dynamic"), "deepseek-chat", 1_000).is_none()
         );
     }
 

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T05:38:58.962851+00:00`_
+_Generated from source artifacts: `2026-06-25T06:30:25.215222+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T05:38:58.804651+00:00`
-- Proof snapshot generated: `2026-06-25T05:38:58.962851+00:00`
+- Queue snapshot generated: `2026-06-25T06:30:25.062192+00:00`
+- Proof snapshot generated: `2026-06-25T06:30:25.215222+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T05:38:58.962851+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=222.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=222.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=219.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=219.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T05:38:58.962851+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 6997 |
-| Pending | 222 |
-| Ported | 373 |
+| Pending | 219 |
+| Ported | 376 |
 | Superseded | 6326 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 222.0,
+        "actual": 219.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T05:38:58.962851+00:00",
+  "generated_at_utc": "2026-06-25T06:30:25.215222+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 222.0,
+    "max_queue_pending_commits": 219.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 222,
-      "ported": 373,
+      "pending": 219,
+      "ported": 376,
       "superseded": 6326
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 222.0,
+        "actual": 219.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T05:38:58.962851+00:00`
+Generated: `2026-06-25T06:30:25.215222+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T05:38:58.962851+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 222.0 |
+| `max_queue_pending_commits` | 219.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1,2400 +1,122 @@
 {
   "sha": {
-    "50943251400b": {
+    "00c045b43f30": {
       "disposition": "ported",
-      "notes": "Adopted upstream shop skill v1.0.1 directly: optional-skills/productivity/shop replaces shop-app and includes CLI/direct-API reference files for catalog, checkout, orders, safety, and legal guidance."
-    },
-    "d7668aaff5b7": {
-      "disposition": "ported",
-      "notes": "Adopted upstream shop metadata tightening: description is <=60 chars and the contributor credit is preserved in optional-skills/productivity/shop/SKILL.md."
-    },
-    "e3adbb5ae9d6": {
-      "disposition": "ported",
-      "notes": "Ported as a Rust-wide memory fix rather than an OpenViking-only Python plugin patch: MemoryManager now strips slash-skill scaffolding before provider prefetch, queued prefetch, or sync fan-out."
-    },
-    "c2c55c444339": {
-      "disposition": "ported",
-      "notes": "Ported in Rust: skill_orchestrator exposes the canonical user-instruction extractor for single-skill and bundle scaffolding, and memory_manager applies it once for every provider with regression coverage."
-    },
-    "44e5848e7418": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream streams subagent text into Electron watch windows and Python tui_gateway mirrors. Ultra has no apps/desktop runtime; Rust subagent/process progress is owned by hermes-agent and hermes-gateway/TUI status surfaces, so the Python/React watch-window mirror is outside the Rust-only runtime."
-    },
-    "bbc842d31ec8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: xAI direct setup/catalog defaults now prefer xai:grok-build-0.1, the Rust xAI web-search backend defaults HERMES_WEB_XAI_MODEL to grok-build-0.1, and focused CLI/tools tests pin the default while keeping grok-4.3 selectable."
-    },
-    "f4ef70f6fc62": {
-      "disposition": "ported",
-      "owner": "docs",
-      "notes": "Ported to Ultra docs without reviving Python runtime paths: website provider/env docs describe grok-build-0.1 as the direct xAI and web-search default, and the bundled Grok Build skill already records default = grok-build-0.1."
-    },
-    "1b962f001e78": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust model picker already passes configured llm_providers.<provider>.base_url into fetch_openai_compatible_live_models before fallback; this slice adds a regression for the resolved base URL /models request builder."
-    },
-    "d1ecebcbfd8c": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream repairs Electron binary re-download for Python/PowerShell/shell desktop packaging. Ultra does not ship the Electron desktop packaging path as Rust runtime; local release/build gates use the Rust workspace and repository scripts instead."
-    },
-    "b7f0c9cd52fe": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop sticky model picker and Settings reasoning/speed controls target React desktop stores. Ultra owns model/provider selection, reasoning, and service_tier defaults through Rust CLI/TUI/gateway config and status surfaces with existing /fast and reasoning coverage."
-    },
-    "cc8e5ec2afbf": {
-      "disposition": "superseded",
-      "notes": "Upstream migrates the Python Discord adapter into a bundled plugin. Ultra's live Discord runtime is Rust-native in crates/hermes-gateway/src/platforms/discord.rs and registered from crates/hermes-cli/src/main.rs; Python plugin migration is not a Rust runtime path."
-    },
-    "7849a3d73f2d": {
-      "disposition": "superseded",
-      "notes": "The upstream Python _platform_status/check_fn fallback does not exist in the Rust gateway. Rust platform state is explicit adapter registration plus PlatformAdapter::is_running, with Discord owned by crates/hermes-gateway/src/platforms/discord.rs."
-    },
-    "d8703e27f5c3": {
-      "disposition": "ported",
-      "notes": "Ported in this batch: website prebuild fetches the live unified skills index, extract-skills emits skills-meta.json, the Skills Hub renders index health/freshness, and npm run check:skills-index runs the local freshness gate via scripts/check-skills-index-freshness.mjs."
-    },
-    "2681c5a12d8d": {
-      "disposition": "ported",
-      "notes": "Ported in Rust CLI: hermes gateway start/status/restart now accept the stale hidden --platform compatibility flag while gateway lifecycle still operates on all configured adapters."
-    },
-    "cc14b74718aa": {
-      "disposition": "ported",
-      "notes": "Ported in this batch: profile create --clone-from now implies a config clone in crates/hermes-cli/src/main.rs, has parser/behavior regression coverage, and website profile docs show the clone-from-only form."
-    },
-    "a218a0f1569c": {
-      "disposition": "superseded",
-      "notes": "Upstream guards Python certifi CA bundle corruption. Ultra builds reqwest with rustls-tls/webpki roots in Cargo.toml and has no Python certifi startup path in the Rust agent or gateway."
-    },
-    "dc90ca4e1740": {
-      "disposition": "superseded",
-      "notes": "Upstream adds the same Python certifi CA guard during Python agent initialization. Ultra's Rust provider clients are constructed through rustls-backed reqwest, so the certifi failure mode is not present."
-    },
-    "7aaae7acd0d6": {
-      "disposition": "superseded",
-      "notes": "Upstream refines the Python SSL guard escape hatch. Ultra has no Python certifi guard path to bypass; TLS trust is owned by Rust reqwest/rustls and webpki roots."
-    },
-    "723c2331bd23": {
-      "disposition": "ported",
-      "notes": "Ported in this batch: terminal.home_mode is a typed Rust config field bridged through TERMINAL_HOME_MODE, local terminal/code subprocesses can use real or $HERMES_HOME/home, HERMES_REAL_HOME is exported, and docs/tests cover the policy."
-    },
-    "61ee2dbfdb40": {
-      "disposition": "superseded",
-      "notes": "Upstream fixes Python s6 profile gateway log directory handling. Ultra uses the Rust/tini-gosu container path documented in docker/entrypoint.sh and existing parity divergence, not upstream s6 stage2 hooks."
-    },
-    "975b9f0a5426": {
-      "disposition": "superseded",
-      "notes": "Upstream contributor docs recommend the Python standard installer. Ultra contributor docs intentionally use the Rust workspace flow in CONTRIBUTING.md with cargo build/test/install, so the upstream Python venv layout does not apply."
-    },
-    "c92a95a130cc": {
-      "disposition": "superseded",
-      "notes": "Desktop React model-picker placement has no apps/desktop runtime in Ultra. The Rust TUI owns model/provider selection in crates/hermes-cli/src/tui.rs and slash/model flows."
-    },
-    "989d5d0cb72a": {
-      "disposition": "superseded",
-      "notes": "Desktop model-status label decluttering targets absent apps/desktop files. Ultra's model labels and picker state are rendered by Rust TUI/CLI surfaces instead."
-    },
-    "0e81d2fb71c1": {
-      "disposition": "superseded",
-      "notes": "Desktop per-model effort preset UI targets absent apps/desktop files. Ultra owns model/provider controls through the Rust TUI model picker and CLI config surfaces."
-    },
-    "a0ec4f52b948": {
-      "disposition": "superseded",
-      "notes": "Desktop settings/provider disconnect UI targets absent apps/desktop files. Ultra already exposes Rust provider credential disconnect behavior through the TUI provider picker and auth state helpers."
-    },
-    "dd0e3e0a052a": {
-      "disposition": "superseded",
-      "notes": "Desktop thread padding is an apps/desktop React-only presentation change. Ultra has no desktop React runtime; CLI/TUI rendering is Rust-owned."
-    },
-    "5b3fa2636632": {
-      "disposition": "superseded",
-      "notes": "Photon/Spectrum remains a Python plus Node optional platform plugin and is not part of Ultra's Rust runtime surface; no Rust-native Photon adapter is scoped in this parity batch."
-    },
-    "a68ac0c49af1": {
-      "disposition": "superseded",
-      "notes": "Desktop /browser connect UI targets absent apps/desktop slash-command wiring. Ultra browser control is Rust-owned through CLI/TUI slash commands and hermes-tools browser backends."
-    },
-    "cb6b4127e795": {
-      "disposition": "superseded",
-      "notes": "Desktop composer model picker sticky state targets absent apps/desktop and tui_gateway Python files. Ultra tracks model/provider session state through Rust gateway runtime state and TUI model switch paths."
-    },
-    "7d938cc5c9c7": {
-      "disposition": "superseded",
-      "notes": "Upstream Python desktop/tui_gateway metadata restoration has no live Ultra path. Rust gateway status/model/provider metadata is explicit in crates/hermes-gateway/src/gateway.rs and Rust session state."
-    },
-    "80e4b8985ea9": {
-      "disposition": "superseded",
-      "notes": "Desktop composer model picker interaction polish targets absent apps/desktop React files. Ultra model picker interactions are owned by the Rust TUI."
-    },
-    "bf8effad023b": {
-      "disposition": "ported",
-      "notes": "Rust config atomic writes now handle cross-device rename failures with a copy fallback that preserves same-directory temp cleanup; tests cover atomic writes and platform EXDEV detection."
-    },
-    "5e851bc6bc51": {
-      "disposition": "ported",
-      "notes": "Rust Discord auto slash registration now caps auto-added commands at Discord's 100-command application limit after reserving explicit command names, preserving gateway-before-plugin ordering with regression coverage."
-    },
-    "972a9885ee20": {
-      "disposition": "ported",
-      "notes": "Rust MCP stdio configs now reject the same high-signal shell-plus-network-egress exfiltration shape before direct client or manager connection. Tests cover the dangerous payload, clean npx, benign shell pipes, and manager rejection."
-    },
-    "efbe1635dd2e": {
-      "disposition": "ported",
-      "notes": "Rust gateway parsing now carries replied-to media through native surfaces: Telegram text replies expose referenced voice/photo/document file IDs, and Discord MESSAGE_CREATE parsing merges referenced-message attachments after current attachments."
-    },
-    "bff78a34dc44": {
-      "disposition": "ported",
-      "notes": "Rust ZAI model metadata and CLI curated models include glm-5.2 with a verified 1M context window; model context tests cover zai/glm-5.2."
-    },
-    "f3fe99863d13": {
-      "disposition": "ported",
-      "notes": "Rust web backends removed the keyless Parallel MCP fallback. Parallel search/extract are REST-only with PARALLEL_API_KEY, and no-key search/extract fall back to local fallback/simple behavior with tests."
-    },
-    "fe54960142d1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop React trigger-popover text wrapping has no matching Rust runtime file. Hermes Agent Ultra renders slash completions through the Rust Ratatui popup in crates/hermes-cli/src/tui.rs, so the TS/CSS truncation fix is superseded by the local TUI surface."
-    },
-    "3ffbdfbcc0dc": {
-      "disposition": "ported",
-      "notes": "Rust port covers the functional slash-command delta: TUI completions now use live App state for /handoff platforms and /tools enable|disable candidates, /personality completions list built-ins, and CLI slash /tools enable|disable persists tools_config plus refreshes active tool schemas. Upstream desktop registry/picker UI and Python tui_gateway context-manager changes are superseded by this Rust-only TUI/CLI/gateway architecture."
-    },
-    "e0e25717116c": {
-      "disposition": "superseded",
-      "notes": "Upstream later reverted the keyless Parallel MCP search fallback in f3fe99863d13. Current Rust web tools intentionally keep Parallel search/extract REST-only behind PARALLEL_API_KEY."
-    },
-    "0a5762c78d11": {
-      "disposition": "superseded",
-      "notes": "Upstream later removed the keyless Parallel MCP search path in f3fe99863d13, so the MCP client identity policy is no longer part of the active Rust runtime surface."
-    },
-    "aaccaada282b": {
-      "disposition": "ported",
-      "notes": "Rust Anthropic provider now carries ordered signed thinking/tool_use content blocks in-memory on parsed responses and replays them before reconstructing from reasoning_content/tool_calls. Regression tests cover interleaved block preservation in parse_response and convert_messages."
-    },
-    "efcbbde48c38": {
-      "disposition": "ported",
-      "notes": "Rust keeps anthropic_content_blocks in-memory only on hermes_core::Message and deliberately does not persist them through SessionPersistence, matching upstream's final no-state-db-column decision while leaving fallback reconstruction for reloaded sessions."
-    },
-    "3e74f75e41ec": {
-      "disposition": "ported",
-      "notes": "Rust port implements upstream coding-context posture through crates/hermes-agent/src/coding_context.rs, AgentConfig/GatewayConfig agent.coding_context, prompt injection with workspace/verify facts, model-family edit-format guidance, prompt-only non-coding skill pruning, a lean coding toolset, ACP default toolset registration, and focus-mode platform tool collapse with live MCP inclusion. Tests cover detection, prompt gating, skill pruning, coding/hermes-acp toolsets, and platform focus behavior."
-    },
-    "e9c47c70422d": {
-      "disposition": "ported",
-      "notes": "Rust CLI/TUI launch model overrides are represented by resolve_cli_chat_provider_model, apply_cli_chat_runtime_env, App::new startup resolution, and sync_runtime_model_env tests covering HERMES_MODEL/HERMES_INFERENCE_MODEL plus provider env synchronization."
-    },
-    "57b43fdd4bf9": {
-      "disposition": "ported",
-      "notes": "Rust startup provider precedence is typed through provider:model resolution and config.llm_providers lookup without treating stale HERMES_INFERENCE_PROVIDER as an explicit launch provider; regression coverage keeps config-selected providers authoritative."
-    },
-    "4db58d45d4e0": {
-      "disposition": "ported",
-      "notes": "Rust startup model parsing trims configured and env-sourced model strings through resolve_startup_model/resolve_provider_and_model, and runtime env synchronization keeps model/provider variables aligned for TUI sessions."
-    },
-    "2dfcc8087a8e": {
-      "disposition": "ported",
-      "notes": "Rust TUI startup uses static config/provider resolution and curated provider defaults only; live model discovery is isolated to explicit model-picker catalog paths, avoiding network lookup during App::new startup."
-    },
-    "e48a497d166b": {
-      "disposition": "ported",
-      "notes": "Rust shares static provider/model knowledge through model_switch curated catalogs, canonical provider IDs, and provider_model_ids_for_config tests for custom provider maps instead of duplicating startup detector code."
-    },
-    "c6fdf48b79eb": {
-      "disposition": "ported",
-      "notes": "Rust model switches call sync_runtime_model_env before rebuilding the active agent, updating HERMES_MODEL, HERMES_INFERENCE_MODEL, HERMES_INFERENCE_PROVIDER, and HERMES_TUI_PROVIDER for subsequent inference paths."
-    },
-    "458ce792d24e": {
-      "disposition": "ported",
-      "notes": "Rust App::switch_model persists the active session model in SessionPersistence by default and rebuilds the agent for the current session, with regression coverage for the session DB row."
-    },
-    "9e4d79b17fcf": {
-      "disposition": "ported",
-      "notes": "Rust sync_runtime_model_env and CLI chat env setup now write HERMES_TUI_PROVIDER unconditionally alongside HERMES_INFERENCE_PROVIDER, covering the explicit-provider carrier bug fixed upstream for /model followed by new sessions."
-    },
-    "443950e82736": {
-      "disposition": "ported",
-      "notes": "Rust model switching consumes GatewayConfig.llm_providers as a provider-keyed map, and model_switch tests cover custom provider slugs, explicit model lists, discover_models=false, and provider catalog entries without list coercion."
-    },
-    "3d90292eda55": {
-      "disposition": "superseded",
-      "notes": "rust models_dev registry already resolves provider aliases in list_provider_models with regression coverage in crates/hermes-intelligence/src/models_dev/client.rs"
-    },
-    "8b1ff55f5382": {
-      "disposition": "superseded",
-      "notes": "rust gateway already strips group mention prefixes for slash recognition in crates/hermes-gateway/src/platforms/wecom_callback.rs"
-    },
-    "15efb410d035": {
-      "disposition": "superseded",
-      "notes": "upstream nixosModules.nix path does not exist in this fork packaging surface; no functional Rust runtime delta"
-    },
-    "22afa066f838": {
-      "disposition": "superseded",
-      "notes": "rust cron runner already guards trailing control payload parse via object-only extraction in crates/hermes-cron/src/runner.rs"
-    },
-    "738d0900fddd": {
-      "disposition": "superseded",
-      "notes": "rust auxiliary transport stack in crates/hermes-intelligence/src/auxiliary/* already uses typed transport path and does not mirror Python auxiliary_client internals"
-    },
-    "f4612785a485": {
-      "disposition": "superseded",
-      "notes": "rust anthropic normalization path is already typed and test-covered; Python adapter refactor not directly portable to Rust architecture"
-    },
-    "42e166c7ea2e": {
-      "disposition": "superseded",
-      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
-    },
-    "401aadb5b892": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "0d1cbc2dda28": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "0e2e69a71dda": {
-      "disposition": "ported",
-      "notes": "Rust hermes_intelligence::rl now has a deterministic BatchDatasetRunner with JSONL prompt/conversation parsing, max-sample batching, resume checkpoints by prompt index/text, per-batch processed/skipped statistics, toolset distribution metadata, JSONL trajectory serialization, and tests for checkpoint resume plus ephemeral prompt non-persistence."
-    },
-    "d36790de9153": {
-      "disposition": "ported",
-      "notes": "Ephemeral system prompts are first-class in Rust for both batch and agent runners: BatchDatasetRunConfig tracks an ephemeral prompt without persisting it to trajectory JSONL or checkpoints, and AgentConfig::ephemeral_system_prompt is appended only to provider API-call messages and stripped from AgentResult persistence, with focused tests for both paths."
-    },
-    "ac6d747fa610": {
-      "disposition": "ported",
-      "notes": "Rust BatchDatasetRunner now supports file-backed checkpoint resumption with BatchRunCheckpoint::load_from_path/save_atomic_to_path, same-directory atomic JSON replacement, per-batch checkpoint writes via run_with_checkpoint_path, and tests proving atomic replacement, no temp-file leaks, per-batch write counts, and resume skips by persisted prompt index/text."
-    },
-    "d63b363cde77": {
-      "disposition": "ported",
-      "notes": "The upstream atomic_json_write/checkpoint test refactor is ported as Rust hermes_intelligence::rl atomic_json_write plus BatchRunCheckpoint load/save helpers and BatchDatasetRunner checkpoint-path resume. Focused tests cover valid/overwrite writes, parent dirs, original preservation on serialization failure, no temp leaks, Unicode/concurrent writes, missing/corrupt checkpoint handling, run-name mismatch fresh starts, last_updated, and persisted resume progress."
-    },
-    "10b4cfeace24": {
-      "disposition": "ported",
-      "notes": "Rust TerminalHandler already surfaces backend CommandOutput.stdout as the user-visible tool return string through format_command_output, including nonzero exit handling. This batch adds an explicit regression test proving backend stdout is returned without relying on a legacy output/stdout compatibility shim."
-    },
-    "a4db3fdee5b9": {
-      "disposition": "superseded",
-      "notes": "The upstream Morph leakage fix is superseded by Rust terminal architecture: terminal execution uses injected TerminalBackend implementations rather than shared Hecate/Morph module globals, and task_id only resolves scoped cwd state. Focused tests prove task-a, task-b, and no-task calls do not share task cwd state."
-    },
-    "fbd3a2fdb88e": {
-      "disposition": "superseded",
-      "notes": "The upstream per-task Morph instance cleanup/leakage patch is superseded by Rust's non-Morph terminal runtime plus task-scoped cwd registry. TerminalHandler tests now prove task_id isolation and explicit workdir precedence, so one task cannot inherit another task's terminal cwd context."
-    },
-    "a5c7422f2315": {
-      "disposition": "superseded",
-      "notes": "Python embedded Hindsight .env setup is superseded by the Rust-only Hindsight runtime: it does not launch hindsight-embed, and legacy local/local_embedded config is normalized to local_external HTTP mode."
-    },
-    "d6b65bbc47cf": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight auto-retain builds structured turn JSON without ASCII escaping, and tests prove non-ASCII user and assistant content survives in the retained payload."
-    },
-    "127048e6430f": {
-      "disposition": "ported",
-      "notes": "Rust HindsightConfig accepts both apiKey and snake_case api_key from config.json, with regression coverage for the snake_case path."
-    },
-    "3e994e38f763": {
-      "disposition": "superseded",
-      "notes": "Hindsight profile env materialization only applies to the upstream Python embedded daemon; the Rust runtime now documents and exposes cloud/local_external HTTP modes only."
-    },
-    "df55660e3c3c": {
-      "disposition": "superseded",
-      "notes": "The unsupported-CPU guard is a Python import workaround for local embedded Hindsight; Rust Hindsight never imports that Python stack and normalizes embedded aliases to local_external."
-    },
-    "93a74f74bf93": {
-      "disposition": "superseded",
-      "notes": "The shared asyncio event-loop shutdown fix is Python-runtime-only; Rust Hindsight uses reqwest blocking clients per operation and has no provider-owned event loop to stop."
-    },
-    "403c82b6b65b": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight supports HINDSIGHT_TIMEOUT and config timeout/hindsight_timeout aliases with a 120s default and focused config coverage."
-    },
-    "f1ba2f0c0b06": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight request clients for auto-recall, auto-retain, and tool calls all use the configured timeout_secs value."
-    },
-    "f9c6c5ab8472": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight now creates a per-initialization document_id and includes it in auto-retain batch bodies, with tests proving resumed sessions get distinct document IDs."
-    },
-    "edff2fbe7efd": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight supports bank_id_template with profile/workspace/platform/user/session placeholders, sanitization tests, schema exposure, and README coverage."
-    },
-    "13683c0842f0": {
-      "disposition": "ported",
-      "notes": "Rust MemoryProviderPlugin now has an on_session_switch hook, MemoryManager broadcasts it to enabled providers, and the TUI calls it when sessions rotate or reset while preserving the active AgentConfig session_id."
-    },
-    "0565497dcc2f": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight drains buffered auto-retain turns through the same retain path during session end and shutdown, with pending-turn state reset after the drain."
-    },
-    "c38dac742b22": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight flushes buffered turns before adopting a new session_id, clears stale prefetch context, resets counters, and has regression coverage for session switch behavior."
-    },
-    "0a5ee01e487a": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight session-switch flushing routes through retain_hindsight_turns and the same document/update-mode targeting helper used by normal auto-retain batches."
-    },
-    "3082fa0829e0": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight probes /version once per API base for update_mode append support, accepts version/api_version response shapes, gates append on semver >= 0.5.0, and falls back to batch document IDs."
-    },
-    "09d66037f8f7": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight append retains send only the pending-turn delta and use the stable session document only when the API advertises append support."
-    },
-    "ea01bdcebe1f": {
-      "disposition": "superseded",
-      "notes": "The Python flush_memories API has no Rust runtime equivalent; Rust providers use lifecycle hooks, shutdown, and explicit retain/write paths instead."
-    },
-    "18beb69b4996": {
-      "disposition": "superseded",
-      "notes": "The embedded Hindsight async-client close fix is Python-only; Rust Hindsight does not start hindsight-embed and uses bounded reqwest clients for HTTP operations."
-    },
-    "0ba6471dd191": {
-      "disposition": "superseded",
-      "notes": "The embedded Hindsight idle-daemon recovery path is superseded by the Rust-only local_external/cloud HTTP modes; no embedded Python daemon is launched."
-    },
-    "96f0ddc6a946": {
-      "disposition": "superseded",
-      "notes": "Baking hindsight-client into Docker only applies to the upstream embedded Python runtime; the Rust runtime keeps Hindsight integration in native HTTP code."
-    },
-    "d03c6fcc45cf": {
-      "disposition": "ported",
-      "notes": "Rust Honcho supports opt-in pinUserPeer/pinPeerName identity mapping so gateway runtime users can resolve to stable configured peers across platforms."
-    },
-    "326c9daa695b": {
-      "disposition": "ported",
-      "notes": "Rust Honcho only treats pinUserPeer/pinPeerName as enabled when the JSON value is a strict boolean true, avoiding truthy-string or mock-style coercion."
-    },
-    "5d36871d923c": {
-      "disposition": "ported",
-      "notes": "Rust Honcho loads global fallback config from ~/.honcho/config.json and ~/.hermes/honcho.json before the active HERMES_HOME honcho.json path."
-    },
-    "d18618f48f18": {
-      "disposition": "ported",
-      "notes": "Rust Honcho respects HOME-anchored default profile fallback paths while still allowing the active HERMES_HOME profile to override them."
-    },
-    "82205276c1ae": {
-      "disposition": "ported",
-      "notes": "Rust Honcho defaults HTTP timeout_secs to 30 seconds and still clamps explicit HONCHO_TIMEOUT_SECS/config values to the supported range."
-    },
-    "02ab255a0d52": {
-      "disposition": "ported",
-      "notes": "Rust Honcho validates baseUrl schemes, strips trailing /vN API suffixes, keeps schemeless hosts as HTTPS, and rejects unsupported URL schemes."
-    },
-    "5883df5574de": {
-      "disposition": "ported",
-      "notes": "Rust Honcho preserves legacy schemeless baseUrl configs by normalizing them to HTTPS instead of dropping the configured host."
-    },
-    "894e0b935bb8": {
-      "disposition": "ported",
-      "notes": "Rust honcho_profile now explains an empty peer card and points users to honcho_search, honcho_context, or honcho_conclude for memory retrieval."
-    },
-    "bea2562fc4b3": {
-      "disposition": "ported",
-      "notes": "Rust Honcho numeric config parsing uses typed f64/usize accessors and bounded defaults instead of raw integer coercion."
-    },
-    "dad021745000": {
-      "disposition": "superseded",
-      "notes": "Python session-cache RLock fixes are superseded by Rust Honcho's Mutex-protected session_key, prefetch, and turn-count state with no shared Python SDK cache."
-    },
-    "5d349ea857d4": {
-      "disposition": "superseded",
-      "notes": "Python get_or_create cache locking is superseded by Rust Honcho's stateless HTTP session operations and Mutex-protected local session key."
-    },
-    "ec4cb16a29ec": {
-      "disposition": "superseded",
-      "notes": "Python peers/sessions cache read locking is superseded by Rust Honcho identity resolution from immutable config plus Mutex-protected plugin state."
-    },
-    "47d5177a7d61": {
-      "disposition": "superseded",
-      "notes": "Python lazy-singleton and Honcho TOCTOU fixes are superseded by Rust plugin instances and explicit Mutex state; no Python lazy singleton remains."
-    },
-    "cd276eef7805": {
-      "disposition": "superseded",
-      "notes": "The Python on_memory_write metadata ABC compatibility shim is not a Rust API surface; Rust memory writes use typed trait methods and provider tool handlers."
-    },
-    "2e3c6627ceac": {
-      "disposition": "ported",
-      "notes": "Rust Honcho includes runtime peer mapping with configured aliases, optional runtime prefixes, and deterministic collision-resistant peer IDs."
-    },
-    "30b391ab366e": {
-      "disposition": "ported",
-      "notes": "Rust Honcho avoids runtime peer collisions by hashing runtime IDs when generating prefixed peer names, with regression coverage."
-    },
-    "00e683020443": {
-      "disposition": "ported",
-      "notes": "Rust Honcho host-level identity mapping config overrides root mappings cleanly, including aiPeer and user peer alias inheritance behavior."
-    },
-    "3cf5e8225d88": {
-      "disposition": "ported",
-      "notes": "Rust Honcho accepts pinUserPeer as the backwards-compatible alias for pinPeerName while keeping strict boolean parsing."
-    },
-    "6feb2afd50cb": {
-      "disposition": "ported",
-      "notes": "Rust Honcho covers pinUserPeer/pinPeerName transition behavior through alias parsing, host-block config, and identity-resolution regression tests."
-    },
-    "1a8e67076a0b": {
-      "disposition": "ported",
-      "notes": "Rust Honcho covers pinUserPeer plus aiPeer edge cases in setup/config parsing and peer-resolution tests."
-    },
-    "7137cccbd134": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking viking_add_resource uploads existing local files and directories through temp_upload and then creates resources with temp_file_id/source_name."
-    },
-    "187951ec6b88": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking local-upload behavior is covered by tests for file URI handling, missing local path rejection, to/parent conflicts, directory zips, and symlink skips."
-    },
-    "2b6345cee302": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking hardens local path uploads by detecting path-like missing sources, expanding ~, rejecting top-level symlinks, and preserving remote URL passthrough."
-    },
-    "6e250a55de50": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking sends bearer Authorization for API-key auth and uses multipart upload headers without forcing JSON Content-Type."
-    },
-    "8fb3e2d63afb": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking always sends configured account/user/agent tenant headers on JSON and multipart requests."
-    },
-    "63991bbd9751": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking skips symlinks when zipping uploaded directories and rejects top-level symlink upload paths."
-    },
-    "2d587c56622f": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking stores provider memory writes through content/write with generated viking:// memory URIs instead of session-message ingestion."
-    },
-    "d61785889678": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking uses target/category-aware memory subdirectories and a shared URI builder instead of private attribute access."
-    },
-    "490b3e76b138": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight defaults recall_types to observation and sends the same configured type list through automatic recall and hindsight_recall tool calls."
-    },
-    "4df62d239e38": {
-      "disposition": "ported",
-      "notes": "Rust Hindsight applies recall_types narrowing to both context injection and explicit tool recall paths."
-    },
-    "b24d239ce177": {
-      "disposition": "ported",
-      "notes": "Rust config.yaml writes now preserve atomic replacement and tighten Unix permissions to owner-only 0600, with container/HERMES_SKIP_CHMOD opt-outs and save/config-set regression coverage."
-    },
-    "fd9b692d330f": {
-      "disposition": "ported",
-      "notes": "Rust config loading now tolerates null top-level config.yaml keys by dropping them before serde deserialization so defaults are used instead of failing startup."
-    },
-    "bfa60234c8bb": {
-      "disposition": "ported",
-      "notes": "Rust config normalization emits a warning for null top-level config.yaml keys while continuing with defaults."
-    },
-    "e3940f980799": {
-      "disposition": "ported",
-      "notes": "Rust config normalization drops a null personalities block before deserialization, preventing stale Python-style personality overlay config from breaking TUI startup."
-    },
-    "53fc10fc9a8b": {
-      "disposition": "ported",
-      "notes": "Rust default personality remains neutral: config defaults to no persona and the explicit default marker resolves to the base Hermes identity without adding a built-in personality overlay."
-    },
-    "395dbcc873c8": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "3ebdd26449dc": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "d78c34928fe9": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "043a118d4128": {
-      "disposition": "superseded",
-      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
-    },
-    "17687911b7c5": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "b62a82e0c3fb": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "9627ee70e57a": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "ad7aad251c60": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "94016dd1aa7e": {
-      "disposition": "superseded",
-      "notes": "optional-skill parity is covered by local multi-registry skill surfaces; upstream single-skill delta is superseded"
-    },
-    "f4031df05dd4": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "04cf4788ccc0": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "65c762b2e83e": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "bf843adf05b8": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "699c770e5c06": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "36ad97337a4a": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "61d9e3366d65": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "647f95b4224c": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "b9f1ac8c1022": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "6e46f99e7e8e": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "84287b0de8dd": {
-      "disposition": "superseded",
-      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
-    },
-    "2f2f654486f9": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "498c01406fce": {
-      "disposition": "superseded",
-      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
-    },
-    "b93c9f639381": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "fa582749e165": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "ec9d0e26d4ed": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "76d2dcdc8e10": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "44cd79e798e4": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "62c2f5d8d2a6": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "ff0985323509": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "162ad3dd1624": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "498bfc7bc12a": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "733e297b8a5c": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "7e2af0c2e872": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "da18fd084a0b": {
-      "disposition": "superseded",
-      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
-    },
-    "dc5ef1ac8ed9": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "24d48ffb8294": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "d87c7b99e2a4": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "292f4683667e": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "c80fa728bd84": {
-      "disposition": "superseded",
-      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
-    },
-    "7d66d30d774e": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "81928f03ab58": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "83c23e88617c": {
-      "disposition": "superseded",
-      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
-    },
-    "5643c2979013": {
-      "disposition": "superseded",
-      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
-    },
-    "850413f1203f": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "07bbd9333708": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "242da9db965c": {
-      "disposition": "superseded",
-      "notes": "skill catalog and runtime integration are already covered by local rust-first skill orchestration; upstream python-side delta superseded"
-    },
-    "9de893e3b078": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "b7fe7ed7bd17": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "e93bfc6c93bf": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "d94fb47717eb": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "cbce5e93fcb9": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "b63f9645f08a": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "98db898c0bd4": {
-      "disposition": "superseded",
-      "notes": "skill catalog and runtime integration are already covered by local rust-first skill orchestration; upstream python-side delta superseded"
-    },
-    "324567c93662": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "cc38282b04d9": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "d3120aeab064": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "26bac67ef90d": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "bf80508d6566": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "afc186fa4eed": {
-      "disposition": "superseded",
-      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
-    },
-    "758c40135f0f": {
-      "disposition": "ported",
-      "notes": "ported in local commit f4cb47a30 (blocking uv.lock check)"
-    },
-    "93679ef27d74": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "7a4d5c123a29": {
-      "disposition": "superseded",
-      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
-    },
-    "2a7047c2ed42": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "7330183d087f": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "4a1840e68350": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "93e25ceb1326": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "1ac8deb3caa3": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "55f518e5216a": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "883e11f0a09a": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "840ebe063eea": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "c7f0aab9497b": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "058c50816c70": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "c179bdab3c5f": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "85383c636309": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "ded194eb6aca": {
-      "disposition": "superseded",
-      "notes": "optional-skill parity is covered by local multi-registry skill surfaces; upstream single-skill delta is superseded"
-    },
-    "d04a0b81ee7c": {
-      "disposition": "superseded",
-      "notes": "skill catalog and runtime integration are already covered by local rust-first skill orchestration; upstream python-side delta superseded"
-    },
-    "8954537f956b": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "236cbe16b62c": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "50f9fee988b6": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "ae4b09ce1073": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "5aa755e4e63c": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "c39168453d01": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "061a18300837": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "b308dd7d750c": {
-      "disposition": "ported",
-      "notes": "ported in local commit d67220e0b (kanban assignee casing fix)"
-    },
-    "0e0ddaac8fa0": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "a91e5a87594b": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "6e5c49bdc40d": {
-      "disposition": "superseded",
-      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
-    },
-    "878611a79dfa": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+      "notes": "Rust OpenViking commit paths are hardened with bounded writer drains, skipped commits when writers outlive the drain budget, dirty-state preservation on skipped/failed end commits, and tests.",
+      "owner": "rust-runtime"
     },
     "00ce5f04d9cf": {
       "disposition": "superseded",
       "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
     },
-    "6062c24fd1c2": {
-      "disposition": "superseded",
-      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
-    },
-    "404640a2b752": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "ae83a54be450": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "da2ed478b505": {
-      "disposition": "ported",
-      "notes": "ported in local commit 0dc31e7eb (achievements auth header fix)"
-    },
-    "80bb5f294755": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "518d37f6af49": {
-      "disposition": "ported",
-      "notes": "ported in local commit c261ffeae (kanban reclaim_first support)"
-    },
-    "0ea234e0932f": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "98c499b235e4": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "a88f201cd404": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "69053832e301": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "3df7e30244c0": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "b8bf2f817d7c": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "4c57a5b31837": {
-      "disposition": "superseded",
-      "notes": "optional-skill parity is covered by local multi-registry skill surfaces; upstream single-skill delta is superseded"
-    },
-    "f2e8ed240536": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "896a7ce261f8": {
-      "disposition": "ported",
-      "notes": "ported in local commit ae995f58b (stocks and finance skill added)"
-    },
-    "ebf2ea584ab2": {
-      "disposition": "superseded",
-      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
-    },
-    "27cfe7254313": {
-      "disposition": "superseded",
-      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
-    },
-    "3e7145e0bbcd": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "657874460f8e": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "2ec8d2b42ffe": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "ce0f529cde11": {
-      "disposition": "superseded",
-      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
-    },
-    "c1eb2dcda7d7": {
-      "disposition": "superseded",
-      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
-    },
-    "7f1b2b456953": {
-      "disposition": "ported",
-      "notes": "Rust terminal approval path denies confirmation-required commands without consent and now pins the same no-retry/no-rephrase/no-same-outcome 'Silence is not consent' contract in crates/hermes-tools/src/tools/terminal.rs."
-    },
-    "7245bc77eb3b": {
-      "disposition": "ported",
-      "notes": "Rust config loading now normalizes Python-style fallback_providers plus legacy fallback_model into a merged fallback_models chain, preserves fallback provider metadata in llm_providers, and forwards that chain into AgentConfig unless HERMES_FALLBACK_MODEL(S) overrides it."
-    },
-    "39fe4ecee3d0": {
-      "disposition": "ported",
-      "notes": "Rust kanban store loading now refuses malformed or semantically empty existing boards.json state, preserves the original bytes, and writes a same-directory boards.json.corrupt.<timestamp> backup before returning an error."
-    },
-    "c4b8f5efee8c": {
-      "disposition": "ported",
-      "notes": "Rust corrupt-store backup derives the backup filename from the canonical store basename and writes only within the original store parent directory, matching the upstream path-injection hardening intent."
-    },
-    "e97a4c8f3795": {
-      "disposition": "ported",
-      "notes": "README.md and local Chinese README now include the upstream Nous Portal setup/status section adapted to hermes-agent-ultra command names."
-    },
-    "cae7537359c0": {
-      "disposition": "superseded",
-      "notes": "Upstream subsequently removed committed infographic assets; hermes-agent-ultra now follows that repo hygiene policy and keeps generated infographics out of tree."
-    },
-    "5772e638c9ba": {
-      "disposition": "ported",
-      "notes": "Removed the tracked infographic/ asset tree and added infographic/ to .gitignore so generated PR infographics stay in PR bodies rather than the repository."
-    },
-    "3589960e03d0": {
-      "disposition": "ported",
-      "notes": "Rust GenericProvider now maps OpenCode Go reasoning controls by model: Kimi K2 and DeepSeek thinking models receive provider-native thinking/reasoning_effort fields while non-target models drop unsupported controls."
-    },
-    "70aaa774be92": {
-      "disposition": "ported",
-      "notes": "Rust reasoning configuration now preserves raw opencode-go effort levels for runtime model-specific mapping, including Kimi xhigh/max to high and minimal omission."
-    },
-    "11e6dd3c606e": {
-      "disposition": "superseded",
-      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
-    },
-    "7a4dc8e8d610": {
-      "disposition": "superseded",
-      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
-    },
-    "e42fcc562596": {
-      "disposition": "ported",
-      "notes": "Rust startup model resolution now pins provider selection to config-derived provider:model state and overwrites stale HERMES_INFERENCE_PROVIDER handoff env during runtime sync; CLI --provider remains the per-invocation override."
-    },
-    "b10f17bf1e93": {
-      "disposition": "ported",
-      "notes": "Imported ntfy as a platform plugin under plugins/platforms/ntfy with standalone send, env enablement, identity hardening, and local plugin regression tests."
-    },
-    "6a8e131a0ab4": {
-      "disposition": "ported",
-      "notes": "Hermes Ultra uses the upstream platform-plugin ntfy shape rather than a bundled core adapter; tests/gateway/test_ntfy_plugin.py covers plugin registration and standalone delivery."
-    },
-    "3b096d6f6dbe": {
-      "disposition": "ported",
-      "notes": "Ntfy robustness and docs are represented by plugins/platforms/ntfy, tests/gateway/test_ntfy_plugin.py, website ntfy messaging docs, sidebars, and environment-variable reference entries."
-    },
-    "9405cdc8dd03": {
-      "disposition": "ported",
-      "notes": "Rust ntfy gateway adapter now tags outgoing messages with X-Tags: hermes-agent and skips incoming events carrying that tag to prevent self-echo loops."
-    },
-    "8055d0f09246": {
-      "disposition": "ported",
-      "notes": "Rust ntfy gateway tests cover echo-tag outbound headers, inbound echo filtering, genuine tagged messages, and env-driven platform enablement; Python release AUTHOR_MAP updates are not part of the Rust release pipeline."
-    },
-    "d473e7c9385e": {
-      "disposition": "ported",
-      "notes": "Rust disk-cleanup auto categorization only marks cron/cronjobs output subtrees as cron-output and explicitly leaves cron/jobs.json plus .tick.lock as control-plane state; covered by hermes-tools disk_cleanup tests."
-    },
-    "c14c37d46b902": {
-      "disposition": "ported",
-      "notes": "Rust OpenViking memory provider now scopes direct content-write URIs under viking://user/{user}/agent/{agent}/memories/{subdir}/..., sends X-OpenViking-Agent and bearer auth headers, maps memory-write targets to OpenViking subdirectories, and covers URI/header/body contracts in crates/hermes-agent/src/memory_plugins/openviking.rs tests."
-    },
-    "7de8cd4c5f67": {
-      "disposition": "ported",
-      "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync."
-    },
-    "5ad2b4c6dab7": {
-      "disposition": "ported",
-      "notes": "Rust SessionPersistence now treats SQLite FTS5 as optional: base session persistence remains available without FTS, FTS deletes are guarded, and tests cover no-FTS degradation helpers."
-    },
-    "97ecfa0fc487": {
-      "disposition": "ported",
-      "notes": "Rust session search degrades content search when FTS is unavailable while keeping recent/session-id lookup live; no separate trigram table exists in Rust."
-    },
-    "355af2c20f49": {
-      "disposition": "ported",
-      "notes": "Rust session DB and search survive missing FTS5 by creating base tables first, optional FTS schema second, and returning search_degraded=fts5_unavailable rather than failing registration/search."
-    },
-    "794519c6ad49": {
-      "disposition": "ported",
-      "notes": "Rust SessionPersistence updates sessions.model on persisted session conflicts, exposes update_session_model/get_session_model, and App::switch_model immediately refreshes existing persisted session metadata."
-    },
-    "3e59be0c412b": {
-      "disposition": "ported",
-      "notes": "Rust SessionPersistence now adds messages.active and sessions.rewind_count, filters loads/search to active rows, preserves inactive audit rows, and exposes soft rewind/recent-user/restore primitives with regression coverage."
-    },
-    "243e836dce95": {
-      "disposition": "ported",
-      "notes": "Rust TUI consumes App pending prefill after /rewind or /undo, restoring the rewound prompt into the composer without auto-submitting while App soft-rewinds active session rows."
-    },
-    "3f7d1c801ddf": {
-      "disposition": "ported",
-      "notes": "Rust /undo [N] and /rewind [N] clamp to active user turns, truncate in-memory context, soft-delete persisted rows, preserve inactive audit rows, and stage the backed-up prompt for editing."
-    },
-    "6a72af044c44": {
-      "disposition": "ported",
-      "notes": "Rust managed gateway availability now uses peek_nous_access_token/is_managed_tool_gateway_ready so Firecrawl and Browser Use availability checks do not run refresh-capable Nous OAuth readers; actual request resolution remains refresh-aware and tests cover expired cached token availability."
-    },
-    "6d2727ef1ce1": {
-      "disposition": "ported",
-      "notes": "Rust config loading normalizes Discord allow_from aliases from platforms.discord.allow_from and platforms.discord.extra.allow_from into allowed_users while preserving DISCORD_ALLOWED_USERS/env precedence, with loader regression coverage."
-    },
-    "8bd00607dc53": {
-      "disposition": "superseded",
-      "notes": "Gmail header casing delta applies to upstream Python Google Workspace bridge; this Rust workspace has no Gmail/Google Workspace runtime tool surface in crates beyond bundled skill synchronization/reference content, so there is no Rust header parser/sender to port."
-    },
-    "cbf851ae1d72": {
-      "disposition": "superseded",
-      "notes": "Upstream patch bounds Python TUI startup MCP discovery; Rust TUI startup does not connect/discover configured MCP servers on App::new, and hermes-mcp discovery remains explicit client/CLI behavior with transport/call timeouts, so the freeze path is absent in current Rust runtime."
-    },
-    "47d2d05892ef": {
-      "disposition": "ported",
-      "notes": "Rust provider picker copy now has provider_picker_description wired into hermes model output, setup provider labels, and the TUI provider modal; tests pin refreshed Nous/OpenRouter/Gemini/xAI/Qwen descriptions."
-    },
-    "e946f49ab550": {
-      "disposition": "ported",
-      "notes": "Rust Gemini API-key and google-gemini-cli OAuth model catalogs now expose gemini-3.5-flash and stop offering retired gemini-3-flash-preview; Gemini auxiliary direct-key default also uses gemini-3.5-flash with regression coverage."
-    },
-    "8104b202691": {
-      "disposition": "ported",
-      "notes": "Rust xAI video generation routes default text vs image models by modality, honors explicit overrides, normalizes local image files to data:image URLs, and has focused video_gen regression coverage for those contracts."
-    },
-    "fabca0bdd82b": {
-      "disposition": "ported",
-      "notes": "Rust TUI already drives model selection through canonical /model provider/model modals; this batch added /session and /switch aliases to the existing /sessions surface while preserving /provider as a distinct provider-status command rather than the removed Python /model alias."
-    },
-    "2ed96372ade3": {
-      "disposition": "ported",
-      "notes": "ported in Rust: hermes-skills sync honors .no-bundled-skills, exposes marker toggle and safe pristine bundled-skill removal; hermes-cli adds skills sync/opt-out/opt-in CLI and slash surfaces with tier-gated destructive removal tests."
-    },
-    "f24b7ed9d953": {
-      "disposition": "ported",
-      "notes": "ported/superseded by Rust Honcho architecture: initialize only loads config and never blocks on network session startup; regression test proves fail-open startup while tools/context remain available."
-    },
-    "32032e1e2d9b": {
-      "disposition": "superseded",
-      "notes": "upstream SimpleX websocket reconnect delta is Python plugin-only in this fork; no Rust SimpleX platform adapter exists under crates, so there is no Rust runtime surface to port under the Rust-only parity policy."
-    },
-    "827ce602dbed": {
-      "disposition": "ported",
-      "notes": "Rust Honcho runtime now strips trailing /vN baseUrl suffixes, derives underscore-safe profile host keys while reading legacy dot-form host blocks, skips loopback auth unless hosts.<host>.apiKey explicitly opts in, and setup/config writes remain owner-only with targeted regression coverage."
-    },
-    "b47cb1bbf279": {
-      "disposition": "ported",
-      "notes": "Rust Kanban JSON store now supports per-task file attachments with path-safe copy, unique filenames, metadata, list/remove commands, worker-context absolute path surfacing, and regression tests for copy/collision/delete/context behavior."
-    },
-    "0cd7d54b0010": {
-      "disposition": "ported",
-      "notes": "Rust Kanban tasks now carry goal_mode and goal_max_turns, CLI add parses --goal/--goal-max-turns, dispatch worker context emits goal-loop instructions, and a callback-injected Rust goal loop covers continue, completion, finalize, and budget-block behavior."
-    },
-    "a5aecf26fa21": {
-      "disposition": "ported",
-      "notes": "Rust config/runtime gateway surface now exposes kanban.dispatch_in_gateway with HERMES_KANBAN_DISPATCH_IN_GATEWAY env override, propagates it into GatewayConfig, and includes it in gateway agent cache-busting signatures; Rust has no separate Kanban DB notifier loop to gate."
-    },
-    "165b2e481afa": {
-      "disposition": "ported",
-      "notes": "Rust config/runtime now exposes agent.api_max_retries with apiMaxRetries alias, config patch/display support, HERMES_AGENT_API_MAX_RETRIES env override, and build_agent_config propagation into RetryConfig.max_retries with focused hermes-config/hermes-cli regression coverage."
-    },
-    "9ff21437a03a": {
-      "disposition": "ported",
-      "notes": "Rust MCP tools/call now coerces stringified object/array arguments before dispatch in both exported MCP server paths, leaves non-object scalar strings untouched, and has focused helper plus JSON-RPC runtime regression coverage."
-    },
-    "e02a6038a420": {
-      "disposition": "ported",
-      "notes": "Rust hermes dump now resolves real session snapshots, defaults exports under HERMES_HOME/sessions/saved/hermes_conversation_<timestamp>.json, and includes system_prompt, session_id, session_start, source_path, model/personality, exported_at, and messages with regression coverage."
-    },
-    "e76d8bf5aaa9": {
-      "disposition": "ported",
-      "notes": "Rust TUI tool-output rendering now defaults to a small 16-line/1KiB retained preview while preserving full agent context/session storage; regression coverage pins truncation and preview-size behavior."
-    },
-    "98903d03139d": {
-      "disposition": "superseded",
-      "notes": "Upstream Python/Node TUI gateway live-session reuse fix targets a separate gateway/socket runtime; Rust resume restores persisted snapshots directly into a single App under the interactive-session lock with existing load_resume_payload/run_resume coverage."
-    },
-    "bd6d0987629e": {
-      "disposition": "superseded",
-      "notes": "Upstream Python TUI gateway live-history hydration race is absent in Rust's direct resume path: resumed messages become App.messages before the TUI loop starts, and subsequent turns append to the same Rust state vector."
-    },
-    "8077e7d2fbbb": {
-      "disposition": "superseded",
-      "notes": "Upstream _session_resume_lock narrowing applies to Python TUI gateway concurrent live-agent construction; Rust interactive resume is guarded by the process-level interactive session lock and has no session.close RPC lock path to port."
-    },
-    "30412a9771cc": {
-      "disposition": "ported",
-      "notes": "Rust disk-cleanup revalidates stale cron-output entries at dry-run and quick-clean time, drops stale control-plane tracked rows, hard-protects cron/jobs.json plus .tick.lock, and deletes only cron/output payloads; covered by crates/hermes-tools disk_cleanup tests."
-    },
-    "46b2afc56b79": {
-      "disposition": "ported",
-      "notes": "Rust session persistence now runs PRAGMA wal_checkpoint(TRUNCATE) after startup auto-maintenance and exposes truncate_wal_checkpoint(); regression tests force WAL growth and assert the sessions.db-wal sidecar shrinks to zero."
-    },
-    "86c64cfb5bd5": {
-      "disposition": "superseded",
-      "notes": "Upstream Discord timeout fix targets Python discord.ui.View message editing. Rust Discord interactions are stateless REST responses/edits and have no discord.ui.View lifecycle; the existing model-picker edit contract already clears components when edits are sent."
-    },
-    "fff0561441d2": {
-      "disposition": "superseded",
-      "notes": "Google Chat OAuth client-secret anchoring is Python adapter-only in upstream; this Rust gateway surface has no Google Chat platform adapter or OAuth helper under crates/hermes-gateway, so no Rust runtime path exists to port."
-    },
-    "7309f3bef7d7": {
-      "disposition": "superseded",
-      "notes": "LINE inbound message-type mapping is Python adapter-only in upstream; this Rust gateway surface has no LINE platform adapter under crates/hermes-gateway and no MessageType.IMAGE crash path to port."
-    },
-    "f736d2be86b8": {
-      "disposition": "ported",
-      "notes": "Rust provider profiles now expose Xiaomi/MiMo as vision-capable, supports_vision can be overridden locally without leaking to provider requests, Xiaomi MiMo models carry vision metadata, and focused Rust tests prove ACP multimodal image parts stay native for vision providers."
-    },
-    "96cd37e212e8": {
-      "disposition": "superseded",
-      "notes": "Upstream leak fix targets Python TUI gateway detached transports and _SlashWorker subprocesses. Rust HTTP websocket handling has no detached slash-worker subprocess lifecycle; in-process SessionManager already exposes explicit remove/idle-expire cleanup APIs."
-    },
-    "122d8788ae23": {
-      "disposition": "ported",
-      "notes": "rust terminal handler provides first-class terminal command execution through TerminalHandler, TOOLSET_TERMINAL, and builtin registry coverage; upstream_core_tool_contracts verifies command/timeout/background/pty/stdin_data schema surface"
-    },
-    "a49596cbb2c1": {
-      "disposition": "ported",
-      "notes": "rust terminal tool refinement is covered by the same TerminalHandler/runtime registry surface, with tests for foreground timeout caps, background guidance, stdin_data, and schema parity"
-    },
-    "20f287547275": {
-      "disposition": "superseded",
-      "notes": "rust browser runtime does not use the Python browser_tool session supervisor; Browserbase/Browser Use backends manage sessions with provider timeout/close contracts and builtin browser surface tests cover the current browser commands without legacy browser_close"
-    },
-    "971ed2bbdf61": {
-      "disposition": "ported",
-      "notes": "rust terminal handler supports sudo password transformation via SUDO_PASSWORD with shell quoting and approval safeguards; crates/hermes-tools/src/tools/terminal.rs tests cover sudo denial, yolo boundaries, and password quoting"
-    },
-    "76d929e17725": {
-      "disposition": "ported",
-      "notes": "rust approval manager and terminal handler implement dangerous command confirmation/denial, hardline blocks, gateway approvals, and session yolo controls with extensive tests in crates/hermes-tools/src/approval.rs and terminal handler tests"
-    },
-    "f5be6177b231": {
-      "disposition": "ported",
-      "notes": "rust text_to_speech/tts_premium tools, MultiTtsBackend providers, gateway voice send surfaces, and voice-compatible media tags cover the upstream TTS product surface; new registry/schema contract proves first-class TTS exposure"
-    },
-    "061fa7090720": {
-      "disposition": "ported",
-      "notes": "rust terminal/process/process_registry surface implements background=true, process list/poll/log/wait/kill/write/submit/close, PTY, stdin_data, and registry exposure; new core runtime schema contract plus terminal/process tests cover it"
-    },
-    "e184f5ab3a51": {
-      "disposition": "ported",
-      "notes": "rust TodoHandler and FileTodoBackend provide create/update/list task management with TOOLSET_TODO and builtin registry exposure; new schema contract proves first-class todo runtime surface"
-    },
-    "9e85408c7bfd": {
-      "disposition": "ported",
-      "notes": "rust todo tool remains first-class in CLI/API toolsets and builtin registration; existing toolset tests and new registry/schema contract cover create/update/list parity"
-    },
-    "ada0b4f131ba": {
-      "disposition": "ported",
-      "notes": "rust gateway/platform adapter surface sends inline image URLs natively and now strips/delivers local MEDIA image markers through validated send_file paths; tests cover inline image extraction and media marker delivery"
-    },
-    "5404a8fcd8a5": {
-      "disposition": "ported",
-      "notes": "rust gateway already supports vision/image URL handling and platform media send paths; this slice adds MEDIA marker extraction/routing with unsafe path blocking to close generated screenshot/image delivery parity"
-    },
-    "b8c3bc78417c": {
-      "disposition": "ported",
-      "notes": "rust browser screenshot/TTS output markers can now be delivered as native platform files via Gateway::send_message_threaded MEDIA extraction; tests cover MEDIA path stripping, canonicalized file delivery, blocked unsafe paths, and existing inline image routing"
-    },
-    "586b0a7047ea": {
-      "disposition": "ported",
-      "notes": "rust text_to_speech/tts_premium providers and gateway MEDIA marker delivery cover TTS audio handoff without Python Edge TTS runtime; existing TTS tests plus gateway media marker tests prove audio file delivery path"
-    },
-    "eb49936a60aa": {
-      "disposition": "superseded",
-      "notes": "upstream docs/install audio-format update is superseded by rust-native TTS providers, media_category/send_file adapter routing, and gateway MEDIA marker delivery tests; no Python install-script runtime remains to port"
-    },
-    "bdac541d1ee2": {
-      "disposition": "ported",
-      "notes": "Rust OpenAI audio key resolution already prefers HERMES_OPENAI_API_KEY over legacy OPENAI_API_KEY and this slice aligns gateway voice STT/TTS error paths with the shared resolver while preserving legacy fallback."
-    },
-    "0858ee2f2701": {
-      "disposition": "ported",
-      "notes": "Rust OpenAI audio key resolution now consistently uses VOICE_TOOLS_OPENAI_KEY first for transcription and gateway voice STT/TTS, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY; focused tests cover precedence and schema/error visibility."
-    },
-    "ec32e9a5406d": {
-      "disposition": "ported",
-      "notes": "Rust transcription now exposes provider-aware Groq STT with GROQ_API_KEY, Groq OpenAI-compatible endpoint/model defaults, model normalization, schema coverage, and gateway SttProvider::GroqWhisper credential/error handling tests."
-    },
-    "b8f8d3ef9e55": {
-      "disposition": "ported",
-      "notes": "Rust transcription now implements the valuable provider fallback portion of the three-provider STT surface: explicit/provider-env OpenAI, Groq, and Mistral/Voxtral with deterministic model normalization and tests. Python faster-whisper local runtime is intentionally not embedded in the Rust runtime."
-    },
-    "5f4b93c20f41": {
-      "disposition": "ported",
-      "notes": "Rust transcription now exposes Mistral/Voxtral STT with MISTRAL_API_KEY, /v1/audio/transcriptions endpoint construction, voxtral model defaults, no unsupported response_format multipart field, schema coverage, and gateway SttProvider::MistralVoxtral tests."
-    },
-    "0f597dd12796": {
-      "disposition": "ported",
-      "notes": "Rust STT provider/model normalization prevents OpenAI whisper-1 from being sent to Groq or Mistral/Voxtral and prevents Groq/Voxtral models from leaking to OpenAI; tool and gateway tests cover mismatch normalization."
-    },
-    "3260413cc7fa": {
-      "disposition": "ported",
-      "notes": "Rust STT override env vars are first-class runtime knobs: HERMES_STT_PROVIDER/STT_PROVIDER, STT_OPENAI_MODEL, STT_GROQ_MODEL, STT_MISTRAL_MODEL, and provider base-url overrides are resolved in the Rust transcription/gateway voice surfaces with tests."
-    },
-    "e27b0b76517c903541af20d0bd606fa7b3c83005": {
-      "disposition": "ported",
-      "notes": "Rust ACP now advertises /steer and /queue, queues prompts without racing active sessions, drains queued turns FIFO after current completion, and exposes an AcpPromptExecutor steer hook; hermes-acp queue/steer tests cover slash discovery, no-run queueing, active queueing, active steer signaling, and queued drain."
-    },
-    "78886365c2a04f3367028190b71c5b4a96433279": {
-      "disposition": "ported",
-      "notes": "Rust ACP cancel now captures the interrupted user prompt and idle /steer replays it with explicit correction/guidance; hermes-acp tests cover cancel replay and clearing interrupted_prompt_text."
-    },
-    "41fa1f1b5cf560c22a7e9adb06eb463d7122f9e0": {
-      "disposition": "ported",
-      "notes": "Rust ACP rewrites idle /steer into a regular user prompt instead of silently queueing it, matching upstream editor-client behavior; hermes-acp idle steer test proves the prompt runs immediately and leaves the queue empty."
-    },
-    "bc5f0e62d9e6c36f8f14a43e5e6c70982f280069": {
-      "disposition": "ported",
-      "notes": "Rust ToolsetManager resolves all/* to the union of registered toolsets and this slice proves the configured platform-toolset path also accepts all/* while preserving custom-token fallback; platform_toolsets tests cover both aliases."
-    },
-    "3078053795e838e47797ede02b44e6dead731aac": {
-      "disposition": "ported",
-      "notes": "Rust mixture_of_agents is now a first-class OpenAI-compatible two-layer MoA runtime with env/model/base-url configuration, parallel reference fanout, retries, minimum-success threshold, aggregator prompt synthesis, toolset/distribution exposure, and deterministic mock HTTP tests."
-    },
-    "ef5eaf8d8757a5e75fa571042abc287430192f53": {
-      "disposition": "ported",
-      "notes": "Rust cron now honors the cron platform_toolsets config path, adds the hermes-cron default platform/toolset surface, hard-denies recursive and interactive cron tools, preserves direct custom-tool fallback, and covers default/configured cron filtering with targeted tests."
-    },
-    "f75b1d21b4c8cacc2b9b9fb87227ff315365cd90": {
-      "disposition": "ported",
-      "notes": "Rust agent loop now treats advertised tool schemas as the runtime allowlist, rejects registered-but-disabled fabricated tool calls in non-streaming and streaming loops, and makes delegate_task inherit the parent enabled tool surface when no explicit child toolset is requested; execute_code schema remains Rust-only and does not advertise disabled sandbox helper tools."
-    },
-    "e7a7872a874837ca36105ca3e90db464cf7c125a": {
-      "disposition": "ported",
-      "notes": "Rust process_registry now exposes deduplicated process notification receipts via notify/record_event/list_events/clear_events. Completion events are one-shot per process session, watch_match identities include command/pattern/output/suppressed/message_id so distinct matches are preserved, and focused tests cover replay dedup plus distinct watch-match emission."
-    },
-    "5bcb63e400987e937e696b385e01285339b565c5": {
-      "disposition": "superseded",
-      "notes": "The Python TUI global _sessions/_pending lock fix is structurally superseded by Rust session managers and pending stores that already use Mutex/RwLock for compound mutations (hermes-acp SessionManager/PermissionStore, hermes-gateway SessionManager/BusySessionCoordinator). This slice also adds a Mutex-backed process notification receipt store for the overlapping process-event flood path."
-    },
-    "19db9cd0760e05dafcd1ae637db946cdd65322ce": {
-      "disposition": "ported",
-      "notes": "Rust ACP SessionManager now exposes a public lock-protected update_session_meta API with COALESCE-style optional model preservation, merges cwd/provider/api_mode/base_url/config options, routes existing update_cwd/update_model through it, and tests missing-session no-op plus single persist callback behavior."
-    },
-    "375c7f9cc379f940f3923ac967793675bdfd2b5c": {
-      "disposition": "ported",
-      "notes": "Rust ACP now renders structured JSON tool results into compact readable completion text, including todo summaries, read_file fenced content, search_files matches/files with JSON-prefix hint handling, skill summaries, browser/media/edit helpers, and generic nested JSON bullets without leaking raw blobs."
-    },
-    "b38d2d133bbb76fb9d91f08c3b1a838f5ce0a5b9": {
-      "disposition": "ported",
-      "notes": "Rust ACP tool completions compute failed status from structured success=false, ok=false, and nonzero exit_code/returncode while keeping status calculation separate from display formatting; focused tests cover the status path."
-    },
-    "eda1c97a1ef8c7d8505f40be1839929e130ad4c4": {
-      "disposition": "ported",
-      "notes": "Rust ACP marks canonical raised-exception outputs beginning with Error executing tool as failed while preserving plain Error: terminal/test output as completed; completion-status tests cover the positive and negative cases."
-    },
-    "9cf1140caaefa6f275667ed1b11a61aabb6199dd": {
-      "disposition": "ported",
-      "notes": "Rust ACP polished tool errors are treated as failed for core tool outputs while generic optional JSON error payloads remain completed; completion-status tests cover both sides of the conservative rule."
-    },
-    "0b9526b4761bbabc98ca48f5c0a3f2dfda765314": {
-      "disposition": "ported",
-      "notes": "Rust ACP session/set_model now has handler-level regression coverage proving model switches preserve existing provider/base_url/api_mode route metadata through the public SessionManager update_session_meta path instead of recreating or clearing provider state."
-    },
-    "f92298fe955fe2ddbea27f4c504ce310ec46545b": {
-      "disposition": "ported",
-      "notes": "Rust ACP maps typed top-level AgentResult usage into PromptResponse.usage through the CLI ACP executor boundary; regression coverage proves prompt/completion/total fields populate ACP input/output/total tokens without relying on a nested result usage dict."
-    },
-    "4e78963fe86a5f2758bf754a7979dc31aaf1a3db": {
-      "disposition": "superseded",
-      "notes": "The dead Python nested usage dict path is structurally superseded by Rust's typed AgentResult.usage and PromptExecutionOutput.usage flow; the CLI ACP usage test proves only the top-level typed fields are converted."
-    },
-    "1bcc87a1535cd4c17dc2bfe45fd198863404e892": {
-      "disposition": "ported",
-      "notes": "Rust ACP initialize advertises loadSession and sessionCapabilities.resume in the wire-format agentCapabilities object; handler tests assert the ACP aliases so editor clients can discover load/resume support."
-    },
-    "c71b1d197f446e264a94f962fd55f285c9dc231f": {
-      "disposition": "ported",
-      "notes": "Rust ACP now converts its slash command table into availableCommands updates with input hints and emits available_commands_update after session new/load/resume/fork; handler and server run_on tests prove the lifecycle and JSON-RPC notification path."
-    },
-    "4764e06fdefa65cb75961da64da1ed63c99a0a2a": {
-      "disposition": "ported",
-      "notes": "Rust ACP exposes the editor session-management surface with load/resume/fork/list plus model/mode/config updates, now including the stable session/set_config_option method alias; handler tests cover camelCase routing and persisted session config."
-    },
-    "d2536a72bf27b3ca01d1b48957e58cb0202b6dfb": {
-      "disposition": "ported",
-      "notes": "Rust ACP replays persisted user and assistant session history on session/load and session/resume as session/update message chunks, skipping non-displayable system messages and preserving malformed-history tolerance."
-    },
-    "f3a4af9cf2a626cb3e055766cb1cff60168d295d": {
-      "disposition": "ported",
-      "notes": "Rust ACP replays assistant reasoning_content/reasoning as agent_thought_chunk before assistant message text and reconstructs persisted tool-call start/completion events during load/resume history replay."
-    },
-    "3034eee38ec516109566c00975be4d0276747c34": {
-      "disposition": "ported",
-      "notes": "Rust ACP server now flushes session/load and session/resume replay notifications before the JSON-RPC response, with run_on coverage proving clients receive transcript updates within the request lifetime."
-    },
-    "741a34945810a7cb5142804660f9e6108e2d49ec": {
-      "disposition": "ported",
-      "notes": "Rust ACP now emits session_info_update after prompt turns refresh session metadata, using the Rust-derived session title so editor clients can update their session list without waiting for a separate list refresh."
-    },
-    "2057977102da26cbf0fa9e699fa4432dbf017566": {
-      "disposition": "ported",
-      "notes": "Rust ACP session_info_update uses the notification refresh moment for updatedAt instead of relying on stored session updated_at fields; prompt-turn coverage asserts a non-empty fresh numeric timestamp."
-    },
-    "658947480a01dc59a2aa7a6a06a6434d7214edff": {
-      "disposition": "ported",
-      "notes": "Rust ACP replay chunk events no longer carry the invalid messageId field; the typed event model omits the field and load replay tests assert serialized user/agent chunks match the ACP schema."
-    },
-    "cdf9793d6d6b97aa99e1b2f27629e52d89eac41d": {
-      "disposition": "ported",
-      "notes": "Rust ACP forwards image prompt blocks as OpenAI-style image_url multimodal content, preserves text-only slash command interception, treats image-bearing slash text as a model prompt, and now advertises promptCapabilities.image during initialize with protocol and handler tests."
-    },
-    "4444d5fe4f65dcbca939a1f39ae58438205e7dad": {
-      "disposition": "ported",
-      "notes": "Rust ACP emits native sessionUpdate=plan events after live todo tool completions, using typed PlanEntry values and shared parser tests for status mapping, cancelled preservation, and wire serialization."
-    },
-    "bd3a5873e11f084d74be876a505a406224a6ef3e": {
-      "disposition": "ported",
-      "notes": "Rust ACP replays native todo plan updates from persisted tool results after tool_call_complete, supports trailing human hints and empty todo lists for plan clearing, and covers replay ordering plus CLI live converter behavior."
-    },
-    "e26f9b207041c03d1aa9a982d29dbfda66df3a82": {
-      "disposition": "ported",
-      "notes": "Rust ACP routes provider reasoning callbacks to agent_thought_chunk updates, routes stream deltas to message_delta updates, and suppresses fallback final-response emission when executor streaming already delivered message content."
-    },
-    "72c8037a24b58b7b1a38a99903cc0bf8a3d7595c": {
-      "disposition": "ported",
-      "notes": "Rust ACP now has dedicated compact completion renderers for web_search, process, delegate_task, session_search, memory, media/cron, plus expanded tool kind/title mappings; tests assert raw JSON/private entry dumps are avoided."
-    },
-    "b294d1d0229ff6026838a04c4cb59c3b13e4827f": {
-      "disposition": "superseded",
-      "notes": "Rust ACP start events already carry compact title/kind/arguments only and do not synthesize read_file output content; existing title tests cover read_file start compactness."
-    },
-    "19854c7cd2f00e3d591e72ccbe2e456ad10c4886": {
-      "disposition": "superseded",
-      "notes": "Rust ACP already fences read_file completion content and intentionally flushes load/resume replay before the RPC response for deterministic local clients; server tests cover replay flushing and read_file formatting."
-    },
-    "9987f3d82486b04151dee2d27d640b3ae01b7b16": {
-      "disposition": "ported",
-      "notes": "Rust ACP now keeps successful web_extract completions silent while rendering compact per-URL failures; read_file fenced completion and compact replay rendering are covered by hermes-acp tools tests."
-    },
-    "6622277f11ca1dee03e868b064fb1851e5598b77": {
-      "disposition": "ported",
-      "notes": "Rust ACP browser_navigate starts already expose polished navigate titles without raw content, and this slice adds regression coverage plus corrected tool kind mappings for polished browser and delegate tools."
-    },
-    "eb612f55748d8f0888f09f055abd86afef925150": {
-      "disposition": "ported",
-      "notes": "Rust ACP web_extract rendering now matches the compact contract: success omits extracted content, structured failures show URL/title/error summaries, and tests prevent raw result dumps."
-    },
-    "ef9a08a872d1ed87eb4c91cf8ad8e8f4ef5a6e2b": {
-      "disposition": "ported",
-      "notes": "Rust ACP now emits native usage_update events with size/used on session lifecycle, model switch, slash-command, and prompt completion paths, enriches /context with usage and compaction threshold text, and ports polished common tool rendering/kind/title behavior with hermes-acp tests."
-    },
-    "9c1bb8d2c729": {
-      "disposition": "ported",
-      "notes": "Rust now exposes /version through CLI/TUI slash dispatch, gateway slash dispatch, and ACP slash handling via a shared hermes-core version_label helper with targeted Rust tests."
-    },
-    "30340eae2f6e": {
-      "disposition": "ported",
-      "notes": "Rust shared version_label includes the workspace package version and optional build git SHA captured by hermes-core build.rs, so CLI/gateway/ACP version surfaces share the same label helper."
-    },
-    "0f45509daf72": {
-      "disposition": "ported",
-      "notes": "Rust agent loop now treats formatted /steer redirects as trusted mid-turn out-of-band user messages appended to the last tool result, adds the shared steer channel system-prompt note when tools are available, and wires ACP active-session steer through the shared marker with regression tests preventing the old User guidance label."
-    },
-    "d41427504ef04": {
-      "disposition": "ported",
-      "notes": "Rust delegation depth now has a first-class AgentConfig max_delegate_depth plus delegation.max_spawn_depth config bridge with floor 1 and no legacy ceiling; env/config values above the old cap pass through with agent, CLI, config, and backend tests."
-    },
-    "9423fda5cb57": {
-      "disposition": "ported",
-      "notes": "Rust delegation config now accepts delegation.model/provider plus documented direct endpoint fields, exposes them through config set/get, propagates them through CLI/HTTP AgentConfig construction, and makes subagents either inherit the parent provider for model-only overrides or build an independent provider for provider/base_url/api_key overrides with structured credential errors."
-    },
-    "f1fe29d1c368": {
-      "disposition": "ported",
-      "notes": "Rust provider config now accepts llm.<provider>.request_timeout_seconds, validates and exposes it through config set/get, propagates it into AgentConfig RuntimeProviderConfig, and applies it to OpenAI-compatible, Codex Responses, Anthropic, OpenRouter, extra provider, fallback/runtime-routing, and client rebuild paths with targeted tests."
-    },
-    "cf786593cd83": {
-      "disposition": "ported",
-      "notes": "Rust now propagates active provider output caps into AgentConfig.max_tokens so gateway/CLI/cron agent paths pass configured max_tokens into provider requests through the existing AgentLoop max_tokens chain."
-    },
-    "1c909e75e1a0": {
-      "disposition": "ported",
-      "notes": "Rust build_agent_config now honors HERMES_MAX_TOKENS as the highest-precedence output-token override and falls back to active provider config caps for CLI and gateway-created agents, with focused precedence tests."
-    },
-    "14275d7baa1a": {
-      "disposition": "ported",
-      "notes": "Rust llm provider config accepts max_output_tokens as an alias for max_tokens, exposes both dotted config set/get spellings, validates positive values, and uses the active provider cap only when HERMES_MAX_TOKENS is unset."
-    },
-    "2dda393f99cb": {
-      "disposition": "ported",
-      "notes": "Rust regression tests cover the max_tokens propagation chain from config parsing/set-get through build_agent_config into AgentConfig.max_tokens precedence, superseding the upstream Python gateway test-only follow-up."
-    },
-    "4b2d00f845eb": {
-      "disposition": "ported",
-      "notes": "Rust custom provider catalogs now preserve `discover_models: false` from both canonical llm_providers and legacy custom_providers, keep explicit `models` subsets without probing live `/models`, and expose config-aware provider lists with Rust model-switch tests."
-    },
-    "7ae8aac3b9b2": {
-      "disposition": "ported",
-      "notes": "Rust terminal and slash/TUI model flows now include configured custom providers, use explicit provider model lists when discovery is disabled, fall back to configured models after empty probes, and guard direct switches against those configured catalogs with CLI/config tests."
-    },
-    "38695254f851": {
-      "disposition": "ported",
-      "notes": "Rust session persistence now exposes FTS index counting and optimize_fts maintenance, VACUUM runs FTS optimization before reclaiming pages, and top-level `hermes sessions optimize` reports FTS index count plus before/after sessions.db size with Rust unit/e2e coverage."
-    },
-    "3d1d0a49fe90": {
-      "disposition": "ported",
-      "notes": "Rust MiniMax direct auxiliary defaults now use MiniMax-M3 for minimax and minimax-cn, MiniMax CN registers as a first-class auxiliary direct-key provider, setup defaults and curated picker fallbacks expose MiniMax-M3 first, and regression tests guard against stale/highspeed defaults."
-    },
-    "da4f407e5173": {
-      "disposition": "ported",
-      "notes": "Rust `hermes portal` now defaults to Nous Portal onboarding/setup, `portal info/status/check` report status, CLI help/README/auth recovery guidance use the human-readable portal alias, and focused CLI tests cover the dispatch without OAuth side effects."
-    },
-    "486b692ddd80": {
-      "disposition": "ported",
-      "notes": "Rust Nous provider request shaping now centralizes Portal attribution tags as product=hermes-agent plus client=hermes-client-v<workspace version>, and request-body tests prove the versioned tag is applied to actual Nous chat completion payloads."
-    },
-    "de07aa7c4046": {
-      "disposition": "ported",
-      "notes": "Rust now exposes a first-class `nous-api` direct API-key provider with aliases, non-OAuth provider capability, setup catalog entry, NOUS_API_KEY/NOUS_BASE_URL runtime resolution, Nous provider construction, Nous model normalization/catalog reuse, and targeted core/CLI/agent tests."
-    },
-    "4447e7d71afa": {
-      "disposition": "ported",
-      "notes": "Rust runtime now supports Kimi Code sk-kimi-* routing to https://api.kimi.com/coding/v1 with KimiCLI user-agent while preserving KIMI_BASE_URL override and legacy Moonshot fallback."
-    },
-    "fcb1944b4f76": {
-      "disposition": "ported",
-      "notes": "Rust now captures Nous credits headers at the provider HTTP boundary, parses the v1 x-nous-credits and x-nous-tool-pool contracts with strict money/bool validation, stores a last-known credits snapshot, appends the credits block to CLI and gateway /usage output, and surfaces depleted/50/75/90 percent usage notices in the TUI status bar with focused Rust tests. Python dev fixtures and desktop-only scaffolding are superseded by the Rust runtime surface."
-    },
-    "c79b6f23e696": {
-      "disposition": "ported",
-      "notes": "Rust credits notices now classify usage-band, grant-spent, and depleted states, suppress flash-style usage/grant-spent notices when a new TUI processing cycle starts, keep depleted sticky, and regression-test that yielded notices stay quiet until the band or grant-spent condition changes."
-    },
-    "5af899c7ca75": {
-      "disposition": "ported",
-      "notes": "Rust profile management now reverse-displays custom aliases from aliases.json in profile list rows and current-profile output, prefers custom aliases over profile-named self aliases, keeps raw profile show output parse-safe, and covers the real CLI create/alias/list/use/current flow."
-    },
-    "b91aade17683": {
-      "disposition": "ported",
-      "notes": "Rust config now detects auxiliary task pins whose provider differs from the selected main provider, top-level and slash-command model switch persistence surfaces warn without auto-clearing legitimate pins, and focused config/model-switch/e2e tests cover stale vs auto/matching slots."
-    },
-    "7f016f5f3360": {
-      "disposition": "ported",
-      "notes": "Rust model-provider preview surfaces now share DEFAULT_VISIBLE_MODELS_PER_PROVIDER=50 for CLI model listing, TUI provider picker details, and slash /provider output, with a regression test proving a 60-model configured provider exposes the first 50 while preserving total count."
-    },
-    "f94363d1f0de": {
-      "disposition": "superseded",
-      "notes": "Desktop arrow-history UI is superseded by Rust TUI input_history navigation: Up/Down dispatch through App::history_prev/history_next for single-line prompts, Ctrl-R searches history, submitted prompts append to the ring, and a focused Rust unit test proves newest-to-oldest recall plus return to the empty draft sentinel."
-    },
-    "ce5003063474": {
-      "disposition": "superseded",
-      "notes": "Desktop queued-composer history integration is superseded by Rust's split design: TUI input history remains a sent-prompt ring while gateway BusySessionCoordinator owns busy-turn queue/steer semantics with queue, reset, finish, and fallback tests. There is no Rust desktop queued-row editor surface to port."
-    },
-    "0cbcc7593562": {
-      "disposition": "superseded",
-      "notes": "Desktop composer-message queue robustness is superseded by Rust gateway BusySessionCoordinator and CLI background queue handling: busy messages queue without interrupt, accepted steers skip the queue, rejected steers fall back to queue, reset/finish clear state deterministically, and slash/background queue tests cover user-visible status."
-    },
-    "40aef6af91e6": {
-      "disposition": "superseded",
-      "notes": "Desktop composer live-steer controls are superseded by Rust first-class /steer support in CLI/TUI/gateway/ACP: the core trusted steer marker is already ported, active-session ACP steer interrupts with that marker, and gateway busy-session steer mode accepts live steering or falls back to queue."
-    },
-    "efa53fb3be51": {
-      "disposition": "superseded",
-      "notes": "Desktop Cmd/Ctrl+Enter steer keybinding policy is not a Rust runtime surface. Rust TUI has its own terminal key contract: Enter submits, Shift+Enter and Ctrl+J insert newlines, Ctrl+Enter/Ctrl+M are submit fallbacks, and focused tests guard those shortcuts."
-    },
-    "8a9ded5b21b1": {
-      "disposition": "ported",
-      "notes": "Rust gateway now has a dependency-free 48 kHz stereo s16le continuous VoiceMixer with ambient loops, ducked speech overlays, clipping, stop/cleanup, and synthesized ambient PCM, plus VoiceManager voice_fx lifecycle integration for join/remove, active checks, ack phrase selection, speech enqueue/read/stop, and focused mixer/manager unit tests."
-    },
-    "4a1907bd10c3": {
-      "disposition": "superseded",
-      "notes": "Upstream change is confined to apps/desktop React i18n wiring and zh-Hans catalog files. Hermes Agent Ultra has no Electron desktop tree in this Rust runtime repo; CLI/TUI/gateway text remains Rust-native and is not backed by the upstream desktop i18n catalog."
-    },
-    "1d9c3ebae0f2": {
-      "disposition": "superseded",
-      "notes": "Upstream persists the Electron desktop language preference through apps/desktop config/runtime stores. Hermes Agent Ultra has no desktop language selector/config surface in this Rust runtime repo, so there is no shared Rust runtime state to port."
-    },
-    "f18a9dbefc59": {
-      "disposition": "superseded",
-      "notes": "Japanese and Traditional Chinese language switching is an apps/desktop component/catalog change. The Rust runtime has no Electron language switcher surface; CLI/TUI/gateway text remains direct Rust command/status output."
-    },
-    "b1b89f843e62": {
-      "disposition": "superseded",
-      "notes": "The upstream nested i18n field-copy refactor only reorganizes apps/desktop TypeScript catalog structures and UI consumers. This Rust runtime repo has no corresponding desktop catalog tree or TypeScript settings-field copy layer."
-    },
-    "812dc6957e19": {
-      "disposition": "superseded",
-      "notes": "Searchable language picker is an apps/desktop React component plus i18n catalog update. Hermes Agent Ultra has no Electron language picker runtime surface to port."
-    },
-    "fbd423b94d50": {
-      "disposition": "superseded",
-      "notes": "Desktop chrome localization only updates apps/desktop UI strings, voice-recorder hooks, and React components. Rust CLI/TUI/gateway chrome is independent and not driven by the upstream desktop i18n catalog."
-    },
-    "112a0732c6a7": {
-      "disposition": "superseded",
-      "notes": "This upstream row only fills apps/desktop Japanese and Traditional Chinese translation files. There is no Rust runtime catalog file or desktop translation asset in this repo."
-    },
-    "c24abf5b3286": {
-      "disposition": "superseded",
-      "notes": "This upstream row only fills apps/desktop Simplified Chinese translation strings. Hermes Agent Ultra has no corresponding desktop translation catalog in the Rust runtime repo."
-    },
-    "1c2189839d0b": {
-      "disposition": "superseded",
-      "notes": "CamelCase settings i18n keys are a desktop TypeScript catalog/runtime-test refactor. No Rust settings parser or gateway command consumes those apps/desktop i18n keys."
-    },
-    "0c0a70774424": {
-      "disposition": "superseded",
-      "notes": "macOS updater-helper repair is confined to upstream apps/bootstrap-installer Tauri paths and Electron main process code. Hermes Agent Ultra's Rust update surface is the CLI release-check path, not an embedded Electron/Tauri helper."
-    },
-    "98528c78c143": {
-      "disposition": "superseded",
-      "notes": "Windows in-app update race handling only touches upstream apps/bootstrap-installer Tauri update code and Electron main process orchestration. This Rust runtime repo does not embed that desktop updater process."
-    },
-    "14fee4f11265": {
-      "disposition": "superseded",
-      "notes": "Windows first-run update handoff retry is an upstream bootstrap-installer Tauri updater behavior. Hermes Agent Ultra has no matching in-app desktop updater; Rust `hermes update` is handled separately by the CLI release-check implementation."
-    },
-    "16beab421f05": {
-      "disposition": "superseded",
-      "notes": "The upstream About-panel fix is Electron-only. Rust already centralizes live version text through hermes_core::version::version_label and exposes it via CLI `version`, TUI `/version`, and gateway `/version`, with focused tests guarding the shared label."
-    },
-    "b94b3622b5fa": {
-      "disposition": "ported",
-      "notes": "Rust gateway now applies per-session profile switching through `/profile <name>`: it resolves aliases from `$HERMES_HOME/profiles/aliases.json`, loads profile YAML, derives provider from either explicit provider or provider:model, applies model/personality/home/profile into GatewayRuntimeContext, preserves missing-file label behavior with a warning, and verifies status/runtime-state behavior with focused gateway route tests. Upstream desktop cross-profile UI is not a Rust runtime surface."
-    },
-    "4891f9ae78b0": {
-      "disposition": "superseded",
-      "notes": "Concurrent multi-profile gateway sockets are Electron desktop store/socket orchestration only. Rust gateway profile routing is session-scoped runtime state and does not expose the upstream apps/desktop multi-socket dashboard layer."
-    },
-    "1a3e608524a3": {
-      "disposition": "superseded",
-      "notes": "Per-profile remote gateway hosts are apps/desktop Electron connection-config and settings UI only. The Rust runtime has no desktop remote-host registry; gateway profile behavior is handled by session-scoped runtime overlays and explicit home/profile state."
-    },
-    "5df732a355c8": {
-      "disposition": "superseded",
-      "notes": "Quick-create profile from the desktop rail is React desktop UI. Rust profile creation is handled by the CLI `hermes profile create` command and profile YAML files; there is no Rust profile rail to port."
-    },
-    "e0121c59d3b3": {
-      "disposition": "superseded",
-      "notes": "Drag-sort profiles in the rail only changes apps/desktop profile-switcher UI state. Rust profiles are filesystem-backed YAML entries listed deterministically by CLI/gateway surfaces, not an ordered desktop rail."
-    },
-    "f764b0400ad7": {
-      "disposition": "superseded",
-      "notes": "Deleting the active profile fallback is a desktop profile-switcher/delete-dialog behavior. Rust CLI profile delete already clears the active marker when deleting the active profile and does not maintain an Electron active-profile rail."
-    },
-    "7b4acadfe765": {
-      "disposition": "superseded",
-      "notes": "Per-profile plus-button session creation in the all-profiles desktop view is apps/desktop sidebar UI. Rust gateway sessions are created by incoming platform messages and can now receive per-session profile overlays through `/profile`."
-    },
-    "ffb53767bfff": {
-      "disposition": "ported",
-      "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."
-    },
-    "a61420952e29": {
-      "disposition": "ported",
-      "notes": "Rust now constructs tool-result messages with the originating tool name in Message.name when the ToolCall is known, including invalid-tool and invalid-JSON result paths, persists messages.name through the SQLite session store with legacy DB migration, and regression-tests model-visible plus persisted tool-result name round trips."
-    },
-    "338c07433699": {
-      "disposition": "ported",
-      "notes": "Rust ntfy sends now distinguish explicit tool/router targets from configured publish-topic replies: gateway-backed messaging marks caller recipients explicit, DeliveryTarget routing preserves is_explicit/thread hints for text and file sends, and NtfyAdapter publishes explicit topics directly while retaining configured publish_topic for non-explicit replies."
-    },
-    "ea266f43e9db": {
-      "disposition": "superseded",
-      "notes": "Rust LocalSearchBackend does not shell through rg/grep or parse merged stderr as matches; it compiles regexes with regex::Regex before traversal, skips unreadable/non-UTF8 files without diagnostic payload parsing, and now regression-tests invalid-regex errors plus partial read failures preserving content/files_only/count matches."
-    },
-    "ec46f5912e30": {
-      "disposition": "ported",
-      "notes": "Rust Gemini direct-provider setup and runtime defaults now use Google AI Studio's OpenAI-compatible /v1beta/openai endpoint, normalize manually supplied native Gemini base URLs to that endpoint, and defensively strip OpenAI-only extra_body/profile fields from native-Gemini request bodies while preserving thinking_config/thinkingConfig. The upstream native maxOutputTokens default is superseded by Rust's OpenAI-compatible max_tokens path."
-    },
-    "b459bac02c98": {
-      "disposition": "ported",
-      "notes": "Rust repo update/autostash safety now ignores the Desktop bootstrap marker .hermes-bootstrap-complete in the root .gitignore, with a hermes-cli regression test guarding that gitignore contract so bootstrap runtime state is not swept into update stashes."
-    },
-    "72eb42d9ecdf": {
-      "disposition": "superseded",
-      "notes": "The upstream Python source-checkout updater's stash/restore versus discard mode is superseded in Rust because top-level hermes update is non-mutating release-check behavior and does not run git checkout/pull/reset/clean against the source tree. The remaining shared safety contract, ignoring .hermes-bootstrap-complete so autostash paths do not capture Desktop bootstrap state, is ported separately under b459bac02c98."
-    },
-    "9ecc331be847": {
-      "disposition": "ported",
-      "notes": "Rust resume now falls back from missing exact snapshot stems to session-id search over saved session snapshots, matching exact, prefix, and substring IDs case-insensitively across both file stems and session_info.session_id, with deterministic exact-before-prefix-before-substring ranking and focused CLI tests."
-    },
-    "580d9240979c": {
-      "disposition": "superseded",
-      "notes": "The upstream SQL-bounded desktop SessionDB optimization is superseded for Rust because the relevant runtime surface is file-backed resume snapshots rather than the Python desktop session-search endpoint. The Rust port avoids message-body scans, searches only snapshot stems plus session_info.session_id metadata, and preserves deterministic bounded result selection for resume."
-    },
-    "c54b93587313": {
-      "disposition": "ported",
-      "notes": "Rust gateway /title now persists user-visible Session.title metadata in SessionManager, exposes bare /title, /status and /sessions title surfaces, emits a session:title hook, and copies title metadata when switching sessions; regression tests cover command parsing, session metadata, and gateway routing."
-    },
-    "02d6bf1c39df": {
-      "disposition": "ported",
-      "notes": "Rust ACP sessions now carry profile/home ownership through session/new, session/load, session/resume, session/fork, session/list, and prompt executor snapshots. The upstream desktop Electron routing pieces are not present in this Rust-only repo; the runtime-equivalent profile-scoped session lifecycle is covered by hermes-acp tests."
-    },
-    "6f6eb871d834": {
-      "disposition": "ported",
-      "notes": "Rust ACP session/new now accepts profile/home metadata and preserves it on the SessionState handed to prompt executors, so new chats can remain attached to their owning profile in the Rust runtime surface. Regression coverage asserts create, prompt, list, and fork profile ownership."
-    },
-    "83c13862f107": {
-      "disposition": "superseded",
-      "notes": "Upstream change is Electron desktop remote-profile read routing only (apps/desktop/electron/main.cjs). This Rust repo has no desktop Electron backend-routing layer; profile ownership is represented in Rust ACP/gateway session metadata instead."
-    },
-    "3e4fa8ca9ca3": {
-      "disposition": "superseded",
-      "notes": "Desktop profile-rail drag-axis polish touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
-    },
-    "9915665e4c51": {
-      "disposition": "superseded",
-      "notes": "Desktop profile-rail cell drag/clamp behavior touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
-    },
-    "fb18bde89740": {
-      "disposition": "superseded",
-      "notes": "Desktop profile-rail haptic reordering touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
-    },
-    "76b98f43ca0a": {
-      "disposition": "superseded",
-      "notes": "Desktop ALL-profiles grouping gate touches only apps/desktop sidebar UI, which is absent from this Rust-only runtime repo."
-    },
-    "0c7def31aa86": {
-      "disposition": "superseded",
-      "notes": "Desktop single-profile rail plus-button behavior touches only apps/desktop sidebar UI, which is absent from this Rust-only runtime repo."
-    },
-    "cf9dc366dd0b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop cross-profile read-only icon/action cleanup is tied to apps/desktop and Python web_server/session DB surfaces. Rust runtime profile ownership is handled through ACP/gateway session metadata, not desktop per-session icon routing."
-    },
-    "86371e6cd8d5": {
-      "disposition": "superseded",
-      "notes": "Desktop profile-swap overlay border/radius styling touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
-    },
-    "1b01fa3acf15": {
-      "disposition": "superseded",
-      "notes": "Desktop long-press profile color picker touches only apps/desktop React UI/storage, which is absent from this Rust-only runtime repo."
-    },
-    "cdfbd89ea539": {
-      "disposition": "ported",
-      "notes": "Rust gateway /title now persists Session.title metadata directly, bare /title reads current title, /status and /sessions expose it, and gateway tests cover the title command lifecycle. No Python TUI session.title RPC is used in the Rust runtime."
-    },
-    "9350e26e681e": {
-      "disposition": "ported",
-      "notes": "Rust exposes the clarify tool as a typed ClarifyHandler with signal, stdio, and gateway channel backends, registers it in built-in/toolset/runtime wiring, and covers schema, trimming, choice normalization, empty-question rejection, stdio auto-answer, and gateway dispatcher roundtrip/timeout behavior."
-    },
-    "c36b256de56a": {
-      "disposition": "ported",
-      "notes": "Rust provides Home Assistant REST tools and backend handlers for entity listing, state lookup, service listing, and service calls, registers the homeassistant toolset and platform aliases, and includes a Home Assistant gateway adapter. Focused tests cover schemas, handler contracts, backend validation, and platform contract startup/routing."
-    },
-    "8e0c48e6d25b": {
-      "disposition": "ported",
-      "notes": "Rust CLI and gateway now resolve otherwise-unknown installed SKILL.md slash commands from configured skill roots, apply enabled/disabled/platform/security filtering, inject full skill content plus invocation args into the normal agent turn, and cover the shared resolver plus CLI and gateway routing with focused tests."
-    },
-    "7966560fb50f": {
-      "disposition": "ported",
-      "notes": "Rust now exposes first-class /reload-skills and /reload_skills in CLI and gateway. The command snapshots installed SKILL.md slash commands through the shared Rust resolver, reports available/blocked/skipped commands, queues an agent-visible next-turn note, and deliberately avoids prompt-cache invalidation. The upstream skills_reload agent tool portion is superseded by the later upstream refactor and not mirrored."
-    },
-    "dd2d1ba5e61c": {
-      "disposition": "ported",
-      "notes": "Rust /reload-skills follows the final upstream behavior: it queues a one-shot system note for the next agent turn, confirms dynamic SKILL.md slash commands are scanned live, and does not delete prompt caches or expose a skills_reload agent tool. CLI and gateway tests cover command routing, snapshot rendering, and one-shot gateway note injection."
-    },
-    "3c252ae44b52": {
-      "disposition": "ported",
-      "notes": "Rust hermes-mcp provides MCP client support through McpClient and McpManager, stdio and HTTP/SSE transports, OAuth/bearer auth, tools/list, tools/call, resources, prompts, stale transport reconnect, and media caching. CLI mcp add/list/remove/test/configure/login/serve wiring and focused hermes-mcp/hermes-cli tests cover the core client surface."
-    },
-    "60effcfc4427": {
-      "disposition": "ported",
-      "notes": "Rust now mirrors the upstream MCP discovery hardening with McpManager::connect_all_parallel for concurrent per-server discovery reports, user-visible CLI config warnings when url and command conflict, URL/transport validation for mcp list/test/configure/login, and regression tests for conflict detection, invalid configs, and failed-server parallel discovery."
-    },
-    "63f5e14c6993": {
-      "disposition": "mirrored",
-      "notes": "Rust repo now includes docs/mcp.md with client configuration, config validation rules, parallel discovery behavior, mcp serve setup, and Sentrux MCP profile examples, plus a README link near the MCP quick commands."
-    },
-    "6716e66e89fc": {
-      "disposition": "ported",
-      "notes": "Rust hermes mcp serve is implemented in crates/hermes-mcp/src/serve.rs and exposed by hermes-cli handle_cli_mcp serve. Tests cover serve tool definitions, session/resource/event/approval tools, numeric coercion, stringified object arguments, and systems MCP conformance; docs/mcp.md documents the server mode."
-    },
-    "654e16187e71": {
-      "disposition": "ported",
-      "notes": "Rust MCP sampling now handles server-initiated sampling/createMessage inside the client transport receive loop, replies with JSON-RPC results or mapped errors, supports per-client and per-server-config SamplingConfig, LlmCallback wiring, model allowlists, max token caps, max RPM rate limits, timeout errors, tool-use responses with max_tool_rounds governance, and SamplingMetrics audit counters. Focused hermes-mcp tests cover direct sampling governance, config inheritance, tool-loop enforcement, and interleaved transport-loop sampling replies."
-    },
-    "3824b0323793": {
-      "disposition": "superseded",
-      "notes": "Python TUI session.title DB/RPC edge cases are superseded by Rust gateway in-memory Session.title storage and command tests; there is no pending DB row queue or Python RPC failure mode in this runtime path."
-    },
-    "492c4c6573b4": {
-      "disposition": "superseded",
-      "notes": "Python TUI pending-title flush/no-op DB lookup edge cases are superseded by Rust gateway Session.title mutation on the active in-memory session, with hook/status/session-list regression coverage."
-    },
-    "3aa86717b60c": {
-      "disposition": "superseded",
-      "notes": "Python TUI pending-title retry and title validation error mapping are superseded by Rust gateway title parsing/storage; invalid empty titles fall through to bare /title read and no DB retry path exists."
-    },
-    "27936ee02dfc": {
-      "disposition": "superseded",
-      "notes": "Python TUI queued-title retry over auto-title DB state is superseded by Rust gateway user title storage on Session.title, which is not delayed behind DB materialization."
-    },
-    "aa948832886a": {
-      "disposition": "ported",
-      "notes": "Rust MCP tools/call now applies schema-aware string argument coercion before dispatch: nullable object/array/type-union fields convert literal \"null\" to JSON null only when the inputSchema permits null, while integer, boolean, object, and array string values are coerced according to the exposed schema. Both generic McpServer and hermes mcp serve paths have focused runtime regression coverage."
-    },
-    "cda64a59612f": {
-      "disposition": "ported",
-      "notes": "Rust ToolsetManager now resolves otherwise-unknown live registry-owned toolsets, including MCP-style dynamic toolsets, through ToolRegistry instead of requiring static toolset registration. Wildcard/list discovery includes live registry toolsets and focused hermes-tools tests cover filtered and unfiltered resolution."
-    },
-    "c10fea8d264e": {
-      "disposition": "ported",
-      "notes": "Rust ToolRegistry now supports explicit live toolset aliases such as server-name to mcp-server-name mappings, exposes alias targets for inspection, removes aliases only when the target toolset loses its last tool, and platform toolset filtering resolves configured MCP server aliases with hermes-tools and hermes-cli regression coverage."
-    },
-    "9b2fb1cc2e95": {
-      "disposition": "ported",
-      "notes": "Rust ACP now parses client-provided mcpServers/mcp_servers during session new/load/resume/fork, converts stdio and HTTP/SSE configs into hermes_mcp configs, preserves stdio env and bearer Authorization headers, registers reachable MCP servers through McpManager, and exposes discovered MCP tools as real callable ToolRegistry tools with provider-safe names and focused hermes-mcp/hermes-acp coverage."
-    },
-    "dfc5563641f0": {
-      "disposition": "ported",
-      "notes": "Rust ACP sessions now include client-provided MCP server toolsets through live ToolRegistry mcp-{server} toolsets and explicit aliases, so tools.list, /tools, initialize tool names, ToolsetManager resolution, and registered MCP dispatch all see the session MCP surface. Focused tests cover toolset expansion and ACP MCP tool visibility."
-    },
-    "93d6e730288e": {
-      "disposition": "ported",
-      "notes": "Rust now exposes late-registered MCP tools to active agents by refreshing the CLI App agent snapshot from the live ToolRegistry, rebuilding planner schemas, and merging live mcp-* toolsets into default platform tool planning while preserving explicit custom platform filters. Tests cover added tools, equal-size replacements, /reload-mcp command refresh, default/custom MCP planning, and the McpManager discovery-to-registry contract."
-    },
-    "2f7c4858a764": {
-      "disposition": "ported",
-      "notes": "Rust /reload-mcp now performs the stale-snapshot refresh that upstream added for late TUI MCP discovery: it re-bridges the active AgentLoop registry from the live ToolRegistry, reports added/removed tools, refreshes model-visible schemas, and keeps connector renegotiation explicitly restart-bound. Focused CLI tests cover late-added MCP tools and same-count replacement visibility."
-    },
-    "f81395975025": {
-      "disposition": "superseded",
-      "notes": "Upstream simple-terminal registration is superseded by Rust TerminalHandler and LocalBackend command execution, explicit background=true lifecycle tracking, timeout/workdir/schema contracts, and process-management tests without the Python Morph VM dependency."
-    },
-    "ab7293bed652": {
-      "disposition": "ported",
-      "notes": "Rust TerminalHandler now has regression coverage proving a nonzero terminal exit code returns normal model-visible command output with [exit code: N] instead of surfacing as ToolError/agent tool failure."
-    },
-    "ba19d530ad24": {
-      "disposition": "superseded",
-      "notes": "Python mini-swe/hecate terminal backend integration is superseded by Rust-native terminal and process backends: command execution, background lifecycle, stdin/PTY/workdir, schema registration, and local runtime contracts are implemented without Python terminal_tool dispatch."
-    },
-    "771cf41fea1f": {
-      "disposition": "superseded",
-      "notes": "Upstream Singularity/run-script terminal environment tuning is not a separate Rust runtime surface; Rust terminal execution already exposes explicit timeout, workdir, background, PTY, stdin, and process-polling contracts through typed handlers and tests."
-    },
-    "bbeed5b5d12d": {
-      "disposition": "superseded",
-      "notes": "Upstream session logging and interactive sudo support is superseded by Rust session-aware terminal/process logging, task cwd mapping, background log reads, SUDO_PASSWORD sudo transformation, approval manager, and gateway/terminal regression coverage."
-    },
-    "5d3398aa8a20": {
-      "disposition": "superseded",
-      "notes": "Upstream terminal approval and CLI feedback refactor is superseded by Rust ApprovalManager plus session-scoped YOLO/approval state, hardline and sudo floors, gateway approval lifecycle, and terminal handler denial/bypass tests."
-    },
-    "bf4223f3818f": {
-      "disposition": "superseded",
-      "notes": "Early Python scrape/crawl compression is superseded by Rust web_extract/web_crawl typed handlers, provider-specific normalized document output, URL secret-exfiltration guards, web content redaction, and tool-result storage/budget controls."
-    },
-    "cde7e64418e0": {
-      "disposition": "ported",
-      "notes": "Rust has first-class web_search/web_extract/web_crawl, vision_analyze, and filtered toolset resolution. This batch adds web_crawl to the web toolset and platform filtering tests, while existing vision tests cover schema, execution, URL safety, local image base64, and response normalization."
-    },
-    "ebb46ba0e6a7": {
-      "disposition": "ported",
-      "notes": "Rust exposes image_generate as a first-class tool with schema/handler coverage and FalImageGenBackend direct/managed transport tests for payload shape, auth routing, model override, and unconfigured errors."
-    },
-    "e1710378b738": {
-      "disposition": "ported",
-      "notes": "Rust builtin registration and toolset resolution now expose image_generate, mixture_of_agents, and the complete web tool trio through typed registries instead of Python model_tools dispatch."
-    },
-    "58d5fa1e4cec": {
-      "disposition": "superseded",
-      "notes": "Python FAL dependency wiring is superseded by Rust reqwest-based FalImageGenBackend with direct FAL_KEY and Nous-managed fal-queue transports plus hermetic backend tests; no Python requirement path remains."
-    },
-    "4ece87efb0dd": {
-      "disposition": "ported",
-      "notes": "Rust Firecrawl support covers search and extract through direct, self-hosted URL, and Nous-managed gateway transports, with response normalization and backend-selection tests for Firecrawl-specific shapes."
-    },
-    "587d1cf72095": {
-      "disposition": "superseded",
-      "notes": "The mixed Python web/MoA/trajectory update is superseded by Rust web provider backends, first-class mixture_of_agents runtime/tests, and Rust session/tool-result persistence. Python trajectory file management is not a separate Rust runtime boundary."
-    },
-    "17608c11422b": {
-      "disposition": "ported",
-      "notes": "Rust ToolsetManager already supports named, recursive, filtered, alias, wildcard, and platform toolsets; this batch ports the upstream web-tools membership by ensuring web_crawl resolves with web_search/web_extract through web and platform defaults."
-    },
-    "8d256779d8fa": {
-      "disposition": "ported",
-      "notes": "Rust OpenAiVisionBackend handles local image files by MIME-sniffing extensions and base64-encoding data URLs, validates remote image URLs against unsafe hosts/schemes, and normalizes empty vision responses with focused tests."
-    },
-    "f957ec226789": {
-      "disposition": "ported",
-      "notes": "Rust toolset_distributions now covers validated probability-weighted distributions against registered ToolsetManager toolsets, including the first-class rl_training toolset added in this batch, with deterministic and sampling contract tests."
-    },
-    "f018999da978": {
-      "disposition": "ported",
-      "notes": "Initial Python RL training tools and loop are ported as Rust rl_* ToolHandler implementations backed by hermes_intelligence::rl run/config/status/metrics types, registered as built-in tools under the rl_training toolset with lifecycle and inference tests."
-    },
-    "f6574978de39": {
-      "disposition": "ported",
-      "notes": "RL training configuration and tools are now first-class Rust runtime surface: rl_list_environments, rl_select_environment, rl_get_current_config, rl_edit_config, rl_start_training, rl_check_status, rl_stop_training, rl_get_results, rl_list_runs, and rl_test_inference are registered and covered."
-    },
-    "12bbca95ecf4": {
-      "disposition": "superseded",
-      "notes": "The vendored tinker-atropos Python submodule path is superseded by Rust-native RL environment descriptors for tinker, atropos-compatible, and custom environments plus local run-manager control; no Python submodule is required for runtime registration."
-    },
-    "3c0d0dba49f9": {
+    "00e683020443": {
       "disposition": "ported",
-      "notes": "Updated RL tools and configuration management are covered by Rust TrainingConfig editing, TrainingStatus serde, TrainingMetrics progression, RunManager lifecycle, registered rl_training toolset membership, and focused hermes-intelligence/hermes-tools tests."
-    },
-    "51c68d4ab1a9": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "3ef97a61b9f1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "77bb64813cb9": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "fa4ebaa8b58b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "79f7e7a1e9d8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "0bc616ecf9f1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "7fbe9b79ab1d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "359f2be12e6c": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "85b65e29f09b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "134643a2fa80": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "a2b8e430e851": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5e55b35cc8fb": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "de8bdf529d64": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "135c65093a0a": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5b71f7dd7249": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "423923095781": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "23c0578bd75d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "0c29cfd1a614": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "31c40c72c03c": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ac76bbe21f8a": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "dd5e97bd7fe0": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "3be9fb73173e": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "d963ad56c19e": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ea4fe1563119": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "746618217950": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "115671ae6b2c": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "1daecfa4b0cb": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "46e513ef5185": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "21e172b94ae8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "d704df2d6e47": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "afec339e967f": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "b6945ce772b3": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e67ab2e042d3": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9bdf01852ac1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "06aa140fa195": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e5472da58470": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "84eb5f1f891b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e618cbee4418": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "55a76ec6695d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e0a999aa8a22": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "6a2909fe5a07": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "d0ea4caf7fc3": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "188e52db9180": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "a23728dfcc50": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "28f1590b7acd": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "c77c470d2762": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "49f1b9e4b44f": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5fca754ee335": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "f45d7dee7d25": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "3aa24e261936": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "c930a49ce9b7": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "1dca7c6207f0": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "a1cda2410b30": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "c711146ad4cd": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "93228d529996": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "1b89715e153f": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "0caa23788f60": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5c0a1fec0c14": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "1927ff217e6b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "7ea37cd08236": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "8a19884bf399": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5a22cd427dd6": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "f66a929a6b78": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "58eb473baa81": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "35a750eedd7b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "712bf4d8e429": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "8c0f15478de9": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "1e1ab31ad6c8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "fb0250ef63c8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "d6e2c940e9d1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "0776d1b19cb3": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "75adf7d603b1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "2b762c53640f": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "f15d2cb5e424": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "41ede963041f": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "947f305f84c5": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "75e29f97ee39": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e68fc4def2ba": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "40420a619b58": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ac9de2e80c01": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "311e80809f50": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ded620b7114d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "88bdb6b07451": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "fd88d527af37": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e026fd88cdbb": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "fd68ae63315a": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9e02b18828a2": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "aecdc75bb001": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "3a5e36cfa50a": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5bb7156949f4": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "38acced6873d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "bc9e33d66b12": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "86643d84e99e": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9cbc37e25b64": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9d07927a23ee": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "bf590c81d0bc": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "385a508e43cb": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+      "notes": "Rust Honcho host-level identity mapping config overrides root mappings cleanly, including aiPeer and user peer alias inheritance behavior."
     },
-    "bd12b3c2321b": {
+    "0138282f97c9": {
       "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+      "notes": "Upstream oversized-message freeze fix targets synchronous React/Streamdown/Shiki desktop rendering. Ultra lacks that renderer; Rust terminal/tool-result truncation and TUI viewport behavior are the applicable runtime surfaces.",
+      "owner": "rust-runtime"
     },
-    "928f1ac0e187": {
+    "016bce1a09ba": {
       "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+      "notes": "Stranded routed session-window recovery is apps/desktop route/resume hook behavior. Ultra sessions are Rust CLI/TUI/gateway sessions, not Electron pop-out windows.",
+      "owner": "rust-runtime"
     },
     "0175be3aa76c": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "b1b0f4b66854": {
+    "020ef76cf16b": {
       "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "b6206020d383": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e003c53b06d8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "f583c6ebd5bd": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "6feb40e70282": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "acce1a2452f8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "1eeb7da2e6e5": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "d29caf382868": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "cfbc47d8937c": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "48d8d80771e2": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "dfd6bcf1ff9c": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "a40e20e1368d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "2c98dc0a9613": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9dbd3c57d700": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ea44011d152e": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9cc47b20cb3f": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "10c78bf625ff": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "500cf537b7d0": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "bcb024ad48bc": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ab706a3346d0": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "439f53cab8e0": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ca8c78e588b7": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ca1fb32c2619": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "3045d54547f7": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "b8234e75996e": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "be2c64be0275": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "8e629b9f386d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "da9425bf9b08": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "aa52cd3b574e": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "7cceead27373": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5d4c93afe476": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e8c837c921e0": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "5e2b83a8ada8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "258984fcb906": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+      "notes": "Upstream cancels discord.py _bot_task zombies after connect timeout. Hermes Agent Ultra's Rust Discord adapter has no discord.py background Bot.start task; start/stop only mark BasePlatformAdapter state and REST sends use reqwest, so the orphaned asyncio client failure mode is absent."
     },
     "021ea2a21b18": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "182092c5fdd5": {
+    "021ed6914162": {
+      "disposition": "ported",
+      "notes": "The final upstream Automation Blueprints terminology cleanup is ported on the local website surface: guides/automation-blueprints replaces the stale automation-templates slug, the sidebar points at the new slug, and the Rust runtime/catalog already use Automation Blueprints naming. Upstream Python docstring/web-server wording is non-runtime for Hermes Agent Ultra's Rust-only implementation."
+    },
+    "02aad08acf46": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "74c8f51e95e4": {
+    "02ab255a0d52": {
+      "disposition": "ported",
+      "notes": "Rust Honcho validates baseUrl schemes, strips trailing /vN API suffixes, keeps schemeless hosts as HTTPS, and rejects unsupported URL schemes."
+    },
+    "02d6bf1c39df": {
+      "disposition": "ported",
+      "notes": "Rust ACP sessions now carry profile/home ownership through session/new, session/load, session/resume, session/fork, session/list, and prompt executor snapshots. The upstream desktop Electron routing pieces are not present in this Rust-only repo; the runtime-equivalent profile-scoped session lifecycle is covered by hermes-acp tests."
+    },
+    "0325e18f3426": {
+      "disposition": "ported",
+      "notes": "Rust Telegram status updates already use send_or_update_status with edit-in-place fallback, and gateway tool progress remains quiet for Telegram by default while /verbose can explicitly raise it. Progress/status docs now describe the Rust-native behavior instead of Python heartbeat binding state."
+    },
+    "039fbb41fc2d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "03d9a95a74b2": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: Hindsight is a first-class bundled memory provider discovered by memory_plugins::discover_available_providers, with config, recall, turn buffering, and owner-only config tests passing.",
+      "owner": "rust-runtime"
+    },
+    "0428945b5b07": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop bootstrap profile-home behavior is superseded by Rust hermes-config home/profile resolution and installer setup; Electron bootstrap is not shipped.",
+      "owner": "rust-runtime"
+    },
+    "043a118d4128": {
+      "disposition": "superseded",
+      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
+    },
+    "0441b7f19feb": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop remote-profile REST routing is superseded by Rust gateway/profile/auth surfaces; Electron connection-config and Python web_server endpoints are not the primary runtime.",
+      "owner": "rust-runtime"
+    },
+    "04730f32e7e8": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: model switches estimate current transcript tokens with shared hermes-intelligence model metadata and append deterministic preflight-compression warnings when the new model threshold would be exceeded. Coverage spans gateway replies, CLI slash-command output, and TUI picker UI-only notices without polluting model context.",
+      "owner": "rust-runtime"
+    },
+    "04b3f195380f": {
+      "disposition": "superseded",
+      "notes": "Upstream session archive propagation targets Python hermes_state.py archived rows plus Electron sidebar archive UI. Hermes Agent Ultra has no Rust session-archive column or setSessionArchived surface; the Rust session_search backend already projects compression roots to their continuation tip, and CLI session deletion operates on saved JSON snapshots rather than soft-archiving SQLite rows."
+    },
+    "04cf4788ccc0": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "0565497dcc2f": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight drains buffered auto-retain turns through the same retain path during session end and shutdown, with pending-turn state reset after the drain."
+    },
+    "058c50816c70": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "0595af0ad19b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "05b9c84ca4b1": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: crates/hermes-gateway/src/platforms/telegram.rs now supports opt-in Bot API 10.1 sendRichMessage with raw rich_message.markdown payloads, legacy fallback, link_preview_options, and feature-gated tests telegram_rich_message_uses_bot_api_10_1_payload_shape / telegram_rich_message_bad_request_falls_back_to_legacy_send.",
+      "owner": "rust-runtime"
+    },
+    "061a18300837": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "061fa7090720": {
+      "disposition": "ported",
+      "notes": "rust terminal/process/process_registry surface implements background=true, process list/poll/log/wait/kill/write/submit/close, PTY, stdin_data, and registry exposure; new core runtime schema contract plus terminal/process tests cover it"
+    },
+    "06aa140fa195": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
@@ -2402,87 +124,476 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "e9b8dd236c79": {
+    "0776d1b19cb3": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "628f9040df43": {
+    "07bbd9333708": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "0858ee2f2701": {
+      "disposition": "ported",
+      "notes": "Rust OpenAI audio key resolution now consistently uses VOICE_TOOLS_OPENAI_KEY first for transcription and gateway voice STT/TTS, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY; focused tests cover precedence and schema/error visibility."
+    },
+    "08b1c44a5330": {
+      "disposition": "superseded",
+      "notes": "Upstream extends discord.py _bot_task cancellation to generic connect exceptions. The Rust Discord adapter has no Python asyncio bot task to cancel and no discord.py reconnect loop; failed sends surface as typed GatewayError values."
+    },
+    "08d89e7aba14": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "09a6a2ddd71d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "3e2d758816b7": {
+    "09bcf5a9370e": {
+      "disposition": "superseded",
+      "notes": "Upstream tool-row copy affordance is desktop React assistant-ui layout. Hermes Agent Ultra has no Electron tool fallback row; terminal/TUI copy behavior is handled by local TUI/terminal clipboard surfaces."
+    },
+    "09d66037f8f7": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight append retains send only the pending-turn delta and use the stable session document only when the API advertises append support."
+    },
+    "0a2ee71cccbf": {
+      "disposition": "ported",
+      "notes": "Darwinian-evolver show_snapshot.py was adopted from upstream and requires the explicit --i-trust-this-file gate before pickle.loads executes."
+    },
+    "0a5762c78d11": {
+      "disposition": "superseded",
+      "notes": "Upstream later removed the keyless Parallel MCP search path in f3fe99863d13, so the MCP client identity policy is no longer part of the active Rust runtime surface."
+    },
+    "0a593f132c41": {
+      "disposition": "ported",
+      "notes": "GitHub skills now resolve shared .env through HERMES_HOME with project fallback instead of hardcoded ~/.hermes."
+    },
+    "0a5ee01e487a": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight session-switch flushing routes through retain_hindsight_turns and the same document/update-mode targeting helper used by normal auto-retain batches."
+    },
+    "0a865e5948cb": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "0a963d8c9a07": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon telemetry toggling changes the Python plugin CLI and Node sidecar. Hermes Agent Ultra has no Rust Photon gateway adapter, and Python/Node plugin runtime changes remain reference-only under the Rust-only runtime policy."
+    },
+    "0b54a33a3467": {
+      "disposition": "ported",
+      "notes": "Ported by Rust-native telemetry shape: agent loop emits request/turn scoped tracing spans for LLM/tool events and Langfuse uses OTLP config without a Python process-global _TRACE_STATE map; Langfuse tests pass.",
+      "owner": "rust-runtime"
+    },
+    "0b9526b4761bbabc98ca48f5c0a3f2dfda765314": {
+      "disposition": "ported",
+      "notes": "Rust ACP session/set_model now has handler-level regression coverage proving model switches preserve existing provider/base_url/api_mode route metadata through the public SessionManager update_session_meta path instead of recreating or clearing provider state."
+    },
+    "0ba6471dd191": {
+      "disposition": "superseded",
+      "notes": "The embedded Hindsight idle-daemon recovery path is superseded by the Rust-only local_external/cloud HTTP modes; no embedded Python daemon is launched."
+    },
+    "0bc616ecf9f1": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "abbf05024131": {
+    "0c0a70774424": {
+      "disposition": "superseded",
+      "notes": "macOS updater-helper repair is confined to upstream apps/bootstrap-installer Tauri paths and Electron main process code. Hermes Agent Ultra's Rust update surface is the CLI release-check path, not an embedded Electron/Tauri helper."
+    },
+    "0c29cfd1a614": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "146e77684b71": {
+    "0c7def31aa86": {
+      "disposition": "superseded",
+      "notes": "Desktop single-profile rail plus-button behavior touches only apps/desktop sidebar UI, which is absent from this Rust-only runtime repo."
+    },
+    "0caa23788f60": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "471a5fc5c93e": {
+    "0cbcc7593562": {
+      "disposition": "superseded",
+      "notes": "Desktop composer-message queue robustness is superseded by Rust gateway BusySessionCoordinator and CLI background queue handling: busy messages queue without interrupt, accepted steers skip the queue, rejected steers fall back to queue, reset/finish clear state deterministically, and slash/background queue tests cover user-visible status."
+    },
+    "0cd7d54b0010": {
+      "disposition": "ported",
+      "notes": "Rust Kanban tasks now carry goal_mode and goal_max_turns, CLI add parses --goal/--goal-max-turns, dispatch worker context emits goal-loop instructions, and a callback-injected Rust goal loop covers continue, completion, finalize, and budget-block behavior."
+    },
+    "0cd98499bb1e": {
+      "disposition": "ported",
+      "notes": "Debugging Hermes TUI commands is bundled locally at skills/software-development/debugging-hermes-tui-commands/SKILL.md and participates in the Rust SKILL.md loader."
+    },
+    "0d1cbc2dda28": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "0d3e2cc53952": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop sidebar dedupe by compression lineage targets React mergeSessionPage. Hermes Agent Ultra has no React desktop sidebar store; Rust session_search already resolves logical compression roots to the visible continuation tip through logical_session_key_for_row and visible_session_id_for_row, with search_session_id_resolves_compression_root_to_tip coverage."
+    },
+    "0dc677f0718b": {
+      "disposition": "ported",
+      "notes": "Hermes-agent durable systems and slash-command guidance is represented in skills/autonomous-ai-agents/hermes-agent/SKILL.md under the local Rust skill catalog."
+    },
+    "0e0ddaac8fa0": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "0e2e69a71dda": {
+      "disposition": "ported",
+      "notes": "Rust hermes_intelligence::rl now has a deterministic BatchDatasetRunner with JSONL prompt/conversation parsing, max-sample batching, resume checkpoints by prompt index/text, per-batch processed/skipped statistics, toolset distribution metadata, JSONL trajectory serialization, and tests for checkpoint resume plus ephemeral prompt non-persistence."
+    },
+    "0e81d2fb71c1": {
+      "disposition": "superseded",
+      "notes": "Desktop per-model effort preset UI targets absent apps/desktop files. Ultra owns model/provider controls through the Rust TUI model picker and CLI config surfaces."
+    },
+    "0ea234e0932f": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "0edeee14c6ce": {
+      "disposition": "superseded",
+      "notes": "Upstream adds Electron-only helper tests for official SSH remote detection. Hermes Agent Ultra has no Electron desktop update helper; the Rust update surface is the HTTPS GitHub release checker in crates/hermes-cli/src/update.rs, so the SSH-origin detection branch is not part of the local runtime."
+    },
+    "0f45509daf72": {
+      "disposition": "ported",
+      "notes": "Rust agent loop now treats formatted /steer redirects as trusted mid-turn out-of-band user messages appended to the last tool result, adds the shared steer channel system-prompt note when tools are available, and wires ACP active-session steer through the shared marker with regression tests preventing the old User guidance label."
+    },
+    "0f597dd12796": {
+      "disposition": "ported",
+      "notes": "Rust STT provider/model normalization prevents OpenAI whisper-1 from being sent to Groq or Mistral/Voxtral and prevents Groq/Voxtral models from leaking to OpenAI; tool and gateway tests cover mismatch normalization."
+    },
+    "0f6eabb89073": {
+      "disposition": "superseded",
+      "notes": "Dedicated website pages for bundled/optional skills are superseded by rust-skills-catalog-governance: the Rust CLI, skill hub, and docs/parity surfaces expose catalog state without mirroring upstream website generation."
+    },
+    "0f75e9904a8f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "0fa7d6f6609c": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: named custom providers are preserved through llm_providers, provider catalog/model guard paths, and app-runtime config mapping; tests cover named custom runtime provider behavior.",
+      "owner": "rust-runtime"
+    },
+    "0fd34e8c5a7a": {
+      "disposition": "superseded",
+      "notes": "Upstream Teams attachment classification fixes the Python Teams gateway adapter. Hermes Agent Ultra does not register a Rust Teams chat gateway adapter; its Teams code is the Rust-native meeting pipeline, while document/image/video/audio caching is already implemented for supported Rust gateway adapters."
+    },
+    "10b4cfeace24": {
+      "disposition": "ported",
+      "notes": "Rust TerminalHandler already surfaces backend CommandOutput.stdout as the user-visible tool return string through format_command_output, including nonzero exit handling. This batch adds an explicit regression test proving backend stdout is returned without relying on a legacy output/stdout compatibility shim."
+    },
+    "10c78bf625ff": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "ccaa5165a006": {
+    "10cd4138cc66": {
+      "disposition": "ported",
+      "notes": "Grok optional skill was adopted from upstream at optional-skills/autonomous-ai-agents/grok/SKILL.md."
+    },
+    "112a0732c6a7": {
+      "disposition": "superseded",
+      "notes": "This upstream row only fills apps/desktop Japanese and Traditional Chinese translation files. There is no Rust runtime catalog file or desktop translation asset in this repo."
+    },
+    "115671ae6b2c": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "de0469e02b14": {
+    "11e6dd3c606e": {
       "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
     },
-    "b2bd31c724c1": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "f033b7dbfbe8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "f993d76874e8": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "66adeef11a71": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    "122d8788ae23": {
+      "disposition": "ported",
+      "notes": "rust terminal handler provides first-class terminal command execution through TerminalHandler, TOOLSET_TERMINAL, and builtin registry coverage; upstream_core_tool_contracts verifies command/timeout/background/pty/stdin_data schema surface"
     },
     "1238d08e0c90": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "d165933c560c": {
+    "12682d96b9c8": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram config: rich_messages deserializes as an explicit opt-in flag with default false, verified by Telegram config tests and rich-message feature tests.",
+      "owner": "rust-runtime"
+    },
+    "127048e6430f": {
+      "disposition": "ported",
+      "notes": "Rust HindsightConfig accepts both apiKey and snake_case api_key from config.json, with regression coverage for the snake_case path."
+    },
+    "12bbca95ecf4": {
+      "disposition": "superseded",
+      "notes": "The vendored tinker-atropos Python submodule path is superseded by Rust-native RL environment descriptors for tinker, atropos-compatible, and custom environments plus local run-manager control; no Python submodule is required for runtime registration."
+    },
+    "13038dc747aa": {
+      "disposition": "ported",
+      "notes": "Google Workspace setup parity is represented by skills/productivity/google-workspace/scripts/setup.py with Python 3.9-compatible syntax and local dependency handling documented in the skill body."
+    },
+    "134643a2fa80": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "135c65093a0a": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "13683c0842f0": {
+      "disposition": "ported",
+      "notes": "Rust MemoryProviderPlugin now has an on_session_switch hook, MemoryManager broadcasts it to enabled providers, and the TUI calls it when sessions rotate or reset while preserving the active AgentConfig session_id."
+    },
+    "1381c89e56fd": {
+      "disposition": "ported",
+      "notes": "Rust topic routing treats Telegram General topic thread_id=1 and threadless messages as the root chat, while every non-General thread gets an independent encoded session key. Python-specific cascade migration and auto-rename guards are superseded because this Rust runtime has no telegram_dm_topic_bindings table and no Telegram topic auto-rename path."
+    },
+    "14275d7baa1a": {
+      "disposition": "ported",
+      "notes": "Rust llm provider config accepts max_output_tokens as an alias for max_tokens, exposes both dotted config set/get spellings, validates positive values, and uses the active provider cap only when HERMES_MAX_TOKENS is unset."
+    },
+    "146e77684b71": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "14fee4f11265": {
+      "disposition": "superseded",
+      "notes": "Windows first-run update handoff retry is an upstream bootstrap-installer Tauri updater behavior. Hermes Agent Ultra has no matching in-app desktop updater; Rust `hermes update` is handled separately by the CLI release-check implementation."
+    },
+    "153060e206cd": {
+      "disposition": "superseded",
+      "notes": "Desktop optimistic base64 thumbnail rendering is React desktop UI only and is outside the Rust CLI/gateway runtime surface."
+    },
+    "1544813bfe56": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust Honcho setup/tests and release secret scan: the Rust setup path does not embed upstream example Telegram UID values and uses operator-supplied peer identity instead.",
+      "owner": "rust-runtime"
+    },
+    "156f4fba923e": {
+      "disposition": "superseded",
+      "notes": "Upstream agent-facing Photon reaction support extends the Python send_message tool and Python adapter. Hermes Agent Ultra's Rust gateway already exposes reaction lifecycle contracts for supported Rust adapters; Photon remains non-Rust reference-only."
+    },
+    "1579a6f4a974": {
+      "disposition": "ported",
+      "notes": "xurl SKILL.md was synced from upstream and now documents Docker HOME credential placement for Hermes tool subprocesses."
+    },
+    "1593ca54066c": {
+      "disposition": "ported",
+      "notes": "Rust ports the Cron Recipes functional surface as Automation Blueprints: hermes-cron::blueprints defines typed slots/defaults/validation/rendering and fills normal CronJob specs, while the Rust CLI/TUI exposes /blueprint and /bp to create jobs through the live CronScheduler. Focused hermes-cron and hermes-cli tests cover catalog fill, quoted values, schedule rendering, typo rejection, and live scheduler creation."
+    },
+    "15be493055eb": {
+      "disposition": "ported",
+      "notes": "Obsidian file workflow coverage is present at skills/note-taking/obsidian/SKILL.md under the local skills catalog."
+    },
+    "15efb410d035": {
+      "disposition": "superseded",
+      "notes": "upstream nixosModules.nix path does not exist in this fork packaging surface; no functional Rust runtime delta"
+    },
+    "162ad3dd1624": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "165b2e481afa": {
+      "disposition": "ported",
+      "notes": "Rust config/runtime now exposes agent.api_max_retries with apiMaxRetries alias, config patch/display support, HERMES_AGENT_API_MAX_RETRIES env override, and build_agent_config propagation into RetryConfig.max_retries with focused hermes-config/hermes-cli regression coverage."
+    },
+    "166d2457b292": {
+      "disposition": "superseded",
+      "notes": "Rust OpenViking avoids the unhealthy-local-autostart class entirely: initialization checks /health and disables the provider for the session when health is not successful.",
+      "owner": "rust-runtime"
+    },
+    "16786f3bb392": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "1699525638ed4feba3fd35f0be5c6d4d2d326a49": {
+      "disposition": "superseded",
+      "notes": "Upstream fixes a Python tui_gateway slash.exec -> command.dispatch fallback for pending-input commands. Ultra's Rust gateway has no split slash.exec/command.dispatch RPC path: slash input is parsed once by crates/hermes-gateway/src/commands.rs into typed GatewayCommandResult variants, and /retry, /undo, /queue, /q, and /steer are consumed directly by crates/hermes-gateway/src/gateway.rs. The fragile client-side fallback failure mode is absent; /goal and /plan are CLI-only Rust commands, not gateway pending-input RPCs.",
+      "owner": "rust-runtime"
+    },
+    "16beab421f05": {
+      "disposition": "superseded",
+      "notes": "The upstream About-panel fix is Electron-only. Rust already centralizes live version text through hermes_core::version::version_label and exposes it via CLI `version`, TUI `/version`, and gateway `/version`, with focused tests guarding the shared label."
+    },
+    "17608c11422b": {
+      "disposition": "ported",
+      "notes": "Rust ToolsetManager already supports named, recursive, filtered, alias, wildcard, and platform toolsets; this batch ports the upstream web-tools membership by ensuring web_crawl resolves with web_search/web_extract through web and platform defaults."
+    },
+    "17687911b7c5": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "1770263cccf7": {
+      "disposition": "superseded",
+      "notes": "Desktop default project directory creation is Electron workspace boot logic. Rust CLI sessions derive cwd/workspace through terminal and context-reference paths."
+    },
+    "17beb55e3c9c3574bce849a75430887dec910423": {
+      "disposition": "superseded",
+      "notes": "Upstream gates Python rich draft previews separately from finals. Ultra has no Telegram sendRichMessageDraft or rich draft-preview runtime surface; rich final send/edit attempts remain controlled by rich_messages.",
+      "owner": "rust-runtime"
+    },
+    "182092c5fdd5": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "183d86b3e04e": {
+      "disposition": "ported",
+      "notes": "Rust provider profile and model-switch code maps reasoning_effort into provider-specific Gemini/OpenRouter reasoning controls, with regression tests for Gemini thinking levels and OpenRouter reasoning objects."
+    },
+    "187951ec6b88": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking local-upload behavior is covered by tests for file URI handling, missing local path rejection, to/parent conflicts, directory zips, and symlink skips."
+    },
+    "188e52db9180": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "18916376f198": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1899c8f507c3": {
+      "disposition": "ported",
+      "notes": "Ported in skills/media/youtube-content: SKILL.md and scripts/fetch_transcript.py already use uv run / uv pip for youtube-transcript-api, matching the upstream helper execution contract.",
+      "owner": "skills"
+    },
+    "18beb69b4996": {
+      "disposition": "superseded",
+      "notes": "The embedded Hindsight async-client close fix is Python-only; Rust Hindsight does not start hindsight-embed and uses bounded reqwest clients for HTTP operations."
+    },
+    "18d61bd06e06": {
+      "disposition": "ported",
+      "notes": "Upstream desktop composer draft persistence is ported into the Rust TUI as state-root backed per-session composer drafts that restore on restart, clear on submit, and stay separate from message persistence."
+    },
+    "1927ff217e6b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "19854c7cd2f00e3d591e72ccbe2e456ad10c4886": {
+      "disposition": "superseded",
+      "notes": "Rust ACP already fences read_file completion content and intentionally flushes load/resume replay before the RPC response for deterministic local clients; server tests cover replay flushing and read_file formatting."
+    },
+    "19c07c40379b": {
+      "disposition": "ported",
+      "notes": "Rust auxiliary client retries unsupported max_tokens responses with max_completion_tokens for newer OpenAI-family custom endpoints, covered by unsupported_max_tokens_retries_with_max_completion_tokens."
+    },
+    "19db9cd0760e05dafcd1ae637db946cdd65322ce": {
+      "disposition": "ported",
+      "notes": "Rust ACP SessionManager now exposes a public lock-protected update_session_meta API with COALESCE-style optional model preservation, merges cwd/provider/api_mode/base_url/config options, routes existing update_cwd/update_model through it, and tests missing-session no-op plus single persist callback behavior."
+    },
+    "1a3cd3d436a1": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1a3e608524a3": {
+      "disposition": "superseded",
+      "notes": "Per-profile remote gateway hosts are apps/desktop Electron connection-config and settings UI only. The Rust runtime has no desktop remote-host registry; gateway profile behavior is handled by session-scoped runtime overlays and explicit home/profile state."
+    },
+    "1a8e67076a0b": {
+      "disposition": "ported",
+      "notes": "Rust Honcho covers pinUserPeer plus aiPeer edge cases in setup/config parsing and peer-resolution tests."
+    },
+    "1ac8deb3caa3": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "1b01fa3acf15": {
+      "disposition": "superseded",
+      "notes": "Desktop long-press profile color picker touches only apps/desktop React UI/storage, which is absent from this Rust-only runtime repo."
+    },
+    "1b16c481708d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop OAuth account-removal UI is superseded by Rust provider/auth config surfaces; Electron onboarding/settings UI is outside the Rust-only shipped runtime.",
+      "owner": "rust-runtime"
+    },
+    "1b89715e153f": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "1b962f001e78": {
+      "disposition": "ported",
+      "notes": "Rust model picker already passes configured llm_providers.<provider>.base_url into fetch_openai_compatible_live_models before fallback; this slice adds a regression for the resolved base URL /models request builder.",
+      "owner": "rust-runtime"
+    },
+    "1bba5f27ab0c": {
+      "disposition": "ported",
+      "notes": "Antigravity CLI operator skill was adopted from upstream at optional-skills/autonomous-ai-agents/antigravity-cli with reference docs."
+    },
+    "1bcc87a1535cd4c17dc2bfe45fd198863404e892": {
+      "disposition": "ported",
+      "notes": "Rust ACP initialize advertises loadSession and sessionCapabilities.resume in the wire-format agentCapabilities object; handler tests assert the ACP aliases so editor clients can discover load/resume support."
     },
     "1c0437dfc5bb": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "5b43bf7d023c": {
+    "1c2189839d0b": {
+      "disposition": "superseded",
+      "notes": "CamelCase settings i18n keys are a desktop TypeScript catalog/runtime-test refactor. No Rust settings parser or gateway command consumes those apps/desktop i18n keys."
+    },
+    "1c909e75e1a0": {
+      "disposition": "ported",
+      "notes": "Rust build_agent_config now honors HERMES_MAX_TOKENS as the highest-precedence output-token override and falls back to active provider config caps for CLI and gateway-created agents, with focused precedence tests."
+    },
+    "1ca29723f0ea": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: preflight-warning generation is no longer swallowed silently; warning/persistence outcomes are built after actual config-write evidence, config-save failures are logged with tracing::warn and surfaced in replies, and CLI/gateway/TUI switch responses consistently surface warning text through UI-only channels where applicable.",
+      "owner": "rust-runtime"
+    },
+    "1cb75b7971a7": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1d9c3ebae0f2": {
+      "disposition": "superseded",
+      "notes": "Upstream persists the Electron desktop language preference through apps/desktop config/runtime stores. Hermes Agent Ultra has no desktop language selector/config surface in this Rust runtime repo, so there is no shared Rust runtime state to port."
+    },
+    "1daecfa4b0cb": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "97524344adbd": {
+    "1db8f7ea8094": {
+      "disposition": "superseded",
+      "notes": "Superseded by Ultra installer design: release binary installation does not depend on managed Node global prefix repair.",
+      "owner": "installer"
+    },
+    "1dca7c6207f0": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "bec07964beb8": {
+    "1e1ab31ad6c8": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "fe2942a5aab7": {
+    "1e25358a8f22": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/desktop ephemeral-port discovery is superseded by Rust gateway/TUI runtime; Ultra does not ship apps/desktop or the Python web_server dashboard backend as the primary runtime.",
+      "owner": "rust-runtime"
+    },
+    "1e755ff5568a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1eb13744b4ab": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "1eeb7da2e6e5": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "8720023e963b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    "1febb0824000": {
+      "disposition": "ported",
+      "notes": "Rust Anthropic/OpenRouter request shaping covers modern thinking controls and strips unsupported fast-model controls in provider_profiles and provider.rs tests, including test_anthropic_strips_sampling_and_unsupported_fast_controls."
     },
-    "5dee40fcc0a1": {
+    "2057977102da26cbf0fa9e699fa4432dbf017566": {
+      "disposition": "ported",
+      "notes": "Rust ACP session_info_update uses the notification refresh moment for updatedAt instead of relying on stored session updated_at fields; prompt-turn coverage asserts a non-empty fresh numeric timestamp."
+    },
+    "20f287547275": {
+      "disposition": "superseded",
+      "notes": "rust browser runtime does not use the Python browser_tool session supervisor; Browserbase/Browser Use backends manage sessions with provider timeout/close contracts and builtin browser surface tests cover the current browser commands without legacy browser_close"
+    },
+    "20fd0bde5d1a": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
@@ -2490,119 +601,671 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "b55ac45264e9": {
+    "218452b05019": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence now detects malformed sessions.db schema, backs up raw DB sidecars, deduplicates sqlite_master, escalates to FTS schema drop and rebuild, auto-heals once during ensure_db, exposes hermes sessions repair, and has focused regression tests."
+    },
+    "21cc9c8d329f": {
+      "disposition": "ported",
+      "notes": "The here.now bundle exists locally at optional-skills/productivity/here-now/SKILL.md with publishing and drive-handoff guidance."
+    },
+    "21e172b94ae8": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "5a3092b60106": {
+    "22afa066f838": {
+      "disposition": "superseded",
+      "notes": "rust cron runner already guards trailing control payload parse via object-only extraction in crates/hermes-cron/src/runner.rs"
+    },
+    "23305cfeabfa": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon DM reaction-key normalization is Python adapter state tracking. There is no local Rust Photon adapter state to update."
+    },
+    "235bfb192b91": {
+      "disposition": "superseded",
+      "notes": "URL-install documentation is superseded by the Rust CLI skills install/search implementation in crates/hermes-cli/src/commands.rs plus local docs/parity skill governance."
+    },
+    "236cbe16b62c": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "23c0578bd75d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "ed81cfe3def7": {
+    "242da9db965c": {
+      "disposition": "superseded",
+      "notes": "skill catalog and runtime integration are already covered by local rust-first skill orchestration; upstream python-side delta superseded"
+    },
+    "243cada157ff": {
+      "disposition": "superseded",
+      "notes": "Typed gateway /model pricing lookups in upstream Python are superseded by Rust slash command parsing, typed model switching, usage pricing database, and session cost guard policy."
+    },
+    "243e836dce95": {
+      "disposition": "ported",
+      "notes": "Rust TUI consumes App pending prefill after /rewind or /undo, restoring the rewound prompt into the composer without auto-submitting while App soft-rewinds active session rows."
+    },
+    "24d48ffb8294": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "24f74eb88853": {
+      "disposition": "superseded",
+      "notes": "Upstream data-selectable-text attributes target the Electron desktop file-preview DOM. Hermes Agent Ultra has no React right-rail file preview surface; file viewing/copy behavior is exposed through Rust CLI/TUI/tool output paths."
+    },
+    "2520c9ad68af": {
+      "disposition": "ported",
+      "notes": "Apple Reminders skill documentation is present at skills/apple/apple-reminders/SKILL.md with macOS platform metadata and alarm/command guidance."
+    },
+    "258984fcb906": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "258d24039fe5": {
+      "disposition": "superseded",
+      "notes": "Desktop thinking-disclosure pending state is React rendering state; Rust reasoning capture/display is handled in provider parsing and gateway/TUI status paths."
+    },
+    "263e008d6beb": {
+      "disposition": "ported",
+      "notes": "Web-pentest optional skill was adopted from upstream at optional-skills/security/web-pentest with scope, technique references, scripts, and report templates."
+    },
+    "2667601c05cd": {
+      "disposition": "ported",
+      "notes": "Ported in Rust message/session rendering: crates/hermes-agent session persistence stores reasoning_content and crates/hermes-cli/src/tui.rs fingerprints/renders reasoning-aware assistant messages.",
+      "owner": "rust-runtime"
+    },
+    "266b5a19f128": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "2681c5a12d8d": {
+      "disposition": "ported",
+      "notes": "Ported in Rust CLI: hermes gateway start/status/restart now accept the stale hidden --platform compatibility flag while gateway lifecycle still operates on all configured adapters."
+    },
+    "26bac67ef90d": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "2708c33c7570": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust-first Honcho docs/tests surface; no real Telegram UID or named user example is required by the Rust Honcho setup path.",
+      "owner": "rust-runtime"
+    },
+    "27936ee02dfc": {
+      "disposition": "superseded",
+      "notes": "Python TUI queued-title retry over auto-title DB state is superseded by Rust gateway user title storage on Session.title, which is not delayed behind DB materialization."
+    },
+    "27a321157970": {
+      "disposition": "superseded",
+      "notes": "VS Code Marketplace theme installation is Electron desktop theming. Hermes Ultra does not load that desktop theme runtime."
+    },
+    "27a6e188c4b4bc66f52b321f055fe18aa866b545": {
+      "disposition": "ported",
+      "notes": "Ported in Rust OpenViking memory plugin: OpenViking tool schema names are centralized as Rust constants and the recall-tool classifier derives from the same search/read/browse constants, keeping write tools intentionally ingestible while preventing schema-name drift.",
+      "owner": "rust-runtime"
+    },
+    "27cfe7254313": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "288f7026e332": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/web Weixin labeling is superseded by Rust gateway platform adapters and TUI surfaces; React messaging page labels are outside the Rust runtime.",
+      "owner": "rust-runtime"
+    },
+    "28bf8fb47d38": {
+      "disposition": "superseded",
+      "notes": "Upstream dashboard profile-clone UI is superseded by Rust profile/config commands and TUI surfaces; apps/desktop/web profile UI code is not shipped in Ultra runtime.",
+      "owner": "rust-runtime"
+    },
+    "28f1590b7acd": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "29147afd637d": {
+      "disposition": "superseded",
+      "notes": "Desktop remote attachment toast copy is React desktop UX only. Rust gateway media limits and send errors are handled in platform adapters."
+    },
+    "292192f7d726": {
+      "disposition": "ported",
+      "notes": "Rust TUI composer draft helpers centralize load/save/clear behavior and keep best-effort IO warnings out of the typing path."
+    },
+    "292f4683667e": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "29e5e127c6f1c35fcc67abf0281c50c237e2929f": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: TelegramMessage now deserializes Bot API rich_message echoes and parse_update flattens native rich blocks into text when Telegram omits text/caption, with focused rich-reply coverage.",
+      "owner": "rust-runtime"
+    },
+    "2a5d51c16e94": {
+      "disposition": "ported",
+      "notes": "Ported in Rust OpenViking provider: current API setup/config/headers/content writes/resource uploads/session writer drain behavior are implemented in crates/hermes-agent memory_plugins/openviking with focused tests passing.",
+      "owner": "rust-runtime"
+    },
+    "2a7047c2ed42": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "2b6345cee302": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking hardens local path uploads by detecting path-like missing sources, expanding ~, rejecting top-level symlinks, and preserving remote URL passthrough."
+    },
+    "2b762c53640f": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "2b972472cee8": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking setup validates manual endpoint, credential mode, API key presence, root tenant account/user requirements, agent defaults, and local no-key mode before persisting config.",
+      "owner": "rust-runtime"
+    },
+    "2c19208224de": {
+      "disposition": "superseded",
+      "notes": "Python Gemini audio tag rewrite is superseded by Rust TTS streaming sanitizer and MultiTtsBackend architecture; the Python tools/tts_tool path is not the runtime source."
+    },
+    "2c2ca0443bba": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking setup/config activation covers the improved setup UX in the Rust CLI and provider runtime without Python startup hooks.",
+      "owner": "rust-runtime"
+    },
+    "2c98dc0a9613": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "2d232c999115": {
+      "disposition": "ported",
+      "notes": "Ported in Rust gateway: display.busy_input_mode is typed/normalized and bridged through HERMES_GATEWAY_BUSY_INPUT_MODE; active-session plain text can queue instead of interrupting, explicit /queue bypasses the busy guard and enqueues a FIFO follow-up, and gateway tests cover queue drain plus ack suppression.",
+      "owner": "rust-runtime"
+    },
+    "2d4046c6de975eff194d6ebdfa4180e5ed86c422": {
+      "disposition": "ported",
+      "notes": "Ported in Rust OpenViking memory plugin: structured batch conversion pre-scans assistant tool calls once, caches parsed tool input by non-empty id, and reuses that cached input for completed and pending tool parts with a fallback parse for uncached/empty-id calls.",
+      "owner": "rust-runtime"
+    },
+    "2d587c56622f": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking stores provider memory writes through content/write with generated viking:// memory URIs instead of session-message ingestion."
+    },
+    "2dace37f6b55": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking now has first-class openviking.json activation, hermes memory setup openviking, none/user/root credential modes, tenant defaults, owner-only config writes, health-gated initialization, and provider tests for setup/config behavior.",
+      "owner": "rust-runtime"
+    },
+    "2dda393f99cb": {
+      "disposition": "ported",
+      "notes": "Rust regression tests cover the max_tokens propagation chain from config parsing/set-get through build_agent_config into AgentConfig.max_tokens precedence, superseding the upstream Python gateway test-only follow-up."
+    },
+    "2dfcc8087a8e": {
+      "disposition": "ported",
+      "notes": "Rust TUI startup uses static config/provider resolution and curated provider defaults only; live model discovery is isolated to explicit model-picker catalog paths, avoiding network lookup during App::new startup."
+    },
+    "2e0c9083db84": {
+      "disposition": "ported",
+      "notes": "Rust PluginManager now exposes tool_request and tool_execution middleware primitives, AgentLoop applies request rewrites before guards/hooks and wraps real tool handler execution with a single-use next_call-equivalent chain. Unit and agent-loop tests cover argument adaptation, execution wrapping, and real autonomous tool execution.",
+      "owner": "rust-runtime"
+    },
+    "2e3c6627ceac": {
+      "disposition": "ported",
+      "notes": "Rust Honcho includes runtime peer mapping with configured aliases, optional runtime prefixes, and deterministic collision-resistant peer IDs."
+    },
+    "2e874ef87926": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "2ea957fc41f4": {
+      "disposition": "ported",
+      "notes": "Stocks is located under optional-skills/finance/stocks/SKILL.md with its script under optional-skills/finance/stocks/scripts/stocks_client.py; stale root finance script copy was backed up and removed."
+    },
+    "2ec8d2b42ffe": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "2ed96372ade3": {
+      "disposition": "ported",
+      "notes": "ported in Rust: hermes-skills sync honors .no-bundled-skills, exposes marker toggle and safe pristine bundled-skill removal; hermes-cli adds skills sync/opt-out/opt-in CLI and slash surfaces with tier-gated destructive removal tests."
+    },
+    "2edebedc9eeb": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: /steer is a structured gateway command, active gateway sessions expose a BusyControlRegistration, hermes-cli attaches AgentLoop InterruptController as ActiveSessionControl, and steer sends the trusted hermes_agent::format_steer_marker into the live run with regression coverage.",
+      "owner": "rust-runtime"
+    },
+    "2f0c8e90e613": {
+      "disposition": "superseded",
+      "notes": "Upstream Telegram QR dashboard onboarding targets the Python web dashboard, which is not a Rust runtime surface in this fork. Rust CLI QR onboarding remains the supported local setup path; adding the upstream Python web_server/dashboard flow would violate the Rust-only runtime boundary."
+    },
+    "2f2f654486f9": {
+      "disposition": "superseded",
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
+    },
+    "2f7c4858a764": {
+      "disposition": "ported",
+      "notes": "Rust /reload-mcp now performs the stale-snapshot refresh that upstream added for late TUI MCP discovery: it re-bridges the active AgentLoop registry from the live ToolRegistry, reports added/removed tools, refreshes model-visible schemas, and keeps connector renegotiation explicitly restart-bound. Focused CLI tests cover late-added MCP tools and same-count replacement visibility."
+    },
+    "2f9d18711fb9": {
+      "disposition": "superseded",
+      "notes": "Superseded by Ultra local Rust gates: scripts/clippy-warning-gate.sh, check-runtime-placeholders, cargo tests, and parity generators define local CI; upstream pytest-timeout/GitHub workflow tuning is optional.",
+      "owner": "local-gates"
+    },
+    "30340eae2f6e": {
+      "disposition": "ported",
+      "notes": "Rust shared version_label includes the workspace package version and optional build git SHA captured by hermes-core build.rs, so CLI/gateway/ACP version surfaces share the same label helper."
+    },
+    "3034eee38ec516109566c00975be4d0276747c34": {
+      "disposition": "ported",
+      "notes": "Rust ACP server now flushes session/load and session/resume replay notifications before the JSON-RPC response, with run_on coverage proving clients receive transcript updates within the request lifetime."
+    },
+    "30377e108ca8": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust-first UI/runtime scope and optional GitHub CI; there is no Electron renderer build gate for the shipped Ultra runtime.",
+      "owner": "local-gates"
+    },
+    "30412a9771cc": {
+      "disposition": "ported",
+      "notes": "Rust disk-cleanup revalidates stale cron-output entries at dry-run and quick-clean time, drops stale control-plane tracked rows, hard-protects cron/jobs.json plus .tick.lock, and deletes only cron/output payloads; covered by crates/hermes-tools disk_cleanup tests."
+    },
+    "3045d54547f7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "3078053795e838e47797ede02b44e6dead731aac": {
+      "disposition": "ported",
+      "notes": "Rust mixture_of_agents is now a first-class OpenAI-compatible two-layer MoA runtime with env/model/base-url configuration, parallel reference fanout, retries, minimum-success threshold, aggregator prompt synthesis, toolset/distribution exposure, and deterministic mock HTTP tests."
+    },
+    "3082fa0829e0": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight probes /version once per API base for update_mode append support, accepts version/api_version response shapes, gates append on semver >= 0.5.0, and falls back to batch document IDs."
+    },
+    "30b391ab366e": {
+      "disposition": "ported",
+      "notes": "Rust Honcho avoids runtime peer collisions by hashing runtime IDs when generating prefixed peer names, with regression coverage."
+    },
+    "311900842e88": {
+      "disposition": "superseded",
+      "notes": "Upstream Discord auto-disconnect behavior is Python adapter voice-state logic. Rust voice lifecycle is explicit join/leave state with VoiceManager tests and no Python reply-mode disconnect path."
+    },
+    "311e80809f50": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "315fdae5f8ad": {
+      "disposition": "superseded",
+      "notes": "Rust OpenViking does not autostart openviking-server from the agent runtime; local setup can use no-key config, while runtime initialization is health-gated and fail-closed.",
+      "owner": "rust-runtime"
+    },
+    "31c40c72c03c": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "31e59fe44d18498ae53f624a3d3d5dbbad2d165e": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: rich send/edit payloads normalize prose single newlines into Telegram hard breaks while preserving protected Markdown regions, with slash-output newline coverage.",
+      "owner": "rust-runtime"
+    },
+    "32032e1e2d9b": {
+      "disposition": "superseded",
+      "notes": "upstream SimpleX websocket reconnect delta is Python plugin-only in this fork; no Rust SimpleX platform adapter exists under crates, so there is no Rust runtime surface to port under the Rust-only parity policy."
+    },
+    "324567c93662": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "3260413cc7fa": {
+      "disposition": "ported",
+      "notes": "Rust STT override env vars are first-class runtime knobs: HERMES_STT_PROVIDER/STT_PROVIDER, STT_OPENAI_MODEL, STT_GROQ_MODEL, STT_MISTRAL_MODEL, and provider base-url overrides are resolved in the Rust transcription/gateway voice surfaces with tests."
+    },
+    "326c9daa695b": {
+      "disposition": "ported",
+      "notes": "Rust Honcho only treats pinUserPeer/pinPeerName as enabled when the JSON value is a strict boolean true, avoiding truthy-string or mock-style coercion."
+    },
+    "338c07433699": {
+      "disposition": "ported",
+      "notes": "Rust ntfy sends now distinguish explicit tool/router targets from configured publish-topic replies: gateway-backed messaging marks caller recipients explicit, DeliveryTarget routing preserves is_explicit/thread hints for text and file sends, and NtfyAdapter publishes explicit topics directly while retaining configured publish_topic for non-explicit replies."
+    },
+    "33b1d144590a": {
+      "disposition": "superseded",
+      "notes": "Electron dependency pin and npm lockfile repair apply to upstream desktop packaging. Ultra has no apps/desktop package tree and builds/releases through the Rust workspace/install scripts.",
+      "owner": "rust-runtime"
     },
     "349a3f601c6c": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "02aad08acf46": {
+    "355af2c20f49": {
+      "disposition": "ported",
+      "notes": "Rust session DB and search survive missing FTS5 by creating base tables first, optional FTS schema second, and returning search_degraded=fts5_unavailable rather than failing registration/search."
+    },
+    "3589960e03d0": {
+      "disposition": "ported",
+      "notes": "Rust GenericProvider now maps OpenCode Go reasoning controls by model: Kimi K2 and DeepSeek thinking models receive provider-native thinking/reasoning_effort fields while non-target models drop unsupported controls."
+    },
+    "359f2be12e6c": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "9d72680ca34a": {
+    "35a750eedd7b": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "20fd0bde5d1a": {
+    "3625dbb8442c": {
+      "disposition": "ported",
+      "notes": "Security redaction guidance is covered by the local Rust approval/credential guard surface plus skill catalog security standards, rather than vendoring upstream-only docs."
+    },
+    "36851fa576eb4079f0397010f418cafa15a4ab26": {
+      "disposition": "superseded",
+      "notes": "Upstream Python setup.py/WebUI read-only-source workaround is structurally absent in Ultra: there is no top-level setup.py or Python WebUI install path. This batch pins the Rust Docker image contract instead: LICENSE/NOTICE are shipped in the image, .dockerignore cannot exclude them, and tests assert immutable /usr/local/bin code with writable HERMES_HOME=/data.",
+      "owner": "rust-runtime"
+    },
+    "368fcf1ff03b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "36ad97337a4a": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "374785ee2613": {
+      "disposition": "ported",
+      "notes": "Kanban dispatcher defaults and failure-limit guidance are represented by the local kanban skills and Rust kanban command surface."
+    },
+    "375c7f9cc379f940f3923ac967793675bdfd2b5c": {
+      "disposition": "ported",
+      "notes": "Rust ACP now renders structured JSON tool results into compact readable completion text, including todo summaries, read_file fenced content, search_files matches/files with JSON-prefix hint handling, skill summaries, browser/media/edit helpers, and generic nested JSON bullets without leaking raw blobs."
+    },
+    "37d717054ef6": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "3824b0323793": {
+      "disposition": "superseded",
+      "notes": "Python TUI session.title DB/RPC edge cases are superseded by Rust gateway in-memory Session.title storage and command tests; there is no pending DB row queue or Python RPC failure mode in this runtime path."
+    },
+    "38273676eab0": {
+      "disposition": "superseded",
+      "notes": "Desktop titlebar drag-region CSS is Electron UI polish and not used by the Rust CLI/gateway runtime."
+    },
+    "385a508e43cb": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "16786f3bb392": {
+    "38695254f851": {
+      "disposition": "ported",
+      "notes": "Rust session persistence now exposes FTS index counting and optimize_fts maintenance, VACUUM runs FTS optimization before reclaiming pages, and top-level `hermes sessions optimize` reports FTS index count plus before/after sessions.db size with Rust unit/e2e coverage."
+    },
+    "386f245d9d25": {
+      "disposition": "ported",
+      "notes": "OpenHands optional skill was adopted from upstream at optional-skills/autonomous-ai-agents/openhands/SKILL.md."
+    },
+    "38acced6873d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "f3af489ec2f7": {
+    "38d3c49aaf2e": {
+      "disposition": "ported",
+      "notes": "Current upstream skill catalog cleanup was adopted where it affects source SKILL.md trees, including optional Baoyu article illustrator and platform/environment frontmatter; generated website docs remain covered by Rust catalog governance."
+    },
+    "395dbcc873c8": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "395ed918915c": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "cadb74adad3c": {
+    "39b76d90137a": {
+      "disposition": "superseded",
+      "notes": "Python wheel/sdist optional-MCP packaging is not used by the Rust/Cargo runtime. Local MCP catalog and config handling are Rust-native."
+    },
+    "39fe4ecee3d0": {
+      "disposition": "ported",
+      "notes": "Rust kanban store loading now refuses malformed or semantically empty existing boards.json state, preserves the original bytes, and writes a same-directory boards.json.corrupt.<timestamp> backup before returning an error."
+    },
+    "3a5e36cfa50a": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "e029b7597bdf": {
+    "3a7ed7be0810": {
+      "disposition": "superseded",
+      "notes": "Python wheel packaging for bundled skills is not a Rust runtime surface; local Rust packaging seeds skills from the repository skills and optional-skills trees through hermes-skills sync logic."
+    },
+    "3aa24e261936": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "c50fb560ef04": {
+    "3aa86717b60c": {
+      "disposition": "superseded",
+      "notes": "Python TUI pending-title retry and title validation error mapping are superseded by Rust gateway title parsing/storage; invalid empty titles fall through to bare /title read and no DB retry path exists."
+    },
+    "3ac6551ba3d3": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking treats same-session switches as prefetch invalidation only and ignores empty new session ids, preventing rewound/no-op switches from corrupting session state.",
+      "owner": "rust-runtime"
+    },
+    "3b096d6f6dbe": {
+      "disposition": "ported",
+      "notes": "Ntfy robustness and docs are represented by plugins/platforms/ntfy, tests/gateway/test_ntfy_plugin.py, website ntfy messaging docs, sidebars, and environment-variable reference entries."
+    },
+    "3be9fb73173e": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "628780b4f322": {
+    "3bfbb3f2a025": {
+      "disposition": "superseded",
+      "notes": "TypeScript/React CI toolchain changes are hosted UI tooling only; local Rust runtime gates are authoritative and GitHub CI is optional."
+    },
+    "3c0d0dba49f9": {
+      "disposition": "ported",
+      "notes": "Updated RL tools and configuration management are covered by Rust TrainingConfig editing, TrainingStatus serde, TrainingMetrics progression, RunManager lifecycle, registered rl_training toolset membership, and focused hermes-intelligence/hermes-tools tests."
+    },
+    "3c252ae44b52": {
+      "disposition": "ported",
+      "notes": "Rust hermes-mcp provides MCP client support through McpClient and McpManager, stdio and HTTP/SSE transports, OAuth/bearer auth, tools/list, tools/call, resources, prompts, stale transport reconnect, and media caching. CLI mcp add/list/remove/test/configure/login/serve wiring and focused hermes-mcp/hermes-cli tests cover the core client surface."
+    },
+    "3c76dac4fdbf": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking config persistence fails closed through owner-only atomic config IO instead of silently ignoring chmod failures; setup tests assert final 0600 mode.",
+      "owner": "rust-runtime"
+    },
+    "3cf5e8225d88": {
+      "disposition": "ported",
+      "notes": "Rust Honcho accepts pinUserPeer as the backwards-compatible alias for pinPeerName while keeping strict boolean parsing."
+    },
+    "3cf7d43262d4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "3d14f01fd674": {
+      "disposition": "ported",
+      "notes": "Rust TUI composer drafts persist on actual input changes instead of conversation/session lifecycle, covering the upstream debounce/write-volume fix without adding a desktop React runtime."
+    },
+    "3d1d0a49fe90": {
+      "disposition": "ported",
+      "notes": "Rust MiniMax direct auxiliary defaults now use MiniMax-M3 for minimax and minimax-cn, MiniMax CN registers as a first-class auxiliary direct-key provider, setup defaults and curated picker fallbacks expose MiniMax-M3 first, and regression tests guard against stale/highspeed defaults."
+    },
+    "3d258097db55": {
+      "disposition": "ported",
+      "notes": "Baoyu article illustrator current upstream optional skill includes tightened description and platforms frontmatter; generated website docs remain superseded by Rust catalog governance."
+    },
+    "3d90292eda55": {
+      "disposition": "superseded",
+      "notes": "rust models_dev registry already resolves provider aliases in list_provider_models with regression coverage in crates/hermes-intelligence/src/models_dev/client.rs"
+    },
+    "3df7e30244c0": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "3e2d758816b7": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "fa42ac094dca": {
+    "3e4fa8ca9ca3": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-rail drag-axis polish touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "3e59be0c412b": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence now adds messages.active and sessions.rewind_count, filters loads/search to active rows, preserves inactive audit rows, and exposes soft rewind/recent-user/restore primitives with regression coverage."
+    },
+    "3e7145e0bbcd": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "3e74f75e41ec": {
+      "disposition": "ported",
+      "notes": "Rust port implements upstream coding-context posture through crates/hermes-agent/src/coding_context.rs, AgentConfig/GatewayConfig agent.coding_context, prompt injection with workspace/verify facts, model-family edit-format guidance, prompt-only non-coding skill pruning, a lean coding toolset, ACP default toolset registration, and focus-mode platform tool collapse with live MCP inclusion. Tests cover detection, prompt gating, skill pruning, coding/hermes-acp toolsets, and platform focus behavior."
+    },
+    "3e994e38f763": {
+      "disposition": "superseded",
+      "notes": "Hindsight profile env materialization only applies to the upstream Python embedded daemon; the Rust runtime now documents and exposes cloud/local_external HTTP modes only."
+    },
+    "3ebdd26449dc": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "3ef97a61b9f1": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "d65b513f23d7": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "b5a457c03303": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "53a2ac8f2dba": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "bddc5fd08734": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9d6992ee8a7b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "ede4f5a4a30b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    "3f7d1c801ddf": {
+      "disposition": "ported",
+      "notes": "Rust /undo [N] and /rewind [N] clamp to active user turns, truncate in-memory context, soft-delete persisted rows, preserve inactive audit rows, and stage the backed-up prompt for editing."
     },
     "3fc67b7333d7": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "694adec6350f": {
+    "3fc7b624d860": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: hermes-cron verifies NAS JWT fire tokens with asymmetric keys/audience/purpose checks and hermes-gateway exposes POST /api/cron/fire behind api-server with focused route coverage.",
+      "owner": "rust-runtime"
+    },
+    "3fde8c153da1": {
+      "disposition": "ported",
+      "notes": "Rust bundled skill scanners prune dependency/cache directories such as node_modules and __pycache__ in crates/hermes-skills/src/sync.rs and guard logic."
+    },
+    "3ffbdfbcc0dc": {
+      "disposition": "ported",
+      "notes": "Rust port covers the functional slash-command delta: TUI completions now use live App state for /handoff platforms and /tools enable|disable candidates, /personality completions list built-ins, and CLI slash /tools enable|disable persists tools_config plus refreshes active tool schemas. Upstream desktop registry/picker UI and Python tui_gateway context-manager changes are superseded by this Rust-only TUI/CLI/gateway architecture."
+    },
+    "401aadb5b892": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "403c82b6b65b": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight supports HINDSIGHT_TIMEOUT and config timeout/hindsight_timeout aliases with a 120s default and focused config coverage."
+    },
+    "40420a619b58": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "d759c13c0963": {
+    "404640a2b752": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "40aef6af91e6": {
+      "disposition": "superseded",
+      "notes": "Desktop composer live-steer controls are superseded by Rust first-class /steer support in CLI/TUI/gateway/ACP: the core trusted steer marker is already ported, active-session ACP steer interrupts with that marker, and gateway busy-session steer mode accepts live steering or falls back to queue."
+    },
+    "411faf08bd678fe3e49b22afcef1e9fd2d7f5592": {
+      "disposition": "ported",
+      "notes": "Ported in Rust/setup/install: hermes-agent now exposes DEFAULT_AGENT_IDENTITY-backed SOUL.md seeding, ignores exact legacy comment-only templates at prompt load, upgrades those templates during setup, preserves customized SOUL.md files, respects explicit/HERMES_HOME resolution, and install.sh seeds the real default persona instead of an empty scaffold.",
+      "owner": "rust-runtime"
+    },
+    "41ede963041f": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "039fbb41fc2d": {
+    "41fa1f1b5cf560c22a7e9adb06eb463d7122f9e0": {
+      "disposition": "ported",
+      "notes": "Rust ACP rewrites idle /steer into a regular user prompt instead of silently queueing it, matching upstream editor-client behavior; hermes-acp idle steer test proves the prompt runs immediately and leaves the queue empty."
+    },
+    "42070ecefb9e": {
+      "disposition": "ported",
+      "notes": "Notion Developer Platform guidance is represented at skills/productivity/notion/SKILL.md with pages, databases, blocks, and search API workflows."
+    },
+    "423923095781": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "ed1e2533b73d": {
+    "425e777f54b8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "42e166c7ea2e": {
+      "disposition": "superseded",
+      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
+    },
+    "435c706e8e5a": {
+      "disposition": "superseded",
+      "notes": "Upstream fix is React desktop session-cache error isolation. Ultra session/error state is Rust-owned by hermes-cli App and hermes-gateway session/runtime state, not the apps/desktop view cache.",
+      "owner": "rust-runtime"
+    },
+    "4373e802a1b9": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust skills registry/index implementation plus local parity gates; GitHub Pages workflow cache behavior is optional for this repo.",
+      "owner": "local-gates"
+    },
+    "439f53cab8e0": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "64da518db413": {
+    "443950e82736": {
+      "disposition": "ported",
+      "notes": "Rust model switching consumes GatewayConfig.llm_providers as a provider-keyed map, and model_switch tests cover custom provider slugs, explicit model lists, discover_models=false, and provider catalog entries without list coercion."
+    },
+    "4440d77bf32d": {
+      "disposition": "superseded",
+      "notes": "Install-method stamping and Python Docker stage2 mutation are absent from Ultra. The Rust container separates code in /usr/local/bin from writable HERMES_HOME=/data and does not chown or mutate an install tree at runtime.",
+      "owner": "rust-runtime"
+    },
+    "4444d5fe4f65dcbca939a1f39ae58438205e7dad": {
+      "disposition": "ported",
+      "notes": "Rust ACP emits native sessionUpdate=plan events after live todo tool completions, using typed PlanEntry values and shared parser tests for status mapping, cancelled preservation, and wire serialization."
+    },
+    "4447e7d71afa": {
+      "disposition": "ported",
+      "notes": "Rust runtime now supports Kimi Code sk-kimi-* routing to https://api.kimi.com/coding/v1 with KimiCLI user-agent while preserving KIMI_BASE_URL override and legacy Moonshot fallback."
+    },
+    "44cd79e798e4": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "44e5848e7418": {
+      "disposition": "superseded",
+      "notes": "Upstream streams subagent text into Electron watch windows and Python tui_gateway mirrors. Ultra has no apps/desktop runtime; Rust subagent/process progress is owned by hermes-agent and hermes-gateway/TUI status surfaces, so the Python/React watch-window mirror is outside the Rust-only runtime.",
+      "owner": "rust-runtime"
+    },
+    "458ce792d24e": {
+      "disposition": "ported",
+      "notes": "Rust App::switch_model persists the active session model in SessionPersistence by default and rebuilds the agent for the current session, with regression coverage for the session DB row."
+    },
+    "45e1689c03b2": {
+      "disposition": "superseded",
+      "notes": "Desktop marketplace submenu HUD token changes are Electron/React styling only."
+    },
+    "464276228940": {
+      "disposition": "superseded",
+      "notes": "Python Langfuse plugin base64 redaction is superseded by Rust telemetry/redaction surfaces and optional plugin divergence; Rust runtime does not emit through that Python plugin."
+    },
+    "46b2afc56b79": {
+      "disposition": "ported",
+      "notes": "Rust session persistence now runs PRAGMA wal_checkpoint(TRUNCATE) after startup auto-maintenance and exposes truncate_wal_checkpoint(); regression tests force WAL growth and assert the sessions.db-wal sidecar shrinks to zero."
+    },
+    "46d758bb3e07": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "46e513ef5185": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "9c264555b018": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    "46fedef07fda": {
+      "disposition": "ported",
+      "notes": "Rust OpenRouterProvider::merge_extra_body strips local reasoning_effort and maps reasoning controls to the provider reasoning object with regression coverage in test_openrouter_merge_extra_body_strips_local_cache_fields."
     },
-    "56be1a63a33d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "cfaa46fcae63": {
+    "471a5fc5c93e": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
@@ -2610,493 +1273,1104 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "9b2a64fa6a27": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "81647458c7a7": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "cd030f5f4029": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "b000e05b117b": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "74239b494209": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "de80d28f3848": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "395ed918915c": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "9b1e0d6f70bb": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "6e7033bb4c79": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "09a6a2ddd71d": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "e0f6a35ac659": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "c1927d2342a7": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
-    },
-    "692ae6dd073b": {
-      "disposition": "superseded",
-      "notes": "Documentation-only upstream README skill table/test-runner update is superseded by local Rust parity docs and repo-native verification scripts; no Rust runtime behavior changes."
-    },
-    "d42b6a2eddc7": {
-      "disposition": "superseded",
-      "notes": "Upstream AGENTS.md plugin/skill documentation refresh is superseded by local AGENTS.md Rust parity rules plus docs/parity compatibility policy and skills governance."
-    },
-    "983bbe2d40f7": {
+    "4764e06fdefa65cb75961da64da1ed63c99a0a2a": {
       "disposition": "ported",
-      "notes": "Local skills catalog already includes the Google DESIGN.md skill at skills/creative/design-md/SKILL.md and optional-skills/creative/design-md/SKILL.md with SKILL.md frontmatter, templates, and platform metadata."
+      "notes": "Rust ACP exposes the editor session-management surface with load/resume/fork/list plus model/mode/config updates, now including the stable session/set_config_option method alias; handler tests cover camelCase routing and persisted session config."
     },
-    "0f6eabb89073": {
+    "47d2d05892ef": {
+      "disposition": "ported",
+      "notes": "Rust provider picker copy now has provider_picker_description wired into hermes model output, setup provider labels, and the TUI provider modal; tests pin refreshed Nous/OpenRouter/Gemini/xAI/Qwen descriptions."
+    },
+    "47d5177a7d61": {
       "disposition": "superseded",
-      "notes": "Dedicated website pages for bundled/optional skills are superseded by rust-skills-catalog-governance: the Rust CLI, skill hub, and docs/parity surfaces expose catalog state without mirroring upstream website generation."
+      "notes": "Python lazy-singleton and Honcho TOCTOU fixes are superseded by Rust plugin instances and explicit Mutex state; no Python lazy singleton remains."
     },
-    "e5d41f05d47e": {
-      "disposition": "ported",
-      "notes": "Spotify skill catalog coverage exists at skills/media/spotify/SKILL.md with cross-platform frontmatter, while Spotify tool surfacing remains gated through the Rust tool/catalog setup paths."
-    },
-    "c34d3f480778": {
-      "disposition": "ported",
-      "notes": "Google Workspace helper parity is present in skills/productivity/google-workspace/scripts/_hermes_home.py, shared by setup.py, gws_bridge.py, and google_api.py for HERMES_HOME resolution."
-    },
-    "13038dc747aa": {
-      "disposition": "ported",
-      "notes": "Google Workspace setup parity is represented by skills/productivity/google-workspace/scripts/setup.py with Python 3.9-compatible syntax and local dependency handling documented in the skill body."
-    },
-    "93977675135a": {
+    "484f484c25bc": {
       "disposition": "superseded",
-      "notes": "The upstream empty feeds category cleanup is superseded by the local curated Rust skills catalog; no empty feeds SKILL.md category is present in skills or optional-skills."
+      "notes": "Upstream sidebar nav drag-region carving targets Electron desktop titlebar behavior in apps/desktop. Hermes Agent Ultra uses the Rust Ratatui CLI/TUI and has no Electron draggable titlebar or React sidebar rows."
     },
-    "4cdb6962ca3f": {
+    "486b692ddd80": {
       "disposition": "ported",
-      "notes": "Hermes Agent skill-authoring guidance is bundled locally at skills/software-development/hermes-agent-skill-authoring/SKILL.md with frontmatter, authoring conventions, and validator-oriented structure."
+      "notes": "Rust Nous provider request shaping now centralizes Portal attribution tags as product=hermes-agent plus client=hermes-client-v<workspace version>, and request-body tests prove the versioned tag is applied to actual Nous chat completion payloads."
     },
-    "0cd98499bb1e": {
-      "disposition": "ported",
-      "notes": "Debugging Hermes TUI commands is bundled locally at skills/software-development/debugging-hermes-tui-commands/SKILL.md and participates in the Rust SKILL.md loader."
-    },
-    "7e3c8a31f0f3": {
-      "disposition": "ported",
-      "notes": "Airtable skill parity is present at skills/productivity/airtable/SKILL.md with Hermes-specific usage guidance and cookbook coverage."
-    },
-    "898ccfd66706": {
-      "disposition": "ported",
-      "notes": "Google OAuth redirect scope parsing is implemented in skills/productivity/google-workspace/scripts/setup.py by extracting the scope query parameter from the pasted callback URL and storing granted scopes."
-    },
-    "235bfb192b91": {
+    "4891f9ae78b0": {
       "disposition": "superseded",
-      "notes": "URL-install documentation is superseded by the Rust CLI skills install/search implementation in crates/hermes-cli/src/commands.rs plus local docs/parity skill governance."
-    },
-    "e3921e7ca4a6": {
-      "disposition": "ported",
-      "notes": "Bundled skill descriptions are kept in SKILL.md frontmatter across the local Rust catalog and exposed through Rust skill scanners; the upstream compression-only docs delta has no separate runtime change."
-    },
-    "9f1b1977bca3": {
-      "disposition": "ported",
-      "notes": "Trigger and usage details live in the local SKILL.md bodies loaded by Rust skill scanners, preserving content without relying on upstream generated catalog pages."
-    },
-    "730347e38f9a": {
-      "disposition": "ported",
-      "notes": "TouchDesigner MCP expansion is present at skills/creative/touchdesigner-mcp with GLSL, post-FX, audio-reactive, geometry, and MCP reference material."
-    },
-    "853ed609a1a4": {
-      "disposition": "ported",
-      "notes": "TouchDesigner MCP is bundled in the local skills tree at skills/creative/touchdesigner-mcp/SKILL.md and is discoverable by the Rust bundled skill scanner."
-    },
-    "aea72c09362b": {
-      "disposition": "ported",
-      "notes": "Spike and sketch skills are bundled locally at skills/software-development/spike/SKILL.md and skills/creative/sketch/SKILL.md with reference material adapted for Hermes usage."
-    },
-    "b81638d749c6": {
-      "disposition": "ported",
-      "notes": "ComfyUI parity is bundled at skills/creative/comfyui/SKILL.md using official comfy-cli lifecycle guidance plus direct REST/WebSocket execution rather than third-party runtime dependencies."
-    },
-    "d7d1503595b3": {
-      "disposition": "ported",
-      "notes": "ComfyUI onboarding coverage is in skills/creative/comfyui/SKILL.md and references, including local/cloud install paths, docs links, launch, workflow execution, and troubleshooting."
-    },
-    "9d7ece362df2": {
-      "disposition": "ported",
-      "notes": "ComfyUI hardware gating is present in skills/creative/comfyui/scripts/hardware_check.py and the skill workflow asks for local/cloud routing based on the verdict."
-    },
-    "ffe1d660a0e4": {
-      "disposition": "ported",
-      "notes": "ComfyUI local-vs-cloud selection is encoded in the skill flow before hardware-sensitive local setup, matching the upstream decision-order fix."
+      "notes": "Concurrent multi-profile gateway sockets are Electron desktop store/socket orchestration only. Rust gateway profile routing is session-scoped runtime state and does not expose the upstream apps/desktop multi-socket dashboard layer."
     },
     "4899bd99c0b7": {
       "disposition": "ported",
       "notes": "ComfyUI is a built-in local bundled skill at skills/creative/comfyui/SKILL.md and is discovered through the Rust bundled skill scanner."
     },
-    "a7780fe05f43": {
-      "disposition": "ported",
-      "notes": "ComfyUI bug-fix coverage is represented by the local skill scripts, tests, workflows, cloud/local guidance, and expanded references under skills/creative/comfyui."
-    },
-    "51b44b6e3fa1": {
-      "disposition": "ported",
-      "notes": "ComfyUI node/registry guidance is represented by the corrected local SKILL.md and reference materials under skills/creative/comfyui, without importing upstream Python runtime."
-    },
-    "f7dfd4ae3664": {
+    "48d8d80771e2": {
       "disposition": "superseded",
-      "notes": "The temporary upstream built-in here.now placement is superseded by the final local optional skill catalog placement at optional-skills/productivity/here-now/SKILL.md."
-    },
-    "21cc9c8d329f": {
-      "disposition": "ported",
-      "notes": "The here.now bundle exists locally at optional-skills/productivity/here-now/SKILL.md with publishing and drive-handoff guidance."
-    },
-    "7cbe943d2dc1": {
-      "disposition": "ported",
-      "notes": "here.now is represented as an optional local skill at optional-skills/productivity/here-now/SKILL.md, matching the final upstream catalog placement."
-    },
-    "511add724987": {
-      "disposition": "ported",
-      "notes": "The video orchestrator optional skill is present at optional-skills/creative/kanban-video-orchestrator/SKILL.md with assets, scripts, and monitoring references."
-    },
-    "a919269eb5c5": {
-      "disposition": "ported",
-      "notes": "Himalaya email skill documentation includes the v1.2.0 folder.aliases syntax in skills/email/himalaya/SKILL.md and reference material."
-    },
-    "81cd67829191": {
-      "disposition": "ported",
-      "notes": "Google Workspace SKILL.md frontmatter declares required_credential_files for google_token.json and google_client_secret.json."
-    },
-    "0dc677f0718b": {
-      "disposition": "ported",
-      "notes": "Hermes-agent durable systems and slash-command guidance is represented in skills/autonomous-ai-agents/hermes-agent/SKILL.md under the local Rust skill catalog."
-    },
-    "15be493055eb": {
-      "disposition": "ported",
-      "notes": "Obsidian file workflow coverage is present at skills/note-taking/obsidian/SKILL.md under the local skills catalog."
-    },
-    "fce58cbe2e02": {
-      "disposition": "ported",
-      "notes": "Anthropic financial-services skills are represented under optional-skills/finance; stale local root stocks wrapper was backed up and removed while upstream stocks/dcf skill files were synced."
-    },
-    "5fa493a2ca6a": {
-      "disposition": "ported",
-      "notes": "Google Workspace setup.py implements --check-live and disabled_client/invalid_client diagnostics for real API auth validation."
-    },
-    "e43d2fe5205e": {
-      "disposition": "ported",
-      "notes": "Google Workspace drive write operations plus Docs/Sheets create/append are implemented in skills/productivity/google-workspace/scripts/google_api.py and documented in the SKILL.md examples."
-    },
-    "ea8e608821b1": {
-      "disposition": "ported",
-      "notes": "Watchers optional skill exists at optional-skills/devops/watchers/SKILL.md with RSS, HTTP JSON, and GitHub polling scripts."
-    },
-    "729a659a3c8a": {
-      "disposition": "ported",
-      "notes": "Teams meeting pipeline skill asset is present at skills/productivity/teams-meeting-pipeline/SKILL.md, backed by the Rust teams_pipeline runtime."
-    },
-    "b18b17f9c9de": {
-      "disposition": "ported",
-      "notes": "Rust dynamic skill command loading filters SKILL.md frontmatter by platform in crates/hermes-tools/src/tools/skill_commands.rs, and local skills declare platforms frontmatter."
-    },
-    "db22efbe88bd": {
-      "disposition": "ported",
-      "notes": "Optional and bundled local skills declare platforms frontmatter and Rust skill loading honors platform aliases/filters during command discovery."
-    },
-    "2ea957fc41f4": {
-      "disposition": "ported",
-      "notes": "Stocks is located under optional-skills/finance/stocks/SKILL.md with its script under optional-skills/finance/stocks/scripts/stocks_client.py; stale root finance script copy was backed up and removed."
-    },
-    "ef98e3f9e60b": {
-      "disposition": "superseded",
-      "notes": "In-tree memory-plugin PR policy docs are superseded by local Rust skill standards, plugin governance, and the approved rust-skills-catalog-governance divergence."
-    },
-    "b08f53a75893": {
-      "disposition": "ported",
-      "notes": "ComfyUI template/workflow integrity material is present under skills/creative/comfyui references, tests, and workflows alongside the bundled skill."
-    },
-    "42070ecefb9e": {
-      "disposition": "ported",
-      "notes": "Notion Developer Platform guidance is represented at skills/productivity/notion/SKILL.md with pages, databases, blocks, and search API workflows."
-    },
-    "374785ee2613": {
-      "disposition": "ported",
-      "notes": "Kanban dispatcher defaults and failure-limit guidance are represented by the local kanban skills and Rust kanban command surface."
-    },
-    "3a7ed7be0810": {
-      "disposition": "superseded",
-      "notes": "Python wheel packaging for bundled skills is not a Rust runtime surface; local Rust packaging seeds skills from the repository skills and optional-skills trees through hermes-skills sync logic."
-    },
-    "b65dfbb4530a": {
-      "disposition": "ported",
-      "notes": "Kanban lane skills are bundled locally at skills/devops/kanban-orchestrator/SKILL.md and skills/devops/kanban-worker/SKILL.md."
-    },
-    "b5c1fe78aa48": {
-      "disposition": "ported",
-      "notes": "Skill bundle aliases are implemented in the Rust CLI via /bundles and skill-bundles discovery in crates/hermes-cli/src/commands.rs, allowing /<slug> to load multiple skills."
-    },
-    "3fde8c153da1": {
-      "disposition": "ported",
-      "notes": "Rust bundled skill scanners prune dependency/cache directories such as node_modules and __pycache__ in crates/hermes-skills/src/sync.rs and guard logic."
-    },
-    "a36221ed9174": {
-      "disposition": "ported",
-      "notes": "The current upstream s6 container supervision skill was adopted at optional-skills/devops/hermes-s6-container-supervision/SKILL.md; generated website/docs changes remain covered by Rust skills governance."
-    },
-    "2520c9ad68af": {
-      "disposition": "ported",
-      "notes": "Apple Reminders skill documentation is present at skills/apple/apple-reminders/SKILL.md with macOS platform metadata and alarm/command guidance."
-    },
-    "3625dbb8442c": {
-      "disposition": "ported",
-      "notes": "Security redaction guidance is covered by the local Rust approval/credential guard surface plus skill catalog security standards, rather than vendoring upstream-only docs."
-    },
-    "51a2c07016b2": {
-      "disposition": "ported",
-      "notes": "X Article ingestion guidance is represented in skills/social-media/xurl/SKILL.md within the local skills catalog."
-    },
-    "38d3c49aaf2e": {
-      "disposition": "ported",
-      "notes": "Current upstream skill catalog cleanup was adopted where it affects source SKILL.md trees, including optional Baoyu article illustrator and platform/environment frontmatter; generated website docs remain covered by Rust catalog governance."
-    },
-    "7c00ffd92c41": {
-      "disposition": "ported",
-      "notes": "Google Workspace setup fallback behavior is represented in skills/productivity/google-workspace/scripts/setup.py, including virtualenv/pip diagnostics and uv-compatible setup guidance."
-    },
-    "87c6edc1d04f": {
-      "disposition": "ported",
-      "notes": "Google Workspace setup.py and gws_bridge.py were synced from upstream source truth and now pass explicit urlopen timeouts for OAuth/live-check network calls."
-    },
-    "aa1e2edd35a8": {
-      "disposition": "ported",
-      "notes": "Upstream EVM multi-chain optional skill was adopted at optional-skills/blockchain/evm with SKILL.md plus evm_client.py covering the 8-chain read-only command surface."
-    },
-    "e3fc0814996d": {
-      "disposition": "ported",
-      "notes": "Upstream blockchain/base merge was adopted by adding optional-skills/blockchain/evm and removing the stale local optional-skills/blockchain/base copy after backup."
-    },
-    "66c70966cd2a": {
-      "disposition": "ported",
-      "notes": "The current upstream optional-skills/blockchain/evm/SKILL.md was adopted, including the tightened modern-format frontmatter and Hermes runtime guidance."
-    },
-    "c9b32a654cd1": {
-      "disposition": "ported",
-      "notes": "Darwinian-evolver was adopted from upstream at optional-skills/research/darwinian-evolver with SKILL.md, helper scripts, and template assets."
-    },
-    "0a2ee71cccbf": {
-      "disposition": "ported",
-      "notes": "Darwinian-evolver show_snapshot.py was adopted from upstream and requires the explicit --i-trust-this-file gate before pickle.loads executes."
-    },
-    "559c6ad94aee": {
-      "disposition": "ported",
-      "notes": "Pinggy tunnel optional skill was adopted from upstream at optional-skills/devops/pinggy-tunnel/SKILL.md."
-    },
-    "5f91b1a48b06": {
-      "disposition": "ported",
-      "notes": "OSINT investigation optional skill was adopted from upstream under optional-skills/research/osint-investigation with source references, scripts, and templates."
-    },
-    "680189b5def4": {
-      "disposition": "ported",
-      "notes": "Baoyu article illustrator was adopted from upstream at optional-skills/creative/baoyu-article-illustrator with SKILL.md, prompts, palettes, styles, and workflow references."
-    },
-    "4bd297094af2": {
-      "disposition": "ported",
-      "notes": "The Hermes-adapted Baoyu article illustrator PORT_NOTES and skill/reference updates were adopted from the current upstream optional skill tree."
-    },
-    "a93de60b6819": {
-      "disposition": "ported",
-      "notes": "Baoyu article illustrator was adopted from current upstream after its Hermes tool-capability alignment, including the prompt and workflow updates."
-    },
-    "3d258097db55": {
-      "disposition": "ported",
-      "notes": "Baoyu article illustrator current upstream optional skill includes tightened description and platforms frontmatter; generated website docs remain superseded by Rust catalog governance."
-    },
-    "1579a6f4a974": {
-      "disposition": "ported",
-      "notes": "xurl SKILL.md was synced from upstream and now documents Docker HOME credential placement for Hermes tool subprocesses."
-    },
-    "5671461c0c58": {
-      "disposition": "ported",
-      "notes": "Code-wiki optional skill was adopted from upstream at optional-skills/software-development/code-wiki with SKILL.md and documentation templates."
-    },
-    "386f245d9d25": {
-      "disposition": "ported",
-      "notes": "OpenHands optional skill was adopted from upstream at optional-skills/autonomous-ai-agents/openhands/SKILL.md."
-    },
-    "263e008d6beb": {
-      "disposition": "ported",
-      "notes": "Web-pentest optional skill was adopted from upstream at optional-skills/security/web-pentest with scope, technique references, scripts, and report templates."
-    },
-    "10cd4138cc66": {
-      "disposition": "ported",
-      "notes": "Grok optional skill was adopted from upstream at optional-skills/autonomous-ai-agents/grok/SKILL.md."
-    },
-    "99ddba94edee": {
-      "disposition": "ported",
-      "notes": "The current upstream Grok skill was adopted in its optional catalog placement with modern Hermes frontmatter and guidance."
-    },
-    "1bba5f27ab0c": {
-      "disposition": "ported",
-      "notes": "Antigravity CLI operator skill was adopted from upstream at optional-skills/autonomous-ai-agents/antigravity-cli with reference docs."
-    },
-    "632a7088a32a": {
-      "disposition": "ported",
-      "notes": "Antigravity CLI optional skill was adopted with Hermes-tool framing and tightened frontmatter from upstream."
-    },
-    "78d7fa1b5c07": {
-      "disposition": "ported",
-      "notes": "Antigravity CLI was adopted in the upstream autonomous-ai-agents optional category, matching the final refactor location."
-    },
-    "ace4b722dc2b": {
-      "disposition": "ported",
-      "notes": "Simplify-code skill was adopted from upstream at skills/software-development/simplify-code/SKILL.md for the parallel three-reviewer cleanup workflow."
-    },
-    "cea87d913904": {
-      "disposition": "superseded",
-      "notes": "Upstream website skills-hub source aggregation is superseded by approved rust-cli-tui-primary-ux-surface and rust-skills-catalog-governance divergences; actual SKILL.md source trees are tracked by Rust loaders and parity queue overrides."
-    },
-    "a1eaad2fc0bf": {
-      "disposition": "superseded",
-      "notes": "Upstream website skills-page lazy catalog fetch is a generated website UX concern, superseded by approved website divergence while Rust skill catalog loading remains native."
-    },
-    "5e9d7a766107": {
-      "disposition": "superseded",
-      "notes": "Upstream skills-hub degenerate-index fix applies to website catalog generation; this Rust fork tracks skill source trees directly and treats website skills pages as approved divergence."
-    },
-    "d6615d8ec7d5": {
-      "disposition": "ported",
-      "notes": "Rust Telegram topic lanes are represented by adapter-level message_thread_id to composite chat_id routing plus Gateway session keys scoped by the encoded chat_id. Regression tests cover independent Telegram topic sessions, /new current-topic isolation, adapter topic send routing, topic binding recovery helpers, and config/env allowed_topics/ignored_threads hydration."
-    },
-    "ede47a54be04": {
-      "disposition": "ported",
-      "notes": "Rust gateway pins Telegram DM-topic routing to the active topic by preserving the encoded topic chat_id through route_message, runtime context, session keys, and outbound sends; telegram_topic_chat_ids_are_independent_session_lanes proves later turns in one topic do not drift to sibling topics."
-    },
-    "95a0955e19f8": {
-      "disposition": "ported",
-      "notes": "Rust /new resets only the current encoded Telegram topic session key and keeps sibling topic lanes intact; telegram_topic_new_resets_only_current_topic_lane proves the topic thread identity survives session reset/split."
-    },
-    "60f84c6c28bf": {
-      "disposition": "ported",
-      "notes": "Rust gateway keeps inbox-style Telegram operational chatter quiet by default via default_tool_progress_for_platform, while /verbose remains config-gated and cycles explicit progress modes; gateway_verbose_command_is_config_gated_and_cycles_tool_progress covers this behavior."
-    },
-    "a4fb0a3ac39f": {
-      "disposition": "ported",
-      "notes": "Rust cron delivery routing preserves explicit inline platform chat ids/--deliver-chat-id, carries DeliverConfig on CronCompletionEvent, and the gateway cron delivery loop sends successful or failed cron completions through registered adapters. Telegram cron deliveries resolve TELEGRAM_CRON_THREAD_ID at fire time for unthreaded/home targets while explicit telegram:chat:thread wins. Tests cover stored chat id preservation, home-channel fallback, explicit thread precedence, webhook serialization, and docs now document the env var."
-    },
-    "a7683d04a964": {
-      "disposition": "ported",
-      "notes": "Rust Telegram topic sessions do not mutate Python SessionStore/SQLite bindings; topic identity is the encoded chat_id:thread_id session key. /new resets only that current encoded key, and /topic <session-id> now reuses the persisted session switch path for restores without split-brain binding state."
-    },
-    "1381c89e56fd": {
-      "disposition": "ported",
-      "notes": "Rust topic routing treats Telegram General topic thread_id=1 and threadless messages as the root chat, while every non-General thread gets an independent encoded session key. Python-specific cascade migration and auto-rename guards are superseded because this Rust runtime has no telegram_dm_topic_bindings table and no Telegram topic auto-rename path."
-    },
-    "d35efb989884": {
-      "disposition": "ported",
-      "notes": "Rust gateway now exposes /topic, /topic help, /topic off, and /topic <session-id>. Authorization is enforced by existing DM/platform access gates before command execution; /topic off is an idempotent no-op because there are no Python SQLite topic bindings to clear."
-    },
-    "0325e18f3426": {
-      "disposition": "ported",
-      "notes": "Rust Telegram status updates already use send_or_update_status with edit-in-place fallback, and gateway tool progress remains quiet for Telegram by default while /verbose can explicitly raise it. Progress/status docs now describe the Rust-native behavior instead of Python heartbeat binding state."
-    },
-    "2f0c8e90e613": {
-      "disposition": "superseded",
-      "notes": "Upstream Telegram QR dashboard onboarding targets the Python web dashboard, which is not a Rust runtime surface in this fork. Rust CLI QR onboarding remains the supported local setup path; adding the upstream Python web_server/dashboard flow would violate the Rust-only runtime boundary."
-    },
-    "dde9c0d19d16": {
-      "disposition": "ported",
-      "notes": "Rust gateway tool-progress callbacks now emit explicit progress messages when enabled, and markdown-capable platforms render terminal commands as full bash fenced code blocks through build_gateway_tool_progress_message. Tests cover Telegram bash blocks, plain-platform compact fallback, and blank-command fallback."
-    },
-    "92dfd70d6a71": {
-      "disposition": "superseded",
-      "notes": "Upstream Photon gRPC iMessage hardening targets Python/Node optional plugin paths. Hermes Ultra's runtime messaging surface is Rust gateway adapters; no Photon sidecar is loaded by the Rust runtime."
-    },
-    "c6dc2fcd2153": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop profile-backend release-before-delete targets Electron and Python profile managers. Rust profile/session lifecycle is managed through typed config, App session state, and SessionPersistence."
-    },
-    "c4811c382fd5": {
-      "disposition": "superseded",
-      "notes": "Electron desktop icon padding changes do not affect the Rust CLI/gateway runtime or local parity gates."
-    },
-    "52f7e24a7496": {
-      "disposition": "superseded",
-      "notes": "Upstream React/TUI Plugins Hub overlay is superseded by Hermes Ultra's Rust skill/plugin governance surfaces and approved Rust CLI/TUI primary UX divergence."
-    },
-    "39b76d90137a": {
-      "disposition": "superseded",
-      "notes": "Python wheel/sdist optional-MCP packaging is not used by the Rust/Cargo runtime. Local MCP catalog and config handling are Rust-native."
-    },
-    "1febb0824000": {
-      "disposition": "ported",
-      "notes": "Rust Anthropic/OpenRouter request shaping covers modern thinking controls and strips unsupported fast-model controls in provider_profiles and provider.rs tests, including test_anthropic_strips_sampling_and_unsupported_fast_controls."
-    },
-    "ba44de06da10": {
-      "disposition": "superseded",
-      "notes": "Electron download self-heal is installer/desktop-only. Hermes Ultra's supported install and verification path is Rust/Cargo plus local parity gates."
-    },
-    "46fedef07fda": {
-      "disposition": "ported",
-      "notes": "Rust OpenRouterProvider::merge_extra_body strips local reasoning_effort and maps reasoning controls to the provider reasoning object with regression coverage in test_openrouter_merge_extra_body_strips_local_cache_fields."
-    },
-    "8d71c3891970": {
-      "disposition": "superseded",
-      "notes": "Electron websocket reconnect and Python tui_gateway session rebind paths are superseded by Rust gateway session state and agent cache rebind behavior."
-    },
-    "68a997fed4a1": {
-      "disposition": "superseded",
-      "notes": "README SEO website links are documentation/website metadata. Local README and parity release docs intentionally describe the Rust Ultra fork rather than mirroring upstream site links."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
     "4906dcfc256b": {
       "disposition": "superseded",
       "notes": "Desktop drag-drop remote workspace staging is an Electron UX path. Rust runtime attachment/file workflows are handled through gateway media and tool file surfaces."
     },
-    "153060e206cd": {
-      "disposition": "superseded",
-      "notes": "Desktop optimistic base64 thumbnail rendering is React desktop UI only and is outside the Rust CLI/gateway runtime surface."
-    },
-    "72154ad879e2": {
-      "disposition": "superseded",
-      "notes": "Hosted GitHub CI uv-cache tuning is optional for this fork; local scripts and Rust gates are the authoritative CI/CD surface."
-    },
-    "891c9a682348": {
-      "disposition": "superseded",
-      "notes": "Desktop eager-upload race fixes target Electron composer stores. Rust gateway media/file handling is separate and locally gated."
-    },
-    "b021497bc84e": {
-      "disposition": "superseded",
-      "notes": "Desktop edit-composer staging spinner is React UI polish and not a Rust runtime parity requirement."
-    },
-    "29147afd637d": {
-      "disposition": "superseded",
-      "notes": "Desktop remote attachment toast copy is React desktop UX only. Rust gateway media limits and send errors are handled in platform adapters."
-    },
-    "218452b05019": {
+    "490b3e76b138": {
       "disposition": "ported",
-      "notes": "Rust SessionPersistence now detects malformed sessions.db schema, backs up raw DB sidecars, deduplicates sqlite_master, escalates to FTS schema drop and rebuild, auto-heals once during ensure_db, exposes hermes sessions repair, and has focused regression tests."
+      "notes": "Rust Hindsight defaults recall_types to observation and sends the same configured type list through automatic recall and hindsight_recall tool calls."
+    },
+    "492c4c6573b4": {
+      "disposition": "superseded",
+      "notes": "Python TUI pending-title flush/no-op DB lookup edge cases are superseded by Rust gateway Session.title mutation on the active in-memory session, with hook/status/session-list regression coverage."
+    },
+    "49596b70cb2d0d328d68645905febb074e494e77": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: SessionPersistence resolves resume targets through compression-continuation children only when the parent ended with end_reason='compression', has ended_at set, and the child was created after that end time; CLI resume snapshot loading follows the resolved tip so parent resumes include post-compression child messages. Focused tests cover non-empty compressed parents, branch-child guardrails, chain traversal, and snapshot reload.",
+      "owner": "rust-runtime"
+    },
+    "498bfc7bc12a": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "498c01406fce": {
+      "disposition": "superseded",
+      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
+    },
+    "49dd91d682a4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "49e743985aaf": {
+      "disposition": "ported",
+      "notes": "Ported in Rust provider profiles: crates/hermes-agent/src/provider.rs has MiniMax-M3 OpenAI reasoning contract tests and crates/hermes-agent/src/auxiliary_builder.rs registers MiniMax-M3 direct providers.",
+      "owner": "rust-runtime"
+    },
+    "49f1b9e4b44f": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "4a1840e68350": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "4a1907bd10c3": {
+      "disposition": "superseded",
+      "notes": "Upstream change is confined to apps/desktop React i18n wiring and zh-Hans catalog files. Hermes Agent Ultra has no Electron desktop tree in this Rust runtime repo; CLI/TUI/gateway text remains Rust-native and is not backed by the upstream desktop i18n catalog."
+    },
+    "4b2d00f845eb": {
+      "disposition": "ported",
+      "notes": "Rust custom provider catalogs now preserve `discover_models: false` from both canonical llm_providers and legacy custom_providers, keep explicit `models` subsets without probing live `/models`, and expose config-aware provider lists with Rust model-switch tests."
+    },
+    "4b7a18600393": {
+      "disposition": "superseded",
+      "notes": "Desktop self-update rebuild retry spans Electron and bootstrap-installer/Tauri paths absent from Ultra. Rust update/release behavior is owned by the CLI and repository release scripts.",
+      "owner": "rust-runtime"
+    },
+    "4bd297094af2": {
+      "disposition": "ported",
+      "notes": "The Hermes-adapted Baoyu article illustrator PORT_NOTES and skill/reference updates were adopted from the current upstream optional skill tree."
+    },
+    "4c57a5b31837": {
+      "disposition": "superseded",
+      "notes": "optional-skill parity is covered by local multi-registry skill surfaces; upstream single-skill delta is superseded"
+    },
+    "4c797d0e23c1": {
+      "disposition": "superseded",
+      "notes": "Windows console child hiding is Electron GUI process management and not part of the Rust CLI/gateway runtime."
+    },
+    "4c8bbe641696": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: ChronosNasCronProvider provisions/cancels/lists NAS-mediated one-shots, scheduler disables in-process polling when managed cron is active, and focused managed-provider tests pass.",
+      "owner": "rust-runtime"
+    },
+    "4cdb6962ca3f": {
+      "disposition": "ported",
+      "notes": "Hermes Agent skill-authoring guidance is bundled locally at skills/software-development/hermes-agent-skill-authoring/SKILL.md with frontmatter, authoring conventions, and validator-oriented structure."
+    },
+    "4db58d45d4e0": {
+      "disposition": "ported",
+      "notes": "Rust startup model parsing trims configured and env-sourced model strings through resolve_startup_model/resolve_provider_and_model, and runtime env synchronization keeps model/provider variables aligned for TUI sessions."
+    },
+    "4ddb03390a95": {
+      "disposition": "superseded",
+      "notes": "Upstream custom OpenAI endpoint API-key collection is desktop onboarding plus Python web_server settings. Hermes Agent Ultra handles model/provider credentials through Rust config/auth/provider flows; the Electron onboarding overlay and Python dashboard endpoint are not local Rust runtime surfaces."
+    },
+    "4df62d239e38": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight applies recall_types narrowing to both context injection and explicit tool recall paths."
+    },
+    "4e78963fe86a5f2758bf754a7979dc31aaf1a3db": {
+      "disposition": "superseded",
+      "notes": "The dead Python nested usage dict path is structurally superseded by Rust's typed AgentResult.usage and PromptExecutionOutput.usage flow; the CLI ACP usage test proves only the top-level typed fields are converted."
+    },
+    "4ece87efb0dd": {
+      "disposition": "ported",
+      "notes": "Rust Firecrawl support covers search and extract through direct, self-hosted URL, and Nous-managed gateway transports, with response normalization and backend-selection tests for Firecrawl-specific shapes."
+    },
+    "4ed2f3399418": {
+      "disposition": "superseded",
+      "notes": "Long user-message scrolling is a desktop React thread presentation fix. Ultra uses Rust terminal/TUI history rendering instead of apps/desktop thread components.",
+      "owner": "rust-runtime"
+    },
+    "500cf537b7d0": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "50943251400b": {
+      "disposition": "ported",
+      "notes": "Adopted upstream shop skill v1.0.1 directly: optional-skills/productivity/shop replaces shop-app and includes CLI/direct-API reference files for catalog, checkout, orders, safety, and legal guidance."
+    },
+    "50f9fee988b6": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "511add724987": {
+      "disposition": "ported",
+      "notes": "The video orchestrator optional skill is present at optional-skills/creative/kanban-video-orchestrator/SKILL.md with assets, scripts, and monitoring references."
+    },
+    "518d37f6af49": {
+      "disposition": "ported",
+      "notes": "ported in local commit c261ffeae (kanban reclaim_first support)"
+    },
+    "51a2c07016b2": {
+      "disposition": "ported",
+      "notes": "X Article ingestion guidance is represented in skills/social-media/xurl/SKILL.md within the local skills catalog."
+    },
+    "51b44b6e3fa1": {
+      "disposition": "ported",
+      "notes": "ComfyUI node/registry guidance is represented by the corrected local SKILL.md and reference materials under skills/creative/comfyui, without importing upstream Python runtime."
+    },
+    "51c68d4ab1a9": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "51ee5b2c94d0": {
+      "disposition": "ported",
+      "notes": "Ported in this batch: display.memory_notifications is typed config with env/config set/get bridge, and gateway background review callbacks are gated by this setting with focused tests.",
+      "owner": "rust-runtime"
+    },
+    "52f7e24a7496": {
+      "disposition": "superseded",
+      "notes": "Upstream React/TUI Plugins Hub overlay is superseded by Hermes Ultra's Rust skill/plugin governance surfaces and approved Rust CLI/TUI primary UX divergence."
+    },
+    "53a2ac8f2dba": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "53fc10fc9a8b": {
+      "disposition": "ported",
+      "notes": "Rust default personality remains neutral: config defaults to no persona and the explicit default marker resolves to the base Hermes identity without adding a built-in personality overlay."
+    },
+    "5404a8fcd8a5": {
+      "disposition": "ported",
+      "notes": "rust gateway already supports vision/image URL handling and platform media send paths; this slice adds MEDIA marker extraction/routing with unsafe path blocking to close generated screenshot/image delivery parity"
+    },
+    "547a014e7eae": {
+      "disposition": "superseded",
+      "notes": "Upstream fix is apps/desktop React markdown preprocessing for huge fenced blocks. Ultra has no Electron desktop renderer; Rust CLI/TUI/gateway output handling and terminal/tool result surfaces own runtime rendering instead.",
+      "owner": "rust-runtime"
+    },
+    "5494c1e9b660": {
+      "disposition": "superseded",
+      "notes": "Rust OpenViking uses repo-native openviking.json with shared atomic owner-only config IO instead of mutating ovcli profiles; dead Python ovcli constants are not part of the Rust runtime.",
+      "owner": "rust-runtime"
+    },
+    "559c6ad94aee": {
+      "disposition": "ported",
+      "notes": "Pinggy tunnel optional skill was adopted from upstream at optional-skills/devops/pinggy-tunnel/SKILL.md."
+    },
+    "55a18e68600d": {
+      "disposition": "superseded",
+      "notes": "Upstream allow_permanent comment/DRY cleanup is Python, desktop React, and ui-tui TypeScript presentation polish. The Rust approval contract remains the source of truth and already exposes allow_permanent on prompts, gateway requests, and hooks."
+    },
+    "55a76ec6695d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "55f518e5216a": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "5643c2979013": {
+      "disposition": "superseded",
+      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
+    },
+    "565b7c8d9d879c6423c55e9be84596936bc489ba": {
+      "disposition": "superseded",
+      "notes": "Upstream repairs lingering Python sendChatAction typing refreshes. Ultra's Rust Telegram adapter does not implement a typing-indicator refresh loop, so there is no post-final typing state to re-arm or clear.",
+      "owner": "rust-runtime"
+    },
+    "5671461c0c58": {
+      "disposition": "ported",
+      "notes": "Code-wiki optional skill was adopted from upstream at optional-skills/software-development/code-wiki with SKILL.md and documentation templates."
+    },
+    "56a0f48ba6d9": {
+      "disposition": "superseded",
+      "notes": "Upstream remote filesystem wiring tightening targets the desktop file tree route. The Rust runtime has no matching Electron bridge; file access remains native Rust tool execution with existing path and approval controls."
+    },
+    "56be1a63a33d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "573b964dc780": {
+      "disposition": "superseded",
+      "notes": "Superseded by Ultra release installer: scripts/install.sh installs release binaries/cargo artifacts and does not use upstream in-place git stashing/update semantics.",
+      "owner": "installer"
+    },
+    "573c4e651154": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon spectrum-ts markdown/reaction support is implemented in the Python adapter and Node sidecar. The Rust gateway does not register Photon, while reaction lifecycle and markdown/document handling are covered for supported Rust adapters."
+    },
+    "5772e638c9ba": {
+      "disposition": "ported",
+      "notes": "Removed the tracked infographic/ asset tree and added infographic/ to .gitignore so generated PR infographics stay in PR bodies rather than the repository."
+    },
+    "57b43fdd4bf9": {
+      "disposition": "ported",
+      "notes": "Rust startup provider precedence is typed through provider:model resolution and config.llm_providers lookup without treating stale HERMES_INFERENCE_PROVIDER as an explicit launch provider; regression coverage keeps config-selected providers authoritative."
+    },
+    "580d9240979c": {
+      "disposition": "superseded",
+      "notes": "The upstream SQL-bounded desktop SessionDB optimization is superseded for Rust because the relevant runtime surface is file-backed resume snapshots rather than the Python desktop session-search endpoint. The Rust port avoids message-body scans, searches only snapshot stems plus session_info.session_id metadata, and preserves deterministic bounded result selection for resume."
+    },
+    "586b0a7047ea": {
+      "disposition": "ported",
+      "notes": "rust text_to_speech/tts_premium providers and gateway MEDIA marker delivery cover TTS audio handoff without Python Edge TTS runtime; existing TTS tests plus gateway media marker tests prove audio file delivery path"
+    },
+    "587d1cf72095": {
+      "disposition": "superseded",
+      "notes": "The mixed Python web/MoA/trajectory update is superseded by Rust web provider backends, first-class mixture_of_agents runtime/tests, and Rust session/tool-result persistence. Python trajectory file management is not a separate Rust runtime boundary."
+    },
+    "5883df5574de": {
+      "disposition": "ported",
+      "notes": "Rust Honcho preserves legacy schemeless baseUrl configs by normalizing them to HTTPS instead of dropping the configured host."
+    },
+    "58d5fa1e4cec": {
+      "disposition": "superseded",
+      "notes": "Python FAL dependency wiring is superseded by Rust reqwest-based FalImageGenBackend with direct FAL_KEY and Nous-managed fal-queue transports plus hermetic backend tests; no Python requirement path remains."
+    },
+    "58eb473baa81": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "590b3c0d7eae": {
+      "disposition": "ported",
+      "notes": "Rust Telegram edit_text now rejects overflow instead of truncating, forcing callers onto split-send fallback; send_message already splits Telegram output and edit_text_rejects_overflow_without_truncating covers the regression."
     },
     "59ea2f98e691": {
       "disposition": "superseded",
       "notes": "Desktop Manage-profiles overflow visibility is Electron/React UI only; Rust profile operations are exposed through CLI/config flows."
     },
-    "93340fa3c1b8": {
+    "5a00bd151896": {
       "disposition": "ported",
-      "notes": "Rust terminal execution honors explicit workdir, task-scoped cwd, and non-local TERMINAL_CWD through TerminalHandler tests, covering the profile terminal.cwd behavior without Python tui_gateway."
+      "notes": "Rust gateway already persists /title immediately because route_message creates the session before command handling and SessionManager::set_title updates live state directly; gateway_title_command_persists_and_surfaces_session_title covers set/show/status/session-list behavior.",
+      "owner": "rust-runtime"
+    },
+    "5a22cd427dd6": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5a3092b60106": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5aa755e4e63c": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "5abe45674dc7": {
+      "disposition": "ported",
+      "notes": "Rust tool execution middleware catches middleware panics and preserves the downstream result when next_call already ran, including error ToolResult values. Regression coverage proves downstream failures survive middleware post-processing failure.",
+      "owner": "rust-runtime"
+    },
+    "5ad2b4c6dab7": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence now treats SQLite FTS5 as optional: base session persistence remains available without FTS, FTS deletes are guarded, and tests cover no-FTS degradation helpers."
+    },
+    "5af899c7ca75": {
+      "disposition": "ported",
+      "notes": "Rust profile management now reverse-displays custom aliases from aliases.json in profile list rows and current-profile output, prefers custom aliases over profile-named self aliases, keeps raw profile show output parse-safe, and covers the real CLI create/alias/list/use/current flow."
+    },
+    "5b3fa2636632": {
+      "disposition": "superseded",
+      "notes": "Photon/Spectrum remains a Python plus Node optional platform plugin and is not part of Ultra's Rust runtime surface; no Rust-native Photon adapter is scoped in this parity batch."
+    },
+    "5b43bf7d023c": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5b71f7dd7249": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5bb7156949f4": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5bcb63e400987e937e696b385e01285339b565c5": {
+      "disposition": "superseded",
+      "notes": "The Python TUI global _sessions/_pending lock fix is structurally superseded by Rust session managers and pending stores that already use Mutex/RwLock for compound mutations (hermes-acp SessionManager/PermissionStore, hermes-gateway SessionManager/BusySessionCoordinator). This slice also adds a Mutex-backed process notification receipt store for the overlapping process-event flood path."
+    },
+    "5c0a1fec0c14": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5d3398aa8a20": {
+      "disposition": "superseded",
+      "notes": "Upstream terminal approval and CLI feedback refactor is superseded by Rust ApprovalManager plus session-scoped YOLO/approval state, hardline and sudo floors, gateway approval lifecycle, and terminal handler denial/bypass tests."
+    },
+    "5d349ea857d4": {
+      "disposition": "superseded",
+      "notes": "Python get_or_create cache locking is superseded by Rust Honcho's stateless HTTP session operations and Mutex-protected local session key."
+    },
+    "5d36871d923c": {
+      "disposition": "ported",
+      "notes": "Rust Honcho loads global fallback config from ~/.honcho/config.json and ~/.hermes/honcho.json before the active HERMES_HOME honcho.json path."
+    },
+    "5d4c93afe476": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5d6c16e97237": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "5d8c44a39341": {
+      "disposition": "superseded",
+      "notes": "Docker matrix dependency preinstall targets upstream image composition. Local Rust build/test gates and Docker policy are authoritative for this fork."
+    },
+    "5dee40fcc0a1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5df732a355c8": {
+      "disposition": "superseded",
+      "notes": "Quick-create profile from the desktop rail is React desktop UI. Rust profile creation is handled by the CLI `hermes profile create` command and profile YAML files; there is no Rust profile rail to port."
+    },
+    "5e2b83a8ada8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5e5308d34d87": {
+      "disposition": "superseded",
+      "notes": "Upstream @types/node version pin is JavaScript/desktop tooling only. Hermes Agent Ultra's release/runtime gates are Rust Cargo based and do not consume the upstream Node type package for runtime behavior."
+    },
+    "5e55b35cc8fb": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5e851bc6bc51": {
+      "disposition": "ported",
+      "notes": "Rust Discord auto slash registration now caps auto-added commands at Discord's 100-command application limit after reserving explicit command names, preserving gateway-before-plugin ordering with regression coverage."
+    },
+    "5e9d7a766107": {
+      "disposition": "superseded",
+      "notes": "Upstream skills-hub degenerate-index fix applies to website catalog generation; this Rust fork tracks skill source trees directly and treats website skills pages as approved divergence."
+    },
+    "5f4b93c20f41": {
+      "disposition": "ported",
+      "notes": "Rust transcription now exposes Mistral/Voxtral STT with MISTRAL_API_KEY, /v1/audio/transcriptions endpoint construction, voxtral model defaults, no unsupported response_format multipart field, schema coverage, and gateway SttProvider::MistralVoxtral tests."
+    },
+    "5f6be7f31bd7": {
+      "disposition": "ported",
+      "notes": "Ported/superseded by Rust-native Microsoft Teams pipeline in crates/hermes-tools/src/teams_pipeline.rs, including Graph auth/download, meeting jobs, Teams sink writer, and tests.",
+      "owner": "rust-runtime"
+    },
+    "5f91b1a48b06": {
+      "disposition": "ported",
+      "notes": "OSINT investigation optional skill was adopted from upstream under optional-skills/research/osint-investigation with source references, scripts, and templates."
+    },
+    "5fa493a2ca6a": {
+      "disposition": "ported",
+      "notes": "Google Workspace setup.py implements --check-live and disabled_client/invalid_client diagnostics for real API auth validation."
+    },
+    "5fca754ee335": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5feec8b4cfcb": {
+      "disposition": "superseded",
+      "notes": "Upstream relay conformance tests target the Python gateway relay adapter. Ultra has no active Rust relay adapter for this experimental contract, so the Python conformance harness is not a Rust runtime requirement.",
+      "owner": "rust-runtime"
+    },
+    "5ffbfed193ad13662b9e402f6667f111a7beae63": {
+      "disposition": "ported",
+      "notes": "Ported as a Rust-native MCP profile instead of a Python optional-mcps manifest: hermes mcp unreal-engine now writes the official Unreal Engine local HTTP endpoint to mcp_servers.json and config.yaml, keeps parallel tool calls disabled for Epic editor-thread execution, exposes status/remove actions, and has focused Rust tests for setup/remove synchronization.",
+      "owner": "rust-runtime"
+    },
+    "6062c24fd1c2": {
+      "disposition": "superseded",
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
+    },
+    "6092be413d59": {
+      "disposition": "superseded",
+      "notes": "Upstream hardens Python/s6 hosted Docker install-tree self-modification. Ultra uses a Rust multi-stage image with immutable /usr/local/bin binaries, /data as HERMES_HOME, and tini/gosu entrypoint ownership only for runtime state.",
+      "owner": "rust-runtime"
+    },
+    "60effcfc4427": {
+      "disposition": "ported",
+      "notes": "Rust now mirrors the upstream MCP discovery hardening with McpManager::connect_all_parallel for concurrent per-server discovery reports, user-visible CLI config warnings when url and command conflict, URL/transport validation for mcp list/test/configure/login, and regression tests for conflict detection, invalid configs, and failed-server parallel discovery."
+    },
+    "60f84c6c28bf": {
+      "disposition": "ported",
+      "notes": "Rust gateway keeps inbox-style Telegram operational chatter quiet by default via default_tool_progress_for_platform, while /verbose remains config-gated and cycles explicit progress modes; gateway_verbose_command_is_config_gated_and_cycles_tool_progress covers this behavior."
+    },
+    "6183e8ce1b5ee79f2d808d0c17ea46fbbf128c37": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram config: Bot API 10.1 rich messages are opt-in/default-off in serde defaults and CLI config mapping, with gateway and CLI tests pinning the default.",
+      "owner": "rust-runtime"
+    },
+    "61d9e3366d65": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "61ee2dbfdb40": {
+      "disposition": "superseded",
+      "notes": "Upstream fixes Python s6 profile gateway log directory handling. Ultra uses the Rust/tini-gosu container path documented in docker/entrypoint.sh and existing parity divergence, not upstream s6 stage2 hooks."
+    },
+    "620fd59b8e6f": {
+      "disposition": "ported",
+      "notes": "Ported in this batch: /model refresh [provider|provider:model] clears signed provider catalog payload/signature files and reloads through the configured provider catalog path with command and cache tests.",
+      "owner": "rust-runtime"
+    },
+    "628780b4f322": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "628f9040df43": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "62c2f5d8d2a6": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "630a4ef03c8e": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "632a7088a32a": {
+      "disposition": "ported",
+      "notes": "Antigravity CLI optional skill was adopted with Hermes-tool framing and tightened frontmatter from upstream."
+    },
+    "635253b9185f": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: display.busy_input_mode accepts interrupt/queue/steer, display.busy_ack_enabled suppresses automatic busy acknowledgements, env/config-set bridges cover HERMES_GATEWAY_BUSY_INPUT_MODE and HERMES_GATEWAY_BUSY_ACK_ENABLED, and gateway tests cover steer fallback/attachment and quiet queueing.",
+      "owner": "rust-runtime"
+    },
+    "63991bbd9751": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking skips symlinks when zipping uploaded directories and rejects top-level symlink upload paths."
+    },
+    "63f5e14c6993": {
+      "disposition": "mirrored",
+      "notes": "Rust repo now includes docs/mcp.md with client configuration, config validation rules, parallel discovery behavior, mcp serve setup, and Sentrux MCP profile examples, plus a README link near the MCP quick commands."
+    },
+    "643dc8279306": {
+      "disposition": "ported",
+      "notes": "Ported in Rust session/provider identity handling: custom provider identity is carried by hermes-config provider profiles and hermes-agent provider construction instead of Python runtime_provider persistence.",
+      "owner": "rust-runtime"
+    },
+    "647f95b4224c": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "64da518db413": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "652dd9c9f248": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: rich sends use reply_parameters instead of reply_to_message_id, latch off proven endpoint capability failures, default rich_messages remains opt-in, and bad-request rich payload failures fall back to legacy sendMessage with tests.",
+      "owner": "rust-runtime"
+    },
+    "654e16187e71": {
+      "disposition": "ported",
+      "notes": "Rust MCP sampling now handles server-initiated sampling/createMessage inside the client transport receive loop, replies with JSON-RPC results or mapped errors, supports per-client and per-server-config SamplingConfig, LlmCallback wiring, model allowlists, max token caps, max RPM rate limits, timeout errors, tool-use responses with max_tool_rounds governance, and SamplingMetrics audit counters. Focused hermes-mcp tests cover direct sampling governance, config inheritance, tool-loop enforcement, and interleaved transport-loop sampling replies."
+    },
+    "657874460f8e": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "658947480a01dc59a2aa7a6a06a6434d7214edff": {
+      "disposition": "ported",
+      "notes": "Rust ACP replay chunk events no longer carry the invalid messageId field; the typed event model omits the field and load replay tests assert serialized user/agent chunks match the ACP schema."
+    },
+    "65c762b2e83e": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "65ddc7c4a1dc": {
+      "disposition": "ported",
+      "notes": "Rust TUI composer drafts are scoped by session id and guarded from programmatic session history; this runtime has no desktop attachment composer to port."
+    },
+    "6622277f11ca1dee03e868b064fb1851e5598b77": {
+      "disposition": "ported",
+      "notes": "Rust ACP browser_navigate starts already expose polished navigate titles without raw content, and this slice adds regression coverage plus corrected tool kind mappings for polished browser and delegate tools."
+    },
+    "66adeef11a71": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "66c70966cd2a": {
+      "disposition": "ported",
+      "notes": "The current upstream optional-skills/blockchain/evm/SKILL.md was adopted, including the tightened modern-format frontmatter and Hermes runtime guidance."
+    },
+    "6716e66e89fc": {
+      "disposition": "ported",
+      "notes": "Rust hermes mcp serve is implemented in crates/hermes-mcp/src/serve.rs and exposed by hermes-cli handle_cli_mcp serve. Tests cover serve tool definitions, session/resource/event/approval tools, numeric coercion, stringified object arguments, and systems MCP conformance; docs/mcp.md documents the server mode."
+    },
+    "67233d1c2ad5": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "680189b5def4": {
+      "disposition": "ported",
+      "notes": "Baoyu article illustrator was adopted from upstream at optional-skills/creative/baoyu-article-illustrator with SKILL.md, prompts, palettes, styles, and workflow references."
+    },
+    "68a997fed4a1": {
+      "disposition": "superseded",
+      "notes": "README SEO website links are documentation/website metadata. Local README and parity release docs intentionally describe the Rust Ultra fork rather than mirroring upstream site links."
+    },
+    "69053832e301": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "692ae6dd073b": {
+      "disposition": "superseded",
+      "notes": "Documentation-only upstream README skill table/test-runner update is superseded by local Rust parity docs and repo-native verification scripts; no Rust runtime behavior changes."
+    },
+    "694adec6350f": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "699c770e5c06": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "6a2909fe5a07": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "6a72af044c44": {
+      "disposition": "ported",
+      "notes": "Rust managed gateway availability now uses peek_nous_access_token/is_managed_tool_gateway_ready so Firecrawl and Browser Use availability checks do not run refresh-capable Nous OAuth readers; actual request resolution remains refresh-aware and tests cover expired cached token availability."
+    },
+    "6a8e131a0ab4": {
+      "disposition": "ported",
+      "notes": "Hermes Ultra uses the upstream platform-plugin ntfy shape rather than a bundled core adapter; tests/gateway/test_ntfy_plugin.py covers plugin registration and standalone delivery."
+    },
+    "6b330522e1fb": {
+      "disposition": "superseded",
+      "notes": "Upstream AGENTS.md design-philosophy text is superseded by local Hermes Rust Parity Rules plus account-level engineering directives."
+    },
+    "6b4073648ece": {
+      "disposition": "ported",
+      "notes": "Ported in Rust config loader precedence: crates/hermes-config/src/loader.rs loads gateway.json, then config.yaml, then cli-config.yaml, then env overrides with explicit layer order and tests.",
+      "owner": "rust-runtime"
+    },
+    "6b76284c7769": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "6c00077d3838": {
+      "disposition": "superseded",
+      "notes": "Upstream RTL/bidi auto-direction is desktop React chat text rendering. Hermes Agent Ultra has no Electron assistant-ui message text component; terminal/TUI rendering follows the local Rust/terminal surfaces."
+    },
+    "6d2727ef1ce1": {
+      "disposition": "ported",
+      "notes": "Rust config loading normalizes Discord allow_from aliases from platforms.discord.allow_from and platforms.discord.extra.allow_from into allowed_users while preserving DISCORD_ALLOWED_USERS/env precedence, with loader regression coverage."
+    },
+    "6de3963e3769": {
+      "disposition": "ported",
+      "notes": "Rust App::switch_model syncs runtime provider/model env and persists the active model per session through SessionPersistence; tests cover session DB model updates and runtime env synchronization."
+    },
+    "6e20c1992ff9": {
+      "disposition": "superseded",
+      "notes": "Relay A2 trust-boundary rewrite applies to the experimental cross-repo relay contract. Ultra keeps the doc as reference only; active Rust gateway adapters enforce their own platform auth paths.",
+      "owner": "rust-runtime"
+    },
+    "6e250a55de50": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking sends bearer Authorization for API-key auth and uses multipart upload headers without forcing JSON Content-Type."
+    },
+    "6e41ca956bbf": {
+      "disposition": "superseded",
+      "notes": "Upstream JetBrains Mono bundling fixes xterm font metrics in the Electron desktop terminal pane. Hermes Agent Ultra has no Electron/xterm terminal pane; terminal execution and rendering are Rust CLI/TUI surfaces using host terminal fonts."
+    },
+    "6e46f99e7e8e": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "6e5c49bdc40d": {
+      "disposition": "superseded",
+      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
+    },
+    "6e7033bb4c79": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "6f6eb871d834": {
+      "disposition": "ported",
+      "notes": "Rust ACP session/new now accepts profile/home metadata and preserves it on the SessionState handed to prompt executors, so new chats can remain attached to their owning profile in the Rust runtime surface. Regression coverage asserts create, prompt, list, and fork profile ownership."
+    },
+    "6feb2afd50cb": {
+      "disposition": "ported",
+      "notes": "Rust Honcho covers pinUserPeer/pinPeerName transition behavior through alias parsing, host-block config, and identity-resolution regression tests."
+    },
+    "6feb40e70282": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "702f4df194ff": {
+      "disposition": "superseded",
+      "notes": "Container stage2 cron ownership repair targets upstream Python container hooks. Hermes Ultra uses Rust cron persistence and local Docker/OrbStack verification policy."
+    },
+    "70aaa774be92": {
+      "disposition": "ported",
+      "notes": "Rust reasoning configuration now preserves raw opencode-go effort levels for runtime model-specific mapping, including Kimi xhigh/max to high and minimal omission."
+    },
+    "70f53f36cb1c": {
+      "disposition": "ported",
+      "notes": "Rust CLI exposes hermes memory setup openviking as the manual setup path, normalizing endpoint values and writing an owner-only openviking.json that activates on later sessions.",
+      "owner": "rust-runtime"
+    },
+    "712bf4d8e429": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7137cccbd134": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking viking_add_resource uploads existing local files and directories through temp_upload and then creates resources with temp_file_id/source_name."
+    },
+    "715b691723c6": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop summarizing indicator is superseded by Rust TUI/gateway status surfaces; React assistant thread/desktop store code is not part of the shipped runtime.",
+      "owner": "rust-runtime"
+    },
+    "72154ad879e2": {
+      "disposition": "superseded",
+      "notes": "Hosted GitHub CI uv-cache tuning is optional for this fork; local scripts and Rust gates are the authoritative CI/CD surface."
+    },
+    "723c2331bd23": {
+      "disposition": "ported",
+      "notes": "Ported in this batch: terminal.home_mode is a typed Rust config field bridged through TERMINAL_HOME_MODE, local terminal/code subprocesses can use real or $HERMES_HOME/home, HERMES_REAL_HOME is exported, and docs/tests cover the policy."
+    },
+    "7245bc77eb3b": {
+      "disposition": "ported",
+      "notes": "Rust config loading now normalizes Python-style fallback_providers plus legacy fallback_model into a merged fallback_models chain, preserves fallback provider metadata in llm_providers, and forwards that chain into AgentConfig unless HERMES_FALLBACK_MODEL(S) overrides it."
+    },
+    "729a659a3c8a": {
+      "disposition": "ported",
+      "notes": "Teams meeting pipeline skill asset is present at skills/productivity/teams-meeting-pipeline/SKILL.md, backed by the Rust teams_pipeline runtime."
+    },
+    "72c8037a24b58b7b1a38a99903cc0bf8a3d7595c": {
+      "disposition": "ported",
+      "notes": "Rust ACP now has dedicated compact completion renderers for web_search, process, delegate_task, session_search, memory, media/cron, plus expanded tool kind/title mappings; tests assert raw JSON/private entry dumps are avoided."
+    },
+    "72eb42d9ecdf": {
+      "disposition": "superseded",
+      "notes": "The upstream Python source-checkout updater's stash/restore versus discard mode is superseded in Rust because top-level hermes update is non-mutating release-check behavior and does not run git checkout/pull/reset/clean against the source tree. The remaining shared safety contract, ignoring .hermes-bootstrap-complete so autostash paths do not capture Desktop bootstrap state, is ported separately under b459bac02c98."
+    },
+    "730347e38f9a": {
+      "disposition": "ported",
+      "notes": "TouchDesigner MCP expansion is present at skills/creative/touchdesigner-mcp with GLSL, post-FX, audio-reactive, geometry, and MCP reference material."
+    },
+    "7309f3bef7d7": {
+      "disposition": "superseded",
+      "notes": "LINE inbound message-type mapping is Python adapter-only in upstream; this Rust gateway surface has no LINE platform adapter under crates/hermes-gateway and no MessageType.IMAGE crash path to port."
+    },
+    "7330183d087f": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "733e297b8a5c": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "738d0900fddd": {
+      "disposition": "superseded",
+      "notes": "rust auxiliary transport stack in crates/hermes-intelligence/src/auxiliary/* already uses typed transport path and does not mirror Python auxiliary_client internals"
+    },
+    "73969771a514": {
+      "disposition": "superseded",
+      "notes": "Upstream dashboard /api/ws MCP discovery targets Python hermes_cli/tui_gateway startup. Hermes Agent Ultra exposes MCP through the Rust hermes-mcp client/server and Rust CLI registration paths; Python dashboard websocket backend discovery is not a Rust runtime surface."
+    },
+    "73a20a6ad62b678d69335ef3a352ccf9ab85167b": {
+      "disposition": "ported",
+      "notes": "Ported to Rust's edit surface: oversized Telegram edit previews are clipped to the Bot API text limit instead of failing mid-stream; final sends continue through the normal send/split path.",
+      "owner": "rust-runtime"
+    },
+    "73cd8622f9fcd5e368060d1a1678e08bd3d0a794": {
+      "disposition": "ported",
+      "notes": "Ported as a Rust-native terminal billing surface: `hermes billing` and `/billing` now render Nous billing state fail-open from the auth store and billing API, support scoped `billing:manage` device-code step-up, explicit-confirmation charge and auto-reload actions with idempotency-key handling and typed error mapping, charge status polling, deterministic portal URL normalization, decimal-string money formatting, and focused Rust tests for state parsing, scope detection, client contracts, CLI parsing, slash behavior, auth isolation, and confirmation gating."
+    },
+    "74180ebf0b1c": {
+      "disposition": "superseded",
+      "notes": "Upstream SimpleX document classification fixes a Python plugin adapter. Hermes Agent Ultra has no Rust SimpleX gateway adapter; document attachment classification is covered in supported Rust adapters such as Discord, Telegram, and Signal."
+    },
+    "741a34945810a7cb5142804660f9e6108e2d49ec": {
+      "disposition": "ported",
+      "notes": "Rust ACP now emits session_info_update after prompt turns refresh session metadata, using the Rust-derived session title so editor clients can update their session list without waiting for a separate list refresh."
+    },
+    "74239b494209": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "743c55efa34f": {
+      "disposition": "superseded",
+      "notes": "Upstream HTML5 backend remount fix targets the desktop file tree drag/drop provider. Hermes Agent Ultra has no React DnD file tree runtime."
+    },
+    "746618217950": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "74c8f51e95e4": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "758c40135f0f": {
+      "disposition": "ported",
+      "notes": "ported in local commit f4cb47a30 (blocking uv.lock check)"
+    },
+    "75adf7d603b1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "75e29f97ee39": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "769f307042d2": {
+      "disposition": "superseded",
+      "notes": "react-simple-icons npm lockfile noise is specific to upstream desktop/package management. Ultra has no npm desktop dependency tree in this Rust runtime repo.",
+      "owner": "rust-runtime"
+    },
+    "76b93869d8ed": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "76b98f43ca0a": {
+      "disposition": "superseded",
+      "notes": "Desktop ALL-profiles grouping gate touches only apps/desktop sidebar UI, which is absent from this Rust-only runtime repo."
+    },
+    "76d2dcdc8e10": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "76d929e17725": {
+      "disposition": "ported",
+      "notes": "rust approval manager and terminal handler implement dangerous command confirmation/denial, hardline blocks, gateway approvals, and session yolo controls with extensive tests in crates/hermes-tools/src/approval.rs and terminal handler tests"
+    },
+    "771cf41fea1f": {
+      "disposition": "superseded",
+      "notes": "Upstream Singularity/run-script terminal environment tuning is not a separate Rust runtime surface; Rust terminal execution already exposes explicit timeout, workdir, background, PTY, stdin, and process-polling contracts through typed handlers and tests."
+    },
+    "77687156b4b8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "77bb64813cb9": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7803cbfbb961": {
+      "disposition": "superseded",
+      "notes": "Desktop HUD surface styling is React/Electron-only and outside the Rust runtime contract."
+    },
+    "7849a3d73f2d": {
+      "disposition": "superseded",
+      "notes": "The upstream Python _platform_status/check_fn fallback does not exist in the Rust gateway. Rust platform state is explicit adapter registration plus PlatformAdapter::is_running, with Discord owned by crates/hermes-gateway/src/platforms/discord.rs."
+    },
+    "78886365c2a04f3367028190b71c5b4a96433279": {
+      "disposition": "ported",
+      "notes": "Rust ACP cancel now captures the interrupted user prompt and idle /steer replays it with explicit correction/guidance; hermes-acp tests cover cancel replay and clearing interrupted_prompt_text."
+    },
+    "78ce91750ec6": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "78d7fa1b5c07": {
+      "disposition": "ported",
+      "notes": "Antigravity CLI was adopted in the upstream autonomous-ai-agents optional category, matching the final refactor location."
+    },
+    "794519c6ad49": {
+      "disposition": "ported",
+      "notes": "Rust SessionPersistence updates sessions.model on persisted session conflicts, exposes update_session_model/get_session_model, and App::switch_model immediately refreshes existing persisted session metadata."
+    },
+    "7966560fb50f": {
+      "disposition": "ported",
+      "notes": "Rust now exposes first-class /reload-skills and /reload_skills in CLI and gateway. The command snapshots installed SKILL.md slash commands through the shared Rust resolver, reports available/blocked/skipped commands, queues an agent-visible next-turn note, and deliberately avoids prompt-cache invalidation. The upstream skills_reload agent tool portion is superseded by the later upstream refactor and not mirrored."
+    },
+    "796f618f9987306722c4e27fdfb757291240386b": {
+      "disposition": "superseded",
+      "notes": "Upstream fixes Python chunk marker placement around Markdown fences. Ultra's Rust Telegram split_message path does not append chunk markers, so the marker-inside-fence corruption mode is absent.",
+      "owner": "rust-runtime"
+    },
+    "79c3ed3cc91a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "79f7e7a1e9d8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7a2d498b9dd2": {
+      "disposition": "superseded",
+      "notes": "Upstream profile session read routing is desktop React hermes.ts/session-picker wiring. Hermes Agent Ultra session state is owned by Rust SessionPersistence, CLI/TUI App state, and gateway session metadata rather than Electron profile session facades."
+    },
+    "7a4d5c123a29": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "7a4dc8e8d610": {
+      "disposition": "superseded",
+      "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
+    },
+    "7aaae7acd0d6": {
+      "disposition": "superseded",
+      "notes": "Upstream refines the Python SSL guard escape hatch. Ultra has no Python certifi guard path to bypass; TLS trust is owned by Rust reqwest/rustls and webpki roots."
+    },
+    "7ae8aac3b9b2": {
+      "disposition": "ported",
+      "notes": "Rust terminal and slash/TUI model flows now include configured custom providers, use explicit provider model lists when discovery is disabled, fall back to configured models after empty probes, and guard direct switches against those configured catalogs with CLI/config tests."
+    },
+    "7b4acadfe765": {
+      "disposition": "superseded",
+      "notes": "Per-profile plus-button session creation in the all-profiles desktop view is apps/desktop sidebar UI. Rust gateway sessions are created by incoming platform messages and can now receive per-session profile overlays through `/profile`."
+    },
+    "7ba5df0d52b9": {
+      "disposition": "superseded",
+      "notes": "Upstream /credits adds Python CLI/gateway billing views and Ink UI-TUI RPC/buttons. Hermes Agent Ultra's Rust runtime has provider auth diagnostics and usage accounting, but it does not ship the upstream Python CLI or Ink TUI money surface, so this UI-only command remains reference-only until a Rust-native billing surface is deliberately designed."
+    },
+    "7c00ffd92c41": {
+      "disposition": "ported",
+      "notes": "Google Workspace setup fallback behavior is represented in skills/productivity/google-workspace/scripts/setup.py, including virtualenv/pip diagnostics and uv-compatible setup guidance."
+    },
+    "7c226cc57fe6": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7cbe943d2dc1": {
+      "disposition": "ported",
+      "notes": "here.now is represented as an optional local skill at optional-skills/productivity/here-now/SKILL.md, matching the final upstream catalog placement."
+    },
+    "7cceead27373": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7d183f64979f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7d66d30d774e": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "7d938cc5c9c7": {
+      "disposition": "superseded",
+      "notes": "Upstream Python desktop/tui_gateway metadata restoration has no live Ultra path. Rust gateway status/model/provider metadata is explicit in crates/hermes-gateway/src/gateway.rs and Rust session state."
+    },
+    "7de8cd4c5f67": {
+      "disposition": "ported",
+      "notes": "TUI voice TTS state now flows through SlashHandlerContext into useMainApp status rendering, with createSlashHandler coverage for /voice tts state sync."
+    },
+    "7e2af0c2e872": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "7e3c8a31f0f3": {
+      "disposition": "ported",
+      "notes": "Airtable skill parity is present at skills/productivity/airtable/SKILL.md with Hermes-specific usage guidance and cookbook coverage."
+    },
+    "7ea37cd08236": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7f016f5f3360": {
+      "disposition": "ported",
+      "notes": "Rust model-provider preview surfaces now share DEFAULT_VISIBLE_MODELS_PER_PROVIDER=50 for CLI model listing, TUI provider picker details, and slash /provider output, with a regression test proving a 60-model configured provider exposes the first 50 while preserving total count."
+    },
+    "7f1b2b456953": {
+      "disposition": "ported",
+      "notes": "Rust terminal approval path denies confirmation-required commands without consent and now pins the same no-retry/no-rephrase/no-same-outcome 'Silence is not consent' contract in crates/hermes-tools/src/tools/terminal.rs."
+    },
+    "7f302c91b240": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7fbe9b79ab1d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "8044bf0206c1": {
+      "disposition": "superseded",
+      "notes": "Superseded by local deterministic gate scripts and optional GitHub CI policy; upstream test-duration upload behavior is not a Rust runtime requirement.",
+      "owner": "local-gates"
+    },
+    "8055d0f09246": {
+      "disposition": "ported",
+      "notes": "Rust ntfy gateway tests cover echo-tag outbound headers, inbound echo filtering, genuine tagged messages, and env-driven platform enablement; Python release AUTHOR_MAP updates are not part of the Rust release pipeline."
+    },
+    "8077e7d2fbbb": {
+      "disposition": "superseded",
+      "notes": "Upstream _session_resume_lock narrowing applies to Python TUI gateway concurrent live-agent construction; Rust interactive resume is guarded by the process-level interactive session lock and has no session.close RPC lock path to port."
+    },
+    "80bb5f294755": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "80e4b8985ea9": {
+      "disposition": "superseded",
+      "notes": "Desktop composer model picker interaction polish targets absent apps/desktop React files. Ultra model picker interactions are owned by the Rust TUI."
+    },
+    "8104b202691": {
+      "disposition": "ported",
+      "notes": "Rust xAI video generation routes default text vs image models by modality, honors explicit overrides, normalizes local image files to data:image URLs, and has focused video_gen regression coverage for those contracts."
+    },
+    "812dc6957e19": {
+      "disposition": "superseded",
+      "notes": "Searchable language picker is an apps/desktop React component plus i18n catalog update. Hermes Agent Ultra has no Electron language picker runtime surface to port."
+    },
+    "813a4e3838f6": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking implements on_session_switch, clears stale prefetch, rotates session id, resets dirty turn state for the new session, and tests the lifecycle hook.",
+      "owner": "rust-runtime"
+    },
+    "81436e143ebb": {
+      "disposition": "superseded",
+      "notes": "Upstream allow_permanent propagation fixes Python/TUI/desktop prompt payloads. Hermes Agent Ultra's Rust approval manager already carries allow_permanent in ApprovalPrompt, GatewayApprovalRequest, and approval hook events, and blocks permanent approvals for Tirith warnings."
+    },
+    "81647458c7a7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "81928f03ab58": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "81cd67829191": {
+      "disposition": "ported",
+      "notes": "Google Workspace SKILL.md frontmatter declares required_credential_files for google_token.json and google_client_secret.json."
+    },
+    "82205276c1ae": {
+      "disposition": "ported",
+      "notes": "Rust Honcho defaults HTTP timeout_secs to 30 seconds and still clamps explicit HONCHO_TIMEOUT_SECS/config values to the supported range."
+    },
+    "827ce602dbed": {
+      "disposition": "ported",
+      "notes": "Rust Honcho runtime now strips trailing /vN baseUrl suffixes, derives underscore-safe profile host keys while reading legacy dot-form host blocks, skips loopback auth unless hosts.<host>.apiKey explicitly opts in, and setup/config writes remain owner-only with targeted regression coverage."
+    },
+    "833410e02bc3": {
+      "disposition": "superseded",
+      "notes": "Desktop ANSI palette and HUD styling is Electron/React UI polish and not used by Rust runtime surfaces."
+    },
+    "83c13862f107": {
+      "disposition": "superseded",
+      "notes": "Upstream change is Electron desktop remote-profile read routing only (apps/desktop/electron/main.cjs). This Rust repo has no desktop Electron backend-routing layer; profile ownership is represented in Rust ACP/gateway session metadata instead."
+    },
+    "83c23e88617c": {
+      "disposition": "superseded",
+      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
+    },
+    "840ebe063eea": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "84287b0de8dd": {
+      "disposition": "superseded",
+      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
+    },
+    "84eb5f1f891b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "850413f1203f": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "8505e9d6691d": {
+      "disposition": "superseded",
+      "notes": "Upstream composer spellcheck is a desktop React/Electron input attribute fix. Hermes Agent Ultra uses the Rust Ratatui TUI/CLI composer and has no browser spellcheck attribute surface."
+    },
+    "85383c636309": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "853ed609a1a4": {
+      "disposition": "ported",
+      "notes": "TouchDesigner MCP is bundled in the local skills tree at skills/creative/touchdesigner-mcp/SKILL.md and is discoverable by the Rust bundled skill scanner."
+    },
+    "85b65e29f09b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "86371e6cd8d5": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-swap overlay border/radius styling touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "86643d84e99e": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "86c64cfb5bd5": {
+      "disposition": "superseded",
+      "notes": "Upstream Discord timeout fix targets Python discord.ui.View message editing. Rust Discord interactions are stateless REST responses/edits and have no discord.ui.View lifecycle; the existing model-picker edit contract already clears components when edits are sent."
+    },
+    "86f2946fbe78": {
+      "disposition": "superseded",
+      "notes": "Dashboard Chat tab recovery is an upstream React web surface. Ultra has no apps/desktop/web ChatPage Rust runtime; CLI/TUI/gateway session recovery is owned by Rust surfaces.",
+      "owner": "rust-runtime"
+    },
+    "8720023e963b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "878611a79dfa": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "87c6edc1d04f": {
+      "disposition": "ported",
+      "notes": "Google Workspace setup.py and gws_bridge.py were synced from upstream source truth and now pass explicit urlopen timeouts for OAuth/live-check network calls."
+    },
+    "883e11f0a09a": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "8878484f8519": {
+      "disposition": "superseded",
+      "notes": "Upstream remote filesystem browsing wires Electron desktop profile routes. Hermes Agent Ultra does not ship the Electron remote file tree; Rust remote/profile behavior is represented by ACP/gateway session metadata and explicit tool surfaces."
+    },
+    "88bdb6b07451": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "891c9a682348": {
+      "disposition": "superseded",
+      "notes": "Desktop eager-upload race fixes target Electron composer stores. Rust gateway media/file handling is separate and locally gated."
+    },
+    "894e0b935bb8": {
+      "disposition": "ported",
+      "notes": "Rust honcho_profile now explains an empty peer card and points users to honcho_search, honcho_context, or honcho_conclude for memory retrieval."
+    },
+    "8954537f956b": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "896a7ce261f8": {
+      "disposition": "ported",
+      "notes": "ported in local commit ae995f58b (stocks and finance skill added)"
+    },
+    "898ccfd66706": {
+      "disposition": "ported",
+      "notes": "Google OAuth redirect scope parsing is implemented in skills/productivity/google-workspace/scripts/setup.py by extracting the scope query parameter from the pasted callback URL and storing granted scopes."
+    },
+    "8a19884bf399": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "8a9ded5b21b1": {
+      "disposition": "ported",
+      "notes": "Rust gateway now has a dependency-free 48 kHz stereo s16le continuous VoiceMixer with ambient loops, ducked speech overlays, clipping, stop/cleanup, and synthesized ambient PCM, plus VoiceManager voice_fx lifecycle integration for join/remove, active checks, ack phrase selection, speech enqueue/read/stop, and focused mixer/manager unit tests."
+    },
+    "8b1ff55f5382": {
+      "disposition": "superseded",
+      "notes": "rust gateway already strips group mention prefixes for slash recognition in crates/hermes-gateway/src/platforms/wecom_callback.rs"
     },
     "8b84d82227a3": {
       "disposition": "superseded",
@@ -3106,391 +2380,615 @@
       "disposition": "superseded",
       "notes": "Desktop sidebar CSS overlap fixes are Electron UI polish and outside the Rust runtime surface."
     },
-    "ab5f1a1f1141": {
+    "8bd00607dc53": {
       "disposition": "superseded",
-      "notes": "Desktop session switcher keybindings target Electron/React UI. Rust session switching and persistence are native CLI/TUI flows."
+      "notes": "Gmail header casing delta applies to upstream Python Google Workspace bridge; this Rust workspace has no Gmail/Google Workspace runtime tool surface in crates beyond bundled skill synchronization/reference content, so there is no Rust header parser/sender to port."
     },
-    "258d24039fe5": {
+    "8c0f15478de9": {
       "disposition": "superseded",
-      "notes": "Desktop thinking-disclosure pending state is React rendering state; Rust reasoning capture/display is handled in provider parsing and gateway/TUI status paths."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "b96bd4808dab": {
-      "disposition": "superseded",
-      "notes": "Opening chats in separate Electron windows is desktop-only and not part of the Rust CLI/gateway runtime."
+    "8c3c08c50be8": {
+      "disposition": "ported",
+      "notes": "Ported/superseded by the Rust TUI model/provider modal implementation in crates/hermes-cli/src/tui.rs; the Python tui_gateway cleanup target is not shipped as the runtime backend.",
+      "owner": "rust-runtime"
     },
-    "27a321157970": {
+    "8cf9d8689d56": {
       "disposition": "superseded",
-      "notes": "VS Code Marketplace theme installation is Electron desktop theming. Hermes Ultra does not load that desktop theme runtime."
+      "notes": "Upstream desktop composer reconnect UX is superseded by Rust TUI/gateway connection surfaces; Electron composer code is intentionally not part of the Rust-only runtime.",
+      "owner": "rust-runtime"
+    },
+    "8d256779d8fa": {
+      "disposition": "ported",
+      "notes": "Rust OpenAiVisionBackend handles local image files by MIME-sniffing extensions and base64-encoding data URLs, validates remote image URLs against unsafe hosts/schemes, and normalizes empty vision responses with focused tests."
+    },
+    "8d71c3891970": {
+      "disposition": "superseded",
+      "notes": "Electron websocket reconnect and Python tui_gateway session rebind paths are superseded by Rust gateway session state and agent cache rebind behavior."
+    },
+    "8e0c48e6d25b": {
+      "disposition": "ported",
+      "notes": "Rust CLI and gateway now resolve otherwise-unknown installed SKILL.md slash commands from configured skill roots, apply enabled/disabled/platform/security filtering, inject full skill content plus invocation args into the normal agent turn, and cover the shared resolver plus CLI and gateway routing with focused tests."
+    },
+    "8e629b9f386d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
     "8f73d0d945d5": {
       "disposition": "superseded",
       "notes": "Desktop terminal pane resizing and palette polish targets React/Electron UI. Rust terminal backend behavior is covered by hermes-tools terminal tests."
     },
-    "1770263cccf7": {
-      "disposition": "superseded",
-      "notes": "Desktop default project directory creation is Electron workspace boot logic. Rust CLI sessions derive cwd/workspace through terminal and context-reference paths."
-    },
-    "6b330522e1fb": {
-      "disposition": "superseded",
-      "notes": "Upstream AGENTS.md design-philosophy text is superseded by local Hermes Rust Parity Rules plus account-level engineering directives."
-    },
-    "833410e02bc3": {
-      "disposition": "superseded",
-      "notes": "Desktop ANSI palette and HUD styling is Electron/React UI polish and not used by Rust runtime surfaces."
-    },
-    "fdc90346eaa3": {
-      "disposition": "superseded",
-      "notes": "Unsafe red-team skill relocation is not imported into the Rust runtime defaults. Local skill catalog already tracks red-team and mlops skills under approved optional governance."
-    },
-    "45e1689c03b2": {
-      "disposition": "superseded",
-      "notes": "Desktop marketplace submenu HUD token changes are Electron/React styling only."
-    },
-    "7803cbfbb961": {
-      "disposition": "superseded",
-      "notes": "Desktop HUD surface styling is React/Electron-only and outside the Rust runtime contract."
-    },
-    "464276228940": {
-      "disposition": "superseded",
-      "notes": "Python Langfuse plugin base64 redaction is superseded by Rust telemetry/redaction surfaces and optional plugin divergence; Rust runtime does not emit through that Python plugin."
-    },
-    "702f4df194ff": {
-      "disposition": "superseded",
-      "notes": "Container stage2 cron ownership repair targets upstream Python container hooks. Hermes Ultra uses Rust cron persistence and local Docker/OrbStack verification policy."
-    },
-    "19c07c40379b": {
+    "8fb3e2d63afb": {
       "disposition": "ported",
-      "notes": "Rust auxiliary client retries unsupported max_tokens responses with max_completion_tokens for newer OpenAI-family custom endpoints, covered by unsupported_max_tokens_retries_with_max_completion_tokens."
+      "notes": "Rust OpenViking always sends configured account/user/agent tenant headers on JSON and multipart requests."
     },
-    "311900842e88": {
+    "8fe334b056d4": {
       "disposition": "superseded",
-      "notes": "Upstream Discord auto-disconnect behavior is Python adapter voice-state logic. Rust voice lifecycle is explicit join/leave state with VoiceManager tests and no Python reply-mode disconnect path."
-    },
-    "e5580f43c258": {
-      "disposition": "ported",
-      "notes": "Rust DiscordInteractionAuthPolicy includes allowed_role_ids and role matching for components, slash commands, autocomplete, and fail-closed paths."
-    },
-    "af978ecb17ef": {
-      "disposition": "superseded",
-      "notes": "Upstream expensive-model picker confirmation is superseded by Rust runtime cost accounting and configurable session spend guard; Hermes Ultra does not use the Python/Electron picker flow."
-    },
-    "243cada157ff": {
-      "disposition": "superseded",
-      "notes": "Typed gateway /model pricing lookups in upstream Python are superseded by Rust slash command parsing, typed model switching, usage pricing database, and session cost guard policy."
-    },
-    "e80754647c90": {
-      "disposition": "superseded",
-      "notes": "Desktop in-thread tool codicon styling is React UI only and not a Rust runtime behavior."
-    },
-    "c1308ebf3f0f": {
-      "disposition": "superseded",
-      "notes": "Desktop filled tool SVG glyphs are React UI styling and outside Rust runtime parity."
-    },
-    "38273676eab0": {
-      "disposition": "superseded",
-      "notes": "Desktop titlebar drag-region CSS is Electron UI polish and not used by the Rust CLI/gateway runtime."
-    },
-    "5d8c44a39341": {
-      "disposition": "superseded",
-      "notes": "Docker matrix dependency preinstall targets upstream image composition. Local Rust build/test gates and Docker policy are authoritative for this fork."
-    },
-    "183d86b3e04e": {
-      "disposition": "ported",
-      "notes": "Rust provider profile and model-switch code maps reasoning_effort into provider-specific Gemini/OpenRouter reasoning controls, with regression tests for Gemini thinking levels and OpenRouter reasoning objects."
-    },
-    "a5c32cdf3055": {
-      "disposition": "superseded",
-      "notes": "Interrupted Python venv self-heal is installer/runtime-specific to upstream Python; Hermes Ultra uses Rust/Cargo install and local shell gates."
-    },
-    "2c19208224de": {
-      "disposition": "superseded",
-      "notes": "Python Gemini audio tag rewrite is superseded by Rust TTS streaming sanitizer and MultiTtsBackend architecture; the Python tools/tts_tool path is not the runtime source."
-    },
-    "4c797d0e23c1": {
-      "disposition": "superseded",
-      "notes": "Windows console child hiding is Electron GUI process management and not part of the Rust CLI/gateway runtime."
-    },
-    "a72bb03757c0": {
-      "disposition": "superseded",
-      "notes": "Docker image-size tuning for upstream Python/Node layers is superseded by local Rust packaging and build policy."
-    },
-    "3bfbb3f2a025": {
-      "disposition": "superseded",
-      "notes": "TypeScript/React CI toolchain changes are hosted UI tooling only; local Rust runtime gates are authoritative and GitHub CI is optional."
-    },
-    "90f4b3040dcc": {
-      "disposition": "superseded",
-      "notes": "React compiler ESLint/concurrently updates target upstream JS tooling and do not affect the Rust runtime parity gate."
-    },
-    "d986bb0c6de6": {
-      "disposition": "superseded",
-      "notes": "Python web dashboard profile builder is superseded by Rust CLI/config/profile flows and approved website/dashboard divergence."
-    },
-    "6de3963e3769": {
-      "disposition": "ported",
-      "notes": "Rust App::switch_model syncs runtime provider/model env and persists the active model per session through SessionPersistence; tests cover session DB model updates and runtime env synchronization."
-    },
-    "590b3c0d7eae": {
-      "disposition": "ported",
-      "notes": "Rust Telegram edit_text now rejects overflow instead of truncating, forcing callers onto split-send fallback; send_message already splits Telegram output and edit_text_rejects_overflow_without_truncating covers the regression."
-    },
-    "0a593f132c41": {
-      "disposition": "ported",
-      "notes": "GitHub skills now resolve shared .env through HERMES_HOME with project fallback instead of hardcoded ~/.hermes."
-    },
-    "d1383a6b1450": {
-      "disposition": "ported",
-      "notes": "Sibling skills touched by upstream now use HERMES_HOME-aware .env resolution or docs, while Hermes-specific skill text keeps the local Rust runtime framing."
-    },
-    "18d61bd06e06": {
-      "disposition": "ported",
-      "notes": "Upstream desktop composer draft persistence is ported into the Rust TUI as state-root backed per-session composer drafts that restore on restart, clear on submit, and stay separate from message persistence."
-    },
-    "3d14f01fd674": {
-      "disposition": "ported",
-      "notes": "Rust TUI composer drafts persist on actual input changes instead of conversation/session lifecycle, covering the upstream debounce/write-volume fix without adding a desktop React runtime."
-    },
-    "65ddc7c4a1dc": {
-      "disposition": "ported",
-      "notes": "Rust TUI composer drafts are scoped by session id and guarded from programmatic session history; this runtime has no desktop attachment composer to port."
-    },
-    "fdc0d1956636": {
-      "disposition": "ported",
-      "notes": "Rust TUI draft wiring restores at startup, clears on submit, and reloads after session-switching slash commands, matching the upstream draft lifecycle fix in the local composer surface."
-    },
-    "c710868fbca9": {
-      "disposition": "ported",
-      "notes": "Rust TUI draft storage is decoupled from App session lifecycle and message persistence; session reset/new session do not write unsent text into conversation state."
-    },
-    "292192f7d726": {
-      "disposition": "ported",
-      "notes": "Rust TUI composer draft helpers centralize load/save/clear behavior and keep best-effort IO warnings out of the typing path."
-    },
-    "d7d281fa37e4": {
-      "disposition": "ported",
-      "notes": "Strict per-thread drafts are implemented for the Rust TUI through per-session draft keys, MRU capped persistence, startup restore, submit clearing, and regression tests."
-    },
-    "f38f7a387013": {
-      "disposition": "superseded",
-      "notes": "Desktop stale runtime session recovery for session.interrupt is superseded by Rust TUI/ACP interrupt architecture: active runs are in-process and keyed directly by the active session, with no desktop runtime-id versus stored-id split."
-    },
-    "04b3f195380f": {
-      "disposition": "superseded",
-      "notes": "Upstream session archive propagation targets Python hermes_state.py archived rows plus Electron sidebar archive UI. Hermes Agent Ultra has no Rust session-archive column or setSessionArchived surface; the Rust session_search backend already projects compression roots to their continuation tip, and CLI session deletion operates on saved JSON snapshots rather than soft-archiving SQLite rows."
-    },
-    "cedd9b6d475b": {
-      "disposition": "superseded",
-      "notes": "Upstream passive update fix avoids SSH origin fetches in Python banner and Electron desktop checks. Hermes Agent Ultra's Rust update command already uses the GitHub HTTPS releases API in crates/hermes-cli/src/update.rs with HERMES_UPDATE_REPO override support and never shells out to git fetch origin for update checks."
-    },
-    "0edeee14c6ce": {
-      "disposition": "superseded",
-      "notes": "Upstream adds Electron-only helper tests for official SSH remote detection. Hermes Agent Ultra has no Electron desktop update helper; the Rust update surface is the HTTPS GitHub release checker in crates/hermes-cli/src/update.rs, so the SSH-origin detection branch is not part of the local runtime."
-    },
-    "0d3e2cc53952": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop sidebar dedupe by compression lineage targets React mergeSessionPage. Hermes Agent Ultra has no React desktop sidebar store; Rust session_search already resolves logical compression roots to the visible continuation tip through logical_session_key_for_row and visible_session_id_for_row, with search_session_id_resolves_compression_root_to_tip coverage."
-    },
-    "e96ca1a0d35a": {
-      "disposition": "ported",
-      "notes": "Rust now drops empty sessions on session rotation and TUI shutdown through SessionPersistence::delete_session_if_empty plus App empty-stub cleanup. The port removes untitled message-free parentless SQLite rows and exact empty snapshots while preserving titled, child, message-bearing, or non-empty snapshot sessions; focused hermes-agent and hermes-cli tests cover the behavior."
-    },
-    "e372803554be": {
-      "disposition": "superseded",
-      "notes": "Upstream desktop session model refresh targets Electron/React sidebar metadata. Rust App::switch_model already synchronizes runtime model env, rebuilds the active agent, and persists the active session model through SessionPersistence with regression coverage for the session DB row."
-    },
-    "b1af653bf6bd": {
-      "disposition": "superseded",
-      "notes": "Upstream local file tree hardening is an Electron desktop filesystem browser fix. Hermes Agent Ultra has no Electron file tree; Rust filesystem access is mediated by typed tool/workdir paths, terminal approval policy, and existing path normalization gates."
-    },
-    "db79e90130fe": {
-      "disposition": "superseded",
-      "notes": "Upstream filesystem routing facade is desktop/Electron backend routing. Hermes Agent Ultra has no desktop filesystem facade; local file operations remain Rust tool and terminal surfaces under approval/workspace policy."
-    },
-    "8878484f8519": {
-      "disposition": "superseded",
-      "notes": "Upstream remote filesystem browsing wires Electron desktop profile routes. Hermes Agent Ultra does not ship the Electron remote file tree; Rust remote/profile behavior is represented by ACP/gateway session metadata and explicit tool surfaces."
-    },
-    "56a0f48ba6d9": {
-      "disposition": "superseded",
-      "notes": "Upstream remote filesystem wiring tightening targets the desktop file tree route. The Rust runtime has no matching Electron bridge; file access remains native Rust tool execution with existing path and approval controls."
-    },
-    "9121834b3198": {
-      "disposition": "superseded",
-      "notes": "Upstream remote workspace defaults are Electron desktop profile defaults. Hermes Agent Ultra workspace/cwd state is carried by CLI, ACP, gateway session metadata, and terminal/workdir normalization rather than desktop remote workspace defaults."
-    },
-    "1593ca54066c": {
-      "disposition": "ported",
-      "notes": "Rust ports the Cron Recipes functional surface as Automation Blueprints: hermes-cron::blueprints defines typed slots/defaults/validation/rendering and fills normal CronJob specs, while the Rust CLI/TUI exposes /blueprint and /bp to create jobs through the live CronScheduler. Focused hermes-cron and hermes-cli tests cover catalog fill, quoted values, schedule rendering, typo rejection, and live scheduler creation."
-    },
-    "cb29e8a82e7e": {
-      "disposition": "ported",
-      "notes": "The upstream Cron Recipes rename is ported under the final Automation Blueprints naming: Rust uses /blueprint and /bp, hermes-cron::blueprints, and created jobs flow through the existing cron scheduler instead of a parallel recipe engine."
-    },
-    "021ed6914162": {
-      "disposition": "ported",
-      "notes": "The final upstream Automation Blueprints terminology cleanup is ported on the local website surface: guides/automation-blueprints replaces the stale automation-templates slug, the sidebar points at the new slug, and the Rust runtime/catalog already use Automation Blueprints naming. Upstream Python docstring/web-server wording is non-runtime for Hermes Agent Ultra's Rust-only implementation."
-    },
-    "73969771a514": {
-      "disposition": "superseded",
-      "notes": "Upstream dashboard /api/ws MCP discovery targets Python hermes_cli/tui_gateway startup. Hermes Agent Ultra exposes MCP through the Rust hermes-mcp client/server and Rust CLI registration paths; Python dashboard websocket backend discovery is not a Rust runtime surface."
-    },
-    "d221e369b8f3": {
-      "disposition": "superseded",
-      "notes": "Upstream assistant-ui message render boundary and virtualizer recovery is Electron/React desktop UI only. Hermes Agent Ultra's owned runtime surface is Rust CLI/TUI/gateway, with no assistant-ui thread virtualizer equivalent."
-    },
-    "e96fe06e4968": {
-      "disposition": "superseded",
-      "notes": "Upstream served dashboard token adoption targets Electron child-process dashboard websocket auth. Hermes Agent Ultra does not ship that Electron backend launcher; Rust gateway/session auth is handled by typed Rust services and CLI config rather than desktop dashboard-token.cjs."
-    },
-    "7a2d498b9dd2": {
-      "disposition": "superseded",
-      "notes": "Upstream profile session read routing is desktop React hermes.ts/session-picker wiring. Hermes Agent Ultra session state is owned by Rust SessionPersistence, CLI/TUI App state, and gateway session metadata rather than Electron profile session facades."
-    },
-    "e3ed7722b5b1": {
-      "disposition": "superseded",
-      "notes": "Upstream foreign-backend token refusal is Electron dashboard-token readiness logic. The local Rust runtime has no Electron dashboard backend token adoption path; gateway sessions are explicit Rust session keys and platform adapters."
-    },
-    "9ff0ba082739": {
-      "disposition": "superseded",
-      "notes": "Upstream port-squat and pickPort self-collision protection targets Electron desktop main.cjs and port-pool.cjs. Hermes Agent Ultra does not launch Electron dashboard child processes; Rust services bind through their own listener lifecycle."
-    },
-    "81436e143ebb": {
-      "disposition": "superseded",
-      "notes": "Upstream allow_permanent propagation fixes Python/TUI/desktop prompt payloads. Hermes Agent Ultra's Rust approval manager already carries allow_permanent in ApprovalPrompt, GatewayApprovalRequest, and approval hook events, and blocks permanent approvals for Tirith warnings."
-    },
-    "cc726aad687a": {
-      "disposition": "superseded",
-      "notes": "Upstream refactors Electron served-token adoption and foreign-backend refusal into a helper. Hermes Agent Ultra has no Electron dashboard-token helper; the underlying local token adoption/refusal failure mode is absent from the Rust runtime."
-    },
-    "b097d7b03352": {
-      "disposition": "superseded",
-      "notes": "Upstream native fetch change is confined to Electron dashboard-token.cjs. Hermes Agent Ultra's Rust runtime does not consume that JavaScript helper."
-    },
-    "55a18e68600d": {
-      "disposition": "superseded",
-      "notes": "Upstream allow_permanent comment/DRY cleanup is Python, desktop React, and ui-tui TypeScript presentation polish. The Rust approval contract remains the source of truth and already exposes allow_permanent on prompts, gateway requests, and hooks."
-    },
-    "e2145a5c9cae": {
-      "disposition": "superseded",
-      "notes": "Upstream embedded dashboard chat gateway stabilization targets ui-tui TypeScript gatewayClient and Python tui_gateway transport behavior. Hermes Agent Ultra release/runtime gates are Rust-first; the local Rust gateway/CLI session path is separate from that embedded JS/Python dashboard chat transport."
-    },
-    "4ddb03390a95": {
-      "disposition": "superseded",
-      "notes": "Upstream custom OpenAI endpoint API-key collection is desktop onboarding plus Python web_server settings. Hermes Agent Ultra handles model/provider credentials through Rust config/auth/provider flows; the Electron onboarding overlay and Python dashboard endpoint are not local Rust runtime surfaces."
-    },
-    "6c00077d3838": {
-      "disposition": "superseded",
-      "notes": "Upstream RTL/bidi auto-direction is desktop React chat text rendering. Hermes Agent Ultra has no Electron assistant-ui message text component; terminal/TUI rendering follows the local Rust/terminal surfaces."
-    },
-    "09bcf5a9370e": {
-      "disposition": "superseded",
-      "notes": "Upstream tool-row copy affordance is desktop React assistant-ui layout. Hermes Agent Ultra has no Electron tool fallback row; terminal/TUI copy behavior is handled by local TUI/terminal clipboard surfaces."
-    },
-    "6e41ca956bbf": {
-      "disposition": "superseded",
-      "notes": "Upstream JetBrains Mono bundling fixes xterm font metrics in the Electron desktop terminal pane. Hermes Agent Ultra has no Electron/xterm terminal pane; terminal execution and rendering are Rust CLI/TUI surfaces using host terminal fonts."
-    },
-    "24f74eb88853": {
-      "disposition": "superseded",
-      "notes": "Upstream data-selectable-text attributes target the Electron desktop file-preview DOM. Hermes Agent Ultra has no React right-rail file preview surface; file viewing/copy behavior is exposed through Rust CLI/TUI/tool output paths."
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
     "906bee9cf791": {
       "disposition": "superseded",
       "notes": "Upstream node-pty staging fixes Nix packaging for the Electron desktop app. Hermes Agent Ultra's release/runtime path is Rust CLI/TUI plus Cargo artifacts; it does not package the upstream Electron desktop node-pty runtime."
     },
-    "0a963d8c9a07": {
+    "90f4b3040dcc": {
       "disposition": "superseded",
-      "notes": "Upstream Photon telemetry toggling changes the Python plugin CLI and Node sidecar. Hermes Agent Ultra has no Rust Photon gateway adapter, and Python/Node plugin runtime changes remain reference-only under the Rust-only runtime policy."
+      "notes": "React compiler ESLint/concurrently updates target upstream JS tooling and do not affect the Rust runtime parity gate."
     },
-    "573c4e651154": {
+    "9121834b3198": {
       "disposition": "superseded",
-      "notes": "Upstream Photon spectrum-ts markdown/reaction support is implemented in the Python adapter and Node sidecar. The Rust gateway does not register Photon, while reaction lifecycle and markdown/document handling are covered for supported Rust adapters."
+      "notes": "Upstream remote workspace defaults are Electron desktop profile defaults. Hermes Agent Ultra workspace/cwd state is carried by CLI, ACP, gateway session metadata, and terminal/workdir normalization rather than desktop remote workspace defaults."
     },
-    "a652131c421b": {
-      "disposition": "superseded",
-      "notes": "Upstream Photon orphan-sidecar cleanup is Python subprocess/Node sidecar lifecycle logic. Hermes Agent Ultra does not run that sidecar from Rust, so this failure mode is outside the local Rust runtime surface."
+    "91e9459e1006": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking tracks all background writers per session id in an inflight writer map and drains every writer for that session before commit.",
+      "owner": "rust-runtime"
     },
-    "9bfff6e16cf1": {
+    "928f1ac0e187": {
       "disposition": "superseded",
-      "notes": "Upstream spectrum-ts dependency bump belongs to the Photon Node sidecar. Hermes Agent Ultra does not ship a Rust Photon adapter or invoke that sidecar from the Rust runtime."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "a23c0b378ca9": {
+    "92a456f711eb": {
       "disposition": "superseded",
-      "notes": "Upstream Photon per-call httpx client fix targets the Python adapter event-loop boundary. Hermes Agent Ultra avoids that Python async client path in the Rust runtime."
+      "notes": "Upstream esbuild/Node audit-loop cleanup is superseded by the Rust-first runtime and local Cargo gates; Node desktop/web package metadata is not a shipped runtime dependency.",
+      "owner": "rust-runtime"
     },
-    "156f4fba923e": {
+    "92dfd70d6a71": {
       "disposition": "superseded",
-      "notes": "Upstream agent-facing Photon reaction support extends the Python send_message tool and Python adapter. Hermes Agent Ultra's Rust gateway already exposes reaction lifecycle contracts for supported Rust adapters; Photon remains non-Rust reference-only."
+      "notes": "Upstream Photon gRPC iMessage hardening targets Python/Node optional plugin paths. Hermes Ultra's runtime messaging surface is Rust gateway adapters; no Photon sidecar is loaded by the Rust runtime."
     },
-    "23305cfeabfa": {
+    "92e6d8c858f6": {
       "disposition": "superseded",
-      "notes": "Upstream Photon DM reaction-key normalization is Python adapter state tracking. There is no local Rust Photon adapter state to update."
+      "notes": "Disposing node-pty sessions during Electron before-quit is desktop main-process cleanup. Ultra PTY/process lifecycle is Rust-owned by hermes-tools terminal/process handlers and not node-pty.",
+      "owner": "rust-runtime"
     },
-    "b4e95a2efe50": {
+    "93228d529996": {
       "disposition": "superseded",
-      "notes": "Upstream Photon Windows-safe os.kill comments document Python sidecar cleanup behavior. Hermes Agent Ultra does not depend on that Python subprocess lifecycle in the Rust runtime."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "74180ebf0b1c": {
-      "disposition": "superseded",
-      "notes": "Upstream SimpleX document classification fixes a Python plugin adapter. Hermes Agent Ultra has no Rust SimpleX gateway adapter; document attachment classification is covered in supported Rust adapters such as Discord, Telegram, and Signal."
+    "93340fa3c1b8": {
+      "disposition": "ported",
+      "notes": "Rust terminal execution honors explicit workdir, task-scoped cwd, and non-local TERMINAL_CWD through TerminalHandler tests, covering the profile terminal.cwd behavior without Python tui_gateway."
     },
-    "7ba5df0d52b9": {
-      "disposition": "superseded",
-      "notes": "Upstream /credits adds Python CLI/gateway billing views and Ink UI-TUI RPC/buttons. Hermes Agent Ultra's Rust runtime has provider auth diagnostics and usage accounting, but it does not ship the upstream Python CLI or Ink TUI money surface, so this UI-only command remains reference-only until a Rust-native billing surface is deliberately designed."
+    "9350e26e681e": {
+      "disposition": "ported",
+      "notes": "Rust exposes the clarify tool as a typed ClarifyHandler with signal, stdio, and gateway channel backends, registers it in built-in/toolset/runtime wiring, and covers schema, trimming, choice normalization, empty-question rejection, stdio auto-answer, and gateway dispatcher roundtrip/timeout behavior."
     },
-    "0fd34e8c5a7a": {
+    "93679ef27d74": {
       "disposition": "superseded",
-      "notes": "Upstream Teams attachment classification fixes the Python Teams gateway adapter. Hermes Agent Ultra does not register a Rust Teams chat gateway adapter; its Teams code is the Rust-native meeting pipeline, while document/image/video/audio caching is already implemented for supported Rust gateway adapters."
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
     },
-    "9c505217044c": {
+    "93977675135a": {
       "disposition": "superseded",
-      "notes": "Upstream Homebrew PATH repair is scoped to the Electron desktop backend environment for Python subprocesses. Hermes Agent Ultra does not ship the upstream Electron desktop backend; the Rust CLI/TUI release path uses Cargo/Homebrew install artifacts and normal shell PATH resolution."
-    },
-    "8505e9d6691d": {
-      "disposition": "superseded",
-      "notes": "Upstream composer spellcheck is a desktop React/Electron input attribute fix. Hermes Agent Ultra uses the Rust Ratatui TUI/CLI composer and has no browser spellcheck attribute surface."
+      "notes": "The upstream empty feeds category cleanup is superseded by the local curated Rust skills catalog; no empty feeds SKILL.md category is present in skills or optional-skills."
     },
     "93a2f680fd18": {
       "disposition": "superseded",
       "notes": "Upstream model visibility dialog hide-all persistence is a desktop settings UI fix. Rust model visibility is resolved through curated provider/model catalogs, config, and CLI/TUI model picker state rather than the Electron dialog store."
     },
-    "743c55efa34f": {
+    "93a74f74bf93": {
       "disposition": "superseded",
-      "notes": "Upstream HTML5 backend remount fix targets the desktop file tree drag/drop provider. Hermes Agent Ultra has no React DnD file tree runtime."
+      "notes": "The shared asyncio event-loop shutdown fix is Python-runtime-only; Rust Hindsight uses reqwest blocking clients per operation and has no provider-owned event loop to stop."
     },
-    "020ef76cf16b": {
+    "93d6e730288e": {
+      "disposition": "ported",
+      "notes": "Rust now exposes late-registered MCP tools to active agents by refreshing the CLI App agent snapshot from the live ToolRegistry, rebuilding planner schemas, and merging live mcp-* toolsets into default platform tool planning while preserving explicit custom platform filters. Tests cover added tools, equal-size replacements, /reload-mcp command refresh, default/custom MCP planning, and the McpManager discovery-to-registry contract."
+    },
+    "93e25ceb1326": {
       "disposition": "superseded",
-      "notes": "Upstream cancels discord.py _bot_task zombies after connect timeout. Hermes Agent Ultra's Rust Discord adapter has no discord.py background Bot.start task; start/stop only mark BasePlatformAdapter state and REST sends use reqwest, so the orphaned asyncio client failure mode is absent."
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
     },
-    "08b1c44a5330": {
+    "94016dd1aa7e": {
       "disposition": "superseded",
-      "notes": "Upstream extends discord.py _bot_task cancellation to generic connect exceptions. The Rust Discord adapter has no Python asyncio bot task to cancel and no discord.py reconnect loop; failed sends surface as typed GatewayError values."
+      "notes": "optional-skill parity is covered by local multi-registry skill surfaces; upstream single-skill delta is superseded"
     },
-    "5e5308d34d87": {
+    "9405cdc8dd03": {
+      "disposition": "ported",
+      "notes": "Rust ntfy gateway adapter now tags outgoing messages with X-Tags: hermes-agent and skips incoming events carrying that tag to prevent self-echo loops."
+    },
+    "9423fda5cb57": {
+      "disposition": "ported",
+      "notes": "Rust delegation config now accepts delegation.model/provider plus documented direct endpoint fields, exposes them through config set/get, propagates them through CLI/HTTP AgentConfig construction, and makes subagents either inherit the parent provider for model-only overrides or build an independent provider for provider/base_url/api_key overrides with structured credential errors."
+    },
+    "94523764fca8": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking setup chooses and normalizes the credential mode before prompting for the corresponding none/user/root API key path, with CLI unit coverage for each setup shape.",
+      "owner": "rust-runtime"
+    },
+    "947f305f84c5": {
       "disposition": "superseded",
-      "notes": "Upstream @types/node version pin is JavaScript/desktop tooling only. Hermes Agent Ultra's release/runtime gates are Rust Cargo based and do not consume the upstream Node type package for runtime behavior."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "c3464ecf453d": {
+    "95a0955e19f8": {
+      "disposition": "ported",
+      "notes": "Rust /new resets only the current encoded Telegram topic session key and keeps sibling topic lanes intact; telegram_topic_new_resets_only_current_topic_lane proves the topic thread identity survives session reset/split."
+    },
+    "9627ee70e57a": {
       "disposition": "superseded",
-      "notes": "Upstream recovers from post-ready discord.py gateway task exits. Hermes Agent Ultra's Discord surface is Rust REST plus pure GatewaySession payload parsing; there is no long-lived discord.py task whose exit can leave the gateway split-brained, and platform_reconnect_watcher already restarts adapters whose Rust running state is false."
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
     },
-    "484f484c25bc": {
+    "96cd37e212e8": {
       "disposition": "superseded",
-      "notes": "Upstream sidebar nav drag-region carving targets Electron desktop titlebar behavior in apps/desktop. Hermes Agent Ultra uses the Rust Ratatui CLI/TUI and has no Electron draggable titlebar or React sidebar rows."
+      "notes": "Upstream leak fix targets Python TUI gateway detached transports and _SlashWorker subprocesses. Rust HTTP websocket handling has no detached slash-worker subprocess lifecycle; in-process SessionManager already exposes explicit remove/idle-expire cleanup APIs."
     },
-    "d62979a6f34f": {
+    "96f0ddc6a946": {
+      "disposition": "superseded",
+      "notes": "Baking hindsight-client into Docker only applies to the upstream embedded Python runtime; the Rust runtime keeps Hindsight integration in native HTTP code."
+    },
+    "9705e7944ae4": {
+      "disposition": "ported",
+      "notes": "Ported in this batch: Rust provider catalog entries no longer truncate picker models to 50; CLI/TUI/model command call sites use the full configured catalog and regression tests cover 60 entries.",
+      "owner": "rust-runtime"
+    },
+    "971ed2bbdf61": {
+      "disposition": "ported",
+      "notes": "rust terminal handler supports sudo password transformation via SUDO_PASSWORD with shell quoting and approval safeguards; crates/hermes-tools/src/tools/terminal.rs tests cover sudo denial, yolo boundaries, and password quoting"
+    },
+    "972a9885ee20": {
+      "disposition": "ported",
+      "notes": "Rust MCP stdio configs now reject the same high-signal shell-plus-network-egress exfiltration shape before direct client or manager connection. Tests cover the dangerous payload, clean npx, benign shell pipes, and manager rejection."
+    },
+    "97524344adbd": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "975b9f0a5426": {
+      "disposition": "superseded",
+      "notes": "Upstream contributor docs recommend the Python standard installer. Ultra contributor docs intentionally use the Rust workspace flow in CONTRIBUTING.md with cargo build/test/install, so the upstream Python venv layout does not apply."
+    },
+    "97ecfa0fc487": {
+      "disposition": "ported",
+      "notes": "Rust session search degrades content search when FTS is unavailable while keeping recent/session-id lookup live; no separate trigram table exists in Rust."
+    },
+    "983bbe2d40f7": {
+      "disposition": "ported",
+      "notes": "Local skills catalog already includes the Google DESIGN.md skill at skills/creative/design-md/SKILL.md and optional-skills/creative/design-md/SKILL.md with SKILL.md frontmatter, templates, and platform metadata."
+    },
+    "98528c78c143": {
+      "disposition": "superseded",
+      "notes": "Windows in-app update race handling only touches upstream apps/bootstrap-installer Tauri update code and Electron main process orchestration. This Rust runtime repo does not embed that desktop updater process."
+    },
+    "98903d03139d": {
+      "disposition": "superseded",
+      "notes": "Upstream Python/Node TUI gateway live-session reuse fix targets a separate gateway/socket runtime; Rust resume restores persisted snapshots directly into a single App under the interactive-session lock with existing load_resume_payload/run_resume coverage."
+    },
+    "989d5d0cb72a": {
+      "disposition": "superseded",
+      "notes": "Desktop model-status label decluttering targets absent apps/desktop files. Ultra's model labels and picker state are rendered by Rust TUI/CLI surfaces instead."
+    },
+    "98c294126baf": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "79c3ed3cc91a": {
+    "98c499b235e4": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "98db898c0bd4": {
+      "disposition": "superseded",
+      "notes": "skill catalog and runtime integration are already covered by local rust-first skill orchestration; upstream python-side delta superseded"
+    },
+    "9915665e4c51": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-rail cell drag/clamp behavior touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "9987f3d82486b04151dee2d27d640b3ae01b7b16": {
+      "disposition": "ported",
+      "notes": "Rust ACP now keeps successful web_extract completions silent while rendering compact per-URL failures; read_file fenced completion and compact replay rendering are covered by hermes-acp tools tests."
+    },
+    "99ddba94edee": {
+      "disposition": "ported",
+      "notes": "The current upstream Grok skill was adopted in its optional catalog placement with modern Hermes frontmatter and guidance."
+    },
+    "99feb036077a": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust Honcho configuration surface: pinUserPeer is the canonical runtime field and peerName is only emitted as a non-empty compatibility label from crates/hermes-cli/src/commands.rs.",
+      "owner": "rust-runtime"
+    },
+    "9b1e0d6f70bb": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9b2a64fa6a27": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9b2fb1cc2e95": {
+      "disposition": "ported",
+      "notes": "Rust ACP now parses client-provided mcpServers/mcp_servers during session new/load/resume/fork, converts stdio and HTTP/SSE configs into hermes_mcp configs, preserves stdio env and bearer Authorization headers, registers reachable MCP servers through McpManager, and exposes discovered MCP tools as real callable ToolRegistry tools with provider-safe names and focused hermes-mcp/hermes-acp coverage."
+    },
+    "9bdf01852ac1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9bfff6e16cf1": {
+      "disposition": "superseded",
+      "notes": "Upstream spectrum-ts dependency bump belongs to the Photon Node sidecar. Hermes Agent Ultra does not ship a Rust Photon adapter or invoke that sidecar from the Rust runtime."
+    },
+    "9c1bb8d2c729": {
+      "disposition": "ported",
+      "notes": "Rust now exposes /version through CLI/TUI slash dispatch, gateway slash dispatch, and ACP slash handling via a shared hermes-core version_label helper with targeted Rust tests."
+    },
+    "9c264555b018": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9c505217044c": {
+      "disposition": "superseded",
+      "notes": "Upstream Homebrew PATH repair is scoped to the Electron desktop backend environment for Python subprocesses. Hermes Agent Ultra does not ship the upstream Electron desktop backend; the Rust CLI/TUI release path uses Cargo/Homebrew install artifacts and normal shell PATH resolution."
+    },
+    "9cbb91abd3a8": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "46d758bb3e07": {
+    "9cbc37e25b64": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9cc47b20cb3f": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9cf1140caaefa6f275667ed1b11a61aabb6199dd": {
+      "disposition": "ported",
+      "notes": "Rust ACP polished tool errors are treated as failed for core tool outputs while generic optional JSON error payloads remain completed; completion-status tests cover both sides of the conservative rule."
+    },
+    "9d07927a23ee": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9d2ec8d35a2a": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "2e874ef87926": {
+    "9d6992ee8a7b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9d72680ca34a": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9d7ece362df2": {
+      "disposition": "ported",
+      "notes": "ComfyUI hardware gating is present in skills/creative/comfyui/scripts/hardware_check.py and the skill workflow asks for local/cloud routing based on the verdict."
+    },
+    "9dbd3c57d700": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9de893e3b078": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "9e02b18828a2": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9e4d79b17fcf": {
+      "disposition": "ported",
+      "notes": "Rust sync_runtime_model_env and CLI chat env setup now write HERMES_TUI_PROVIDER unconditionally alongside HERMES_INFERENCE_PROVIDER, covering the explicit-provider carrier bug fixed upstream for /model followed by new sessions."
+    },
+    "9e85408c7bfd": {
+      "disposition": "ported",
+      "notes": "rust todo tool remains first-class in CLI/API toolsets and builtin registration; existing toolset tests and new registry/schema contract cover create/update/list parity"
+    },
+    "9eb0bcd60fc6": {
+      "disposition": "superseded",
+      "notes": "Superseded by local Rust build/test gates and optional official GitHub CI; upstream nix workflow removal has no Rust runtime port target.",
+      "owner": "local-gates"
+    },
+    "9ecc331be847": {
+      "disposition": "ported",
+      "notes": "Rust resume now falls back from missing exact snapshot stems to session-id search over saved session snapshots, matching exact, prefix, and substring IDs case-insensitively across both file stems and session_info.session_id, with deterministic exact-before-prefix-before-substring ranking and focused CLI tests."
+    },
+    "9f1b1977bca3": {
+      "disposition": "ported",
+      "notes": "Trigger and usage details live in the local SKILL.md bodies loaded by Rust skill scanners, preserving content without relying on upstream generated catalog pages."
+    },
+    "9f33d673e9e6": {
+      "disposition": "ported",
+      "notes": "Ported by Rust session state persistence: ACP/session models store cwd and update_cwd contracts in Rust tests; Python tui_gateway profile-db persistence is not the shipped runtime path.",
+      "owner": "rust-runtime"
+    },
+    "9ff0ba082739": {
+      "disposition": "superseded",
+      "notes": "Upstream port-squat and pickPort self-collision protection targets Electron desktop main.cjs and port-pool.cjs. Hermes Agent Ultra does not launch Electron dashboard child processes; Rust services bind through their own listener lifecycle."
+    },
+    "9ff21437a03a": {
+      "disposition": "ported",
+      "notes": "Rust MCP tools/call now coerces stringified object/array arguments before dispatch in both exported MCP server paths, leaves non-object scalar strings untouched, and has focused helper plus JSON-RPC runtime regression coverage."
+    },
+    "a0ec4f52b948": {
+      "disposition": "superseded",
+      "notes": "Desktop settings/provider disconnect UI targets absent apps/desktop files. Ultra already exposes Rust provider credential disconnect behavior through the TUI provider picker and auth state helpers."
+    },
+    "a1cda2410b30": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "a1eaad2fc0bf": {
+      "disposition": "superseded",
+      "notes": "Upstream website skills-page lazy catalog fetch is a generated website UX concern, superseded by approved website divergence while Rust skill catalog loading remains native."
+    },
+    "a1f51feb72b4": {
+      "disposition": "ported",
+      "notes": "Ported/satisfied in Rust final architecture: rich delivery is opt-in and only attempted for eligible normal text sends, not status edits; StreamConsumer has no adapter-specific rich fresh-final hook to duplicate previews, and existing stream fresh-final tests preserve final-delivery state.",
+      "owner": "rust-runtime"
+    },
+    "a218a0f1569c": {
+      "disposition": "superseded",
+      "notes": "Upstream guards Python certifi CA bundle corruption. Ultra builds reqwest with rustls-tls/webpki roots in Cargo.toml and has no Python certifi startup path in the Rust agent or gateway."
+    },
+    "a23728dfcc50": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "a23c0b378ca9": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon per-call httpx client fix targets the Python adapter event-loop boundary. Hermes Agent Ultra avoids that Python async client path in the Rust runtime."
+    },
+    "a2b8e430e851": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "a30b40c73ab6": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking sync_turn captures the target session id before spawning the writer and on_session_end drains tracked writers before commit, preventing session-boundary races.",
+      "owner": "rust-runtime"
+    },
+    "a36221ed9174": {
+      "disposition": "ported",
+      "notes": "The current upstream s6 container supervision skill was adopted at optional-skills/devops/hermes-s6-container-supervision/SKILL.md; generated website/docs changes remain covered by Rust skills governance."
+    },
+    "a376ca00819e": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Hindsight plugin: HINDSIGHT_RETAIN_TAGS and HINDSIGHT_RETAIN_OBSERVATION_SCOPES/profile config parse into retain tags and observation_scopes, auto-retain includes session lineage tags, tool-call tags merge with defaults, and Hindsight tests cover payload/config normalization.",
+      "owner": "rust-runtime"
+    },
+    "a40e20e1368d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "a49596cbb2c1": {
+      "disposition": "ported",
+      "notes": "rust terminal tool refinement is covered by the same TerminalHandler/runtime registry surface, with tests for foreground timeout caps, background guidance, stdin_data, and schema parity"
+    },
+    "a4db3fdee5b9": {
+      "disposition": "superseded",
+      "notes": "The upstream Morph leakage fix is superseded by Rust terminal architecture: terminal execution uses injected TerminalBackend implementations rather than shared Hecate/Morph module globals, and task_id only resolves scoped cwd state. Focused tests prove task-a, task-b, and no-task calls do not share task cwd state."
+    },
+    "a4ee1f223d5f": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust-first installer and no Node desktop runtime: scripts/install.sh manages binary PATH/install location without upstream managed-Node global npm package requirements.",
+      "owner": "installer"
+    },
+    "a4fb0a3ac39f": {
+      "disposition": "ported",
+      "notes": "Rust cron delivery routing preserves explicit inline platform chat ids/--deliver-chat-id, carries DeliverConfig on CronCompletionEvent, and the gateway cron delivery loop sends successful or failed cron completions through registered adapters. Telegram cron deliveries resolve TELEGRAM_CRON_THREAD_ID at fire time for unthreaded/home targets while explicit telegram:chat:thread wins. Tests cover stored chat id preservation, home-channel fallback, explicit thread precedence, webhook serialization, and docs now document the env var."
+    },
+    "a59d5e37e8ab": {
+      "disposition": "superseded",
+      "notes": "Superseded by later upstream policy and Rust final state: Telegram rich messages are deliberately opt-in via TelegramConfig.rich_messages instead of always on because client rendering remains uneven.",
+      "owner": "rust-runtime"
+    },
+    "a5aecf26fa21": {
+      "disposition": "ported",
+      "notes": "Rust config/runtime gateway surface now exposes kanban.dispatch_in_gateway with HERMES_KANBAN_DISPATCH_IN_GATEWAY env override, propagates it into GatewayConfig, and includes it in gateway agent cache-busting signatures; Rust has no separate Kanban DB notifier loop to gate."
+    },
+    "a5c32cdf3055": {
+      "disposition": "superseded",
+      "notes": "Interrupted Python venv self-heal is installer/runtime-specific to upstream Python; Hermes Ultra uses Rust/Cargo install and local shell gates."
+    },
+    "a5c7422f2315": {
+      "disposition": "superseded",
+      "notes": "Python embedded Hindsight .env setup is superseded by the Rust-only Hindsight runtime: it does not launch hindsight-embed, and legacy local/local_embedded config is normalized to local_external HTTP mode."
+    },
+    "a61420952e29": {
+      "disposition": "ported",
+      "notes": "Rust now constructs tool-result messages with the originating tool name in Message.name when the ToolCall is known, including invalid-tool and invalid-JSON result paths, persists messages.name through the SQLite session store with legacy DB migration, and regression-tests model-visible plus persisted tool-result name round trips."
+    },
+    "a652131c421b": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon orphan-sidecar cleanup is Python subprocess/Node sidecar lifecycle logic. Hermes Agent Ultra does not run that sidecar from Rust, so this failure mode is outside the local Rust runtime surface."
+    },
+    "a68ac0c49af1": {
+      "disposition": "superseded",
+      "notes": "Desktop /browser connect UI targets absent apps/desktop slash-command wiring. Ultra browser control is Rust-owned through CLI/TUI slash commands and hermes-tools browser backends."
+    },
+    "a72bb03757c0": {
+      "disposition": "superseded",
+      "notes": "Docker image-size tuning for upstream Python/Node layers is superseded by local Rust packaging and build policy."
+    },
+    "a7683d04a964": {
+      "disposition": "ported",
+      "notes": "Rust Telegram topic sessions do not mutate Python SessionStore/SQLite bindings; topic identity is the encoded chat_id:thread_id session key. /new resets only that current encoded key, and /topic <session-id> now reuses the persisted session switch path for restores without split-brain binding state."
+    },
+    "a7780fe05f43": {
+      "disposition": "ported",
+      "notes": "ComfyUI bug-fix coverage is represented by the local skill scripts, tests, workflows, cloud/local guidance, and expanded references under skills/creative/comfyui."
+    },
+    "a88f201cd404": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "a919269eb5c5": {
+      "disposition": "ported",
+      "notes": "Himalaya email skill documentation includes the v1.2.0 folder.aliases syntax in skills/email/himalaya/SKILL.md and reference material."
+    },
+    "a91e5a87594b": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "a93de60b6819": {
+      "disposition": "ported",
+      "notes": "Baoyu article illustrator was adopted from current upstream after its Hermes tool-capability alignment, including the prompt and workflow updates."
+    },
+    "a9669323922f6e79482536f2c05846c354571528": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: rich newline normalization protects Markdown pipe tables from hard-break injection, preserving table layout with focused regression coverage.",
+      "owner": "rust-runtime"
+    },
+    "aa1e2edd35a8": {
+      "disposition": "ported",
+      "notes": "Upstream EVM multi-chain optional skill was adopted at optional-skills/blockchain/evm with SKILL.md plus evm_client.py covering the 8-chain read-only command surface."
+    },
+    "aa52cd3b574e": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "aa53a78d6703": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "aa948832886a": {
+      "disposition": "ported",
+      "notes": "Rust MCP tools/call now applies schema-aware string argument coercion before dispatch: nullable object/array/type-union fields convert literal \"null\" to JSON null only when the inputSchema permits null, while integer, boolean, object, and array string values are coerced according to the exposed schema. Both generic McpServer and hermes mcp serve paths have focused runtime regression coverage."
+    },
+    "aaccaada282b": {
+      "disposition": "ported",
+      "notes": "Rust Anthropic provider now carries ordered signed thinking/tool_use content blocks in-memory on parsed responses and replays them before reconstructing from reasoning_content/tool_calls. Regression tests cover interleaved block preservation in parse_response and convert_messages."
+    },
+    "ab1a42fcea4f": {
+      "disposition": "superseded",
+      "notes": "Relay connector contract is retained only as experimental/reference documentation; current Ultra Rust runtime does not register the upstream Python relay adapter as a first-class platform surface.",
+      "owner": "rust-runtime"
+    },
+    "ab5f1a1f1141": {
+      "disposition": "superseded",
+      "notes": "Desktop session switcher keybindings target Electron/React UI. Rust session switching and persistence are native CLI/TUI flows."
+    },
+    "ab706a3346d0": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ab7293bed652": {
+      "disposition": "ported",
+      "notes": "Rust TerminalHandler now has regression coverage proving a nonzero terminal exit code returns normal model-visible command output with [exit code: N] instead of surfacing as ToolError/agent tool failure."
+    },
+    "abbf05024131": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ac6d747fa610": {
+      "disposition": "ported",
+      "notes": "Rust BatchDatasetRunner now supports file-backed checkpoint resumption with BatchRunCheckpoint::load_from_path/save_atomic_to_path, same-directory atomic JSON replacement, per-batch checkpoint writes via run_with_checkpoint_path, and tests proving atomic replacement, no temp-file leaks, per-batch write counts, and resume skips by persisted prompt index/text."
+    },
+    "ac76bbe21f8a": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ac9de2e80c01": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "acce1a2452f8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ace4b722dc2b": {
+      "disposition": "ported",
+      "notes": "Simplify-code skill was adopted from upstream at skills/software-development/simplify-code/SKILL.md for the parallel three-reviewer cleanup workflow."
+    },
+    "ad7aad251c60": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "ada0b4f131ba": {
+      "disposition": "ported",
+      "notes": "rust gateway/platform adapter surface sends inline image URLs natively and now strips/delivers local MEDIA image markers through validated send_file paths; tests cover inline image extraction and media marker delivery"
+    },
+    "ae433634db56": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "ae4b09ce1073": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "ae83a54be450": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "ae8fa11097e1": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: crates/hermes-cron loads cron.provider/cron.chronos config, constructs ChronosNasCronProvider from environment/config, and scheduler tests cover managed provider reconciliation.",
+      "owner": "rust-runtime"
+    },
+    "aea72c09362b": {
+      "disposition": "ported",
+      "notes": "Spike and sketch skills are bundled locally at skills/software-development/spike/SKILL.md and skills/creative/sketch/SKILL.md with reference material adapted for Hermes usage."
+    },
+    "aecdc75bb001": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "af978ecb17ef": {
+      "disposition": "superseded",
+      "notes": "Upstream expensive-model picker confirmation is superseded by Rust runtime cost accounting and configurable session spend guard; Hermes Ultra does not use the Python/Electron picker flow."
+    },
+    "afc186fa4eed": {
+      "disposition": "superseded",
+      "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
+    },
+    "afec339e967f": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b000e05b117b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b021497bc84e": {
+      "disposition": "superseded",
+      "notes": "Desktop edit-composer staging spinner is React UI polish and not a Rust runtime parity requirement."
+    },
+    "b0288ae9b6ea": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b07b7894ec55": {
+      "disposition": "superseded",
+      "notes": "Streaming paint in unfocused secondary Electron windows is an apps/desktop BrowserWindow preference fix. Ultra has no Electron session windows; Rust TUI/gateway streaming is terminal/platform-adapter driven.",
+      "owner": "rust-runtime"
+    },
+    "b08f53a75893": {
+      "disposition": "ported",
+      "notes": "ComfyUI template/workflow integrity material is present under skills/creative/comfyui references, tests, and workflows alongside the bundled skill."
+    },
+    "b097d7b03352": {
+      "disposition": "superseded",
+      "notes": "Upstream native fetch change is confined to Electron dashboard-token.cjs. Hermes Agent Ultra's Rust runtime does not consume that JavaScript helper."
+    },
+    "b0e25c9cb295": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking save_config writes openviking.json through shared owner-only atomic config IO with 0600 permissions and regression coverage.",
+      "owner": "rust-runtime"
+    },
+    "b10f17bf1e93": {
+      "disposition": "ported",
+      "notes": "Imported ntfy as a platform plugin under plugins/platforms/ntfy with standalone send, env enablement, identity hardening, and local plugin regression tests."
+    },
+    "b15dc58064eb": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
@@ -3498,47 +2996,243 @@
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
+    "b18b17f9c9de": {
+      "disposition": "ported",
+      "notes": "Rust dynamic skill command loading filters SKILL.md frontmatter by platform in crates/hermes-tools/src/tools/skill_commands.rs, and local skills declare platforms frontmatter."
+    },
+    "b1af653bf6bd": {
+      "disposition": "superseded",
+      "notes": "Upstream local file tree hardening is an Electron desktop filesystem browser fix. Hermes Agent Ultra has no Electron file tree; Rust filesystem access is mediated by typed tool/workdir paths, terminal approval policy, and existing path normalization gates."
+    },
+    "b1b0f4b66854": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b1b89f843e62": {
+      "disposition": "superseded",
+      "notes": "The upstream nested i18n field-copy refactor only reorganizes apps/desktop TypeScript catalog structures and UI consumers. This Rust runtime repo has no corresponding desktop catalog tree or TypeScript settings-field copy layer."
+    },
+    "b24d239ce177": {
+      "disposition": "ported",
+      "notes": "Rust config.yaml writes now preserve atomic replacement and tighten Unix permissions to owner-only 0600, with container/HERMES_SKIP_CHMOD opt-outs and save/config-set regression coverage."
+    },
+    "b294d1d0229ff6026838a04c4cb59c3b13e4827f": {
+      "disposition": "superseded",
+      "notes": "Rust ACP start events already carry compact title/kind/arguments only and do not synthesize read_file output content; existing title tests cover read_file start compactness."
+    },
+    "b2bd31c724c1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b308dd7d750c": {
+      "disposition": "ported",
+      "notes": "ported in local commit d67220e0b (kanban assignee casing fix)"
+    },
+    "b38d2d133bbb76fb9d91f08c3b1a838f5ce0a5b9": {
+      "disposition": "ported",
+      "notes": "Rust ACP tool completions compute failed status from structured success=false, ok=false, and nonzero exit_code/returncode while keeping status calculation separate from display formatting; focused tests cover the status path."
+    },
+    "b459bac02c98": {
+      "disposition": "ported",
+      "notes": "Rust repo update/autostash safety now ignores the Desktop bootstrap marker .hermes-bootstrap-complete in the root .gitignore, with a hermes-cli regression test guarding that gitignore contract so bootstrap runtime state is not swept into update stashes."
+    },
+    "b47cb1bbf279": {
+      "disposition": "ported",
+      "notes": "Rust Kanban JSON store now supports per-task file attachments with path-safe copy, unique filenames, metadata, list/remove commands, worker-context absolute path surfacing, and regression tests for copy/collision/delete/context behavior."
+    },
+    "b4ba3f5e3b37": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b4e95a2efe50": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon Windows-safe os.kill comments document Python sidecar cleanup behavior. Hermes Agent Ultra does not depend on that Python subprocess lifecycle in the Rust runtime."
+    },
+    "b55ac45264e9": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b5a457c03303": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b5c1fe78aa48": {
+      "disposition": "ported",
+      "notes": "Skill bundle aliases are implemented in the Rust CLI via /bundles and skill-bundles discovery in crates/hermes-cli/src/commands.rs, allowing /<slug> to load multiple skills."
+    },
+    "b6206020d383": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b62a82e0c3fb": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "b63f9645f08a": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "b65dfbb4530a": {
+      "disposition": "ported",
+      "notes": "Kanban lane skills are bundled locally at skills/devops/kanban-orchestrator/SKILL.md and skills/devops/kanban-worker/SKILL.md."
+    },
+    "b6945ce772b3": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b6c7ebf028d8": {
+      "disposition": "ported",
+      "notes": "Ported through Rust provider/profile routing: hermes-config normalizes provider config and hermes-agent provider profiles drive request-body behavior; the Python desktop/TUI backend is not the active runtime path.",
+      "owner": "rust-runtime"
+    },
+    "b75757d4aa85": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: scheduler mutation paths reconcile/cancel managed Chronos jobs, cron.chronos config is documented in docs/chronos-managed-cron-contract.md, and managed fire duplicate/stale tests pass.",
+      "owner": "rust-runtime"
+    },
+    "b7f0c9cd52fe": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop sticky model picker and Settings reasoning/speed controls target React desktop stores. Ultra owns model/provider selection, reasoning, and service_tier defaults through Rust CLI/TUI/gateway config and status surfaces with existing /fast and reasoning coverage.",
+      "owner": "rust-runtime"
+    },
+    "b7fe7ed7bd17": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "b81638d749c6": {
+      "disposition": "ported",
+      "notes": "ComfyUI parity is bundled at skills/creative/comfyui/SKILL.md using official comfy-cli lifecycle guidance plus direct REST/WebSocket execution rather than third-party runtime dependencies."
+    },
+    "b8234e75996e": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "b82d2e549fa5": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "b82eca2bebd8": {
+      "disposition": "superseded",
+      "notes": "Upstream fix isolates React desktop message render crashes. Ultra does not ship apps/desktop; Rust CLI/TUI/gateway rendering paths do not use the Streamdown/root-boundary pipeline fixed upstream.",
+      "owner": "rust-runtime"
+    },
+    "b8bf2f817d7c": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "b8c3bc78417c": {
+      "disposition": "ported",
+      "notes": "rust browser screenshot/TTS output markers can now be delivered as native platform files via Gateway::send_message_threaded MEDIA extraction; tests cover MEDIA path stripping, canonicalized file delivery, blocked unsafe paths, and existing inline image routing"
+    },
+    "b8f8d3ef9e55": {
+      "disposition": "ported",
+      "notes": "Rust transcription now implements the valuable provider fallback portion of the three-provider STT surface: explicit/provider-env OpenAI, Groq, and Mistral/Voxtral with deterministic model normalization and tests. Python faster-whisper local runtime is intentionally not embedded in the Rust runtime."
+    },
+    "b91aade17683": {
+      "disposition": "ported",
+      "notes": "Rust config now detects auxiliary task pins whose provider differs from the selected main provider, top-level and slash-command model switch persistence surfaces warn without auto-clearing legitimate pins, and focused config/model-switch/e2e tests cover stale vs auto/matching slots."
+    },
+    "b93c9f639381": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "b94b3622b5fa": {
+      "disposition": "ported",
+      "notes": "Rust gateway now applies per-session profile switching through `/profile <name>`: it resolves aliases from `$HERMES_HOME/profiles/aliases.json`, loads profile YAML, derives provider from either explicit provider or provider:model, applies model/personality/home/profile into GatewayRuntimeContext, preserves missing-file label behavior with a warning, and verifies status/runtime-state behavior with focused gateway route tests. Upstream desktop cross-profile UI is not a Rust runtime surface."
+    },
+    "b96bd4808dab": {
+      "disposition": "superseded",
+      "notes": "Opening chats in separate Electron windows is desktop-only and not part of the Rust CLI/gateway runtime."
+    },
+    "b9f1ac8c1022": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "ba19d530ad24": {
+      "disposition": "superseded",
+      "notes": "Python mini-swe/hecate terminal backend integration is superseded by Rust-native terminal and process backends: command execution, background lifecycle, stdin/PTY/workdir, schema registration, and local runtime contracts are implemented without Python terminal_tool dispatch."
+    },
+    "ba44de06da10": {
+      "disposition": "superseded",
+      "notes": "Electron download self-heal is installer/desktop-only. Hermes Ultra's supported install and verification path is Rust/Cargo plus local parity gates."
+    },
+    "bb5cb3283898": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Honcho setup/runtime: crates/hermes-cli/src/commands.rs and hermes_agent::memory_plugins::honcho own pinUserPeer identity mapping, legacy peerName behavior, runtimePeerPrefix, and userPeerAliases; Python Honcho CLI delta has no remaining runtime target.",
+      "owner": "rust-runtime"
+    },
+    "bbc842d31ec8": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: xAI direct setup/catalog defaults now prefer xai:grok-build-0.1, the Rust xAI web-search backend defaults HERMES_WEB_XAI_MODEL to grok-build-0.1, and focused CLI/tools tests pin the default while keeping grok-4.3 selectable.",
+      "owner": "rust-runtime"
+    },
+    "bbeed5b5d12d": {
+      "disposition": "superseded",
+      "notes": "Upstream session logging and interactive sudo support is superseded by Rust session-aware terminal/process logging, task cwd mapping, background log reads, SUDO_PASSWORD sudo transformation, approval manager, and gateway/terminal regression coverage."
+    },
     "bbf020e709ec": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "e90672696ea7": {
+    "bc3f4ed70fa5": {
+      "disposition": "ported",
+      "notes": "Ported in Rust TUI/App model switching: explicit provider:model selections flow through App::switch_model without the Python desktop/TUI redundant-switch backend.",
+      "owner": "rust-runtime"
+    },
+    "bc5f0e62d9e6c36f8f14a43e5e6c70982f280069": {
+      "disposition": "ported",
+      "notes": "Rust ToolsetManager resolves all/* to the union of registered toolsets and this slice proves the configured platform-toolset path also accepts all/* while preserving custom-token fallback; platform_toolsets tests cover both aliases."
+    },
+    "bc9e33d66b12": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "bcb024ad48bc": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "bd12b3c2321b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "bd3a5873e11f084d74be876a505a406224a6ef3e": {
+      "disposition": "ported",
+      "notes": "Rust ACP replays native todo plan updates from persisted tool results after tool_call_complete, supports trailing human hints and empty todo lists for plan clearing, and covers replay ordering plus CLI live converter behavior."
+    },
+    "bd6d0987629e": {
+      "disposition": "superseded",
+      "notes": "Upstream Python TUI gateway live-history hydration race is absent in Rust's direct resume path: resumed messages become App.messages before the TUI loop starts, and subsequent turns append to the same Rust state vector."
+    },
+    "bdac541d1ee2": {
+      "disposition": "ported",
+      "notes": "Rust OpenAI audio key resolution already prefers HERMES_OPENAI_API_KEY over legacy OPENAI_API_KEY and this slice aligns gateway voice STT/TTS error paths with the shared resolver while preserving legacy fallback."
+    },
+    "bdd3868b577a": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "0595af0ad19b": {
+    "bddc5fd08734": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "dd12a5403de9": {
+    "be2c2beb96e578542b24bdb275071044a853ebbd": {
+      "disposition": "ported",
+      "notes": "Ported in Rust OpenViking memory plugin: canonical OpenViking tool_status values and inbound alias sets are named constants; conversion emits completed/error/pending consistently and tests cover JSON error result mapping.",
+      "owner": "rust-runtime"
+    },
+    "be2c64be0275": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "1a3cd3d436a1": {
+    "bea2562fc4b3": {
+      "disposition": "ported",
+      "notes": "Rust Honcho numeric config parsing uses typed f64/usize accessors and bounded defaults instead of raw integer coercion."
+    },
+    "bec07964beb8": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "78ce91750ec6": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "d14f6c95632b": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "7c226cc57fe6": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "edc36f3a4589": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "3cf7d43262d4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "7d183f64979f": {
+    "bee13817f069": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
@@ -3546,845 +3240,1166 @@
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "f23a4b7bb3b8": {
+    "bf4223f3818f": {
+      "disposition": "superseded",
+      "notes": "Early Python scrape/crawl compression is superseded by Rust web_extract/web_crawl typed handlers, provider-specific normalized document output, URL secret-exfiltration guards, web content redaction, and tool-result storage/budget controls."
+    },
+    "bf590c81d0bc": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "bf80508d6566": {
+      "disposition": "superseded",
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
+    },
+    "bf843adf05b8": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "bf8effad023b": {
+      "disposition": "ported",
+      "notes": "Rust config atomic writes now handle cross-device rename failures with a copy fallback that preserves same-directory temp cleanup; tests cover atomic writes and platform EXDEV detection."
+    },
+    "bfa60234c8bb": {
+      "disposition": "ported",
+      "notes": "Rust config normalization emits a warning for null top-level config.yaml keys while continuing with defaults."
+    },
+    "bff78a34dc44": {
+      "disposition": "ported",
+      "notes": "Rust ZAI model metadata and CLI curated models include glm-5.2 with a verified 1M context window; model context tests cover zai/glm-5.2."
+    },
+    "c02192ff6ace129fc9bcc2f8907eabd6eb3f0f1d": {
+      "disposition": "ported",
+      "notes": "Ported in Rust image_generate: the tool request/schema now carries image_url and reference_image_urls, FAL has a typed model catalog with edit endpoints/reference caps/payload filtering plus runtime FAL_IMAGE_MODEL/config selection, OpenAI Codex remains explicit text-only, and Rust tests cover forwarding, endpoint routing, reference clamping, capabilities, and unsupported-modality errors.",
+      "owner": "rust-runtime"
+    },
+    "c10fea8d264e": {
+      "disposition": "ported",
+      "notes": "Rust ToolRegistry now supports explicit live toolset aliases such as server-name to mcp-server-name mappings, exposes alias targets for inspection, removes aliases only when the target toolset loses its last tool, and platform toolset filtering resolves configured MCP server aliases with hermes-tools and hermes-cli regression coverage."
+    },
+    "c1308ebf3f0f": {
+      "disposition": "superseded",
+      "notes": "Desktop filled tool SVG glyphs are React UI styling and outside Rust runtime parity."
+    },
+    "c14c37d46b902": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking memory provider now scopes direct content-write URIs under viking://user/{user}/agent/{agent}/memories/{subdir}/..., sends X-OpenViking-Agent and bearer auth headers, maps memory-write targets to OpenViking subdirectories, and covers URI/header/body contracts in crates/hermes-agent/src/memory_plugins/openviking.rs tests."
+    },
+    "c179bdab3c5f": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "c1927d2342a7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "c1eb2dcda7d7": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "c1f11f8c69f9721a4b5227231a6ff23a91826f76": {
+      "disposition": "superseded",
+      "notes": "Upstream indexes streamed rich finals in a Python rich_sent_store fallback. Ultra's Rust Telegram path has no rich_sent_store; rich edit/send payloads are generated from live adapter state and native rich echoes are parsed directly.",
+      "owner": "rust-runtime"
+    },
+    "c1f9eb0ec4b9": {
+      "disposition": "superseded",
+      "notes": "Dynamic electronDist self-heal supersedes an upstream desktop packaging failure class. Ultra has no Electron builder/runtime in this repo, so the Rust build/install path is unaffected.",
+      "owner": "rust-runtime"
+    },
+    "c24abf5b3286": {
+      "disposition": "superseded",
+      "notes": "This upstream row only fills apps/desktop Simplified Chinese translation strings. Hermes Agent Ultra has no corresponding desktop translation catalog in the Rust runtime repo."
+    },
+    "c276b017adc4": {
+      "disposition": "superseded",
+      "notes": "Connector-to-gateway relay channel auth, signed HTTP inbound receiver, and enroll CLI are upstream Python relay surfaces. Ultra does not expose that experimental relay adapter in Rust.",
+      "owner": "rust-runtime"
+    },
+    "c2c55c444339": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: skill_orchestrator exposes the canonical user-instruction extractor for single-skill and bundle scaffolding, and memory_manager applies it once for every provider with regression coverage."
+    },
+    "c2fa302e933a": {
+      "disposition": "superseded",
+      "notes": "Desktop backend-skew toast nag is apps/desktop update-store UX. Ultra does not run that Electron update store; Rust CLI/TUI version/status surfaces own runtime skew reporting.",
+      "owner": "rust-runtime"
+    },
+    "c3464ecf453d": {
+      "disposition": "superseded",
+      "notes": "Upstream recovers from post-ready discord.py gateway task exits. Hermes Agent Ultra's Discord surface is Rust REST plus pure GatewaySession payload parsing; there is no long-lived discord.py task whose exit can leave the gateway split-brained, and platform_reconnect_watcher already restarts adapters whose Rust running state is false."
+    },
+    "c34840e22e08": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: /api/cron/fire is served by the Rust API server route with Chronos NAS auth bypassing the generic API token path only for that route; focused api-server feature test passes.",
+      "owner": "rust-runtime"
+    },
+    "c34d3f480778": {
+      "disposition": "ported",
+      "notes": "Google Workspace helper parity is present in skills/productivity/google-workspace/scripts/_hermes_home.py, shared by setup.py, gws_bridge.py, and google_api.py for HERMES_HOME resolution."
+    },
+    "c36b256de56a": {
+      "disposition": "ported",
+      "notes": "Rust provides Home Assistant REST tools and backend handlers for entity listing, state lookup, service listing, and service calls, registers the homeassistant toolset and platform aliases, and includes a Home Assistant gateway adapter. Focused tests cover schemas, handler contracts, backend validation, and platform contract startup/routing."
+    },
+    "c37c6eaf296a": {
+      "disposition": "ported",
+      "notes": "Rust already provides Home Assistant as first-class native runtime surface: REST backend, ha_list_entities/ha_get_state/ha_list_services/ha_call_service handlers, homeassistant toolset and aliases, send-message platform routing, and gateway adapter coverage. The upstream Python bundled-plugin migration is represented by Rust-native built-in registration and platform contract tests rather than a Python plugin package.",
+      "owner": "rust-runtime"
+    },
+    "c38dac742b22": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight flushes buffered turns before adopting a new session_id, clears stale prefetch context, resets counters, and has regression coverage for session switch behavior."
+    },
+    "c39168453d01": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "c4811c382fd5": {
+      "disposition": "superseded",
+      "notes": "Electron desktop icon padding changes do not affect the Rust CLI/gateway runtime or local parity gates."
+    },
+    "c4b8f5efee8c": {
+      "disposition": "ported",
+      "notes": "Rust corrupt-store backup derives the backup filename from the canonical store basename and writes only within the original store parent directory, matching the upstream path-injection hardening intent."
+    },
+    "c50fb560ef04": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "c54b93587313": {
+      "disposition": "ported",
+      "notes": "Rust gateway /title now persists user-visible Session.title metadata in SessionManager, exposes bare /title, /status and /sessions title surfaces, emits a session:title hook, and copies title metadata when switching sessions; regression tests cover command parsing, session metadata, and gateway routing."
+    },
+    "c61815232abe": {
+      "disposition": "ported",
+      "notes": "Ported by Rust TUI model picker: crates/hermes-cli/src/tui.rs constructs provider:model selections and calls App::switch_model, so dashboard-side Python model update glue is not the active runtime path.",
+      "owner": "rust-runtime"
+    },
+    "c6b0eb4de0e5": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop remote-artifact authenticated download is superseded by Rust gateway/media delivery boundaries; Electron artifacts UI and Python web_server files endpoint are outside the Rust-only runtime.",
+      "owner": "rust-runtime"
+    },
+    "c6c8abbadb80": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: default static agent toolsets no longer expose send_message, messaging was removed from built-in toolset distributions, explicit SendMessageHandler/GatewayMessagingBackend remain for gateway/cron/CLI runtime sends, and hermes-mcp default tool-call timeout is now 300s with env override/cap coverage.",
+      "owner": "rust-runtime"
+    },
+    "c6dc2fcd2153": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop profile-backend release-before-delete targets Electron and Python profile managers. Rust profile/session lifecycle is managed through typed config, App session state, and SessionPersistence."
+    },
+    "c6fdf48b79eb": {
+      "disposition": "ported",
+      "notes": "Rust model switches call sync_runtime_model_env before rebuilding the active agent, updating HERMES_MODEL, HERMES_INFERENCE_MODEL, HERMES_INFERENCE_PROVIDER, and HERMES_TUI_PROVIDER for subsequent inference paths."
+    },
+    "c710868fbca9": {
+      "disposition": "ported",
+      "notes": "Rust TUI draft storage is decoupled from App session lifecycle and message persistence; session reset/new session do not write unsent text into conversation state."
+    },
+    "c711146ad4cd": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "c71b1d197f446e264a94f962fd55f285c9dc231f": {
+      "disposition": "ported",
+      "notes": "Rust ACP now converts its slash command table into availableCommands updates with input hints and emits available_commands_update after session new/load/resume/fork; handler and server run_on tests prove the lifecycle and JSON-RPC notification path."
+    },
+    "c7513df4f9e4": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Honcho setup semantics: pinUserPeer is only true for the single-user/operator peer shape; multi/hybrid runtime peers are modeled through runtimePeerPrefix/userPeerAliases.",
+      "owner": "rust-runtime"
+    },
+    "c77c470d2762": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "c79b6f23e696": {
+      "disposition": "ported",
+      "notes": "Rust credits notices now classify usage-band, grant-spent, and depleted states, suppress flash-style usage/grant-spent notices when a new TUI processing cycle starts, keep depleted sticky, and regression-test that yielded notices stay quiet until the band or grant-spent condition changes."
+    },
+    "c7b7f92ec14a5c43deef844804f0bf6a7f2d992d": {
+      "disposition": "ported",
+      "notes": "Ported in Rust OpenViking memory plugin: sync_turn now receives canonical structured messages through MemoryManager, extracts the current turn, writes /messages/batch parts for user/assistant/tool results, preserves tool inputs/outputs/status, skips OpenViking recall echoes, and falls back to prior text sync on batch failure. Focused Rust tests cover tool result coalescing, pending tool calls, JSON error status, recall skip, response text parts, and Rust-flattened tool_call arguments.",
+      "owner": "rust-runtime"
+    },
+    "c7f0aab9497b": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "c80fa728bd84": {
+      "disposition": "superseded",
+      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
+    },
+    "c835448908e7": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking does not block command/session-switch callers on old-session writer drains; old commits run through a deferred finalizer and non-blocking switch coverage asserts prompt return.",
+      "owner": "rust-runtime"
+    },
+    "c92a95a130cc": {
+      "disposition": "superseded",
+      "notes": "Desktop React model-picker placement has no apps/desktop runtime in Ultra. The Rust TUI owns model/provider selection in crates/hermes-cli/src/tui.rs and slash/model flows."
+    },
+    "c930a49ce9b7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "c9b32a654cd1": {
+      "disposition": "ported",
+      "notes": "Darwinian-evolver was adopted from upstream at optional-skills/research/darwinian-evolver with SKILL.md, helper scripts, and template assets."
+    },
+    "ca1fb32c2619": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ca8c78e588b7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "cadb74adad3c": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "cae7537359c0": {
+      "disposition": "superseded",
+      "notes": "Upstream subsequently removed committed infographic assets; hermes-agent-ultra now follows that repo hygiene policy and keeps generated infographics out of tree."
+    },
+    "cb29e8a82e7e": {
+      "disposition": "ported",
+      "notes": "The upstream Cron Recipes rename is ported under the final Automation Blueprints naming: Rust uses /blueprint and /bp, hermes-cron::blueprints, and created jobs flow through the existing cron scheduler instead of a parallel recipe engine."
+    },
+    "cb6b4127e795": {
+      "disposition": "superseded",
+      "notes": "Desktop composer model picker sticky state targets absent apps/desktop and tui_gateway Python files. Ultra tracks model/provider session state through Rust gateway runtime state and TUI model switch paths."
+    },
+    "cbce5e93fcb9": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "cbd6ba1bdd916d8342f6c741cb290b62dd89dbc4": {
+      "disposition": "superseded",
+      "notes": "Upstream durable lazy Python install target is superseded by Ultra Rust packaging: the container ships a compiled /usr/local/bin/hermes binary, has no top-level setup.py/pip install surface, keeps runtime state under /data, and now has Dockerfile contracts proving code immutability plus license packaging.",
+      "owner": "rust-runtime"
+    },
+    "cbf851ae1d72": {
+      "disposition": "superseded",
+      "notes": "Upstream patch bounds Python TUI startup MCP discovery; Rust TUI startup does not connect/discover configured MCP servers on App::new, and hermes-mcp discovery remains explicit client/CLI behavior with transport/call timeouts, so the freeze path is absent in current Rust runtime."
+    },
+    "cc14b74718aa": {
+      "disposition": "ported",
+      "notes": "Ported in this batch: profile create --clone-from now implies a config clone in crates/hermes-cli/src/main.rs, has parser/behavior regression coverage, and website profile docs show the clone-from-only form."
+    },
+    "cc38282b04d9": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "cc726aad687a": {
+      "disposition": "superseded",
+      "notes": "Upstream refactors Electron served-token adoption and foreign-backend refusal into a helper. Hermes Agent Ultra has no Electron dashboard-token helper; the underlying local token adoption/refusal failure mode is absent from the Rust runtime."
+    },
+    "cc8e5ec2afbf": {
+      "disposition": "superseded",
+      "notes": "Upstream migrates the Python Discord adapter into a bundled plugin. Ultra's live Discord runtime is Rust-native in crates/hermes-gateway/src/platforms/discord.rs and registered from crates/hermes-cli/src/main.rs; Python plugin migration is not a Rust runtime path."
+    },
+    "ccaa5165a006": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "cd030f5f4029": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "cd276eef7805": {
+      "disposition": "superseded",
+      "notes": "The Python on_memory_write metadata ABC compatibility shim is not a Rust API surface; Rust memory writes use typed trait methods and provider tool handlers."
+    },
+    "cda64a59612f": {
+      "disposition": "ported",
+      "notes": "Rust ToolsetManager now resolves otherwise-unknown live registry-owned toolsets, including MCP-style dynamic toolsets, through ToolRegistry instead of requiring static toolset registration. Wildcard/list discovery includes live registry toolsets and focused hermes-tools tests cover filtered and unfiltered resolution."
+    },
+    "cde7e64418e0": {
+      "disposition": "ported",
+      "notes": "Rust has first-class web_search/web_extract/web_crawl, vision_analyze, and filtered toolset resolution. This batch adds web_crawl to the web toolset and platform filtering tests, while existing vision tests cover schema, execution, URL safety, local image base64, and response normalization."
+    },
+    "cdf9793d6d6b97aa99e1b2f27629e52d89eac41d": {
+      "disposition": "ported",
+      "notes": "Rust ACP forwards image prompt blocks as OpenAI-style image_url multimodal content, preserves text-only slash command interception, treats image-bearing slash text as a model prompt, and now advertises promptCapabilities.image during initialize with protocol and handler tests."
+    },
+    "cdfbd89ea539": {
+      "disposition": "ported",
+      "notes": "Rust gateway /title now persists Session.title metadata directly, bare /title reads current title, /status and /sessions expose it, and gateway tests cover the title command lifecycle. No Python TUI session.title RPC is used in the Rust runtime."
+    },
+    "ce0f529cde11": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "ce5003063474": {
+      "disposition": "superseded",
+      "notes": "Desktop queued-composer history integration is superseded by Rust's split design: TUI input history remains a sent-prompt ring while gateway BusySessionCoordinator owns busy-turn queue/steer semantics with queue, reset, finish, and fallback tests. There is no Rust desktop queued-row editor surface to port."
+    },
+    "cea87d913904": {
+      "disposition": "superseded",
+      "notes": "Upstream website skills-hub source aggregation is superseded by approved rust-cli-tui-primary-ux-surface and rust-skills-catalog-governance divergences; actual SKILL.md source trees are tracked by Rust loaders and parity queue overrides."
+    },
+    "cedd9b6d475b": {
+      "disposition": "superseded",
+      "notes": "Upstream passive update fix avoids SSH origin fetches in Python banner and Electron desktop checks. Hermes Agent Ultra's Rust update command already uses the GitHub HTTPS releases API in crates/hermes-cli/src/update.rs with HERMES_UPDATE_REPO override support and never shells out to git fetch origin for update checks."
+    },
+    "cf786593cd83": {
+      "disposition": "ported",
+      "notes": "Rust now propagates active provider output caps into AgentConfig.max_tokens so gateway/CLI/cron agent paths pass configured max_tokens into provider requests through the existing AgentLoop max_tokens chain."
+    },
+    "cf9dc366dd0b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop cross-profile read-only icon/action cleanup is tied to apps/desktop and Python web_server/session DB surfaces. Rust runtime profile ownership is handled through ACP/gateway session metadata, not desktop per-session icon routing."
+    },
+    "cfaa46fcae63": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "cfbc47d8937c": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d03c6fcc45cf": {
+      "disposition": "ported",
+      "notes": "Rust Honcho supports opt-in pinUserPeer/pinPeerName identity mapping so gateway runtime users can resolve to stable configured peers across platforms."
+    },
+    "d04a0b81ee7c": {
+      "disposition": "superseded",
+      "notes": "skill catalog and runtime integration are already covered by local rust-first skill orchestration; upstream python-side delta superseded"
+    },
+    "d0ea4caf7fc3": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d1383a6b1450": {
+      "disposition": "ported",
+      "notes": "Sibling skills touched by upstream now use HERMES_HOME-aware .env resolution or docs, while Hermes-specific skill text keeps the local Rust runtime framing."
+    },
+    "d14f6c95632b": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "18916376f198": {
+    "d165933c560c": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d1771114eda9": {
+      "disposition": "ported",
+      "notes": "Rust session_search now sanitizes FTS5 MATCH input by quoting query terms before execution, so colon-containing queries are treated as literal search text instead of FTS column filters. Regression coverage proves workspace:hermes searches return matching sessions without error.",
+      "owner": "rust-runtime"
+    },
+    "d18618f48f18": {
+      "disposition": "ported",
+      "notes": "Rust Honcho respects HOME-anchored default profile fallback paths while still allowing the active HERMES_HOME profile to override them."
+    },
+    "d1ecebcbfd8c": {
+      "disposition": "superseded",
+      "notes": "Upstream repairs Electron binary re-download for Python/PowerShell/shell desktop packaging. Ultra does not ship the Electron desktop packaging path as Rust runtime; local release/build gates use the Rust workspace and repository scripts instead.",
+      "owner": "rust-runtime"
+    },
+    "d221e369b8f3": {
+      "disposition": "superseded",
+      "notes": "Upstream assistant-ui message render boundary and virtualizer recovery is Electron/React desktop UI only. Hermes Agent Ultra's owned runtime surface is Rust CLI/TUI/gateway, with no assistant-ui thread virtualizer equivalent."
+    },
+    "d2536a72bf27b3ca01d1b48957e58cb0202b6dfb": {
+      "disposition": "ported",
+      "notes": "Rust ACP replays persisted user and assistant session history on session/load and session/resume as session/update message chunks, skipping non-displayable system messages and preserving malformed-history tolerance."
+    },
+    "d29caf382868": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d2c53ff5583e": {
+      "disposition": "superseded",
+      "notes": "WS-only inbound relay is part of the upstream experimental Python relay adapter. Ultra keeps native Rust platform adapters and does not expose the relay adapter as active runtime surface.",
+      "owner": "rust-runtime"
+    },
+    "d3120aeab064": {
+      "disposition": "superseded",
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
+    },
+    "d35efb989884": {
+      "disposition": "ported",
+      "notes": "Rust gateway now exposes /topic, /topic help, /topic off, and /topic <session-id>. Authorization is enforced by existing DM/platform access gates before command execution; /topic off is an idempotent no-op because there are no Python SQLite topic bindings to clear."
+    },
+    "d36790de9153": {
+      "disposition": "ported",
+      "notes": "Ephemeral system prompts are first-class in Rust for both batch and agent runners: BatchDatasetRunConfig tracks an ephemeral prompt without persisting it to trajectory JSONL or checkpoints, and AgentConfig::ephemeral_system_prompt is appended only to provider API-call messages and stripped from AgentResult persistence, with focused tests for both paths."
+    },
+    "d41427504ef04": {
+      "disposition": "ported",
+      "notes": "Rust delegation depth now has a first-class AgentConfig max_delegate_depth plus delegation.max_spawn_depth config bridge with floor 1 and no legacy ceiling; env/config values above the old cap pass through with agent, CLI, config, and backend tests."
+    },
+    "d42b6a2eddc7": {
+      "disposition": "superseded",
+      "notes": "Upstream AGENTS.md plugin/skill documentation refresh is superseded by local AGENTS.md Rust parity rules plus docs/parity compatibility policy and skills governance."
+    },
+    "d473e7c9385e": {
+      "disposition": "ported",
+      "notes": "Rust disk-cleanup auto categorization only marks cron/cronjobs output subtrees as cron-output and explicitly leaves cron/jobs.json plus .tick.lock as control-plane state; covered by hermes-tools disk_cleanup tests."
+    },
+    "d4be583d986f7bcca4f8414fd21ef9e34b18c948": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: the default command-menu cap is 60 while still clamping to Telegram's 100-command API maximum, with command ordering/cap coverage.",
+      "owner": "rust-runtime"
+    },
+    "d61785889678": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking uses target/category-aware memory subdirectories and a shared URI builder instead of private attribute access."
+    },
+    "d62979a6f34f": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "7f302c91b240": {
+    "d63b363cde77": {
+      "disposition": "ported",
+      "notes": "The upstream atomic_json_write/checkpoint test refactor is ported as Rust hermes_intelligence::rl atomic_json_write plus BatchRunCheckpoint load/save helpers and BatchDatasetRunner checkpoint-path resume. Focused tests cover valid/overwrite writes, parent dirs, original preservation on serialization failure, no temp leaks, Unicode/concurrent writes, missing/corrupt checkpoint handling, run-name mismatch fresh starts, last_updated, and persisted resume progress."
+    },
+    "d65b513f23d7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d6615d8ec7d5": {
+      "disposition": "ported",
+      "notes": "Rust Telegram topic lanes are represented by adapter-level message_thread_id to composite chat_id routing plus Gateway session keys scoped by the encoded chat_id. Regression tests cover independent Telegram topic sessions, /new current-topic isolation, adapter topic send routing, topic binding recovery helpers, and config/env allowed_topics/ignored_threads hydration."
+    },
+    "d6b65bbc47cf": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight auto-retain builds structured turn JSON without ASCII escaping, and tests prove non-ASCII user and assistant content survives in the retained payload."
+    },
+    "d6e2c940e9d1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d704df2d6e47": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d759c13c0963": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d7668aaff5b7": {
+      "disposition": "ported",
+      "notes": "Adopted upstream shop metadata tightening: description is <=60 chars and the contributor credit is preserved in optional-skills/productivity/shop/SKILL.md."
+    },
+    "d78c34928fe9": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "d7cd0bc0863cda1a203f00422b1441ca2d9890ed": {
+      "disposition": "ported",
+      "notes": "Ported in Rust OpenViking memory plugin: structured sync preserves assistant attribution via peer_id on assistant/tool-part batch messages, supports response-style text parts, replaces the first synced user message with the already-sanitized user content, and receives redacted canonical transcript values from MemoryManager.",
+      "owner": "rust-runtime"
+    },
+    "d7d1503595b3": {
+      "disposition": "ported",
+      "notes": "ComfyUI onboarding coverage is in skills/creative/comfyui/SKILL.md and references, including local/cloud install paths, docs links, launch, workflow execution, and troubleshooting."
+    },
+    "d7d281fa37e4": {
+      "disposition": "ported",
+      "notes": "Strict per-thread drafts are implemented for the Rust TUI through per-session draft keys, MRU capped persistence, startup restore, submit clearing, and regression tests."
+    },
+    "d7dfeed6dc42": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Honcho setup: setup_honcho_provider builds the gateway-gated identity tree for single/multi/hybrid deployments with aiPeer, pinUserPeer, runtimePeerPrefix, and aliases.",
+      "owner": "rust-runtime"
+    },
+    "d842155da1e8": {
+      "disposition": "ported",
+      "notes": "Ported by Rust session/profile scoping: hermes-config resolves effective HERMES_HOME/profile config before runtime state, and ACP/session stores cwd explicitly in Rust session models.",
+      "owner": "rust-runtime"
+    },
+    "d8703e27f5c3": {
+      "disposition": "ported",
+      "notes": "Ported in this batch: website prebuild fetches the live unified skills index, extract-skills emits skills-meta.json, the Skills Hub renders index health/freshness, and npm run check:skills-index runs the local freshness gate via scripts/check-skills-index-freshness.mjs."
+    },
+    "d87c7b99e2a4": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "d94fb47717eb": {
+      "disposition": "superseded",
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "d963ad56c19e": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "d986bb0c6de6": {
+      "disposition": "superseded",
+      "notes": "Python web dashboard profile builder is superseded by Rust CLI/config/profile flows and approved website/dashboard divergence."
+    },
+    "da18fd084a0b": {
+      "disposition": "superseded",
+      "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
+    },
+    "da2ed478b505": {
+      "disposition": "ported",
+      "notes": "ported in local commit 0dc31e7eb (achievements auth header fix)"
+    },
+    "da4f407e5173": {
+      "disposition": "ported",
+      "notes": "Rust `hermes portal` now defaults to Nous Portal onboarding/setup, `portal info/status/check` report status, CLI help/README/auth recovery guidance use the human-readable portal alias, and focused CLI tests cover the dispatch without OAuth side effects."
+    },
+    "da9425bf9b08": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "dad021745000": {
+      "disposition": "superseded",
+      "notes": "Python session-cache RLock fixes are superseded by Rust Honcho's Mutex-protected session_key, prefetch, and turn-count state with no shared Python SDK cache."
+    },
+    "db22efbe88bd": {
+      "disposition": "ported",
+      "notes": "Optional and bundled local skills declare platforms frontmatter and Rust skill loading honors platform aliases/filters during command discovery."
+    },
+    "db79e90130fe": {
+      "disposition": "superseded",
+      "notes": "Upstream filesystem routing facade is desktop/Electron backend routing. Hermes Agent Ultra has no desktop filesystem facade; local file operations remain Rust tool and terminal surfaces under approval/workspace policy."
+    },
+    "dbe14ce35d9cb087ae9fe3e3f166f6c475297e25": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: startup registers BotCommand menus for default/private/group scopes from the Rust gateway command catalog with configurable priority, mode, and cap.",
+      "owner": "rust-runtime"
+    },
+    "dc5ef1ac8ed9": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "dc90ca4e1740": {
+      "disposition": "superseded",
+      "notes": "Upstream adds the same Python certifi CA guard during Python agent initialization. Ultra's Rust provider clients are constructed through rustls-backed reqwest, so the certifi failure mode is not present."
+    },
+    "dd0e3e0a052a": {
+      "disposition": "superseded",
+      "notes": "Desktop thread padding is an apps/desktop React-only presentation change. Ultra has no desktop React runtime; CLI/TUI rendering is Rust-owned."
+    },
+    "dd12a5403de9": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "1e755ff5568a": {
+    "dd2d1ba5e61c": {
+      "disposition": "ported",
+      "notes": "Rust /reload-skills follows the final upstream behavior: it queues a one-shot system note for the next agent turn, confirms dynamic SKILL.md slash commands are scanned live, and does not delete prompt caches or expose a skills_reload agent tool. CLI and gateway tests cover command routing, snapshot rendering, and one-shot gateway note injection."
+    },
+    "dd5e97bd7fe0": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "dde9c0d19d16": {
+      "disposition": "ported",
+      "notes": "Rust gateway tool-progress callbacks now emit explicit progress messages when enabled, and markdown-capable platforms render terminal commands as full bash fenced code blocks through build_gateway_tool_progress_message. Tests cover Telegram bash blocks, plain-platform compact fallback, and blank-command fallback."
+    },
+    "de0469e02b14": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "de07aa7c4046": {
+      "disposition": "ported",
+      "notes": "Rust now exposes a first-class `nous-api` direct API-key provider with aliases, non-OAuth provider capability, setup catalog entry, NOUS_API_KEY/NOUS_BASE_URL runtime resolution, Nous provider construction, Nous model normalization/catalog reuse, and targeted core/CLI/agent tests."
+    },
+    "de80d28f3848": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "de8bdf529d64": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ded194eb6aca": {
+      "disposition": "superseded",
+      "notes": "optional-skill parity is covered by local multi-registry skill surfaces; upstream single-skill delta is superseded"
+    },
+    "ded620b7114d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "df55660e3c3c": {
+      "disposition": "superseded",
+      "notes": "The unsupported-CPU guard is a Python import workaround for local embedded Hindsight; Rust Hindsight never imports that Python stack and normalizes embedded aliases to local_external."
+    },
+    "dfc5563641f0": {
+      "disposition": "ported",
+      "notes": "Rust ACP sessions now include client-provided MCP server toolsets through live ToolRegistry mcp-{server} toolsets and explicit aliases, so tools.list, /tools, initialize tool names, ToolsetManager resolution, and registered MCP dispatch all see the session MCP surface. Focused tests cover toolset expansion and ACP MCP tool visibility."
+    },
+    "dfd6bcf1ff9c": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e003c53b06d8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e0121c59d3b3": {
+      "disposition": "superseded",
+      "notes": "Drag-sort profiles in the rail only changes apps/desktop profile-switcher UI state. Rust profiles are filesystem-backed YAML entries listed deterministically by CLI/gateway surfaces, not an ordered desktop rail."
+    },
+    "e026fd88cdbb": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e029b7597bdf": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e02a6038a420": {
+      "disposition": "ported",
+      "notes": "Rust hermes dump now resolves real session snapshots, defaults exports under HERMES_HOME/sessions/saved/hermes_conversation_<timestamp>.json, and includes system_prompt, session_id, session_start, source_path, model/personality, exported_at, and messages with regression coverage."
+    },
+    "e0492aa2dca0": {
+      "disposition": "superseded",
+      "notes": "Superseded by user policy and local gate scripts: official GitHub pull_request CI is optional, while local shell/Rust gates define the required validation before push.",
+      "owner": "local-gates"
+    },
+    "e0a999aa8a22": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e0e25717116c": {
+      "disposition": "superseded",
+      "notes": "Upstream later reverted the keyless Parallel MCP search fallback in f3fe99863d13. Current Rust web tools intentionally keep Parallel search/extract REST-only behind PARALLEL_API_KEY."
+    },
+    "e0f6a35ac659": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e1710378b738": {
+      "disposition": "ported",
+      "notes": "Rust builtin registration and toolset resolution now expose image_generate, mixture_of_agents, and the complete web tool trio through typed registries instead of Python model_tools dispatch."
+    },
+    "e184f5ab3a51": {
+      "disposition": "ported",
+      "notes": "rust TodoHandler and FileTodoBackend provide create/update/list task management with TOOLSET_TODO and builtin registry exposure; new schema contract proves first-class todo runtime surface"
+    },
+    "e1d10ec1ed29": {
+      "disposition": "ported",
+      "notes": "Ported by Rust-native telemetry shape: Langfuse endpoint/header/resource config is centralized in hermes-telemetry and span scope is carried by tracing fields rather than Python trace-key prefixes; focused tests pass.",
+      "owner": "rust-runtime"
+    },
+    "e2145a5c9cae": {
+      "disposition": "superseded",
+      "notes": "Upstream embedded dashboard chat gateway stabilization targets ui-tui TypeScript gatewayClient and Python tui_gateway transport behavior. Hermes Agent Ultra release/runtime gates are Rust-first; the local Rust gateway/CLI session path is separate from that embedded JS/Python dashboard chat transport."
+    },
+    "e256f4aae493": {
+      "disposition": "ported",
+      "notes": "Ported by Rust session/provider persistence boundaries: session state and provider selections are explicit Rust App/Gateway state rather than restoring a bare billing provider from Python tui_gateway state.",
+      "owner": "rust-runtime"
+    },
+    "e26f9b207041c03d1aa9a982d29dbfda66df3a82": {
+      "disposition": "ported",
+      "notes": "Rust ACP routes provider reasoning callbacks to agent_thought_chunk updates, routes stream deltas to message_delta updates, and suppresses fallback final-response emission when executor streaming already delivered message content."
+    },
+    "e27b0b76517c903541af20d0bd606fa7b3c83005": {
+      "disposition": "ported",
+      "notes": "Rust ACP now advertises /steer and /queue, queues prompts without racing active sessions, drains queued turns FIFO after current completion, and exposes an AcpPromptExecutor steer hook; hermes-acp queue/steer tests cover slash discovery, no-run queueing, active queueing, active steer signaling, and queued drain."
+    },
+    "e372803554be": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop session model refresh targets Electron/React sidebar metadata. Rust App::switch_model already synchronizes runtime model env, rebuilds the active agent, and persists the active session model through SessionPersistence with regression coverage for the session DB row."
+    },
+    "e3921e7ca4a6": {
+      "disposition": "ported",
+      "notes": "Bundled skill descriptions are kept in SKILL.md frontmatter across the local Rust catalog and exposed through Rust skill scanners; the upstream compression-only docs delta has no separate runtime change."
+    },
+    "e3940f980799": {
+      "disposition": "ported",
+      "notes": "Rust config normalization drops a null personalities block before deserialization, preventing stale Python-style personality overlay config from breaking TUI startup."
+    },
+    "e3adbb5ae9d6": {
+      "disposition": "ported",
+      "notes": "Ported as a Rust-wide memory fix rather than an OpenViking-only Python plugin patch: MemoryManager now strips slash-skill scaffolding before provider prefetch, queued prefetch, or sync fan-out."
+    },
+    "e3ed7722b5b1": {
+      "disposition": "superseded",
+      "notes": "Upstream foreign-backend token refusal is Electron dashboard-token readiness logic. The local Rust runtime has no Electron dashboard backend token adoption path; gateway sessions are explicit Rust session keys and platform adapters."
+    },
+    "e3fc0814996d": {
+      "disposition": "ported",
+      "notes": "Upstream blockchain/base merge was adopted by adding optional-skills/blockchain/evm and removing the stale local optional-skills/blockchain/base copy after backup."
+    },
+    "e42fcc562596": {
+      "disposition": "ported",
+      "notes": "Rust startup model resolution now pins provider selection to config-derived provider:model state and overwrites stale HERMES_INFERENCE_PROVIDER handoff env during runtime sync; CLI --provider remains the per-invocation override."
+    },
+    "e43d2fe5205e": {
+      "disposition": "ported",
+      "notes": "Google Workspace drive write operations plus Docs/Sheets create/append are implemented in skills/productivity/google-workspace/scripts/google_api.py and documented in the SKILL.md examples."
+    },
+    "e48a497d166b": {
+      "disposition": "ported",
+      "notes": "Rust shares static provider/model knowledge through model_switch curated catalogs, canonical provider IDs, and provider_model_ids_for_config tests for custom provider maps instead of duplicating startup detector code."
+    },
+    "e5472da58470": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e5580f43c258": {
+      "disposition": "ported",
+      "notes": "Rust DiscordInteractionAuthPolicy includes allowed_role_ids and role matching for components, slash commands, autocomplete, and fail-closed paths."
+    },
+    "e5d41f05d47e": {
+      "disposition": "ported",
+      "notes": "Spotify skill catalog coverage exists at skills/media/spotify/SKILL.md with cross-platform frontmatter, while Spotify tool surfacing remains gated through the Rust tool/catalog setup paths."
+    },
+    "e618cbee4418": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e67ab2e042d3": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e68fc4def2ba": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e76d8bf5aaa9": {
+      "disposition": "ported",
+      "notes": "Rust TUI tool-output rendering now defaults to a small 16-line/1KiB retained preview while preserving full agent context/session storage; regression coverage pins truncation and preview-size behavior."
+    },
+    "e7a7872a874837ca36105ca3e90db464cf7c125a": {
+      "disposition": "ported",
+      "notes": "Rust process_registry now exposes deduplicated process notification receipts via notify/record_event/list_events/clear_events. Completion events are one-shot per process session, watch_match identities include command/pattern/output/suppressed/message_id so distinct matches are preserved, and focused tests cover replay dedup plus distinct watch-match emission."
+    },
+    "e80754647c90": {
+      "disposition": "superseded",
+      "notes": "Desktop in-thread tool codicon styling is React UI only and not a Rust runtime behavior."
+    },
+    "e8c837c921e0": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e90672696ea7": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "76b93869d8ed": {
+    "e93bfc6c93bf": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
     },
-    "77687156b4b8": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    "e946f49ab550": {
+      "disposition": "ported",
+      "notes": "Rust Gemini API-key and google-gemini-cli OAuth model catalogs now expose gemini-3.5-flash and stop offering retired gemini-3-flash-preview; Gemini auxiliary direct-key default also uses gemini-3.5-flash with regression coverage."
     },
-    "b15dc58064eb": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    "e96ca1a0d35a": {
+      "disposition": "ported",
+      "notes": "Rust now drops empty sessions on session rotation and TUI shutdown through SessionPersistence::delete_session_if_empty plus App empty-stub cleanup. The port removes untitled message-free parentless SQLite rows and exact empty snapshots while preserving titled, child, message-bearing, or non-empty snapshot sessions; focused hermes-agent and hermes-cli tests cover the behavior."
     },
-    "b82d2e549fa5": {
+    "e96fe06e4968": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream served dashboard token adoption targets Electron child-process dashboard websocket auth. Hermes Agent Ultra does not ship that Electron backend launcher; Rust gateway/session auth is handled by typed Rust services and CLI config rather than desktop dashboard-token.cjs."
     },
-    "bdd3868b577a": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "266b5a19f128": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "5d6c16e97237": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "aa53a78d6703": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "425e777f54b8": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "0a865e5948cb": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "6b76284c7769": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    "e97a4c8f3795": {
+      "disposition": "ported",
+      "notes": "README.md and local Chinese README now include the upstream Nous Portal setup/status section adapted to hermes-agent-ultra command names."
     },
     "e986e3fc689c": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "b4ba3f5e3b37": {
+    "e9b8dd236c79": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "630a4ef03c8e": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    "e9c47c70422d": {
+      "disposition": "ported",
+      "notes": "Rust CLI/TUI launch model overrides are represented by resolve_cli_chat_provider_model, apply_cli_chat_runtime_env, App::new startup resolution, and sync_runtime_model_env tests covering HERMES_MODEL/HERMES_INFERENCE_MODEL plus provider env synchronization."
     },
-    "b0288ae9b6ea": {
+    "ea01bdcebe1f": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "The Python flush_memories API has no Rust runtime equivalent; Rust providers use lifecycle hooks, shutdown, and explicit retain/write paths instead."
     },
-    "9cbb91abd3a8": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    "ea056b05598cab8330555defe095988c3a7928f9": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter: rich-message eligibility now rejects CJK scripts to avoid Telegram desktop garbling, with guard and legacy-payload tests.",
+      "owner": "rust-runtime"
     },
-    "49dd91d682a4": {
+    "ea266f43e9db": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Rust LocalSearchBackend does not shell through rg/grep or parse merged stderr as matches; it compiles regexes with regex::Regex before traversal, skips unreadable/non-UTF8 files without diagnostic payload parsing, and now regression-tests invalid-regex errors plus partial read failures preserving content/files_only/count matches."
     },
-    "1eb13744b4ab": {
+    "ea44011d152e": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "08d89e7aba14": {
+    "ea4fe1563119": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "8fe334b056d4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "fbabf438a17c": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "bee13817f069": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    "ea8e608821b1": {
+      "disposition": "ported",
+      "notes": "Watchers optional skill exists at optional-skills/devops/watchers/SKILL.md with RSS, HTTP JSON, and GitHub polling scripts."
     },
     "eae3836eb661": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "ae433634db56": {
+    "eb49936a60aa": {
+      "disposition": "superseded",
+      "notes": "upstream docs/install audio-format update is superseded by rust-native TTS providers, media_category/send_file adapter routing, and gateway MEDIA marker delivery tests; no Python install-script runtime remains to port"
+    },
+    "eb51c180e6484ec15809d04c25a8115e6e48dc3c": {
+      "disposition": "ported",
+      "notes": "Ported to Ultra Docker/Rust dashboard contract: docker-compose runs dashboard on 127.0.0.1 by default, docs remove the stale HERMES_DASHBOARD side-process/insecure escape hatch, and Rust API server bind guards still require API_SERVER_KEY for network-accessible binds even when dashboard --insecure acknowledges non-localhost binding.",
+      "owner": "rust-runtime"
+    },
+    "eb612f55748d8f0888f09f055abd86afef925150": {
+      "disposition": "ported",
+      "notes": "Rust ACP web_extract rendering now matches the compact contract: success omits extracted content, structured failures show URL/title/error summaries, and tests prevent raw result dumps."
+    },
+    "ebb46ba0e6a7": {
+      "disposition": "ported",
+      "notes": "Rust exposes image_generate as a first-class tool with schema/handler coverage and FalImageGenBackend direct/managed transport tests for payload shape, auth routing, model override, and unconfigured errors."
+    },
+    "ebf2ea584ab2": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "ec32e9a5406d": {
+      "disposition": "ported",
+      "notes": "Rust transcription now exposes provider-aware Groq STT with GROQ_API_KEY, Groq OpenAI-compatible endpoint/model defaults, model normalization, schema coverage, and gateway SttProvider::GroqWhisper credential/error handling tests."
+    },
+    "ec46f5912e30": {
+      "disposition": "ported",
+      "notes": "Rust Gemini direct-provider setup and runtime defaults now use Google AI Studio's OpenAI-compatible /v1beta/openai endpoint, normalize manually supplied native Gemini base URLs to that endpoint, and defensively strip OpenAI-only extra_body/profile fields from native-Gemini request bodies while preserving thinking_config/thinkingConfig. The upstream native maxOutputTokens default is superseded by Rust's OpenAI-compatible max_tokens path."
+    },
+    "ec4cb16a29ec": {
+      "disposition": "superseded",
+      "notes": "Python peers/sessions cache read locking is superseded by Rust Honcho identity resolution from immutable config plus Mutex-protected plugin state."
+    },
+    "ec9d0e26d4ed": {
+      "disposition": "superseded",
+      "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
+    },
+    "ed1e2533b73d": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "ed20f5ed0605": {
+      "disposition": "ported",
+      "notes": "Ported by Rust explicit model switching: crates/hermes-cli/src/tui.rs provider/model modal calls App::switch_model directly, allowing operator-selected models to escape stale config defaults.",
+      "owner": "rust-runtime"
+    },
+    "ed81cfe3def7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "eda1c97a1ef8c7d8505f40be1839929e130ad4c4": {
+      "disposition": "ported",
+      "notes": "Rust ACP marks canonical raised-exception outputs beginning with Error executing tool as failed while preserving plain Error: terminal/test output as completed; completion-status tests cover the positive and negative cases."
+    },
+    "edc36f3a4589": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "eddbf291a415": {
+      "disposition": "ported",
+      "notes": "Rust OpenViking session switch rotates in-memory state immediately, clears stale prefetch, and defers old-session drain/commit so late writes do not target the new session.",
+      "owner": "rust-runtime"
+    },
+    "ede47a54be04": {
+      "disposition": "ported",
+      "notes": "Rust gateway pins Telegram DM-topic routing to the active topic by preserving the encoded topic chat_id through route_message, runtime context, session keys, and outbound sends; telegram_topic_chat_ids_are_independent_session_lanes proves later turns in one topic do not drift to sibling topics."
+    },
+    "ede4f5a4a30b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "edff2fbe7efd": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight supports bank_id_template with profile/workspace/platform/user/session placeholders, sanitization tests, schema exposure, and README coverage."
+    },
+    "ee41aa0c1a0a": {
+      "disposition": "superseded",
+      "notes": "Chat error banner dismissal is React desktop local view state. Ultra handles turn errors through Rust CLI/TUI/gateway messages and does not persist the upstream desktop banner component.",
+      "owner": "rust-runtime"
+    },
+    "ef5eaf8d8757a5e75fa571042abc287430192f53": {
+      "disposition": "ported",
+      "notes": "Rust cron now honors the cron platform_toolsets config path, adds the hermes-cron default platform/toolset surface, hard-denies recursive and interactive cron tools, preserves direct custom-tool fallback, and covers default/configured cron filtering with targeted tests."
+    },
+    "ef98e3f9e60b": {
+      "disposition": "superseded",
+      "notes": "In-tree memory-plugin PR policy docs are superseded by local Rust skill standards, plugin governance, and the approved rust-skills-catalog-governance divergence."
+    },
+    "ef9a08a872d1ed87eb4c91cf8ad8e8f4ef5a6e2b": {
+      "disposition": "ported",
+      "notes": "Rust ACP now emits native usage_update events with size/used on session lifecycle, model switch, slash-command, and prompt completion paths, enriches /context with usage and compaction threshold text, and ports polished common tool rendering/kind/title behavior with hermes-acp tests."
+    },
+    "efa53fb3be51": {
+      "disposition": "superseded",
+      "notes": "Desktop Cmd/Ctrl+Enter steer keybinding policy is not a Rust runtime surface. Rust TUI has its own terminal key contract: Enter submits, Shift+Enter and Ctrl+J insert newlines, Ctrl+Enter/Ctrl+M are submit fallbacks, and focused tests guard those shortcuts."
+    },
+    "efbe1635dd2e": {
+      "disposition": "ported",
+      "notes": "Rust gateway parsing now carries replied-to media through native surfaces: Telegram text replies expose referenced voice/photo/document file IDs, and Discord MESSAGE_CREATE parsing merges referenced-message attachments after current attachments."
+    },
+    "efcbbde48c38": {
+      "disposition": "ported",
+      "notes": "Rust keeps anthropic_content_blocks in-memory only on hermes_core::Message and deliberately does not persist them through SessionPersistence, matching upstream's final no-state-db-column decision while leaving fallback reconstruction for reloaded sessions."
+    },
+    "f018999da978": {
+      "disposition": "ported",
+      "notes": "Initial Python RL training tools and loop are ported as Rust rl_* ToolHandler implementations backed by hermes_intelligence::rl run/config/status/metrics types, registered as built-in tools under the rl_training toolset with lifecycle and inference tests."
+    },
+    "f033b7dbfbe8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "f15d2cb5e424": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "f18a9dbefc59": {
+      "disposition": "superseded",
+      "notes": "Japanese and Traditional Chinese language switching is an apps/desktop component/catalog change. The Rust runtime has no Electron language switcher surface; CLI/TUI/gateway text remains direct Rust command/status output."
+    },
+    "f1ba2f0c0b06": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight request clients for auto-recall, auto-retain, and tool calls all use the configured timeout_secs value."
+    },
+    "f1fe29d1c368": {
+      "disposition": "ported",
+      "notes": "Rust provider config now accepts llm.<provider>.request_timeout_seconds, validates and exposes it through config set/get, propagates it into AgentConfig RuntimeProviderConfig, and applies it to OpenAI-compatible, Codex Responses, Anthropic, OpenRouter, extra provider, fallback/runtime-routing, and client rebuild paths with targeted tests."
+    },
+    "f23a4b7bb3b8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "f24b7ed9d953": {
+      "disposition": "ported",
+      "notes": "ported/superseded by Rust Honcho architecture: initialize only loads config and never blocks on network session startup; regression test proves fail-open startup while tools/context remain available."
+    },
+    "f2e8ed240536": {
+      "disposition": "superseded",
+      "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "f38f7a387013": {
+      "disposition": "superseded",
+      "notes": "Desktop stale runtime session recovery for session.interrupt is superseded by Rust TUI/ACP interrupt architecture: active runs are in-process and keyed directly by the active session, with no desktop runtime-id versus stored-id split."
+    },
+    "f3a4af9cf2a626cb3e055766cb1cff60168d295d": {
+      "disposition": "ported",
+      "notes": "Rust ACP replays assistant reasoning_content/reasoning as agent_thought_chunk before assistant message text and reconstructs persisted tool-call start/completion events during load/resume history replay."
+    },
+    "f3af489ec2f7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
     "f3b32e9f5220": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
-    "368fcf1ff03b": {
+    "f3fe99863d13": {
+      "disposition": "ported",
+      "notes": "Rust web backends removed the keyless Parallel MCP fallback. Parallel search/extract are REST-only with PARALLEL_API_KEY, and no-key search/extract fall back to local fallback/simple behavior with tests."
+    },
+    "f4031df05dd4": {
       "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "1cb75b7971a7": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "37d717054ef6": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "9d2ec8d35a2a": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "98c294126baf": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "0f75e9904a8f": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "67233d1c2ad5": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
-    },
-    "05b9c84ca4b1": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: crates/hermes-gateway/src/platforms/telegram.rs now supports opt-in Bot API 10.1 sendRichMessage with raw rich_message.markdown payloads, legacy fallback, link_preview_options, and feature-gated tests telegram_rich_message_uses_bot_api_10_1_payload_shape / telegram_rich_message_bad_request_falls_back_to_legacy_send."
-    },
-    "652dd9c9f248": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: rich sends use reply_parameters instead of reply_to_message_id, latch off proven endpoint capability failures, default rich_messages remains opt-in, and bad-request rich payload failures fall back to legacy sendMessage with tests."
-    },
-    "a59d5e37e8ab": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by later upstream policy and Rust final state: Telegram rich messages are deliberately opt-in via TelegramConfig.rich_messages instead of always on because client rendering remains uneven."
-    },
-    "12682d96b9c8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram config: rich_messages deserializes as an explicit opt-in flag with default false, verified by Telegram config tests and rich-message feature tests."
-    },
-    "a1f51feb72b4": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/satisfied in Rust final architecture: rich delivery is opt-in and only attempted for eligible normal text sends, not status edits; StreamConsumer has no adapter-specific rich fresh-final hook to duplicate previews, and existing stream fresh-final tests preserve final-delivery state."
-    },
-    "a376ca00819e": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Hindsight plugin: HINDSIGHT_RETAIN_TAGS and HINDSIGHT_RETAIN_OBSERVATION_SCOPES/profile config parse into retain tags and observation_scopes, auto-retain includes session lineage tags, tool-call tags merge with defaults, and Hindsight tests cover payload/config normalization."
-    },
-    "bb5cb3283898": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Honcho setup/runtime: crates/hermes-cli/src/commands.rs and hermes_agent::memory_plugins::honcho own pinUserPeer identity mapping, legacy peerName behavior, runtimePeerPrefix, and userPeerAliases; Python Honcho CLI delta has no remaining runtime target."
-    },
-    "d7dfeed6dc42": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Honcho setup: setup_honcho_provider builds the gateway-gated identity tree for single/multi/hybrid deployments with aiPeer, pinUserPeer, runtimePeerPrefix, and aliases."
-    },
-    "99feb036077a": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust Honcho configuration surface: pinUserPeer is the canonical runtime field and peerName is only emitted as a non-empty compatibility label from crates/hermes-cli/src/commands.rs."
-    },
-    "2708c33c7570": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust-first Honcho docs/tests surface; no real Telegram UID or named user example is required by the Rust Honcho setup path."
-    },
-    "1544813bfe56": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust Honcho setup/tests and release secret scan: the Rust setup path does not embed upstream example Telegram UID values and uses operator-supplied peer identity instead."
-    },
-    "c7513df4f9e4": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Honcho setup semantics: pinUserPeer is only true for the single-user/operator peer shape; multi/hybrid runtime peers are modeled through runtimePeerPrefix/userPeerAliases."
-    },
-    "c61815232abe": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust TUI model picker: crates/hermes-cli/src/tui.rs constructs provider:model selections and calls App::switch_model, so dashboard-side Python model update glue is not the active runtime path."
-    },
-    "8c3c08c50be8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/superseded by the Rust TUI model/provider modal implementation in crates/hermes-cli/src/tui.rs; the Python tui_gateway cleanup target is not shipped as the runtime backend."
-    },
-    "bc3f4ed70fa5": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust TUI/App model switching: explicit provider:model selections flow through App::switch_model without the Python desktop/TUI redundant-switch backend."
-    },
-    "6b4073648ece": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust config loader precedence: crates/hermes-config/src/loader.rs loads gateway.json, then config.yaml, then cli-config.yaml, then env overrides with explicit layer order and tests."
-    },
-    "b6c7ebf028d8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported through Rust provider/profile routing: hermes-config normalizes provider config and hermes-agent provider profiles drive request-body behavior; the Python desktop/TUI backend is not the active runtime path."
-    },
-    "e256f4aae493": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust session/provider persistence boundaries: session state and provider selections are explicit Rust App/Gateway state rather than restoring a bare billing provider from Python tui_gateway state."
-    },
-    "643dc8279306": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust session/provider identity handling: custom provider identity is carried by hermes-config provider profiles and hermes-agent provider construction instead of Python runtime_provider persistence."
-    },
-    "2667601c05cd": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust message/session rendering: crates/hermes-agent session persistence stores reasoning_content and crates/hermes-cli/src/tui.rs fingerprints/renders reasoning-aware assistant messages."
-    },
-    "d842155da1e8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust session/profile scoping: hermes-config resolves effective HERMES_HOME/profile config before runtime state, and ACP/session stores cwd explicitly in Rust session models."
-    },
-    "9f33d673e9e6": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust session state persistence: ACP/session models store cwd and update_cwd contracts in Rust tests; Python tui_gateway profile-db persistence is not the shipped runtime path."
-    },
-    "ed20f5ed0605": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust explicit model switching: crates/hermes-cli/src/tui.rs provider/model modal calls App::switch_model directly, allowing operator-selected models to escape stale config defaults."
-    },
-    "2f9d18711fb9": {
-      "disposition": "superseded",
-      "owner": "local-gates",
-      "notes": "Superseded by Ultra local Rust gates: scripts/clippy-warning-gate.sh, check-runtime-placeholders, cargo tests, and parity generators define local CI; upstream pytest-timeout/GitHub workflow tuning is optional."
-    },
-    "8044bf0206c1": {
-      "disposition": "superseded",
-      "owner": "local-gates",
-      "notes": "Superseded by local deterministic gate scripts and optional GitHub CI policy; upstream test-duration upload behavior is not a Rust runtime requirement."
-    },
-    "573b964dc780": {
-      "disposition": "superseded",
-      "owner": "installer",
-      "notes": "Superseded by Ultra release installer: scripts/install.sh installs release binaries/cargo artifacts and does not use upstream in-place git stashing/update semantics."
-    },
-    "4373e802a1b9": {
-      "disposition": "superseded",
-      "owner": "local-gates",
-      "notes": "Superseded by Rust skills registry/index implementation plus local parity gates; GitHub Pages workflow cache behavior is optional for this repo."
-    },
-    "a4ee1f223d5f": {
-      "disposition": "superseded",
-      "owner": "installer",
-      "notes": "Superseded by Rust-first installer and no Node desktop runtime: scripts/install.sh manages binary PATH/install location without upstream managed-Node global npm package requirements."
-    },
-    "1db8f7ea8094": {
-      "disposition": "superseded",
-      "owner": "installer",
-      "notes": "Superseded by Ultra installer design: release binary installation does not depend on managed Node global prefix repair."
-    },
-    "30377e108ca8": {
-      "disposition": "superseded",
-      "owner": "local-gates",
-      "notes": "Superseded by Rust-first UI/runtime scope and optional GitHub CI; there is no Electron renderer build gate for the shipped Ultra runtime."
-    },
-    "9eb0bcd60fc6": {
-      "disposition": "superseded",
-      "owner": "local-gates",
-      "notes": "Superseded by local Rust build/test gates and optional official GitHub CI; upstream nix workflow removal has no Rust runtime port target."
-    },
-    "e0492aa2dca0": {
-      "disposition": "superseded",
-      "owner": "local-gates",
-      "notes": "Superseded by user policy and local gate scripts: official GitHub pull_request CI is optional, while local shell/Rust gates define the required validation before push."
-    },
-    "1899c8f507c3": {
-      "disposition": "ported",
-      "owner": "skills",
-      "notes": "Ported in skills/media/youtube-content: SKILL.md and scripts/fetch_transcript.py already use uv run / uv pip for youtube-transcript-api, matching the upstream helper execution contract."
-    },
-    "5f6be7f31bd7": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/superseded by Rust-native Microsoft Teams pipeline in crates/hermes-tools/src/teams_pipeline.rs, including Graph auth/download, meeting jobs, Teams sink writer, and tests."
-    },
-    "49e743985aaf": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust provider profiles: crates/hermes-agent/src/provider.rs has MiniMax-M3 OpenAI reasoning contract tests and crates/hermes-agent/src/auxiliary_builder.rs registers MiniMax-M3 direct providers."
-    },
-    "1e25358a8f22": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop ephemeral-port discovery is superseded by Rust gateway/TUI runtime; Ultra does not ship apps/desktop or the Python web_server dashboard backend as the primary runtime."
-    },
-    "8cf9d8689d56": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop composer reconnect UX is superseded by Rust TUI/gateway connection surfaces; Electron composer code is intentionally not part of the Rust-only runtime."
-    },
-    "28bf8fb47d38": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream dashboard profile-clone UI is superseded by Rust profile/config commands and TUI surfaces; apps/desktop/web profile UI code is not shipped in Ultra runtime."
-    },
-    "1b16c481708d": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop OAuth account-removal UI is superseded by Rust provider/auth config surfaces; Electron onboarding/settings UI is outside the Rust-only shipped runtime."
-    },
-    "715b691723c6": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop summarizing indicator is superseded by Rust TUI/gateway status surfaces; React assistant thread/desktop store code is not part of the shipped runtime."
-    },
-    "0428945b5b07": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop bootstrap profile-home behavior is superseded by Rust hermes-config home/profile resolution and installer setup; Electron bootstrap is not shipped."
-    },
-    "288f7026e332": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop/web Weixin labeling is superseded by Rust gateway platform adapters and TUI surfaces; React messaging page labels are outside the Rust runtime."
-    },
-    "92a456f711eb": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream esbuild/Node audit-loop cleanup is superseded by the Rust-first runtime and local Cargo gates; Node desktop/web package metadata is not a shipped runtime dependency."
-    },
-    "f7c1cbe66ffa": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop download-link docs are superseded by Ultra README/install docs and release installer; /desktop website routing is not a Rust runtime target."
-    },
-    "0441b7f19feb": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop remote-profile REST routing is superseded by Rust gateway/profile/auth surfaces; Electron connection-config and Python web_server endpoints are not the primary runtime."
-    },
-    "c6b0eb4de0e5": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop remote-artifact authenticated download is superseded by Rust gateway/media delivery boundaries; Electron artifacts UI and Python web_server files endpoint are outside the Rust-only runtime."
-    },
-    "d1771114eda9": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust session_search now sanitizes FTS5 MATCH input by quoting query terms before execution, so colon-containing queries are treated as literal search text instead of FTS column filters. Regression coverage proves workspace:hermes searches return matching sessions without error."
-    },
-    "2e0c9083db84": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust PluginManager now exposes tool_request and tool_execution middleware primitives, AgentLoop applies request rewrites before guards/hooks and wraps real tool handler execution with a single-use next_call-equivalent chain. Unit and agent-loop tests cover argument adaptation, execution wrapping, and real autonomous tool execution."
-    },
-    "5abe45674dc7": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust tool execution middleware catches middleware panics and preserves the downstream result when next_call already ran, including error ToolResult values. Regression coverage proves downstream failures survive middleware post-processing failure."
-    },
-    "c37c6eaf296a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust already provides Home Assistant as first-class native runtime surface: REST backend, ha_list_entities/ha_get_state/ha_list_services/ha_call_service handlers, homeassistant toolset and aliases, send-message platform routing, and gateway adapter coverage. The upstream Python bundled-plugin migration is represented by Rust-native built-in registration and platform contract tests rather than a Python plugin package."
-    },
-    "2d232c999115": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust gateway: display.busy_input_mode is typed/normalized and bridged through HERMES_GATEWAY_BUSY_INPUT_MODE; active-session plain text can queue instead of interrupting, explicit /queue bypasses the busy guard and enqueues a FIFO follow-up, and gateway tests cover queue drain plus ack suppression."
-    },
-    "2edebedc9eeb": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: /steer is a structured gateway command, active gateway sessions expose a BusyControlRegistration, hermes-cli attaches AgentLoop InterruptController as ActiveSessionControl, and steer sends the trusted hermes_agent::format_steer_marker into the live run with regression coverage."
-    },
-    "635253b9185f": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: display.busy_input_mode accepts interrupt/queue/steer, display.busy_ack_enabled suppresses automatic busy acknowledgements, env/config-set bridges cover HERMES_GATEWAY_BUSY_INPUT_MODE and HERMES_GATEWAY_BUSY_ACK_ENABLED, and gateway tests cover steer fallback/attachment and quiet queueing."
-    },
-    "2dace37f6b55": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking now has first-class openviking.json activation, hermes memory setup openviking, none/user/root credential modes, tenant defaults, owner-only config writes, health-gated initialization, and provider tests for setup/config behavior."
-    },
-    "b0e25c9cb295": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking save_config writes openviking.json through shared owner-only atomic config IO with 0600 permissions and regression coverage."
-    },
-    "70f53f36cb1c": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust CLI exposes hermes memory setup openviking as the manual setup path, normalizing endpoint values and writing an owner-only openviking.json that activates on later sessions."
-    },
-    "94523764fca8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking setup chooses and normalizes the credential mode before prompting for the corresponding none/user/root API key path, with CLI unit coverage for each setup shape."
-    },
-    "2b972472cee8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking setup validates manual endpoint, credential mode, API key presence, root tenant account/user requirements, agent defaults, and local no-key mode before persisting config."
-    },
-    "3c76dac4fdbf": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking config persistence fails closed through owner-only atomic config IO instead of silently ignoring chmod failures; setup tests assert final 0600 mode."
-    },
-    "2c2ca0443bba": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking setup/config activation covers the improved setup UX in the Rust CLI and provider runtime without Python startup hooks."
-    },
-    "315fdae5f8ad": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking does not autostart openviking-server from the agent runtime; local setup can use no-key config, while runtime initialization is health-gated and fail-closed."
-    },
-    "166d2457b292": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking avoids the unhealthy-local-autostart class entirely: initialization checks /health and disables the provider for the session when health is not successful."
-    },
-    "813a4e3838f6": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking implements on_session_switch, clears stale prefetch, rotates session id, resets dirty turn state for the new session, and tests the lifecycle hook."
-    },
-    "a30b40c73ab6": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking sync_turn captures the target session id before spawning the writer and on_session_end drains tracked writers before commit, preventing session-boundary races."
-    },
-    "eddbf291a415": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking session switch rotates in-memory state immediately, clears stale prefetch, and defers old-session drain/commit so late writes do not target the new session."
-    },
-    "91e9459e1006": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking tracks all background writers per session id in an inflight writer map and drains every writer for that session before commit."
-    },
-    "00c045b43f30": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking commit paths are hardened with bounded writer drains, skipped commits when writers outlive the drain budget, dirty-state preservation on skipped/failed end commits, and tests."
-    },
-    "3ac6551ba3d3": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking treats same-session switches as prefetch invalidation only and ignores empty new session ids, preventing rewound/no-op switches from corrupting session state."
-    },
-    "c835448908e7": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking does not block command/session-switch callers on old-session writer drains; old commits run through a deferred finalizer and non-blocking switch coverage asserts prompt return."
-    },
-    "5494c1e9b660": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenViking uses repo-native openviking.json with shared atomic owner-only config IO instead of mutating ovcli profiles; dead Python ovcli constants are not part of the Rust runtime."
-    },
-    "c6c8abbadb80": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: default static agent toolsets no longer expose send_message, messaging was removed from built-in toolset distributions, explicit SendMessageHandler/GatewayMessagingBackend remain for gateway/cron/CLI runtime sends, and hermes-mcp default tool-call timeout is now 300s with env override/cap coverage."
-    },
-    "5a00bd151896": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust gateway already persists /title immediately because route_message creates the session before command handling and SessionManager::set_title updates live state directly; gateway_title_command_persists_and_surfaces_session_title covers set/show/status/session-list behavior."
-    },
-    "547a014e7eae": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fix is apps/desktop React markdown preprocessing for huge fenced blocks. Ultra has no Electron desktop renderer; Rust CLI/TUI/gateway output handling and terminal/tool result surfaces own runtime rendering instead."
-    },
-    "b82eca2bebd8": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fix isolates React desktop message render crashes. Ultra does not ship apps/desktop; Rust CLI/TUI/gateway rendering paths do not use the Streamdown/root-boundary pipeline fixed upstream."
-    },
-    "435c706e8e5a": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fix is React desktop session-cache error isolation. Ultra session/error state is Rust-owned by hermes-cli App and hermes-gateway session/runtime state, not the apps/desktop view cache."
+      "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
     },
     "f4100f439430": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream RTL list-marker/blockquote fix targets desktop DOM/CSS. Ultra has no React DOM transcript; terminal/TUI text rendering is Rust-native and not affected by browser dir=auto box direction."
+      "notes": "Upstream RTL list-marker/blockquote fix targets desktop DOM/CSS. Ultra has no React DOM transcript; terminal/TUI text rendering is Rust-native and not affected by browser dir=auto box direction.",
+      "owner": "rust-runtime"
     },
-    "0138282f97c9": {
+    "f45d7dee7d25": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream oversized-message freeze fix targets synchronous React/Streamdown/Shiki desktop rendering. Ultra lacks that renderer; Rust terminal/tool-result truncation and TUI viewport behavior are the applicable runtime surfaces."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "c2fa302e933a": {
+    "f4612785a485": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Desktop backend-skew toast nag is apps/desktop update-store UX. Ultra does not run that Electron update store; Rust CLI/TUI version/status surfaces own runtime skew reporting."
+      "notes": "rust anthropic normalization path is already typed and test-covered; Python adapter refactor not directly portable to Rust architecture"
     },
-    "b07b7894ec55": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Streaming paint in unfocused secondary Electron windows is an apps/desktop BrowserWindow preference fix. Ultra has no Electron session windows; Rust TUI/gateway streaming is terminal/platform-adapter driven."
-    },
-    "33b1d144590a": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Electron dependency pin and npm lockfile repair apply to upstream desktop packaging. Ultra has no apps/desktop package tree and builds/releases through the Rust workspace/install scripts."
-    },
-    "ee41aa0c1a0a": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Chat error banner dismissal is React desktop local view state. Ultra handles turn errors through Rust CLI/TUI/gateway messages and does not persist the upstream desktop banner component."
-    },
-    "016bce1a09ba": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Stranded routed session-window recovery is apps/desktop route/resume hook behavior. Ultra sessions are Rust CLI/TUI/gateway sessions, not Electron pop-out windows."
-    },
-    "f8098c6b6fe5": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Static electronDist path repair is desktop/npm packaging only. Ultra does not package Electron from apps/desktop; Rust release/install verification is cargo/Homebrew/script based."
-    },
-    "c1f9eb0ec4b9": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Dynamic electronDist self-heal supersedes an upstream desktop packaging failure class. Ultra has no Electron builder/runtime in this repo, so the Rust build/install path is unaffected."
-    },
-    "4b7a18600393": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Desktop self-update rebuild retry spans Electron and bootstrap-installer/Tauri paths absent from Ultra. Rust update/release behavior is owned by the CLI and repository release scripts."
-    },
-    "92e6d8c858f6": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Disposing node-pty sessions during Electron before-quit is desktop main-process cleanup. Ultra PTY/process lifecycle is Rust-owned by hermes-tools terminal/process handlers and not node-pty."
-    },
-    "4ed2f3399418": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Long user-message scrolling is a desktop React thread presentation fix. Ultra uses Rust terminal/TUI history rendering instead of apps/desktop thread components."
-    },
-    "769f307042d2": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "react-simple-icons npm lockfile noise is specific to upstream desktop/package management. Ultra has no npm desktop dependency tree in this Rust runtime repo."
-    },
-    "fd674af47fa6": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Photon/Spectrum is an upstream Python plus Node optional platform plugin. Ultra does not expose a Rust-native Photon adapter, so this iMessage attachment salvage fix is outside the Rust runtime surface."
-    },
-    "6092be413d59": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream hardens Python/s6 hosted Docker install-tree self-modification. Ultra uses a Rust multi-stage image with immutable /usr/local/bin binaries, /data as HERMES_HOME, and tini/gosu entrypoint ownership only for runtime state."
-    },
-    "ab1a42fcea4f": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Relay connector contract is retained only as experimental/reference documentation; current Ultra Rust runtime does not register the upstream Python relay adapter as a first-class platform surface."
-    },
-    "5feec8b4cfcb": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream relay conformance tests target the Python gateway relay adapter. Ultra has no active Rust relay adapter for this experimental contract, so the Python conformance harness is not a Rust runtime requirement."
-    },
-    "6e20c1992ff9": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Relay A2 trust-boundary rewrite applies to the experimental cross-repo relay contract. Ultra keeps the doc as reference only; active Rust gateway adapters enforce their own platform auth paths."
-    },
-    "86f2946fbe78": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Dashboard Chat tab recovery is an upstream React web surface. Ultra has no apps/desktop/web ChatPage Rust runtime; CLI/TUI/gateway session recovery is owned by Rust surfaces."
-    },
-    "c276b017adc4": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Connector-to-gateway relay channel auth, signed HTTP inbound receiver, and enroll CLI are upstream Python relay surfaces. Ultra does not expose that experimental relay adapter in Rust."
-    },
-    "ae8fa11097e1": {
+    "f4ef70f6fc62": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: crates/hermes-cron loads cron.provider/cron.chronos config, constructs ChronosNasCronProvider from environment/config, and scheduler tests cover managed provider reconciliation."
-    },
-    "4440d77bf32d": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Install-method stamping and Python Docker stage2 mutation are absent from Ultra. The Rust container separates code in /usr/local/bin from writable HERMES_HOME=/data and does not chown or mutate an install tree at runtime."
-    },
-    "4c8bbe641696": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: ChronosNasCronProvider provisions/cancels/lists NAS-mediated one-shots, scheduler disables in-process polling when managed cron is active, and focused managed-provider tests pass."
-    },
-    "3fc7b624d860": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: hermes-cron verifies NAS JWT fire tokens with asymmetric keys/audience/purpose checks and hermes-gateway exposes POST /api/cron/fire behind api-server with focused route coverage."
-    },
-    "b75757d4aa85": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: scheduler mutation paths reconcile/cancel managed Chronos jobs, cron.chronos config is documented in docs/chronos-managed-cron-contract.md, and managed fire duplicate/stale tests pass."
-    },
-    "0b54a33a3467": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust-native telemetry shape: agent loop emits request/turn scoped tracing spans for LLM/tool events and Langfuse uses OTLP config without a Python process-global _TRACE_STATE map; Langfuse tests pass."
-    },
-    "e1d10ec1ed29": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust-native telemetry shape: Langfuse endpoint/header/resource config is centralized in hermes-telemetry and span scope is carried by tracing fields rather than Python trace-key prefixes; focused tests pass."
+      "notes": "Ported to Ultra docs without reviving Python runtime paths: website provider/env docs describe grok-build-0.1 as the direct xAI and web-search default, and the bundled Grok Build skill already records default = grok-build-0.1.",
+      "owner": "docs"
     },
     "f4fbaa6cda8b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust-native telemetry shape: there is no unbounded Python _TRACE_STATE dict in Ultra; spans are created/dropped per LLM/tool event and Langfuse OTLP config tests pass."
+      "notes": "Ported by Rust-native telemetry shape: there is no unbounded Python _TRACE_STATE dict in Ultra; spans are created/dropped per LLM/tool event and Langfuse OTLP config tests pass.",
+      "owner": "rust-runtime"
     },
-    "2a5d51c16e94": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking provider: current API setup/config/headers/content writes/resource uploads/session writer drain behavior are implemented in crates/hermes-agent memory_plugins/openviking with focused tests passing."
-    },
-    "0fa7d6f6609c": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: named custom providers are preserved through llm_providers, provider catalog/model guard paths, and app-runtime config mapping; tests cover named custom runtime provider behavior."
-    },
-    "51ee5b2c94d0": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in this batch: display.memory_notifications is typed config with env/config set/get bridge, and gateway background review callbacks are gated by this setting with focused tests."
-    },
-    "9705e7944ae4": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in this batch: Rust provider catalog entries no longer truncate picker models to 50; CLI/TUI/model command call sites use the full configured catalog and regression tests cover 60 entries."
-    },
-    "03d9a95a74b2": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: Hindsight is a first-class bundled memory provider discovered by memory_plugins::discover_available_providers, with config, recall, turn buffering, and owner-only config tests passing."
-    },
-    "d2c53ff5583e": {
+    "f583c6ebd5bd": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "WS-only inbound relay is part of the upstream experimental Python relay adapter. Ultra keeps native Rust platform adapters and does not expose the relay adapter as active runtime surface."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "c34840e22e08": {
+    "f5be6177b231": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: /api/cron/fire is served by the Rust API server route with Chronos NAS auth bypassing the generic API token path only for that route; focused api-server feature test passes."
+      "notes": "rust text_to_speech/tts_premium tools, MultiTtsBackend providers, gateway voice send surfaces, and voice-compatible media tags cover the upstream TTS product surface; new registry/schema contract proves first-class TTS exposure"
     },
-    "620fd59b8e6f": {
+    "f6574978de39": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in this batch: /model refresh [provider|provider:model] clears signed provider catalog payload/signature files and reloads through the configured provider catalog path with command and cache tests."
+      "notes": "RL training configuration and tools are now first-class Rust runtime surface: rl_list_environments, rl_select_environment, rl_get_current_config, rl_edit_config, rl_start_training, rl_check_status, rl_stop_training, rl_get_results, rl_list_runs, and rl_test_inference are registered and covered."
     },
-    "49596b70cb2d0d328d68645905febb074e494e77": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: SessionPersistence resolves resume targets through compression-continuation children only when the parent ended with end_reason='compression', has ended_at set, and the child was created after that end time; CLI resume snapshot loading follows the resolved tip so parent resumes include post-compression child messages. Focused tests cover non-empty compressed parents, branch-child guardrails, chain traversal, and snapshot reload."
-    },
-    "1699525638ed4feba3fd35f0be5c6d4d2d326a49": {
+    "f66a929a6b78": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fixes a Python tui_gateway slash.exec -> command.dispatch fallback for pending-input commands. Ultra's Rust gateway has no split slash.exec/command.dispatch RPC path: slash input is parsed once by crates/hermes-gateway/src/commands.rs into typed GatewayCommandResult variants, and /retry, /undo, /queue, /q, and /steer are consumed directly by crates/hermes-gateway/src/gateway.rs. The fragile client-side fallback failure mode is absent; /goal and /plan are CLI-only Rust commands, not gateway pending-input RPCs."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "c02192ff6ace129fc9bcc2f8907eabd6eb3f0f1d": {
+    "f736d2be86b8": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust image_generate: the tool request/schema now carries image_url and reference_image_urls, FAL has a typed model catalog with edit endpoints/reference caps/payload filtering plus runtime FAL_IMAGE_MODEL/config selection, OpenAI Codex remains explicit text-only, and Rust tests cover forwarding, endpoint routing, reference clamping, capabilities, and unsupported-modality errors."
+      "notes": "Rust provider profiles now expose Xiaomi/MiMo as vision-capable, supports_vision can be overridden locally without leaking to provider requests, Xiaomi MiMo models carry vision metadata, and focused Rust tests prove ACP multimodal image parts stay native for vision providers."
     },
-    "5ffbfed193ad13662b9e402f6667f111a7beae63": {
+    "f75b1d21b4c8cacc2b9b9fb87227ff315365cd90": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as a Rust-native MCP profile instead of a Python optional-mcps manifest: hermes mcp unreal-engine now writes the official Unreal Engine local HTTP endpoint to mcp_servers.json and config.yaml, keeps parallel tool calls disabled for Epic editor-thread execution, exposes status/remove actions, and has focused Rust tests for setup/remove synchronization."
+      "notes": "Rust agent loop now treats advertised tool schemas as the runtime allowlist, rejects registered-but-disabled fabricated tool calls in non-streaming and streaming loops, and makes delegate_task inherit the parent enabled tool surface when no explicit child toolset is requested; execute_code schema remains Rust-only and does not advertise disabled sandbox helper tools."
     },
-    "73cd8622f9fcd5e368060d1a1678e08bd3d0a794": {
-      "disposition": "ported",
-      "notes": "Ported as a Rust-native terminal billing surface: `hermes billing` and `/billing` now render Nous billing state fail-open from the auth store and billing API, support scoped `billing:manage` device-code step-up, explicit-confirmation charge and auto-reload actions with idempotency-key handling and typed error mapping, charge status polling, deterministic portal URL normalization, decimal-string money formatting, and focused Rust tests for state parsing, scope detection, client contracts, CLI parsing, slash behavior, auth isolation, and confirmation gating."
-    },
-    "36851fa576eb4079f0397010f418cafa15a4ab26": {
+    "f764b0400ad7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python setup.py/WebUI read-only-source workaround is structurally absent in Ultra: there is no top-level setup.py or Python WebUI install path. This batch pins the Rust Docker image contract instead: LICENSE/NOTICE are shipped in the image, .dockerignore cannot exclude them, and tests assert immutable /usr/local/bin code with writable HERMES_HOME=/data."
+      "notes": "Deleting the active profile fallback is a desktop profile-switcher/delete-dialog behavior. Rust CLI profile delete already clears the active marker when deleting the active profile and does not maintain an Electron active-profile rail."
     },
-    "eb51c180e6484ec15809d04c25a8115e6e48dc3c": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported to Ultra Docker/Rust dashboard contract: docker-compose runs dashboard on 127.0.0.1 by default, docs remove the stale HERMES_DASHBOARD side-process/insecure escape hatch, and Rust API server bind guards still require API_SERVER_KEY for network-accessible binds even when dashboard --insecure acknowledges non-localhost binding."
-    },
-    "cbd6ba1bdd916d8342f6c741cb290b62dd89dbc4": {
+    "f7c1cbe66ffa": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream durable lazy Python install target is superseded by Ultra Rust packaging: the container ships a compiled /usr/local/bin/hermes binary, has no top-level setup.py/pip install surface, keeps runtime state under /data, and now has Dockerfile contracts proving code immutability plus license packaging."
+      "notes": "Upstream desktop download-link docs are superseded by Ultra README/install docs and release installer; /desktop website routing is not a Rust runtime target.",
+      "owner": "rust-runtime"
     },
-    "411faf08bd678fe3e49b22afcef1e9fd2d7f5592": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust/setup/install: hermes-agent now exposes DEFAULT_AGENT_IDENTITY-backed SOUL.md seeding, ignores exact legacy comment-only templates at prompt load, upgrades those templates during setup, preserves customized SOUL.md files, respects explicit/HERMES_HOME resolution, and install.sh seeds the real default persona instead of an empty scaffold."
+    "f7dfd4ae3664": {
+      "disposition": "superseded",
+      "notes": "The temporary upstream built-in here.now placement is superseded by the final local optional skill catalog placement at optional-skills/productivity/here-now/SKILL.md."
     },
-    "c7b7f92ec14a5c43deef844804f0bf6a7f2d992d": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking memory plugin: sync_turn now receives canonical structured messages through MemoryManager, extracts the current turn, writes /messages/batch parts for user/assistant/tool results, preserves tool inputs/outputs/status, skips OpenViking recall echoes, and falls back to prior text sync on batch failure. Focused Rust tests cover tool result coalescing, pending tool calls, JSON error status, recall skip, response text parts, and Rust-flattened tool_call arguments."
+    "f8098c6b6fe5": {
+      "disposition": "superseded",
+      "notes": "Static electronDist path repair is desktop/npm packaging only. Ultra does not package Electron from apps/desktop; Rust release/install verification is cargo/Homebrew/script based.",
+      "owner": "rust-runtime"
     },
-    "d7cd0bc0863cda1a203f00422b1441ca2d9890ed": {
+    "f81395975025": {
+      "disposition": "superseded",
+      "notes": "Upstream simple-terminal registration is superseded by Rust TerminalHandler and LocalBackend command execution, explicit background=true lifecycle tracking, timeout/workdir/schema contracts, and process-management tests without the Python Morph VM dependency."
+    },
+    "f92298fe955fe2ddbea27f4c504ce310ec46545b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking memory plugin: structured sync preserves assistant attribution via peer_id on assistant/tool-part batch messages, supports response-style text parts, replaces the first synced user message with the already-sanitized user content, and receives redacted canonical transcript values from MemoryManager."
+      "notes": "Rust ACP maps typed top-level AgentResult usage into PromptResponse.usage through the CLI ACP executor boundary; regression coverage proves prompt/completion/total fields populate ACP input/output/total tokens without relying on a nested result usage dict."
+    },
+    "f94363d1f0de": {
+      "disposition": "superseded",
+      "notes": "Desktop arrow-history UI is superseded by Rust TUI input_history navigation: Up/Down dispatch through App::history_prev/history_next for single-line prompts, Ctrl-R searches history, submitted prompts append to the ring, and a focused Rust unit test proves newest-to-oldest recall plus return to the empty draft sentinel."
+    },
+    "f957ec226789": {
+      "disposition": "ported",
+      "notes": "Rust toolset_distributions now covers validated probability-weighted distributions against registered ToolsetManager toolsets, including the first-class rl_training toolset added in this batch, with deterministic and sampling contract tests."
+    },
+    "f993d76874e8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "f9c6c5ab8472": {
+      "disposition": "ported",
+      "notes": "Rust Hindsight now creates a per-initialization document_id and includes it in auto-retain batch bodies, with tests proving resumed sessions get distinct document IDs."
+    },
+    "fa42ac094dca": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "fa4ebaa8b58b": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "fa582749e165": {
+      "disposition": "superseded",
+      "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "fabca0bdd82b": {
+      "disposition": "ported",
+      "notes": "Rust TUI already drives model selection through canonical /model provider/model modals; this batch added /session and /switch aliases to the existing /sessions surface while preserving /provider as a distinct provider-status command rather than the removed Python /model alias."
+    },
+    "fad4b40d9d38": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: gateway /model now parses --session/--global/--provider with Unicode dash normalization, persists plain/default and --global switches through typed config.yaml writes, exposes model_switch.persist_switch_by_default via config normalization, and propagates the updated gateway default to fresh sessions/status/runtime context with regression tests.",
+      "owner": "rust-runtime"
+    },
+    "fb0250ef63c8": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "fb18bde89740": {
+      "disposition": "superseded",
+      "notes": "Desktop profile-rail haptic reordering touches only apps/desktop React UI, which is absent from this Rust-only runtime repo."
+    },
+    "fbabf438a17c": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "fbd3a2fdb88e": {
+      "disposition": "superseded",
+      "notes": "The upstream per-task Morph instance cleanup/leakage patch is superseded by Rust's non-Morph terminal runtime plus task-scoped cwd registry. TerminalHandler tests now prove task_id isolation and explicit workdir precedence, so one task cannot inherit another task's terminal cwd context."
+    },
+    "fbd423b94d50": {
+      "disposition": "superseded",
+      "notes": "Desktop chrome localization only updates apps/desktop UI strings, voice-recorder hooks, and React components. Rust CLI/TUI/gateway chrome is independent and not driven by the upstream desktop i18n catalog."
     },
     "fcac0f94d4844f904a6eaa8a2b667299408b9f92": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking memory plugin: recall-tool skip tracking only records non-empty tool ids, so an empty OpenViking recall result cannot poison the skip set for unrelated empty-id tool results. The sync trace env toggle uses the canonical truthy set {1,true,yes,on}. Regression test covers empty-id recall plus non-recall tool result preservation."
+      "notes": "Ported in Rust OpenViking memory plugin: recall-tool skip tracking only records non-empty tool ids, so an empty OpenViking recall result cannot poison the skip set for unrelated empty-id tool results. The sync trace env toggle uses the canonical truthy set {1,true,yes,on}. Regression test covers empty-id recall plus non-recall tool result preservation.",
+      "owner": "rust-runtime"
     },
-    "27a6e188c4b4bc66f52b321f055fe18aa866b545": {
+    "fcb1944b4f76": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking memory plugin: OpenViking tool schema names are centralized as Rust constants and the recall-tool classifier derives from the same search/read/browse constants, keeping write tools intentionally ingestible while preventing schema-name drift."
+      "notes": "Rust now captures Nous credits headers at the provider HTTP boundary, parses the v1 x-nous-credits and x-nous-tool-pool contracts with strict money/bool validation, stores a last-known credits snapshot, appends the credits block to CLI and gateway /usage output, and surfaces depleted/50/75/90 percent usage notices in the TUI status bar with focused Rust tests. Python dev fixtures and desktop-only scaffolding are superseded by the Rust runtime surface."
     },
-    "2d4046c6de975eff194d6ebdfa4180e5ed86c422": {
+    "fce58cbe2e02": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking memory plugin: structured batch conversion pre-scans assistant tool calls once, caches parsed tool input by non-empty id, and reuses that cached input for completed and pending tool parts with a fallback parse for uncached/empty-id calls."
+      "notes": "Anthropic financial-services skills are represented under optional-skills/finance; stale local root stocks wrapper was backed up and removed while upstream stocks/dcf skill files were synced."
     },
-    "be2c2beb96e578542b24bdb275071044a853ebbd": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking memory plugin: canonical OpenViking tool_status values and inbound alias sets are named constants; conversion emits completed/error/pending consistently and tests cover JSON error result mapping."
-    },
-    "29e5e127c6f1c35fcc67abf0281c50c237e2929f": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: TelegramMessage now deserializes Bot API rich_message echoes and parse_update flattens native rich blocks into text when Telegram omits text/caption, with focused rich-reply coverage."
-    },
-    "c1f11f8c69f9721a4b5227231a6ff23a91826f76": {
+    "fd674af47fa6": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream indexes streamed rich finals in a Python rich_sent_store fallback. Ultra's Rust Telegram path has no rich_sent_store; rich edit/send payloads are generated from live adapter state and native rich echoes are parsed directly."
+      "notes": "Photon/Spectrum is an upstream Python plus Node optional platform plugin. Ultra does not expose a Rust-native Photon adapter, so this iMessage attachment salvage fix is outside the Rust runtime surface.",
+      "owner": "rust-runtime"
     },
-    "796f618f9987306722c4e27fdfb757291240386b": {
+    "fd68ae63315a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fixes Python chunk marker placement around Markdown fences. Ultra's Rust Telegram split_message path does not append chunk markers, so the marker-inside-fence corruption mode is absent."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "31e59fe44d18498ae53f624a3d3d5dbbad2d165e": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: rich send/edit payloads normalize prose single newlines into Telegram hard breaks while preserving protected Markdown regions, with slash-output newline coverage."
-    },
-    "a9669323922f6e79482536f2c05846c354571528": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: rich newline normalization protects Markdown pipe tables from hard-break injection, preserving table layout with focused regression coverage."
-    },
-    "ea056b05598cab8330555defe095988c3a7928f9": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: rich-message eligibility now rejects CJK scripts to avoid Telegram desktop garbling, with guard and legacy-payload tests."
-    },
-    "6183e8ce1b5ee79f2d808d0c17ea46fbbf128c37": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram config: Bot API 10.1 rich messages are opt-in/default-off in serde defaults and CLI config mapping, with gateway and CLI tests pinning the default."
-    },
-    "565b7c8d9d879c6423c55e9be84596936bc489ba": {
+    "fd88d527af37": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream repairs lingering Python sendChatAction typing refreshes. Ultra's Rust Telegram adapter does not implement a typing-indicator refresh loop, so there is no post-final typing state to re-arm or clear."
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
-    "dbe14ce35d9cb087ae9fe3e3f166f6c475297e25": {
+    "fd9b692d330f": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: startup registers BotCommand menus for default/private/group scopes from the Rust gateway command catalog with configurable priority, mode, and cap."
+      "notes": "Rust config loading now tolerates null top-level config.yaml keys by dropping them before serde deserialization so defaults are used instead of failing startup."
     },
-    "d4be583d986f7bcca4f8414fd21ef9e34b18c948": {
+    "fdc0d1956636": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter: the default command-menu cap is 60 while still clamping to Telegram's 100-command API maximum, with command ordering/cap coverage."
+      "notes": "Rust TUI draft wiring restores at startup, clears on submit, and reloads after session-switching slash commands, matching the upstream draft lifecycle fix in the local composer surface."
     },
-    "73a20a6ad62b678d69335ef3a352ccf9ab85167b": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported to Rust's edit surface: oversized Telegram edit previews are clipped to the Bot API text limit instead of failing mid-stream; final sends continue through the normal send/split path."
-    },
-    "17beb55e3c9c3574bce849a75430887dec910423": {
+    "fdc90346eaa3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream gates Python rich draft previews separately from finals. Ultra has no Telegram sendRichMessageDraft or rich draft-preview runtime surface; rich final send/edit attempts remain controlled by rich_messages."
+      "notes": "Unsafe red-team skill relocation is not imported into the Rust runtime defaults. Local skill catalog already tracks red-team and mlops skills under approved optional governance."
+    },
+    "fe2942a5aab7": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "fe54960142d1": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop React trigger-popover text wrapping has no matching Rust runtime file. Hermes Agent Ultra renders slash completions through the Rust Ratatui popup in crates/hermes-cli/src/tui.rs, so the TS/CSS truncation fix is superseded by the local TUI surface."
+    },
+    "ff0985323509": {
+      "disposition": "superseded",
+      "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
+    },
+    "ffb53767bfff": {
+      "disposition": "ported",
+      "notes": "Rust config now resolves HERMES_PREFILL_MESSAGES_FILE > top-level prefill_messages_file > legacy agent.prefill_messages_file, loads JSON prefill messages relative to HERMES_HOME/config home, injects them ephemerally into CLI/HTTP/gateway/cron agent contexts through AgentConfig.prefill_messages, and strips them from returned/persisted history with focused config/CLI/HTTP/agent/cron/gateway tests."
+    },
+    "ffe1d660a0e4": {
+      "disposition": "ported",
+      "notes": "ComfyUI local-vs-cloud selection is encoded in the skill flow before hardware-sensitive local setup, matching the upstream decision-order fix."
+    },
+    "fff0561441d2": {
+      "disposition": "superseded",
+      "notes": "Google Chat OAuth client-secret anchoring is Python adapter-only in upstream; this Rust gateway surface has no Google Chat platform adapter or OAuth helper under crates/hermes-gateway, so no Rust runtime path exists to port."
     }
   },
   "subject_patterns": [
     {
-      "pattern": "^docs\\(cron\\):",
       "disposition": "mirrored",
-      "notes": "cron docs changes are mirrored by file-state sync from upstream website/docs surface"
+      "notes": "cron docs changes are mirrored by file-state sync from upstream website/docs surface",
+      "pattern": "^docs\\(cron\\):"
     }
   ]
 }

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T05:38:58.804651+00:00`
+Generated: `2026-06-25T06:30:25.062192+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `6997`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T05:38:58.804651+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 222 |
-| ported | 373 |
+| pending | 219 |
+| ported | 376 |
 | superseded | 6326 |
 
 ## First 100 Pending Commits
@@ -32,7 +32,6 @@ Generated: `2026-06-25T05:38:58.804651+00:00`
 | `bce1e36b5769` | #20 | fix(discord): unwrap dict choices + soft-boundary truncate clarify buttons |
 | `92451151c642` | #22 | Revert "feat(skills): add html-artifact skill, fold in sketch + architecture-diagram + concept-diagrams (#48899)" |
 | `9a2f2756f7e6` | #26 | fix(desktop): allow selecting slash output and shell logs in thread (#49063) |
-| `fad4b40d9d38` | #20 | fix(model): persist /model switch by default across sessions |
 | `6cb04be779de` | #26 | feat(desktop): Keys tab groups by backend provider identity |
 | `ee0de638d719` | #26 | feat(desktop): add API-keys search; keep provider lists priority-sorted |
 | `d91b8d8368bb` | #26 | test(desktop): make keyVar a typed EnvVarInfo factory |
@@ -96,8 +95,6 @@ Generated: `2026-06-25T05:38:58.804651+00:00`
 | `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
 | `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
 | `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
-| `04730f32e7e8` | #20 | fix(cli): warn when in-session model switch will preflight-compress |
-| `1ca29723f0ea` | #20 | fix(cli): log instead of swallow preflight-warning errors; consistent TUI warning field |
 | `dd042fc4dfb1` | #20 | fix(tools): preserve core tools when a platform bundle is disabled |
 | `c7e8854cb383` | #20 | fix(tui): persist session messages on force-quit / signal shutdown |
 | `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
@@ -125,3 +122,6 @@ Generated: `2026-06-25T05:38:58.804651+00:00`
 | `7785655b4ece` | #26 | fix(desktop): keep the floating composer in-bounds so it can't be lost off-screen |
 | `37c37c9dc511` | #26 | fix(antigravity): register google-antigravity ProviderProfile + AUTHOR_MAP |
 | `16aeba17078d` | #26 | fix(desktop): clamp composer peel-off under cursor |
+| `bef1d3e4ff6a` | #26 | fix(desktop): filter undefined entries in AttachmentList to prevent refText crash on session switch (#49624) |
+| `13ce8119067e` | #26 | fix: show desktop approval fallback (#46548) |
+| `e5e25836350a` | #26 | fix(desktop): relaunch on Linux after in-app update instead of hanging (#45205) |


### PR DESCRIPTION
## Summary
- add typed `model_switch.persist_switch_by_default` config and Python-YAML compatibility
- make Rust gateway `/model` parse `--session`, `--global`, `--provider`, Unicode dash variants, and persist default/global switches through typed `config.yaml`
- share model-switch preflight warning logic through `hermes-intelligence` and surface warnings in gateway replies, CLI `/model` output, and TUI picker UI-only notices
- switch touched runtime fallbacks/tests from legacy `gpt-4o` literals to `dynamic`
- update parity queue/proof/dashboard artifacts for the three closed upstream commits

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-intelligence -p hermes-config -p hermes-gateway -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test --workspace`
- targeted tests for `hermes-intelligence`, `hermes-config`, `hermes-gateway`, and CLI model-switch paths

## Known residual gate
- `python3 scripts/generate-global-parity-proof.py --check-ci` exits 1 from pre-existing queue/tree-drift thresholds: pending queue remains 219, max_commits_behind 5880 > 5500, max_upstream_patch_missing 5657 > 5000.
