### PR TITLE
parity(delivery): preserve long output for chunking adapters

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -10795,12 +10795,13 @@ async fn run_cron_gateway_delivery_loop(
         };
 
         if let Err(err) = gateway
-            .send_message_explicit(
+            .send_message_explicit_with_audit_label(
                 target.platform,
                 &target.chat_id,
                 &text,
                 None,
                 target.thread_id.as_deref(),
+                Some(&event.job_id),
             )
             .await
         {

--- a/crates/hermes-cli/tests/e2e_cli.rs
+++ b/crates/hermes-cli/tests/e2e_cli.rs
@@ -3,7 +3,22 @@ use std::fs;
 
 #[test]
 fn e2e_cli_model_command_prints_current_model() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("config.yaml"),
+        r#"
+model: local-test:deterministic
+llm_providers:
+  local-test:
+    base_url: http://127.0.0.1:9/v1
+    discover_models: false
+    models:
+      deterministic: {}
+"#,
+    )
+    .expect("write config");
     let mut cmd = Command::cargo_bin("hermes").expect("binary exists");
+    cmd.env("HERMES_HOME", dir.path());
     cmd.arg("model");
     cmd.assert().success();
 }

--- a/crates/hermes-core/src/traits.rs
+++ b/crates/hermes-core/src/traits.rs
@@ -76,6 +76,8 @@ pub struct SendMessageOptions {
     /// True for lifecycle/status sends that should not become conversational
     /// history boundaries on platforms that backfill channel context.
     pub non_conversational: bool,
+    /// Stable label used when saving full long-form output before truncation.
+    pub delivery_audit_label: Option<String>,
 }
 
 impl SendMessageOptions {
@@ -85,6 +87,7 @@ impl SendMessageOptions {
             explicit_chat_id: false,
             notify: false,
             non_conversational: false,
+            delivery_audit_label: None,
         }
     }
 
@@ -94,6 +97,7 @@ impl SendMessageOptions {
             explicit_chat_id: true,
             notify: false,
             non_conversational: false,
+            delivery_audit_label: None,
         }
     }
 
@@ -103,6 +107,7 @@ impl SendMessageOptions {
             explicit_chat_id: false,
             notify: true,
             non_conversational: false,
+            delivery_audit_label: None,
         }
     }
 
@@ -112,7 +117,13 @@ impl SendMessageOptions {
             explicit_chat_id: false,
             notify: false,
             non_conversational: true,
+            delivery_audit_label: None,
         }
+    }
+
+    pub fn with_delivery_audit_label(mut self, label: impl Into<String>) -> Self {
+        self.delivery_audit_label = Some(label.into());
+        self
     }
 }
 
