### PR TITLE
parity(approval): redact gateway approval prompts

### DIFF
--- a/crates/hermes-tools/src/approval.rs
+++ b/crates/hermes-tools/src/approval.rs
@@ -323,6 +323,19 @@ pub struct GatewayApprovalRequest {
     pub allow_permanent: bool,
 }
 
+impl GatewayApprovalRequest {
+    /// Return a user-facing copy safe to emit over gateway/TUI/chat transports.
+    ///
+    /// The pending approval queue keeps the raw command for local resolution
+    /// state, but client-facing approval prompts are a hard secret-egress
+    /// boundary and must not echo credential-shaped command text.
+    pub fn redacted_for_display(&self) -> Self {
+        let mut request = self.clone();
+        request.command = redact_approval_command(&request.command);
+        request
+    }
+}
+
 #[derive(Debug)]
 pub struct GatewayApprovalEntry {
     request: GatewayApprovalRequest,
@@ -976,7 +989,7 @@ fn submit_gateway_approval_and_wait(
             .push_back(entry.clone());
     }
 
-    callback(request);
+    callback(request.redacted_for_display());
 
     if let Some(choice) = entry.wait(timeout) {
         GatewayApprovalWaitOutcome::Resolved(choice)
@@ -991,6 +1004,16 @@ fn submit_gateway_approval_and_wait(
         }
         GatewayApprovalWaitOutcome::TimedOut
     }
+}
+
+/// Redact credentials from a command before it is shown in approval prompts.
+///
+/// Tirith/security scanners may redact their findings, but approval prompts
+/// are built from the raw command string. This seam is intentionally
+/// unconditional so gateway/TUI/chat approval transports cannot leak secrets
+/// even if a broader user-facing redaction preference is disabled elsewhere.
+pub fn redact_approval_command(command: impl ToString) -> String {
+    hermes_intelligence::redact_sensitive_text(command)
 }
 
 /// Enable yolo approval bypass for a single session key.
