### PR TITLE
parity(slack): preserve voice clip audio metadata

### DIFF
--- a/crates/hermes-gateway/src/media.rs
+++ b/crates/hermes-gateway/src/media.rs
@@ -507,6 +507,8 @@ impl MediaCache {
                 return Ok(None);
             }
             "image"
+        } else if mime.starts_with("audio/") {
+            "audio"
         } else if mime.starts_with("video/") {
             "video"
         } else if document_mime_supported(&mime)
@@ -883,6 +885,12 @@ fn mime_from_extension(ext: &str) -> Option<&'static str> {
         ".jpg" | ".jpeg" => Some("image/jpeg"),
         ".gif" => Some("image/gif"),
         ".webp" => Some("image/webp"),
+        ".mp3" | ".mpeg" | ".mpga" => Some("audio/mpeg"),
+        ".m4a" => Some("audio/mp4"),
+        ".wav" => Some("audio/wav"),
+        ".ogg" | ".oga" => Some("audio/ogg"),
+        ".aac" => Some("audio/aac"),
+        ".flac" => Some("audio/flac"),
         ".mp4" | ".m4v" => Some("video/mp4"),
         ".mov" => Some("video/quicktime"),
         _ => mime_for_extension(&normalized),
@@ -1007,6 +1015,28 @@ mod tests {
             .expect("pdf");
         assert_eq!(doc.kind, "document");
         assert!(doc.context_note().contains("report.pdf"));
+
+        let audio = cache
+            .cache_media_bytes(
+                b"mp4-aac-bytes",
+                Some("audio_message.mp4"),
+                Some("audio/mp4"),
+                None,
+            )
+            .await
+            .unwrap()
+            .expect("audio/mp4");
+        assert_eq!(audio.kind, "audio");
+        assert_eq!(audio.media_type, "audio/mp4");
+        assert!(audio.path.starts_with(dir.path().join("audio")));
+
+        let m4a = cache
+            .cache_media_bytes(b"m4a-bytes", Some("clip.m4a"), None, None)
+            .await
+            .unwrap()
+            .expect("m4a extension");
+        assert_eq!(m4a.kind, "audio");
+        assert_eq!(m4a.media_type, "audio/mp4");
 
         let invalid = cache
             .cache_media_bytes(b"<html>", Some("bad.png"), Some("image/png"), None)

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -9,6 +9,7 @@
 //! App Home tab publishing, interactive component handling, modals, user info,
 //! reactions, topic setting, and permalinks.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,6 +30,39 @@ const SLACK_API_BASE: &str = "https://slack.com/api";
 
 /// Maximum message length for Slack (4000 characters for text blocks).
 const MAX_MESSAGE_LENGTH: usize = 4000;
+
+const SLACK_AUDIO_MIME_TO_EXT: &[(&str, &str)] = &[
+    ("audio/ogg", ".ogg"),
+    ("audio/opus", ".ogg"),
+    ("audio/mpeg", ".mp3"),
+    ("audio/mp3", ".mp3"),
+    ("audio/wav", ".wav"),
+    ("audio/x-wav", ".wav"),
+    ("audio/webm", ".webm"),
+    ("audio/mp4", ".m4a"),
+    ("audio/x-m4a", ".m4a"),
+    ("audio/m4a", ".m4a"),
+    ("audio/aac", ".m4a"),
+    ("audio/flac", ".flac"),
+    ("audio/x-flac", ".flac"),
+];
+
+const SLACK_STT_SUPPORTED_EXTS: &[&str] = &[
+    ".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac",
+];
+
+const SLACK_EXT_TO_AUDIO_MIME: &[(&str, &str)] = &[
+    (".mp4", "audio/mp4"),
+    (".m4a", "audio/mp4"),
+    (".mp3", "audio/mpeg"),
+    (".mpeg", "audio/mpeg"),
+    (".mpga", "audio/mpeg"),
+    (".wav", "audio/wav"),
+    (".webm", "audio/webm"),
+    (".ogg", "audio/ogg"),
+    (".aac", "audio/aac"),
+    (".flac", "audio/flac"),
+];
 
 fn default_true() -> bool {
     true
@@ -204,6 +238,37 @@ pub struct SlackEvent {
     pub bot_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlackMediaKind {
+    Audio,
+    Video,
+    Image,
+    Document,
+    Unsupported,
+}
+
+/// Slack file attachment metadata preserved by the Socket Mode parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlackMediaFile {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub mimetype: Option<String>,
+    pub subtype: Option<String>,
+    pub url_private: Option<String>,
+    pub url_private_download: Option<String>,
+    pub kind: SlackMediaKind,
+    pub cache_extension: Option<String>,
+    pub reported_mime_type: Option<String>,
+}
+
+impl SlackMediaFile {
+    pub fn download_url(&self) -> Option<&str> {
+        self.url_private_download
+            .as_deref()
+            .or(self.url_private.as_deref())
+    }
+}
+
 /// Incoming message parsed from a Slack event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncomingSlackMessage {
@@ -213,6 +278,7 @@ pub struct IncomingSlackMessage {
     pub ts: String,
     pub thread_ts: Option<String>,
     pub is_bot: bool,
+    pub media_files: Vec<SlackMediaFile>,
 }
 
 /// Token-free mention policy used by Socket Mode routing.
@@ -230,6 +296,55 @@ impl SlackMentionPolicy {
             bot_user_id: config.bot_user_id.clone(),
             mention_patterns: config.mention_patterns.clone(),
         }
+    }
+}
+
+impl SlackMediaFile {
+    fn from_value(file: &serde_json::Value) -> Option<Self> {
+        let id = slack_value_string(file, "id");
+        let name = slack_value_string(file, "name");
+        let mimetype =
+            slack_value_string(file, "mimetype").or_else(|| slack_value_string(file, "mime_type"));
+        let subtype = slack_value_string(file, "subtype");
+        let url_private = slack_value_string(file, "url_private");
+        let url_private_download = slack_value_string(file, "url_private_download");
+
+        if id.is_none()
+            && name.is_none()
+            && mimetype.is_none()
+            && subtype.is_none()
+            && url_private.is_none()
+            && url_private_download.is_none()
+        {
+            return None;
+        }
+
+        let kind = slack_media_kind(name.as_deref(), mimetype.as_deref(), subtype.as_deref());
+        let (cache_extension, reported_mime_type) = if kind == SlackMediaKind::Audio {
+            let ext = resolve_slack_audio_ext(name.as_deref(), mimetype.as_deref());
+            let reported = slack_audio_mime_for_ext(&ext).to_string();
+            (Some(ext), Some(reported))
+        } else {
+            (
+                None,
+                mimetype
+                    .as_deref()
+                    .map(slack_mime_key)
+                    .filter(|s| !s.is_empty()),
+            )
+        };
+
+        Some(Self {
+            id,
+            name,
+            mimetype,
+            subtype,
+            url_private,
+            url_private_download,
+            kind,
+            cache_extension,
+            reported_mime_type,
+        })
     }
 }
 
