### PR TITLE
parity(mcp): keep HTTP sessions alive

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -720,13 +720,26 @@ fn acp_mcp_server_to_hermes_config(
             }
             Some((name, config))
         }
-        McpServerConfig::Http { name, url, headers }
-        | McpServerConfig::Sse { name, url, headers } => {
+        McpServerConfig::Http {
+            name,
+            url,
+            headers,
+            keepalive_interval,
+        }
+        | McpServerConfig::Sse {
+            name,
+            url,
+            headers,
+            keepalive_interval,
+        } => {
             let name = sanitize_mcp_name_component(name.trim());
             if name.is_empty() || url.trim().is_empty() {
                 return None;
             }
             let mut config = HermesMcpServerConfig::http(url.trim());
+            if let Some(seconds) = keepalive_interval {
+                config = config.with_keepalive_interval(*seconds);
+            }
             if let Some(token) = bearer_token_from_headers(headers) {
                 config = config.with_auth(Arc::new(BearerTokenAuth::new(token)));
             }

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -408,12 +408,16 @@ pub enum McpServerConfig {
         url: String,
         #[serde(default)]
         headers: Vec<EnvVar>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        keepalive_interval: Option<u64>,
     },
     Sse {
         name: String,
         url: String,
         #[serde(default)]
         headers: Vec<EnvVar>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        keepalive_interval: Option<u64>,
     },
 }
 

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -14800,20 +14800,24 @@ fn render_mcp_runtime_status(
                 .unwrap_or("<stdio>");
             let _ = writeln!(
                 out,
-                "  - {:<18} {}  [source:config.yaml; parallel_tool_calls:{}]",
+                "  - {:<18} {}  [source:config.yaml; parallel_tool_calls:{}; keepalive:{}]",
                 server.name,
                 endpoint,
                 if server.supports_parallel_tool_calls {
                     "on"
                 } else {
                     "off"
-                }
+                },
+                server
+                    .keepalive_interval
+                    .map(|secs| format!("{secs}s"))
+                    .unwrap_or_else(|| "default".to_string())
             );
         }
         if let Some(server) = json_servers.iter().find(|server| server.name == name) {
             let _ = writeln!(
                 out,
-                "  - {:<18} {}  [source:mcp_servers.json; {}; enabled:{}; parallel_tool_calls:{}]",
+                "  - {:<18} {}  [source:mcp_servers.json; {}; enabled:{}; parallel_tool_calls:{}; keepalive:{}]",
                 server.name,
                 server.transport_display(),
                 server.transport_kind().as_str(),
@@ -14822,7 +14826,11 @@ fn render_mcp_runtime_status(
                     "on"
                 } else {
                     "off"
-                }
+                },
+                server
+                    .keepalive_interval
+                    .map(|secs| format!("{secs}s"))
+                    .unwrap_or_else(|| "default".to_string())
             );
         }
     }
@@ -25600,7 +25608,7 @@ pub async fn handle_cli_mcp(
                 println!("MCP servers ({}):", mcp_config_path.display());
                 for entry in &config.servers {
                     println!(
-                        "  • {} — {}  [{}; enabled:{}; parallel_tool_calls:{}]",
+                        "  • {} — {}  [{}; enabled:{}; parallel_tool_calls:{}; keepalive:{}]",
                         entry.name,
                         entry.transport_display(),
                         entry.transport_kind().as_str(),
@@ -25609,7 +25617,11 @@ pub async fn handle_cli_mcp(
                             "on"
                         } else {
                             "off"
-                        }
+                        },
+                        entry
+                            .keepalive_interval
+                            .map(|secs| format!("{secs}s"))
+                            .unwrap_or_else(|| "default".to_string())
                     );
                 }
             }