@@ -1575,6 +1598,49 @@ mod tests {
 
     fn interactive_context(tirith_result: TirithResult) -> CommandGuardContext {
         CommandGuardContext::interactive_with_tirith(tirith_result)
+    }
+
+    #[test]
+    fn test_redact_approval_command_removes_credential_values() {
+        let fake_ghp = format!("ghp_{}", "X".repeat(36));
+        let raw = format!("curl -H 'Authorization: token {fake_ghp}' https://api.github.com/user");
+        let redacted = redact_approval_command(&raw);
+        assert!(!redacted.contains(&fake_ghp));
+        assert!(redacted.contains("curl"));
+        assert!(redacted.contains("github.com"));
+
+        let fake_openai = format!("sk-proj-{}", "X".repeat(40));
+        let raw = format!("OPENAI_API_KEY={fake_openai} python s.py");
+        let redacted = redact_approval_command(&raw);
+        assert!(!redacted.contains(&fake_openai));
+        assert!(redacted.contains("python s.py"));
+
+        let clean = "ls -la /tmp && echo hello";
+        assert_eq!(redact_approval_command(clean), clean);
+    }
+
+    #[test]
+    fn test_gateway_approval_request_display_copy_redacts_command_only() {
+        let fake_ghp = format!("ghp_{}", "X".repeat(36));
+        let raw_command =
+            format!("curl -H 'Authorization: token {fake_ghp}' https://api.github.com/user");
+        let request = GatewayApprovalRequest {
+            session_key: "display-redaction".to_string(),
+            command: raw_command.clone(),
+            description: "review command".to_string(),
+            pattern_key: "tirith:credential".to_string(),
+            pattern_keys: vec!["tirith:credential".to_string()],
+            allow_permanent: false,
+        };
+
+        let display = request.redacted_for_display();
+
+        assert_eq!(request.command, raw_command);
+        assert!(!display.command.contains(&fake_ghp));
+        assert!(display.command.contains("github.com"));
+        assert_eq!(display.description, request.description);
+        assert_eq!(display.pattern_keys, request.pattern_keys);
+        assert_eq!(display.allow_permanent, request.allow_permanent);
     }
 
     #[test]
@@ -2189,6 +2255,69 @@ mod tests {
         assert!(result.approved);
         assert!(result.user_approved);
         assert!(is_approved(session, "tirith:gateway_unique_e2e"));
+        unregister_gateway_notify(session);
+        reset_approval_state_unlocked();
+    }
+
+    #[test]
+    fn test_gateway_approval_notify_emits_redacted_command_but_queues_raw() {
+        let _guard = lock_test_state();
+        reset_approval_state_unlocked();
+        let session = "gateway-redacted-egress";
+        let fake_ghp = format!("ghp_{}", "X".repeat(36));
+        let raw_command =
+            format!("curl -H 'Authorization: token {fake_ghp}' https://api.github.com/user");
+        let (tx, rx) = std::sync::mpsc::channel();
+        register_gateway_notify(session, move |request| {
+            tx.send(request).expect("notify request should send");
+        });
+
+        let session_for_thread = session.to_string();
+        let command_for_thread = raw_command.clone();
+        let handle = std::thread::spawn(move || {
+            check_all_command_guards_with_context(
+                &command_for_thread,
+                "local",
+                CommandGuardContext {
+                    gateway: true,
+                    ask: true,
+                    session_key: Some(session_for_thread),
+                    gateway_approval_timeout: Duration::from_secs(5),
+                    tirith_result: Ok(Some(TirithResult::warn(
+                        "credential_redaction",
+                        "credential-shaped command",
+                    ))),
+                    ..CommandGuardContext::default()
+                },
+                None,
+            )
+            .expect("gateway guard should return")
+        });
+
+        let display_request = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("gateway notify should fire");
+        assert!(!display_request.command.contains(&fake_ghp));
+        assert!(display_request.command.contains("github.com"));
+        assert_eq!(display_request.pattern_key, "tirith:credential_redaction");
+
+        let queued_raw = {
+            let queues = GATEWAY_QUEUES.lock().expect("gateway queue lock poisoned");
+            queues
+                .get(session)
+                .and_then(|entries| entries.front())
+                .map(|entry| entry.request().command.clone())
+                .expect("raw approval should remain queued")
+        };
+        assert_eq!(queued_raw, raw_command);
+
+        assert_eq!(
+            resolve_gateway_approval(session, ApprovalChoice::Session, false),
+            1
+        );
+        let result = handle.join().expect("gateway guard thread should join");
+        assert!(result.approved);
+        assert!(result.user_approved);
         unregister_gateway_notify(session);
         reset_approval_state_unlocked();
     }

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T13:23:53.625915+00:00`_
+_Generated from source artifacts: `2026-06-25T13:45:12.366800+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T13:23:53.485793+00:00`
-- Proof snapshot generated: `2026-06-25T13:23:53.625915+00:00`
+- Queue snapshot generated: `2026-06-25T13:45:12.212154+00:00`
+- Proof snapshot generated: `2026-06-25T13:45:12.366800+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T13:23:53.625915+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=190.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=190.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=189.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=189.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T13:23:53.625915+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7012 |
-| Pending | 190 |
-| Ported | 405 |
+| Pending | 189 |
+| Ported | 406 |
 | Superseded | 6341 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 190.0,
+        "actual": 189.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T13:23:53.625915+00:00",
+  "generated_at_utc": "2026-06-25T13:45:12.366800+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 190.0,
+    "max_queue_pending_commits": 189.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 190,
-      "ported": 405,
+      "pending": 189,
+      "ported": 406,
       "superseded": 6341
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 190.0,
+        "actual": 189.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T13:23:53.625915+00:00`
+Generated: `2026-06-25T13:45:12.366800+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T13:23:53.625915+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 190.0 |
+| `max_queue_pending_commits` | 189.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4568,6 +4568,11 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust /learn prompt now embeds the full hardline skill-authoring standards: <=60-char description count-and-trim, platforms gating, human-first author credit, Hermes wrapped-tool framing, and scripts/references/templates layout. Gateway tests assert the standards remain present."
+    },
+    "c080b2dc3ee6": {
+      "disposition": "ported",
+      "notes": "Rust approval gateway callbacks now emit GatewayApprovalRequest::redacted_for_display using redact_approval_command before user-facing TUI/chat transports, while the internal queue retains the raw command for resolution; hermes-tools approval tests cover credential redaction, command-structure preservation, and raw-queue/redacted-egress behavior.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T13:23:53.485793+00:00`
+Generated: `2026-06-25T13:45:12.212154+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T13:23:53.485793+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 190 |
-| ported | 405 |
+| pending | 189 |
+| ported | 406 |
 | superseded | 6341 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- Add a Rust approval-command redaction seam for gateway approval prompts.
- Emit `GatewayApprovalRequest::redacted_for_display()` to user-facing gateway/TUI/chat callbacks while retaining the raw command in the internal pending-approval queue for local resolution state.
- Close upstream parity row `c080b2dc3ee6` as ported and regenerate parity proof/dashboard artifacts (`pending 190 -> 189`, `ported 405 -> 406`).

## Root Cause
Upstream fixed a third approval-prompt egress where a raw command containing credential-shaped text could be emitted to a TUI JSON-RPC client. The Rust approval callback path needed an equivalent hard egress boundary so callback transports cannot echo raw credential values.

## Validation
- `cargo test -p hermes-tools approval --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools` (`new=0`)
- `cargo build --workspace`
- `cargo test --workspace`

All Cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` and `CARGO_INCREMENTAL=0`.