@@ -258,6 +269,15 @@ pub trait PlatformAdapter: Send + Sync {
 
     /// Check whether the adapter is currently running.
     fn is_running(&self) -> bool;
+
+    /// Whether this adapter splits long outgoing text into multiple messages.
+    ///
+    /// The gateway uses this to preserve full long-form cron/tool output for
+    /// adapters that chunk natively, while retaining truncation and audit-file
+    /// fallback for adapters with single-message limits.
+    fn splits_long_messages(&self) -> bool {
+        false
+    }
 
     /// Return the name of this platform (e.g. "telegram", "discord").
     fn platform_name(&self) -> &str;

--- a/crates/hermes-gateway/src/delivery.rs
+++ b/crates/hermes-gateway/src/delivery.rs
@@ -4,16 +4,132 @@
 //! for specifying where messages should be routed, and a `DeliveryRouter`
 //! that holds registered adapters and dispatches messages accordingly.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::RwLock;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::media::validate_media_delivery_path;
 use hermes_core::errors::GatewayError;
 use hermes_core::traits::{PlatformAdapter, SendMessageOptions};
+
+/// Cap before gateway-level truncation for adapters that cannot split long text.
+pub(crate) const MAX_PLATFORM_OUTPUT: usize = 4000;
+static AUDIT_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn prepare_platform_message_for_adapter<'a>(
+    adapter: &dyn PlatformAdapter,
+    message: &'a str,
+    audit_label: Option<&str>,
+) -> Result<Cow<'a, str>, GatewayError> {
+    prepare_platform_message_for_adapter_at(
+        adapter,
+        message,
+        audit_label,
+        &hermes_config::hermes_home(),
+    )
+}
+
+fn prepare_platform_message_for_adapter_at<'a>(
+    adapter: &dyn PlatformAdapter,
+    message: &'a str,
+    audit_label: Option<&str>,
+    hermes_home: &Path,
+) -> Result<Cow<'a, str>, GatewayError> {
+    if message.chars().count() <= MAX_PLATFORM_OUTPUT {
+        return Ok(Cow::Borrowed(message));
+    }
+
+    let label = sanitized_audit_label(audit_label, adapter.platform_name());
+    if adapter.splits_long_messages() {
+        match save_full_platform_output_at(message, &label, hermes_home) {
+            Ok(saved_path) => info!(
+                platform = adapter.platform_name(),
+                path = %saved_path.display(),
+                chars = message.chars().count(),
+                "Preserved long platform output for chunking adapter"
+            ),
+            Err(err) => warn!(
+                platform = adapter.platform_name(),
+                error = %err,
+                chars = message.chars().count(),
+                "Failed to save long platform output audit copy; delivering full content"
+            ),
+        }
+        return Ok(Cow::Borrowed(message));
+    }
+
+    let saved_path = save_full_platform_output_at(message, &label, hermes_home).map_err(|err| {
+        GatewayError::SendFailed(format!(
+            "Failed to save full platform output before truncation: {err}"
+        ))
+    })?;
+    let footer = format!(
+        "\n\n... [truncated, full output saved to {}]",
+        saved_path.display()
+    );
+    let visible = MAX_PLATFORM_OUTPUT.saturating_sub(footer.chars().count());
+    let mut truncated = message.chars().take(visible).collect::<String>();
+    truncated.push_str(&footer);
+    info!(
+        platform = adapter.platform_name(),
+        path = %saved_path.display(),
+        original_chars = message.chars().count(),
+        delivered_chars = truncated.chars().count(),
+        "Truncated long platform output for non-chunking adapter"
+    );
+    Ok(Cow::Owned(truncated))
+}
+
+fn save_full_platform_output_at(
+    content: &str,
+    label: &str,
+    hermes_home: &Path,
+) -> std::io::Result<PathBuf> {
+    let output_dir = hermes_home.join("cron").join("output");
+    std::fs::create_dir_all(&output_dir)?;
+    let now_millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let sequence = AUDIT_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let path = output_dir.join(format!(
+        "{}_{}_{}_{}.txt",
+        label,
+        now_millis,
+        std::process::id(),
+        sequence
+    ));
+    std::fs::write(&path, content)?;
+    Ok(path)
+}
+
+fn sanitized_audit_label(label: Option<&str>, fallback: &str) -> String {
+    let raw = label
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback);
+    let mut sanitized = String::with_capacity(raw.len().min(64));
+    for ch in raw.chars().take(64) {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            sanitized.push(ch);
+        } else if !sanitized.ends_with('_') {
+            sanitized.push('_');
+        }
+    }
+    let trimmed = sanitized.trim_matches('_');
+    if trimmed.is_empty() {
+        "platform-output".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // DeliveryItem
@@ -357,6 +473,7 @@ impl DeliveryRouter {
                     explicit_chat_id: target.is_explicit,
                     notify: false,
                     non_conversational: false,
+                    delivery_audit_label: None,
                 },
             )
             .await
@@ -394,8 +511,13 @@ impl DeliveryRouter {
                         "Adapter is not running, attempting delivery anyway"
                     );
                 }
+                let message = prepare_platform_message_for_adapter(
+                    adapter.as_ref(),
+                    message,
+                    options.delivery_audit_label.as_deref(),
+                )?;
                 adapter
-                    .send_message_with_options(chat_id, message, None, options)
+                    .send_message_with_options(chat_id, message.as_ref(), None, options)
                     .await
             }
             None => {
@@ -470,6 +592,7 @@ impl DeliveryRouter {
                             explicit_chat_id: target.is_explicit,
                             notify: false,
                             non_conversational: false,
+                            delivery_audit_label: None,
                         },
                     )
                     .await