@@ -25695,6 +25707,7 @@ pub async fn handle_cli_mcp(
                 yaml_command,
                 yaml_url,
                 yaml_parallel,
+                None,
                 false,
             )?;
             println!(
@@ -25728,7 +25741,7 @@ pub async fn handle_cli_mcp(
                         .map_err(|e| hermes_core::AgentError::Config(e.to_string()))?;
                     std::fs::write(&mcp_config_path, json)
                         .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-                    update_yaml_mcp_server(&config_dir, &srv, None, None, false, true)?;
+                    update_yaml_mcp_server(&config_dir, &srv, None, None, false, None, true)?;
                     println!("MCP server '{}' removed.", srv);
                     if mcp_auth_path.exists() {
                         let raw = std::fs::read_to_string(&mcp_auth_path).unwrap_or_default();
@@ -25794,6 +25807,13 @@ pub async fn handle_cli_mcp(
                         } else {
                             "off"
                         }
+                    );
+                    println!(
+                        "  Keepalive interval: {}",
+                        entry
+                            .keepalive_interval
+                            .map(|secs| format!("{secs}s"))
+                            .unwrap_or_else(|| "default".to_string())
                     );
                     if entry.transport_kind() == McpTransportKind::Http {
                         let url = entry.url.as_deref().unwrap_or_default();
@@ -25946,7 +25966,8 @@ fn unreal_mcp_entry() -> serde_json::Value {
     serde_json::json!({
         "url": UNREAL_MCP_URL,
         "enabled": true,
-        "supports_parallel_tool_calls": false
+        "supports_parallel_tool_calls": false,
+        "keepalive_interval": 10
     })
 }
 
@@ -25956,6 +25977,7 @@ fn update_yaml_mcp_server(
     command: Option<String>,
     url: Option<String>,
     supports_parallel_tool_calls: bool,
+    keepalive_interval: Option<u64>,
     remove: bool,
 ) -> Result<(), hermes_core::AgentError> {
     let cfg_path = config_dir.join("config.yaml");
@@ -25968,6 +25990,7 @@ fn update_yaml_mcp_server(
             command,
             url,
             supports_parallel_tool_calls,
+            keepalive_interval,
         });
         cfg.mcp_servers.sort_by(|a, b| a.name.cmp(&b.name));
     }
@@ -25997,6 +26020,7 @@ fn upsert_sentrux_mcp_profile(config_dir: &Path) -> Result<bool, hermes_core::Ag
         Some(format!("{SENTRUX_MCP_COMMAND} {SENTRUX_MCP_ARG}")),
         None,
         true,
+        None,
         false,
     )?;
     Ok(command_on_path(SENTRUX_MCP_COMMAND))
@@ -26024,6 +26048,7 @@ fn upsert_unreal_mcp_profile(config_dir: &Path) -> Result<(), hermes_core::Agent
         None,
         Some(UNREAL_MCP_URL.to_string()),
         false,
+        Some(10),
         false,
     )
 }
@@ -26043,7 +26068,15 @@ fn remove_sentrux_mcp_profile(config_dir: &Path) -> Result<(), hermes_core::Agen
         std::fs::write(&mcp_config_path, json)
             .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
     }
-    update_yaml_mcp_server(config_dir, SENTRUX_MCP_SERVER_NAME, None, None, false, true)
+    update_yaml_mcp_server(
+        config_dir,
+        SENTRUX_MCP_SERVER_NAME,
+        None,
+        None,
+        false,
+        None,
+        true,
+    )
 }
 
 fn remove_unreal_mcp_profile(config_dir: &Path) -> Result<(), hermes_core::AgentError> {
@@ -26061,7 +26094,15 @@ fn remove_unreal_mcp_profile(config_dir: &Path) -> Result<(), hermes_core::Agent
         std::fs::write(&mcp_config_path, json)
             .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
     }
-    update_yaml_mcp_server(config_dir, UNREAL_MCP_SERVER_NAME, None, None, false, true)
+    update_yaml_mcp_server(
+        config_dir,
+        UNREAL_MCP_SERVER_NAME,
+        None,
+        None,
+        false,
+        None,
+        true,
+    )
 }
 
 fn sentrux_mcp_status(config_dir: &Path) -> (bool, bool, bool) {
@@ -30536,6 +30577,7 @@ mod tests {
             command: Some("local-mcp".to_string()),
             url: None,
             supports_parallel_tool_calls: false,
+            keepalive_interval: None,
         }];
 
         let status = render_mcp_runtime_status(&yaml, Some(&cfg), &path);
@@ -31106,6 +31148,10 @@ mod tests {
                 .and_then(|v| v.as_bool()),
             Some(false)
         );
+        assert_eq!(
+            unreal.get("keepalive_interval").and_then(|v| v.as_u64()),
+            Some(10)
+        );
 
         let cfg = hermes_config::load_user_config_file(&config_dir.join("config.yaml"))
             .expect("load config.yaml");
@@ -31114,7 +31160,8 @@ mod tests {
                 .iter()
                 .any(|entry| entry.name == UNREAL_MCP_SERVER_NAME
                     && entry.url.as_deref() == Some(UNREAL_MCP_URL)
-                    && !entry.supports_parallel_tool_calls),
+                    && !entry.supports_parallel_tool_calls
+                    && entry.keepalive_interval == Some(10)),
             "config.yaml mcp_servers should include the Unreal HTTP profile"
         );
 

--- a/crates/hermes-cli/src/mcp_config.rs
+++ b/crates/hermes-cli/src/mcp_config.rs
@@ -35,6 +35,8 @@ pub struct McpServerEntry {
     pub enabled: bool,
     #[serde(default)]
     pub supports_parallel_tool_calls: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keepalive_interval: Option<u64>,
     #[serde(default)]
     pub warnings: Vec<String>,
 }
