### PR TITLE
parity(gateway): port Slack wake words and retry-after signals

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -4715,7 +4715,11 @@ fn extra_string_set(platform_cfg: &PlatformConfig, key: &str) -> HashSet<String>
     values
 }
 
-#[cfg(any(feature = "gateway-telegram", feature = "gateway-whatsapp"))]
+#[cfg(any(
+    feature = "gateway-slack",
+    feature = "gateway-telegram",
+    feature = "gateway-whatsapp"
+))]
 fn extra_string_vec(platform_cfg: &PlatformConfig, key: &str) -> Vec<String> {
     let Some(raw) = platform_cfg.extra.get(key) else {
         return Vec::new();
@@ -5759,6 +5763,13 @@ async fn register_gateway_adapters(
                     app_token: extra_string(platform_cfg, "app_token"),
                     socket_mode: extra_bool(platform_cfg, "socket_mode", false),
                     reactions: extra_bool(platform_cfg, "reactions", true),
+                    require_mention: platform_cfg
+                        .require_mention
+                        .or_else(|| extra_bool_loose(platform_cfg, "require_mention"))
+                        .unwrap_or(false),
+                    bot_user_id: extra_string(platform_cfg, "bot_user_id")
+                        .or_else(|| extra_string(platform_cfg, "bot_id")),
+                    mention_patterns: extra_string_vec(platform_cfg, "mention_patterns"),
                     proxy: Default::default(),
                 };
                 match SlackAdapter::new(slack_cfg) {

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -13,7 +13,6 @@ use crate::config::{
 };
 use crate::merge::merge_configs;
 use crate::paths;
-use crate::platform::PlatformConfig;
 
 // ---------------------------------------------------------------------------
 // ConfigError conversion helpers
@@ -2363,25 +2362,6 @@ pub fn apply_env_overrides(config: &mut GatewayConfig) {
             for provider in config.llm_providers.values_mut() {
                 provider.base_url = Some(v.clone());
             }
-        }
-    }
-
-    if let Ok(token) = std::env::var("SLACK_BOT_TOKEN") {
-        let trimmed = token.trim();
-        if !trimmed.is_empty() {
-            let slack = config
-                .platforms
-                .entry("slack".to_string())
-                .or_insert_with(PlatformConfig::default);
-            let enabled_was_explicit = slack
-                .extra
-                .remove("_enabled_explicit")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            if !slack.enabled && !enabled_was_explicit {
-                slack.enabled = true;
-            }
-            slack.token = Some(trimmed.to_string());
         }
     }
 

--- a/crates/hermes-config/src/python_platform_env.rs
+++ b/crates/hermes-config/src/python_platform_env.rs
@@ -23,9 +23,36 @@ fn comma_list_to_strings(raw: &str) -> Vec<String> {
 }
 
 fn json_array_or_csv(raw: &str) -> Vec<String> {
-    serde_json::from_str::<Vec<String>>(raw)
-        .unwrap_or_else(|_| comma_list_to_strings(raw))
-        .into_iter()
+    if let Ok(value) = serde_json::from_str::<Value>(raw) {
+        let values = match value {
+            Value::Array(values) => values
+                .into_iter()
+                .filter_map(|value| match value {
+                    Value::String(s) => Some(s),
+                    Value::Number(n) => Some(n.to_string()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            Value::String(s) => vec![s],
+            _ => Vec::new(),
+        };
+        if !values.is_empty() {
+            return values
+                .into_iter()
+                .flat_map(|s| {
+                    s.replace('\n', ",")
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|part| !part.is_empty())
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+        }
+    }
+
+    raw.replace('\n', ",")
+        .split(',')
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect()
@@ -453,10 +480,73 @@ fn apply_discord_env(config: &mut GatewayConfig) {
     }
 }
 
+fn apply_slack_env(config: &mut GatewayConfig) {
+    let token = env_nonempty("SLACK_BOT_TOKEN");
+    let app_token = env_nonempty("SLACK_APP_TOKEN");
+    let socket_mode = env_nonempty("SLACK_SOCKET_MODE");
+    let reactions = env_nonempty("SLACK_REACTIONS");
+    let require_mention = env_nonempty("SLACK_REQUIRE_MENTION");
+    let bot_user_id = env_nonempty("SLACK_BOT_USER_ID").or_else(|| env_nonempty("SLACK_BOT_ID"));
+    let mention_patterns = env_nonempty("SLACK_MENTION_PATTERNS");
+    let allowed_users = env_nonempty("SLACK_ALLOWED_USERS");
+
+    if token.is_none()
+        && app_token.is_none()
+        && socket_mode.is_none()
+        && reactions.is_none()
+        && require_mention.is_none()
+        && bot_user_id.is_none()
+        && mention_patterns.is_none()
+        && allowed_users.is_none()
+    {
+        return;
+    }
+
+    let slack = config
+        .platforms
+        .entry("slack".into())
+        .or_insert_with(PlatformConfig::default);
+    if let Some(token) = token {
+        let enabled_was_explicit = slack
+            .extra
+            .remove("_enabled_explicit")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !slack.enabled && !enabled_was_explicit {
+            slack.enabled = true;
+        }
+        slack.token = Some(token);
+    }
+    if let Some(v) = app_token {
+        set_extra(slack, "app_token", json!(v));
+    }
+    if let Some(v) = socket_mode {
+        set_extra(slack, "socket_mode", json!(env_bool(&v)));
+    }
+    if let Some(v) = reactions {
+        set_extra(slack, "reactions", json!(env_bool(&v)));
+    }
+    if let Some(v) = require_mention {
+        let parsed = env_bool(&v);
+        slack.require_mention = Some(parsed);
+        set_extra(slack, "require_mention", json!(parsed));
+    }
+    if let Some(v) = bot_user_id {
+        set_extra(slack, "bot_user_id", json!(v));
+    }
+    if let Some(v) = mention_patterns {
+        set_extra(slack, "mention_patterns", json!(json_array_or_csv(&v)));
+    }
+    if let Some(v) = allowed_users {
+        slack.allowed_users = comma_list_to_strings(&v);
+    }
+}
+
 /// 应用与 Python 文档一致的平台环境变量到 `platforms`。
 pub fn apply_python_named_platform_env(config: &mut GatewayConfig) {
     apply_telegram_env(config);
     apply_discord_env(config);
+    apply_slack_env(config);
     apply_weixin_env(config);
     apply_dingtalk_env(config);
     apply_mattermost_env(config);
@@ -721,6 +811,106 @@ mod tests {
 
         unsafe {
             std::env::remove_var("TELEGRAM_REPLY_TO_MODE");
+        }
+    }
+
+    #[test]
+    fn json_array_or_csv_splits_mixed_newline_and_csv_fallback() {
+        assert_eq!(
+            json_array_or_csv("chompy\\b\n@hermes, sigma"),
+            vec!["chompy\\b", "@hermes", "sigma"]
+        );
+        assert_eq!(
+            json_array_or_csv(r#""wake one,wake two""#),
+            vec!["wake one", "wake two"]
+        );
+    }
+
+    #[test]
+    fn slack_env_sets_socket_mode_require_mention_and_patterns() {
+        let _env = env_lock();
+        unsafe {
+            std::env::set_var("SLACK_BOT_TOKEN", "slack-token");
+            std::env::set_var("SLACK_APP_TOKEN", "xapp-token");
+            std::env::set_var("SLACK_SOCKET_MODE", "true");
+            std::env::set_var("SLACK_REACTIONS", "0");
+            std::env::set_var("SLACK_REQUIRE_MENTION", "yes");
+            std::env::set_var("SLACK_BOT_USER_ID", "UBOT");
+            std::env::set_var("SLACK_MENTION_PATTERNS", "chompy\\b\n@hermes, sigma");
+            std::env::set_var("SLACK_ALLOWED_USERS", "U1, U2");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        apply_python_named_platform_env(&mut cfg);
+        let slack = cfg.platforms.get("slack").expect("slack block");
+        assert!(slack.enabled);
+        assert_eq!(slack.token.as_deref(), Some("slack-token"));
+        assert_eq!(slack.require_mention, Some(true));
+        assert_eq!(slack.allowed_users, vec!["U1", "U2"]);
+        assert_eq!(
+            slack.extra.get("app_token").and_then(|v| v.as_str()),
+            Some("xapp-token")
+        );
+        assert_eq!(
+            slack.extra.get("socket_mode").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            slack.extra.get("reactions").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            slack.extra.get("bot_user_id").and_then(|v| v.as_str()),
+            Some("UBOT")
+        );
+        assert_eq!(
+            slack
+                .extra
+                .get("mention_patterns")
+                .and_then(|v| v.as_array())
+                .map(|items| items
+                    .iter()
+                    .filter_map(|item| item.as_str())
+                    .collect::<Vec<_>>()),
+            Some(vec!["chompy\\b", "@hermes", "sigma"])
+        );
+
+        unsafe {
+            std::env::remove_var("SLACK_BOT_TOKEN");
+            std::env::remove_var("SLACK_APP_TOKEN");
+            std::env::remove_var("SLACK_SOCKET_MODE");
+            std::env::remove_var("SLACK_REACTIONS");
+            std::env::remove_var("SLACK_REQUIRE_MENTION");
+            std::env::remove_var("SLACK_BOT_USER_ID");
+            std::env::remove_var("SLACK_MENTION_PATTERNS");
+            std::env::remove_var("SLACK_ALLOWED_USERS");
+        }
+    }
+
+    #[test]
+    fn slack_env_token_respects_explicit_disable_marker() {
+        let _env = env_lock();
+        unsafe {
+            std::env::set_var("SLACK_BOT_TOKEN", "slack-token");
+        }
+
+        let mut cfg = GatewayConfig::default();
+        let slack = cfg
+            .platforms
+            .entry("slack".to_string())
+            .or_insert_with(PlatformConfig::default);
+        slack.enabled = false;
+        slack
+            .extra
+            .insert("_enabled_explicit".to_string(), json!(true));
+
+        apply_python_named_platform_env(&mut cfg);
+        let slack = cfg.platforms.get("slack").expect("slack block");
+        assert!(!slack.enabled);
+        assert_eq!(slack.token.as_deref(), Some("slack-token"));
+
+        unsafe {
+            std::env::remove_var("SLACK_BOT_TOKEN");
         }
     }
 

--- a/crates/hermes-core/src/errors.rs
+++ b/crates/hermes-core/src/errors.rs
@@ -72,6 +72,9 @@ pub enum GatewayError {
     #[error("Authentication error: {0}")]
     Auth(String),
 
+    #[error("Rate limited{0}", retry_after_secs.map(|s| format!(" (retry after {}s)", s)).unwrap_or_default())]
+    RateLimited { retry_after_secs: Option<u64> },
+
     #[error("Session expired: {0}")]
     SessionExpired(String),
 }
@@ -166,6 +169,14 @@ mod tests {
     fn tool_error_display() {
         let err = ToolError::NotFound("my_tool".into());
         assert_eq!(err.to_string(), "Tool not found: my_tool");
+    }
+
+    #[test]
+    fn gateway_error_rate_limit_display() {
+        let err = GatewayError::RateLimited {
+            retry_after_secs: Some(42),
+        };
+        assert_eq!(err.to_string(), "Rate limited (retry after 42s)");
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/matrix.rs
+++ b/crates/hermes-gateway/src/platforms/matrix.rs
@@ -231,6 +231,20 @@ pub struct RoomMember {
     pub membership: String,
 }
 
+/// Matrix room identity metadata used for DM-vs-room routing decisions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatrixRoomIdentity {
+    pub room_id: String,
+    pub room_name: Option<String>,
+    pub canonical_alias: Option<String>,
+    pub server_name: Option<String>,
+    pub joined_member_count: Option<usize>,
+    pub is_direct_account_data: bool,
+    pub direct_conflict: bool,
+    pub chat_type: String,
+    pub display_name: String,
+}
+
 // ---------------------------------------------------------------------------
 // E2EE support
 // ---------------------------------------------------------------------------
@@ -1638,6 +1652,90 @@ impl MatrixAdapter {
         Ok(members)
     }
 
+    fn room_server_name(room_id: &str) -> Option<String> {
+        room_id
+            .rsplit_once(':')
+            .map(|(_, server)| server.trim())
+            .filter(|server| !server.is_empty())
+            .map(str::to_string)
+    }
+
+    pub fn classify_room_identity(
+        room_id: &str,
+        room_name: Option<String>,
+        canonical_alias: Option<String>,
+        joined_member_count: Option<usize>,
+        is_direct_account_data: bool,
+    ) -> MatrixRoomIdentity {
+        let has_explicit_name = room_name
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|name| !name.is_empty());
+        let is_likely_dm = joined_member_count.is_some_and(|count| count <= 2)
+            || (joined_member_count.is_none() && is_direct_account_data && !has_explicit_name);
+        let direct_conflict = is_direct_account_data
+            && has_explicit_name
+            && joined_member_count.is_none_or(|n| n > 2);
+        let display_name = room_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .or_else(|| {
+                canonical_alias
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|alias| !alias.is_empty())
+            })
+            .unwrap_or(room_id)
+            .to_string();
+
+        MatrixRoomIdentity {
+            room_id: room_id.to_string(),
+            room_name,
+            canonical_alias,
+            server_name: Self::room_server_name(room_id),
+            joined_member_count,
+            is_direct_account_data,
+            direct_conflict,
+            chat_type: if is_likely_dm { "dm" } else { "room" }.to_string(),
+            display_name,
+        }
+    }
+
+    pub async fn resolve_room_identity(
+        &self,
+        room_id: &str,
+        is_direct_account_data: bool,
+    ) -> MatrixRoomIdentity {
+        let room_name = match self.get_room_name(room_id).await {
+            Ok(name) => name,
+            Err(err) => {
+                debug!(room_id, error = %err, "Matrix room name lookup unavailable");
+                None
+            }
+        };
+        let joined_member_count = match self.get_room_members(room_id).await {
+            Ok(members) => Some(
+                members
+                    .iter()
+                    .filter(|member| member.membership == "join")
+                    .count(),
+            ),
+            Err(err) => {
+                debug!(room_id, error = %err, "Matrix room member count lookup unavailable");
+                None
+            }
+        };
+
+        Self::classify_room_identity(
+            room_id,
+            room_name,
+            None,
+            joined_member_count,
+            is_direct_account_data,
+        )
+    }
+
     /// Get the power levels for a room.
     pub async fn get_room_power_levels(
         &self,
@@ -2637,6 +2735,54 @@ mod tests {
             Some("image/png")
         );
         assert_eq!(normalized_image_content_type(Some("text/plain")), None);
+    }
+
+    #[test]
+    fn matrix_room_identity_uses_member_count_for_named_dm() {
+        let identity = MatrixAdapter::classify_room_identity(
+            "!dm:example.org",
+            Some("Alice & Hermes".into()),
+            None,
+            Some(2),
+            true,
+        );
+
+        assert_eq!(identity.chat_type, "dm");
+        assert!(!identity.direct_conflict);
+        assert_eq!(identity.display_name, "Alice & Hermes");
+        assert_eq!(identity.server_name.as_deref(), Some("example.org"));
+    }
+
+    #[test]
+    fn matrix_room_identity_marks_stale_direct_room_conflict() {
+        let identity = MatrixAdapter::classify_room_identity(
+            "!room:example.org",
+            Some("Project Room".into()),
+            Some("#project:example.org".into()),
+            Some(3),
+            true,
+        );
+
+        assert_eq!(identity.chat_type, "room");
+        assert!(identity.direct_conflict);
+        assert_eq!(identity.joined_member_count, Some(3));
+    }
+
+    #[test]
+    fn matrix_room_identity_falls_back_to_direct_name_heuristic_without_count() {
+        let unnamed_direct =
+            MatrixAdapter::classify_room_identity("!legacy:example.org", None, None, None, true);
+        assert_eq!(unnamed_direct.chat_type, "dm");
+
+        let named_direct = MatrixAdapter::classify_room_identity(
+            "!legacy-room:example.org",
+            Some("Explicit Room".into()),
+            None,
+            None,
+            true,
+        );
+        assert_eq!(named_direct.chat_type, "room");
+        assert!(named_direct.direct_conflict);
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -12,10 +12,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use regex::{Regex, RegexBuilder};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
@@ -54,6 +55,18 @@ pub struct SlackConfig {
     /// Whether reaction lifecycle updates are enabled.
     #[serde(default = "default_true")]
     pub reactions: bool,
+
+    /// Whether non-DM channel messages must mention or wake-word address the bot.
+    #[serde(default)]
+    pub require_mention: bool,
+
+    /// Optional Slack bot user id used for literal `<@BOTID>` mention checks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bot_user_id: Option<String>,
+
+    /// Extra regex wake words accepted when `require_mention` is enabled.
+    #[serde(default)]
+    pub mention_patterns: Vec<String>,
 
     /// Proxy configuration for outbound requests.
     #[serde(default)]
@@ -202,6 +215,24 @@ pub struct IncomingSlackMessage {
     pub is_bot: bool,
 }
 
+/// Token-free mention policy used by Socket Mode routing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SlackMentionPolicy {
+    pub require_mention: bool,
+    pub bot_user_id: Option<String>,
+    pub mention_patterns: Vec<String>,
+}
+
+impl SlackMentionPolicy {
+    fn from_config(config: &SlackConfig) -> Self {
+        Self {
+            require_mention: config.require_mention,
+            bot_user_id: config.bot_user_id.clone(),
+            mention_patterns: config.mention_patterns.clone(),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Socket Mode session management
 // ---------------------------------------------------------------------------
@@ -231,13 +262,23 @@ pub enum SocketModeAction {
 pub struct SocketModeSession {
     state: SocketModeConnectionState,
     envelopes_acked: u64,
+    mention_policy: SlackMentionPolicy,
 }
 
 impl SocketModeSession {
     pub fn new() -> Self {
+        Self::with_mention_policy(SlackMentionPolicy::default())
+    }
+
+    pub fn with_config(config: &SlackConfig) -> Self {
+        Self::with_mention_policy(SlackMentionPolicy::from_config(config))
+    }
+
+    pub fn with_mention_policy(mention_policy: SlackMentionPolicy) -> Self {
         Self {
             state: SocketModeConnectionState::Disconnected,
             envelopes_acked: 0,
+            mention_policy,
         }
     }
 
@@ -280,7 +321,8 @@ impl SocketModeSession {
             }
             "events_api" => {
                 self.envelopes_acked += 1;
-                match SlackAdapter::parse_event(envelope) {
+                match SlackAdapter::parse_event_with_mention_policy(envelope, &self.mention_policy)
+                {
                     Some(msg) => SocketModeAction::MessageEvent(msg),
                     None => SocketModeAction::Ack,
                 }
@@ -917,6 +959,45 @@ impl SlackAdapter {
 
     /// Parse a Socket Mode envelope into an IncomingSlackMessage.
     pub fn parse_event(envelope: &SocketModeEnvelope) -> Option<IncomingSlackMessage> {
+        Self::parse_event_unfiltered(envelope)
+    }
+
+    /// Parse a Socket Mode envelope and apply Slack mention/wake-word policy.
+    pub fn parse_event_with_config(
+        envelope: &SocketModeEnvelope,
+        config: &SlackConfig,
+    ) -> Option<IncomingSlackMessage> {
+        Self::parse_event_with_mention_policy(envelope, &SlackMentionPolicy::from_config(config))
+    }
+
+    pub fn parse_event_with_mention_policy(
+        envelope: &SocketModeEnvelope,
+        policy: &SlackMentionPolicy,
+    ) -> Option<IncomingSlackMessage> {
+        let msg = Self::parse_event_unfiltered(envelope)?;
+        if slack_event_is_dm(envelope, &msg.channel) || !policy.require_mention {
+            return Some(msg);
+        }
+
+        let env_bot_user_id = std::env::var("SLACK_BOT_USER_ID")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let bot_user_id = policy
+            .bot_user_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .or(env_bot_user_id.as_deref());
+
+        if slack_message_is_addressed(&msg.text, bot_user_id, &policy.mention_patterns) {
+            return Some(msg);
+        }
+
+        None
+    }
+
+    fn parse_event_unfiltered(envelope: &SocketModeEnvelope) -> Option<IncomingSlackMessage> {
         let payload = envelope.payload.as_ref()?;
         let event = payload.get("event")?;
 
@@ -1352,6 +1433,109 @@ fn reactions_toggle_enabled(raw: Option<&str>, default_enabled: bool) -> bool {
     }
 }
 
+fn slack_event_is_dm(envelope: &SocketModeEnvelope, channel_id: &str) -> bool {
+    let channel_type = envelope
+        .payload
+        .as_ref()
+        .and_then(|payload| payload.get("event"))
+        .and_then(|event| event.get("channel_type"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    matches!(channel_type, "im" | "mpim") || channel_id.starts_with('D')
+}
+
+fn parse_slack_mention_pattern_values(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        match value {
+            serde_json::Value::Array(values) => {
+                return values
+                    .into_iter()
+                    .filter_map(|value| match value {
+                        serde_json::Value::String(s) => Some(s),
+                        serde_json::Value::Number(n) => Some(n.to_string()),
+                        _ => None,
+                    })
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+            serde_json::Value::String(s) => {
+                return s
+                    .trim()
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|part| !part.is_empty())
+                    .map(str::to_string)
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+
+    trimmed
+        .replace('\n', ",")
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn slack_mention_pattern_sources(configured: &[String]) -> Vec<String> {
+    let mut patterns: Vec<String> = configured
+        .iter()
+        .flat_map(|pattern| parse_slack_mention_pattern_values(pattern))
+        .collect();
+    if patterns.is_empty() {
+        if let Ok(raw) = std::env::var("SLACK_MENTION_PATTERNS") {
+            patterns = parse_slack_mention_pattern_values(&raw);
+        }
+    }
+    patterns
+}
+
+fn compile_slack_mention_patterns(configured: &[String]) -> Vec<Regex> {
+    slack_mention_pattern_sources(configured)
+        .into_iter()
+        .filter_map(
+            |pattern| match RegexBuilder::new(&pattern).case_insensitive(true).build() {
+                Ok(regex) => Some(regex),
+                Err(err) => {
+                    warn!(pattern = %pattern, error = %err, "Invalid Slack mention pattern");
+                    None
+                }
+            },
+        )
+        .collect()
+}
+
+fn slack_message_matches_mention_patterns(text: &str, configured: &[String]) -> bool {
+    if text.trim().is_empty() {
+        return false;
+    }
+    compile_slack_mention_patterns(configured)
+        .iter()
+        .any(|pattern| pattern.is_match(text))
+}
+
+fn slack_message_is_addressed(
+    text: &str,
+    bot_user_id: Option<&str>,
+    mention_patterns: &[String],
+) -> bool {
+    if let Some(bot_user_id) = bot_user_id.map(str::trim).filter(|s| !s.is_empty()) {
+        if text.contains(&format!("<@{bot_user_id}>")) {
+            return true;
+        }
+    }
+    slack_message_matches_mention_patterns(text, mention_patterns)
+}
+
 /// Split a message into chunks that fit within the given max length.
 fn split_message(text: &str, max_len: usize) -> Vec<String> {
     if text.len() <= max_len {
@@ -1405,8 +1589,28 @@ fn slack_image_url_blocks(image_url: &str, caption: Option<&str>) -> (serde_json
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
     use wiremock::matchers::{method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn slack_test_config() -> SlackConfig {
+        SlackConfig {
+            token: "xoxb-test".into(),
+            app_token: None,
+            socket_mode: false,
+            reactions: true,
+            require_mention: false,
+            bot_user_id: None,
+            mention_patterns: Vec::new(),
+            proxy: AdapterProxyConfig::default(),
+        }
+    }
 
     // --- Original tests (preserved) ---
 
@@ -1479,6 +1683,133 @@ mod tests {
             })),
         };
         assert!(SlackAdapter::parse_event(&env).is_none());
+    }
+
+    #[test]
+    fn slack_mention_patterns_parse_json_string_and_csv_newlines() {
+        assert_eq!(
+            parse_slack_mention_pattern_values(r#"["^\\s*chompy\\b","@hermes"]"#),
+            vec![r"^\s*chompy\b", "@hermes"]
+        );
+        assert_eq!(
+            parse_slack_mention_pattern_values("chompy\\b\n@hermes, sigma"),
+            vec!["chompy\\b", "@hermes", "sigma"]
+        );
+        assert_eq!(
+            parse_slack_mention_pattern_values(r#""hey hermes""#),
+            vec!["hey hermes"]
+        );
+    }
+
+    #[test]
+    fn slack_mention_patterns_env_fallback_splits_mixed_csv_and_newlines() {
+        let _env = env_lock();
+        unsafe {
+            std::env::set_var("SLACK_MENTION_PATTERNS", "chompy\\b\n@hermes, sigma");
+        }
+        assert!(slack_message_matches_mention_patterns(
+            "SIGMA status",
+            &Vec::new()
+        ));
+        assert!(slack_message_matches_mention_patterns(
+            "hey @Hermes",
+            &Vec::new()
+        ));
+        assert!(!slack_message_matches_mention_patterns(
+            "plain channel chatter",
+            &Vec::new()
+        ));
+        unsafe {
+            std::env::remove_var("SLACK_MENTION_PATTERNS");
+        }
+    }
+
+    #[test]
+    fn parse_event_with_config_requires_mention_but_accepts_wake_word() {
+        let mut cfg = slack_test_config();
+        cfg.require_mention = true;
+        cfg.bot_user_id = Some("UBOT".into());
+        cfg.mention_patterns = vec![r"^\s*chompy\b".into()];
+
+        let env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env123".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "Chompy check gateway",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "user": "U456",
+                    "ts": "1.0"
+                }
+            })),
+        };
+
+        let msg = SlackAdapter::parse_event_with_config(&env, &cfg).unwrap();
+        assert_eq!(msg.text, "Chompy check gateway");
+    }
+
+    #[test]
+    fn parse_event_with_config_blocks_unaddressed_channel_but_allows_dm() {
+        let mut cfg = slack_test_config();
+        cfg.require_mention = true;
+        cfg.bot_user_id = Some("UBOT".into());
+
+        let channel_env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env123".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "general channel chatter",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "user": "U456",
+                    "ts": "1.0"
+                }
+            })),
+        };
+        assert!(SlackAdapter::parse_event_with_config(&channel_env, &cfg).is_none());
+
+        let dm_env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env124".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "dm chatter",
+                    "channel": "D123",
+                    "channel_type": "im",
+                    "user": "U456",
+                    "ts": "2.0"
+                }
+            })),
+        };
+        assert!(SlackAdapter::parse_event_with_config(&dm_env, &cfg).is_some());
+    }
+
+    #[test]
+    fn parse_event_with_config_accepts_literal_bot_mention() {
+        let mut cfg = slack_test_config();
+        cfg.require_mention = true;
+        cfg.bot_user_id = Some("UBOT".into());
+
+        let env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env123".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "<@UBOT> status",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "user": "U456",
+                    "ts": "1.0"
+                }
+            })),
+        };
+        assert!(SlackAdapter::parse_event_with_config(&env, &cfg).is_some());
     }
 
     // --- Socket Mode session ---
@@ -1556,6 +1887,50 @@ mod tests {
             })),
         };
         assert_eq!(session.handle_envelope(&non_msg), SocketModeAction::Ack);
+        assert_eq!(session.envelopes_acked(), 2);
+    }
+
+    #[test]
+    fn handle_envelope_events_api_respects_mention_policy() {
+        let mut cfg = slack_test_config();
+        cfg.require_mention = true;
+        cfg.mention_patterns = vec![r"^\s*chompy\b".into()];
+        let mut session = SocketModeSession::with_config(&cfg);
+
+        let unaddressed = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("e1".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "general chatter",
+                    "channel": "C9",
+                    "channel_type": "channel",
+                    "user": "UA",
+                    "ts": "1.2"
+                }
+            })),
+        };
+        assert_eq!(session.handle_envelope(&unaddressed), SocketModeAction::Ack);
+
+        let addressed = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("e2".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "Chompy status",
+                    "channel": "C9",
+                    "channel_type": "channel",
+                    "user": "UA",
+                    "ts": "1.3"
+                }
+            })),
+        };
+        match session.handle_envelope(&addressed) {
+            SocketModeAction::MessageEvent(m) => assert_eq!(m.text, "Chompy status"),
+            other => panic!("Expected MessageEvent, got {:?}", other),
+        }
         assert_eq!(session.envelopes_acked(), 2);
     }
 
