### PR TITLE
parity(runtime): close safety tooling backlog slice

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -6325,6 +6325,13 @@ fn handle_compress_rules_command(
     Ok(CommandResult::Handled)
 }
 
+fn estimate_message_tokens_for_compress(messages: &[hermes_core::Message]) -> usize {
+    messages
+        .iter()
+        .map(|m| m.content.as_ref().map_or(0, |c| c.len()) / 4)
+        .sum()
+}
+
 fn handle_compress_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     if args
         .first()
@@ -6342,6 +6349,8 @@ fn handle_compress_command(app: &mut App, args: &[&str]) -> Result<CommandResult
         return Ok(CommandResult::Handled);
     }
 
+    let before_count = msg_count;
+    let before_tokens = estimate_message_tokens_for_compress(&app.messages);
     let keep = std::cmp::max(2, msg_count / 3);
     let removed = msg_count - keep;
     let summary_text = format!(
@@ -6355,14 +6364,14 @@ fn handle_compress_command(app: &mut App, args: &[&str]) -> Result<CommandResult
     app.messages
         .push(hermes_core::Message::system(summary_text));
     app.messages.extend(retained);
+    let after_count = app.messages.len();
+    let after_tokens = estimate_message_tokens_for_compress(&app.messages);
 
     emit_command_output(
         app,
         format!(
-            "Compressed context: removed {} messages, kept {}. Total now: {}.",
-            removed,
-            keep,
-            app.messages.len(),
+            "Compressed: {} → {} messages / ~{} → ~{} tokens.\nCompressed context: removed {} messages, kept {}. Total now: {}.",
+            before_count, after_count, before_tokens, after_tokens, removed, keep, after_count
         ),
     );
     Ok(CommandResult::Handled)
@@ -30042,6 +30051,27 @@ mod tests {
                 .as_deref(),
             Some("320")
         );
+    }
+
+    #[tokio::test]
+    async fn compress_command_reports_before_after_message_and_token_summary() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        app.messages = (0..6)
+            .map(|idx| hermes_core::Message::user(format!("message-{idx} {}", "x".repeat(80))))
+            .collect();
+
+        handle_slash_command(&mut app, "/compress", &[])
+            .await
+            .expect("compress command");
+
+        let output = latest_ui_assistant_text(&app);
+        assert!(output.contains("Compressed:"));
+        assert!(output.contains("6 → 3 messages"));
+        assert!(output.contains("tokens"));
+        assert!(output.contains("removed 4 messages, kept 2"));
     }
 
     #[test]

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -804,6 +804,12 @@ pub struct AgentLoopBehaviorConfig {
     /// toolset. `on` forces prompt-only posture; `off` disables it.
     #[serde(default = "default_agent_coding_context")]
     pub coding_context: String,
+    /// Toolsets to subtract after the platform/default toolset selection.
+    ///
+    /// Platform bundle names (`hermes-*`) are interpreted by the Rust planner as
+    /// non-core deltas so core tools shared by other presets stay available.
+    #[serde(default)]
+    pub disabled_toolsets: Vec<String>,
     /// When true (default), spawn the extra LLM pass for memory/skill review — Python has no master off-switch.
     #[serde(default = "default_agent_background_review_enabled")]
     pub background_review_enabled: bool,
@@ -887,6 +893,7 @@ impl Default for AgentLoopBehaviorConfig {
             skill_creation_nudge_interval: default_agent_skill_nudge_interval(),
             skip_context_files: default_agent_skip_context_files(),
             coding_context: default_agent_coding_context(),
+            disabled_toolsets: Vec::new(),
             background_review_enabled: default_agent_background_review_enabled(),
             code_index_enabled: default_agent_code_index_enabled(),
             code_index_max_files: default_agent_code_index_max_files(),

--- a/crates/hermes-gateway/src/media.rs
+++ b/crates/hermes-gateway/src/media.rs
@@ -57,6 +57,13 @@ impl CachedMedia {
 // MediaCacheConfig
 // ---------------------------------------------------------------------------
 
+/// Default cap for a single inbound/downloaded media payload.
+///
+/// This bounds the in-memory and on-disk blast radius of hostile media links or
+/// unusually large platform uploads while keeping ordinary images, voice notes,
+/// and short clips well inside the default.
+pub const DEFAULT_INBOUND_MEDIA_MAX_BYTES: u64 = 128 * 1024 * 1024;
+
 /// Configuration for the media cache.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MediaCacheConfig {
@@ -83,7 +90,7 @@ impl Default for MediaCacheConfig {
             cache_dir: default_cache_dir(),
             max_size: 0,
             ttl_seconds: 0,
-            max_file_size: 0,
+            max_file_size: DEFAULT_INBOUND_MEDIA_MAX_BYTES,
         }
     }
 }
@@ -529,6 +536,20 @@ impl MediaCache {
         data: &[u8],
         display_name: &str,
     ) -> Result<PathBuf, GatewayError> {
+        self.validate_max_file_size(data.len() as u64, "inbound media payload")?;
+        if self.max_size > 0 {
+            let current_size = self.calculate_cache_size().await.unwrap_or(0);
+            if current_size.saturating_add(data.len() as u64) > self.max_size {
+                return Err(GatewayError::ConnectionFailed(format!(
+                    "Cache size limit exceeded while caching {} (current={}, incoming={}, max={})",
+                    display_name,
+                    current_size,
+                    data.len(),
+                    self.max_size
+                )));
+            }
+        }
+
         let dest_dir = self.cache_dir.join(subdir);
         fs::create_dir_all(&dest_dir).await.map_err(|e| {
             GatewayError::ConnectionFailed(format!(
@@ -554,6 +575,16 @@ impl MediaCache {
             GatewayError::ConnectionFailed(format!("Failed to flush file {:?}: {}", dest_path, e))
         })?;
         Ok(dest_path)
+    }
+
+    fn validate_max_file_size(&self, size: u64, context: &str) -> Result<(), GatewayError> {
+        if self.max_file_size > 0 && size > self.max_file_size {
+            return Err(GatewayError::ConnectionFailed(format!(
+                "File too large for {}: {} bytes exceeds max_file_size {}",
+                context, size, self.max_file_size
+            )));
+        }
+        Ok(())
     }
 
     /// Generic file caching implementation.
@@ -622,52 +653,79 @@ impl MediaCache {
 
         if self.max_file_size > 0 {
             if let Some(content_length) = response.content_length() {
-                if content_length > self.max_file_size {
-                    return Err(GatewayError::ConnectionFailed(format!(
-                        "File too large: {} bytes exceeds max_file_size {}",
-                        content_length, self.max_file_size
-                    )));
-                }
+                self.validate_max_file_size(content_length, "Content-Length")?;
             }
         }
 
-        let bytes = response.bytes().await.map_err(|e| {
-            GatewayError::ConnectionFailed(format!("Failed to read response body: {}", e))
-        })?;
-
-        if self.max_file_size > 0 && bytes.len() as u64 > self.max_file_size {
+        let current_size = if self.max_size > 0 {
+            self.calculate_cache_size().await.unwrap_or(0)
+        } else {
+            0
+        };
+        let tmp_path = dest_dir.join(format!(
+            ".{}.{}.part",
+            safe_name,
+            uuid::Uuid::new_v4().simple()
+        ));
+        if !is_path_within(&tmp_path, &dest_dir) {
             return Err(GatewayError::ConnectionFailed(format!(
-                "File too large after download: {} bytes exceeds max_file_size {}",
-                bytes.len(),
-                self.max_file_size
+                "Refusing to cache temporary file outside cache directory: {}",
+                safe_name
             )));
         }
 
-        // Check cache size limits
-        if self.max_size > 0 {
-            let current_size = self.calculate_cache_size().await.unwrap_or(0);
-            if current_size + bytes.len() as u64 > self.max_size {
-                return Err(GatewayError::ConnectionFailed(format!(
-                    "Cache size limit exceeded while caching {} (current={}, incoming={}, max={})",
-                    safe_name,
-                    current_size,
-                    bytes.len(),
-                    self.max_size
-                )));
+        let download_result: Result<u64, GatewayError> = async {
+            let mut file = fs::File::create(&tmp_path).await.map_err(|e| {
+                GatewayError::ConnectionFailed(format!(
+                    "Failed to create file {:?}: {}",
+                    tmp_path, e
+                ))
+            })?;
+            let mut response = response;
+            let mut total = 0u64;
+            while let Some(chunk) = response.chunk().await.map_err(|e| {
+                GatewayError::ConnectionFailed(format!("Failed to read response body: {}", e))
+            })? {
+                total = total.saturating_add(chunk.len() as u64);
+                self.validate_max_file_size(total, "downloaded body")?;
+                if self.max_size > 0 && current_size.saturating_add(total) > self.max_size {
+                    return Err(GatewayError::ConnectionFailed(format!(
+                        "Cache size limit exceeded while caching {} (current={}, incoming={}, max={})",
+                        safe_name, current_size, total, self.max_size
+                    )));
+                }
+                file.write_all(&chunk).await.map_err(|e| {
+                    GatewayError::ConnectionFailed(format!(
+                        "Failed to write file {:?}: {}",
+                        tmp_path, e
+                    ))
+                })?;
             }
+            file.flush().await.map_err(|e| {
+                GatewayError::ConnectionFailed(format!("Failed to flush file {:?}: {}", tmp_path, e))
+            })?;
+            Ok(total)
+        }
+        .await;
+
+        if let Err(err) = download_result {
+            let _ = fs::remove_file(&tmp_path).await;
+            return Err(err);
         }
 
-        // Write to file
-        let mut file = fs::File::create(&dest_path).await.map_err(|e| {
-            GatewayError::ConnectionFailed(format!("Failed to create file {:?}: {}", dest_path, e))
-        })?;
-
-        file.write_all(&bytes).await.map_err(|e| {
-            GatewayError::ConnectionFailed(format!("Failed to write file {:?}: {}", dest_path, e))
-        })?;
-
-        file.flush().await.map_err(|e| {
-            GatewayError::ConnectionFailed(format!("Failed to flush file {:?}: {}", dest_path, e))
+        if fs::try_exists(&dest_path).await.unwrap_or(false) {
+            fs::remove_file(&dest_path).await.map_err(|e| {
+                GatewayError::ConnectionFailed(format!(
+                    "Failed to replace existing cached file {:?}: {}",
+                    dest_path, e
+                ))
+            })?;
+        }
+        fs::rename(&tmp_path, &dest_path).await.map_err(|e| {
+            GatewayError::ConnectionFailed(format!(
+                "Failed to move cached file {:?} to {:?}: {}",
+                tmp_path, dest_path, e
+            ))
         })?;
 
         debug!("Cached {} -> {:?}", url, dest_path);
@@ -867,7 +925,7 @@ mod tests {
         assert!(!config.cache_dir.is_empty());
         assert_eq!(config.max_size, 0);
         assert_eq!(config.ttl_seconds, 0);
-        assert_eq!(config.max_file_size, 0);
+        assert_eq!(config.max_file_size, DEFAULT_INBOUND_MEDIA_MAX_BYTES);
     }
 
     #[tokio::test]
@@ -955,6 +1013,69 @@ mod tests {
             .await
             .unwrap();
         assert!(invalid.is_none());
+    }
+
+    #[tokio::test]
+    async fn cache_media_bytes_rejects_oversized_payload_before_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MediaCache::new(&MediaCacheConfig {
+            cache_dir: dir.path().to_string_lossy().to_string(),
+            max_size: 0,
+            ttl_seconds: 0,
+            max_file_size: 4,
+        })
+        .unwrap();
+
+        let err = cache
+            .cache_media_bytes(b"%PDF-1.4", Some("report.pdf"), None, None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("inbound media payload"));
+        assert!(!dir.path().join("documents").exists());
+    }
+
+    #[tokio::test]
+    async fn cache_file_rejects_oversized_content_length_before_body() {
+        crate::ssrf::reset_allow_private_cache_for_tests();
+        std::env::set_var("HERMES_ALLOW_PRIVATE_URLS", "true");
+        crate::ssrf::reset_allow_private_cache_for_tests();
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        let served = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            use tokio::io::AsyncReadExt;
+            let mut buf = [0u8; 512];
+            let _ = stream.read(&mut buf).await;
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\noversized")
+                .await
+                .unwrap();
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MediaCache::new(&MediaCacheConfig {
+            cache_dir: dir.path().to_string_lossy().to_string(),
+            max_size: 0,
+            ttl_seconds: 0,
+            max_file_size: 4,
+        })
+        .unwrap();
+
+        let err = cache
+            .cache_document(&format!("http://{addr}/big.pdf"), "big.pdf")
+            .await
+            .unwrap_err();
+        served.await.unwrap();
+
+        assert!(err.to_string().contains("Content-Length"));
+        assert!(!dir.path().join("documents").join("big.pdf").exists());
+
+        std::env::remove_var("HERMES_ALLOW_PRIVATE_URLS");
+        crate::ssrf::reset_allow_private_cache_for_tests();
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/bluebubbles.rs
+++ b/crates/hermes-gateway/src/platforms/bluebubbles.rs
@@ -12,6 +12,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::platforms::helpers::download_media_url;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlueBubblesConfig {
@@ -242,33 +243,7 @@ impl PlatformAdapter for BlueBubblesAdapter {
             return self.send_file(chat_id, &decoded_path, caption).await;
         }
 
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/feishu.rs
+++ b/crates/hermes-gateway/src/platforms/feishu.rs
@@ -21,6 +21,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::platforms::helpers::download_media_url;
 
 const FEISHU_API_BASE: &str = "https://open.feishu.cn/open-apis";
 
@@ -1417,33 +1418,7 @@ impl PlatformAdapter for FeishuAdapter {
         image_url: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (image_bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/helpers.rs
+++ b/crates/hermes-gateway/src/platforms/helpers.rs
@@ -144,6 +144,73 @@ fn looks_like_image_url(url: &str) -> bool {
     .any(|ext| base.ends_with(ext))
 }
 
+/// Download a remote media URL into memory while enforcing the gateway media cap.
+///
+/// Some platform APIs require uploading downloaded image bytes through their
+/// native file endpoint. Keep those paths bounded even when the response omits
+/// or lies about `Content-Length`.
+pub async fn download_media_url(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<(Vec<u8>, Option<String>), String> {
+    download_media_url_with_limit(client, url, crate::media::DEFAULT_INBOUND_MEDIA_MAX_BYTES).await
+}
+
+pub async fn download_media_url_with_limit(
+    client: &reqwest::Client,
+    url: &str,
+    max_bytes: u64,
+) -> Result<(Vec<u8>, Option<String>), String> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("status {}", resp.status()));
+    }
+
+    if max_bytes > 0 {
+        if let Some(content_length) = resp.content_length() {
+            if content_length > max_bytes {
+                return Err(format!(
+                    "Content-Length {content_length} exceeds media cap {max_bytes}"
+                ));
+            }
+        }
+    }
+
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+
+    let mut resp = resp;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| format!("read body failed: {e}"))?
+    {
+        let next_len = bytes
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| "media body size overflow".to_string())?;
+        if max_bytes > 0 && next_len as u64 > max_bytes {
+            return Err(format!(
+                "downloaded body {next_len} exceeds media cap {max_bytes}"
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    if bytes.is_empty() {
+        return Err("empty body".to_string());
+    }
+    Ok((bytes, content_type))
+}
+
 /// Extract inline images from markdown and HTML.
 ///
 /// Supports:
@@ -329,6 +396,8 @@ pub fn media_category(ext: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_split_long_message_short() {
@@ -403,6 +472,48 @@ mod tests {
         let (cleaned, images) = extract_inline_images(text);
         assert_eq!(images.len(), 0);
         assert_eq!(cleaned, "A <img src=\"https://example.com/not-image\"> B");
+    }
+
+    #[tokio::test]
+    async fn download_media_url_with_limit_preserves_content_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(vec![1, 2, 3, 4]),
+            )
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let (bytes, content_type) = download_media_url_with_limit(&client, &server.uri(), 8)
+            .await
+            .expect("download media");
+        assert_eq!(bytes, vec![1, 2, 3, 4]);
+        assert_eq!(content_type.as_deref(), Some("image/png"));
+    }
+
+    #[tokio::test]
+    async fn download_media_url_with_limit_rejects_oversized_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(vec![1, 2, 3, 4, 5]),
+            )
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let err = download_media_url_with_limit(&client, &server.uri(), 4)
+            .await
+            .expect_err("oversized body should fail");
+        assert!(
+            err.contains("Content-Length") || err.contains("downloaded body"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/matrix.rs
+++ b/crates/hermes-gateway/src/platforms/matrix.rs
@@ -50,7 +50,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
-use crate::platforms::helpers::{media_category, mime_from_extension};
+use crate::platforms::helpers::{download_media_url, media_category, mime_from_extension};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -2517,33 +2517,7 @@ impl PlatformAdapter for MatrixAdapter {
         image_url: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let file_bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if file_bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((file_bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (file_bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/mattermost.rs
+++ b/crates/hermes-gateway/src/platforms/mattermost.rs
@@ -15,6 +15,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::platforms::helpers::download_media_url;
 
 #[cfg(test)]
 use std::future::Future;
@@ -782,33 +783,7 @@ impl PlatformAdapter for MattermostAdapter {
         image_url: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/signal.rs
+++ b/crates/hermes-gateway/src/platforms/signal.rs
@@ -13,6 +13,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::platforms::helpers::download_media_url;
 use crate::platforms::signal_rate_limit;
 
 // ---------------------------------------------------------------------------
@@ -584,33 +585,7 @@ impl PlatformAdapter for SignalAdapter {
             return self.send_file(chat_id, &decoded_path, caption).await;
         }
 
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/wecom.rs
+++ b/crates/hermes-gateway/src/platforms/wecom.rs
@@ -12,6 +12,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
+use crate::platforms::helpers::download_media_url;
 
 const WECOM_API_BASE: &str = "https://qyapi.weixin.qq.com/cgi-bin";
 
@@ -403,33 +404,7 @@ impl PlatformAdapter for WeComAdapter {
             return self.send_file(chat_id, &decoded_path, caption).await;
         }
 
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/wecom_callback.rs
+++ b/crates/hermes-gateway/src/platforms/wecom_callback.rs
@@ -23,6 +23,7 @@ use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
 use crate::gateway::IncomingMessage;
+use crate::platforms::helpers::download_media_url;
 
 const WECOM_API_BASE: &str = "https://qyapi.weixin.qq.com/cgi-bin";
 const DEDUP_TTL_SECS: u64 = 300;
@@ -559,33 +560,7 @@ impl PlatformAdapter for WeComCallbackAdapter {
             return self.send_file(chat_id, &decoded_path, caption).await;
         }
 
-        let downloaded = async {
-            let resp = self
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.client, image_url).await;
 
         let (bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/platforms/weixin.rs
+++ b/crates/hermes-gateway/src/platforms/weixin.rs
@@ -27,7 +27,7 @@ use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
 use crate::gateway::IncomingMessage;
-use crate::platforms::helpers::split_long_message;
+use crate::platforms::helpers::{download_media_url, split_long_message};
 
 const ILINK_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
 const WEIXIN_CDN_BASE: &str = "https://novac2c.cdn.weixin.qq.com/c2c";
@@ -1376,34 +1376,7 @@ impl PlatformAdapter for WeChatAdapter {
             return self.send_file(chat_id, &decoded_path, caption).await;
         }
 
-        let downloaded = async {
-            let resp = self
-                .inner
-                .client
-                .get(image_url)
-                .send()
-                .await
-                .map_err(|e| format!("request failed: {e}"))?;
-            if !resp.status().is_success() {
-                return Err(format!("status {}", resp.status()));
-            }
-
-            let content_type = resp
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|h| h.to_str().ok())
-                .map(|s| s.to_string());
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| format!("read body failed: {e}"))?
-                .to_vec();
-            if bytes.is_empty() {
-                return Err("empty body".to_string());
-            }
-            Ok((bytes, content_type))
-        }
-        .await;
+        let downloaded = download_media_url(&self.inner.client, image_url).await;
 
         let (bytes, content_type) = match downloaded {
             Ok(result) => result,

--- a/crates/hermes-gateway/src/ssrf.rs
+++ b/crates/hermes-gateway/src/ssrf.rs
@@ -67,7 +67,7 @@ fn global_allow_private_urls() -> bool {
 }
 
 #[cfg(test)]
-fn reset_allow_private_cache_for_tests() {
+pub(crate) fn reset_allow_private_cache_for_tests() {
     let mut guard = ALLOW_PRIVATE_URLS_CACHE
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/crates/hermes-tool-planning/src/lib.rs
+++ b/crates/hermes-tool-planning/src/lib.rs
@@ -97,6 +97,60 @@ fn append_live_mcp_toolsets(requested: &mut Vec<String>, manager: &ToolsetManage
     }
 }
 
+fn candidate_toolset_tokens<'a>(canonical: &'a str, original: &'a str) -> Vec<&'a str> {
+    if canonical == original {
+        vec![canonical]
+    } else {
+        vec![canonical, original]
+    }
+}
+
+fn platform_bundle_non_core_tools(manager: &ToolsetManager, name: &str) -> Option<Vec<String>> {
+    let resolved = manager.resolve_toolset(name).ok()?;
+    if !name.starts_with("hermes-") {
+        return Some(resolved);
+    }
+
+    let core: HashSet<String> = manager
+        .resolve_toolset("hermes-cli")
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    let mut delta: Vec<String> = resolved
+        .into_iter()
+        .filter(|tool| !core.contains(tool))
+        .collect();
+    delta.sort();
+    Some(delta)
+}
+
+fn apply_disabled_toolsets(
+    names: &mut HashSet<String>,
+    disabled_toolsets: &[String],
+    manager: &ToolsetManager,
+) {
+    for token in disabled_toolsets {
+        let original = token.trim();
+        if original.is_empty() {
+            continue;
+        }
+        let canonical = canonical_toolset_token(original);
+        let mut matched = false;
+        for candidate in candidate_toolset_tokens(&canonical, original) {
+            if let Some(to_remove) = platform_bundle_non_core_tools(manager, candidate) {
+                for name in to_remove {
+                    names.remove(&name);
+                }
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            tracing::warn!("Unknown disabled toolset/token '{}'", original);
+        }
+    }
+}
+
 fn coding_focus_toolsets(
     config: &GatewayConfig,
     platform: &str,
@@ -135,13 +189,8 @@ pub fn resolve_platform_tool_names(
             continue;
         }
         let canonical = canonical_toolset_token(original);
-        let candidates = if canonical == original {
-            vec![canonical.as_str()]
-        } else {
-            vec![canonical.as_str(), original]
-        };
         let mut matched = false;
-        for candidate in candidates {
+        for candidate in candidate_toolset_tokens(&canonical, original) {
             if let Ok(resolved) = manager.resolve_toolset(candidate) {
                 for name in resolved {
                     names.insert(name);
@@ -176,6 +225,7 @@ pub fn resolve_platform_tool_names(
             names.insert(trimmed.to_string());
         }
     }
+    apply_disabled_toolsets(&mut names, &config.agent.disabled_toolsets, &manager);
     for tool_name in &config.tools_config.disabled {
         let trimmed = tool_name.trim();
         if trimmed.is_empty() {
@@ -490,6 +540,41 @@ mod tests {
         let reg = registry_with_minimal_tools();
         let names = resolve_platform_tool_names(&cfg, "cli", &reg);
         assert!(!names.contains(&"terminal".to_string()));
+    }
+
+    #[test]
+    fn agent_disabled_toolsets_remove_regular_toolset_after_platform_resolution() {
+        let mut cfg = GatewayConfig::default();
+        cfg.platform_toolsets
+            .insert("cli".to_string(), vec!["hermes-cli".to_string()]);
+        cfg.agent.disabled_toolsets = vec!["browser".to_string()];
+        let reg = registry_with_minimal_tools();
+
+        let names = resolve_platform_tool_names(&cfg, "cli", &reg);
+
+        assert!(names.contains(&"terminal".to_string()));
+        assert!(names.contains(&"read_file".to_string()));
+        assert!(!names.contains(&"browser_navigate".to_string()));
+        assert!(!names.contains(&"browser_snapshot".to_string()));
+    }
+
+    #[test]
+    fn agent_disabled_platform_bundle_preserves_core_tools() {
+        let mut cfg = GatewayConfig::default();
+        cfg.platform_toolsets
+            .insert("discord".to_string(), vec!["hermes-discord".to_string()]);
+        cfg.agent.disabled_toolsets = vec!["hermes-discord".to_string()];
+        let reg = registry_with_minimal_tools();
+
+        let names = resolve_platform_tool_names(&cfg, "discord", &reg);
+
+        assert!(names.contains(&"terminal".to_string()));
+        assert!(names.contains(&"read_file".to_string()));
+        assert!(names.contains(&"web_search".to_string()));
+        assert!(
+            !names.is_empty(),
+            "disabling a platform bundle must not wipe shared core tools"
+        );
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T07:03:01.007793+00:00`_
+_Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T07:03:00.694496+00:00`
-- Proof snapshot generated: `2026-06-25T07:03:01.007793+00:00`
+- Queue snapshot generated: `2026-06-25T07:40:42.585742+00:00`
+- Proof snapshot generated: `2026-06-25T07:40:42.894185+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T07:03:01.007793+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=216.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=216.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=213.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=213.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T07:03:01.007793+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 6997 |
-| Pending | 216 |
-| Ported | 379 |
+| Pending | 213 |
+| Ported | 382 |
 | Superseded | 6326 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 216.0,
+        "actual": 213.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T07:03:01.007793+00:00",
+  "generated_at_utc": "2026-06-25T07:40:42.894185+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 216.0,
+    "max_queue_pending_commits": 213.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 216,
-      "ported": 379,
+      "pending": 213,
+      "ported": 382,
       "superseded": 6326
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 216.0,
+        "actual": 213.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T07:03:01.007793+00:00`
+Generated: `2026-06-25T07:40:42.894185+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T07:03:01.007793+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 216.0 |
+| `max_queue_pending_commits` | 213.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4408,6 +4408,21 @@
     "fff0561441d2": {
       "disposition": "superseded",
       "notes": "Google Chat OAuth client-secret anchoring is Python adapter-only in upstream; this Rust gateway surface has no Google Chat platform adapter or OAuth helper under crates/hermes-gateway, so no Rust runtime path exists to port."
+    },
+    "dd042fc4dfb1": {
+      "disposition": "ported",
+      "notes": "Rust tool planning now honors agent.disabled_toolsets after platform/default toolset resolution while treating hermes-* platform bundles as non-core deltas, so disabling a platform bundle preserves shared core tools such as terminal/read_file/web_search. Focused hermes-tool-planning tests cover regular toolset removal and platform-bundle core preservation.",
+      "owner": "rust-runtime"
+    },
+    "d0de4601d204": {
+      "disposition": "ported",
+      "notes": "Rust /compress now emits a before/after message and estimated-token summary before the existing removal detail, with focused CLI coverage for the user-visible command output.",
+      "owner": "rust-runtime"
+    },
+    "93ea9b04aff2": {
+      "disposition": "ported",
+      "notes": "Rust gateway media handling now applies a default 128MiB inbound media cap, rejects oversized cached byte payloads and Content-Length values, streams MediaCache downloads with running-size enforcement, and routes direct platform image-url downloads for native-upload adapters through a shared bounded streaming helper. Focused gateway tests cover helper success/oversize and MediaCache oversize rejection.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T07:03:00.694496+00:00`
+Generated: `2026-06-25T07:40:42.585742+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `6997`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T07:03:00.694496+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 216 |
-| ported | 379 |
+| pending | 213 |
+| ported | 382 |
 | superseded | 6326 |
 
 ## First 100 Pending Commits
@@ -92,16 +92,13 @@ Generated: `2026-06-25T07:03:00.694496+00:00`
 | `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
 | `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
 | `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
-| `dd042fc4dfb1` | #20 | fix(tools): preserve core tools when a platform bundle is disabled |
 | `c7e8854cb383` | #20 | fix(tui): persist session messages on force-quit / signal shutdown |
 | `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
 | `0e47f68a479a` | #26 | fix(desktop): rename branched session via session.title RPC |
 | `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
 | `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
-| `d0de4601d204` | #20 | fix(tui): /compress shows a before/after summary (#46686) |
 | `7bc6f1806284` | #23 | fix(hindsight): skip local_embedded daemon when running as root |
-| `93ea9b04aff2` | #20 | fix(gateway): cap inbound media download size to prevent memory exhaustion |
 | `587b5b9ac223` | #23 | fix(backup): capture memory-provider state stored outside HERMES_HOME (#50325) |
 | `2a4542333ee1` | #26 | fix(photon): classify Envoy overflow errors as retryable; add typing cooldown |
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
@@ -125,3 +122,6 @@ Generated: `2026-06-25T07:03:00.694496+00:00`
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
 | `77fdbbfe81d8` | #20 | fix(whatsapp): validate bridge PID identity before killing stale pidfile entry |
 | `069ab40c5f3f` | #20 | fix(whatsapp): only kill LISTENers when freeing the bridge port, never clients |
+| `615a8e651606` | #20 | fix(whatsapp): add missing re import + fix test import path after adapter relocation |
+| `b6d2ac176e27` | #23 | feat(mem0): add self-hosted support via MEM0_HOST / host config |
+| `452a725ae19f` | #23 | fix(mem0): address PR review — restore docstrings, keep api_key required |


### PR DESCRIPTION
## Summary
- port upstream toolset-disable parity: `agent.disabled_toolsets` now subtracts toolsets after platform/default resolution while preserving shared core tools for `hermes-*` platform bundles
- port `/compress` UX parity: command output now reports before/after message and estimated-token counts before existing removal details
- port inbound media cap parity: default 128MiB media cap, streaming cache downloads with Content-Length/body enforcement, and bounded direct image-url downloads for native-upload platform adapters
- update parity overrides/proof/dashboard: pending `216 -> 213`, ported `379 -> 382`

## Upstream SHAs closed
- `dd042fc4dfb1` fix(tools): preserve core tools when a platform bundle is disabled
- `d0de4601d204` fix(tui): /compress shows a before/after summary (#46686)
- `93ea9b04aff2` fix(gateway): cap inbound media download size to prevent memory exhaustion

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-cli -p hermes-config -p hermes-gateway -p hermes-tool-planning` -> `seen=200 allowlist=200 new=0 stale=0`
- focused tests for media helper/cache, disabled toolsets, `/compress`, and config roundtrips
- `cargo test -p hermes-tool-planning` -> 19 passed
- `cargo test -p hermes-config` -> 179 unit + 8 prop tests passed
- `cargo test -p hermes-gateway` -> 309 unit + integration/doc surfaces passed
- `cargo test -p hermes-cli` -> 539 unit + binaries/e2e tests passed
- `cargo build --workspace` -> passed
- `cargo test --workspace` -> passed

## Guardrails
- OAuth/sign-in guarded paths were not modified.
- Build/test artifacts used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` with `CARGO_INCREMENTAL=0`.