@@ -96,6 +98,8 @@ struct RawMcpServerEntry {
     enabled: Option<bool>,
     #[serde(default)]
     supports_parallel_tool_calls: bool,
+    #[serde(default)]
+    keepalive_interval: Option<u64>,
 }
 
 fn default_enabled() -> bool {
@@ -148,6 +152,7 @@ fn parse_entry(name: &str, raw: RawMcpServerEntry) -> Result<McpServerEntry, Str
         url,
         enabled: raw.enabled.unwrap_or(true),
         supports_parallel_tool_calls: raw.supports_parallel_tool_calls,
+        keepalive_interval: raw.keepalive_interval,
         warnings,
     })
 }
@@ -216,7 +221,8 @@ mod tests {
                 "url": "https://example.com/mcp",
                 "command": "npx",
                 "args": ["-y", "server"],
-                "supports_parallel_tool_calls": true
+                "supports_parallel_tool_calls": true,
+                "keepalive_interval": 10
               }
             }"#,
         )
@@ -225,6 +231,7 @@ mod tests {
         assert_eq!(entry.transport_kind(), McpTransportKind::Http);
         assert_eq!(entry.transport_display(), "https://example.com/mcp");
         assert!(entry.supports_parallel_tool_calls);
+        assert_eq!(entry.keepalive_interval, Some(10));
         assert_eq!(cfg.warnings().count(), 1);
         assert!(cfg
             .warnings()

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -1713,6 +1713,9 @@ pub struct McpServerEntry {
     /// Whether this MCP server supports parallel tool calls safely.
     #[serde(default)]
     pub supports_parallel_tool_calls: bool,
+    /// Optional HTTP/SSE session keepalive cadence in seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keepalive_interval: Option<u64>,
 }
 
 /// Active profile info.
@@ -2046,6 +2049,7 @@ mcp_servers:
   - name: local
     command: hermes-mcp
     auth: null
+    keepalive_interval: 10
 "#,
         )
         .expect("null-valued config fields should deserialize");
@@ -2059,6 +2063,7 @@ mcp_servers:
         assert_eq!(cfg.tts["provider"], serde_json::Value::Null);
         assert_eq!(cfg.mcp_servers.len(), 1);
         assert_eq!(cfg.mcp_servers[0].name, "local");
+        assert_eq!(cfg.mcp_servers[0].keepalive_interval, Some(10));
     }
 
     #[test]

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -97,6 +97,9 @@ pub type LlmCallback = Arc<
 
 const DEFAULT_MCP_CALL_TIMEOUT_SECS: u64 = 300;
 const MAX_MCP_CALL_TIMEOUT_SECS: u64 = 900;
