### PR TITLE
parity(config): honor managed scope overlays

### DIFF
--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -31,10 +31,11 @@ pub use config::{
 };
 pub use loader::{
     apply_user_config_patch, atomic_json_write, atomic_json_write_pretty, atomic_write_bytes,
-    atomic_yaml_write, load_config, load_prefill_messages, load_prefill_messages_file,
-    load_user_config_file, resolve_prefill_messages_file, resolve_prefill_messages_path,
-    save_config_yaml, set_user_config_value, user_config_field_display, validate_config,
-    ConfigError, ConfigSetResult,
+    atomic_yaml_write, load_config, load_effective_config_yaml_value, load_prefill_messages,
+    load_prefill_messages_file, load_user_config_file, managed_scope_dir,
+    resolve_prefill_messages_file, resolve_prefill_messages_path, save_config_yaml,
+    set_user_config_value, user_config_field_display, validate_config, ConfigError,
+    ConfigSetResult,
 };
 pub use managed_gateway::{
     build_vendor_gateway_url, coerce_modal_mode, env_var_enabled, get_tool_gateway_scheme,

--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -11,8 +11,12 @@ use crate::config::{
     DisplayConfig, GatewayConfig, LlmProviderConfig, ProxyConfig, TerminalBackendType,
     TerminalConfig, TerminalHomeMode, WebConfig,
 };
-use crate::merge::merge_configs;
+use crate::merge::{deep_merge, merge_configs};
 use crate::paths;
+
+const MANAGED_SCOPE_ENV: &str = "HERMES_MANAGED_DIR";
+#[cfg(not(test))]
+const DEFAULT_MANAGED_SCOPE_DIR: &str = "/etc/hermes";
 
 // ---------------------------------------------------------------------------
 // ConfigError conversion helpers
@@ -181,6 +185,14 @@ pub fn load_dotenv() {
         // Project env only fills gaps when user env exists; otherwise it can override.
         load_dotenv_file(&project_env, !env_file.exists());
     }
+
+    if let Some(managed_env) = managed_scope_dir()
+        .map(|dir| dir.join(".env"))
+        .filter(|path| path.exists())
+    {
+        // Administrator-pinned env always wins over shell/user/project dotenv.
+        load_dotenv_file(&managed_env, true);
+    }
 }
 
 fn load_dotenv_file(path: &Path, override_existing: bool) {
@@ -302,13 +314,132 @@ fn env_truthy(name: &str) -> bool {
     })
 }
 