@@ -508,6 +631,7 @@ mod tests {
 
     struct MessageRecordingAdapter {
         messages: Arc<Mutex<Vec<RecordedMessage>>>,
+        splits_long_messages: bool,
     }
 
     #[async_trait]
@@ -620,9 +744,82 @@ mod tests {
             true
         }
 
+        fn splits_long_messages(&self) -> bool {
+            self.splits_long_messages
+        }
+
         fn platform_name(&self) -> &str {
             "ntfy"
         }
+    }
+
+    #[test]
+    fn prepare_platform_message_truncates_and_saves_for_non_chunking_adapter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let adapter = MessageRecordingAdapter {
+            messages,
+            splits_long_messages: false,
+        };
+        let content = "x".repeat(MAX_PLATFORM_OUTPUT + 1200);
+
+        let prepared = prepare_platform_message_for_adapter_at(
+            &adapter,
+            &content,
+            Some("job/unsafe label"),
+            tmp.path(),
+        )
+        .expect("prepare");
+
+        assert!(prepared.chars().count() <= MAX_PLATFORM_OUTPUT);
+        assert!(prepared.contains("truncated, full output saved to"));
+        assert_ne!(prepared.as_ref(), content);
+        let saved: Vec<_> = std::fs::read_dir(tmp.path().join("cron").join("output"))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(saved.len(), 1);
+        assert!(saved[0]
+            .file_name()
+            .to_string_lossy()
+            .starts_with("job_unsafe_label_"));
+        assert_eq!(std::fs::read_to_string(saved[0].path()).unwrap(), content);
+    }
+
+    #[test]
+    fn prepare_platform_message_preserves_and_saves_for_chunking_adapter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let adapter = MessageRecordingAdapter {
+            messages,
+            splits_long_messages: true,
+        };
+        let content = "x".repeat(MAX_PLATFORM_OUTPUT + 1200);
+
+        let prepared =
+            prepare_platform_message_for_adapter_at(&adapter, &content, Some("job2"), tmp.path())
+                .expect("prepare");
+
+        assert_eq!(prepared.as_ref(), content);
+        let saved: Vec<_> = std::fs::read_dir(tmp.path().join("cron").join("output"))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(saved.len(), 1);
+        assert!(saved[0].file_name().to_string_lossy().starts_with("job2_"));
+        assert_eq!(std::fs::read_to_string(saved[0].path()).unwrap(), content);
+    }
+
+    #[test]
+    fn save_full_platform_output_uses_unique_paths_for_same_label() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let first = save_full_platform_output_at("first", "same-job", tmp.path()).unwrap();
+        let second = save_full_platform_output_at("second", "same-job", tmp.path()).unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(std::fs::read_to_string(first).unwrap(), "first");
+        assert_eq!(std::fs::read_to_string(second).unwrap(), "second");
     }
 
     #[test]