+const DEFAULT_MCP_KEEPALIVE_INTERVAL_SECS: u64 = 180;
+const MIN_MCP_KEEPALIVE_INTERVAL_SECS: u64 = 5;
+const MCP_KEEPALIVE_PROBE_TIMEOUT_SECS: u64 = 30;
 const STALE_TRANSPORT_MARKERS: &[&str] = &[
     "closedresourceerror",
     "closed resource",
@@ -226,6 +229,9 @@ pub struct McpServerConfig {
     /// Whether this server supports concurrent tool calls from one session.
     #[serde(default)]
     pub supports_parallel_tool_calls: bool,
+    /// Optional liveness probe cadence for HTTP/SSE sessions, in seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keepalive_interval: Option<u64>,
     /// Optional sampling policy for server-initiated LLM requests.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sampling: Option<SamplingConfig>,
@@ -245,6 +251,7 @@ impl std::fmt::Debug for McpServerConfig {
                 "supports_parallel_tool_calls",
                 &self.supports_parallel_tool_calls,
             )
+            .field("keepalive_interval", &self.keepalive_interval)
             .field("sampling", &self.sampling)
             .field(
                 "auth_provider",
@@ -261,6 +268,7 @@ impl PartialEq for McpServerConfig {
             && self.env == other.env
             && self.url == other.url
             && self.supports_parallel_tool_calls == other.supports_parallel_tool_calls
+            && self.keepalive_interval == other.keepalive_interval
             && self.sampling == other.sampling
     }
 }
@@ -274,6 +282,7 @@ impl McpServerConfig {
             env: HashMap::new(),
             url: None,
             supports_parallel_tool_calls: false,
+            keepalive_interval: None,
             sampling: None,
             auth_provider: None,
         }
@@ -287,6 +296,7 @@ impl McpServerConfig {
             env: HashMap::new(),
             url: Some(url.into()),
             supports_parallel_tool_calls: false,
+            keepalive_interval: None,
             sampling: None,
             auth_provider: None,
         }
@@ -295,6 +305,12 @@ impl McpServerConfig {
     /// Set explicit parallel-tool-call capability for this server.
     pub fn with_parallel_tool_calls(mut self, enabled: bool) -> Self {
         self.supports_parallel_tool_calls = enabled;
+        self
+    }
+
+    /// Set the HTTP/SSE session keepalive cadence in seconds.
+    pub fn with_keepalive_interval(mut self, seconds: u64) -> Self {
+        self.keepalive_interval = Some(seconds);
         self
     }
 
@@ -699,6 +715,8 @@ pub struct McpClient {
     sampling_metrics: SamplingMetrics,
     /// Timestamp when the client connected (for uptime tracking).
     connected_at: Option<Instant>,
+    /// Latched when a server returns JSON-RPC -32601 for optional `ping`.
+    ping_unsupported: bool,
 }
 
 impl McpClient {
@@ -718,6 +736,7 @@ impl McpClient {
             sampling_tool_rounds: 0,
             sampling_metrics: SamplingMetrics::default(),
             connected_at: None,
+            ping_unsupported: false,
         }
     }
 
@@ -761,6 +780,7 @@ impl McpClient {
 
         self.connected = true;
         self.connected_at = Some(Instant::now());
+        self.ping_unsupported = false;
 
         Ok(())
     }
@@ -898,6 +918,73 @@ impl McpClient {
     /// Return the uptime of this connection, if connected.
     pub fn uptime(&self) -> Option<std::time::Duration> {
         self.connected_at.map(|t| t.elapsed())
+    }
+
+    /// Cheaply exercise the MCP session so HTTP/SSE servers do not expire it idle.
+    pub async fn keepalive_probe(&mut self) -> Result<(), McpError> {
+        if !self.ping_unsupported {
+            match tokio::time::timeout(
+                Duration::from_secs(MCP_KEEPALIVE_PROBE_TIMEOUT_SECS),
+                self.send_request("ping", serde_json::json!({})),
+            )
+            .await
+            {
+                Ok(Ok(_)) => return Ok(()),
+                Ok(Err(err)) if matches!(err, McpError::MethodNotFound(_)) => {
+                    if self.tools.is_empty() {
+                        return Err(err);
+                    }
+                    self.ping_unsupported = true;
+                    info!(
+                        "MCP server does not implement optional ping; using tools/list for keepalive on this connection."
+                    );
+                }
+                Ok(Err(err)) => return Err(err),
+                Err(_) => {
+                    return Err(McpError::ConnectionError(format!(
+                        "MCP keepalive ping timed out after {}s",
+                        MCP_KEEPALIVE_PROBE_TIMEOUT_SECS
+                    )));
+                }
+            }
+        }
+
+        tokio::time::timeout(
+            Duration::from_secs(MCP_KEEPALIVE_PROBE_TIMEOUT_SECS),
+            self.list_tools(),
+        )
+        .await
+        .map_err(|_| {
+            McpError::ConnectionError(format!(
+                "MCP keepalive tools/list timed out after {}s",
+                MCP_KEEPALIVE_PROBE_TIMEOUT_SECS
+            ))
+        })??;
+        Ok(())
+    }
+
+    async fn reconnect_after_keepalive_failure(&mut self) -> Result<(), McpError> {
+        let config = self.config.clone();
+        let sampling_config = self.sampling_config.clone();
+        let sampling_callback = self.sampling_callback.clone();
+        if let Some(mut transport) = self.transport.take() {
+            let _ = transport.close().await;
+        }
+        self.connected = false;
+        self.connected_at = None;
+        self.tools.clear();
+        self.resources.clear();
+
+        let mut replacement = McpClient::new(config);
+        if let Some(config) = sampling_config {
+            replacement.set_sampling_config(config);
+        }
+        if let Some(callback) = sampling_callback {
+            replacement.set_sampling_callback(callback);
+        }
+        replacement.connect().await?;
+        *self = replacement;
+        Ok(())
     }
 
     /// Set the sampling configuration for server-initiated LLM requests.
@@ -1676,6 +1763,111 @@ struct ManagedMcpClient {
     registered_tools: Vec<String>,
     available: Arc<AtomicBool>,
     connected_at: Instant,
+    keepalive_shutdown: Arc<AtomicBool>,
+    keepalive_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+fn mcp_keepalive_interval_duration(config: &McpServerConfig) -> Duration {
+    Duration::from_secs(
+        config
+            .keepalive_interval
+            .unwrap_or(DEFAULT_MCP_KEEPALIVE_INTERVAL_SECS)
+            .max(MIN_MCP_KEEPALIVE_INTERVAL_SECS),
+    )
+}
+
+fn spawn_keepalive_task(
+    server_name: String,
+    config: &McpServerConfig,
+    client: SharedMcpClient,
+    available: Arc<AtomicBool>,
+    shutdown: Arc<AtomicBool>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if !config.is_http() {
+        return None;
+    }
+    let interval = mcp_keepalive_interval_duration(config);
+    Some(tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            if shutdown.load(Ordering::SeqCst) || !available.load(Ordering::SeqCst) {
+                break;
+            }
+
+            let probe = {
+                let mut client = client.lock().await;
+                client.keepalive_probe().await
+            };
+            if probe.is_ok() {
+                continue;
+            }
+
+            let probe_err = probe.expect_err("probe failed");
+            warn!(
+                "MCP server '{}' keepalive failed ({}); reconnecting once",
+                server_name, probe_err
+            );
+            let reconnect = {
+                let mut client = client.lock().await;
+                client.reconnect_after_keepalive_failure().await
+            };
+            if let Err(err) = reconnect {
+                warn!(
+                    "MCP server '{}' keepalive reconnect failed: {}",
+                    server_name, err
+                );
+                available.store(false, Ordering::SeqCst);
+                break;
+            }
+        }
+    }))
+}
+
+fn make_managed_client(
+    name: &str,
+    client: McpClient,
+    tool_registry: &ToolRegistry,
+) -> ManagedMcpClient {
+    let cached_tools = client.cached_tools().to_vec();
+    let cached_resources = client.cached_resources().to_vec();
+    let transport_type = transport_type_for_config(&client.config).to_string();
+    let config = client.config.clone();
+    let shared_client = Arc::new(tokio::sync::Mutex::new(client));
+    let available = Arc::new(AtomicBool::new(true));
+    let registered_tools = register_mcp_tools_in_registry(
+        tool_registry,
+        name,
+        Arc::clone(&shared_client),
+        &cached_tools,
+        Arc::clone(&available),
+    );
+    let keepalive_shutdown = Arc::new(AtomicBool::new(false));
+    let keepalive_task = spawn_keepalive_task(
+        name.to_string(),
+        &config,
+        Arc::clone(&shared_client),
+        Arc::clone(&available),
+        Arc::clone(&keepalive_shutdown),
+    );
+    ManagedMcpClient {
+        client: shared_client,
+        config,
+        transport_type,
+        cached_tools,
+        cached_resources,
+        registered_tools,
+        available,
+        connected_at: Instant::now(),
+        keepalive_shutdown,
+        keepalive_task,
+    }
+}
+
+fn stop_keepalive_task(managed: &mut ManagedMcpClient) {
+    managed.keepalive_shutdown.store(true, Ordering::SeqCst);
+    if let Some(task) = managed.keepalive_task.take() {
+        task.abort();
+    }
 }
 
 fn register_mcp_tools_in_registry(
@@ -1800,35 +1992,15 @@ impl McpManager {
         }
         client.connect().await?;
 
-        let tools = client.cached_tools();
-        debug!("Discovered {} tools from server '{}'", tools.len(), name);
-
-        let cached_tools = tools.to_vec();
-        let cached_resources = client.cached_resources().to_vec();
-        let transport_type = transport_type_for_config(&client.config).to_string();
-        let config = client.config.clone();
-        let shared_client = Arc::new(tokio::sync::Mutex::new(client));
-        let available = Arc::new(AtomicBool::new(true));
-        let registered_tools = register_mcp_tools_in_registry(
-            self.tool_registry.as_ref(),
-            name,
-            Arc::clone(&shared_client),
-            &cached_tools,
-            Arc::clone(&available),
+        debug!(
+            "Discovered {} tools from server '{}'",
+            client.cached_tools().len(),
+            name
         );
 
         self.clients.insert(
             name.to_string(),
-            ManagedMcpClient {
-                client: shared_client,
-                config,
-                transport_type,
-                cached_tools,
-                cached_resources,
-                registered_tools,
-                available,
-                connected_at: Instant::now(),
-            },
+            make_managed_client(name, client, self.tool_registry.as_ref()),
         );
         Ok(())
     }
@@ -1845,31 +2017,9 @@ impl McpManager {
         }
         let mut client = McpClient::new(config);
         client.finish_connect_with_transport(transport).await?;
-        let cached_tools = client.cached_tools().to_vec();
-        let cached_resources = client.cached_resources().to_vec();
-        let transport_type = transport_type_for_config(&client.config).to_string();
-        let config = client.config.clone();
-        let shared_client = Arc::new(tokio::sync::Mutex::new(client));
-        let available = Arc::new(AtomicBool::new(true));
-        let registered_tools = register_mcp_tools_in_registry(
-            self.tool_registry.as_ref(),
-            name,
-            Arc::clone(&shared_client),
-            &cached_tools,
-            Arc::clone(&available),
-        );
         self.clients.insert(
             name.to_string(),
-            ManagedMcpClient {
-                client: shared_client,
-                config,
-                transport_type,
-                cached_tools,
-                cached_resources,
-                registered_tools,
-                available,
-                connected_at: Instant::now(),
-            },
+            make_managed_client(name, client, self.tool_registry.as_ref()),
         );
         Ok(())
     }
@@ -1954,30 +2104,9 @@ impl McpManager {
                             "Discovered {} tools from MCP server '{}'",
                             report.tool_count, report.name
                         );
-                        let cached_tools = client.cached_tools().to_vec();
-                        let cached_resources = client.cached_resources().to_vec();
-                        let config = client.config.clone();
-                        let shared_client = Arc::new(tokio::sync::Mutex::new(client));
-                        let available = Arc::new(AtomicBool::new(true));
-                        let registered_tools = register_mcp_tools_in_registry(
-                            self.tool_registry.as_ref(),
-                            &report.name,
-                            Arc::clone(&shared_client),
-                            &cached_tools,
-                            Arc::clone(&available),
-                        );
                         self.clients.insert(
                             report.name.clone(),
-                            ManagedMcpClient {
-                                client: shared_client,
-                                config,
-                                transport_type: report.transport_type.clone(),
-                                cached_tools,
-                                cached_resources,
-                                registered_tools,
-                                available,
-                                connected_at: Instant::now(),
-                            },
+                            make_managed_client(&report.name, client, self.tool_registry.as_ref()),
                         );
                     }
                     reports.push((index, report));
@@ -2015,8 +2144,9 @@ impl McpManager {
 
     /// Disconnect from an MCP server and remove it from the active list.
     pub async fn disconnect(&mut self, name: &str) -> Result<(), McpError> {
-        if let Some(managed) = self.clients.remove(name) {
+        if let Some(mut managed) = self.clients.remove(name) {
             info!("Disconnecting from MCP server: {}", name);
+            stop_keepalive_task(&mut managed);
             managed.available.store(false, Ordering::SeqCst);
             deregister_mcp_tools(self.tool_registry.as_ref(), managed.registered_tools);
             let mut client = managed.client.lock().await;
@@ -2341,8 +2471,9 @@ impl McpManager {
 mod tests {
     use super::{
         cache_mcp_image_block, is_stale_transport_error, mcp_call_timeout_duration,
-        validate_mcp_server_config, LlmCallback, McpClient, McpManager, McpServerConfig,
-        SamplingConfig,
+        mcp_keepalive_interval_duration, validate_mcp_server_config, LlmCallback, McpClient,
+        McpManager, McpServerConfig, SamplingConfig, DEFAULT_MCP_KEEPALIVE_INTERVAL_SECS,
+        MIN_MCP_KEEPALIVE_INTERVAL_SECS,
     };
     use crate::transport::McpTransport;
     use crate::McpError;
@@ -2411,6 +2542,29 @@ mod tests {
         std::env::set_var("HERMES_MCP_CALL_TIMEOUT_SECS", "9999");
         assert_eq!(mcp_call_timeout_duration().as_secs(), 900);
         std::env::remove_var("HERMES_MCP_CALL_TIMEOUT_SECS");
+    }
+
+    #[test]
+    fn mcp_keepalive_interval_defaults_and_clamps_floor() {
+        assert_eq!(
+            mcp_keepalive_interval_duration(&McpServerConfig::http("http://localhost/mcp"))
+                .as_secs(),
+            DEFAULT_MCP_KEEPALIVE_INTERVAL_SECS
+        );
+        assert_eq!(
+            mcp_keepalive_interval_duration(
+                &McpServerConfig::http("http://localhost/mcp").with_keepalive_interval(1)
+            )
+            .as_secs(),
+            MIN_MCP_KEEPALIVE_INTERVAL_SECS
+        );
+        assert_eq!(
+            mcp_keepalive_interval_duration(
+                &McpServerConfig::http("http://localhost/mcp").with_keepalive_interval(10)
+            )
+            .as_secs(),
+            10
+        );
     }
 
     #[test]
@@ -2535,6 +2689,139 @@ mod tests {
         assert!(!client.is_connected());
         assert!(client.cached_tools().is_empty());
         assert!(client.cached_resources().is_empty());
+    }
+
+    #[tokio::test]
+    async fn keepalive_probe_uses_ping_instead_of_tools_list_payload() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let transport = FakeTransport::new_with_sent(
+            vec![
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake", "version": "0"}
+                    }
+                }),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                        "tools": [{
+                            "name": "pingable",
+                            "description": "tool",
+                            "inputSchema": {"type": "object"}
+                        }]
+                    }
+                }),
+                json!({"jsonrpc": "2.0", "id": 3, "result": {}}),
+            ],
+            closed,
+            sent.clone(),
+        );
+        let mut client = McpClient::new(McpServerConfig::http("http://localhost/mcp"));
+        client
+            .finish_connect_with_transport(Box::new(transport))
+            .await
+            .expect("connect fake http server");
+
+        client.keepalive_probe().await.expect("keepalive ping");
+
+        let methods: Vec<String> = sent
+            .lock()
+            .expect("sent lock")
+            .iter()
+            .filter_map(|msg| {
+                msg.get("method")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        assert_eq!(
+            methods,
+            vec![
+                "initialize",
+                "notifications/initialized",
+                "tools/list",
+                "ping"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn keepalive_probe_latches_ping_unsupported_and_falls_back_to_tools_list() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let tool_result = json!({
+            "tools": [{
+                "name": "fallback",
+                "description": "tool",
+                "inputSchema": {"type": "object"}
+            }]
+        });
+        let transport = FakeTransport::new_with_sent(
+            vec![
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake", "version": "0"}
+                    }
+                }),
+                json!({"jsonrpc": "2.0", "id": 2, "result": tool_result.clone()}),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "error": {"code": -32601, "message": "Method not found: ping"}
+                }),
+                json!({"jsonrpc": "2.0", "id": 4, "result": tool_result.clone()}),
+                json!({"jsonrpc": "2.0", "id": 5, "result": tool_result}),
+            ],
+            closed,
+            sent.clone(),
+        );
+        let mut client = McpClient::new(McpServerConfig::http("http://localhost/mcp"));
+        client
+            .finish_connect_with_transport(Box::new(transport))
+            .await
+            .expect("connect fake http server");
+
+        client
+            .keepalive_probe()
+            .await
+            .expect("first fallback keepalive");
+        assert!(client.ping_unsupported);
+        client
+            .keepalive_probe()
+            .await
+            .expect("latched fallback keepalive");
+
+        let methods: Vec<String> = sent
+            .lock()
+            .expect("sent lock")
+            .iter()
+            .filter_map(|msg| {
+                msg.get("method")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        assert_eq!(
+            methods,
+            vec![
+                "initialize",
+                "notifications/initialized",
+                "tools/list",
+                "ping",
+                "tools/list",
+                "tools/list"
+            ]
+        );
     }
 
     #[tokio::test]

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -32,7 +32,8 @@ Equivalent JSON shape:
   },
   "remote-api": {
     "url": "https://example.com/mcp",
-    "enabled": true
+    "enabled": true,
+    "keepalive_interval": 10
   }
 }
 ```
@@ -43,6 +44,7 @@ Validation rules:
 - `url` must use `http` or `https`.
 - If both `url` and `command` are present, HTTP wins and the CLI prints a warning.
 - `supports_parallel_tool_calls` is preserved and displayed by `mcp list` and `mcp test`.
+- `keepalive_interval` is optional for HTTP/SSE servers. It defaults to 180 seconds and is floored at 5 seconds; set it below a server's idle session TTL when that server expires sessions aggressively.
 
 ## Runtime Behavior
 
@@ -52,6 +54,7 @@ Validation rules:
 - `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, and `prompts/get` client methods.
 - Parallel connection/discovery reporting through `McpManager::connect_all_parallel`.
 - Server-initiated sampling through `sampling/createMessage` with per-client policy, callback wiring, rate limits, token caps, model allowlists, tool-loop limits, and audit counters.