+/// Return the active managed-scope directory, if configured.
+///
+/// Python Hermes treats `$HERMES_MANAGED_DIR` as an optional administrator
+/// overlay and falls back to `/etc/hermes` in production. Unit tests skip the
+/// default path so a developer machine's real managed install cannot leak into
+/// deterministic tests.
+pub fn managed_scope_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(MANAGED_SCOPE_ENV)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty() && path.is_dir())
+    {
+        return Some(path);
+    }
+
+    #[cfg(not(test))]
+    {
+        let path = PathBuf::from(DEFAULT_MANAGED_SCOPE_DIR);
+        if path.is_dir() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+fn load_managed_config_yaml_value() -> Option<serde_yaml::Value> {
+    let path = managed_scope_dir()?.join("config.yaml");
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            tracing::warn!("managed scope: failed to read {}: {err}", path.display());
+            return None;
+        }
+    };
+    if contents.trim().is_empty() {
+        return None;
+    }
+
+    let mut root: serde_yaml::Value = match serde_yaml::from_str(&contents) {
+        Ok(root) => root,
+        Err(err) => {
+            tracing::warn!("managed scope: failed to parse {}: {err}", path.display());
+            return None;
+        }
+    };
+    expand_env_vars_in_yaml(&mut root);
+    let serde_yaml::Value::Mapping(ref mut map) = root else {
+        tracing::warn!(
+            "managed scope: ignoring non-mapping config at {}",
+            path.display()
+        );
+        return None;
+    };
+    crate::python_yaml_compat::normalize_config_yaml_root(map);
+    mark_platform_enabled_explicit(&mut root, "slack");
+    mark_platform_enabled_explicit(&mut root, "ntfy");
+    Some(root)
+}
+
+fn load_managed_config_overlay_json() -> Option<serde_json::Value> {
+    let yaml = load_managed_config_yaml_value()?;
+    match serde_json::to_value(yaml) {
+        Ok(value) if value.is_object() => Some(value),
+        Ok(_) => None,
+        Err(err) => {
+            tracing::warn!("managed scope: failed to convert config overlay: {err}");
+            None
+        }
+    }
+}
+
+fn read_config_yaml_as_json(path: &Path) -> Option<serde_json::Value> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(_) => return None,
+    };
+    if contents.trim().is_empty() {
+        return Some(serde_json::json!({}));
+    }
+    match serde_yaml::from_str::<serde_json::Value>(&contents) {
+        Ok(value) if value.is_object() => Some(value),
+        Ok(_) => {
+            tracing::warn!("Ignoring non-mapping config at {}", path.display());
+            None
+        }
+        Err(err) => {
+            tracing::warn!("Failed to parse {}: {err}", path.display());
+            None
+        }
+    }
+}
+
+/// Load raw user config plus managed-scope overlay for standalone runtime readers.
+///
+/// This intentionally returns a raw value instead of [`GatewayConfig`] so
+/// narrow subsystems can keep reading upstream-compatible keys that the typed
+/// config model does not own, while still honoring administrator-pinned leaves.
+pub fn load_effective_config_yaml_value(path: &Path) -> Option<serde_json::Value> {
+    let ignore_user_config = env_truthy("HERMES_IGNORE_USER_CONFIG");
+    let mut base = if ignore_user_config {
+        None
+    } else {
+        read_config_yaml_as_json(path)
+    }
+    .unwrap_or_else(|| serde_json::json!({}));
+    let had_user = base.as_object().is_some_and(|obj| !obj.is_empty());
+
+    let managed = load_managed_config_overlay_json();
+    if let Some(overlay) = &managed {
+        deep_merge(&mut base, overlay);
+    }
+
+    if had_user || managed.is_some() {
+        Some(base)
+    } else {
+        None
+    }
+}
+
 // ---------------------------------------------------------------------------
 // load_config
 // ---------------------------------------------------------------------------
 
 /// Load the full configuration, applying the priority chain:
 ///