@@ -1023,6 +1138,7 @@ impl SlackAdapter {
             .get("thread_ts")
             .and_then(|v| v.as_str())
             .map(String::from);
+        let media_files = parse_slack_media_files(event);
 
         Some(IncomingSlackMessage {
             channel,
@@ -1031,6 +1147,7 @@ impl SlackAdapter {
             ts,
             thread_ts,
             is_bot: false,
+            media_files,
         })
     }
 
@@ -1444,6 +1561,141 @@ fn slack_event_is_dm(envelope: &SocketModeEnvelope, channel_id: &str) -> bool {
     matches!(channel_type, "im" | "mpim") || channel_id.starts_with('D')
 }
 
+fn slack_value_string(value: &serde_json::Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn slack_mime_key(raw: &str) -> String {
+    raw.split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn slack_filename_ext(file_name: &str) -> Option<String> {
+    Path::new(file_name)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| format!(".{}", ext.to_ascii_lowercase()))
+}
+
+fn slack_stt_extension_supported(ext: &str) -> bool {
+    SLACK_STT_SUPPORTED_EXTS.contains(&ext)
+}
+
+fn resolve_slack_audio_ext(file_name: Option<&str>, mimetype: Option<&str>) -> String {
+    if let Some(ext) = file_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .and_then(slack_filename_ext)
+        .filter(|ext| slack_stt_extension_supported(ext))
+    {
+        return ext;
+    }
+
+    let mime_key = mimetype.map(slack_mime_key).unwrap_or_default();
+    if let Some((_, ext)) = SLACK_AUDIO_MIME_TO_EXT
+        .iter()
+        .find(|(known, _)| *known == mime_key)
+    {
+        return (*ext).to_string();
+    }
+
+    ".m4a".to_string()
+}
+
+fn slack_audio_mime_for_ext(ext: &str) -> &'static str {
+    SLACK_EXT_TO_AUDIO_MIME
+        .iter()
+        .find_map(|(known, mime)| (*known == ext).then_some(*mime))
+        .unwrap_or("audio/mp4")
+}
+
+fn slack_file_is_voice_clip(name: Option<&str>, subtype: Option<&str>) -> bool {
+    if subtype
+        .map(str::trim)
+        .map(|s| s.eq_ignore_ascii_case("slack_audio"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    name.map(str::trim)
+        .map(|s| s.to_ascii_lowercase())
+        .map(|s| s.starts_with("audio_message"))
+        .unwrap_or(false)
+}
+
+fn slack_media_kind(
+    name: Option<&str>,
+    mimetype: Option<&str>,
+    subtype: Option<&str>,
+) -> SlackMediaKind {
+    let mime_key = mimetype.map(slack_mime_key).unwrap_or_default();
+    let ext = name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .and_then(slack_filename_ext);
+    let voice_clip = slack_file_is_voice_clip(name, subtype);
+
+    if mime_key.starts_with("audio/") || voice_clip {
+        return SlackMediaKind::Audio;
+    }
+
+    if matches!(
+        ext.as_deref(),
+        Some(".m4a" | ".mp3" | ".mpeg" | ".mpga" | ".wav" | ".ogg" | ".aac" | ".flac")
+    ) {
+        return SlackMediaKind::Audio;
+    }
+
+    if mime_key.starts_with("video/")
+        || matches!(ext.as_deref(), Some(".mp4" | ".m4v" | ".mov" | ".webm"))
+    {
+        return SlackMediaKind::Video;
+    }
+
+    if mime_key.starts_with("image/")
+        || matches!(
+            ext.as_deref(),
+            Some(".png" | ".jpg" | ".jpeg" | ".gif" | ".webp")
+        )
+    {
+        return SlackMediaKind::Image;
+    }
+
+    if mime_key.starts_with("application/")
+        || mime_key.starts_with("text/")
+        || matches!(
+            ext.as_deref(),
+            Some(".pdf" | ".md" | ".txt" | ".csv" | ".json" | ".docx" | ".xlsx" | ".pptx" | ".zip")
+        )
+    {
+        return SlackMediaKind::Document;
+    }
+
+    SlackMediaKind::Unsupported
+}
+
+fn parse_slack_media_files(event: &serde_json::Value) -> Vec<SlackMediaFile> {
+    event
+        .get("files")
+        .and_then(|files| files.as_array())
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(SlackMediaFile::from_value)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn parse_slack_mention_pattern_values(raw: &str) -> Vec<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -1643,6 +1895,137 @@ mod tests {
         assert_eq!(msg.user_id, Some("U456".into()));
         assert_eq!(msg.text, "hello bot");
         assert!(!msg.is_bot);
+        assert!(msg.media_files.is_empty());
+    }
+
+    #[test]
+    fn slack_audio_ext_resolution_preserves_container_extensions() {
+        assert_eq!(
+            resolve_slack_audio_ext(Some("audio_message.mp4"), Some("audio/mp4")),
+            ".mp4"
+        );
+        assert_eq!(
+            resolve_slack_audio_ext(Some("voice.ogg"), Some("audio/ogg")),
+            ".ogg"
+        );
+        assert_eq!(
+            resolve_slack_audio_ext(Some("clip.m4a"), Some("audio/x-m4a")),
+            ".m4a"
+        );
+        assert_eq!(resolve_slack_audio_ext(Some(""), Some("audio/mp4")), ".m4a");
+        assert_eq!(
+            resolve_slack_audio_ext(Some("weird"), Some("audio/x-future-codec")),
+            ".m4a"
+        );
+    }
+
+    #[test]
+    fn slack_voice_clip_detection_uses_stable_slack_markers() {
+        assert!(slack_file_is_voice_clip(Some("audio_message.mp4"), None));
+        assert!(slack_file_is_voice_clip(
+            Some("clip.mp4"),
+            Some("slack_audio")
+        ));
+        assert!(!slack_file_is_voice_clip(Some("vacation.mp4"), None));
+        assert!(!slack_file_is_voice_clip(
+            Some("screen_recording.mp4"),
+            Some("slack_video")
+        ));
+    }
+
+    #[test]
+    fn parse_event_preserves_audio_mp4_voice_attachment_metadata() {
+        let env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env123".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "",
+                    "channel": "C123",
+                    "user": "U456",
+                    "ts": "1.0",
+                    "files": [{
+                        "id": "F1",
+                        "name": "audio_message.mp4",
+                        "mimetype": "audio/mp4",
+                        "url_private": "https://files.slack.test/F1",
+                        "url_private_download": "https://files.slack.test/F1/download"
+                    }]
+                }
+            })),
+        };
+
+        let msg = SlackAdapter::parse_event(&env).unwrap();
+        assert_eq!(msg.media_files.len(), 1);
+        let file = &msg.media_files[0];
+        assert_eq!(file.kind, SlackMediaKind::Audio);
+        assert_eq!(file.cache_extension.as_deref(), Some(".mp4"));
+        assert_eq!(file.reported_mime_type.as_deref(), Some("audio/mp4"));
+        assert_eq!(
+            file.download_url(),
+            Some("https://files.slack.test/F1/download")
+        );
+    }
+
+    #[test]
+    fn parse_event_reroutes_video_mp4_slack_voice_clip_to_audio() {
+        let env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env123".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "",
+                    "channel": "C123",
+                    "user": "U456",
+                    "ts": "1.0",
+                    "files": [{
+                        "id": "F2",
+                        "name": "voice.wav",
+                        "subtype": "slack_audio",
+                        "mimetype": "video/mp4",
+                        "url_private": "https://files.slack.test/F2"
+                    }]
+                }
+            })),
+        };
+
+        let msg = SlackAdapter::parse_event(&env).unwrap();
+        let file = &msg.media_files[0];
+        assert_eq!(file.kind, SlackMediaKind::Audio);
+        assert_eq!(file.cache_extension.as_deref(), Some(".wav"));
+        assert_eq!(file.reported_mime_type.as_deref(), Some("audio/wav"));
+    }
+
+    #[test]
+    fn parse_event_keeps_real_slack_video_on_video_path() {
+        let env = SocketModeEnvelope {
+            envelope_type: "events_api".into(),
+            envelope_id: Some("env123".into()),
+            payload: Some(serde_json::json!({
+                "event": {
+                    "type": "message",
+                    "text": "watch this",
+                    "channel": "C123",
+                    "user": "U456",
+                    "ts": "1.0",
+                    "files": [{
+                        "id": "F3",
+                        "name": "vacation.mp4",
+                        "subtype": "slack_video",
+                        "mimetype": "video/mp4",
+                        "url_private": "https://files.slack.test/F3"
+                    }]
+                }
+            })),
+        };
+
+        let msg = SlackAdapter::parse_event(&env).unwrap();
+        let file = &msg.media_files[0];
+        assert_eq!(file.kind, SlackMediaKind::Video);
+        assert_eq!(file.cache_extension, None);
+        assert_eq!(file.reported_mime_type.as_deref(), Some("video/mp4"));
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T13:45:12.366800+00:00`_
+_Generated from source artifacts: `2026-06-25T14:06:56.788977+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T13:45:12.212154+00:00`
-- Proof snapshot generated: `2026-06-25T13:45:12.366800+00:00`
+- Queue snapshot generated: `2026-06-25T14:06:56.661112+00:00`
+- Proof snapshot generated: `2026-06-25T14:06:56.788977+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T13:45:12.366800+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=189.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=189.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=187.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=187.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T13:45:12.366800+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7012 |
-| Pending | 189 |
-| Ported | 406 |
+| Pending | 187 |
+| Ported | 408 |
 | Superseded | 6341 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 189.0,
+        "actual": 187.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T13:45:12.366800+00:00",
+  "generated_at_utc": "2026-06-25T14:06:56.788977+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 189.0,
+    "max_queue_pending_commits": 187.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 189,
-      "ported": 406,
+      "pending": 187,
+      "ported": 408,
       "superseded": 6341
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 189.0,
+        "actual": 187.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T13:45:12.366800+00:00`
+Generated: `2026-06-25T14:06:56.788977+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T13:45:12.366800+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 189.0 |
+| `max_queue_pending_commits` | 187.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4573,6 +4573,16 @@
       "disposition": "ported",
       "notes": "Rust approval gateway callbacks now emit GatewayApprovalRequest::redacted_for_display using redact_approval_command before user-facing TUI/chat transports, while the internal queue retains the raw command for resolution; hermes-tools approval tests cover credential redaction, command-structure preservation, and raw-queue/redacted-egress behavior.",
       "owner": "rust-runtime"
+    },
+    "21965841612d": {
+      "disposition": "ported",
+      "notes": "Rust Slack Socket Mode parsing now preserves event.files as typed SlackMediaFile metadata, resolves inbound audio cache extensions from filename before MIME, maps audio/mp4 to .m4a fallback instead of .ogg, reroutes Slack voice clips marked slack_audio or audio_message* from video/mp4 to audio, and hermes-gateway Slack-feature tests cover audio/mp4, mislabeled voice clips, and real videos staying on the video path.",
+      "owner": "rust-runtime"
+    },
+    "5ecf3bf0e07": {
+      "disposition": "ported",
+      "notes": "Rust Slack voice-clip routing reports audio MIME from the selected cached extension via the Slack extension-to-audio-MIME map, so rerouted clips cached as .wav/.mp3/.ogg/etc expose coherent audio/* media types; hermes-gateway Slack-feature tests cover ext-matched reported MIME.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T13:45:12.212154+00:00`
+Generated: `2026-06-25T14:06:56.661112+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T13:45:12.212154+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 189 |
-| ported | 406 |
+| pending | 187 |
+| ported | 408 |
 | superseded | 6341 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- Preserve Slack `event.files` metadata in Rust Socket Mode parsing as typed `SlackMediaFile` records.
- Route Slack voice clips marked `slack_audio` or `audio_message*` as audio even when Slack reports `video/mp4`.
- Resolve audio cache extensions from filename first, then MIME, and default unknown audio to `.m4a` rather than `.ogg`.
- Add coherent extension-to-`audio/*` reporting for rerouted clips and let `MediaCache::cache_media_bytes` store explicit audio payloads under `cache/audio`.
- Mark upstream Slack voice/audio commits `21965841612d` and `5ecf3bf0e07` as ported and regenerate parity artifacts.

## Verification
- `cargo fmt --all --check`
- `cargo test -p hermes-gateway --features slack slack --lib` -> 46 passed
- `cargo test -p hermes-gateway media --lib` -> 23 passed
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features slack` -> new=0
- `cargo build --workspace`
- `cargo test --workspace`

## Parity Delta
- Pending queue: `189 -> 187`
- Ported queue: `406 -> 408`