+- HTTP/SSE keepalive probes using MCP `ping`, with `tools/list` fallback for servers that do not implement optional `ping`, plus reconnect on failed keepalive.
 - Stale transport detection with one reconnect attempt on tool calls.
 - Bearer/OAuth authentication providers for remote servers.
 - Media block caching for image tool responses.

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T10:30:09.039417+00:00`_
+_Generated from source artifacts: `2026-06-25T11:10:05.199152+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T10:29:48.601584+00:00`
-- Proof snapshot generated: `2026-06-25T10:30:09.039417+00:00`
+- Queue snapshot generated: `2026-06-25T11:10:05.059592+00:00`
+- Proof snapshot generated: `2026-06-25T11:10:05.199152+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T10:30:09.039417+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=203.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=203.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=202.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=202.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T10:30:09.039417+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7011 |
-| Pending | 203 |
-| Ported | 394 |
+| Pending | 202 |
+| Ported | 395 |
 | Superseded | 6338 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 203.0,
+        "actual": 202.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T10:30:09.039417+00:00",
+  "generated_at_utc": "2026-06-25T11:10:05.199152+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 203.0,
+    "max_queue_pending_commits": 202.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 203,
-      "ported": 394,
+      "pending": 202,
+      "ported": 395,
       "superseded": 6338
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 203.0,
+        "actual": 202.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T10:30:09.039417+00:00`
+Generated: `2026-06-25T11:10:05.199152+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T10:30:09.039417+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 203.0 |
+| `max_queue_pending_commits` | 202.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4489,6 +4489,11 @@
       "owner": "rust-runtime",
       "notes": "Rust CLI /reasoning now exposes full|clamp runtime modes, status/help report the active mode, and the TUI live-thinking preview keeps complete text in full mode while retaining compact caps in clamp mode. Focused command and TUI tests cover mode switching, status/help output, and cap bypass behavior; detailed transcript rendering already preserves stored reasoning_content line-for-line."
     },