-///   env vars  >  .env  >  cli-config.yaml > config.yaml > gateway.json > defaults
+///   managed config/env > env vars > .env > cli-config.yaml > config.yaml > gateway.json > defaults
 ///
 /// If `home_dir` is provided it overrides the `HERMES_HOME` env var.
 pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError> {
@@ -372,6 +503,24 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
     normalize_platform_aliases(&mut config);
     normalize_provider_secrets(&mut config);
 
+    let managed_overlay = load_managed_config_overlay_json();
+    if let Some(overlay) = &managed_overlay {
+        let mut managed_config = config.clone();
+        if apply_managed_config_overlay(&mut managed_config, overlay) {
+            normalize_platform_aliases(&mut managed_config);
+            normalize_provider_secrets(&mut managed_config);
+            match validate_config(&managed_config) {
+                Ok(()) => {
+                    config = managed_config;
+                    bridge_managed_overlay_to_env(&config, overlay);
+                }
+                Err(err) => {
+                    tracing::warn!("managed scope: ignoring invalid config overlay: {err}");
+                }
+            }
+        }
+    }
+
     // Record the effective home dir
     config.home_dir = Some(effective_home);
 
@@ -379,6 +528,145 @@ pub fn load_config(home_dir: Option<&str>) -> Result<GatewayConfig, ConfigError>
     validate_config(&config)?;
 
     Ok(config)
+}
+
+fn apply_managed_config_overlay(config: &mut GatewayConfig, overlay: &serde_json::Value) -> bool {
+    let original = config.clone();
+    let mut base = match serde_json::to_value(&*config) {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!("managed scope: failed to serialize base config: {err}");
+            return false;
+        }
+    };
+    deep_merge(&mut base, overlay);
+    match serde_json::from_value::<GatewayConfig>(base) {
+        Ok(mut merged) => {
+            merged.home_dir = original.home_dir;
+            *config = merged;
+            true
+        }
+        Err(err) => {
+            tracing::warn!("managed scope: failed to apply config overlay: {err}");
+            *config = original;
+            false
+        }
+    }
+}
+
+fn bridge_managed_overlay_to_env(config: &GatewayConfig, overlay: &serde_json::Value) {
+    if overlay.get("model").is_some() {
+        if let Some(model) = config.model.as_deref() {
+            set_env_override("HERMES_MODEL", model.to_string());
+        }
+    }
+    if overlay.get("personality").is_some() {
+        if let Some(personality) = config.personality.as_deref() {
+            set_env_override("HERMES_PERSONALITY", personality.to_string());
+        }
+    }
+    if overlay.get("max_turns").is_some() {
+        set_env_override("HERMES_MAX_TURNS", config.max_turns.to_string());
+    }
+    if overlay.get("system_prompt").is_some() {
+        if let Some(prompt) = config.system_prompt.as_deref() {
+            set_env_override("HERMES_SYSTEM_PROMPT", prompt.to_string());
+        }
+    }
+    if overlay.get("prefill_messages_file").is_some() {
+        if let Some(path) = config.prefill_messages_file.as_deref() {
+            set_env_override("HERMES_PREFILL_MESSAGES_FILE", path.to_string());
+        }
+    }
+    if let Some(kanban) = overlay.get("kanban").and_then(|value| value.as_object()) {
+        if kanban.contains_key("dispatch_in_gateway") {
+            set_env_override(
+                "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
+                config.kanban.dispatch_in_gateway.to_string(),
+            );
+        }
+    }
+    if let Some(security) = overlay.get("security").and_then(|value| value.as_object()) {
+        if security.contains_key("allow_private_urls") {
+            set_env_override(
+                "HERMES_ALLOW_PRIVATE_URLS",
+                config.security.allow_private_urls.to_string(),
+            );
+        }
+    }
+    bridge_managed_section_to_env(
+        &config.terminal,
+        overlay.get("terminal"),
+        terminal_config_env_bridge_pairs(),
+    );
+    bridge_managed_section_to_env(
+        &config.web,
+        overlay.get("web"),
+        web_config_env_bridge_pairs(),
+    );
+    bridge_managed_section_to_env(
+        &config.display,
+        overlay.get("display"),
+        display_config_env_bridge_pairs(),
+    );
+}
+
+fn bridge_managed_section_to_env<T: serde::Serialize>(
+    config: &T,
+    overlay: Option<&serde_json::Value>,
+    pairs: &[(&str, &str)],
+) {
+    let Some(overlay_map) = overlay.and_then(|value| value.as_object()) else {
+        return;
+    };
+    let config_value = match serde_json::to_value(config) {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!("managed scope: failed to bridge config section to env: {err}");
+            return;
+        }
+    };
+    for (overlay_key, env_key) in pairs {
+        if !overlay_map.contains_key(*overlay_key) {
+            continue;
+        }
+        let config_key = match *overlay_key {
+            "env_type" => "backend",
+            "cwd" => "workdir",
+            key => key,
+        };
+        if let Some(value) = config_value
+            .get(config_key)
+            .and_then(json_value_to_env_string)
+        {
+            set_env_override(env_key, value);
+        }
+    }
+}
+
+fn json_value_to_env_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Array(values) => {
+            let joined = values
+                .iter()
+                .filter_map(json_value_to_env_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            (!joined.trim().is_empty()).then_some(joined)
+        }
+        _ => None,
+    }
+}
+
+fn set_env_override(name: &str, value: String) {
+    if value.trim().is_empty() {
+        return;
+    }
+    // SAFETY: configuration loading runs during CLI/gateway startup.
+    unsafe { std::env::set_var(name, value) };
 }
 
 // ---------------------------------------------------------------------------
