### PR TITLE
parity(model-switch): keep failed swaps as no-ops

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -333,6 +333,10 @@ pub struct App {
     pub quorum_armed_once: bool,
     /// Animated companion pet settings.
     pub pet_settings: PetSettings,
+
+    /// Test-only hook for proving model-switch rollback on rebuild failure.
+    #[cfg(test)]
+    fail_model_rebuild_for: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -404,6 +408,8 @@ impl Clone for App {
             pending_system_notes: self.pending_system_notes.clone(),
             quorum_armed_once: self.quorum_armed_once,
             pet_settings: self.pet_settings.clone(),
+            #[cfg(test)]
+            fail_model_rebuild_for: self.fail_model_rebuild_for.clone(),
         }
     }
 }
@@ -2172,6 +2178,8 @@ impl App {
             pending_system_notes: Vec::new(),
             quorum_armed_once: false,
             pet_settings: load_pet_settings(),
+            #[cfg(test)]
+            fail_model_rebuild_for: None,
         };
         app.ensure_session_stub_snapshot();
         Ok(app)
@@ -2678,11 +2686,30 @@ impl App {
 
     /// Switch the active model, rebuilding the provider and agent loop.
     pub fn switch_model(&mut self, provider_model: &str) {
-        self.current_model = provider_model.to_string();
+        if let Err(err) = self.try_switch_model(provider_model) {
+            tracing::warn!(
+                model = provider_model,
+                error = %err,
+                "Model switch failed; keeping previous model"
+            );
+        }
+    }
+
+    /// Switch the active model transactionally.
+    ///
+    /// The new provider/agent is built before mutating `current_model`, runtime
+    /// env, or session persistence so a failed rebuild is a no-op for the
+    /// current conversation.
+    pub fn try_switch_model(&mut self, provider_model: &str) -> Result<(), AgentError> {
+        let next_model = provider_model.trim();
+        if next_model.is_empty() {
+            return Err(AgentError::Config("model cannot be empty".to_string()));
+        }
+
+        let next_agent = self.build_agent_for_model(next_model)?;
+        self.current_model = next_model.to_string();
         sync_runtime_model_env(&self.config, &self.current_model);
-
-        self.rebuild_agent_for_active_session();
-
+        self.agent = next_agent;
         match SessionPersistence::new(&self.state_root)
             .update_session_model(&self.session_id, &self.current_model)
         {
@@ -2696,6 +2723,12 @@ impl App {
         }
 
         tracing::info!("Switched model to: {}", provider_model);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_model_rebuild_failure_for_test(&mut self, provider_model: &str) {
+        self.fail_model_rebuild_for = Some(provider_model.to_string());
     }
 
     /// Warn before a user-initiated model switch if the current transcript is
@@ -2711,22 +2744,56 @@ impl App {
     }
 
     fn rebuild_agent_for_active_session(&mut self) {
-        let provider = build_provider(&self.config, &self.current_model);
-        let mut agent_config = build_agent_config(&self.config, &self.current_model);
-        agent_config.session_id = Some(self.session_id.clone());
-        let agent_tool_registry = Arc::new(bridge_tool_registry(&self.tool_registry));
+        match self.build_agent_for_model(&self.current_model) {
+            Ok(agent) => {
+                self.agent = agent;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    model = %self.current_model,
+                    error = %err,
+                    "Agent rebuild failed; keeping previous agent"
+                );
+            }
+        }
+    }
 
-        let agent_inner = hermes_agent::attach_discovered_memory(AgentLoop::new(
-            agent_config,
-            agent_tool_registry,
-            provider,
-        ))
-        .with_callbacks(Self::stream_callbacks(self.stream_handle_shared.clone()));
-        let orchestrator = Arc::new(SubAgentOrchestrator::from_parent(
-            &agent_inner,
-            self.state_root.clone(),
-        ));
-        self.agent = Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator));
+    fn build_agent_for_model(&self, provider_model: &str) -> Result<Arc<AgentLoop>, AgentError> {
+        #[cfg(test)]
+        if self
+            .fail_model_rebuild_for
+            .as_deref()
+            .is_some_and(|model| model == provider_model)
+        {
+            return Err(AgentError::Config(format!(
+                "test forced rebuild failure for {provider_model}"
+            )));
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let provider = build_provider(&self.config, provider_model);
+            let mut agent_config = build_agent_config(&self.config, provider_model);
+            agent_config.session_id = Some(self.session_id.clone());
+            let agent_tool_registry = Arc::new(bridge_tool_registry(&self.tool_registry));
+
+            let agent_inner = hermes_agent::attach_discovered_memory(AgentLoop::new(
+                agent_config,
+                agent_tool_registry,
+                provider,
+            ))
+            .with_callbacks(Self::stream_callbacks(self.stream_handle_shared.clone()));
+            let orchestrator = Arc::new(SubAgentOrchestrator::from_parent(
+                &agent_inner,
+                self.state_root.clone(),
+            ));
+            Arc::new(agent_inner.with_sub_agent_orchestrator(orchestrator))
+        }));
+
+        result.map_err(|_| {
+            AgentError::Config(format!(
+                "model switch rebuild panicked for {provider_model}"
+            ))
+        })
     }
 
     pub fn refresh_agent_tool_snapshot(&mut self) -> AgentToolSnapshotRefresh {
@@ -4157,6 +4224,7 @@ mod tests {
             pending_system_notes: Vec::new(),
             quorum_armed_once: false,
             pet_settings: PetSettings::default(),
+            fail_model_rebuild_for: None,
         }
     }
 
