### PR TITLE
test(tools): serialize Hermes home env fixtures

### DIFF
--- a/crates/hermes-tools/src/backends/code_execution.rs
+++ b/crates/hermes-tools/src/backends/code_execution.rs
@@ -155,6 +155,7 @@ impl CodeExecutionBackend for LocalCodeExecutionBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hermes_config::managed_gateway::test_lock;
 
     #[tokio::test]
     async fn missing_language_does_not_default_to_python() {
@@ -178,8 +179,9 @@ mod tests {
         assert!(err.to_string().contains("Python execution is disabled"));
     }
 
-    #[tokio::test]
-    async fn profile_home_mode_sets_home_for_shell_snippets() {
+    #[test]
+    fn profile_home_mode_sets_home_for_shell_snippets() {
+        let _global_env = test_lock::lock();
         let real = tempfile::tempdir().expect("real home");
         let hermes = tempfile::tempdir().expect("hermes home");
         let _home = EnvGuard::set("HOME", real.path().to_string_lossy().as_ref());
@@ -188,14 +190,20 @@ mod tests {
         let _mode = EnvGuard::set("TERMINAL_HOME_MODE", "profile");
         let backend = LocalCodeExecutionBackend::default();
 
-        let raw = backend
-            .execute(
-                "printf '%s|%s' \"$HOME\" \"$HERMES_REAL_HOME\"",
-                Some("bash"),
-                Some(5),
-            )
-            .await
-            .expect("bash should run");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let raw = runtime.block_on(async {
+            backend
+                .execute(
+                    "printf '%s|%s' \"$HOME\" \"$HERMES_REAL_HOME\"",
+                    Some("bash"),
+                    Some(5),
+                )
+                .await
+        });
+        let raw = raw.expect("bash should run");
         let payload: serde_json::Value = serde_json::from_str(&raw).expect("json payload");
         assert_eq!(
             payload["stdout"].as_str().unwrap(),

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -1169,6 +1169,7 @@ mod tests {
 
     #[test]
     fn builtin_registry_registers_terminal_tools_for_managed_modal_surface() {
+        let _global_env = hermes_config::managed_gateway::test_lock::lock();
         let _lock = lock_env();
         let home = tempfile::tempdir().expect("temp home");
         let hermes_home = tempfile::tempdir().expect("temp hermes home");

--- a/crates/hermes-tools/src/tools/auth_snapshot.rs
+++ b/crates/hermes-tools/src/tools/auth_snapshot.rs
@@ -546,6 +546,7 @@ mod tests {
 
     #[test]
     fn status_reports_oauth_state_presence_without_secret_value() {
+        let _global_env = hermes_config::managed_gateway::test_lock::lock();
         let _lock = env_lock();
         let temp = tempdir().expect("tempdir");
         let _home = EnvGuard::set("HERMES_HOME", temp.path().to_string_lossy().as_ref());

--- a/crates/hermes-tools/src/tools/integrations_snapshot.rs
+++ b/crates/hermes-tools/src/tools/integrations_snapshot.rs
@@ -787,25 +787,32 @@ mod tests {
         assert!(!raw.contains("sk-"));
     }
 
-    #[tokio::test]
-    async fn repair_plan_flags_missing_auth_without_writing_snapshot_file() {
-        let _lock = env_lock().await;
+    #[test]
+    fn repair_plan_flags_missing_auth_without_writing_snapshot_file() {
+        let _global_env = hermes_config::managed_gateway::test_lock::lock();
         let home = tempdir().expect("home");
-        let _home = EnvGuard::set("HERMES_HOME", home.path().to_string_lossy().as_ref());
-        let _provider = EnvGuard::set("HERMES_AUTH_DEFAULT_PROVIDER", "openrouter");
-        let _key = EnvGuard::remove("OPENROUTER_API_KEY");
-        let _legacy_key = EnvGuard::remove("HERMES_OPENAI_API_KEY");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let raw = runtime.block_on(async {
+            let _lock = env_lock().await;
+            let _home = EnvGuard::set("HERMES_HOME", home.path().to_string_lossy().as_ref());
+            let _provider = EnvGuard::set("HERMES_AUTH_DEFAULT_PROVIDER", "openrouter");
+            let _key = EnvGuard::remove("OPENROUTER_API_KEY");
+            let _legacy_key = EnvGuard::remove("HERMES_OPENAI_API_KEY");
 
-        let registry = ToolRegistry::new();
-        let handler = IntegrationsSnapshotHandler::new(Arc::new(registry));
-        let raw = handler
-            .execute(json!({
-                "action": "repair",
-                "probe_memory": false,
-                "include_plugins": false
-            }))
-            .await
-            .expect("execute");
+            let registry = ToolRegistry::new();
+            let handler = IntegrationsSnapshotHandler::new(Arc::new(registry));
+            handler
+                .execute(json!({
+                    "action": "repair",
+                    "probe_memory": false,
+                    "include_plugins": false
+                }))
+                .await
+        });
+        let raw = raw.expect("execute");
         let payload: Value = serde_json::from_str(&raw).expect("json");
 
         assert_eq!(payload["status"], "ok");


### PR DESCRIPTION
## Summary
- serialize hermes-tools tests that mutate HERMES_HOME with the shared managed-gateway test lock
- convert two async env-fixture tests to explicit current-thread runtime harnesses to avoid holding a synchronous lock across .await
- prevents workspace-level browser backend selection races against Browserbase config tests

## Verification
- cargo fmt --all --check
- cargo test -p hermes-tools
- git diff --check
- scripts/clippy-warning-gate.sh --check -- -p hermes-tools
- cargo build --workspace
- cargo test --workspace

Artifacts used CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation and CARGO_INCREMENTAL=0.