@@ -2475,6 +2763,32 @@ mod tests {
         }
     }
 
+    fn remove_test_env(name: &str) {
+        // SAFETY: tests serialize env mutation with ENV_LOCK.
+        unsafe { std::env::remove_var(name) };
+    }
+
+    fn set_test_env(name: &str, value: impl AsRef<std::ffi::OsStr>) {
+        // SAFETY: tests serialize env mutation with ENV_LOCK.
+        unsafe { std::env::set_var(name, value) };
+    }
+
+    fn clear_managed_scope_test_env() {
+        for name in [
+            "HERMES_HOME",
+            "HERMES_MANAGED_DIR",
+            "HERMES_IGNORE_USER_CONFIG",
+            "HERMES_MODEL",
+            "HERMES_MAX_TURNS",
+            "HERMES_WEB_BACKEND",
+            "HERMES_WEB_SEARCH_BACKEND",
+            "HERMES_GATEWAY_BUSY_INPUT_MODE",
+            "HERMES_GATEWAY_BUSY_ACK_ENABLED",
+        ] {
+            remove_test_env(name);
+        }
+    }
+
     #[test]
     fn validate_valid_config() {
         let config = GatewayConfig::default();
@@ -3140,6 +3454,239 @@ terminal:
             "false"
         );
         clear_terminal_env_bridge_vars();
