### PR TITLE
parity(mcp): tighten refresh tool gates

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -2865,14 +2865,14 @@ impl App {
     }
 
     pub fn refresh_agent_tool_snapshot(&mut self) -> AgentToolSnapshotRefresh {
-        let before = sorted_tool_names(self.agent.tool_registry.names());
+        let before = sorted_tool_schema_names(&self.tool_schemas);
         self.tool_schemas = hermes_tool_planning::resolve_platform_tool_schemas(
             &self.config,
             "cli",
             &self.tool_registry,
         );
         self.rebuild_agent_for_active_session();
-        let after = sorted_tool_names(self.agent.tool_registry.names());
+        let after = sorted_tool_schema_names(&self.tool_schemas);
         let before_set: BTreeSet<_> = before.iter().cloned().collect();
         let after_set: BTreeSet<_> = after.iter().cloned().collect();
 
@@ -4213,11 +4213,15 @@ mod tests {
         }
     }
 
-    fn register_test_tool(tools: &ToolRegistry, name: &'static str) {
+    fn register_test_tool_in_toolset(
+        tools: &ToolRegistry,
+        name: &'static str,
+        toolset: &'static str,
+    ) {
         let handler: Arc<dyn hermes_core::ToolHandler> = Arc::new(TestToolHandler { name });
         tools.register(
             name,
-            "test",
+            toolset,
             handler.schema(),
             handler,
             Arc::new(|| true),
@@ -4227,6 +4231,10 @@ mod tests {
             "T",
             None,
         );
+    }
+
+    fn register_test_tool(tools: &ToolRegistry, name: &'static str) {
+        register_test_tool_in_toolset(tools, name, "test");
     }
 
     fn build_minimal_test_app() -> App {
@@ -4360,6 +4368,31 @@ mod tests {
         assert_eq!(refresh.before_count, 0);
         assert_eq!(refresh.after_count, 0);
         assert!(!refresh.changed());
+    }
+
+    #[test]
+    fn refresh_agent_tool_snapshot_reports_advertised_surface_only() {
+        let mut app = build_minimal_test_app();
+        Arc::make_mut(&mut app.config)
+            .platform_toolsets
+            .insert("cli".to_string(), vec!["test".to_string()]);
+        register_test_tool(&app.tool_registry, "allowed_tool");
+        register_test_tool_in_toolset(&app.tool_registry, "mcp_srv_hidden", "mcp-srv");
+
+        let refresh = app.refresh_agent_tool_snapshot();
+
+        assert_eq!(refresh.before_count, 0);
+        assert_eq!(refresh.after_count, 1);
+        assert_eq!(refresh.added, vec!["allowed_tool".to_string()]);
+        assert!(refresh.removed.is_empty());
+        assert!(app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "allowed_tool"));
+        assert!(!app
+            .tool_schemas
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_hidden"));
     }
 
     #[test]
@@ -6212,7 +6245,11 @@ mod tests {
 // Helper: bridge hermes_tools::ToolRegistry → agent_loop::ToolRegistry
 // ---------------------------------------------------------------------------
 
-fn sorted_tool_names(mut names: Vec<String>) -> Vec<String> {
+fn sorted_tool_schema_names(schemas: &[ToolSchema]) -> Vec<String> {
+    let mut names = schemas
+        .iter()
+        .map(|schema| schema.name.clone())
+        .collect::<Vec<_>>();
     names.sort();
     names
 }

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -27711,25 +27711,11 @@ struct CliAcpPromptExecutor {
 
 impl CliAcpPromptExecutor {
     fn current_tool_schemas(&self) -> Vec<hermes_core::ToolSchema> {
-        let mut schemas = hermes_tool_planning::resolve_platform_tool_schemas(
+        hermes_tool_planning::resolve_platform_tool_schemas(
             self.config.as_ref(),
             "cli",
             &self.tool_registry,
-        );
-        let mut seen: HashSet<String> = schemas.iter().map(|schema| schema.name.clone()).collect();
-        let mcp_tool_names: HashSet<String> = self
-            .tool_registry
-            .list_tools()
-            .into_iter()
-            .filter(|entry| entry.toolset.starts_with("mcp-"))
-            .map(|entry| entry.name)
-            .collect();
-        for schema in self.tool_registry.get_definitions() {
-            if mcp_tool_names.contains(&schema.name) && seen.insert(schema.name.clone()) {
-                schemas.push(schema);
-            }
-        }
-        schemas
+        )
     }
 }
 
@@ -28972,7 +28958,7 @@ mod tests {
     }
 
     #[test]
-    fn acp_prompt_executor_resolves_tool_schemas_from_current_registry() {
+    fn acp_prompt_executor_respects_mcp_toolset_gate() {
         let mut config = GatewayConfig::default();
         config
             .platform_toolsets
@@ -29028,6 +29014,43 @@ mod tests {
             "mcp",
             None,
         );
+
+        assert!(!executor
+            .current_tool_schemas()
+            .iter()
+            .any(|schema| schema.name == "mcp_srv_ping"));
+    }
+
+    #[test]
+    fn acp_prompt_executor_allows_explicit_mcp_toolset_alias() {
+        let mut config = GatewayConfig::default();
+        config
+            .platform_toolsets
+            .insert("cli".to_string(), vec!["srv".to_string()]);
+        let tool_registry = Arc::new(hermes_tools::ToolRegistry::new());
+        let executor = CliAcpPromptExecutor {
+            config: Arc::new(config),
+            tool_registry: Arc::clone(&tool_registry),
+            interrupts: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let schema = hermes_core::tool_schema(
+            "mcp_srv_ping",
+            "MCP ping",
+            hermes_core::JsonSchema::new("object"),
+        );
+        tool_registry.register(
+            "mcp_srv_ping",
+            "mcp-srv",
+            schema.clone(),
+            Arc::new(CliNoopTool { schema }),
+            Arc::new(|| true),
+            Vec::new(),
+            true,
+            "MCP ping",
+            "mcp",
+            None,
+        );
+        tool_registry.register_toolset_alias("srv", "mcp-srv");
 
         assert!(executor
             .current_tool_schemas()

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T11:50:12.183619+00:00`_
+_Generated from source artifacts: `2026-06-25T12:20:28.697216+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T11:50:12.042888+00:00`
-- Proof snapshot generated: `2026-06-25T11:50:12.183619+00:00`
+- Queue snapshot generated: `2026-06-25T12:20:28.572991+00:00`
+- Proof snapshot generated: `2026-06-25T12:20:28.697216+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T11:50:12.183619+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=197.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=197.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=196.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=196.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-25T11:50:12.183619+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7011 |
-| Pending | 197 |
-| Ported | 397 |
-| Superseded | 6341 |
+| Total commits in queue | 7012 |
+| Pending | 196 |
+| Ported | 398 |
+| Superseded | 6342 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 197.0,
+        "actual": 196.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T11:50:12.183619+00:00",
+  "generated_at_utc": "2026-06-25T12:20:28.697216+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 197.0,
+    "max_queue_pending_commits": 196.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,12 +299,12 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 197,
-      "ported": 397,
-      "superseded": 6341
+      "pending": 196,
+      "ported": 398,
+      "superseded": 6342
     },
     "by_target_ticket": {
-      "20": 3139,
+      "20": 3140,
       "21": 130,
       "22": 957,
       "23": 488,
@@ -314,7 +314,7 @@
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7011
+    "total_commits": 7012
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 197.0,
+        "actual": 196.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T11:50:12.183619+00:00`
+Generated: `2026-06-25T12:20:28.697216+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T11:50:12.183619+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 197.0 |
+| `max_queue_pending_commits` | 196.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,9 +93,9 @@ Generated: `2026-06-25T11:50:12.183619+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7011`.
+- Upstream missing commits tracked: `7012`.
 - By target ticket:
-  - `#20`: `3139`
+  - `#20`: `3140`
   - `#21`: `130`
   - `#22`: `957`
   - `#23`: `488`

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4528,6 +4528,11 @@
       "disposition": "superseded",
       "notes": "Upstream malformed int/float env crash class is Python ValueError-specific. Rust numeric env reads in the corresponding config/gateway/agent/tool surfaces are fail-soft through parse().ok(), if-let Ok(...), or unwrap_or(default), so malformed values do not panic during adapter/agent init.",
       "owner": "rust-runtime"
+    },
+    "b6e2a54a94f5": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust MCP refresh parity now diffs reload snapshots against the advertised tool schema surface, so restricted/custom platform toolsets do not report hidden MCP handlers as added. ACP prompt execution no longer appends all live mcp-* schemas after planner filtering; explicit MCP server aliases still resolve through the shared platform planner. Python in-place tools/valid_tool_names race and post-build memory/context reinjection issues are superseded by Rust AgentLoop construction plus advertised-tool-name guards."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,12 +1,12 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T11:50:12.042888+00:00`
+Generated: `2026-06-25T12:20:28.572991+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7011`.
+- Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3139 |
+| #20 | GPAR-01 tests+CI parity | 3140 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 957 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
@@ -17,9 +17,9 @@ Generated: `2026-06-25T11:50:12.042888+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 197 |
-| ported | 397 |
-| superseded | 6341 |
+| pending | 196 |
+| ported | 398 |
+| superseded | 6342 |
 
 ## First 100 Pending Commits
 
@@ -44,7 +44,6 @@ Generated: `2026-06-25T11:50:12.042888+00:00`
 | `553cf4f97757` | #26 | feat(desktop): restart the gateway from Cmd+K, with statusbar spinner feedback |
 | `a1639921ac44` | #26 | fix(desktop): offer a Restart gateway action on messaging save/toggle toasts |
 | `929dbf777801` | #26 | fix(desktop): make rendered logs selectable so they can be copied |
-| `b6e2a54a94f5` | #20 | fix(mcp): address adversarial review round 1 (cache parity, gates, races) |
 | `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
 | `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |
 | `866f1d65c4aa` | #26 | chore(desktop): sync package.json version fallback to 0.17.0 (#49236) |
@@ -125,3 +124,4 @@ Generated: `2026-06-25T11:50:12.042888+00:00`
 | `86e4521cb1d9` | #23 | fix(delivery): make cron output truncation configurable + adapter-aware |
 | `e9cd8c5bf3ea` | #23 | fix(delivery): drop env-var knob, flag all chunking adapters |
 | `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |
+| `ff85af3fc7d3` | #20 | feat(goals): /goal wait <pid> — park the loop on a background process (#50503) |


### PR DESCRIPTION
## Summary
- Tighten `/reload-mcp` snapshot reporting to diff the advertised tool schema surface instead of the full internal executor registry.
- Stop ACP prompt execution from appending every live `mcp-*` schema after shared platform-toolset filtering.
- Preserve explicit MCP server aliases through `hermes_tool_planning` and add regression coverage for restricted/no-leak and explicit-allow cases.
- Mark upstream `b6e2a54a94f5` as ported and regenerate parity artifacts.

## Parity Delta
- Pending queue: `197 -> 196`
- Ported queue: `397 -> 398`
- Upstream queue was regenerated after fetch; `upstream/main` is `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4` and total tracked commits are `7012`.

## Verification
- `cargo fmt --all --check`
- `cargo check -p hermes-cli`
- `cargo test -p hermes-cli refresh_agent_tool_snapshot --quiet` (`4 passed`)
- `cargo test -p hermes-cli acp_prompt_executor --quiet` (`2 passed`)
- `git diff --check`
- stale model diff guard: no new `gpt-4o` / `4o` literals in diff
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-cli` (`seen=200 allowlist=200 new=0 stale=0`)
- `cargo build --workspace`
- `cargo test --workspace`
