### PR TITLE
parity(objective): add wait barriers

### DIFF
--- a/crates/hermes-cli/src/alpha_runtime.rs
+++ b/crates/hermes-cli/src/alpha_runtime.rs
@@ -91,6 +91,23 @@ pub struct ObjectiveContract {
     pub trading_sensitive: bool,
     #[serde(default)]
     pub counterfactual_journal: Vec<CounterfactualEntry>,
+    #[serde(default)]
+    pub waiting_on_pid: Option<u32>,
+    #[serde(default)]
+    pub waiting_on_session: Option<String>,
+    #[serde(default)]
+    pub waiting_until_unix_ms: i64,
+    #[serde(default)]
+    pub waiting_reason: String,
+    #[serde(default)]
+    pub waiting_since: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectiveWaitTarget {
+    Pid(u32),
+    Session(String),
+    Time { until_unix_ms: i64 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -515,6 +532,18 @@ fn objective_behavior_directives_for_mode(mode: &str) -> Vec<String> {
 
 fn default_objective_behavior_directives() -> Vec<String> {
     objective_behavior_directives_for_mode(&default_objective_behavior_mode())
+}
+
+pub fn objective_now_unix_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+fn clear_objective_wait_fields(contract: &mut ObjectiveContract) {
+    contract.waiting_on_pid = None;
+    contract.waiting_on_session = None;
+    contract.waiting_until_unix_ms = 0;
+    contract.waiting_reason.clear();
+    contract.waiting_since.clear();
 }
 
 pub fn canonical_objective_lifecycle_status(status: &str) -> String {
@@ -1139,6 +1168,7 @@ pub fn upsert_objective_contract(
         .as_ref()
         .map(|v| v.counterfactual_journal.clone())
         .unwrap_or_default();
+    let preserve_existing_wait = existing_objective.eq_ignore_ascii_case(objective_text.trim());
     let contract = ObjectiveContract {
         id: objective_id(objective_text),
         created_at,
@@ -1164,6 +1194,30 @@ pub fn upsert_objective_contract(
         confidence: calibrate_confidence(objective_text),
         trading_sensitive,
         counterfactual_journal,
+        waiting_on_pid: existing
+            .as_ref()
+            .filter(|_| preserve_existing_wait)
+            .and_then(|v| v.waiting_on_pid),
+        waiting_on_session: existing
+            .as_ref()
+            .filter(|_| preserve_existing_wait)
+            .and_then(|v| v.waiting_on_session.clone())
+            .filter(|v| !v.trim().is_empty()),
+        waiting_until_unix_ms: existing
+            .as_ref()
+            .filter(|_| preserve_existing_wait)
+            .map(|v| v.waiting_until_unix_ms)
+            .unwrap_or_default(),
+        waiting_reason: existing
+            .as_ref()
+            .filter(|_| preserve_existing_wait)
+            .map(|v| v.waiting_reason.trim().to_string())
+            .unwrap_or_default(),
+        waiting_since: existing
+            .as_ref()
+            .filter(|_| preserve_existing_wait)
+            .map(|v| v.waiting_since.trim().to_string())
+            .unwrap_or_default(),
     };
     write_json_file(&objective_contract_path(), &contract)?;
     Ok(contract)
@@ -1198,6 +1252,7 @@ pub fn set_objective_contract_lifecycle_status(
         )
     })?;
     contract.lifecycle_status = canonical_objective_lifecycle_status(status);
+    clear_objective_wait_fields(&mut contract);
     if let Some(reason) = reason {
         let trimmed = reason.trim();
         if !trimmed.is_empty() {
@@ -1210,6 +1265,157 @@ pub fn set_objective_contract_lifecycle_status(
     contract.updated_at = now_rfc3339();
     write_json_file(&objective_contract_path(), &contract)?;
     Ok(contract)
+}
+
+pub fn set_objective_contract_wait_pid(
+    pid: u32,
+    reason: Option<&str>,
+) -> Result<ObjectiveContract, AgentError> {
+    if pid == 0 {
+        return Err(AgentError::Config(
+            "objective wait pid must be positive".to_string(),
+        ));
+    }
+    let mut contract = load_objective_contract()?.ok_or_else(|| {
+        AgentError::Config(
+            "objective contract is not initialized; run `/objective <text>` first".to_string(),
+        )
+    })?;
+    if !objective_lifecycle_is_active(&contract.lifecycle_status) {
+        return Err(AgentError::Config(
+            "objective wait requires an active objective".to_string(),
+        ));
+    }
+    clear_objective_wait_fields(&mut contract);
+    contract.waiting_on_pid = Some(pid);
+    contract.waiting_reason = reason.unwrap_or("").trim().to_string();
+    contract.waiting_since = now_rfc3339();
+    contract.updated_at = now_rfc3339();
+    write_json_file(&objective_contract_path(), &contract)?;
+    Ok(contract)
+}
+
+pub fn set_objective_contract_wait_session(
+    session_id: &str,
+    reason: Option<&str>,
+) -> Result<ObjectiveContract, AgentError> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Err(AgentError::Config(
+            "objective wait session id cannot be empty".to_string(),
+        ));
+    }
+    let mut contract = load_objective_contract()?.ok_or_else(|| {
+        AgentError::Config(
+            "objective contract is not initialized; run `/objective <text>` first".to_string(),
+        )
+    })?;
+    if !objective_lifecycle_is_active(&contract.lifecycle_status) {
+        return Err(AgentError::Config(
+            "objective wait requires an active objective".to_string(),
+        ));
+    }
+    clear_objective_wait_fields(&mut contract);
+    contract.waiting_on_session = Some(session_id.to_string());
+    contract.waiting_reason = reason.unwrap_or("").trim().to_string();
+    contract.waiting_since = now_rfc3339();
+    contract.updated_at = now_rfc3339();
+    write_json_file(&objective_contract_path(), &contract)?;
+    Ok(contract)
+}
+
+pub fn set_objective_contract_wait_seconds(
+    seconds: u64,
+    reason: Option<&str>,
+) -> Result<ObjectiveContract, AgentError> {
+    if seconds == 0 {
+        return Err(AgentError::Config(
+            "objective wait seconds must be positive".to_string(),
+        ));
+    }
+    let mut contract = load_objective_contract()?.ok_or_else(|| {
+        AgentError::Config(
+            "objective contract is not initialized; run `/objective <text>` first".to_string(),
+        )
+    })?;
+    if !objective_lifecycle_is_active(&contract.lifecycle_status) {
+        return Err(AgentError::Config(
+            "objective wait requires an active objective".to_string(),
+        ));
+    }
+    let delta_ms = i64::try_from(seconds.saturating_mul(1000)).unwrap_or(i64::MAX);
+    clear_objective_wait_fields(&mut contract);
+    contract.waiting_until_unix_ms = objective_now_unix_ms().saturating_add(delta_ms);
+    contract.waiting_reason = reason.unwrap_or("").trim().to_string();
+    contract.waiting_since = now_rfc3339();
+    contract.updated_at = now_rfc3339();
+    write_json_file(&objective_contract_path(), &contract)?;
+    Ok(contract)
+}
+
+pub fn clear_objective_contract_wait_barrier() -> Result<ObjectiveContract, AgentError> {
+    let mut contract = load_objective_contract()?.ok_or_else(|| {
+        AgentError::Config(
+            "objective contract is not initialized; run `/objective <text>` first".to_string(),
+        )
+    })?;
+    clear_objective_wait_fields(&mut contract);
+    contract.updated_at = now_rfc3339();
+    write_json_file(&objective_contract_path(), &contract)?;
+    Ok(contract)
+}
+
+pub fn objective_wait_target(contract: &ObjectiveContract) -> Option<ObjectiveWaitTarget> {
+    if let Some(pid) = contract.waiting_on_pid.filter(|pid| *pid > 0) {
+        return Some(ObjectiveWaitTarget::Pid(pid));
+    }
+    if let Some(session_id) = contract
+        .waiting_on_session
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        return Some(ObjectiveWaitTarget::Session(session_id.to_string()));
+    }
+    if contract.waiting_until_unix_ms > 0 {
+        return Some(ObjectiveWaitTarget::Time {
+            until_unix_ms: contract.waiting_until_unix_ms,
+        });
+    }
+    None
+}
+
+pub fn objective_wait_remaining_seconds(contract: &ObjectiveContract) -> Option<i64> {
+    if contract.waiting_until_unix_ms <= 0 {
+        return None;
+    }
+    Some(
+        contract
+            .waiting_until_unix_ms
+            .saturating_sub(objective_now_unix_ms())
+            .saturating_add(999)
+            / 1000,
+    )
+}
+
+pub fn summarize_objective_wait_barrier(contract: &ObjectiveContract) -> String {
+    let reason = contract.waiting_reason.trim();
+    let suffix = if reason.is_empty() {
+        String::new()
+    } else {
+        format!(" reason={reason}")
+    };
+    match objective_wait_target(contract) {
+        Some(ObjectiveWaitTarget::Pid(pid)) => format!("pid={pid}{suffix}"),
+        Some(ObjectiveWaitTarget::Session(session_id)) => {
+            format!("session_id={session_id}{suffix}")
+        }
+        Some(ObjectiveWaitTarget::Time { until_unix_ms }) => {
+            let remaining = objective_wait_remaining_seconds(contract).unwrap_or_default();
+            format!("until_unix_ms={until_unix_ms} remaining_seconds={remaining}{suffix}")
+        }
+        None => "none".to_string(),
+    }
 }
 
 pub fn set_objective_contract_behavior_mode(mode: &str) -> Result<ObjectiveContract, AgentError> {
@@ -1928,10 +2134,11 @@ pub fn summarize_objective_contract(contract: &ObjectiveContract) -> String {
         .collect::<Vec<_>>()
         .join(", ");
     format!(
-        "objective_id: {}\nlifecycle_status: {}\nbehavior_mode: {}\nconfidence: {:.2}\nutility_terms: {}\nhard_constraints: {}\nhorizons: {}",
+        "objective_id: {}\nlifecycle_status: {}\nbehavior_mode: {}\nwait_barrier: {}\nconfidence: {:.2}\nutility_terms: {}\nhard_constraints: {}\nhorizons: {}",
         contract.id,
         canonical_objective_lifecycle_status(&contract.lifecycle_status),
         canonical_objective_behavior_mode(&contract.behavior_mode),
+        summarize_objective_wait_barrier(contract),
         contract.confidence,
         terms,
         constraints,
@@ -3593,6 +3800,85 @@ mod tests {
                 canonical_objective_lifecycle_status(&replaced.lifecycle_status),
                 "active"
             );
+        });
+    }
+
+    #[test]
+    fn objective_wait_barrier_roundtrip_and_lifecycle_clear() {
+        with_test_hermes_home(|| {
+            upsert_objective_contract("stabilize runtime telemetry", false).expect("objective set");
+
+            let waiting =
+                set_objective_contract_wait_pid(4242, Some("build still running")).expect("wait");
+            assert_eq!(waiting.waiting_on_pid, Some(4242));
+            assert_eq!(waiting.waiting_reason, "build still running");
+            assert!(matches!(
+                objective_wait_target(&waiting),
+                Some(ObjectiveWaitTarget::Pid(4242))
+            ));
+            let reloaded = load_objective_contract()
+                .expect("load objective")
+                .expect("objective present");
+            assert_eq!(reloaded.waiting_on_pid, Some(4242));
+
+            let session_wait =
+                set_objective_contract_wait_session("proc_abc", Some("watcher")).expect("wait");
+            assert_eq!(session_wait.waiting_on_session.as_deref(), Some("proc_abc"));
+            assert!(matches!(
+                objective_wait_target(&session_wait),
+                Some(ObjectiveWaitTarget::Session(ref session_id)) if session_id == "proc_abc"
+            ));
+
+            let seconds_wait =
+                set_objective_contract_wait_seconds(30, Some("backoff")).expect("wait seconds");
+            assert!(seconds_wait.waiting_until_unix_ms > objective_now_unix_ms());
+            assert!(objective_wait_remaining_seconds(&seconds_wait).unwrap_or_default() > 0);
+
+            let paused = set_objective_contract_lifecycle_status("pause", Some("manual hold"))
+                .expect("pause");
+            assert!(objective_wait_target(&paused).is_none());
+            assert_eq!(summarize_objective_wait_barrier(&paused), "none");
+        });
+    }
+
+    #[test]
+    fn objective_legacy_contract_loads_without_wait_fields() {
+        with_test_hermes_home(|| {
+            ensure_alpha_dir().expect("alpha dir");
+            let path = objective_contract_path();
+            std::fs::write(
+                &path,
+                serde_json::json!({
+                    "id": "obj-legacy",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "objective_text": "legacy objective",
+                    "lifecycle_status": "active",
+                    "status_reason": "",
+                    "behavior_mode": "balanced",
+                    "behavior_directives": [],
+                    "success_criteria": [],
+                    "utility": {"objective": "legacy", "terms": [], "hard_constraints": []},
+                    "horizons": [],
+                    "promotion_gate": {
+                        "min_patch_items": 1,
+                        "min_unique_files": 1,
+                        "min_unique_commands": 1,
+                        "require_objective_state": true
+                    },
+                    "confidence": 0.5,
+                    "trading_sensitive": false,
+                    "counterfactual_journal": []
+                })
+                .to_string(),
+            )
+            .expect("write legacy");
+            let loaded = load_objective_contract()
+                .expect("load objective")
+                .expect("objective present");
+            assert!(objective_wait_target(&loaded).is_none());
+            assert_eq!(loaded.waiting_until_unix_ms, 0);
+            assert!(loaded.waiting_reason.is_empty());
         });
     }
 

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 use hermes_agent::agent_loop::ToolRegistry as AgentToolRegistry;
@@ -36,8 +36,10 @@ use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
 
 use crate::alpha_runtime::{
-    canonical_objective_behavior_mode, load_objective_contract, load_quorum_policy,
-    objective_lifecycle_is_active, ObjectiveContract, QuorumPolicy,
+    canonical_objective_behavior_mode, clear_objective_contract_wait_barrier,
+    load_objective_contract, load_quorum_policy, objective_lifecycle_is_active,
+    objective_now_unix_ms, objective_wait_remaining_seconds, objective_wait_target,
+    summarize_objective_wait_barrier, ObjectiveContract, ObjectiveWaitTarget, QuorumPolicy,
 };
 use crate::auth::{
     login_nous_device_code, resolve_gemini_oauth_runtime_credentials,
@@ -746,7 +748,99 @@ impl App {
         (has_future_language && !has_execution_evidence) || has_weakness_markers
     }
 
-    fn should_force_objective_continuation(
+    #[cfg(unix)]
+    fn objective_pid_is_alive(pid: u32) -> bool {
+        // SAFETY: signal 0 performs a liveness/permission probe without sending a signal.
+        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if rc == 0 {
+            true
+        } else {
+            matches!(
+                std::io::Error::last_os_error().raw_os_error(),
+                Some(libc::EPERM)
+            )
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn objective_pid_is_alive(_pid: u32) -> bool {
+        false
+    }
+
+    fn clear_stale_objective_wait_barrier(&self, reason: &str) {
+        match clear_objective_contract_wait_barrier() {
+            Ok(updated) => Self::emit_lifecycle_event(
+                &self.stream_handle_shared,
+                format!(
+                    "objective wait barrier auto-cleared: {} (objective_id={})",
+                    reason, updated.id
+                ),
+            ),
+            Err(err) => tracing::warn!("objective wait barrier auto-clear failed: {}", err),
+        }
+    }
+
+    async fn process_session_is_running(&self, session_id: &str) -> bool {
+        let raw = self
+            .tool_registry
+            .dispatch_async("process", json!({"action":"poll","session_id":session_id}))
+            .await;
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            return false;
+        };
+        value
+            .get("status")
+            .and_then(Value::as_str)
+            .map(|status| status.eq_ignore_ascii_case("running"))
+            .unwrap_or(false)
+    }
+
+    async fn objective_wait_barrier_active_message(
+        &self,
+        contract: &ObjectiveContract,
+    ) -> Option<String> {
+        match objective_wait_target(contract)? {
+            ObjectiveWaitTarget::Pid(pid) => {
+                if Self::objective_pid_is_alive(pid) {
+                    Some(format!(
+                        "objective wait barrier active: {}",
+                        summarize_objective_wait_barrier(contract)
+                    ))
+                } else {
+                    self.clear_stale_objective_wait_barrier(&format!("pid {pid} is not running"));
+                    None
+                }
+            }
+            ObjectiveWaitTarget::Session(session_id) => {
+                if self.process_session_is_running(&session_id).await {
+                    Some(format!(
+                        "objective wait barrier active: {}",
+                        summarize_objective_wait_barrier(contract)
+                    ))
+                } else {
+                    self.clear_stale_objective_wait_barrier(&format!(
+                        "process session {session_id} is not running"
+                    ));
+                    None
+                }
+            }
+            ObjectiveWaitTarget::Time { until_unix_ms } => {
+                if objective_now_unix_ms() < until_unix_ms {
+                    let remaining = objective_wait_remaining_seconds(contract).unwrap_or_default();
+                    Some(format!(
+                        "objective wait barrier active: {} (remaining_seconds={})",
+                        summarize_objective_wait_barrier(contract),
+                        remaining.max(0)
+                    ))
+                } else {
+                    self.clear_stale_objective_wait_barrier("timer elapsed");
+                    None
+                }
+            }
+        }
+    }
+
+    async fn should_force_objective_continuation(
         &self,
         result: &hermes_core::AgentResult,
         baseline_len: usize,
@@ -757,6 +851,10 @@ impl App {
         let contract = Self::load_active_objective_contract()?;
         let behavior_mode = canonical_objective_behavior_mode(&contract.behavior_mode);
         if !matches!(behavior_mode.as_str(), "autonomous" | "mission") {
+            return None;
+        }
+        if let Some(message) = self.objective_wait_barrier_active_message(&contract).await {
+            Self::emit_lifecycle_event(&self.stream_handle_shared, message);
             return None;
         }
 
@@ -3399,8 +3497,9 @@ impl App {
                     let interrupted = result.interrupted;
                     let finished_naturally = result.finished_naturally;
                     if objective_continuation_attempts < objective_continuation_limit {
-                        if let Some(reason) =
-                            self.should_force_objective_continuation(&result, baseline_len)
+                        if let Some(reason) = self
+                            .should_force_objective_continuation(&result, baseline_len)
+                            .await
                         {
                             self.messages = result.messages;
                             self.messages.push(hermes_core::Message::system(
@@ -4166,6 +4265,14 @@ mod tests {
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
         test_env_lock::lock()
+    }
+
+    fn block_on_test<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
     }
 
     struct EnvSnapshot {
@@ -5907,7 +6014,52 @@ mod tests {
         };
 
         let reason = app.should_force_objective_continuation(&result, baseline_len);
+        let reason = block_on_test(reason);
         assert!(reason.is_some());
+
+        match prev_home {
+            Some(val) => std::env::set_var("HERMES_HOME", val),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        std::env::remove_var("HERMES_OBJECTIVE_EXECUTION_ENFORCER");
+    }
+
+    #[test]
+    fn test_objective_wait_timer_parks_continuation_enforcer() {
+        let _lock = env_test_lock();
+        let prev_home = std::env::var("HERMES_HOME").ok();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HERMES_HOME", tmp.path());
+        std::env::set_var("HERMES_OBJECTIVE_EXECUTION_ENFORCER", "1");
+
+        let mut app = build_minimal_test_app();
+        app.messages.push(hermes_core::Message::user(
+            "Proceed with objective and improve outcomes continuously.",
+        ));
+        upsert_objective_contract(
+            "Run this assignment in perpetuity and continuously improve output quality",
+            false,
+        )
+        .expect("set objective");
+        set_objective_contract_behavior_mode("mission").expect("set mission mode");
+        crate::alpha_runtime::set_objective_contract_wait_seconds(60, Some("CI cooldown"))
+            .expect("set wait");
+
+        let baseline_len = app.messages.len();
+        let mut result_messages = app.messages.clone();
+        result_messages.push(hermes_core::Message::assistant(
+            "I will proceed with the next steps and share updates shortly.",
+        ));
+        let result = hermes_core::AgentResult {
+            messages: result_messages,
+            finished_naturally: true,
+            total_turns: 1,
+            ..Default::default()
+        };
+
+        let reason = app.should_force_objective_continuation(&result, baseline_len);
+        let reason = block_on_test(reason);
+        assert!(reason.is_none());
 
         match prev_home {
             Some(val) => std::env::set_var("HERMES_HOME", val),

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -48,19 +48,22 @@ use sha2::{Digest, Sha256};
 use crate::alpha_runtime::{
     append_counterfactual, append_objective_learning_entry, build_objective_dag_from_contract,
     canonical_objective_behavior_mode, canonical_objective_lifecycle_status,
-    clear_objective_contract, clear_objective_dag, clear_objective_learning_ledger,
-    enqueue_loop_event, ensure_alpha_runtime_bootstrap, ensure_trading_runtime_bootstrap,
-    load_alpha_loops, load_claim_verifier_policy, load_contextlattice_policy,
-    load_last_trading_alpha_report, load_objective_contract, load_objective_dag,
-    load_objective_ensemble_policy, load_objective_eval_trend, load_objective_learning_ledger,
-    load_objective_profile, load_objective_simulation_policy, load_quorum_policy,
-    objective_lifecycle_is_active, objective_profile_specialized_for, recover_orphan_loop_events,
-    refresh_trading_alpha_report, render_mission_board, render_trading_alpha_board,
-    replay_loop_queue, reset_objective_profile_generalized, set_claim_verifier_enabled,
-    set_contextlattice_policy_mode, set_objective_contract_behavior_mode,
-    set_objective_contract_lifecycle_status, set_objective_ensemble_mode, set_objective_profile,
+    clear_objective_contract, clear_objective_contract_wait_barrier, clear_objective_dag,
+    clear_objective_learning_ledger, enqueue_loop_event, ensure_alpha_runtime_bootstrap,
+    ensure_trading_runtime_bootstrap, load_alpha_loops, load_claim_verifier_policy,
+    load_contextlattice_policy, load_last_trading_alpha_report, load_objective_contract,
+    load_objective_dag, load_objective_ensemble_policy, load_objective_eval_trend,
+    load_objective_learning_ledger, load_objective_profile, load_objective_simulation_policy,
+    load_quorum_policy, objective_lifecycle_is_active, objective_profile_specialized_for,
+    recover_orphan_loop_events, refresh_trading_alpha_report, render_mission_board,
+    render_trading_alpha_board, replay_loop_queue, reset_objective_profile_generalized,
+    set_claim_verifier_enabled, set_contextlattice_policy_mode,
+    set_objective_contract_behavior_mode, set_objective_contract_lifecycle_status,
+    set_objective_contract_wait_pid, set_objective_contract_wait_seconds,
+    set_objective_contract_wait_session, set_objective_ensemble_mode, set_objective_profile,
     set_objective_simulation_mode, set_quorum_policy, summarize_objective_contract,
-    upsert_objective_contract, utility_terms_from_contract, ObjectiveLearningLedgerEntry,
+    summarize_objective_wait_barrier, upsert_objective_contract, utility_terms_from_contract,
+    ObjectiveLearningLedgerEntry,
 };
 use crate::app::{build_runtime_cron_scheduler, App, PetDock, PetSettings};
 use crate::kanban::{
@@ -255,7 +258,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ),
     (
         "/objective",
-        "Set/show objective contract + profile/policies (`status|verify|plan|constraints|counterfactual|profile|context|simulator|ensemble|ledger|dag|eval|clear`)",
+        "Set/show objective contract + profile/policies (`status|verify|plan|constraints|counterfactual|wait|unwait|profile|context|simulator|ensemble|ledger|dag|eval|clear`)",
     ),
     (
         "/claims",
@@ -3334,6 +3337,10 @@ fn command_nested_candidates(cmd: &str, subcommand: &str, arg_position: usize) -
             .iter()
             .map(|v| (*v).to_string())
             .collect(),
+        ("/objective", "wait", 1) => ["--session", "--seconds", "for"]
+            .iter()
+            .map(|v| (*v).to_string())
+            .collect(),
         ("/model", "why-not", 1) => [
             "--cap",
             "--min-context",
@@ -3362,6 +3369,8 @@ fn command_subcommand_overrides(cmd: &str) -> &'static [&'static str] {
             "plan",
             "constraints",
             "counterfactual",
+            "wait",
+            "unwait",
             "profile",
             "context",
             "simulator",
@@ -17245,11 +17254,190 @@ fn apply_objective_lifecycle_update(
     Ok(CommandResult::Handled)
 }
 
+enum ObjectiveWaitRequest {
+    Pid(u32, String),
+    Session(String, String),
+    Seconds(u64, String),
+}
+
+fn parse_objective_wait_seconds(raw: &str) -> Option<u64> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let without_suffix = trimmed
+        .strip_suffix('s')
+        .or_else(|| trimmed.strip_suffix("sec"))
+        .or_else(|| trimmed.strip_suffix("secs"))
+        .or_else(|| trimmed.strip_suffix("seconds"))
+        .unwrap_or(trimmed);
+    without_suffix.trim().parse::<u64>().ok().filter(|v| *v > 0)
+}
+
+fn parse_objective_wait_request(args: &[&str]) -> Result<ObjectiveWaitRequest, String> {
+    let Some(raw_target) = args.get(1).map(|v| v.trim()).filter(|v| !v.is_empty()) else {
+        return Err(
+            "Usage: /objective wait <pid|session_id|session:<id>|--session <id>|--seconds <n>|for <n>s> [reason...]"
+                .to_string(),
+        );
+    };
+    let lower = raw_target.to_ascii_lowercase();
+    let reason_from = |start: usize| -> String {
+        args.get(start..)
+            .unwrap_or(&[])
+            .join(" ")
+            .trim()
+            .to_string()
+    };
+
+    if matches!(lower.as_str(), "--session" | "session" | "sid") {
+        let Some(session_id) = args.get(2).map(|v| v.trim()).filter(|v| !v.is_empty()) else {
+            return Err("Usage: /objective wait --session <session_id> [reason...]".to_string());
+        };
+        return Ok(ObjectiveWaitRequest::Session(
+            session_id.to_string(),
+            reason_from(3),
+        ));
+    }
+
+    if matches!(
+        lower.as_str(),
+        "--seconds" | "seconds" | "second" | "secs" | "sec" | "for" | "timer"
+    ) {
+        let Some(raw_seconds) = args.get(2).map(|v| v.trim()).filter(|v| !v.is_empty()) else {
+            return Err("Usage: /objective wait --seconds <seconds> [reason...]".to_string());
+        };
+        let seconds = parse_objective_wait_seconds(raw_seconds)
+            .ok_or_else(|| "objective wait seconds must be positive".to_string())?;
+        return Ok(ObjectiveWaitRequest::Seconds(seconds, reason_from(3)));
+    }
+
+    for prefix in ["session:", "sid:"] {
+        if let Some(session_id) = raw_target.strip_prefix(prefix) {
+            let session_id = session_id.trim();
+            if session_id.is_empty() {
+                return Err("objective wait session id cannot be empty".to_string());
+            }
+            return Ok(ObjectiveWaitRequest::Session(
+                session_id.to_string(),
+                reason_from(2),
+            ));
+        }
+    }
+
+    for prefix in ["seconds:", "secs:", "sec:", "for:"] {
+        if let Some(raw_seconds) = raw_target.strip_prefix(prefix) {
+            let seconds = parse_objective_wait_seconds(raw_seconds)
+                .ok_or_else(|| "objective wait seconds must be positive".to_string())?;
+            return Ok(ObjectiveWaitRequest::Seconds(seconds, reason_from(2)));
+        }
+    }
+
+    if let Some(seconds) = parse_objective_wait_seconds(raw_target).filter(|_| {
+        raw_target.ends_with('s') || lower.ends_with("sec") || lower.ends_with("seconds")
+    }) {
+        return Ok(ObjectiveWaitRequest::Seconds(seconds, reason_from(2)));
+    }
+
+    if let Ok(pid) = raw_target.parse::<u32>() {
+        if pid == 0 {
+            return Err("objective wait pid must be positive".to_string());
+        }
+        return Ok(ObjectiveWaitRequest::Pid(pid, reason_from(2)));
+    }
+
+    Ok(ObjectiveWaitRequest::Session(
+        raw_target.to_string(),
+        reason_from(2),
+    ))
+}
+
+fn apply_objective_wait_request(
+    app: &mut App,
+    request: ObjectiveWaitRequest,
+) -> Result<CommandResult, AgentError> {
+    let (updated, decision, command) = match request {
+        ObjectiveWaitRequest::Pid(pid, reason) => (
+            set_objective_contract_wait_pid(pid, Some(&reason))?,
+            "objective_wait_pid".to_string(),
+            format!("/objective wait {pid}"),
+        ),
+        ObjectiveWaitRequest::Session(session_id, reason) => (
+            set_objective_contract_wait_session(&session_id, Some(&reason))?,
+            "objective_wait_session".to_string(),
+            format!("/objective wait --session {session_id}"),
+        ),
+        ObjectiveWaitRequest::Seconds(seconds, reason) => (
+            set_objective_contract_wait_seconds(seconds, Some(&reason))?,
+            "objective_wait_seconds".to_string(),
+            format!("/objective wait --seconds {seconds}"),
+        ),
+    };
+
+    let _ = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
+        recorded_at: String::new(),
+        objective_id: updated.id.clone(),
+        objective_state: canonical_objective_lifecycle_status(&updated.lifecycle_status),
+        decision,
+        evidence_files: vec!["alpha/objective_contract.json".to_string()],
+        evidence_commands: vec![command],
+        notes: format!(
+            "Objective wait barrier set: {}",
+            summarize_objective_wait_barrier(&updated)
+        ),
+    });
+
+    let mut out = String::new();
+    out.push_str("Objective wait barrier set\n");
+    out.push_str("--------------------------\n");
+    let _ = writeln!(out, "objective_id={}", updated.id);
+    let _ = writeln!(
+        out,
+        "wait_barrier={}",
+        summarize_objective_wait_barrier(&updated)
+    );
+    let _ = writeln!(out, "continuation_enforcer=parked_until_released");
+    emit_command_output(app, out.trim_end());
+    Ok(CommandResult::Handled)
+}
+
 fn handle_objective_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
-    let objective_usage = "Usage: `/objective <text>` or `/objective status|verify|plan|constraints|counterfactual <scenario> | <expected_delta>|lifecycle [status|active|pause|resume|budget-limited|achieved|unmet]|behavior [status|list|balanced|strict|autonomous|mission|minimal]|profile [status|list|general|me|set <id>]|context [status|list|max|balanced|fast]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|dag [status|rebuild|clear]|eval [status|tail [n]]|clear`.";
+    let objective_usage = "Usage: `/objective <text>` or `/objective status|verify|plan|constraints|counterfactual <scenario> | <expected_delta>|wait <pid|session_id|--session <id>|--seconds <n>|for <n>s> [reason...]|unwait|lifecycle [status|active|pause|resume|budget-limited|achieved|unmet]|behavior [status|list|balanced|strict|autonomous|mission|minimal]|profile [status|list|general|me|set <id>]|context [status|list|max|balanced|fast]|simulator [status|balanced|strict|aggressive]|ensemble [status|committee|single|debate]|ledger [status|tail [n]|clear]|dag [status|rebuild|clear]|eval [status|tail [n]]|clear`.";
 
     if let Some(first) = args.first() {
         let cmd = first.trim().to_ascii_lowercase();
+
+        if cmd == "wait" {
+            match parse_objective_wait_request(args) {
+                Ok(request) => return apply_objective_wait_request(app, request),
+                Err(usage) => {
+                    emit_command_output(app, usage);
+                    return Ok(CommandResult::Handled);
+                }
+            }
+        }
+
+        if cmd == "unwait" || cmd == "clear-wait" || cmd == "clear_wait" {
+            let updated = clear_objective_contract_wait_barrier()?;
+            let _ = append_objective_learning_entry(ObjectiveLearningLedgerEntry {
+                recorded_at: String::new(),
+                objective_id: updated.id.clone(),
+                objective_state: canonical_objective_lifecycle_status(&updated.lifecycle_status),
+                decision: "objective_unwait".to_string(),
+                evidence_files: vec!["alpha/objective_contract.json".to_string()],
+                evidence_commands: vec!["/objective unwait".to_string()],
+                notes: "Objective wait barrier cleared by operator command.".to_string(),
+            });
+            emit_command_output(
+                app,
+                format!(
+                    "Objective wait barrier cleared.\nobjective_id={}\nwait_barrier={}",
+                    updated.id,
+                    summarize_objective_wait_barrier(&updated)
+                ),
+            );
+            return Ok(CommandResult::Handled);
+        }
 
         let lifecycle_alias = match cmd.as_str() {
             "pause" => Some("paused"),
@@ -29819,6 +30007,86 @@ mod tests {
         assert_eq!(resume_result, CommandResult::Handled);
         assert_eq!(app.session_objective.as_deref(), Some("stabilize indexing"));
         assert!(latest_ui_assistant_text(&app).contains("status=active"));
+    }
+
+    #[tokio::test]
+    async fn objective_wait_pid_and_unwait_update_contract() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        handle_slash_command(&mut app, "/objective", &["stabilize", "release"])
+            .await
+            .expect("set objective");
+
+        let wait_result = handle_slash_command(
+            &mut app,
+            "/objective",
+            &["wait", "4242", "CI", "still", "running"],
+        )
+        .await
+        .expect("set wait pid");
+        assert_eq!(wait_result, CommandResult::Handled);
+        let output = latest_ui_assistant_text(&app);
+        assert!(output.contains("Objective wait barrier set"));
+        assert!(output.contains("pid=4242"));
+        let contract = load_objective_contract()
+            .expect("load contract")
+            .expect("contract");
+        assert_eq!(contract.waiting_on_pid, Some(4242));
+        assert_eq!(contract.waiting_reason, "CI still running");
+
+        let unwait_result = handle_slash_command(&mut app, "/goal", &["unwait"])
+            .await
+            .expect("unwait");
+        assert_eq!(unwait_result, CommandResult::Handled);
+        let contract = load_objective_contract()
+            .expect("load contract")
+            .expect("contract");
+        assert!(contract.waiting_on_pid.is_none());
+        assert!(contract.waiting_on_session.is_none());
+        assert_eq!(contract.waiting_until_unix_ms, 0);
+    }
+
+    #[tokio::test]
+    async fn objective_wait_supports_session_and_seconds_forms() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+
+        handle_slash_command(&mut app, "/objective", &["ship", "build"])
+            .await
+            .expect("set objective");
+
+        handle_slash_command(
+            &mut app,
+            "/objective",
+            &["wait", "--session", "proc_abc", "build", "watcher"],
+        )
+        .await
+        .expect("set session wait");
+        let contract = load_objective_contract()
+            .expect("load contract")
+            .expect("contract");
+        assert_eq!(contract.waiting_on_session.as_deref(), Some("proc_abc"));
+        assert_eq!(contract.waiting_reason, "build watcher");
+
+        handle_slash_command(
+            &mut app,
+            "/objective",
+            &["wait", "for", "30s", "rate", "limit"],
+        )
+        .await
+        .expect("set seconds wait");
+        let contract = load_objective_contract()
+            .expect("load contract")
+            .expect("contract");
+        assert!(contract.waiting_on_session.is_none());
+        assert!(contract.waiting_until_unix_ms > crate::alpha_runtime::objective_now_unix_ms());
+        assert_eq!(contract.waiting_reason, "rate limit");
+        assert!(latest_ui_assistant_text(&app).contains("remaining_seconds="));
     }
 
     #[tokio::test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T12:20:28.697216+00:00`_
+_Generated from source artifacts: `2026-06-25T12:44:22.163367+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T12:20:28.572991+00:00`
-- Proof snapshot generated: `2026-06-25T12:20:28.697216+00:00`
+- Queue snapshot generated: `2026-06-25T12:44:22.004656+00:00`
+- Proof snapshot generated: `2026-06-25T12:44:22.163367+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T12:20:28.697216+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=196.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=196.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=195.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=195.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T12:20:28.697216+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7012 |
-| Pending | 196 |
-| Ported | 398 |
+| Pending | 195 |
+| Ported | 399 |
 | Superseded | 6342 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 196.0,
+        "actual": 195.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T12:20:28.697216+00:00",
+  "generated_at_utc": "2026-06-25T12:44:22.163367+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 196.0,
+    "max_queue_pending_commits": 195.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 196,
-      "ported": 398,
+      "pending": 195,
+      "ported": 399,
       "superseded": 6342
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 196.0,
+        "actual": 195.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T12:20:28.697216+00:00`
+Generated: `2026-06-25T12:44:22.163367+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T12:20:28.697216+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 196.0 |
+| `max_queue_pending_commits` | 195.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4533,6 +4533,11 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust MCP refresh parity now diffs reload snapshots against the advertised tool schema surface, so restricted/custom platform toolsets do not report hidden MCP handlers as added. ACP prompt execution no longer appends all live mcp-* schemas after planner filtering; explicit MCP server aliases still resolve through the shared platform planner. Python in-place tools/valid_tool_names race and post-build memory/context reinjection issues are superseded by Rust AgentLoop construction plus advertised-tool-name guards."
+    },
+    "ff85af3fc7d3": {
+      "disposition": "ported",
+      "notes": "Rust Objective OS now has durable wait barriers for /objective and /goal: PID, process-session, and timed waits persist in the objective contract, pause/resume lifecycle clears stale waits, and the mission/autonomous continuation enforcer parks while live barriers are active and fail-safe clears stale ones.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T12:20:28.572991+00:00`
+Generated: `2026-06-25T12:44:22.004656+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T12:20:28.572991+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 196 |
-| ported | 398 |
+| pending | 195 |
+| ported | 399 |
 | superseded | 6342 |
 
 ## First 100 Pending Commits
@@ -124,4 +124,4 @@ Generated: `2026-06-25T12:20:28.572991+00:00`
 | `86e4521cb1d9` | #23 | fix(delivery): make cron output truncation configurable + adapter-aware |
 | `e9cd8c5bf3ea` | #23 | fix(delivery): drop env-var knob, flag all chunking adapters |
 | `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |
-| `ff85af3fc7d3` | #20 | feat(goals): /goal wait <pid> — park the loop on a background process (#50503) |
+| `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |


### PR DESCRIPTION
## Summary
- Port upstream goal wait behavior into Rust Objective OS as durable wait barriers.
- Add PID, process-session, and timed waits to objective contracts with backward-compatible serde defaults.
- Add /objective and /goal wait/unwait command handling, status output, autocomplete, and objective ledger entries.
- Make mission/autonomous continuation enforcement park while live barriers are active and fail-safe clear stale PID/session/timer barriers.
- Mark upstream ff85af3fc7d3 as ported and regenerate parity artifacts.

## Verification
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo fmt --all --check
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo check -p hermes-cli
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli objective_wait --quiet
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli should_force_objective_continuation --quiet
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test -p hermes-cli objective_wait_timer --quiet
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- stale model diff guard: No new stale model literals in diff.
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli (seen=200 allowlist=200 new=0 stale=0)
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo build --workspace
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation CARGO_INCREMENTAL=0 cargo test --workspace
- git diff --check

## Parity Delta
- pending: 196 -> 195
- ported: 398 -> 399
