### PR TITLE
parity(tui): persist interrupted sessions

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2564,6 +2564,74 @@ impl App {
         let _ = plugin_manager.invoke_hook(hook, &context);
     }
 
+    fn notify_memory_session_end(&self, messages: &[hermes_core::Message]) {
+        let Some(memory_manager) = self.agent.memory_manager.as_ref() else {
+            return;
+        };
+        let Ok(memory_manager) = memory_manager.lock() else {
+            tracing::warn!("Memory manager lock poisoned during interrupted session finalize");
+            return;
+        };
+        let as_values = messages
+            .iter()
+            .filter_map(|message| serde_json::to_value(message).ok())
+            .collect::<Vec<_>>();
+        memory_manager.on_session_end(&as_values);
+    }
+
+    fn invoke_interrupted_session_end_hook(&self, reason: &str) {
+        let Some(plugin_manager) = self.agent.plugin_manager.as_ref() else {
+            return;
+        };
+        let Ok(plugin_manager) = plugin_manager.lock() else {
+            tracing::warn!(
+                hook = HookType::OnSessionEnd.as_str(),
+                "Plugin manager lock poisoned"
+            );
+            return;
+        };
+        let context = serde_json::json!({
+            "session_id": self.session_id.as_str(),
+            "completed": false,
+            "interrupted": true,
+            "model": self.current_model.as_str(),
+            "platform": "tui",
+            "reason": reason,
+        });
+        let _ = plugin_manager.invoke_hook(HookType::OnSessionEnd, &context);
+    }
+
+    /// Flush the best available TUI transcript when the process exits before
+    /// `AgentRunComplete` can publish the final agent result.
+    pub fn finalize_interrupted_tui_session(
+        &mut self,
+        partial_assistant: Option<&str>,
+        reason: &str,
+    ) -> Result<(), AgentError> {
+        if let Some(partial) = partial_assistant
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+        {
+            let duplicate_tail = self
+                .messages
+                .last()
+                .and_then(|message| message.content.as_deref())
+                .is_some_and(|content| content.trim() == partial);
+            if !duplicate_tail {
+                self.messages.push(hermes_core::Message::assistant(partial));
+            }
+        }
+
+        if self.messages.is_empty() && self.session_objective.is_none() {
+            return Ok(());
+        }
+
+        self.persist_session_snapshot(None)?;
+        self.notify_memory_session_end(&self.messages);
+        self.invoke_interrupted_session_end_hook(reason);
+        Ok(())
+    }
+
     fn notify_memory_session_switch(
         &self,
         new_session_id: &str,
@@ -4623,6 +4691,30 @@ mod tests {
                     HookResult::Ok
                 }),
             );
+            let end_seen = self.seen.clone();
+            ctx.on(
+                HookType::OnSessionEnd,
+                Arc::new(move |value| {
+                    let session_id = value
+                        .get("session_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let interrupted = value
+                        .get("interrupted")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let reason = value
+                        .get("reason")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    end_seen.lock().unwrap().push((
+                        format!("on_session_end:interrupted={interrupted}:reason={reason}"),
+                        session_id,
+                    ));
+                    HookResult::Ok
+                }),
+            );
         }
     }
 
@@ -4681,6 +4773,29 @@ mod tests {
         );
         assert_eq!(app.session_id, "test-session");
         assert_eq!(app.agent.config.session_id.as_deref(), Some("test-session"));
+    }
+
+    #[test]
+    fn finalize_interrupted_tui_session_invokes_session_end_hook() {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = build_minimal_test_app();
+        app.state_root = tmp.path().join("custom-state-root");
+        app.session_id = "hooked-force-quit".to_string();
+        app.messages = vec![hermes_core::Message::user("still save this")];
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        attach_lifecycle_recorder(&mut app, seen.clone());
+
+        app.finalize_interrupted_tui_session(None, "shutdown_signal")
+            .expect("finalize interrupted session");
+
+        assert_eq!(
+            seen.lock().unwrap().clone(),
+            vec![(
+                "on_session_end:interrupted=true:reason=shutdown_signal".to_string(),
+                "hooked-force-quit".to_string()
+            )]
+        );
     }
 
     #[test]