@@ -723,6 +920,7 @@ mod tests {
                 "ntfy",
                 Arc::new(MessageRecordingAdapter {
                     messages: messages.clone(),
+                    splits_long_messages: false,
                 }),
             )
             .await;

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -38,6 +38,7 @@ use hermes_tools::skill_commands::{
 
 use crate::background::{BackgroundTaskManager, TaskStatus};
 use crate::commands::{handle_command, GatewayCommandResult, ModelSwitchRequest, ModelSwitchScope};
+use crate::delivery::prepare_platform_message_for_adapter;
 use crate::dm::{DmDecision, DmManager};
 use crate::hooks::{HookEvent, HookRegistry};
 use crate::media::validate_media_delivery_path;
@@ -3302,14 +3303,44 @@ impl Gateway {
         parse_mode: Option<ParseMode>,
         thread_id: Option<&str>,
     ) -> Result<(), GatewayError> {
-        self.send_message_with_options(
-            platform,
-            chat_id,
-            text,
-            parse_mode,
-            SendMessageOptions::explicit_threaded(thread_id),
+        self.send_message_explicit_with_audit_label(
+            platform, chat_id, text, parse_mode, thread_id, None,
         )
         .await
+    }
+
+    pub async fn send_message_explicit_with_audit_label(
+        &self,
+        platform: &str,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        thread_id: Option<&str>,
+        audit_label: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        let mut options = SendMessageOptions::explicit_threaded(thread_id);
+        if let Some(label) = audit_label {
+            options = options.with_delivery_audit_label(label.to_string());
+        }
+        self.send_message_with_options(platform, chat_id, text, parse_mode, options)
+            .await
+    }
+
+    async fn send_adapter_text_with_options(
+        adapter: &Arc<dyn PlatformAdapter>,
+        chat_id: &str,
+        text: &str,
+        parse_mode: Option<ParseMode>,
+        options: SendMessageOptions,
+    ) -> Result<(), GatewayError> {
+        let prepared = prepare_platform_message_for_adapter(
+            adapter.as_ref(),
+            text,
+            options.delivery_audit_label.as_deref(),
+        )?;
+        adapter
+            .send_message_with_options(chat_id, prepared.as_ref(), parse_mode, options)
+            .await
     }
 
     async fn send_message_with_options(
@@ -3327,19 +3358,26 @@ impl Gateway {
         let (cleaned, images) = extract_inline_images(&without_media);
         if images.is_empty() && media_files.is_empty() {
             if without_media == text {
-                return adapter
-                    .send_message_with_options(chat_id, text, parse_mode, options)
-                    .await;
-            }
-            return adapter
-                .send_message_with_options(chat_id, &cleaned, parse_mode, options)
+                return Self::send_adapter_text_with_options(
+                    &adapter, chat_id, text, parse_mode, options,
+                )
                 .await;
+            }
+            return Self::send_adapter_text_with_options(
+                &adapter, chat_id, &cleaned, parse_mode, options,
+            )
+            .await;
         }
 
         if !cleaned.is_empty() {
-            adapter
-                .send_message_with_options(chat_id, &cleaned, parse_mode.clone(), options.clone())
-                .await?;
+            Self::send_adapter_text_with_options(
+                &adapter,
+                chat_id,
+                &cleaned,
+                parse_mode.clone(),
+                options.clone(),
+            )
+            .await?;
         }
 
         for image in images {
@@ -3359,14 +3397,14 @@ impl Gateway {
                     Some(caption) if !caption.is_empty() => format!("{caption}\n{}", image.url),
                     _ => image.url.clone(),
                 };
-                adapter
-                    .send_message_with_options(
-                        chat_id,
-                        &fallback,
-                        Some(ParseMode::Plain),
-                        options.clone(),
-                    )
-                    .await?;
+                Self::send_adapter_text_with_options(
+                    &adapter,
+                    chat_id,
+                    &fallback,
+                    Some(ParseMode::Plain),
+                    options.clone(),
+                )
+                .await?;
             }
         }
 
@@ -3379,14 +3417,14 @@ impl Gateway {
                     as_voice = media.as_voice,
                     "refusing to deliver unsafe MEDIA marker path"
                 );
-                adapter
-                    .send_message_with_options(
-                        chat_id,
-                        "[media attachment blocked: unsafe local file path]",
-                        Some(ParseMode::Plain),
-                        options.clone(),
-                    )
-                    .await?;
+                Self::send_adapter_text_with_options(
+                    &adapter,
+                    chat_id,
+                    "[media attachment blocked: unsafe local file path]",
+                    Some(ParseMode::Plain),
+                    options.clone(),
+                )
+                .await?;
                 continue;
             };
             let Some(validated_path) = validated_path.to_str() else {
@@ -3397,14 +3435,14 @@ impl Gateway {
                     as_voice = media.as_voice,
                     "refusing to deliver non-UTF-8 MEDIA marker path"
                 );
-                adapter
-                    .send_message_with_options(
-                        chat_id,
-                        "[media attachment blocked: non-UTF-8 local file path]",
-                        Some(ParseMode::Plain),
-                        options.clone(),
-                    )
-                    .await?;
+                Self::send_adapter_text_with_options(
+                    &adapter,
+                    chat_id,
+                    "[media attachment blocked: non-UTF-8 local file path]",
+                    Some(ParseMode::Plain),
+                    options.clone(),
+                )
+                .await?;
                 continue;
             };
 
@@ -3420,14 +3458,14 @@ impl Gateway {
                     error = %err,
                     "native media file send failed; falling back to plain file marker"
                 );
-                adapter
-                    .send_message_with_options(
-                        chat_id,
-                        &format!("[media attachment] {validated_path}"),
-                        Some(ParseMode::Plain),
-                        options.clone(),
-                    )
-                    .await?;
+                Self::send_adapter_text_with_options(
+                    &adapter,
+                    chat_id,
+                    &format!("[media attachment] {validated_path}"),
+                    Some(ParseMode::Plain),
+                    options.clone(),
+                )
+                .await?;
             }
         }
 
