### PR TITLE
fix(parity): keep queue pending out of coverage critical gate

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,6 +1,6 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
+_Generated from source artifacts: `2026-06-25T08:37:52.088568+00:00`_
 
 ## Snapshot
 
@@ -8,7 +8,7 @@ _Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
 - Queue snapshot generated: `2026-06-25T08:21:54.340532+00:00`
-- Proof snapshot generated: `2026-06-25T07:40:42.894185+00:00`
+- Proof snapshot generated: `2026-06-25T08:37:52.088568+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=213.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=213.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=207.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=207.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -29,7 +29,7 @@ _Generated from source artifacts: `2026-06-25T07:40:42.894185+00:00`_
 | Tracked behavior rows | 419 |
 | Covered behavior rows | 419 |
 | Tracked behavior coverage ratio | 1.0000 |
-| Rust test functions | 3630 |
+| Rust test functions | 3749 |
 | Missing Rust test refs | 0 |
 | Critical gaps | 0 |
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T08:21:58.990126+00:00",
+  "generated_at_utc": "2026-06-25T08:37:52.088568+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -512,7 +512,7 @@
   },
   "test_coverage_audit_summary": {
     "audit_gate": {
-      "advisory_gaps": 3,
+      "advisory_gaps": 4,
       "critical_gaps": 0,
       "pass": true
     },
@@ -524,10 +524,10 @@
       "divergence_review_overdue": 0,
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
-      "queue_pending": 0,
-      "queue_total": 6132,
-      "rust_test_files": 314,
-      "rust_test_functions": 3630,
+      "queue_pending": 207,
+      "queue_total": 6997,
+      "rust_test_files": 315,
+      "rust_test_functions": 3749,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T08:21:58.990126+00:00`
+Generated: `2026-06-25T08:37:52.088568+00:00`
 
 ## Gate Status
 

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -1,6 +1,11 @@
 {
   "advisory_gaps": [
     {
+      "kind": "upstream_queue_pending",
+      "message": "upstream missing queue has pending rows; queue closure is enforced by global parity thresholds",
+      "pending": 207
+    },
+    {
       "kind": "nonzero_tree_drift",
       "message": "max_commits_behind remains nonzero in parity matrix",
       "metric": "max_commits_behind",
@@ -20,7 +25,7 @@
     }
   ],
   "audit_gate": {
-    "advisory_gaps": 3,
+    "advisory_gaps": 4,
     "critical_gaps": 0,
     "pass": true
   },
@@ -90,7 +95,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-06-23T11:48:53.898884+00:00",
+  "generated_at_utc": "2026-06-25T08:37:52.001151+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -221,13 +226,14 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 24,
+      "direct_test_evidence_count": 25,
       "direct_test_evidence_sample": [
         "crates/hermes-app-runtime/src/lib.rs",
         "crates/hermes-cli/src/alpha_runtime.rs",
         "crates/hermes-cli/src/app.rs",
         "crates/hermes-cli/src/auth.rs",
         "crates/hermes-cli/src/banner.rs",
+        "crates/hermes-cli/src/billing.rs",
         "crates/hermes-cli/src/checklist.rs",
         "crates/hermes-cli/src/claw_migrate.rs",
         "crates/hermes-cli/src/cli.rs",
@@ -248,13 +254,14 @@
         "crates/hermes-cli/src/tui.rs",
         "crates/hermes-source-parity-tests/tests/cli_command_contract.rs"
       ],
-      "evidence_count": 41,
+      "evidence_count": 42,
       "evidence_sample": [
         "crates/hermes-app-runtime/src/lib.rs",
         "crates/hermes-cli/src/alpha_runtime.rs",
         "crates/hermes-cli/src/app.rs",
         "crates/hermes-cli/src/auth.rs",
         "crates/hermes-cli/src/banner.rs",
+        "crates/hermes-cli/src/billing.rs",
         "crates/hermes-cli/src/bin/hermes-ultra.rs",
         "crates/hermes-cli/src/bin/hermes.rs",
         "crates/hermes-cli/src/checklist.rs",
@@ -273,8 +280,7 @@
         "crates/hermes-cli/src/mcp_config.rs",
         "crates/hermes-cli/src/model_switch.rs",
         "crates/hermes-cli/src/pairing_store.rs",
-        "crates/hermes-cli/src/platform_toolsets.rs",
-        "crates/hermes-cli/src/profiles.rs"
+        "crates/hermes-cli/src/platform_toolsets.rs"
       ],
       "id": "cli-command-surface",
       "mapped": true,
@@ -313,7 +319,7 @@
         "crates/hermes-agent/src/memory_plugins/openviking.rs",
         "crates/hermes-agent/src/memory_plugins/retaindb.rs"
       ],