@@ -5030,6 +5145,66 @@ mod tests {
             .join("sessions")
             .join("persist-after-run.json");
         assert!(path.exists());
+        let raw = std::fs::read_to_string(path).expect("read snapshot");
+        let value: serde_json::Value = serde_json::from_str(&raw).expect("parse snapshot");
+        assert_eq!(
+            value
+                .get("messages")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.len()),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn finalize_interrupted_tui_session_persists_user_and_partial_stream() {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = build_minimal_test_app();
+        app.state_root = tmp.path().join("custom-state-root");
+        app.session_id = "force-quit-session".to_string();
+        app.messages = vec![hermes_core::Message::user("diagnose this")];
+
+        app.finalize_interrupted_tui_session(Some("partial answer"), "ctrl_c")
+            .expect("finalize interrupted session");
+
+        let path = app
+            .state_root
+            .join("sessions")
+            .join("force-quit-session.json");
+        let raw = std::fs::read_to_string(path).expect("read snapshot");
+        let value: serde_json::Value = serde_json::from_str(&raw).expect("parse snapshot");
+        let contents = value
+            .get("messages")
+            .and_then(|v| v.as_array())
+            .expect("messages")
+            .iter()
+            .filter_map(|message| message.get("content").and_then(|v| v.as_str()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(contents, vec!["diagnose this", "partial answer"]);
+    }
+
+    #[test]
+    fn finalize_interrupted_tui_session_does_not_duplicate_partial_tail() {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = build_minimal_test_app();
+        app.state_root = tmp.path().join("custom-state-root");
+        app.session_id = "force-quit-dedupe".to_string();
+        app.messages = vec![
+            hermes_core::Message::user("question"),
+            hermes_core::Message::assistant("partial answer"),
+        ];
+
+        app.finalize_interrupted_tui_session(Some("partial answer"), "shutdown_signal")
+            .expect("finalize interrupted session");
+
+        assert_eq!(app.messages.len(), 2);
+        let path = app
+            .state_root
+            .join("sessions")
+            .join("force-quit-dedupe.json");
         let raw = std::fs::read_to_string(path).expect("read snapshot");
         let value: serde_json::Value = serde_json::from_str(&raw).expect("parse snapshot");
         assert_eq!(

--- a/crates/hermes-cli/src/tui.rs
+++ b/crates/hermes-cli/src/tui.rs
@@ -4926,6 +4926,21 @@ fn handle_managed_app_run_complete(
     state.awaiting_run_complete = false;
 }
 
+fn finalize_interrupted_tui_session(app: &mut App, state: &mut TuiState, reason: &str) {
+    let partial_assistant = if state.stream_buffer.trim().is_empty() {
+        None
+    } else {
+        Some(state.stream_buffer.clone())
+    };
+    if let Err(err) = app.finalize_interrupted_tui_session(partial_assistant.as_deref(), reason) {
+        tracing::warn!(reason, error = %err, "interrupted TUI session autosave skipped");
+        state.push_activity(format!("⚠ interrupted autosave skipped: {}", err));
+    } else if !app.messages.is_empty() {
+        state.push_activity("interrupted session snapshot flushed".to_string());
+    }
+    state.awaiting_run_complete = false;
+}
+
 fn extract_file_like_hints(text: &str, limit: usize) -> Vec<String> {
     let mut out = Vec::new();
     for token in text.split_whitespace() {
@@ -5366,6 +5381,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                             if state.processing {
                                 app.interrupt_controller.interrupt(None);
                                 abort_and_join_task(&mut active_agent_task).await;
+                                finalize_interrupted_tui_session(&mut app, &mut state, "ctrl_c");
                                 tui.event_sender().send(Event::Interrupt).ok();
                             }
                             app.running = false;
@@ -5399,6 +5415,13 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                         if should_quit {
                             app.interrupt_controller.interrupt(None);
                             abort_and_join_task(&mut active_agent_task).await;
+                            if state.processing {
+                                finalize_interrupted_tui_session(
+                                    &mut app,
+                                    &mut state,
+                                    "tui_quit",
+                                );
+                            }
                             app.running = false;
                             break 'main_loop;
                         }
@@ -5702,6 +5725,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                     }
                     Some(Event::Interrupt) => {
                         abort_and_join_task(&mut active_agent_task).await;
+                        finalize_interrupted_tui_session(&mut app, &mut state, "interrupt_event");
                         state.finish_processing_cycle("⏹ interrupted after");
                         state.stream_buffer.clear();
                         state.stream_muted = false;
@@ -5713,6 +5737,7 @@ pub async fn run(mut app: App) -> Result<(), AgentError> {
                     Some(Event::Shutdown) => {
                         app.interrupt_controller.interrupt(None);
                         abort_and_join_task(&mut active_agent_task).await;
+                        finalize_interrupted_tui_session(&mut app, &mut state, "shutdown_signal");
                         state.finish_processing_cycle("⏹ interrupted after");
                         state.stream_buffer.clear();
                         state.stream_muted = false;

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T11:10:05.199152+00:00`_
+_Generated from source artifacts: `2026-06-25T11:29:12.194547+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T11:10:05.059592+00:00`
-- Proof snapshot generated: `2026-06-25T11:10:05.199152+00:00`
+- Queue snapshot generated: `2026-06-25T11:29:12.057671+00:00`
+- Proof snapshot generated: `2026-06-25T11:29:12.194547+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T11:10:05.199152+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=202.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=202.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=198.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=198.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,9 +75,9 @@ _Generated from source artifacts: `2026-06-25T11:10:05.199152+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7011 |
-| Pending | 202 |
-| Ported | 395 |
-| Superseded | 6338 |
+| Pending | 198 |
+| Ported | 396 |
+| Superseded | 6341 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 202.0,
+        "actual": 198.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T11:10:05.199152+00:00",
+  "generated_at_utc": "2026-06-25T11:29:12.194547+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 202.0,
+    "max_queue_pending_commits": 198.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 202,
-      "ported": 395,
-      "superseded": 6338
+      "pending": 198,
+      "ported": 396,
+      "superseded": 6341
     },
     "by_target_ticket": {
       "20": 3139,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 202.0,
+        "actual": 198.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T11:10:05.199152+00:00`
+Generated: `2026-06-25T11:29:12.194547+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T11:10:05.199152+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 202.0 |
+| `max_queue_pending_commits` | 198.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4503,6 +4503,26 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust Telegram parser already preserves current documents and replied group documents when the addressed message has no own media, only filtering oversized documents. Existing Telegram parse tests cover document metadata and replied-document size behavior."
+    },
+    "c7e8854cb383": {
+      "disposition": "ported",
+      "notes": "Rust TUI force-quit/signal shutdown now flushes the best available session transcript before clearing stream state: durable messages plus partial streamed assistant text are persisted to the session snapshot, memory providers receive on_session_end, and plugins receive on_session_end with interrupted=true. Covered by hermes-cli finalizer and lifecycle tests.",
+      "owner": "rust-runtime"
+    },
+    "5f55f0ff85f0": {
+      "disposition": "superseded",
+      "notes": "Upstream Teams media attachment fix targets the Python Teams chat plugin. Hermes Agent Ultra Rust gateway has no Teams chat adapter module; its Rust Teams surface is the meeting-summary pipeline, while chat media delivery is handled generically through Gateway::send_message media markers and registered adapter send_file/send_image_url implementations.",
+      "owner": "rust-runtime"
+    },
+    "8cf7df867e7d": {
+      "disposition": "superseded",
+      "notes": "Upstream Raft check_fn log-spam fix targets a Python bundled raft platform plugin. Hermes Agent Ultra Rust gateway has no raft platform adapter/check_fn registration path, so the repeated load_gateway_config warning failure mode is absent.",
+      "owner": "rust-runtime"
+    },
+    "a7dd98c8609c": {
+      "disposition": "superseded",
+      "notes": "Upstream malformed int/float env crash class is Python ValueError-specific. Rust numeric env reads in the corresponding config/gateway/agent/tool surfaces are fail-soft through parse().ok(), if-let Ok(...), or unwrap_or(default), so malformed values do not panic during adapter/agent init.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T11:10:05.059592+00:00`
+Generated: `2026-06-25T11:29:12.057671+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-25T11:10:05.059592+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 202 |
-| ported | 395 |
-| superseded | 6338 |
+| pending | 198 |
+| ported | 396 |
+| superseded | 6341 |
 
 ## First 100 Pending Commits
 
@@ -53,16 +53,13 @@ Generated: `2026-06-25T11:10:05.059592+00:00`
 | `d4e7dd609da6` | #23 | refactor(windows): tidy managed-node resolver helpers |
 | `a7983d5ad768` | #20 | fix(dashboard): hide sidecar sessions from history (#49269) |
 | `d799284b1554` | #21 | feat(optional-skills/creative-ideation): expand to v2.1.0 method library (#42402) |
-| `5f55f0ff85f0` | #20 | feat(teams): native send_video/send_voice/send_document attachments (#49308) |
 | `8ebe37f6ad2d` | #26 | feat(desktop): notify renderer when GPU acceleration is disabled due to remote display |
-| `8cf7df867e7d` | #20 | fix(plugins): silence raft check_fn log spam for users without raft CLI |
 | `1b7b4d138a67` | #26 | fix(desktop): handle slash exec dispatch payloads (#49358) |
 | `236f0597e562` | #26 | feat(desktop): pop the composer out into a draggable floating window |
 | `f697c97e02f0` | #26 | fix(desktop): keep floating composer radius consistent with docked |
 | `eed78d6ebb51` | #26 | fix(desktop): composer popout polish — peel-off placement, panels, chip editing |
 | `ae8db1ab531b` | #26 | fix(desktop): mute hidden link-title window so historical links don't autoplay audio |
 | `7eb9678c5470` | #26 | test(desktop): cover link-title window audio muting |
-| `a7dd98c8609c` | #23 | fix(env): guard remaining malformed int/float env var casts with utils helpers |
 | `5600105478ff` | #20 | refactor(gateway): migrate slack/dingtalk/whatsapp/matrix/feishu/telegram/wecom/email/sms adapters to bundled plugins |
 | `404fe730b7a2` | #26 | fix: add tooltips to right sidebar header buttons |
 | `838daca9f4cf` | #26 | chore(desktop): format tooltip indentation + author map for #49697 |
@@ -91,7 +88,6 @@ Generated: `2026-06-25T11:10:05.059592+00:00`
 | `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
 | `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
 | `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
-| `c7e8854cb383` | #20 | fix(tui): persist session messages on force-quit / signal shutdown |
 | `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
 | `0e47f68a479a` | #26 | fix(desktop): rename branched session via session.title RPC |
 | `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
@@ -125,3 +121,7 @@ Generated: `2026-06-25T11:10:05.059592+00:00`
 | `ac128af1cec3` | #26 | feat(desktop): syntax-highlight inline diffs via Shiki |
 | `64a507da44d2` | #20 | feat(relay): handle passthrough_forward over the WS (Phase 5 §5.1, gateway half) (#50702) |
 | `61c266b0dc75` | #26 | style(desktop): soften dark-mode syntax highlighting |
+| `8845f3316c26` | #20 | fix(security): restrict dashboard plugin backend import to bundled plugins (#43719) |
+| `2e779d11a03d` | #23 | feat(mem0): v3 API, OSS mode, update/delete tools, telemetry & review fixes (#15624) |
+| `86e4521cb1d9` | #23 | fix(delivery): make cron output truncation configurable + adapter-aware |
+| `e9cd8c5bf3ea` | #23 | fix(delivery): drop env-var knob, flag all chunking adapters |


### PR DESCRIPTION
## Summary
- Persist the best available TUI transcript when Ctrl-C, quit, interrupt, or shutdown aborts an active run before AgentRunComplete.
- Flush durable messages plus partial streamed assistant text to the session snapshot, notify memory providers with on_session_end, and emit plugin on_session_end with interrupted=true.
- Update parity ledger: c7e8854cb383 ported; Teams chat attachment, Raft check_fn spam, and Python malformed numeric env rows classified as superseded for Rust runtime.

## Verification
- cargo fmt --all --check
- git diff --check
- stale model literal diff guard: no new gpt-4o/4o literals
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- cargo check -p hermes-cli
- cargo test -p hermes-cli finalize_interrupted_tui_session --quiet
- cargo test -p hermes-cli session_lifecycle_hooks --quiet
- cargo test -p hermes-cli --quiet
- scripts/clippy-warning-gate.sh --check -- -p hermes-cli (new=0)
- cargo build --workspace