### PR TITLE
parity(matrix): sanitize formatted markdown html

### DIFF
--- a/crates/hermes-gateway/src/platforms/matrix.rs
+++ b/crates/hermes-gateway/src/platforms/matrix.rs
@@ -545,7 +545,7 @@ impl MatrixE2ee {
 /// and `[text](url)` links. This is intentionally simple; a full
 /// CommonMark parser (e.g. `pulldown-cmark`) can replace it later.
 pub fn markdown_to_html(md: &str) -> String {
-    let mut html = md.to_string();
+    let mut html = escape_html_text(md);
 
     // Code blocks (triple backtick) — must come before inline code
     let code_block_re = Regex::new(r"```(\w*)\n([\s\S]*?)```").expect("valid regex");
@@ -583,13 +583,49 @@ pub fn markdown_to_html(md: &str) -> String {
     // Links [text](url)
     let link_re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").expect("valid regex");
     html = link_re
-        .replace_all(&html, r#"<a href="$2">$1</a>"#)
+        .replace_all(&html, |caps: &regex::Captures| {
+            let label = &caps[1];
+            let href = caps[2].trim();
+            if markdown_href_is_safe(href) {
+                format!(
+                    r#"<a href="{}">{}</a>"#,
+                    escape_preescaped_attr(href),
+                    label
+                )
+            } else {
+                label.to_string()
+            }
+        })
         .into_owned();
 
     // Line breaks
     html = html.replace('\n', "<br/>");
 
     html
+}
+
+fn markdown_href_is_safe(href: &str) -> bool {
+    let lower = href.trim_start().to_ascii_lowercase();
+    lower.starts_with("https://") || lower.starts_with("http://") || lower.starts_with("mailto:")
+}
+
+fn escape_html_text(raw: &str) -> String {
+    let mut escaped = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn escape_preescaped_attr(raw: &str) -> String {
+    raw.replace('`', "&#96;")
 }
 
 // ---------------------------------------------------------------------------
@@ -2687,6 +2723,34 @@ mod tests {
     fn test_markdown_to_html_link() {
         let html = markdown_to_html("[click](https://example.com)");
         assert!(html.contains(r#"<a href="https://example.com">click</a>"#));
+    }
+
+    #[test]
+    fn test_markdown_to_html_escapes_raw_html() {
+        let html = markdown_to_html(r#"hi <img src=x onerror=alert(1)> <script>x</script>"#);
+
+        assert!(!html.contains("<img"));
+        assert!(!html.contains("<script"));
+        assert!(html.contains("&lt;img src=x onerror=alert(1)&gt;"));
+        assert!(html.contains("&lt;script&gt;x&lt;/script&gt;"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_rejects_unsafe_link_scheme() {
+        let html = markdown_to_html("[click](javascript:alert(1)) [mail](mailto:a@example.com)");
+
+        assert!(!html.contains("javascript:"));
+        assert!(!html.contains("<a href=\"javascript:"));
+        assert!(html.contains("click)"));
+        assert!(html.contains(r#"<a href="mailto:a@example.com">mail</a>"#));
+    }
+
+    #[test]
+    fn test_markdown_to_html_escapes_link_label_and_href() {
+        let html = markdown_to_html(r#"[<b>x</b>](https://example.com/?q="bad"&ok=1)"#);
+
+        assert!(html.contains("&lt;b&gt;x&lt;/b&gt;"));
+        assert!(html.contains(r#"href="https://example.com/?q=&quot;bad&quot;&amp;ok=1""#));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 181.0,
+        "actual": 179.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T15:09:18.019350+00:00",
+  "generated_at_utc": "2026-06-25T15:56:31.017422+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 181.0,
+    "max_queue_pending_commits": 179.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 181,
-      "ported": 413,
-      "superseded": 6342
+      "pending": 179,
+      "ported": 414,
+      "superseded": 6343
     },
     "by_target_ticket": {
       "20": 3140,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 181.0,
+        "actual": 179.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T15:09:18.019350+00:00`
+Generated: `2026-06-25T15:56:31.017422+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T15:09:18.019350+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 181.0 |
+| `max_queue_pending_commits` | 179.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4613,6 +4613,16 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust intentionally keeps the delivery cap constant with no new HERMES_DELIVERY_MAX_PLATFORM_OUTPUT env knob; verified Rust chunking adapters (Discord, Telegram, Slack, WhatsApp, Weixin) opt into splits_long_messages, while non-chunking Rust adapters remain conservative and protected by truncation plus full-output audit files. The upstream-only Teams/Yuanbao/WhatsApp Cloud adapter flags have no Rust files in this tree."
+    },
+    "5b45fb269a06": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Upstream sanitizes JS kanban dashboard markdown before HTML insertion. The Rust runtime equivalent sink is Matrix formatted_body generation: markdown_to_html now escapes raw HTML before markdown expansion, only emits links for http/https/mailto hrefs, escapes generated link attributes, and feature-enabled Matrix tests cover raw <script>/<img> payloads, unsafe javascript: links, safe mailto links, and escaped labels/hrefs."
+    },
+    "b6d107240819": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fixes Python CLI --worktree branching from stale local HEAD. The Rust CLI in this repository has no --worktree/git-worktree creation path (rg across crates finds only TERMINAL_CWD consumption and docs/tests), so there is no Rust runtime worktree-base resolver to patch. Existing Rust terminal/file tools consume an already-materialized TERMINAL_CWD and do not create branches."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T15:09:17.893661+00:00`
+Generated: `2026-06-25T15:56:30.884476+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7012`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-25T15:09:17.893661+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 181 |
-| ported | 413 |
-| superseded | 6342 |
+| pending | 179 |
+| ported | 414 |
+| superseded | 6343 |
 
 ## First 100 Pending Commits
 
@@ -97,8 +97,6 @@ Generated: `2026-06-25T15:09:17.893661+00:00`
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
 | `5e3e89cc05d3` | #23 | feat(hindsight): configurable embedded daemon health grace timeout (#50341) |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
-| `b6d107240819` | #20 | fix(cli): branch new worktrees from the fresh remote tip, not stale local HEAD (#50355) |
-| `5b45fb269a06` | #20 | fix(security): sanitize kanban markdown html |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
 | `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
 | `7785655b4ece` | #26 | fix(desktop): keep the floating composer in-bounds so it can't be lost off-screen |
@@ -125,3 +123,5 @@ Generated: `2026-06-25T15:09:17.893661+00:00`
 | `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |
 | `f2e37549c673` | #20 | feat(computer_use): cross-platform cua-driver (macOS/Windows/Linux) |
 | `e3505c7f73a4` | #26 | fix(computer_use): reconcile Linux gate with stale "gated off" comments |
+| `70e7132e2ff7` | #20 | fix(openviking): gate memory writes and add viking_forget |
+| `c7e0501e9b58` | #23 | fix(openviking): drain memory mirror workers on shutdown |


### PR DESCRIPTION
## Summary
- sanitize Matrix formatted markdown HTML by escaping raw HTML before markdown expansion
- only emit Matrix formatted links for `http`, `https`, and `mailto` hrefs; unsafe schemes render as text
- add Matrix feature tests for raw `<script>/<img>` payloads, unsafe `javascript:` hrefs, safe `mailto:` links, and escaped labels/hrefs
- classify upstream Python `--worktree` stale-HEAD fix as superseded because this Rust CLI has no branch-creating worktree path

## Parity
- pending queue: `181 -> 179`
- ported: `413 -> 414`
- superseded: `6342 -> 6343`

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features matrix markdown_to_html --lib` -> 7 passed
- `cargo fmt --all --check` -> passed
- `git diff --check` -> passed
- `scripts/check-rust-runtime-no-python.sh` -> passed
- `scripts/check-runtime-placeholders.sh` -> passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-gateway --features matrix` -> pass (`seen=200 allowlist=200 new=0 stale=0`)

Build artifacts stayed on `/Volumes/wd_black`.