-      "evidence_count": 51,
+      "evidence_count": 52,
       "evidence_sample": [
         "crates/hermes-agent/src/agent_loop.rs",
         "crates/hermes-agent/src/api_bridge.rs",
@@ -331,6 +337,7 @@
         "crates/hermes-agent/src/honcho_provider.rs",
         "crates/hermes-agent/src/interrupt.rs",
         "crates/hermes-agent/src/lib.rs",
+        "crates/hermes-agent/src/local_backends.rs",
         "crates/hermes-agent/src/lsp_context.rs",
         "crates/hermes-agent/src/memory_manager.rs",
         "crates/hermes-agent/src/memory_plugins/byterover.rs",
@@ -338,8 +345,7 @@
         "crates/hermes-agent/src/memory_plugins/contextlattice.rs",
         "crates/hermes-agent/src/memory_plugins/hindsight.rs",
         "crates/hermes-agent/src/memory_plugins/holographic.rs",
-        "crates/hermes-agent/src/memory_plugins/honcho.rs",
-        "crates/hermes-agent/src/memory_plugins/mem0.rs"
+        "crates/hermes-agent/src/memory_plugins/honcho.rs"
       ],
       "id": "agent-loop-and-runtime",
       "mapped": true,
@@ -565,10 +571,10 @@
     "divergence_review_overdue": 0,
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
-    "queue_pending": 0,
-    "queue_total": 6132,
-    "rust_test_files": 314,
-    "rust_test_functions": 3630,
+    "queue_pending": 207,
+    "queue_total": 6997,
+    "rust_test_files": 315,
+    "rust_test_functions": 3749,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,12 +1,12 @@
 # Test Coverage Audit
 
-Generated: `2026-06-23T11:48:53.898884+00:00`
+Generated: `2026-06-25T08:37:52.001151+00:00`
 
 ## Gate
 
 - Audit gate: **PASS**
 - Critical gaps: `0`
-- Advisory gaps: `3`
+- Advisory gaps: `4`
 
 ## Summary
 
@@ -15,13 +15,13 @@ Generated: `2026-06-23T11:48:53.898884+00:00`
 | `tracked_behavior_rows` | 419 |
 | `covered_behavior_rows` | 419 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
-| `rust_test_files` | 314 |
-| `rust_test_functions` | 3630 |
+| `rust_test_files` | 315 |
+| `rust_test_functions` | 3749 |
 | `coverage_manifest_entries` | 409 |
 | `coverage_manifest_entries_with_valid_rust_tests` | 409 |
 | `missing_rust_test_refs` | 0 |
-| `queue_pending` | 0 |
-| `queue_total` | 6132 |
+| `queue_pending` | 207 |
+| `queue_total` | 6997 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 
@@ -39,8 +39,8 @@ Generated: `2026-06-23T11:48:53.898884+00:00`
 | --- | --- | ---: | ---: |
 | `gateway-platform-behavior` | `direct_rust_test` | 25 | 22 |
 | `tool-runtime-behavior` | `direct_rust_test` | 91 | 82 |
-| `cli-command-surface` | `direct_rust_test` | 41 | 24 |
-| `agent-loop-and-runtime` | `direct_rust_test` | 51 | 47 |
+| `cli-command-surface` | `direct_rust_test` | 42 | 25 |
+| `agent-loop-and-runtime` | `direct_rust_test` | 52 | 47 |
 | `acp-protocol-and-transport` | `direct_rust_test` | 9 | 8 |
 | `skills-management-contract` | `direct_rust_test` | 10 | 9 |
 | `cron-and-scheduler-runtime` | `direct_rust_test` | 12 | 9 |
@@ -54,6 +54,7 @@ Generated: `2026-06-23T11:48:53.898884+00:00`
 
 ## Advisory Gaps
 
+- `upstream_queue_pending`: upstream missing queue has pending rows; queue closure is enforced by global parity thresholds
 - `nonzero_tree_drift`: max_commits_behind remains nonzero in parity matrix
 - `nonzero_tree_drift`: max_upstream_patch_missing remains nonzero in parity matrix
 - `nonzero_tree_drift`: max_files_only_upstream remains nonzero in parity matrix

--- a/scripts/generate-test-coverage-audit.py
+++ b/scripts/generate-test-coverage-audit.py
@@ -342,8 +342,12 @@ def main() -> int:
     by_disposition = queue_summary.get("by_disposition", {})
     queue_pending = int(by_disposition.get("pending", 0) or 0)
     if queue_pending:
-        critical_gaps.append(
-            critical_gap("upstream_queue_pending", "upstream missing queue has pending rows", pending=queue_pending)
+        advisory_gaps.append(
+            advisory(
+                "upstream_queue_pending",
+                "upstream missing queue has pending rows; queue closure is enforced by global parity thresholds",
+                pending=queue_pending,
+            )
         )
 
     intent_summary = intent_mapping.get("summary", {})


### PR DESCRIPTION
## Summary
- keep upstream queue pending rows visible in the coverage audit as an advisory instead of a critical coverage failure
- leave queue closure enforcement to global parity thresholds/release policy
- regenerate affected parity audit/proof/dashboard artifacts

## Verification
- `python3 scripts/generate-test-coverage-audit.py --check`
- `python3 -m py_compile scripts/generate-test-coverage-audit.py`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p hermes-source-parity-tests test_coverage_audit_gate_passes`
- `cargo test -p hermes-source-parity-tests`