@@ -4263,6 +4331,80 @@ mod tests {
         assert_eq!(
             app.agent.config.session_id.as_deref(),
             Some(app.session_id.as_str())
+        );
+
+        for (key, value) in saved_env {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
+    fn try_switch_model_failure_is_noop_for_session_state() {
+        let _guard = env_test_lock();
+        let env_keys = [
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+            "HERMES_TUI_PROVIDER",
+        ];
+        let saved_env: Vec<(&str, Option<String>)> = env_keys
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = build_minimal_test_app_with_state_root(tmp.path().to_path_buf());
+        let persistence = SessionPersistence::new(tmp.path());
+        persistence
+            .persist_session(
+                &app.session_id,
+                &[hermes_core::Message::user("hello")],
+                Some(&app.current_model),
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let old_model = "anthropic:claude-sonnet-4-6";
+        app.try_switch_model(old_model).expect("baseline switch");
+        let old_agent_model = app.agent.config.model.clone();
+        assert_eq!(
+            persistence.get_session_model(&app.session_id).unwrap(),
+            Some(old_model.to_string())
+        );
+        assert_eq!(
+            std::env::var("HERMES_MODEL").ok().as_deref(),
+            Some(old_model)
+        );
+
+        let broken_model = "openrouter:zai/glm-5.2";
+        app.force_model_rebuild_failure_for_test(broken_model);
+        let err = app
+            .try_switch_model(broken_model)
+            .expect_err("forced rebuild failure");
+
+        assert!(err.to_string().contains("test forced rebuild failure"));
+        assert_eq!(app.current_model, old_model);
+        assert_eq!(app.agent.config.model, old_agent_model);
+        assert_eq!(
+            persistence.get_session_model(&app.session_id).unwrap(),
+            Some(old_model.to_string())
+        );
+        assert_eq!(
+            std::env::var("HERMES_MODEL").ok().as_deref(),
+            Some(old_model)
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_MODEL").ok().as_deref(),
+            Some(old_model)
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_PROVIDER").ok().as_deref(),
+            Some("anthropic")
         );
 
         for (key, value) in saved_env {

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -4315,6 +4315,23 @@ fn format_model_persistence_note(app: &App) -> String {
     note
 }
 
+fn try_switch_model_or_emit_failure(app: &mut App, provider_model: &str) -> bool {
+    let previous_model = app.current_model.clone();
+    match app.try_switch_model(provider_model) {
+        Ok(()) => true,
+        Err(err) => {
+            emit_command_output(
+                app,
+                format!(
+                    "Model switch to {} failed ({}); staying on {}.",
+                    provider_model, err, previous_model
+                ),
+            );
+            false
+        }
+    }
+}
+
 async fn pick_model_for_provider(
     app: &mut App,
     provider: &str,
@@ -4375,7 +4392,9 @@ async fn pick_model_for_provider(
     let (guarded, note) =
         guard_provider_model_selection_for_config(&provider_model, &app.config).await?;
     let warning = app.model_switch_preflight_warning(&guarded);
-    app.switch_model(&guarded);
+    if !try_switch_model_or_emit_failure(app, &guarded) {
+        return Ok(false);
+    }
     let mut msg = format!("Model switched to: {}", guarded);
     if let Some(n) = note {
         msg.push_str("\n");
@@ -5076,7 +5095,9 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
                 }
             }
             let warning = app.model_switch_preflight_warning(&guarded);
-            app.switch_model(&guarded);
+            if !try_switch_model_or_emit_failure(app, &guarded) {
+                return Ok(CommandResult::Handled);
+            }
             let mut msg = format!("Model switched to: {}", guarded);
             if let Some(n) = note {
                 msg.push_str("\n");
@@ -31527,6 +31548,41 @@ install_command: "uv pip install -r requirements.txt"
             1,
             "warning must not append model context"
         );
+    }
+
+    #[tokio::test]
+    async fn model_switch_command_failure_does_not_commit_or_claim_success() {
+        let _lock = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        let mut cfg = (*app.config).clone();
+        cfg.model = Some("anthropic:claude-sonnet-4-6".to_string());
+        cfg.llm_providers.insert(
+            "compact-provider".to_string(),
+            LlmProviderConfig {
+                models: vec!["deepseek-chat".to_string()],
+                discover_models: false,
+                ..LlmProviderConfig::default()
+            },
+        );
+        app.config = Arc::new(cfg);
+        app.try_switch_model("anthropic:claude-sonnet-4-6")
+            .expect("baseline switch");
+        app.force_model_rebuild_failure_for_test("compact-provider:deepseek-chat");
+
+        handle_model_command(
+            &mut app,
+            &["deepseek-chat", "--provider", "compact-provider"],
+        )
+        .await
+        .expect("model switch failure should be reported, not thrown");
+
+        let out = latest_ui_assistant_text(&app);
+        assert!(out.contains("Model switch to compact-provider:deepseek-chat failed"));
+        assert!(out.contains("staying on anthropic:claude-sonnet-4-6"));
+        assert!(!out.contains("Model switched to: compact-provider:deepseek-chat"));
+        assert_eq!(app.current_model, "anthropic:claude-sonnet-4-6");
     }
 
     #[test]

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -4802,7 +4802,17 @@ async fn process_modal_confirm(state: &mut TuiState, app: &mut App) -> Result<()
         PickerKind::ModelForProvider { provider } => {
             let provider_model = format!("{provider}:{}", item.value.trim());
             let warning = app.model_switch_preflight_warning(&provider_model);
-            app.switch_model(&provider_model);
+            if let Err(err) = app.try_switch_model(&provider_model) {
+                let previous = app.current_model.clone();
+                let notice = format!(
+                    "Model switch to {} failed ({}); staying on {}.",
+                    provider_model, err, previous
+                );
+                app.push_ui_assistant(notice.clone());
+                state.close_modal();
+                state.status_message = notice;
+                return Ok(());
+            }
             let mut notice = format!("Model switched to: {}", provider_model);
             if let Some(warning) = warning.as_deref() {
                 notice.push('\n');

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T09:53:46.928327+00:00`_
+_Generated from source artifacts: `2026-06-25T10:11:20.433534+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T09:53:46.748993+00:00`
-- Proof snapshot generated: `2026-06-25T09:53:46.928327+00:00`
+- Queue snapshot generated: `2026-06-25T10:11:20.158160+00:00`
+- Proof snapshot generated: `2026-06-25T10:11:20.433534+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T09:53:46.928327+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=205.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=205.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=204.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=204.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T09:53:46.928327+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7011 |
-| Pending | 205 |
-| Ported | 392 |
+| Pending | 204 |
+| Ported | 393 |
 | Superseded | 6338 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 205.0,
+        "actual": 204.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T09:53:46.928327+00:00",
+  "generated_at_utc": "2026-06-25T10:11:20.433534+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 205.0,
+    "max_queue_pending_commits": 204.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 205,
-      "ported": 392,
+      "pending": 204,
+      "ported": 393,
       "superseded": 6338
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 205.0,
+        "actual": 204.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T09:53:46.928327+00:00`
+Generated: `2026-06-25T10:11:20.433534+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T09:53:46.928327+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 205.0 |
+| `max_queue_pending_commits` | 204.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4474,6 +4474,11 @@
       "owner": "rust-runtime",
       "notes": "Rust Telegram send paths now surface Bot API parameters.retry_after as typed GatewayError::RateLimited for JSON and multipart sends, preserving server-requested flood-control delay instead of flattening it into a generic SendFailed string. Focused tests cover retry_after parsing and typed error mapping."
     },
+    "99f3072aa06a": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust CLI model switching is now transactional: App::try_switch_model builds the replacement provider/agent before mutating current_model, runtime env, or session DB state, while user-facing /model and TUI picker paths abort with a failure notice instead of claiming success. Focused app and command tests force a rebuild failure and verify the old model, env, agent config, and session model remain intact."
+    },
     "c0409a87ff05": {
       "disposition": "ported",
       "owner": "rust-runtime",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T09:53:46.748993+00:00`
+Generated: `2026-06-25T10:11:20.158160+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T09:53:46.748993+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 205 |
-| ported | 392 |
+| pending | 204 |
+| ported | 393 |
 | superseded | 6338 |
 
 ## First 100 Pending Commits
@@ -107,7 +107,6 @@ Generated: `2026-06-25T09:53:46.748993+00:00`
 | `b6d107240819` | #20 | fix(cli): branch new worktrees from the fresh remote tip, not stale local HEAD (#50355) |
 | `5b45fb269a06` | #20 | fix(security): sanitize kanban markdown html |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
-| `99f3072aa06a` | #20 | fix(model-switch): a failed in-place swap must be a no-op, not a dead session (#50375) |
 | `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
 | `7785655b4ece` | #26 | fix(desktop): keep the floating composer in-bounds so it can't be lost off-screen |
 | `37c37c9dc511` | #26 | fix(antigravity): register google-antigravity ProviderProfile + AUTHOR_MAP |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T09:53:46.748993+00:00`
 | `b9b4756ab480` | #22 | fix dashboard chat session titles |
 | `a61baa961572` | #26 | feat(desktop): PR-style file diffs in chat |
 | `c6fbd5a10494` | #26 | style(desktop): lead --dt-font-mono with bundled JetBrains Mono |
+| `ac128af1cec3` | #26 | feat(desktop): syntax-highlight inline diffs via Shiki |


### PR DESCRIPTION
## Summary
- Make CLI model switching transactional with `App::try_switch_model`: build the replacement provider/agent before mutating `current_model`, runtime env, or session DB state.
- Update user-facing `/model` and TUI model picker paths to abort with a failure notice instead of claiming success when a switch fails.
- Add focused regressions that force a rebuild failure and verify the old model, env, agent config, and session DB model remain intact.
- Mark upstream `99f3072aa06a` as ported and regenerate parity queue/proof/dashboard artifacts.

## Parity
- Closes upstream row `99f3072aa06a` (`fix(model-switch): a failed in-place swap must be a no-op, not a dead session`).
- Queue delta: pending `205 -> 204`, ported `392 -> 393`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff -U0 | rg -n "gpt-4o|4o"` guard returned no matches
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli try_switch_model_failure_is_noop_for_session_state --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli model_switch_command_failure_does_not_commit_or_claim_success --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli model_switch --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo check -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli` (`new=0`)
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace`
