### PR TITLE
parity(gateway): classify send failures by kind

### DIFF
--- a/crates/hermes-core/src/errors.rs
+++ b/crates/hermes-core/src/errors.rs
@@ -57,6 +57,137 @@ pub enum ToolError {
     SchemaViolation(String),
 }
 
+/// Platform-neutral category for gateway send failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SendErrorKind {
+    /// Content exceeded a platform message-size cap.
+    TooLong,
+    /// Markup/entities could not be parsed by the platform.
+    BadFormat,
+    /// The bot is blocked, kicked, unauthenticated, or lacks post rights.
+    Forbidden,
+    /// The target chat, thread, topic, or message no longer exists.
+    NotFound,
+    /// Platform flood control or rate limiting throttled the send.
+    RateLimited,
+    /// Connection-level failure that is safe to retry.
+    Transient,
+    /// No known provider error shape matched.
+    Unknown,
+}
+
+impl SendErrorKind {
+    pub const ALL: [Self; 7] = [
+        Self::TooLong,
+        Self::BadFormat,
+        Self::Forbidden,
+        Self::NotFound,
+        Self::RateLimited,
+        Self::Transient,
+        Self::Unknown,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TooLong => "too_long",
+            Self::BadFormat => "bad_format",
+            Self::Forbidden => "forbidden",
+            Self::NotFound => "not_found",
+            Self::RateLimited => "rate_limited",
+            Self::Transient => "transient",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for SendErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub const SEND_ERROR_KINDS: &[SendErrorKind] = &SendErrorKind::ALL;
+
+/// Classify a provider send failure without tying consumers to raw text shapes.
+pub fn classify_send_error_text(error_text: &str) -> SendErrorKind {
+    let blob = error_text.to_lowercase();
+    if blob.trim().is_empty() {
+        return SendErrorKind::Unknown;
+    }
+
+    if blob.contains("message_too_long")
+        || blob.contains("too long")
+        || blob.contains("message is too long")
+    {
+        return SendErrorKind::TooLong;
+    }
+
+    if blob.contains("can't parse entities")
+        || blob.contains("cant parse entities")
+        || blob.contains("can't find end")
+        || blob.contains("unsupported start tag")
+        || (blob.contains("entity") && blob.contains("parse"))
+        || (blob.contains("bad request") && blob.contains("entit"))
+    {
+        return SendErrorKind::BadFormat;
+    }
+
+    if blob.contains("forbidden")
+        || blob.contains("bot was blocked")
+        || blob.contains("blocked by the user")
+        || blob.contains("user is deactivated")
+        || blob.contains("not enough rights")
+        || blob.contains("have no rights")
+        || blob.contains("not a member")
+    {
+        return SendErrorKind::Forbidden;
+    }
+
+    if blob.contains("chat not found")
+        || blob.contains("message to edit not found")
+        || blob.contains("message to reply not found")
+        || blob.contains("thread not found")
+        || blob.contains("topic_deleted")
+        || blob.contains("message_id_invalid")
+    {
+        return SendErrorKind::NotFound;
+    }
+
+    if blob.contains("flood")
+        || blob.contains("too many requests")
+        || blob.contains("retry after")
+        || blob.contains("rate limit")
+    {
+        return SendErrorKind::RateLimited;
+    }
+
+    if blob.contains("timeout")
+        || blob.contains("timed out")
+        || blob.contains("connection reset")
+        || blob.contains("connection aborted")
+        || blob.contains("connection refused")
+        || blob.contains("connection closed")
+        || blob.contains("broken pipe")
+        || blob.contains("temporarily unavailable")
+        || blob.contains("dns")
+        || blob.contains("tls")
+        || blob.contains("ssl")
+        || blob.contains("econnreset")
+        || blob.contains("econnrefused")
+        || blob.contains("connecttimeout")
+        || blob.contains("network")
+        || blob.contains("transport")
+        || blob.contains("http 502")
+        || blob.contains("http 503")
+        || blob.contains("http 504")
+    {
+        return SendErrorKind::Transient;
+    }
+
+    SendErrorKind::Unknown
+}
+
 /// Error type for gateway / platform communication failures.
 #[derive(Debug, thiserror::Error)]
 pub enum GatewayError {
@@ -77,6 +208,29 @@ pub enum GatewayError {
 
     #[error("Session expired: {0}")]
     SessionExpired(String),
+}
+
+impl GatewayError {
+    pub fn send_error_kind(&self) -> SendErrorKind {
+        match self {
+            GatewayError::RateLimited { .. } => SendErrorKind::RateLimited,
+            GatewayError::Auth(message) => match classify_send_error_text(message) {
+                SendErrorKind::Unknown => SendErrorKind::Forbidden,
+                kind => kind,
+            },
+            GatewayError::ConnectionFailed(message) => match classify_send_error_text(message) {
+                SendErrorKind::Unknown => SendErrorKind::Transient,
+                kind => kind,
+            },
+            GatewayError::SendFailed(message)
+            | GatewayError::Platform(message)
+            | GatewayError::SessionExpired(message) => classify_send_error_text(message),
+        }
+    }
+
+    pub fn is_send_error_kind(&self, kind: SendErrorKind) -> bool {
+        self.send_error_kind() == kind
+    }
 }
 
 /// Error type for configuration parsing and validation.
@@ -177,6 +331,77 @@ mod tests {
             retry_after_secs: Some(42),
         };
         assert_eq!(err.to_string(), "Rate limited (retry after 42s)");
+    }
+
+    #[test]
+    fn send_error_kind_names_match_wire_contract() {
+        let names: Vec<_> = SEND_ERROR_KINDS.iter().map(|kind| kind.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "too_long",
+                "bad_format",
+                "forbidden",
+                "not_found",
+                "rate_limited",
+                "transient",
+                "unknown",
+            ]
+        );
+        assert_eq!(
+            serde_json::to_string(&SendErrorKind::TooLong).unwrap(),
+            "\"too_long\""
+        );
+    }
+
+    #[test]
+    fn classify_send_error_text_covers_provider_shapes() {
+        let cases = [
+            ("Bad Request: message_too_long", SendErrorKind::TooLong),
+            (
+                "Bad Request: can't parse entities: Can't find end of the entity",
+                SendErrorKind::BadFormat,
+            ),
+            (
+                "Forbidden: bot was blocked by the user",
+                SendErrorKind::Forbidden,
+            ),
+            ("Bad Request: chat not found", SendErrorKind::NotFound),
+            (
+                "Too Many Requests: retry after 12",
+                SendErrorKind::RateLimited,
+            ),
+            (
+                "request failed: connection reset by peer",
+                SendErrorKind::Transient,
+            ),
+            ("provider said no", SendErrorKind::Unknown),
+        ];
+
+        for (text, expected) in cases {
+            assert_eq!(classify_send_error_text(text), expected, "{text}");
+        }
+    }
+
+    #[test]
+    fn gateway_error_exposes_send_error_kind() {
+        assert_eq!(
+            GatewayError::RateLimited {
+                retry_after_secs: Some(5)
+            }
+            .send_error_kind(),
+            SendErrorKind::RateLimited
+        );
+        assert_eq!(
+            GatewayError::Auth("bad token".into()).send_error_kind(),
+            SendErrorKind::Forbidden
+        );
+        assert_eq!(
+            GatewayError::ConnectionFailed("dial failed".into()).send_error_kind(),
+            SendErrorKind::Transient
+        );
+        assert!(GatewayError::SendFailed("message_id_invalid".into())
+            .is_send_error_kind(SendErrorKind::NotFound));
     }
 
     #[test]

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -15,7 +15,10 @@ pub mod types;
 pub mod version;
 
 // Re-export all error types
-pub use errors::{AgentError, ConfigError, GatewayError, ToolError};
+pub use errors::{
+    classify_send_error_text, AgentError, ConfigError, GatewayError, SendErrorKind, ToolError,
+    SEND_ERROR_KINDS,
+};
 
 // Re-export all core types
 pub use types::{

--- a/crates/hermes-gateway/src/stream.rs
+++ b/crates/hermes-gateway/src/stream.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 
+use hermes_core::errors::{GatewayError, SendErrorKind};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio::time::Instant;
@@ -602,6 +603,16 @@ impl StreamConsumer {
         self.already_sent = true;
     }
 
+    /// Record a failed edit from a typed send-failure category.
+    pub fn mark_edit_failed_by_kind(&mut self, kind: SendErrorKind) {
+        self.mark_edit_failed(matches!(kind, SendErrorKind::RateLimited));
+    }
+
+    /// Record a failed edit from the shared gateway error taxonomy.
+    pub fn mark_edit_failed_for_error(&mut self, error: &GatewayError) {
+        self.mark_edit_failed_by_kind(error.send_error_kind());
+    }
+
     // -- Segment management -------------------------------------------------
 
     /// Does the consumer need the caller to start a new message (i.e., there
@@ -853,6 +864,38 @@ mod tests {
         c.mark_edit_success("msg_1");
 
         c.mark_edit_failed(false);
+        assert!(!c.edit_supported());
+        assert!(c.fallback_final_send());
+        assert!(c.already_sent());
+    }
+
+    #[test]
+    fn consumer_rate_limited_error_uses_flood_backoff() {
+        let mut c = StreamConsumer::new("tg", "c1", StreamConfig::default());
+        c.on_delta("text");
+        c.mark_edit_success("msg_1");
+
+        c.mark_edit_failed_for_error(&GatewayError::SendFailed(
+            "Too Many Requests: retry after 3".into(),
+        ));
+
+        assert_eq!(c.flood_strikes(), 1);
+        assert_eq!(c.current_edit_interval_ms(), 600);
+        assert!(c.edit_supported());
+        assert!(!c.fallback_final_send());
+    }
+
+    #[test]
+    fn consumer_permanent_send_error_falls_back_immediately() {
+        let mut c = StreamConsumer::new("tg", "c1", StreamConfig::default());
+        c.on_delta("text");
+        c.mark_edit_success("msg_1");
+
+        c.mark_edit_failed_for_error(&GatewayError::SendFailed(
+            "Forbidden: bot was blocked by the user".into(),
+        ));
+
+        assert_eq!(c.flood_strikes(), 0);
         assert!(!c.edit_supported());
         assert!(c.fallback_final_send());
         assert!(c.already_sent());

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T09:41:00.871757+00:00`_
+_Generated from source artifacts: `2026-06-25T09:53:46.928327+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T09:41:00.732386+00:00`
-- Proof snapshot generated: `2026-06-25T09:41:00.871757+00:00`
+- Queue snapshot generated: `2026-06-25T09:53:46.748993+00:00`
+- Proof snapshot generated: `2026-06-25T09:53:46.928327+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T09:41:00.871757+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=206.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=206.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=205.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=205.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T09:41:00.871757+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7011 |
-| Pending | 206 |
-| Ported | 391 |
+| Pending | 205 |
+| Ported | 392 |
 | Superseded | 6338 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 206.0,
+        "actual": 205.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T09:41:00.871757+00:00",
+  "generated_at_utc": "2026-06-25T09:53:46.928327+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 206.0,
+    "max_queue_pending_commits": 205.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 206,
-      "ported": 391,
+      "pending": 205,
+      "ported": 392,
       "superseded": 6338
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 206.0,
+        "actual": 205.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T09:41:00.871757+00:00`
+Generated: `2026-06-25T09:53:46.928327+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T09:41:00.871757+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 206.0 |
+| `max_queue_pending_commits` | 205.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4474,6 +4474,11 @@
       "owner": "rust-runtime",
       "notes": "Rust Telegram send paths now surface Bot API parameters.retry_after as typed GatewayError::RateLimited for JSON and multipart sends, preserving server-requested flood-control delay instead of flattening it into a generic SendFailed string. Focused tests cover retry_after parsing and typed error mapping."
     },
+    "c0409a87ff05": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust core now exposes the platform-neutral SendErrorKind taxonomy, classify_send_error_text, and GatewayError::send_error_kind for deterministic send-failure branching. StreamConsumer can consume typed GatewayError/SendErrorKind values so rate-limited edit failures keep adaptive flood backoff while permanent send failures fall back immediately, with focused hermes-core and hermes-gateway tests."
+    },
     "4314d451ca96": {
       "disposition": "ported",
       "owner": "rust-runtime",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T09:41:00.732386+00:00`
+Generated: `2026-06-25T09:53:46.748993+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T09:41:00.732386+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 206 |
-| ported | 391 |
+| pending | 205 |
+| ported | 392 |
 | superseded | 6338 |
 
 ## First 100 Pending Commits
@@ -104,7 +104,6 @@ Generated: `2026-06-25T09:41:00.732386+00:00`
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
 | `5e3e89cc05d3` | #23 | feat(hindsight): configurable embedded daemon health grace timeout (#50341) |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
-| `c0409a87ff05` | #23 | feat(gateway): typed send-error classification (SendResult.error_kind) (#50342) |
 | `b6d107240819` | #20 | fix(cli): branch new worktrees from the fresh remote tip, not stale local HEAD (#50355) |
 | `5b45fb269a06` | #20 | fix(security): sanitize kanban markdown html |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T09:41:00.732386+00:00`
 | `95d53c3bcb06` | #20 | feat(cli): /reasoning full — show complete thinking, not 10-line clamp (#50499) |
 | `b9b4756ab480` | #22 | fix dashboard chat session titles |
 | `a61baa961572` | #26 | feat(desktop): PR-style file diffs in chat |
+| `c6fbd5a10494` | #26 | style(desktop): lead --dt-font-mono with bundled JetBrains Mono |


### PR DESCRIPTION
## Summary
- Add a Rust-native `SendErrorKind` taxonomy plus `classify_send_error_text` and `GatewayError::send_error_kind` in `hermes-core`.
- Add `StreamConsumer` helpers that consume `SendErrorKind` / `GatewayError`, preserving adaptive flood backoff for rate-limited edits and immediate fallback for permanent failures.
- Mark upstream `c0409a87ff05` as ported and regenerate parity queue/proof/dashboard artifacts.

## Parity
- Closes upstream row `c0409a87ff05` (`feat(gateway): typed send-error classification (SendResult.error_kind)`).
- Queue delta: pending `206 -> 205`, ported `391 -> 392`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-core --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway consumer_rate_limited_error_uses_flood_backoff --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway consumer_permanent_send_error_falls_back_immediately --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features slack,telegram,matrix stream --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features slack,telegram,matrix --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo check -p hermes-core -p hermes-gateway --features hermes-gateway/slack,hermes-gateway/telegram,hermes-gateway/matrix`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-gateway --features hermes-gateway/slack,hermes-gateway/telegram,hermes-gateway/matrix` (`new=0`)
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace`
- `git diff -U0 | rg -n "gpt-4o|4o"` guard returned no matches
