### PR TITLE
parity(gateway): harden email and whatsapp runtime config

### DIFF
--- a/crates/hermes-gateway/src/platforms/email.rs
+++ b/crates/hermes-gateway/src/platforms/email.rs
@@ -42,6 +42,45 @@ fn default_poll_interval() -> u64 {
     60
 }
 
+fn trim_email_config(mut config: EmailConfig) -> EmailConfig {
+    config.imap_host = config.imap_host.trim().to_string();
+    config.smtp_host = config.smtp_host.trim().to_string();
+    config.username = config.username.trim().to_string();
+    config.password = config.password.trim().to_string();
+    config
+}
+
+fn require_email_fields(fields: &[(&'static str, &str)]) -> Result<(), GatewayError> {
+    let missing = fields
+        .iter()
+        .filter_map(|(name, value)| {
+            if value.trim().is_empty() {
+                Some(*name)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(GatewayError::Platform(format!(
+        "email_missing_configuration: missing {}",
+        missing.join(", ")
+    )))
+}
+
+fn validate_email_config(config: &EmailConfig) -> Result<(), GatewayError> {
+    require_email_fields(&[
+        ("imap_host", &config.imap_host),
+        ("smtp_host", &config.smtp_host),
+        ("username", &config.username),
+        ("password", &config.password),
+    ])
+}
+
 pub struct EmailAdapter {
     base: BasePlatformAdapter,
     config: EmailConfig,
@@ -50,6 +89,8 @@ pub struct EmailAdapter {
 
 impl EmailAdapter {
     pub fn new(config: EmailConfig) -> Result<Self, GatewayError> {
+        let config = trim_email_config(config);
+        validate_email_config(&config)?;
         let base = BasePlatformAdapter::new(&config.username).with_proxy(config.proxy.clone());
         base.validate_token()?;
         Ok(Self {
@@ -264,6 +305,15 @@ fn smtp_send_raw(
     use std::net::TcpStream;
     use std::time::Duration;
 
+    let host = host.trim();
+    let username = username.trim();
+    let password = password.trim();
+    require_email_fields(&[
+        ("smtp_host", host),
+        ("username", username),
+        ("password", password),
+    ])?;
+
     let addr = format!("{host}:{port}");
     let mut stream = TcpStream::connect(&addr)
         .map_err(|e| GatewayError::SendFailed(format!("SMTP connect {addr}: {e}")))?;
@@ -369,6 +419,15 @@ fn imap_fetch_unseen(
     use std::io::{Read, Write};
     use std::net::TcpStream;
     use std::time::Duration;
+
+    let host = host.trim();
+    let username = username.trim();
+    let password = password.trim();
+    require_email_fields(&[
+        ("imap_host", host),
+        ("username", username),
+        ("password", password),
+    ])?;
 
     let addr = format!("{host}:{port}");
 
@@ -580,6 +639,81 @@ fn base64_encode_lines(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn config() -> EmailConfig {
+        EmailConfig {
+            imap_host: "imap.example.com".to_string(),
+            imap_port: 993,
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            username: "agent@example.com".to_string(),
+            password: "secret".to_string(),
+            poll_interval_secs: 60,
+            proxy: AdapterProxyConfig::default(),
+        }
+    }
+
+    #[test]
+    fn email_adapter_trims_config_before_use() {
+        let adapter = EmailAdapter::new(EmailConfig {
+            imap_host: " imap.example.com ".to_string(),
+            smtp_host: "\tsmtp.example.com\n".to_string(),
+            username: " agent@example.com ".to_string(),
+            password: " secret ".to_string(),
+            ..config()
+        })
+        .expect("adapter");
+
+        assert_eq!(adapter.config().imap_host, "imap.example.com");
+        assert_eq!(adapter.config().smtp_host, "smtp.example.com");
+        assert_eq!(adapter.config().username, "agent@example.com");
+        assert_eq!(adapter.config().password, "secret");
+    }
+
+    #[test]
+    fn email_adapter_rejects_blank_required_config() {
+        let result = EmailAdapter::new(EmailConfig {
+            imap_host: " ".to_string(),
+            smtp_host: "\t".to_string(),
+            username: "".to_string(),
+            password: "\n".to_string(),
+            ..config()
+        });
+        let err = match result {
+            Ok(_) => panic!("missing config should fail"),
+            Err(err) => err,
+        };
+
+        let msg = err.to_string();
+        assert!(msg.contains("email_missing_configuration"));
+        assert!(msg.contains("imap_host"));
+        assert!(msg.contains("smtp_host"));
+        assert!(msg.contains("username"));
+        assert!(msg.contains("password"));
+    }
+
+    #[test]
+    fn raw_email_paths_reject_blank_host_before_network() {
+        let smtp_err = smtp_send_raw(
+            " ",
+            587,
+            "agent@example.com",
+            "secret",
+            "agent@example.com",
+            "user@example.com",
+            "subject",
+            "body",
+            None,
+        )
+        .expect_err("blank SMTP host should fail before connect");
+        assert!(smtp_err.to_string().contains("email_missing_configuration"));
+        assert!(smtp_err.to_string().contains("smtp_host"));
+
+        let imap_err = imap_fetch_unseen(" ", 993, "agent@example.com", "secret")
+            .expect_err("blank IMAP host should fail before TLS/connect");
+        assert!(imap_err.to_string().contains("email_missing_configuration"));
+        assert!(imap_err.to_string().contains("imap_host"));
+    }
 
     #[test]
     fn image_email_body_with_caption() {

--- a/crates/hermes-gateway/src/platforms/whatsapp.rs
+++ b/crates/hermes-gateway/src/platforms/whatsapp.rs
@@ -249,12 +249,7 @@ impl WhatsAppAdapter {
             .ok_or_else(|| GatewayError::SendFailed("phone_number_id not configured".into()))?;
 
         let url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
-        let body = serde_json::json!({
-            "messaging_product": "whatsapp",
-            "to": to,
-            "type": "text",
-            "text": { "body": text }
-        });
+        let body = build_text_body(to, text);
 
         let resp = self
             .client
@@ -462,15 +457,7 @@ impl WhatsAppAdapter {
             .ok_or_else(|| GatewayError::SendFailed("phone_number_id not configured".into()))?;
 
         let url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
-        let body = serde_json::json!({
-            "messaging_product": "whatsapp",
-            "to": to,
-            "type": "reaction",
-            "reaction": {
-                "message_id": message_id,
-                "emoji": emoji
-            }
-        });
+        let body = build_reaction_body(to, message_id, emoji);
 
         let resp = self
             .client
@@ -543,7 +530,41 @@ fn build_link_media_body(
 
     serde_json::json!({
         "messaging_product": "whatsapp",
-        "to": to,
+        "to": normalize_cloud_recipient(to),
+        "type": media_type,
+        media_type: media_obj
+    })
+}
+
+fn build_text_body(to: &str, text: &str) -> serde_json::Value {
+    serde_json::json!({
+        "messaging_product": "whatsapp",
+        "to": normalize_cloud_recipient(to),
+        "type": "text",
+        "text": { "body": text }
+    })
+}
+
+fn build_reaction_body(to: &str, message_id: &str, emoji: &str) -> serde_json::Value {
+    serde_json::json!({
+        "messaging_product": "whatsapp",
+        "to": normalize_cloud_recipient(to),
+        "type": "reaction",
+        "reaction": {
+            "message_id": message_id,
+            "emoji": emoji
+        }
+    })
+}
+
+fn build_uploaded_media_body(
+    to: &str,
+    media_type: &str,
+    media_obj: serde_json::Value,
+) -> serde_json::Value {
+    serde_json::json!({
+        "messaging_product": "whatsapp",
+        "to": normalize_cloud_recipient(to),
         "type": media_type,
         media_type: media_obj
     })
@@ -574,7 +595,7 @@ mod tests {
     #[test]
     fn build_link_media_body_with_caption() {
         let body = build_link_media_body(
-            "15551234567",
+            "+1 (555) 123-4567",
             "image",
             "https://example.com/preview.png",
             Some("Status update"),
@@ -599,6 +620,58 @@ mod tests {
         assert_eq!(body["type"], "image");
         assert_eq!(body["image"]["link"], "https://example.com/preview.png");
         assert!(body["image"]["caption"].is_null());
+    }
+
+    #[test]
+    fn outbound_payload_builders_normalize_cloud_recipients() {
+        let text = build_text_body("+1 555 123 4567", "hello");
+        assert_eq!(text["to"], "15551234567");
+        assert_eq!(text["text"]["body"], "hello");
+
+        let reaction = build_reaction_body("15551234567:7@s.whatsapp.net", "wamid.1", "👍");
+        assert_eq!(reaction["to"], "15551234567");
+        assert_eq!(reaction["reaction"]["message_id"], "wamid.1");
+
+        let uploaded = build_uploaded_media_body(
+            "+1 (555) 123-4567",
+            "document",
+            serde_json::json!({"id": "media-1"}),
+        );
+        assert_eq!(uploaded["to"], "15551234567");
+        assert_eq!(uploaded["document"]["id"], "media-1");
+    }
+
+    #[test]
+    fn normalize_cloud_recipient_accepts_phone_like_values() {
+        assert_eq!(
+            normalize_cloud_recipient(" +1 (555) 123-4567 "),
+            "15551234567"
+        );
+        assert_eq!(normalize_cloud_recipient("1555.123.4567"), "15551234567");
+    }
+
+    #[test]
+    fn normalize_cloud_recipient_converts_user_jids_to_cloud_phone() {
+        assert_eq!(
+            normalize_cloud_recipient("15551234567:11@s.whatsapp.net"),
+            "15551234567"
+        );
+        assert_eq!(
+            normalize_cloud_recipient("+15551234567@s.whatsapp.net"),
+            "15551234567"
+        );
+    }
+
+    #[test]
+    fn normalize_cloud_recipient_preserves_non_cloud_group_targets() {
+        assert_eq!(
+            normalize_cloud_recipient("120363001234567890@g.us"),
+            "120363001234567890@g.us"
+        );
+        assert_eq!(
+            normalize_cloud_recipient("status@broadcast"),
+            "status@broadcast"
+        );
     }
 
     #[test]
@@ -795,12 +868,7 @@ impl PlatformAdapter for WhatsAppAdapter {
             media_obj["filename"] = serde_json::Value::String(file_name.to_string());
         }
 
-        let body = serde_json::json!({
-            "messaging_product": "whatsapp",
-            "to": chat_id,
-            "type": media_type,
-            media_type: media_obj
-        });
+        let body = build_uploaded_media_body(chat_id, media_type, media_obj);
 
         let resp = self
             .client
@@ -886,6 +954,54 @@ fn normalize_whatsapp_id(value: &str) -> String {
         .trim_end_matches("@s.whatsapp.net")
         .trim_end_matches("@lid")
         .to_ascii_lowercase()
+}
+
+fn normalize_cloud_recipient(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if lower == "status@broadcast" || lower.ends_with("@g.us") || lower.ends_with("@newsletter") {
+        return trimmed.to_string();
+    }
+
+    if lower.ends_with("@s.whatsapp.net") || lower.ends_with("@lid") {
+        let local = trimmed
+            .split('@')
+            .next()
+            .unwrap_or(trimmed)
+            .split(':')
+            .next()
+            .unwrap_or(trimmed);
+        let digits = digits_only(local);
+        return if digits.is_empty() {
+            local.trim_start_matches('+').to_string()
+        } else {
+            digits
+        };
+    }
+
+    if trimmed.contains('@') {
+        return trimmed.to_string();
+    }
+
+    let phone_like = trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_digit() || matches!(ch, '+' | ' ' | '-' | '(' | ')' | '.'));
+    if phone_like {
+        let digits = digits_only(trimmed);
+        if !digits.is_empty() {
+            return digits;
+        }
+    }
+
+    trimmed.to_string()
+}
+
+fn digits_only(value: &str) -> String {
+    value.chars().filter(|ch| ch.is_ascii_digit()).collect()
 }
 
 fn contains_normalized_whatsapp_id(list: &[String], candidate: &str) -> bool {

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -7,7 +7,7 @@ _Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T07:40:42.585742+00:00`
+- Queue snapshot generated: `2026-06-25T08:21:54.340532+00:00`
 - Proof snapshot generated: `2026-06-25T07:40:42.894185+00:00`
 
 ## Gate Status
@@ -75,9 +75,9 @@ _Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 6997 |
-| Pending | 213 |
-| Ported | 382 |
-| Superseded | 6326 |
+| Pending | 207 |
+| Ported | 385 |
+| Superseded | 6329 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 213.0,
+        "actual": 207.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T07:40:42.894185+00:00",
+  "generated_at_utc": "2026-06-25T08:21:58.990126+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 213.0,
+    "max_queue_pending_commits": 207.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 213,
-      "ported": 382,
-      "superseded": 6326
+      "pending": 207,
+      "ported": 385,
+      "superseded": 6329
     },
     "by_target_ticket": {
       "20": 3132,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 213.0,
+        "actual": 207.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T07:40:42.894185+00:00`
+Generated: `2026-06-25T08:21:58.990126+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T07:40:42.894185+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 213.0 |
+| `max_queue_pending_commits` | 207.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4423,6 +4423,36 @@
       "disposition": "ported",
       "notes": "Rust gateway media handling now applies a default 128MiB inbound media cap, rejects oversized cached byte payloads and Content-Length values, streams MediaCache downloads with running-size enforcement, and routes direct platform image-url downloads for native-upload adapters through a shared bounded streaming helper. Focused gateway tests cover helper success/oversize and MediaCache oversize rejection.",
       "owner": "rust-runtime"
+    },
+    "a4b1554c7349": {
+      "disposition": "ported",
+      "notes": "Rust WhatsApp Cloud API payload builders normalize outbound recipients for text, reaction, linked media, and uploaded media sends: phone-like values are reduced to digits and Baileys user JIDs collapse to their phone component, while group/status targets are preserved because this Rust adapter does not run the Baileys bridge.",
+      "owner": "rust-runtime"
+    },
+    "b7f6cb9c8ba3": {
+      "disposition": "ported",
+      "notes": "Rust email adapter trims typed IMAP/SMTP/username/password settings and rejects missing fields with email_missing_configuration before adapter construction or raw IMAP/SMTP network calls. The Rust gateway already reads hosts from typed platform config, so the upstream extra/env fallback is covered by the local config surface.",
+      "owner": "rust-runtime"
+    },
+    "f79e0a7060d0": {
+      "disposition": "ported",
+      "notes": "Blank and whitespace-only email settings now fail as email_missing_configuration before gateway registration/connect and before private raw SMTP/IMAP paths can touch the network, avoiding the upstream missing-config retry loop failure mode in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
+    "77fdbbfe81d8": {
+      "disposition": "superseded",
+      "notes": "Upstream validates Baileys bridge PID identity before killing a stale pidfile process. Hermes Agent Ultra's Rust WhatsApp platform is a Meta Cloud API adapter with no local Baileys bridge pidfile or bridge-process kill path, so this failure mode is absent.",
+      "owner": "rust-runtime"
+    },
+    "069ab40c5f3f": {
+      "disposition": "superseded",
+      "notes": "Upstream bridge-port cleanup only kills LISTENers for the Baileys bridge. Hermes Agent Ultra's Rust WhatsApp Cloud API adapter has no local bridge port reaper, so it cannot kill unrelated client sockets through this path.",
+      "owner": "rust-runtime"
+    },
+    "615a8e651606": {
+      "disposition": "superseded",
+      "notes": "Upstream fixes a Python re import and Python test relocation after WhatsApp adapter plugin migration. The Rust WhatsApp module is compile-tested under the whatsapp feature and has no Python adapter import path.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T07:40:42.585742+00:00`
+Generated: `2026-06-25T08:21:54.340532+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `6997`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-25T07:40:42.585742+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 213 |
-| ported | 382 |
-| superseded | 6326 |
+| pending | 207 |
+| ported | 385 |
+| superseded | 6329 |
 
 ## First 100 Pending Commits
 
@@ -108,10 +108,7 @@ Generated: `2026-06-25T07:40:42.585742+00:00`
 | `b6d107240819` | #20 | fix(cli): branch new worktrees from the fresh remote tip, not stale local HEAD (#50355) |
 | `5b45fb269a06` | #20 | fix(security): sanitize kanban markdown html |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
-| `a4b1554c7349` | #20 | fix(whatsapp): normalize bare phone targets to JIDs before bridge send |
 | `99f3072aa06a` | #20 | fix(model-switch): a failed in-place swap must be a no-op, not a dead session (#50375) |
-| `b7f6cb9c8ba3` | #20 | fix(email): resolve IMAP/SMTP host from config and validate before connecting |
-| `f79e0a7060d0` | #20 | fix(email): mark missing-config as non-retryable + reject blank env vars (#40715) |
 | `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
 | `7785655b4ece` | #26 | fix(desktop): keep the floating composer in-bounds so it can't be lost off-screen |
 | `37c37c9dc511` | #26 | fix(antigravity): register google-antigravity ProviderProfile + AUTHOR_MAP |
@@ -120,8 +117,11 @@ Generated: `2026-06-25T07:40:42.585742+00:00`
 | `13ce8119067e` | #26 | fix: show desktop approval fallback (#46548) |
 | `e5e25836350a` | #26 | fix(desktop): relaunch on Linux after in-app update instead of hanging (#45205) |
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
-| `77fdbbfe81d8` | #20 | fix(whatsapp): validate bridge PID identity before killing stale pidfile entry |
-| `069ab40c5f3f` | #20 | fix(whatsapp): only kill LISTENers when freeing the bridge port, never clients |
-| `615a8e651606` | #20 | fix(whatsapp): add missing re import + fix test import path after adapter relocation |
 | `b6d2ac176e27` | #23 | feat(mem0): add self-hosted support via MEM0_HOST / host config |
 | `452a725ae19f` | #23 | fix(mem0): address PR review — restore docstrings, keep api_key required |
+| `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
+| `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
+| `0768ed3b33e4` | #26 | docs(agents): fix stale platform adapter path in token-lock note |
+| `95d53c3bcb06` | #20 | feat(cli): /reasoning full — show complete thinking, not 10-line clamp (#50499) |
+| `4314d451ca96` | #20 | fix(gateway): accept any inbound file type across all messaging platforms |
+| `b5bd66eac9b1` | #20 | fix(telegram): observed/replied group docs of any type are cached too |


### PR DESCRIPTION
## Summary
- harden Rust email adapter config by trimming required fields and failing fast with `email_missing_configuration` before adapter construction or raw IMAP/SMTP network calls
- normalize WhatsApp Cloud API outbound recipients for text, reaction, linked media, and uploaded media payload builders
- classify six upstream queue items with Rust runtime evidence and regenerate parity proof/dashboard artifacts

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features 'email whatsapp'`\n- `cargo test -p hermes-gateway --features 'email whatsapp'`\n- `cargo build --workspace`\n- `cargo test --workspace`\n\n## Parity delta\n- pending: 213 -> 207\n- ported: 382 -> 385\n- superseded: 6326 -> 6329\n