@@ -4490,6 +4528,53 @@ mod tests {
             "[image] https://cdn.example.com/x.png | caption=diagram"
         );
         assert_eq!(sent[2].1, "[image] https://fal.media/abc");
+    }
+
+    #[tokio::test]
+    async fn gateway_explicit_send_truncates_long_non_chunking_output_with_audit_label() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home_guard = HermesHomeEnvGuard::set(tmp.path());
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let adapter = Arc::new(TestAdapter {
+            messages: sent.clone(),
+        });
+        let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+        let gw = Gateway::with_defaults(session_mgr, GatewayConfig::default());
+        gw.register_adapter("test", adapter).await;
+        let full_output = "x".repeat(crate::delivery::MAX_PLATFORM_OUTPUT + 1200);
+
+        gw.send_message_explicit_with_audit_label(
+            "test",
+            "chat1",
+            &full_output,
+            None,
+            None,
+            Some("cron/job 42"),
+        )
+        .await
+        .expect("send should succeed");
+
+        let sent = sent.lock().unwrap();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].0, "chat1");
+        assert!(sent[0].1.chars().count() <= crate::delivery::MAX_PLATFORM_OUTPUT);
+        assert!(sent[0].1.contains("truncated, full output saved to"));
+        assert_ne!(sent[0].1, full_output);
+        drop(sent);
+
+        let saved: Vec<_> = std::fs::read_dir(tmp.path().join("cron").join("output"))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(saved.len(), 1);
+        assert!(saved[0]
+            .file_name()
+            .to_string_lossy()
+            .starts_with("cron_job_42_"));
+        assert_eq!(
+            std::fs::read_to_string(saved[0].path()).unwrap(),
+            full_output
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -3993,6 +3993,10 @@ impl PlatformAdapter for DiscordAdapter {
         self.base.is_running()
     }
 
+    fn splits_long_messages(&self) -> bool {
+        true
+    }
+
     fn platform_name(&self) -> &str {
         "discord"
     }

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -1531,6 +1531,10 @@ impl PlatformAdapter for SlackAdapter {
         self.base.is_running()
     }
 
+    fn splits_long_messages(&self) -> bool {
+        true
+    }
+
     fn platform_name(&self) -> &str {
         "slack"
     }

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -3099,6 +3099,10 @@ impl PlatformAdapter for TelegramAdapter {
         self.base.is_running()
     }
 
+    fn splits_long_messages(&self) -> bool {
+        true
+    }
+
     fn platform_name(&self) -> &str {
         "telegram"
     }

--- a/crates/hermes-gateway/src/platforms/weixin.rs
+++ b/crates/hermes-gateway/src/platforms/weixin.rs
@@ -1437,6 +1437,10 @@ impl PlatformAdapter for WeChatAdapter {
         self.inner.base.is_running()
     }
 
+    fn splits_long_messages(&self) -> bool {
+        true
+    }
+
     fn platform_name(&self) -> &str {
         "weixin"
     }

--- a/crates/hermes-gateway/src/platforms/whatsapp.rs
+++ b/crates/hermes-gateway/src/platforms/whatsapp.rs
@@ -900,6 +900,11 @@ impl PlatformAdapter for WhatsAppAdapter {
     fn is_running(&self) -> bool {
         self.base.is_running()
     }
+
+    fn splits_long_messages(&self) -> bool {
+        true
+    }
+
     fn platform_name(&self) -> &str {
         "whatsapp"
     }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 183.0,
+        "actual": 181.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T14:46:46.664108+00:00",
+  "generated_at_utc": "2026-06-25T15:09:18.019350+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 183.0,
+    "max_queue_pending_commits": 181.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 183,
-      "ported": 411,
+      "pending": 181,
+      "ported": 413,
       "superseded": 6342
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 183.0,
+        "actual": 181.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T14:46:46.664108+00:00`
+Generated: `2026-06-25T15:09:18.019350+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T14:46:46.664108+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 183.0 |
+| `max_queue_pending_commits` | 181.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4603,6 +4603,16 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Upstream fixes Python discord.py auto-create-thread duplicate MESSAGE_CREATE dispatch. The Rust Discord adapter has no live inbound auto-create-thread dispatcher calling create_thread from message handling; duplicate suppression is centralized in Gateway::should_suppress_duplicate before session dispatch, so the Python thread-starter preseed path is absent."
+    },
+    "86e4521cb1d9": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust gateway delivery now has adapter-aware long-output handling: PlatformAdapter exposes splits_long_messages, DeliveryRouter and live Gateway sends preserve full payloads for verified chunking adapters while saving audit copies, non-chunking adapters truncate to 4000 chars with a full-output file footer, and cron gateway delivery passes the job id as the audit label. Focused delivery/gateway tests cover chunking preservation, non-chunking truncation, audit-file contents, and job-label sanitization."
+    },
+    "e9cd8c5bf3ea": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust intentionally keeps the delivery cap constant with no new HERMES_DELIVERY_MAX_PLATFORM_OUTPUT env knob; verified Rust chunking adapters (Discord, Telegram, Slack, WhatsApp, Weixin) opt into splits_long_messages, while non-chunking Rust adapters remain conservative and protected by truncation plus full-output audit files. The upstream-only Teams/Yuanbao/WhatsApp Cloud adapter flags have no Rust files in this tree."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T14:46:38.745838+00:00`
+Generated: `2026-06-25T15:09:17.893661+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-25T14:46:38.745838+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 183 |
-| ported | 411 |
+| pending | 181 |
+| ported | 413 |
 | superseded | 6342 |
 
 ## First 100 Pending Commits
@@ -121,7 +121,7 @@ Generated: `2026-06-25T14:46:38.745838+00:00`
 | `61c266b0dc75` | #26 | style(desktop): soften dark-mode syntax highlighting |
 | `8845f3316c26` | #20 | fix(security): restrict dashboard plugin backend import to bundled plugins (#43719) |
 | `2e779d11a03d` | #23 | feat(mem0): v3 API, OSS mode, update/delete tools, telemetry & review fixes (#15624) |
-| `86e4521cb1d9` | #23 | fix(delivery): make cron output truncation configurable + adapter-aware |
-| `e9cd8c5bf3ea` | #23 | fix(delivery): drop env-var knob, flag all chunking adapters |
 | `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |
 | `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |
+| `f2e37549c673` | #20 | feat(computer_use): cross-platform cua-driver (macOS/Windows/Linux) |
+| `e3505c7f73a4` | #26 | fix(computer_use): reconcile Linux gate with stale "gated off" comments |


### PR DESCRIPTION
## Summary
- Add adapter-aware long-output delivery handling for cron/tool output.
- Preserve full content for verified chunking adapters while saving audit copies.
- Keep non-chunking adapters safe with 4000-character truncation plus a full-output file footer.
- Thread cron job ids through the live gateway send path as sanitized audit labels.
- Harden the CLI `model` e2e test with a deterministic local provider fixture so it does not hit network/default auth state.
- Mark upstream delivery commits `86e4521cb1d9` and `e9cd8c5bf3ea` as ported; parity pending count moves `183 -> 181`.

## Rust Surface
- `PlatformAdapter::splits_long_messages()` defaults to `false`.
- Verified Rust chunking adapters opt in: Discord, Telegram, Slack, WhatsApp, Weixin.
- Both `DeliveryRouter` and the live `Gateway` send path use the same preparation helper.
- Audit filenames include a monotonic sequence suffix to avoid same-label collisions.

## Verification
- `cargo test -p hermes-gateway --lib`
- `cargo test --workspace`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-gateway -p hermes-cli`

All cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/cargo-targets/hermes-agent-ultra-target-delegation` and `CARGO_INCREMENTAL=0`.
