### PR TITLE
parity(cli): add reasoning full display mode

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -434,7 +434,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/redraw", "Force a local repaint pulse in the TUI"),
     (
         "/reasoning",
-        "Reasoning controls (display + effort: status/on/off/set <low|medium|high|xhigh>)",
+        "Reasoning controls (display + effort: status/on/off/full/clamp/set <level>)",
     ),
     (
         "/raw",
@@ -12944,8 +12944,18 @@ fn reasoning_display_flag() -> &'static std::sync::atomic::AtomicBool {
     &SHOW_REASONING
 }
 
+fn reasoning_full_flag() -> &'static std::sync::atomic::AtomicBool {
+    static FULL_REASONING: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+    &FULL_REASONING
+}
+
 fn set_reasoning_display(enabled: bool) {
     reasoning_display_flag().store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub(crate) fn set_reasoning_full(enabled: bool) {
+    reasoning_full_flag().store(enabled, std::sync::atomic::Ordering::Relaxed);
 }
 
 fn toggle_reasoning_display() -> bool {
@@ -12955,6 +12965,10 @@ fn toggle_reasoning_display() -> bool {
 
 fn reasoning_display_enabled() -> bool {
     reasoning_display_flag().load(std::sync::atomic::Ordering::Relaxed)
+}
+
+pub(crate) fn reasoning_full_enabled() -> bool {
+    reasoning_full_flag().load(std::sync::atomic::Ordering::Relaxed)
 }
 
 fn parse_reasoning_effort(raw: &str) -> Result<Option<&'static str>, AgentError> {
@@ -13136,11 +13150,16 @@ fn handle_reasoning_command(app: &mut App, args: &[&str]) -> Result<CommandResul
             emit_command_output(
                 app,
                 format!(
-                    "Reasoning status\n- display: {}\n- effort: {}\n- provider: {}",
+                    "Reasoning status\n- display: {}\n- mode: {}\n- effort: {}\n- provider: {}",
                     if reasoning_display_enabled() {
                         "ON"
                     } else {
                         "OFF"
+                    },
+                    if reasoning_full_enabled() {
+                        "full"
+                    } else {
+                        "clamp"
                     },
                     effort,
                     provider
@@ -13170,6 +13189,20 @@ fn handle_reasoning_command(app: &mut App, args: &[&str]) -> Result<CommandResul
             emit_command_output(
                 app,
                 "Reasoning display: OFF — model reasoning will be hidden.",
+            );
+        }
+        "full" => {
+            set_reasoning_full(true);
+            emit_command_output(
+                app,
+                "Reasoning mode: full — live thinking previews keep complete text.",
+            );
+        }
+        "clamp" => {
+            set_reasoning_full(false);
+            emit_command_output(
+                app,
+                "Reasoning mode: clamp — live thinking previews use compact caps.",
             );
         }
         "set" | "level" | "effort" => {
@@ -13203,8 +13236,9 @@ fn handle_reasoning_command(app: &mut App, args: &[&str]) -> Result<CommandResul
                 app,
                 "Reasoning controls:\n\
                  - /reasoning                 Toggle reasoning display\n\
-                 - /reasoning status          Show display + effort state\n\
+                 - /reasoning status          Show display + mode + effort state\n\
                  - /reasoning on|off          Explicitly show/hide reasoning\n\
+                 - /reasoning full|clamp      Keep full thinking previews or compact them\n\
                  - /reasoning set <level>     Set provider reasoning effort\n\
                  Levels: minimal, low, medium, high, xhigh, auto",
             );
@@ -28112,6 +28146,21 @@ mod tests {
         }
     }
 
+    struct ReasoningFullResetGuard;
+
+    impl ReasoningFullResetGuard {
+        fn new() -> Self {
+            set_reasoning_full(false);
+            Self
+        }
+    }
+
+    impl Drop for ReasoningFullResetGuard {
+        fn drop(&mut self) {
+            set_reasoning_full(false);
+        }
+    }
+
     async fn build_test_app_with_stream(home: &Path) -> App {
         let config_dir = home.join("config");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
@@ -28383,6 +28432,41 @@ mod tests {
             latest_ui_assistant_text(&app),
             hermes_core::version::version_label()
         );
+    }
+
+    #[tokio::test]
+    async fn reasoning_full_and_clamp_commands_update_mode_and_status() {
+        let _guard = env_test_lock();
+        let _reasoning_guard = ReasoningFullResetGuard::new();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        let result = handle_slash_command(&mut app, "/reasoning", &["full"])
+            .await
+            .expect("reasoning full command");
+        assert_eq!(result, CommandResult::Handled);
+        assert!(reasoning_full_enabled());
+        assert!(latest_ui_assistant_text(&app).contains("Reasoning mode: full"));
+
+        handle_slash_command(&mut app, "/reasoning", &["status"])
+            .await
+            .expect("reasoning status command");
+        let status = latest_ui_assistant_text(&app);
+        assert!(status.contains("- display: OFF"));
+        assert!(status.contains("- mode: full"));
+        assert!(status.contains("- effort: auto"));
+
+        handle_slash_command(&mut app, "/reasoning", &["help"])
+            .await
+            .expect("reasoning help command");
+        assert!(latest_ui_assistant_text(&app).contains("/reasoning full|clamp"));
+
+        handle_slash_command(&mut app, "/reasoning", &["clamp"])
+            .await
+            .expect("reasoning clamp command");
+        assert!(!reasoning_full_enabled());
+        assert!(latest_ui_assistant_text(&app).contains("Reasoning mode: clamp"));
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -1226,17 +1226,22 @@ pub async fn provider_model_ids_with_client(
     client: &ModelsDevClient,
 ) -> Vec<String> {
     let normalized = canonical_provider_id(provider);
-    let curated = provider_curated_models(&normalized);
+    let catalog_provider = if normalized == "nous-api" {
+        "nous"
+    } else {
+        normalized.as_str()
+    };
+    let curated = provider_curated_models(catalog_provider);
     if curated.is_empty() {
         return Vec::new();
     }
-    if let Some(cached) = load_provider_catalog_cache(&normalized) {
+    if let Some(cached) = load_provider_catalog_cache(catalog_provider) {
         if !cached.is_empty() {
             return cached;
         }
     }
 
-    let computed = if normalized == "bedrock" {
+    let computed = if catalog_provider == "bedrock" {
         let region = resolve_bedrock_region();
         let mut seen: HashSet<String> = HashSet::new();
         let mut merged: Vec<String> = Vec::new();
@@ -1261,7 +1266,7 @@ pub async fn provider_model_ids_with_client(
             }
         }
         merged
-    } else if matches!(normalized.as_str(), "nous" | "nous-api") {
+    } else if catalog_provider == "nous" {
         // Nous model picker should always include curated compatibility picks
         // (including kimi-k2.6), then append live/models.dev discoveries.
         let mut seen: HashSet<String> = HashSet::new();
@@ -1297,7 +1302,7 @@ pub async fn provider_model_ids_with_client(
         } else {
             merged
         }
-    } else if normalized == "huggingface" {
+    } else if catalog_provider == "huggingface" {
         // For Hugging Face, prefer curated stable picks first, then append live
         // router models and models.dev-discovered agentic entries.
         let mut seen: HashSet<String> = HashSet::new();
@@ -1331,12 +1336,12 @@ pub async fn provider_model_ids_with_client(
         }
         merged
     } else if matches!(
-        normalized.as_str(),
+        catalog_provider,
         "gmi" | "arcee" | "xiaomi" | "tencent-tokenhub"
     ) {
         let mut seen: HashSet<String> = HashSet::new();
         let mut merged: Vec<String> = Vec::new();
-        if let Some((base_url, token)) = openai_compatible_catalog_credentials(&normalized) {
+        if let Some((base_url, token)) = openai_compatible_catalog_credentials(catalog_provider) {
             let live = fetch_openai_compatible_live_models(base_url.as_str(), Some(&token)).await;
             for model in live {
                 let key = model.to_ascii_lowercase();
@@ -1352,13 +1357,13 @@ pub async fn provider_model_ids_with_client(
             }
         }
         merged
-    } else if is_local_openai_compatible_provider(&normalized) {
+    } else if is_local_openai_compatible_provider(catalog_provider) {
         let mut seen: HashSet<String> = HashSet::new();
         let mut merged: Vec<String> = Vec::new();
-        if let Some(base_url) = local_provider_resolved_base_url(&normalized) {
+        if let Some(base_url) = local_provider_resolved_base_url(catalog_provider) {
             let live = fetch_openai_compatible_live_models(
                 base_url.as_str(),
-                local_provider_api_key(&normalized).as_deref(),
+                local_provider_api_key(catalog_provider).as_deref(),
             )
             .await;
             for model in live {
@@ -1375,19 +1380,19 @@ pub async fn provider_model_ids_with_client(
             }
         }
         merged
-    } else if !is_models_dev_preferred_provider(&normalized) {
+    } else if !is_models_dev_preferred_provider(catalog_provider) {
         curated.iter().map(|model| model.to_string()).collect()
     } else {
         // Best-effort refresh: if fetch/list fails or returns empty, curated stays as fallback.
         client.fetch(false).await;
-        let models_dev = client.list_agentic_models(&normalized);
+        let models_dev = client.list_agentic_models(catalog_provider);
         if models_dev.is_empty() {
             curated.iter().map(|model| model.to_string()).collect()
         } else {
             merge_with_models_dev(&models_dev, curated)
         }
     };
-    persist_provider_catalog_cache(&normalized, &computed);
+    persist_provider_catalog_cache(catalog_provider, &computed);
     computed
 }
 
@@ -1811,6 +1816,9 @@ mod tests {
 
     #[tokio::test]
     async fn nous_provider_uses_curated_plus_openrouter_agentic_catalog() {
+        let _guard = env_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = ScopedCatalogEnv::new(tmp.path());
         let client = seeded_client(json!({
             "openrouter": {
                 "models": {

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -676,6 +676,9 @@ impl TuiState {
             self.live_thinking.push(' ');
         }
         self.live_thinking.push_str(chunk);
+        if crate::commands::reasoning_full_enabled() {
+            return;
+        }
         const MAX_CHARS: usize = 260;
         if self.live_thinking.chars().count() > MAX_CHARS {
             let tail: String = self
@@ -2156,7 +2159,11 @@ fn render_live_details(
                     .bg(colors.background),
             ),
             Span::styled(
-                truncate_chars(&state.live_thinking, 140),
+                if crate::commands::reasoning_full_enabled() {
+                    state.live_thinking.clone()
+                } else {
+                    truncate_chars(&state.live_thinking, 140)
+                },
                 Style::default().fg(colors.accent).bg(colors.background),
             ),
         ]));
@@ -5851,6 +5858,21 @@ mod tests {
         test_env_lock::lock()
     }
 
+    struct ReasoningFullGuard;
+
+    impl ReasoningFullGuard {
+        fn set(enabled: bool) -> Self {
+            crate::commands::set_reasoning_full(enabled);
+            Self
+        }
+    }
+
+    impl Drop for ReasoningFullGuard {
+        fn drop(&mut self) {
+            crate::commands::set_reasoning_full(false);
+        }
+    }
+
     #[test]
     fn test_input_mode_display() {
         assert_eq!(InputMode::Normal.to_string(), "NORMAL");
@@ -6037,11 +6059,23 @@ mod tests {
 
     #[test]
     fn test_append_live_thinking_is_capped() {
+        let _guard = env_test_lock();
+        let _reasoning_guard = ReasoningFullGuard::set(false);
         let mut state = TuiState::default();
         let long = "x".repeat(400);
         state.append_live_thinking(&long);
         assert!(state.live_thinking.chars().count() <= 260);
         assert!(state.live_thinking.starts_with('…'));
+    }
+
+    #[test]
+    fn test_append_live_thinking_keeps_full_when_reasoning_full_enabled() {
+        let _guard = env_test_lock();
+        let _reasoning_guard = ReasoningFullGuard::set(true);
+        let mut state = TuiState::default();
+        let long = "x".repeat(400);
+        state.append_live_thinking(&long);
+        assert_eq!(state.live_thinking, long);
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T10:11:20.433534+00:00`_
+_Generated from source artifacts: `2026-06-25T10:30:09.039417+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T10:11:20.158160+00:00`
-- Proof snapshot generated: `2026-06-25T10:11:20.433534+00:00`
+- Queue snapshot generated: `2026-06-25T10:29:48.601584+00:00`
+- Proof snapshot generated: `2026-06-25T10:30:09.039417+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T10:11:20.433534+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=204.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=204.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=203.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=203.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T10:11:20.433534+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7011 |
-| Pending | 204 |
-| Ported | 393 |
+| Pending | 203 |
+| Ported | 394 |
 | Superseded | 6338 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 204.0,
+        "actual": 203.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T10:11:20.433534+00:00",
+  "generated_at_utc": "2026-06-25T10:30:09.039417+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 204.0,
+    "max_queue_pending_commits": 203.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 204,
-      "ported": 393,
+      "pending": 203,
+      "ported": 394,
       "superseded": 6338
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 204.0,
+        "actual": 203.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T10:11:20.433534+00:00`
+Generated: `2026-06-25T10:30:09.039417+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T10:11:20.433534+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 204.0 |
+| `max_queue_pending_commits` | 203.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4484,6 +4484,11 @@
       "owner": "rust-runtime",
       "notes": "Rust core now exposes the platform-neutral SendErrorKind taxonomy, classify_send_error_text, and GatewayError::send_error_kind for deterministic send-failure branching. StreamConsumer can consume typed GatewayError/SendErrorKind values so rate-limited edit failures keep adaptive flood backoff while permanent send failures fall back immediately, with focused hermes-core and hermes-gateway tests."
     },
+    "95d53c3bcb06": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust CLI /reasoning now exposes full|clamp runtime modes, status/help report the active mode, and the TUI live-thinking preview keeps complete text in full mode while retaining compact caps in clamp mode. Focused command and TUI tests cover mode switching, status/help output, and cap bypass behavior; detailed transcript rendering already preserves stored reasoning_content line-for-line."
+    },
     "4314d451ca96": {
       "disposition": "ported",
       "owner": "rust-runtime",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T10:11:20.158160+00:00`
+Generated: `2026-06-25T10:29:48.601584+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T10:11:20.158160+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 204 |
-| ported | 393 |
+| pending | 203 |
+| ported | 394 |
 | superseded | 6338 |
 
 ## First 100 Pending Commits
@@ -120,8 +120,8 @@ Generated: `2026-06-25T10:11:20.158160+00:00`
 | `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
 | `0768ed3b33e4` | #26 | docs(agents): fix stale platform adapter path in token-lock note |
-| `95d53c3bcb06` | #20 | feat(cli): /reasoning full — show complete thinking, not 10-line clamp (#50499) |
 | `b9b4756ab480` | #22 | fix dashboard chat session titles |
 | `a61baa961572` | #26 | feat(desktop): PR-style file diffs in chat |
 | `c6fbd5a10494` | #26 | style(desktop): lead --dt-font-mono with bundled JetBrains Mono |
 | `ac128af1cec3` | #26 | feat(desktop): syntax-highlight inline diffs via Shiki |
+| `64a507da44d2` | #20 | feat(relay): handle passthrough_forward over the WS (Phase 5 §5.1, gateway half) (#50702) |


### PR DESCRIPTION
## Summary
- Port upstream `/reasoning full|clamp` behavior into the Rust CLI/TUI runtime.
- Add `/reasoning` mode status/help output and wire TUI live-thinking previews to keep full text in `full` mode while preserving compact caps in `clamp` mode.
- Harden `nous`/`nous-api` model catalog aliasing so both reuse the same cache identity; this fixed a deterministic full-package test failure from stale per-alias catalog cache state without changing model defaults.
- Mark upstream `95d53c3bcb06` ported and regenerate parity proof/dashboard artifacts.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `if git diff -U0 | rg -n "gpt-4o|4o"; then exit 1; else echo "No new stale model literals in diff."; fi`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli reasoning_full_and_clamp_commands_update_mode_and_status --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli test_append_live_thinking --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli reasoning --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli nous_provider_uses_curated_plus_openrouter_agentic_catalog --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli --quiet`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo check -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace`
