### PR TITLE
parity(discord): delete obsolete commands first

### DIFF
--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -1725,6 +1725,30 @@ pub fn plan_discord_command_sync(
         ..DiscordCommandSyncSummary::default()
     };
 
+    let desired_keys = desired
+        .iter()
+        .filter_map(command_key)
+        .collect::<BTreeSet<_>>();
+    let obsolete_keys = existing_by_key
+        .keys()
+        .filter(|key| !desired_keys.contains(*key))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    // Discord rejects upserts that would briefly exceed the 100-command cap,
+    // so remove obsolete commands before creating replacement commands.
+    for key in obsolete_keys {
+        if let Some(existing_payload) = existing_by_key.remove(&key) {
+            let name = command_key(existing_payload)
+                .map(|(name, _)| name)
+                .unwrap_or_else(|| key.0.clone());
+            summary.deleted += 1;
+            summary
+                .mutations
+                .push(DiscordCommandSyncMutation::Delete { name });
+        }
+    }
+
     for desired_payload in desired {
         let Some((name, command_type)) = command_key(desired_payload) else {
             continue;
@@ -1765,12 +1789,6 @@ pub fn plan_discord_command_sync(
         }
     }
 
-    for ((name, _), _) in existing_by_key {
-        summary.deleted += 1;
-        summary
-            .mutations
-            .push(DiscordCommandSyncMutation::Delete { name });
-    }
     summary
 }
 
@@ -5091,6 +5109,33 @@ mod tests {
         assert_eq!(summary.recreated, 2);
         assert_eq!(summary.created, 1);
         assert_eq!(summary.deleted, 1);
+        assert_eq!(
+            summary.mutations.first(),
+            Some(&DiscordCommandSyncMutation::Delete {
+                name: "old-command".into()
+            })
+        );
+        let delete_index = summary
+            .mutations
+            .iter()
+            .position(|mutation| {
+                mutation
+                    == &DiscordCommandSyncMutation::Delete {
+                        name: "old-command".into(),
+                    }
+            })
+            .expect("obsolete command delete mutation");
+        let create_index = summary
+            .mutations
+            .iter()
+            .position(|mutation| {
+                mutation
+                    == &DiscordCommandSyncMutation::Create {
+                        name: "metricas".into(),
+                    }
+            })
+            .expect("new command create mutation");
+        assert!(delete_index < create_index);
         assert!(summary
             .mutations
             .contains(&DiscordCommandSyncMutation::Update {

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 186.0,
+        "actual": 183.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T14:23:42.398429+00:00",
+  "generated_at_utc": "2026-06-25T14:46:46.664108+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 186.0,
+    "max_queue_pending_commits": 183.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 186,
-      "ported": 409,
-      "superseded": 6341
+      "pending": 183,
+      "ported": 411,
+      "superseded": 6342
     },
     "by_target_ticket": {
       "20": 3140,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 186.0,
+        "actual": 183.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T14:23:42.398429+00:00`
+Generated: `2026-06-25T14:46:46.664108+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T14:23:42.398429+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 186.0 |
+| `max_queue_pending_commits` | 183.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4588,6 +4588,21 @@
       "disposition": "ported",
       "notes": "Rust Telegram adapter now owns TelegramTopicBindingStore state, exposes bind/read/prune helpers, and prunes the stale (chat_id, message_thread_id) binding when Bot API reports thread/message_thread not found before retrying JSON or multipart sends without thread context. hermes-gateway Telegram tests cover store removal and thread-fallback pruning.",
       "owner": "rust-runtime"
+    },
+    "e9b86f352fc7": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Discord command diff planner now deletes obsolete application commands before create/update/recreate mutations, preserving the upstream fix for Discord 100-command cap; the focused command-sync test asserts delete-before-create ordering."
+    },
+    "4b7f3826c2ce": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust Telegram adapter constructs Bot API clients through the shared reqwest platform_http_client_builder, including fallback-IP resolution and proxy branches, and the shared platform HTTP pool tests assert the CLOSE_WAIT-safe keepalive expiry below 5s with bounded idle connections."
+    },
+    "807bdc17f62b": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fixes Python discord.py auto-create-thread duplicate MESSAGE_CREATE dispatch. The Rust Discord adapter has no live inbound auto-create-thread dispatcher calling create_thread from message handling; duplicate suppression is centralized in Gateway::should_suppress_duplicate before session dispatch, so the Python thread-starter preseed path is absent."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T14:23:42.258769+00:00`
+Generated: `2026-06-25T14:46:38.745838+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-25T14:23:42.258769+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 186 |
-| ported | 409 |
-| superseded | 6341 |
+| pending | 183 |
+| ported | 411 |
+| superseded | 6342 |
 
 ## First 100 Pending Commits
 


### PR DESCRIPTION
## Summary
- reorder Rust Discord command-sync planning so obsolete commands are deleted before create/update/recreate mutations
- add regression coverage asserting delete-before-create ordering for the Discord command cap case
- update parity queue/proof: pending 186 -> 183, ported 409 -> 411, superseded 6341 -> 6342

## Parity Evidence
- `e9b86f352fc7` ported: delete obsolete slash commands first
- `4b7f3826c2ce` ported: Telegram uses shared Rust reqwest platform HTTP pool limits with keepalive expiry coverage
- `807bdc17f62b` superseded: Python discord.py auto-thread duplicate path is absent in Rust; central gateway dedup remains the live dispatch guard

## Verification
- `cargo fmt --all --check`
- `cargo test -p hermes-gateway --features discord discord_command_sync_plans_diffs_recreates_and_deletes --lib`
- `cargo test -p hermes-gateway platform_http_client_limits --lib`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features discord`
- `cargo build --workspace`
- `cargo test --workspace`
