### PR TITLE
parity(runtime): add RPC facts oneshot learn verification

### DIFF
--- a/crates/hermes-agent/src/coding_context.rs
+++ b/crates/hermes-agent/src/coding_context.rs
@@ -9,6 +9,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde::{Deserialize, Serialize};
+
 pub const CODING_TOOLSET: &str = "coding";
 
 const INTERACTIVE_CODING_PLATFORMS: &[&str] = &["", "cli", "tui", "acp", "desktop", "local"];
@@ -133,6 +135,16 @@ pub struct RuntimeMode {
     pub mode: CodingContextMode,
     pub workspace_root: Option<PathBuf>,
     pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectFacts {
+    pub root: String,
+    pub manifests: Vec<String>,
+    pub package_managers: Vec<String>,
+    pub verify_commands: Vec<String>,
+    pub context_files: Vec<String>,
 }
 
 impl RuntimeMode {
@@ -285,6 +297,33 @@ pub fn build_coding_workspace_block(root: &Path) -> Option<String> {
     (lines.len() > 2).then(|| lines.join("\n"))
 }
 
+pub fn detect_project_facts(root: &Path) -> ProjectFacts {
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let manifests = project_manifest_names(&root);
+    let package_managers = package_managers(&root);
+    let verify_commands = verify_commands(&root);
+    let context_files = CONTEXT_FILES
+        .iter()
+        .copied()
+        .filter(|name| root.join(name).is_file())
+        .map(str::to_string)
+        .collect();
+
+    ProjectFacts {
+        root: root.display().to_string(),
+        manifests,
+        package_managers,
+        verify_commands,
+        context_files,
+    }
+}
+
+pub fn project_facts_for(cwd: Option<&Path>) -> Option<ProjectFacts> {
+    let resolved = resolve_cwd(cwd);
+    let root = workspace_root(&resolved)?;
+    Some(detect_project_facts(&root))
+}
+
 fn normalize_platform(platform: Option<&str>) -> String {
     platform
         .unwrap_or("")
@@ -371,6 +410,27 @@ fn detected_project_markers(root: &Path) -> Vec<String> {
         }
     }
     markers
+}
+
+fn project_manifest_names(root: &Path) -> Vec<String> {
+    PROJECT_MARKERS
+        .iter()
+        .copied()
+        .filter(|marker| !CONTEXT_FILES.contains(marker))
+        .filter(|marker| root.join(marker).exists())
+        .map(str::to_string)
+        .collect()
+}
+
+fn package_managers(root: &Path) -> Vec<String> {
+    let mut managers = Vec::new();
+    if let Some(pm) = js_package_manager(root) {
+        managers.push(pm.to_string());
+    }
+    if let Some(pm) = python_package_manager(root) {
+        managers.push(pm.to_string());
+    }
+    dedup_truncate(managers)
 }
 
 fn js_package_manager(root: &Path) -> Option<&'static str> {
@@ -656,6 +716,37 @@ mod tests {
         assert!(!block.contains("run dev"));
         assert!(block.contains("Context files: AGENTS.md"));
         assert!(block.contains("Status:"));
+    }
+
+    #[test]
+    fn project_facts_are_structured_from_workspace_detector() {
+        let tmp = tempfile::tempdir().unwrap();
+        git_init(tmp.path());
+        std::fs::write(
+            tmp.path().join("package.json"),
+            r#"{"scripts":{"test":"vitest","lint":"eslint .","dev":"vite"}}"#,
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("pnpm-lock.yaml"), "").unwrap();
+        std::fs::write(tmp.path().join("AGENTS.md"), "# rules").unwrap();
+
+        let facts = project_facts_for(Some(tmp.path())).expect("project facts");
+
+        assert_eq!(
+            facts.root,
+            tmp.path().canonicalize().unwrap().display().to_string()
+        );
+        assert!(facts.manifests.contains(&"package.json".to_string()));
+        assert_eq!(facts.package_managers, vec!["pnpm".to_string()]);
+        assert!(facts.verify_commands.contains(&"pnpm run test".to_string()));
+        assert!(facts.verify_commands.contains(&"pnpm run lint".to_string()));
+        assert!(!facts.verify_commands.iter().any(|cmd| cmd.contains("dev")));
+        assert_eq!(facts.context_files, vec!["AGENTS.md".to_string()]);
+
+        let rendered = build_coding_workspace_block(tmp.path()).unwrap();
+        for command in &facts.verify_commands {
+            assert!(rendered.contains(command));
+        }
     }
 
     #[test]

--- a/crates/hermes-agent/src/lib.rs
+++ b/crates/hermes-agent/src/lib.rs
@@ -25,6 +25,7 @@ pub mod memory_manager;
 pub mod memory_plugins;
 pub mod model_normalize;
 pub mod oauth;
+pub mod oneshot;
 pub mod plugins;
 pub mod provider;
 pub mod provider_profiles;
@@ -65,6 +66,11 @@ pub use auxiliary_builder::{
     AuxiliaryWiringSummary,
 };
 pub use bedrock::BedrockProvider;
+pub use hermes_intelligence::auxiliary::AuxiliaryConfig;
+pub use oneshot::{
+    render_template as render_oneshot_template, run_oneshot_with_client, strip_wrapping_code_fence,
+    truncate_template_text, OneShotError, OneShotRequest,
+};
 pub use provider::{AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider};
 pub use providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,

--- a/crates/hermes-agent/src/oneshot.rs
+++ b/crates/hermes-agent/src/oneshot.rs
@@ -1,0 +1,291 @@
+//! Stateless one-shot LLM helpers for UI/runtime chores.
+//!
+//! A one-shot call runs outside a conversation. It never appends to session
+//! history and is intended for small generative tasks such as commit-message
+//! drafts, rename suggestions, and summaries.
+
+use std::time::Duration;
+
+use hermes_core::Message;
+use hermes_intelligence::auxiliary::{
+    AuxiliaryClient, AuxiliaryError, AuxiliaryRequest, AuxiliaryTask,
+};
+use serde_json::{Map, Value};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum OneShotError {
+    #[error("unknown one-shot template: {0}")]
+    UnknownTemplate(String),
+    #[error("one-shot requires a template or instructions/input")]
+    EmptyPrompt,
+    #[error(transparent)]
+    Auxiliary(#[from] AuxiliaryError),
+}
+
+#[derive(Debug, Clone)]
+pub struct OneShotRequest {
+    pub instructions: String,
+    pub user_input: String,
+    pub template: Option<String>,
+    pub variables: Map<String, Value>,
+    pub task: String,
+    pub max_tokens: u32,
+    pub temperature: Option<f64>,
+    pub timeout_secs: Option<u64>,
+}
+
+impl Default for OneShotRequest {
+    fn default() -> Self {
+        Self {
+            instructions: String::new(),
+            user_input: String::new(),
+            template: None,
+            variables: Map::new(),
+            task: "title".to_string(),
+            max_tokens: 1024,
+            temperature: Some(0.3),
+            timeout_secs: Some(60),
+        }
+    }
+}
+
+const COMMIT_MESSAGE_INSTRUCTIONS: &str = "You write git commit messages. Given a diff of staged changes, write ONE concise Conventional Commits message describing what changed and why.\n\
+Rules:\n\
+- Subject line: type(scope): summary, imperative mood, lower-case, no trailing period, <= 72 characters. Types: feat, fix, refactor, perf, docs, test, build, chore, style, ci.\n\
+- Omit the scope if it is not obvious.\n\
+- Add a short body only when the change needs explanation; skip it for small or obvious changes.\n\
+- Describe the actual change, never restate the diff line by line.\n\
+- Return only the commit message text, with no quotes, markdown fences, or preamble.";
+
+pub fn truncate_template_text(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let mut end = limit.min(text.len());
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n...(truncated)", text[..end].trim_end())
+}
+
+pub fn render_template(
+    name: &str,
+    variables: &Map<String, Value>,
+) -> Result<(String, String), OneShotError> {
+    match name.trim() {
+        "commit_message" => Ok(render_commit_message_template(variables)),
+        other => Err(OneShotError::UnknownTemplate(other.to_string())),
+    }
+}
+
+fn variable_string(variables: &Map<String, Value>, key: &str) -> String {
+    variables
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn render_commit_message_template(variables: &Map<String, Value>) -> (String, String) {
+    let diff = truncate_template_text(&variable_string(variables, "diff"), 12_000);
+    let recent_commits =
+        truncate_template_text(&variable_string(variables, "recent_commits"), 1_500);
+    let avoid = truncate_template_text(&variable_string(variables, "avoid"), 1_000);
+
+    let mut parts = Vec::new();
+    if !recent_commits.trim().is_empty() {
+        parts.push(format!(
+            "Recent commit subjects from this repo (match their style/conventions):\n{recent_commits}"
+        ));
+    }
+    parts.push(format!(
+        "Diff to describe:\n{}",
+        if diff.trim().is_empty() {
+            "(no textual diff available)"
+        } else {
+            diff.as_str()
+        }
+    ));
+    if !avoid.trim().is_empty() {
+        parts.push(format!(
+            "You already proposed this message and the user wants a different one. Write a new message with different wording and do not repeat it:\n{avoid}"
+        ));
+    }
+
+    (COMMIT_MESSAGE_INSTRUCTIONS.to_string(), parts.join("\n\n"))
+}
+
+pub fn strip_wrapping_code_fence(text: &str) -> String {
+    let trimmed = text.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed.to_string();
+    }
+    let lines = trimmed.lines().collect::<Vec<_>>();
+    if lines.len() >= 2
+        && lines.first().is_some_and(|line| line.starts_with("```"))
+        && lines.last().is_some_and(|line| line.trim() == "```")
+    {
+        return lines[1..lines.len() - 1].join("\n").trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+pub async fn run_oneshot_with_client(
+    client: &AuxiliaryClient,
+    mut request: OneShotRequest,
+) -> Result<String, OneShotError> {
+    if let Some(template) = request
+        .template
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let (instructions, user_input) = render_template(template, &request.variables)?;
+        request.instructions = instructions;
+        request.user_input = user_input;
+    }
+
+    if request.instructions.trim().is_empty() && request.user_input.trim().is_empty() {
+        return Err(OneShotError::EmptyPrompt);
+    }
+
+    let mut messages = Vec::new();
+    if !request.instructions.trim().is_empty() {
+        messages.push(Message::system(request.instructions));
+    }
+    messages.push(Message::user(request.user_input));
+
+    let mut aux_request = AuxiliaryRequest::new(AuxiliaryTask::from_str(&request.task), messages)
+        .with_max_tokens(request.max_tokens);
+    if let Some(temperature) = request.temperature {
+        aux_request = aux_request.with_temperature(temperature);
+    }
+    if let Some(timeout_secs) = request.timeout_secs.filter(|value| *value > 0) {
+        aux_request = aux_request.with_timeout(Duration::from_secs(timeout_secs));
+    }
+
+    let response = client.call(aux_request).await?;
+    let text = response
+        .text()
+        .or(response.response.message.reasoning_content.as_deref())
+        .unwrap_or_default();
+    Ok(strip_wrapping_code_fence(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
+    use hermes_core::{
+        AgentError, LlmProvider, LlmResponse, MessageRole, StreamChunk, ToolSchema, UsageStats,
+    };
+    use hermes_intelligence::auxiliary::{AuxiliarySource, ProviderCandidate};
+    use std::sync::{Arc, Mutex};
+
+    struct ScriptedProvider {
+        response: String,
+        calls: Mutex<Vec<Vec<Message>>>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for ScriptedProvider {
+        async fn chat_completion(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            model: Option<&str>,
+            _extra_body: Option<&Value>,
+        ) -> Result<LlmResponse, AgentError> {
+            self.calls.lock().unwrap().push(messages.to_vec());
+            Ok(LlmResponse {
+                message: Message::assistant(self.response.clone()),
+                finish_reason: Some("stop".into()),
+                model: model.unwrap_or("scripted").to_string(),
+                usage: Some(UsageStats {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                    estimated_cost: None,
+                }),
+            })
+        }
+
+        fn chat_completion_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_tokens: Option<u32>,
+            _temperature: Option<f64>,
+            _model: Option<&str>,
+            _extra_body: Option<&Value>,
+        ) -> BoxStream<'static, Result<StreamChunk, AgentError>> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    fn scripted_client(provider: Arc<ScriptedProvider>) -> AuxiliaryClient {
+        AuxiliaryClient::builder()
+            .add_candidate(ProviderCandidate::new(
+                AuxiliarySource::Custom,
+                "scripted-model",
+                provider,
+            ))
+            .build()
+    }
+
+    #[test]
+    fn commit_message_template_includes_diff_recent_and_avoid() {
+        let mut vars = Map::new();
+        vars.insert(
+            "diff".into(),
+            Value::String("diff --git a/x b/x\n+new".into()),
+        );
+        vars.insert("recent_commits".into(), Value::String("feat: old".into()));
+        vars.insert("avoid".into(), Value::String("fix: old wording".into()));
+
+        let (instructions, user_input) = render_template("commit_message", &vars).unwrap();
+
+        assert!(instructions.contains("Conventional Commits"));
+        assert!(user_input.contains("diff --git a/x b/x"));
+        assert!(user_input.contains("feat: old"));
+        assert!(user_input.contains("fix: old wording"));
+    }
+
+    #[test]
+    fn strip_wrapping_code_fence_removes_single_outer_fence() {
+        assert_eq!(strip_wrapping_code_fence("```text\nhello\n```"), "hello");
+        assert_eq!(strip_wrapping_code_fence("plain text"), "plain text");
+    }
+
+    #[tokio::test]
+    async fn run_oneshot_uses_auxiliary_client_without_session_mutation() {
+        let provider = Arc::new(ScriptedProvider {
+            response: "```text\nfix(cli): tighten checks\n```".into(),
+            calls: Mutex::new(Vec::new()),
+        });
+        let client = scripted_client(provider.clone());
+        let mut vars = Map::new();
+        vars.insert("diff".into(), Value::String("+changed".into()));
+
+        let text = run_oneshot_with_client(
+            &client,
+            OneShotRequest {
+                template: Some("commit_message".into()),
+                variables: vars,
+                ..OneShotRequest::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(text, "fix(cli): tighten checks");
+        let calls = provider.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0][0].role, MessageRole::System);
+        assert_eq!(calls[0][1].role, MessageRole::User);
+    }
+}

--- a/crates/hermes-gateway/src/commands.rs
+++ b/crates/hermes-gateway/src/commands.rs
@@ -20,6 +20,8 @@ pub enum GatewayCommandResult {
     QueuePrompt { prompt: String },
     /// Steer the currently active session without starting a new turn.
     SteerPrompt { prompt: String },
+    /// Forward a synthesized prompt into the normal agent loop.
+    ForwardPrompt { prompt: String },
     /// Show usage statistics.
     ShowUsage(String),
     /// Compress the conversation context.
@@ -218,6 +220,12 @@ pub fn all_commands() -> Vec<CommandInfo> {
             aliases: &[],
             description: "Side conversation without context",
             usage: "/btw <prompt>",
+        },
+        CommandInfo {
+            name: "/learn",
+            aliases: &[],
+            description: "Turn a user-provided lesson into durable Hermes learning work",
+            usage: "/learn <lesson or behavior to learn>",
         },
         CommandInfo {
             name: "/reasoning",
@@ -546,6 +554,55 @@ isolated by thread ID. The root DM remains a normal Hermes chat."
         .to_string()
 }
 
+const LEARN_AUTHORING_STANDARDS: &str = r###"Follow the Hermes skill-authoring standards exactly. These are the same HARDLINE rules a maintainer enforces in review:
+
+Frontmatter:
+- name: lowercase-hyphenated, <=64 chars, no spaces.
+- description: ONE sentence, <=60 characters, ends with a period. State the capability, not the implementation. No marketing words (powerful, comprehensive, seamless, advanced, robust). Do NOT repeat the skill name. If the description contains a colon, wrap the whole value in double quotes. This is not cosmetic: the system-prompt skill index truncates the description to 60 chars, so COUNT the characters and trim before saving.
+- version: 0.1.0
+- author: the human you are authoring this for, first; "Hermes Agent" second. Never credit only the tool.
+- platforms: declare [macos], [linux], and/or [windows] if the skill uses OS-bound primitives. Prefer fixing it cross-platform first; gate only when the dependency is genuinely platform-bound.
+- metadata.hermes.tags: a few Capitalized, Relevant, Tags.
+
+Body section order (omit a section only if it genuinely has no content):
+1. "# <Human Title>" then a 2-3 sentence intro: what it does, what it does NOT do, and the key dependency stance.
+2. "## When to Use" - concrete trigger phrases.
+3. "## Prerequisites" - exact env vars, install steps, credentials.
+4. "## How to Run" - the canonical invocation, framed through Hermes tools.
+5. "## Quick Reference" - a flat command/endpoint list.
+6. "## Procedure" - numbered steps with copy-paste-exact commands.
+7. "## Pitfalls" - known limits and things that look broken but are not.
+8. "## Verification" - one command/check that proves the skill worked.
+
+Hermes-tool framing:
+- Reference Hermes tools by name: `terminal`, `read_file`, `write_file`, `search_files`, `patch`, `web_extract`, `web_search`, `vision_analyze`, `browser_navigate`, `delegate_task`, `image_generate`, `text_to_speech`, `cronjob`, `memory`, `skill_view`, `execute_code`.
+- Do NOT name shell utilities the agent already has wrapped: say `read_file` not cat/head/tail, `search_files` not grep/rg/find/ls, `patch` not sed/awk, `web_extract` not curl-to-scrape, `write_file` not echo>file or heredocs.
+- Third-party CLIs are fine inside scripts, but prose still frames them as "invoke through the `terminal` tool".
+
+Quality bar:
+- Prefer exact commands, endpoint URLs, function signatures, and config keys that appear verbatim in the source. Never invent flags, paths, or APIs.
+- Keep it tight and scannable. Do not re-paste source docs.
+- Do not write a router/index/hub skill that only points at other skills.
+- Larger scripts/parsers belong in `scripts/`, references go in `references/`, and templates go in `templates/`."###;
+
+fn build_learn_prompt(lesson: &str) -> String {
+    let lesson = lesson.trim();
+    let source = if lesson.is_empty() {
+        "the workflow we just went through in this conversation"
+    } else {
+        lesson
+    };
+    format!(
+        "[/learn] The user wants you to learn a reusable skill from the source(s) they described and save it.\n\n\
+What to learn from:\n{source}\n\n\
+Do this:\n\
+1. Gather the material. Resolve whatever the user named using existing tools: `read_file`/`search_files` for local files or directories, `web_extract` for URLs, the current conversation history if they referred to something you just did, and the pasted text as-is. If scope is ambiguous, make a reasonable choice and note it; do not stall.\n\
+2. Author one SKILL.md and save it with `skill_manage` (action=\"create\"). Pick a sensible category. If the procedure needs a non-trivial script, add it under the skill's `scripts/` with `skill_manage` write_file and reference it by relative path.\n\n\
+{LEARN_AUTHORING_STANDARDS}\n\n\
+When done, tell the user the skill name, its category, and a one-line summary of what it captured."
+    )
+}
+
 /// Parse and dispatch a gateway slash command.
 pub fn handle_command(input: &str) -> GatewayCommandResult {
     let trimmed = input.trim();
@@ -686,6 +743,17 @@ pub fn handle_command(input: &str) -> GatewayCommandResult {
             } else {
                 GatewayCommandResult::BtwTask {
                     prompt: args.clone(),
+                }
+            }
+        }
+        "/learn" => {
+            if args.is_empty() {
+                GatewayCommandResult::Reply(
+                    "Usage: /learn <lesson or behavior to learn>".to_string(),
+                )
+            } else {
+                GatewayCommandResult::ForwardPrompt {
+                    prompt: build_learn_prompt(&args),
                 }
             }
         }
@@ -1052,6 +1120,49 @@ mod tests {
     }
 
     #[test]
+    fn learn_command_forwards_structured_learning_prompt() {
+        match handle_command("/learn prefer targeted tests before full cargo test") {
+            GatewayCommandResult::ForwardPrompt { prompt } => {
+                assert!(prompt.contains("[/learn]"));
+                assert!(prompt.contains("learn a reusable skill"));
+                assert!(prompt.contains("prefer targeted tests before full cargo test"));
+                assert!(prompt.contains("skill_manage"));
+            }
+            other => panic!("Expected ForwardPrompt, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn learn_prompt_embeds_full_skill_authoring_standards() {
+        let GatewayCommandResult::ForwardPrompt { prompt } =
+            handle_command("/learn package an ffmpeg workflow")
+        else {
+            panic!("Expected ForwardPrompt");
+        };
+        let lower = prompt.to_ascii_lowercase();
+        assert!(lower.contains("<=60"));
+        assert!(lower.contains("count the characters"));
+        assert!(lower.contains("platforms"));
+        assert!(lower.contains("author"));
+        for tool in ["read_file", "search_files", "patch", "write_file"] {
+            assert!(prompt.contains(tool), "{tool}");
+        }
+        assert!(prompt.contains("scripts/"));
+        assert!(prompt.contains("references/"));
+        assert!(prompt.contains("templates/"));
+    }
+
+    #[test]
+    fn learn_command_requires_lesson_text_and_is_registered() {
+        match handle_command("/learn") {
+            GatewayCommandResult::Reply(msg) => assert!(msg.contains("Usage: /learn")),
+            other => panic!("Expected usage reply, got {:?}", other),
+        }
+        assert!(is_registered_command_name("/learn"));
+        assert!(should_bypass_active_session(Some("/learn")));
+    }
+
+    #[test]
     fn test_case_insensitive() {
         match handle_command("/NEW") {
             GatewayCommandResult::ResetSession(_) => {}
@@ -1092,6 +1203,7 @@ mod tests {
             "tasks",
             "background",
             "steer",
+            "learn",
             "start",
             "help",
             "commands",

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -767,6 +767,20 @@ impl Gateway {
         self.session_manager.get_messages(&key).await.len()
     }
 
+    /// Effective model for a composed platform/chat/user session, including
+    /// per-session overrides and process-wide `/model --global` state.
+    pub async fn effective_model_for_session(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        user_id: &str,
+    ) -> Option<String> {
+        let key = self
+            .session_manager
+            .compose_session_key(platform, chat_id, user_id);
+        self.effective_session_model(&key).await
+    }
+
     async fn clear_session_boundary_security_state(&self, session_key: &str) {
         if session_key.is_empty() {
             return;
@@ -1601,6 +1615,9 @@ impl Gateway {
                 .await;
             }
         }
+        if let GatewayCommandResult::ForwardPrompt { prompt } = result {
+            return Ok(SlashCommandOutcome::ForwardToAgent { message: prompt });
+        }
         let handled = self
             .apply_command_result(incoming, session_key, result)
             .await?;
@@ -1969,6 +1986,7 @@ impl Gateway {
                 .await?;
                 Ok(true)
             }
+            GatewayCommandResult::ForwardPrompt { .. } => Ok(false),
             GatewayCommandResult::ShowUsage(_) => {
                 let text = self.build_usage_text(session_key).await;
                 self.send_message(&incoming.platform, &incoming.chat_id, &text, None)

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -37,7 +37,11 @@ use hermes_agent::providers_extra::{
 };
 use hermes_agent::session_persistence::SessionPersistence;
 use hermes_agent::smart_model_routing::ApiMode;
-use hermes_agent::{leading_system_prompt_for_persist, AgentConfig, AgentLoop};
+use hermes_agent::{
+    build_auxiliary_client_with_main_runtime, leading_system_prompt_for_persist,
+    run_oneshot_with_client, AgentConfig, AgentLoop, AuxiliaryConfig, AuxiliaryMainRuntime,
+    OneShotError, OneShotRequest,
+};
 use hermes_config::GatewayConfig;
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
@@ -46,7 +50,7 @@ use hermes_gateway::gateway::{GatewayConfig as RuntimeGatewayConfig, IncomingMes
 use hermes_gateway::{DmManager, Gateway, GatewayRuntimeContext, SessionManager};
 use hermes_tools::ToolRegistry;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 pub const HTTP_PLATFORM: &str = "http";
 const SESSION_KEY_HEADER: &str = "x-hermes-session-key";
@@ -174,7 +178,7 @@ impl HttpServerState {
                 Box::pin(async move {
                     hermes_telemetry::record_llm_request();
                     let effective_model = resolve_model_for_gateway(
-                        config.model.as_deref().unwrap_or("gpt-4o"),
+                        config.model.as_deref().unwrap_or("dynamic"),
                         &ctx,
                     );
                     let agent = build_agent_for_gateway_context(config.as_ref(), &ctx, agent_tools);
@@ -214,7 +218,7 @@ impl HttpServerState {
                 Box::pin(async move {
                     hermes_telemetry::record_llm_request();
                     let effective_model = resolve_model_for_gateway(
-                        config.model.as_deref().unwrap_or("gpt-4o"),
+                        config.model.as_deref().unwrap_or("dynamic"),
                         &ctx,
                     );
                     let agent = build_agent_for_gateway_context(config.as_ref(), &ctx, agent_tools);
@@ -367,6 +371,35 @@ pub struct CommandResponse {
     pub output: String,
 }
 
+fn default_rpc_params() -> Value {
+    Value::Object(Map::new())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RpcRequest {
+    #[serde(default)]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default = "default_rpc_params")]
+    pub params: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RpcErrorBody {
+    pub code: i64,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RpcResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcErrorBody>,
+}
+
 fn max_request_body_bytes() -> usize {
     const DEFAULT: usize = 2 * 1024 * 1024;
     std::env::var("HERMES_HTTP_MAX_BODY_BYTES")
@@ -388,6 +421,7 @@ pub fn router(state: HttpServerState) -> Router {
         .route("/metrics", get(metrics_prometheus))
         .route("/v1/sessions/{session_id}/messages", post(send_message))
         .route("/v1/commands", post(exec_command))
+        .route("/v1/rpc", post(exec_rpc))
         .route("/v1/ws/{session_id}", get(ws_upgrade))
         .with_state(state)
         .layer(middleware::from_fn(move |req, next| {
@@ -466,11 +500,7 @@ async fn send_message(
 
     if req.model.is_some() || req.provider.is_some() {
         let full = resolve_model(
-            state
-                .config
-                .model
-                .as_deref()
-                .unwrap_or("openai:gpt-4o-mini"),
+            state.config.model.as_deref().unwrap_or("dynamic"),
             req.provider.as_deref(),
             req.model.as_deref(),
         );
@@ -598,6 +628,154 @@ async fn exec_command(
         accepted: true,
         output,
     }))
+}
+
+fn rpc_ok(id: Option<Value>, result: Value) -> Json<RpcResponse> {
+    Json(RpcResponse {
+        id,
+        result: Some(result),
+        error: None,
+    })
+}
+
+fn rpc_err(id: Option<Value>, code: i64, message: impl Into<String>) -> Json<RpcResponse> {
+    Json(RpcResponse {
+        id,
+        result: None,
+        error: Some(RpcErrorBody {
+            code,
+            message: message.into(),
+        }),
+    })
+}
+
+fn rpc_param_str(params: &Value, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn rpc_param_u32(params: &Value, key: &str, default: u32) -> u32 {
+    params
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn rpc_param_f64(params: &Value, key: &str, default: Option<f64>) -> Option<f64> {
+    match params.get(key) {
+        Some(Value::Number(number)) => number.as_f64(),
+        Some(Value::String(raw)) => raw.trim().parse::<f64>().ok(),
+        Some(Value::Null) | None => default,
+        _ => default,
+    }
+}
+
+fn rpc_param_variables(params: &Value) -> Map<String, Value> {
+    params
+        .get("variables")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn main_runtime_from_model(model: Option<String>) -> Option<AuxiliaryMainRuntime> {
+    let model = model?;
+    let (provider, model_part) = model.split_once(':')?;
+    let provider = provider.trim();
+    let model_part = model_part.trim();
+    if provider.is_empty() || model_part.is_empty() {
+        return None;
+    }
+    Some(AuxiliaryMainRuntime::new(provider, model_part))
+}
+
+async fn exec_rpc(
+    State(state): State<HttpServerState>,
+    Json(req): Json<RpcRequest>,
+) -> Json<RpcResponse> {
+    hermes_telemetry::record_http_request();
+    let RpcRequest { id, method, params } = req;
+    let method = method.trim();
+    match method {
+        "project.facts" => {
+            let cwd = rpc_param_str(&params, "cwd").map(PathBuf::from);
+            let facts = hermes_agent::coding_context::project_facts_for(cwd.as_deref());
+            rpc_ok(id, serde_json::json!({ "facts": facts }))
+        }
+        "verification.status" => {
+            let cwd = rpc_param_str(&params, "cwd").map(PathBuf::from);
+            let session_id = rpc_param_str(&params, "session_id")
+                .or_else(|| rpc_param_str(&params, "session_key"));
+            let verification = hermes_tools::verification_evidence::verification_status(
+                session_id.as_deref(),
+                cwd.as_deref(),
+            );
+            rpc_ok(id, serde_json::json!({ "verification": verification }))
+        }
+        "llm.oneshot" => {
+            let template = rpc_param_str(&params, "template");
+            let instructions = rpc_param_str(&params, "instructions").unwrap_or_default();
+            let user_input = rpc_param_str(&params, "input")
+                .or_else(|| rpc_param_str(&params, "user_input"))
+                .unwrap_or_default();
+            if template.is_none() && instructions.trim().is_empty() && user_input.trim().is_empty()
+            {
+                return rpc_err(
+                    id,
+                    4030,
+                    "llm.oneshot requires a template or instructions/input",
+                );
+            }
+
+            let session_id = rpc_param_str(&params, "session_id")
+                .or_else(|| rpc_param_str(&params, "session_key"));
+            let user_id = http_user_id(rpc_param_str(&params, "user_id"));
+            let main_runtime = match session_id.as_deref() {
+                Some(session_id) => main_runtime_from_model(
+                    state
+                        .gateway
+                        .effective_model_for_session(HTTP_PLATFORM, session_id, &user_id)
+                        .await,
+                ),
+                None => main_runtime_from_model(state.config.model.clone()),
+            };
+            let (client, _summary) =
+                build_auxiliary_client_with_main_runtime(AuxiliaryConfig::default(), main_runtime);
+            let request = OneShotRequest {
+                instructions,
+                user_input,
+                template,
+                variables: rpc_param_variables(&params),
+                task: rpc_param_str(&params, "task").unwrap_or_else(|| "title".to_string()),
+                max_tokens: rpc_param_u32(&params, "max_tokens", 1024),
+                temperature: rpc_param_f64(&params, "temperature", Some(0.3)),
+                timeout_secs: params
+                    .get("timeout")
+                    .and_then(Value::as_u64)
+                    .filter(|value| *value > 0)
+                    .or(Some(60)),
+            };
+            match run_oneshot_with_client(&client, request).await {
+                Ok(text) => rpc_ok(id, serde_json::json!({ "text": text })),
+                Err(OneShotError::UnknownTemplate(template)) => {
+                    rpc_err(id, 4031, format!("unknown one-shot template: {template}"))
+                }
+                Err(OneShotError::EmptyPrompt) => rpc_err(
+                    id,
+                    4032,
+                    "llm.oneshot requires a template or instructions/input",
+                ),
+                Err(err) => rpc_err(id, 5030, format!("one-shot generation failed: {err}")),
+            }
+        }
+        _ => rpc_err(id, -32601, format!("unknown method: {method}")),
+    }
 }
 
 async fn ws_upgrade(
@@ -912,7 +1090,7 @@ fn build_agent_for_gateway_context(
     agent_tools: Arc<hermes_agent::agent_loop::ToolRegistry>,
 ) -> AgentLoop {
     let effective_model =
-        resolve_model_for_gateway(config.model.as_deref().unwrap_or("gpt-4o"), ctx);
+        resolve_model_for_gateway(config.model.as_deref().unwrap_or("dynamic"), ctx);
     let provider = build_provider(config, &effective_model);
     let mut agent_config = build_agent_config(config, &effective_model);
     if let Some(personality) = ctx.personality.clone() {
@@ -998,7 +1176,7 @@ mod tests {
             },
         );
 
-        let agent_config = build_agent_config(&config, "openai:gpt-4o");
+        let agent_config = build_agent_config(&config, "openai:dynamic");
 
         assert_eq!(
             agent_config
@@ -1023,7 +1201,7 @@ mod tests {
             ..GatewayConfig::default()
         };
 
-        let agent_config = build_agent_config(&config, "openai:gpt-4o");
+        let agent_config = build_agent_config(&config, "openai:dynamic");
 
         assert_eq!(agent_config.prefill_messages.len(), 2);
         assert_eq!(

--- a/crates/hermes-http/tests/http_smoke.rs
+++ b/crates/hermes-http/tests/http_smoke.rs
@@ -1,7 +1,53 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
 use tower::ServiceExt;
+
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct EnvGuard {
+    key: &'static str,
+    old: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let old = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, old }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.old {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+async fn post_rpc(payload: serde_json::Value) -> serde_json::Value {
+    let cfg = hermes_config::GatewayConfig::default();
+    let state = hermes_http::HttpServerState::build(cfg).await.unwrap();
+    let app = hermes_http::router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/rpc")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body).unwrap()
+}
 
 #[tokio::test]
 async fn health_ok() {
@@ -70,4 +116,106 @@ async fn command_help_runs_through_gateway() {
         "unexpected output: {}",
         out
     );
+}
+
+#[tokio::test]
+async fn rpc_project_facts_returns_structured_workspace_data() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let repo = tempfile::tempdir().unwrap();
+    std::fs::write(
+        repo.path().join("Cargo.toml"),
+        "[package]\nname='rpc-facts'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    std::fs::write(repo.path().join("AGENTS.md"), "# rules").unwrap();
+
+    let payload = serde_json::json!({
+        "id": 1,
+        "method": "project.facts",
+        "params": { "cwd": repo.path() }
+    });
+
+    let v = post_rpc(payload).await;
+
+    assert_eq!(v["id"], 1);
+    assert_eq!(v["error"], serde_json::Value::Null);
+    let facts = &v["result"]["facts"];
+    assert_eq!(
+        facts["root"],
+        repo.path().canonicalize().unwrap().display().to_string()
+    );
+    assert!(facts["manifests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "Cargo.toml"));
+    assert!(facts["verifyCommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "cargo test"));
+    assert!(facts["contextFiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|value| value == "AGENTS.md"));
+}
+
+#[tokio::test]
+async fn rpc_verification_status_returns_passive_terminal_evidence() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::write(
+        repo.join("Cargo.toml"),
+        "[package]\nname='rpc-verification'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    let _home = EnvGuard::set("HERMES_HOME", home.to_str().unwrap());
+    hermes_tools::verification_evidence::record_terminal_result(
+        "cargo   test -p hermes-http",
+        Some(&repo),
+        Some("sid-1"),
+        0,
+        "ok",
+    )
+    .unwrap();
+
+    let payload = serde_json::json!({
+        "id": "verify",
+        "method": "verification.status",
+        "params": { "cwd": repo, "session_id": "sid-1" }
+    });
+
+    let v = post_rpc(payload).await;
+
+    assert_eq!(v["id"], "verify");
+    assert_eq!(v["result"]["verification"]["status"], "passed");
+    assert_eq!(
+        v["result"]["verification"]["evidence"]["canonicalCommand"],
+        "cargo test -p hermes-http"
+    );
+    assert_eq!(
+        v["result"]["verification"]["evidence"]["outputPreview"],
+        "ok"
+    );
+}
+
+#[tokio::test]
+async fn rpc_llm_oneshot_rejects_missing_prompt_without_provider_call() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let payload = serde_json::json!({
+        "id": "missing",
+        "method": "llm.oneshot",
+        "params": {}
+    });
+
+    let v = post_rpc(payload).await;
+
+    assert_eq!(v["id"], "missing");
+    assert_eq!(v["error"]["code"], 4030);
+    assert!(v["result"].is_null());
 }

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -24,6 +24,7 @@ pub mod toolset;
 pub mod toolset_distributions;
 pub mod tts_streaming;
 pub mod v4a_patch;
+pub mod verification_evidence;
 pub mod website_policy;
 
 // Re-export registry types

--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -5,6 +5,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use hermes_core::{
@@ -122,6 +123,18 @@ fn long_lived_foreground_error(command: &str) -> Option<String> {
     long_lived.then(|| {
         "This foreground command appears to start a long-lived server/watch process. Run it with background=true, then verify readiness with logs or a health check.".to_string()
     })
+}
+
+fn terminal_verification_recording_enabled() -> bool {
+    !cfg!(test)
+        || std::env::var("HERMES_RECORD_VERIFICATION_EVIDENCE_IN_TESTS")
+            .ok()
+            .is_some_and(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +272,24 @@ impl ToolHandler for TerminalHandler {
             )
             .await
         {
-            Ok(output) => Ok(format_command_output(&output)),
+            Ok(output) => {
+                let rendered = format_command_output(&output);
+                if !background && terminal_verification_recording_enabled() {
+                    let session_id = params
+                        .get("session_id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                        .or_else(|| std::env::var("HERMES_SESSION_KEY").ok());
+                    let _ = crate::verification_evidence::record_terminal_result(
+                        command,
+                        workdir.map(Path::new),
+                        session_id.as_deref(),
+                        output.exit_code,
+                        &rendered,
+                    );
+                }
+                Ok(rendered)
+            }
             Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
         }
     }
@@ -939,6 +969,46 @@ mod tests {
         let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
         let result = block_on(handler.execute(json!({"command": "echo hello"}))).unwrap();
         assert!(result.contains("echo hello"));
+    }
+
+    #[test]
+    fn terminal_handler_records_verification_evidence_when_enabled_in_tests() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _yolo = EnvGuard::remove("HERMES_YOLO_MODE");
+        let _sudo = EnvGuard::remove("SUDO_PASSWORD");
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(
+            repo.join("Cargo.toml"),
+            "[package]\nname='terminal-evidence'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        let _home = EnvGuard::set("HERMES_HOME", home.to_str().unwrap());
+        let _recording = EnvGuard::set("HERMES_RECORD_VERIFICATION_EVIDENCE_IN_TESTS", "1");
+        let _session = EnvGuard::remove("HERMES_SESSION_KEY");
+        let handler = TerminalHandler::new(std::sync::Arc::new(MockBackend));
+
+        let rendered = block_on(handler.execute(json!({
+            "command": "cargo test -p hermes-tools",
+            "workdir": repo,
+            "session_id": "terminal-sid"
+        })))
+        .unwrap();
+
+        assert!(rendered.contains("cargo test -p hermes-tools"));
+        let status = crate::verification_evidence::verification_status(
+            Some("terminal-sid"),
+            Some(&tmp.path().join("repo")),
+        );
+        assert_eq!(status.status, "passed");
+        let evidence = status.evidence.expect("recorded evidence");
+        assert_eq!(evidence.canonical_command, "cargo test -p hermes-tools");
+        assert_eq!(evidence.scope, "full");
+        assert!(evidence
+            .output_preview
+            .contains("output of: cargo test -p hermes-tools"));
     }
 
     #[test]

--- a/crates/hermes-tools/src/verification_evidence.rs
+++ b/crates/hermes-tools/src/verification_evidence.rs
@@ -1,0 +1,280 @@
+//! Passive coding verification evidence.
+//!
+//! Terminal commands record bounded results here after execution. Consumers can
+//! query the best known status for a workspace/session without running checks.
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+const MAX_OUTPUT_PREVIEW_BYTES: usize = 4_000;
+const LEDGER_RELATIVE_PATH: &[&str] = &["verification", "terminal_evidence.jsonl"];
+
+const PROJECT_MARKERS: &[&str] = &[
+    ".git",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "go.mod",
+    "Makefile",
+    "AGENTS.md",
+    "CLAUDE.md",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationEvidence {
+    pub command: String,
+    pub canonical_command: String,
+    pub cwd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub exit_code: i32,
+    pub output_preview: String,
+    pub recorded_at: String,
+    pub scope: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationStatus {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<VerificationEvidence>,
+}
+
+pub fn verification_ledger_path() -> PathBuf {
+    LEDGER_RELATIVE_PATH
+        .iter()
+        .fold(hermes_config::hermes_home(), |path, part| path.join(part))
+}
+
+pub fn canonical_command(command: &str) -> String {
+    command.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn output_preview(output: &str) -> String {
+    if output.len() <= MAX_OUTPUT_PREVIEW_BYTES {
+        return output.to_string();
+    }
+    let mut end = MAX_OUTPUT_PREVIEW_BYTES.min(output.len());
+    while !output.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n...(truncated)", output[..end].trim_end())
+}
+
+fn command_scope(command: &str) -> &'static str {
+    let lower = command.to_ascii_lowercase();
+    let full_markers = [
+        "cargo test",
+        "cargo check",
+        "cargo build",
+        "cargo fmt",
+        "pytest",
+        "npm run test",
+        "npm test",
+        "pnpm run test",
+        "pnpm test",
+        "yarn test",
+        "bun test",
+        "make test",
+        "make check",
+        "go test",
+        "mvn test",
+        "gradle test",
+        "lint",
+        "typecheck",
+    ];
+    if full_markers.iter().any(|marker| lower.contains(marker)) {
+        "full"
+    } else {
+        "targeted"
+    }
+}
+
+fn canonical_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn workspace_root_from(start: &Path) -> Option<PathBuf> {
+    let start = canonical_path(start);
+    start.ancestors().find_map(|candidate| {
+        PROJECT_MARKERS
+            .iter()
+            .any(|marker| candidate.join(marker).exists())
+            .then(|| candidate.to_path_buf())
+    })
+}
+
+fn cwd_or_current(cwd: Option<&Path>) -> PathBuf {
+    cwd.map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+pub fn record_terminal_result(
+    command: &str,
+    cwd: Option<&Path>,
+    session_id: Option<&str>,
+    exit_code: i32,
+    output: &str,
+) -> std::io::Result<VerificationEvidence> {
+    let cwd = canonical_path(&cwd_or_current(cwd));
+    let canonical = canonical_command(command);
+    let evidence = VerificationEvidence {
+        command: command.to_string(),
+        canonical_command: canonical.clone(),
+        cwd: cwd.display().to_string(),
+        session_id: session_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        exit_code,
+        output_preview: output_preview(output),
+        recorded_at: Utc::now().to_rfc3339(),
+        scope: command_scope(&canonical).to_string(),
+    };
+
+    let path = verification_ledger_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    serde_json::to_writer(&mut file, &evidence).map_err(std::io::Error::other)?;
+    file.write_all(b"\n")?;
+    Ok(evidence)
+}
+
+pub fn verification_status(session_id: Option<&str>, cwd: Option<&Path>) -> VerificationStatus {
+    let cwd = cwd_or_current(cwd);
+    let Some(root) = workspace_root_from(&cwd) else {
+        return VerificationStatus {
+            status: "not_applicable".to_string(),
+            evidence: None,
+        };
+    };
+    let query_session = session_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let path = verification_ledger_path();
+    let Ok(file) = std::fs::File::open(path) else {
+        return VerificationStatus {
+            status: "unknown".to_string(),
+            evidence: None,
+        };
+    };
+
+    let mut best = None;
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let Ok(evidence) = serde_json::from_str::<VerificationEvidence>(&line) else {
+            continue;
+        };
+        let evidence_cwd = PathBuf::from(&evidence.cwd);
+        if workspace_root_from(&evidence_cwd).as_deref() != Some(root.as_path()) {
+            continue;
+        }
+        if let Some(query_session) = query_session.as_deref() {
+            if evidence.session_id.as_deref() != Some(query_session) {
+                continue;
+            }
+        }
+        best = Some(evidence);
+    }
+
+    match best {
+        Some(evidence) => VerificationStatus {
+            status: if evidence.exit_code == 0 {
+                "passed".to_string()
+            } else {
+                "failed".to_string()
+            },
+            evidence: Some(evidence),
+        },
+        None => VerificationStatus {
+            status: "unknown".to_string(),
+            evidence: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct EnvGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn records_and_reads_passive_verification_status() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(
+            repo.join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        let _home = EnvGuard::set("HERMES_HOME", home.to_str().unwrap());
+
+        let evidence =
+            record_terminal_result(" cargo   test ", Some(&repo), Some("sid"), 0, "green").unwrap();
+
+        assert_eq!(evidence.canonical_command, "cargo test");
+        assert_eq!(evidence.scope, "full");
+
+        let status = verification_status(Some("sid"), Some(&repo));
+        assert_eq!(status.status, "passed");
+        assert_eq!(
+            status
+                .evidence
+                .as_ref()
+                .map(|ev| ev.output_preview.as_str()),
+            Some("green")
+        );
+    }
+
+    #[test]
+    fn reports_not_applicable_outside_workspace() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        let _home = EnvGuard::set("HERMES_HOME", home.to_str().unwrap());
+
+        let status = verification_status(Some("sid"), Some(&plain));
+
+        assert_eq!(status.status, "not_applicable");
+        assert!(status.evidence.is_none());
+    }
+}

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T12:44:22.163367+00:00`_
+_Generated from source artifacts: `2026-06-25T13:23:53.625915+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T12:44:22.004656+00:00`
-- Proof snapshot generated: `2026-06-25T12:44:22.163367+00:00`
+- Queue snapshot generated: `2026-06-25T13:23:53.485793+00:00`
+- Proof snapshot generated: `2026-06-25T13:23:53.625915+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T12:44:22.163367+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=195.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=195.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=190.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=190.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,9 +75,9 @@ _Generated from source artifacts: `2026-06-25T12:44:22.163367+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7012 |
-| Pending | 195 |
-| Ported | 399 |
-| Superseded | 6342 |
+| Pending | 190 |
+| Ported | 405 |
+| Superseded | 6341 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 195.0,
+        "actual": 190.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T12:44:22.163367+00:00",
+  "generated_at_utc": "2026-06-25T13:23:53.625915+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 195.0,
+    "max_queue_pending_commits": 190.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 195,
-      "ported": 399,
-      "superseded": 6342
+      "pending": 190,
+      "ported": 405,
+      "superseded": 6341
     },
     "by_target_ticket": {
       "20": 3140,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 195.0,
+        "actual": 190.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T12:44:22.163367+00:00`
+Generated: `2026-06-25T13:23:53.625915+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T12:44:22.163367+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 195.0 |
+| `max_queue_pending_commits` | 190.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4538,6 +4538,36 @@
       "disposition": "ported",
       "notes": "Rust Objective OS now has durable wait barriers for /objective and /goal: PID, process-session, and timed waits persist in the objective contract, pause/resume lifecycle clears stale waits, and the mission/autonomous continuation enforcer parks while live barriers are active and fail-safe clears stale ones.",
       "owner": "rust-runtime"
+    },
+    "af7b7f632272": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust coding context now exposes structured ProjectFacts via hermes_agent::coding_context and the HTTP JSON-RPC project.facts method. Focused agent and HTTP route tests cover manifests, package managers, verification commands, context files, and null outside-workspace behavior."
+    },
+    "211ba9c7d31d": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust one-shot helper now renders commit-message templates, strips wrapping code fences, runs through the auxiliary client without session mutation, and exposes llm.oneshot over HTTP JSON-RPC with deterministic validation errors. Focused agent and HTTP tests cover template rendering, client usage, and missing-prompt failure."
+    },
+    "e32ebc6aa26f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust gateway now registers /learn as a first-class slash command that builds a standards-guided skill-learning prompt and forwards it into the normal agent loop. The prompt uses existing agent tools, skill_manage, and the hardline Hermes skill-authoring rules; gateway tests cover registration, bypass behavior, and prompt contents."
+    },
+    "a4fa1481e281": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust gateway command dispatch now routes /learn through a ForwardPrompt result into SlashCommandOutcome::ForwardToAgent, so the synthesized learning prompt fires as a normal agent turn instead of being handled as a static reply. Gateway tests lock the parser and active-session bypass behavior."
+    },
+    "7ef0f360d0ce": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust tools now record bounded passive terminal verification evidence under HERMES_HOME and HTTP JSON-RPC exposes verification.status for workspace/session lookup. Focused tools and HTTP route tests cover ledger recording, pass/fail status, session filtering, workspace scoping, and not-applicable behavior."
+    },
+    "e62afaca6259": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust /learn prompt now embeds the full hardline skill-authoring standards: <=60-char description count-and-trim, platforms gating, human-first author credit, Hermes wrapped-tool framing, and scripts/references/templates layout. Gateway tests assert the standards remain present."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T12:44:22.004656+00:00`
+Generated: `2026-06-25T13:23:53.485793+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-25T12:44:22.004656+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 195 |
-| ported | 399 |
-| superseded | 6342 |
+| pending | 190 |
+| ported | 405 |
+| superseded | 6341 |
 
 ## First 100 Pending Commits
 


### PR DESCRIPTION
## Summary
- Add structured Rust project facts and expose them through HTTP JSON-RPC `project.facts`.
- Add Rust one-shot auxiliary LLM helper and HTTP JSON-RPC `llm.oneshot` validation/runtime plumbing.
- Add passive terminal verification evidence ledger plus HTTP JSON-RPC `verification.status`.
- Add Rust gateway `/learn` command that forwards a standards-guided skill-learning prompt into the agent loop.
- Mark the six closed upstream parity items as ported and regenerate parity queue/proof/dashboard artifacts.

## Parity Delta
- `pending`: 195 -> 190
- `ported`: 399 -> 405
- Closed SHAs: `af7b7f632272`, `211ba9c7d31d`, `e32ebc6aa26f`, `a4fa1481e281`, `7ef0f360d0ce`, `e62afaca6259`

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-tools -p hermes-gateway -p hermes-http` (`new=0`)
- `cargo build --workspace`
- `cargo test --workspace`
- Focused tests for project facts, one-shot helper, verification evidence, terminal evidence recording, gateway `/learn`, and HTTP RPC routes

## Notes
- No OAuth/sign-in surfaces changed.
- Runtime defaults in edited HTTP paths use `dynamic`, not legacy fixed model literals.