@@ -1868,6 +2243,9 @@ mod tests {
             app_token: None,
             socket_mode: false,
             reactions: true,
+            require_mention: false,
+            bot_user_id: None,
+            mention_patterns: Vec::new(),
             proxy: AdapterProxyConfig::default(),
         })
         .expect("adapter");
@@ -1904,6 +2282,9 @@ mod tests {
             app_token: None,
             socket_mode: false,
             reactions: true,
+            require_mention: false,
+            bot_user_id: None,
+            mention_patterns: Vec::new(),
             proxy: AdapterProxyConfig::default(),
         })
         .expect("adapter");

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -1891,6 +1891,8 @@ impl TelegramAdapter {
             Ok(resp) => {
                 let description = resp
                     .description
+                    .as_deref()
+                    .map(str::to_string)
                     .unwrap_or_else(|| format!("{method} failed"));
                 if Self::thread_or_reply_missing(&description)
                     && Self::strip_thread_fields_for_fallback(&mut body)
@@ -1899,13 +1901,12 @@ impl TelegramAdapter {
                     if retry.ok {
                         return Ok(retry);
                     }
-                    return Err(GatewayError::SendFailed(
-                        retry
-                            .description
-                            .unwrap_or_else(|| format!("{method} fallback failed")),
+                    return Err(Self::telegram_response_error(
+                        &format!("{method} fallback"),
+                        &retry,
                     ));
                 }
-                Err(GatewayError::SendFailed(description))
+                Err(Self::telegram_response_error(method, &resp))
             }
             Err(err) if Self::gateway_error_thread_or_reply_missing(&err) => {
                 if Self::strip_thread_fields_for_fallback(&mut body) {
@@ -2186,10 +2187,9 @@ impl TelegramAdapter {
         let status = resp.status();
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             let body_text = resp.text().await.unwrap_or_default();
-            return Err(GatewayError::SendFailed(format!(
-                "Rate limited on {}: {}",
-                request.method, body_text
-            )));
+            return Err(GatewayError::RateLimited {
+                retry_after_secs: Self::retry_after_from_telegram_body(&body_text),
+            });
         }
 
         let result: TelegramResponse<SentMessage> = resp.json().await.map_err(|e| {
@@ -2208,11 +2208,7 @@ impl TelegramAdapter {
                 )
             })
         } else {
-            Err(GatewayError::SendFailed(
-                result
-                    .description
-                    .unwrap_or_else(|| format!("{} failed", request.method)),
-            ))
+            Err(Self::telegram_response_error(request.method, &result))
         }
     }
 
@@ -2740,6 +2736,31 @@ impl TelegramAdapter {
     /// Detects HTTP 429 (rate limited) responses, extracts `retry_after`
     /// from the response body, sleeps, then retries up to
     /// `RATE_LIMIT_MAX_RETRIES` times.
+    fn telegram_response_error<T>(method: &str, response: &TelegramResponse<T>) -> GatewayError {
+        if let Some(retry_after_secs) = response
+            .parameters
+            .as_ref()
+            .and_then(|parameters| parameters.retry_after)
+        {
+            return GatewayError::RateLimited {
+                retry_after_secs: Some(retry_after_secs),
+            };
+        }
+
+        GatewayError::SendFailed(
+            response
+                .description
+                .clone()
+                .unwrap_or_else(|| format!("{method} failed")),
+        )
+    }
+
+    fn retry_after_from_telegram_body(text: &str) -> Option<u64> {
+        serde_json::from_str::<serde_json::Value>(text)
+            .ok()
+            .and_then(|value| value.get("parameters")?.get("retry_after")?.as_u64())
+    }
+
     async fn post_json<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
@@ -2757,17 +2778,13 @@ impl TelegramAdapter {
             if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
                 let text = resp.text().await.unwrap_or_default();
 
-                let retry_after = serde_json::from_str::<serde_json::Value>(&text)
-                    .ok()
-                    .and_then(|v| v.get("parameters")?.get("retry_after")?.as_u64())
-                    .unwrap_or(5);
+                let retry_after = Self::retry_after_from_telegram_body(&text).unwrap_or(5);
 
                 retries += 1;
                 if retries > RATE_LIMIT_MAX_RETRIES {
-                    return Err(GatewayError::SendFailed(format!(
-                        "Rate limited after {} retries (retry_after={}s): {}",
-                        retries, retry_after, text
-                    )));
+                    return Err(GatewayError::RateLimited {
+                        retry_after_secs: Some(retry_after),
+                    });
                 }
 
                 warn!(
@@ -2781,6 +2798,11 @@ impl TelegramAdapter {
 
             if !status.is_success() {
                 let text = resp.text().await.unwrap_or_default();
+                if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    return Err(GatewayError::RateLimited {
+                        retry_after_secs: Self::retry_after_from_telegram_body(&text),
+                    });
+                }
                 return Err(GatewayError::SendFailed(format!(
                     "Telegram API returned HTTP {}: {}",
                     status, text
@@ -4800,6 +4822,37 @@ mod tests {
         let resp: TelegramResponse<serde_json::Value> = serde_json::from_str(json).unwrap();
         assert!(!resp.ok);
         assert_eq!(resp.parameters.as_ref().unwrap().retry_after, Some(5));
+    }
+
+    #[test]
+    fn telegram_response_error_uses_typed_retry_after() {
+        let resp: TelegramResponse<serde_json::Value> = serde_json::from_value(serde_json::json!({
+            "ok": false,
+            "description": "Too Many Requests: retry after 37",
+            "parameters": {"retry_after": 37}
+        }))
+        .unwrap();
+        let err = TelegramAdapter::telegram_response_error("sendRichMessage", &resp);
+        assert!(matches!(
+            err,
+            GatewayError::RateLimited {
+                retry_after_secs: Some(37)
+            }
+        ));
+    }
+
+    #[test]
+    fn telegram_retry_after_parser_reads_bot_api_body() {
+        assert_eq!(
+            TelegramAdapter::retry_after_from_telegram_body(
+                r#"{"ok":false,"parameters":{"retry_after":25}}"#
+            ),
+            Some(25)
+        );
+        assert_eq!(
+            TelegramAdapter::retry_after_from_telegram_body(r#"{"ok":false}"#),
+            None
+        );
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T08:37:52.088568+00:00`_
+_Generated from source artifacts: `2026-06-25T09:41:00.871757+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T08:21:54.340532+00:00`
-- Proof snapshot generated: `2026-06-25T08:37:52.088568+00:00`
+- Queue snapshot generated: `2026-06-25T09:41:00.732386+00:00`
+- Proof snapshot generated: `2026-06-25T09:41:00.871757+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T08:37:52.088568+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=207.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=207.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=206.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=206.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-25T08:37:52.088568+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 6997 |
-| Pending | 207 |
-| Ported | 385 |
-| Superseded | 6329 |
+| Total commits in queue | 7011 |
+| Pending | 206 |
+| Ported | 391 |
+| Superseded | 6338 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 207.0,
+        "actual": 206.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T08:37:52.088568+00:00",
+  "generated_at_utc": "2026-06-25T09:41:00.871757+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 207.0,
+    "max_queue_pending_commits": 206.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,22 +299,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 207,
-      "ported": 385,
-      "superseded": 6329
+      "pending": 206,
+      "ported": 391,
+      "superseded": 6338
     },
     "by_target_ticket": {
-      "20": 3132,
+      "20": 3139,
       "21": 130,
       "22": 957,
       "23": 488,
       "24": 22,
       "25": 145,
-      "26": 2123
+      "26": 2130
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 6997
+    "total_commits": 7011
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 207.0,
+        "actual": 206.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T08:37:52.088568+00:00`
+Generated: `2026-06-25T09:41:00.871757+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T08:37:52.088568+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 207.0 |
+| `max_queue_pending_commits` | 206.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-25T08:37:52.088568+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `6997`.
+- Upstream missing commits tracked: `7011`.
 - By target ticket:
-  - `#20`: `3132`
+  - `#20`: `3139`
   - `#21`: `130`
   - `#22`: `957`
   - `#23`: `488`
   - `#24`: `22`
   - `#25`: `145`
-  - `#26`: `2123`
+  - `#26`: `2130`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4453,6 +4453,36 @@
       "disposition": "superseded",
       "notes": "Upstream fixes a Python re import and Python test relocation after WhatsApp adapter plugin migration. The Rust WhatsApp module is compile-tested under the whatsapp feature and has no Python adapter import path.",
       "owner": "rust-runtime"
+    },
+    "49662687646d": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Slack Socket Mode session handling now enforces require_mention with literal <@bot_user_id> mentions and documented mention_patterns wake-word regexes. CLI config mapping and SLACK_MENTION_PATTERNS env bridging are covered by focused Rust tests."
+    },
+    "441bd6d8dbe5": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Slack mention-pattern parsing accepts JSON list/string values and mixed newline/comma fallback from SLACK_MENTION_PATTERNS, with tests covering the CSV/newline split regression."
+    },
+    "4aa793345ec9": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Matrix adapter now has MatrixRoomIdentity classification and async resolution helpers that use joined_member_count <= 2 as the primary DM signal, preserve named DMs, and flag stale m.direct conflicts for rooms with 3+ members. Focused tests cover named DM and stale direct-room behavior."
+    },
+    "404b06ac4fc3": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Telegram send paths now surface Bot API parameters.retry_after as typed GatewayError::RateLimited for JSON and multipart sends, preserving server-requested flood-control delay instead of flattening it into a generic SendFailed string. Focused tests cover retry_after parsing and typed error mapping."
+    },
+    "4314d451ca96": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust gateway media cache already accepts arbitrary inbound document bytes and records unknown types as application/octet-stream, while Slack/Telegram/Discord document surfaces preserve file metadata and focused media/Telegram document tests cover the behavior."
+    },
+    "b5bd66eac9b1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Telegram parser already preserves current documents and replied group documents when the addressed message has no own media, only filtering oversized documents. Existing Telegram parse tests cover document metadata and replied-document size behavior."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T08:21:54.340532+00:00`
+Generated: `2026-06-25T09:41:00.732386+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `6997`.
+- Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3132 |
+| #20 | GPAR-01 tests+CI parity | 3139 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 957 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 145 |
-| #26 | GPAR-07 upstream queue backfill | 2123 |
+| #26 | GPAR-07 upstream queue backfill | 2130 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 207 |
-| ported | 385 |
-| superseded | 6329 |
+| pending | 206 |
+| ported | 391 |
+| superseded | 6338 |
 
 ## First 100 Pending Commits
 
@@ -123,5 +123,5 @@ Generated: `2026-06-25T08:21:54.340532+00:00`
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
 | `0768ed3b33e4` | #26 | docs(agents): fix stale platform adapter path in token-lock note |
 | `95d53c3bcb06` | #20 | feat(cli): /reasoning full — show complete thinking, not 10-line clamp (#50499) |
-| `4314d451ca96` | #20 | fix(gateway): accept any inbound file type across all messaging platforms |
-| `b5bd66eac9b1` | #20 | fix(telegram): observed/replied group docs of any type are cached too |
+| `b9b4756ab480` | #22 | fix dashboard chat session titles |
+| `a61baa961572` | #26 | feat(desktop): PR-style file diffs in chat |


### PR DESCRIPTION
## Summary
- Port Slack wake-word parity into Rust Socket Mode handling: `require_mention`, literal `<@bot_user_id>`, config/env `mention_patterns`, and CLI/env wiring.
- Port Telegram Bot API `retry_after` flood-control metadata into typed `GatewayError::RateLimited` JSON/multipart send paths.
- Add Matrix room identity classification/resolution using `joined_member_count <= 2` as the DM signal and stale `m.direct` conflict detection.
- Refresh parity ledgers and move six upstream rows to `ported`.

## Closed upstream rows
- `49662687646d` Slack documented `mention_patterns` wake words
- `441bd6d8dbe5` Slack CSV/newline mention-pattern fallback
- `4aa793345ec9` Matrix `member_count` DM signal for named DM rooms
- `404b06ac4fc3` Telegram `retry_after` flood-control signal
- `4314d451ca96` arbitrary inbound file-type/document cache evidence
- `b5bd66eac9b1` Telegram observed/replied group docs evidence

## Verification
- `cargo test -p hermes-config`: 182 lib tests + 8 prop tests passed
- `cargo test -p hermes-core`: 72 lib tests + 1 invalid-json prop + 4 reasoning-content props + 2 parser props passed
- `cargo test -p hermes-gateway --features slack,telegram,matrix`: 442 lib tests + 11 contract tests + 1 e2e + 2 SSRF props passed; doc-test ignored/ok
- `cargo check --workspace`: passed
- `cargo check -p hermes-cli --features gateway-slack,gateway-telegram,gateway-matrix`: passed
- `scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-config -p hermes-gateway -p hermes-cli --features hermes-gateway/slack,hermes-gateway/telegram,hermes-gateway/matrix,hermes-cli/gateway-slack,hermes-cli/gateway-telegram,hermes-cli/gateway-matrix`: `seen=200 allowlist=200 new=0 stale=0`
- `cargo build --workspace`: passed
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- `scripts/check-rust-runtime-no-python.sh`: passed
- `scripts/check-runtime-placeholders.sh`: passed
- diff-scoped `gpt-4o|4o` literal check: no new literals

## Parity dashboard
- Queue total: 7011
- Pending: 206
- Ported: 391
- Superseded: 6338
- Test coverage audit: PASS
- SOTA harness matrix: PASS
- Behavioral similarity diff: PASS
- Deep problem-solving diff: PASS

Known existing gate state: release/CI tree-drift gates still fail on pending queue/tree drift thresholds, not on this slice's local checks.