+    }
+
+    #[test]
+    fn managed_scope_dir_ignores_missing_override() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let dir = tempdir().unwrap();
+        set_test_env("HERMES_MANAGED_DIR", dir.path().join("missing"));
+
+        assert!(managed_scope_dir().is_none());
+
+        clear_managed_scope_test_env();
+    }
+
+    #[test]
+    fn load_config_applies_managed_overlay_after_env_and_preserves_siblings() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        clear_web_env_bridge_vars();
+        clear_display_env_bridge_vars();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(
+            home.path().join("config.yaml"),
+            r#"
+max_turns: 12
+display:
+  busy_input_mode: queue
+  busy_ack_enabled: false
+web:
+  backend: user-web
+  search_backend: user-search
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            managed.path().join("config.yaml"),
+            r#"
+display:
+  busy_input_mode: steer
+web:
+  backend: managed-web
+"#,
+        )
+        .unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+        set_test_env("HERMES_WEB_BACKEND", "shell-web");
+        set_test_env("HERMES_GATEWAY_BUSY_INPUT_MODE", "interrupt");
+
+        let cfg = load_config(Some(home.path().to_string_lossy().as_ref())).unwrap();
+
+        assert_eq!(cfg.max_turns, 12);
+        assert_eq!(cfg.display.normalized_busy_input_mode(), "steer");
+        assert!(!cfg.display.busy_ack_enabled());
+        assert_eq!(cfg.web.backend, "managed-web");
+        assert_eq!(cfg.web.search_backend, "user-search");
+        assert_eq!(std::env::var("HERMES_WEB_BACKEND").unwrap(), "managed-web");
+        assert_eq!(
+            std::env::var("HERMES_GATEWAY_BUSY_INPUT_MODE").unwrap(),
+            "steer"
+        );
+
+        clear_managed_scope_test_env();
+        clear_web_env_bridge_vars();
+        clear_display_env_bridge_vars();
+    }
+
+    #[test]
+    fn load_dotenv_managed_env_overrides_user_dotenv_and_shell() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(home.path().join(".env"), "HERMES_MODEL=user/env\n").unwrap();
+        std::fs::write(managed.path().join(".env"), "HERMES_MODEL=managed/env\n").unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+        set_test_env("HERMES_MODEL", "shell/env");
+
+        let cfg = load_config(Some(home.path().to_string_lossy().as_ref())).unwrap();
+
+        assert_eq!(cfg.model.as_deref(), Some("managed/env"));
+        assert_eq!(std::env::var("HERMES_MODEL").unwrap(), "managed/env");
+
+        clear_managed_scope_test_env();
+    }
+
+    #[test]
+    fn load_config_managed_overlay_normalizes_root_model_string() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(
+            home.path().join("config.yaml"),
+            "model: user/model\nfallback_models:\n  - user/fallback\n",
+        )
+        .unwrap();
+        std::fs::write(managed.path().join("config.yaml"), "model: managed/model\n").unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+
+        let cfg = load_config(Some(home.path().to_string_lossy().as_ref())).unwrap();
+
+        assert_eq!(cfg.model.as_deref(), Some("managed/model"));
+        assert_eq!(cfg.fallback_models, vec!["user/fallback".to_string()]);
+
+        clear_managed_scope_test_env();
+    }
+
+    #[test]
+    fn load_config_managed_overlay_is_fail_open_on_malformed_yaml() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(home.path().join("config.yaml"), "max_turns: 17\n").unwrap();
+        std::fs::write(managed.path().join("config.yaml"), ":\n").unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+
+        let cfg = load_config(Some(home.path().to_string_lossy().as_ref())).unwrap();
+
+        assert_eq!(cfg.max_turns, 17);
+
+        clear_managed_scope_test_env();
+    }
+
+    #[test]
+    fn load_config_managed_overlay_is_fail_open_on_invalid_values() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(home.path().join("config.yaml"), "max_turns: 17\n").unwrap();
+        std::fs::write(managed.path().join("config.yaml"), "max_turns: 0\n").unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+
+        let cfg = load_config(Some(home.path().to_string_lossy().as_ref())).unwrap();
+
+        assert_eq!(cfg.max_turns, 17);
+
+        clear_managed_scope_test_env();
+    }
+
+    #[test]
+    fn load_config_ignore_user_config_still_honors_managed_scope() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(home.path().join("config.yaml"), "max_turns: 777\n").unwrap();
+        std::fs::write(managed.path().join("config.yaml"), "max_turns: 42\n").unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+        set_test_env("HERMES_IGNORE_USER_CONFIG", "1");
+
+        let cfg = load_config(Some(home.path().to_string_lossy().as_ref())).unwrap();
+
+        assert_eq!(cfg.max_turns, 42);
+
+        clear_managed_scope_test_env();
+    }
+
+    #[test]
+    fn load_effective_config_yaml_value_applies_managed_raw_overlay() {
+        use tempfile::tempdir;
+
+        let _global_guard = crate::managed_gateway::test_lock::lock();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_managed_scope_test_env();
+        let home = tempdir().unwrap();
+        let managed = tempdir().unwrap();
+        std::fs::write(
+            home.path().join("config.yaml"),
+            r#"
+cron:
+  provider: user
+  chronos:
+    portal_url: https://user.example
+    callback_url: https://agent.example
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            managed.path().join("config.yaml"),
+            r#"
+cron:
+  provider: chronos
+  chronos:
+    portal_url: https://managed.example
+"#,
+        )
+        .unwrap();
+        set_test_env("HERMES_HOME", home.path());
+        set_test_env("HERMES_MANAGED_DIR", managed.path());
+
+        let root = load_effective_config_yaml_value(&home.path().join("config.yaml")).unwrap();
+
+        assert_eq!(root["cron"]["provider"], "chronos");
+        assert_eq!(
+            root["cron"]["chronos"]["portal_url"],
+            "https://managed.example"
+        );
+        assert_eq!(
+            root["cron"]["chronos"]["callback_url"],
+            "https://agent.example"
+        );
+
+        clear_managed_scope_test_env();
     }
 
     #[test]