+    "40722058e532": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust MCP HTTP/SSE clients now honor per-server keepalive_interval with a 180s default and 5s floor, probe idle sessions with MCP ping, latch -32601 ping-unsupported responses to tools/list fallback, and run manager-owned keepalive workers that reconnect failed HTTP sessions once. Config.yaml, mcp_servers.json, ACP-provided MCP servers, docs/status output, and the Unreal MCP profile carry the interval; focused fake-transport and parser/profile tests cover the behavior."
+    },
     "4314d451ca96": {
       "disposition": "ported",
       "owner": "rust-runtime",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T10:29:48.601584+00:00`
+Generated: `2026-06-25T11:10:05.059592+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T10:29:48.601584+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 203 |
-| ported | 394 |
+| pending | 202 |
+| ported | 395 |
 | superseded | 6338 |
 
 ## First 100 Pending Commits
@@ -47,7 +47,6 @@ Generated: `2026-06-25T10:29:48.601584+00:00`
 | `929dbf777801` | #26 | fix(desktop): make rendered logs selectable so they can be copied |
 | `b6e2a54a94f5` | #20 | fix(mcp): address adversarial review round 1 (cache parity, gates, races) |
 | `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
-| `40722058e532` | #20 | fix(mcp): keep short-TTL HTTP sessions alive with configurable ping keepalive |
 | `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |
 | `866f1d65c4aa` | #26 | chore(desktop): sync package.json version fallback to 0.17.0 (#49236) |
 | `7a7b56d49830` | #23 | fix(windows): prefer managed node for whatsapp and desktop |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T10:29:48.601584+00:00`
 | `c6fbd5a10494` | #26 | style(desktop): lead --dt-font-mono with bundled JetBrains Mono |
 | `ac128af1cec3` | #26 | feat(desktop): syntax-highlight inline diffs via Shiki |
 | `64a507da44d2` | #20 | feat(relay): handle passthrough_forward over the WS (Phase 5 §5.1, gateway half) (#50702) |
+| `61c266b0dc75` | #26 | style(desktop): soften dark-mode syntax highlighting |


### PR DESCRIPTION
## Summary
- Port upstream `40722058e532` as Rust-native MCP HTTP/SSE keepalive support.
- Add per-server `keepalive_interval` across `config.yaml`, `mcp_servers.json`, ACP-provided MCP servers, status output, docs, and the Unreal MCP profile.
- Add MCP client `ping` keepalive with `tools/list` fallback for `-32601` ping-unsupported servers, plus manager-owned background keepalive workers that reconnect failed HTTP sessions once.
- Regenerate parity queue/proof/dashboard: pending `203 -> 202`, ported `394 -> 395`.

## Verification
- `cargo fmt --all --check`
- `cargo check -p hermes-mcp -p hermes-cli -p hermes-acp -p hermes-config`
- `cargo test -p hermes-mcp keepalive --quiet`
- `cargo test -p hermes-mcp --quiet`
- `cargo test -p hermes-cli mcp --quiet`
- `cargo test -p hermes-cli test_mcp_unreal_engine_setup_syncs_json_and_yaml --quiet`
- `cargo test -p hermes-cli parses_object_config_and_warns_when_url_and_command_conflict --quiet`
- `cargo test -p hermes-config config_null_string_guards_match_python_tool_defaults --quiet`
- `cargo test -p hermes-config mcp --quiet`
- `cargo test -p hermes-acp mcp --quiet`
- `cargo test -p hermes-acp --quiet`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- stale model literal diff guard: no new `gpt-4o` / `4o` literals
- `scripts/clippy-warning-gate.sh --check -- -p hermes-mcp -p hermes-cli -p hermes-acp -p hermes-config`
- `cargo build --workspace`
