### PR TITLE
parity(telegram): prune stale topic bindings

### DIFF
--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -720,6 +720,12 @@ impl TelegramTopicBindingStore {
             .retain(|_, binding| binding.session_id != session_id);
     }
 
+    pub fn remove(&mut self, chat_id: &str, thread_id: &str) -> bool {
+        self.bindings
+            .remove(&(chat_id.to_string(), thread_id.to_string()))
+            .is_some()
+    }
+
     pub fn list_for_chat(&self, chat_id: &str) -> Vec<TelegramTopicBinding> {
         let mut rows = self
             .bindings
@@ -793,6 +799,8 @@ pub struct TelegramAdapter {
     approval_counter: AtomicU64,
     /// Latched off after the rich endpoint is proven unavailable.
     rich_send_disabled: Mutex<bool>,
+    /// DM topic bindings used to recover Telegram clients that strip topic ids.
+    topic_bindings: Mutex<TelegramTopicBindingStore>,
 }
 
 #[derive(Clone, Copy)]
@@ -845,12 +853,48 @@ impl TelegramAdapter {
             approval_state: Mutex::new(HashMap::new()),
             approval_counter: AtomicU64::new(1),
             rich_send_disabled: Mutex::new(false),
+            topic_bindings: Mutex::new(TelegramTopicBindingStore::default()),
         })
     }
 
     /// Get a reference to the configuration.
     pub fn config(&self) -> &TelegramConfig {
         &self.config
+    }
+
+    pub fn bind_dm_topic(
+        &self,
+        chat_id: impl Into<String>,
+        thread_id: impl Into<String>,
+        session_id: impl Into<String>,
+        user_id: impl Into<String>,
+        title: Option<String>,
+        operator_declared: bool,
+    ) {
+        if let Ok(mut store) = self.topic_bindings.lock() {
+            store.bind(
+                chat_id,
+                thread_id,
+                session_id,
+                user_id,
+                title,
+                operator_declared,
+            );
+        }
+    }
+
+    pub fn dm_topic_binding(&self, chat_id: &str, thread_id: &str) -> Option<TelegramTopicBinding> {
+        self.topic_bindings
+            .lock()
+            .ok()
+            .and_then(|store| store.get(chat_id, thread_id).cloned())
+    }
+
+    pub fn prune_stale_dm_topic_binding(&self, chat_id: &str, thread_id: &str) -> bool {
+        self.topic_bindings
+            .lock()
+            .map(|mut store| store.remove(chat_id, thread_id))
+            .unwrap_or(false)
     }
 
     fn split_gateway_chat_thread(chat_id: &str) -> (&str, Option<i64>) {
@@ -1889,6 +1933,7 @@ impl TelegramAdapter {
         match self.post_json(&url, &body).await {
             Ok(resp) if resp.ok => Ok(resp),
             Ok(resp) => {
+                let stale_topic_target = Self::thread_fallback_target_from_body(&body);
                 let description = resp
                     .description
                     .as_deref()
@@ -1897,6 +1942,7 @@ impl TelegramAdapter {
                 if Self::thread_or_reply_missing(&description)
                     && Self::strip_thread_fields_for_fallback(&mut body)
                 {
+                    self.prune_stale_dm_topic_binding_target(stale_topic_target);
                     let retry = self.post_json(&url, &body).await?;
                     if retry.ok {
                         return Ok(retry);
@@ -1909,7 +1955,9 @@ impl TelegramAdapter {
                 Err(Self::telegram_response_error(method, &resp))
             }
             Err(err) if Self::gateway_error_thread_or_reply_missing(&err) => {
+                let stale_topic_target = Self::thread_fallback_target_from_body(&body);
                 if Self::strip_thread_fields_for_fallback(&mut body) {
+                    self.prune_stale_dm_topic_binding_target(stale_topic_target);
                     self.post_json(&url, &body).await
                 } else {
                     Err(err)
@@ -1927,6 +1975,35 @@ impl TelegramAdapter {
         let removed_reply = obj.remove("reply_to_message_id").is_some();
         let removed_reply_parameters = obj.remove("reply_parameters").is_some();
         removed_thread || removed_reply || removed_reply_parameters
+    }
+
+    fn thread_fallback_target_from_body(body: &serde_json::Value) -> Option<(String, String)> {
+        let obj = body.as_object()?;
+        let chat_id = Self::telegram_id_value_to_string(obj.get("chat_id")?)?;
+        let thread_id = Self::telegram_id_value_to_string(obj.get("message_thread_id")?)?;
+        Some((chat_id, thread_id))
+    }
+
+    fn telegram_id_value_to_string(value: &serde_json::Value) -> Option<String> {
+        value
+            .as_str()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| value.as_i64().map(|id| id.to_string()))
+    }
+
+    fn prune_stale_dm_topic_binding_target(&self, target: Option<(String, String)>) {
+        let Some((chat_id, thread_id)) = target else {
+            return;
+        };
+        if self.prune_stale_dm_topic_binding(&chat_id, &thread_id) {
+            info!(
+                chat_id = %chat_id,
+                thread_id = %thread_id,
+                "Pruned stale Telegram DM topic binding after Bot API reported the thread missing"
+            );
+        }
     }
 
     fn gateway_error_thread_or_reply_missing(err: &GatewayError) -> bool {
@@ -2134,6 +2211,12 @@ impl TelegramAdapter {
                 if Self::gateway_error_thread_or_reply_missing(&err)
                     && request.has_thread_context() =>
             {
+                if let Some(thread_id) = request.message_thread_id {
+                    self.prune_stale_dm_topic_binding_target(Some((
+                        request.chat_id.to_string(),
+                        thread_id.to_string(),
+                    )));
+                }
                 self.send_multipart_once(request.without_thread_context())
                     .await
             }
@@ -3602,6 +3685,9 @@ mod tests {
         );
         store.remove_session("session-b");
         assert!(store.get("208214988", "222").is_none());
+        assert!(store.remove("208214988", "111"));
+        assert!(store.get("208214988", "111").is_none());
+        assert!(!store.remove("208214988", "missing"));
         store.disable("208214988", "user1");
         assert!(!store.is_enabled("208214988", "user1"));
     }
@@ -3632,6 +3718,8 @@ mod tests {
 
         let mut adapter = test_adapter(test_config());
         adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+        adapter.bind_dm_topic("123", "999", "session-dead-topic", "user1", None, false);
+        assert!(adapter.dm_topic_binding("123", "999").is_some());
 
         let ids = adapter
             .send_text_with_keyboard(
@@ -3651,6 +3739,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ids, vec![77]);
+        assert!(adapter.dm_topic_binding("123", "999").is_none());
         let requests = server.received_requests().await.expect("requests");
         assert_eq!(requests.len(), 2);
         let first: Value = requests[0].body_json().expect("json");

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-25T14:06:56.788977+00:00`_
+_Generated from source artifacts: `2026-06-25T14:23:42.398429+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-25T14:06:56.661112+00:00`
-- Proof snapshot generated: `2026-06-25T14:06:56.788977+00:00`
+- Queue snapshot generated: `2026-06-25T14:23:42.258769+00:00`
+- Proof snapshot generated: `2026-06-25T14:23:42.398429+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-25T14:06:56.788977+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=187.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=187.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=186.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=186.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-25T14:06:56.788977+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7012 |
-| Pending | 187 |
-| Ported | 408 |
+| Pending | 186 |
+| Ported | 409 |
 | Superseded | 6341 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 187.0,
+        "actual": 186.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T14:06:56.788977+00:00",
+  "generated_at_utc": "2026-06-25T14:23:42.398429+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 187.0,
+    "max_queue_pending_commits": 186.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 187,
-      "ported": 408,
+      "pending": 186,
+      "ported": 409,
       "superseded": 6341
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 187.0,
+        "actual": 186.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T14:06:56.788977+00:00`
+Generated: `2026-06-25T14:23:42.398429+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T14:06:56.788977+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 187.0 |
+| `max_queue_pending_commits` | 186.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4583,6 +4583,11 @@
       "disposition": "ported",
       "notes": "Rust Slack voice-clip routing reports audio MIME from the selected cached extension via the Slack extension-to-audio-MIME map, so rerouted clips cached as .wav/.mp3/.ogg/etc expose coherent audio/* media types; hermes-gateway Slack-feature tests cover ext-matched reported MIME.",
       "owner": "rust-runtime"
+    },
+    "142a5751a2b3": {
+      "disposition": "ported",
+      "notes": "Rust Telegram adapter now owns TelegramTopicBindingStore state, exposes bind/read/prune helpers, and prunes the stale (chat_id, message_thread_id) binding when Bot API reports thread/message_thread not found before retrying JSON or multipart sends without thread context. hermes-gateway Telegram tests cover store removal and thread-fallback pruning.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T14:06:56.661112+00:00`
+Generated: `2026-06-25T14:23:42.258769+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T14:06:56.661112+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 187 |
-| ported | 408 |
+| pending | 186 |
+| ported | 409 |
 | superseded | 6341 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## What Changed
- Added Rust-native stale Telegram DM topic binding pruning when Bot API reports `message thread not found` / thread-missing fallback conditions.
- Gave `TelegramAdapter` an owned `TelegramTopicBindingStore` with bind/read/prune helpers so fallback sends can remove dead `(chat_id, message_thread_id)` recovery state before retrying without thread context.
- Applied the pruning path to JSON sends and multipart sends, preserving best-effort retry behavior.
- Updated parity queue artifacts: upstream `142a5751a2b3` is now `ported`; pending queue count moves `187 -> 186`, ported count `408 -> 409`.

## Tests
- `cargo fmt --all --check`
- `cargo test -p hermes-gateway --features telegram telegram --lib`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features telegram`
- `cargo build --workspace`
- `cargo test --workspace`