--- a/crates/hermes-cron/src/chronos.rs
+++ b/crates/hermes-cron/src/chronos.rs
@@ -116,8 +116,7 @@ impl ChronosConfig {
 }
 
 fn load_config_yaml() -> Option<Value> {
-    let bytes = std::fs::read(hermes_config::config_path()).ok()?;
-    serde_yaml::from_slice::<Value>(&bytes).ok()
+    hermes_config::load_effective_config_yaml_value(&hermes_config::config_path())
 }
 
 fn yaml_string(root: &Option<Value>, path: &[&str]) -> Option<String> {
@@ -467,6 +466,49 @@ mod tests {
     use super::*;
     use jsonwebtoken::{encode, EncodingKey, Header};
     use serde_json::json;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(vars: &[&'static str]) -> Self {
+            let saved = vars
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect();
+            for name in vars {
+                // SAFETY: tests serialize env mutation with ENV_LOCK.
+                unsafe { std::env::remove_var(name) };
+            }
+            Self { saved }
+        }
+
+        fn set(&self, name: &str, value: impl AsRef<std::ffi::OsStr>) {
+            // SAFETY: tests serialize env mutation with ENV_LOCK.
+            unsafe { std::env::set_var(name, value) };
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.drain(..).rev() {
+                match value {
+                    Some(value) => {
+                        // SAFETY: tests serialize env mutation with ENV_LOCK.
+                        unsafe { std::env::set_var(name, value) };
+                    }
+                    None => {
+                        // SAFETY: tests serialize env mutation with ENV_LOCK.
+                        unsafe { std::env::remove_var(name) };
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn config_reads_upstream_chronos_yaml_shape() {
@@ -495,6 +537,55 @@ mod tests {
             ),
             42
         );
+    }
+
+    #[test]
+    fn config_load_honors_managed_scope_overlay() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let env = EnvGuard::new(&[
+            "HERMES_HOME",
+            "HERMES_MANAGED_DIR",
+            "HERMES_CRON_PROVIDER",
+            "HERMES_CHRONOS_PORTAL_URL",
+            "HERMES_CHRONOS_CALLBACK_URL",
+            "HERMES_CHRONOS_EXPECTED_AUDIENCE",
+            "HERMES_CHRONOS_NAS_JWKS_URL",
+            "HERMES_CHRONOS_TOKEN_LEEWAY_SECONDS",
+            "HERMES_CHRONOS_REQUEST_TIMEOUT_SECONDS",
+        ]);
+        let home = tempfile::tempdir().unwrap();
+        let managed = tempfile::tempdir().unwrap();
+        std::fs::write(
+            home.path().join("config.yaml"),
+            r#"
+cron:
+  provider: user
+  chronos:
+    portal_url: https://user.example
+    callback_url: https://agent.example/callback
+    request_timeout_seconds: 23
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            managed.path().join("config.yaml"),
+            r#"
+cron:
+  provider: chronos
+  chronos:
+    portal_url: https://managed.example
+"#,
+        )
+        .unwrap();
+        env.set("HERMES_HOME", home.path());
+        env.set("HERMES_MANAGED_DIR", managed.path());
+
+        let config = ChronosConfig::load();
+
+        assert_eq!(config.provider, "chronos");
+        assert_eq!(config.portal_url, "https://managed.example");
+        assert_eq!(config.callback_url, "https://agent.example/callback");
+        assert_eq!(config.request_timeout_seconds, 23);
     }
 
     #[tokio::test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T11:29:12.194547+00:00`_
+_Generated from source artifacts: `2026-06-25T11:50:12.183619+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T11:29:12.057671+00:00`
-- Proof snapshot generated: `2026-06-25T11:29:12.194547+00:00`
+- Queue snapshot generated: `2026-06-25T11:50:12.042888+00:00`
+- Proof snapshot generated: `2026-06-25T11:50:12.183619+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T11:29:12.194547+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=198.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=198.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=197.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=197.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T11:29:12.194547+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7011 |
-| Pending | 198 |
-| Ported | 396 |
+| Pending | 197 |
+| Ported | 397 |
 | Superseded | 6341 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 198.0,
+        "actual": 197.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T11:29:12.194547+00:00",
+  "generated_at_utc": "2026-06-25T11:50:12.183619+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 198.0,
+    "max_queue_pending_commits": 197.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 198,
-      "ported": 396,
+      "pending": 197,
+      "ported": 397,
       "superseded": 6341
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 198.0,
+        "actual": 197.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T11:29:12.194547+00:00`
+Generated: `2026-06-25T11:50:12.183619+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T11:29:12.194547+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 198.0 |
+| `max_queue_pending_commits` | 197.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -2984,6 +2984,11 @@
       "notes": "Rust OpenViking save_config writes openviking.json through shared owner-only atomic config IO with 0600 permissions and regression coverage.",
       "owner": "rust-runtime"
     },
+    "b0e47a98f9ed": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: hermes-config now honors HERMES_MANAGED_DIR and production /etc/hermes managed scope. Managed .env wins over shell/user/project dotenv, managed config overlays the effective GatewayConfig per leaf after env overrides, managed keys are mirrored back to env for downstream runtime readers, and Chronos standalone config reads use the same raw managed overlay without persisting managed values to user config.",
+      "owner": "rust-runtime"
+    },
     "b10f17bf1e93": {
       "disposition": "ported",
       "notes": "Imported ntfy as a platform plugin under plugins/platforms/ntfy with standalone send, env enablement, identity hardening, and local plugin regression tests."

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T11:29:12.057671+00:00`
+Generated: `2026-06-25T11:50:12.042888+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7011`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T11:29:12.057671+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 198 |
-| ported | 396 |
+| pending | 197 |
+| ported | 397 |
 | superseded | 6341 |
 
 ## First 100 Pending Commits
@@ -38,7 +38,6 @@ Generated: `2026-06-25T11:29:12.057671+00:00`
 | `db744e7d1e58` | #21 | feat(simplify-code): add risk-tiered application, Chesterton's Fence, slop + silent failure detection |
 | `6c44471bfdb8` | #23 | fix(hindsight): lazy-install cloud client dependency |
 | `13d4b5fe2f45` | #23 | fix(hindsight): align client version to 0.6.1 across all sources |
-| `b0e47a98f9ed` | #20 | fix(managed-scope): honor managed scope in all standalone config loaders |
 | `9026a8c78974` | #22 | feat(gateway): add Raft bundled platform plugin with activity hooks |
 | `7d86178cf51a` | #26 | fix(raft): set stdin=DEVNULL on bridge subprocess |
 | `6308d3416ab9` | #26 | fix(desktop): rename "Restart messaging" -> "Restart gateway" |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T11:29:12.057671+00:00`
 | `2e779d11a03d` | #23 | feat(mem0): v3 API, OSS mode, update/delete tools, telemetry & review fixes (#15624) |
 | `86e4521cb1d9` | #23 | fix(delivery): make cron output truncation configurable + adapter-aware |
 | `e9cd8c5bf3ea` | #23 | fix(delivery): drop env-var knob, flag all chunking adapters |
+| `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |


### PR DESCRIPTION
## Summary
- Port Rust managed-scope config behavior for upstream b0e47a98f9ed.
- Add HERMES_MANAGED_DIR and production /etc/hermes managed-scope discovery.
- Load managed .env after shell/user/project dotenv so administrator-pinned env wins.
- Apply managed config as a raw per-leaf overlay after env overrides without manufacturing typed defaults, validate fail-open, and mirror pinned runtime keys back to env for downstream readers.
- Expose load_effective_config_yaml_value for standalone config readers and route Chronos through it.
- Mark b0e47a98f9ed ported and regenerate parity docs: pending 198 -> 197, ported 396 -> 397.

## Verification
- cargo fmt --all --check
- cargo check -p hermes-config -p hermes-cron
- cargo test -p hermes-config managed --quiet
- cargo test -p hermes-config --lib --quiet
- cargo test -p hermes-cron --lib --quiet
- git diff --check
- stale model diff guard: no new gpt-4o/4o literals
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-cron
- cargo build --workspace
- cargo test --workspace

## Scope Guards
- OAuth/sign-in paths untouched.
- Cargo artifacts were built under /Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation.