### PR TITLE
parity(memory): add Mem0 management and OpenViking forget

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/mem0.rs
+++ b/crates/hermes-agent/src/memory_plugins/mem0.rs
@@ -1,12 +1,13 @@
 //! Mem0 memory provider plugin.
 //!
-//! Implements `MemoryProviderPlugin` for Mem0 Platform — server-side LLM fact
+//! Implements `MemoryProviderPlugin` for Mem0 — server-side LLM fact
 //! extraction, semantic search with reranking, and automatic deduplication.
 //!
 //! Mirrors the Python `plugins/memory/mem0/__init__.py`.
 //!
 //! Configuration:
-//!   - `MEM0_API_KEY` (required)
+//!   - `MEM0_API_KEY` (required for cloud, optional for self-hosted)
+//!   - `MEM0_HOST` / `MEM0_BASE_URL` (self-hosted Mem0 URL or API base URL)
 //!   - `MEM0_USER_ID` (default: "hermes-user")
 //!   - `MEM0_AGENT_ID` (default: "hermes")
 //!   - `$HERMES_HOME/mem0.json` overrides
@@ -28,11 +29,18 @@ const BREAKER_COOLDOWN_SECS: u64 = 120;
 // Tool schemas
 // ---------------------------------------------------------------------------
 
-fn profile_schema() -> Value {
+fn list_schema() -> Value {
     json!({
-        "name": "mem0_profile",
-        "description": "Retrieve all stored memories about the user — preferences, facts, project context. Fast, no reranking.",
-        "parameters": {"type": "object", "properties": {}, "required": []}
+        "name": "mem0_list",
+        "description": "List all stored memories about the user. Use at conversation start for a full overview.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "page": {"type": "integer", "description": "Page number (default: 1)."},
+                "page_size": {"type": "integer", "description": "Results per page (default: 100, max: 200)."}
+            },
+            "required": []
+        }
     })
 }
 
@@ -52,16 +60,45 @@ fn search_schema() -> Value {
     })
 }
 
-fn conclude_schema() -> Value {
+fn add_schema() -> Value {
     json!({
-        "name": "mem0_conclude",
+        "name": "mem0_add",
         "description": "Store a durable fact about the user. Use for explicit preferences, corrections, or decisions.",
         "parameters": {
             "type": "object",
             "properties": {
-                "conclusion": {"type": "string", "description": "The fact to store."}
+                "content": {"type": "string", "description": "The fact to store."}
             },
-            "required": ["conclusion"]
+            "required": ["content"]
+        }
+    })
+}
+
+fn update_schema() -> Value {
+    json!({
+        "name": "mem0_update",
+        "description": "Update an existing memory by ID.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "memory_id": {"type": "string", "description": "Memory ID to update."},
+                "text": {"type": "string", "description": "New memory text."}
+            },
+            "required": ["memory_id", "text"]
+        }
+    })
+}
+
+fn delete_schema() -> Value {
+    json!({
+        "name": "mem0_delete",
+        "description": "Delete an existing memory by ID.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "memory_id": {"type": "string", "description": "Memory ID to delete."}
+            },
+            "required": ["memory_id"]
         }
     })
 }
@@ -72,6 +109,7 @@ fn conclude_schema() -> Value {
 
 #[derive(Debug, Clone)]
 struct Mem0Config {
+    mode: String,
     api_key: String,
     user_id: String,
     agent_id: String,
@@ -89,17 +127,31 @@ impl Mem0Config {
         config_io::default_hermes_home().join("mem0.json")
     }
 
-    fn configured_api_key_at(path: &std::path::Path) -> bool {
-        config_io::json_file_has_nonempty_string(path, &["api_key"])
+    fn configured_at(path: &std::path::Path) -> bool {
+        config_io::json_file_has_nonempty_string(path, &["api_key", "host", "base_url"])
     }
 
     fn load(hermes_home: &str) -> Self {
+        let env_host = std::env::var("MEM0_HOST").unwrap_or_default();
+        let env_base_url = std::env::var("MEM0_BASE_URL").unwrap_or_default();
         let mut config = Self {
+            mode: std::env::var("MEM0_MODE").unwrap_or_else(|_| {
+                if env_host.trim().is_empty() {
+                    "platform".into()
+                } else {
+                    "oss".into()
+                }
+            }),
             api_key: std::env::var("MEM0_API_KEY").unwrap_or_default(),
             user_id: std::env::var("MEM0_USER_ID").unwrap_or_else(|_| "hermes-user".into()),
             agent_id: std::env::var("MEM0_AGENT_ID").unwrap_or_else(|_| "hermes".into()),
-            base_url: std::env::var("MEM0_BASE_URL")
-                .unwrap_or_else(|_| "https://api.mem0.ai/v1".into()),
+            base_url: if !env_base_url.trim().is_empty() {
+                env_base_url
+            } else if !env_host.trim().is_empty() {
+                env_host
+            } else {
+                "https://api.mem0.ai/v1".into()
+            },
             api_timeout_secs: 10.0,
             rerank: true,
         };
@@ -118,7 +170,16 @@ impl Mem0Config {
                 if let Some(aid) = raw.get("agent_id").and_then(|v| v.as_str()) {
                     config.agent_id = aid.to_string();
                 }
-                if let Some(base_url) = raw.get("base_url").and_then(|v| v.as_str()) {
+                if let Some(mode) = raw.get("mode").and_then(|v| v.as_str()) {
+                    if !mode.trim().is_empty() {
+                        config.mode = mode.to_string();
+                    }
+                }
+                if let Some(base_url) = raw
+                    .get("base_url")
+                    .or_else(|| raw.get("host"))
+                    .and_then(|v| v.as_str())
+                {
                     if !base_url.is_empty() {
                         config.base_url = base_url.to_string();
                     }
@@ -136,9 +197,28 @@ impl Mem0Config {
             }
         }
 
+        config.mode = normalize_mem0_mode(&config.mode);
         config.base_url = config.base_url.trim_end_matches('/').to_string();
         config
     }
+}
+
+fn normalize_mem0_mode(raw: &str) -> String {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "oss" | "self-hosted" | "self_hosted" | "local" => "oss".to_string(),
+        _ => "platform".to_string(),
+    }
+}
+
+fn validate_mem0_memory_id(raw: &str) -> Result<String, String> {
+    let id = raw.trim();
+    if id.is_empty() {
+        return Err("Missing required parameter: memory_id".to_string());
+    }
+    if id.contains('/') || id.contains('?') || id.contains('#') {
+        return Err("memory_id must be an exact Mem0 memory ID, not a path or URL".to_string());
+    }
+    Ok(id.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -240,9 +320,12 @@ impl Mem0MemoryPlugin {
         let url = Self::build_url(config, path);
         let mut req = client
             .request(method.clone(), &url)
-            .header("Authorization", format!("Bearer {}", config.api_key))
-            .header("X-API-Key", &config.api_key)
             .header("Content-Type", "application/json");
+        if !config.api_key.trim().is_empty() {
+            req = req
+                .header("Authorization", format!("Bearer {}", config.api_key))
+                .header("X-API-Key", &config.api_key);
+        }
         if let Some(items) = query {
             req = req.query(items);
         }
@@ -310,10 +393,12 @@ impl Mem0MemoryPlugin {
         Err(last_error)
     }
 
-    fn list_memories(config: &Mem0Config) -> Result<Vec<Value>, String> {
+    fn list_memories(config: &Mem0Config, page: u64, page_size: u64) -> Result<Vec<Value>, String> {
         let query = vec![
             ("user_id", config.user_id.clone()),
             ("agent_id", config.agent_id.clone()),
+            ("page", page.max(1).to_string()),
+            ("page_size", page_size.clamp(1, 200).to_string()),
         ];
         let mut last_error = String::new();
         for path in ["memories", "memory"] {
@@ -359,6 +444,50 @@ impl Mem0MemoryPlugin {
         }
         Err(last_error)
     }
+
+    fn update_memory(config: &Mem0Config, memory_id: &str, text: &str) -> Result<Value, String> {
+        let memory_id = validate_mem0_memory_id(memory_id)?;
+        let text = text.trim();
+        if text.is_empty() {
+            return Err("Missing required parameter: text".to_string());
+        }
+        let payload = json!({
+            "memory_id": memory_id,
+            "text": text,
+            "memory": text,
+        });
+        let mut last_error = String::new();
+        for (method, path) in [
+            (Method::PATCH, format!("memories/{memory_id}")),
+            (Method::PUT, format!("memories/{memory_id}")),
+            (Method::POST, "memories/update".to_string()),
+            (Method::PATCH, format!("memory/{memory_id}")),
+            (Method::PUT, format!("memory/{memory_id}")),
+        ] {
+            match Self::send_json(config, method, &path, Some(&payload), None) {
+                Ok(v) => return Ok(v),
+                Err(e) => last_error = e,
+            }
+        }
+        Err(last_error)
+    }
+
+    fn delete_memory(config: &Mem0Config, memory_id: &str) -> Result<Value, String> {
+        let memory_id = validate_mem0_memory_id(memory_id)?;
+        let payload = json!({"memory_id": memory_id});
+        let mut last_error = String::new();
+        for (method, path, body) in [
+            (Method::DELETE, format!("memories/{memory_id}"), None),
+            (Method::DELETE, format!("memory/{memory_id}"), None),
+            (Method::POST, "memories/delete".to_string(), Some(&payload)),
+        ] {
+            match Self::send_json(config, method, &path, body, None) {
+                Ok(v) => return Ok(v),
+                Err(e) => last_error = e,
+            }
+        }
+        Err(last_error)
+    }
 }
 
 impl MemoryProviderPlugin for Mem0MemoryPlugin {
@@ -371,7 +500,11 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
             .unwrap_or_default()
             .trim()
             .is_empty()
-            || Mem0Config::configured_api_key_at(&Mem0Config::default_config_path())
+            || !std::env::var("MEM0_HOST")
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            || Mem0Config::configured_at(&Mem0Config::default_config_path())
     }
 
     fn initialize(&self, session_id: &str, hermes_home: &str) {
@@ -382,16 +515,23 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
 
     fn system_prompt_block(&self) -> String {
         let config = self.config.lock().unwrap();
-        let user_id = config
+        let (user_id, mode_label) = config
             .as_ref()
-            .map(|c| c.user_id.as_str())
-            .unwrap_or("hermes-user");
+            .map(|c| {
+                let mode_label = if c.mode == "oss" {
+                    format!("OSS/self-hosted at {}", c.base_url)
+                } else {
+                    "platform".to_string()
+                };
+                (c.user_id.as_str(), mode_label)
+            })
+            .unwrap_or(("hermes-user", "platform".to_string()));
         format!(
             "# Mem0 Memory\n\
-             Active. User: {}.\n\
-             Use mem0_search to find memories, mem0_conclude to store facts, \
-             mem0_profile for a full overview.",
-            user_id
+             Active. Mode: {}. User: {}.\n\
+             Use mem0_search to find memories, mem0_add to store facts, \
+             mem0_list for a full overview, and mem0_update/mem0_delete to manage by ID.",
+            mode_label, user_id
         )
     }
 
@@ -484,7 +624,13 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
     }
 
     fn get_tool_schemas(&self) -> Vec<Value> {
-        vec![profile_schema(), search_schema(), conclude_schema()]
+        vec![
+            list_schema(),
+            search_schema(),
+            add_schema(),
+            update_schema(),
+            delete_schema(),
+        ]
     }
 
     fn handle_tool_call(&self, tool_name: &str, args: &Value) -> String {
@@ -496,22 +642,46 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
         }
 
         match tool_name {
-            "mem0_profile" => {
+            "mem0_list" | "mem0_profile" => {
+                let page = args
+                    .get("page")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1)
+                    .max(1);
+                let page_size = args
+                    .get("page_size")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(100)
+                    .clamp(1, 200);
                 let config = match self.config_snapshot() {
                     Ok(c) => c,
                     Err(e) => return json!({"error": e}).to_string(),
                 };
-                match Self::list_memories(&config) {
+                match Self::list_memories(&config, page, page_size) {
                     Ok(memories) => {
                         self.record_success();
-                        let lines: Vec<String> = memories
+                        let items: Vec<Value> = memories
                             .iter()
-                            .filter_map(Self::extract_memory_text)
+                            .filter_map(|item| {
+                                let memory = Self::extract_memory_text(item)?;
+                                Some(json!({
+                                    "id": item.get("id").cloned().unwrap_or(Value::Null),
+                                    "memory": memory,
+                                }))
+                            })
                             .collect();
-                        if lines.is_empty() {
+                        if items.is_empty() {
                             return json!({"result": "No memories stored yet."}).to_string();
                         }
-                        json!({"result": lines.join("\n"), "count": lines.len()}).to_string()
+                        if tool_name == "mem0_profile" {
+                            let lines = items
+                                .iter()
+                                .filter_map(|item| item.get("memory").and_then(Value::as_str))
+                                .collect::<Vec<_>>();
+                            return json!({"result": lines.join("\n"), "count": lines.len()})
+                                .to_string();
+                        }
+                        json!({"results": items, "count": items.len(), "page": page, "page_size": page_size}).to_string()
                     }
                     Err(e) => {
                         self.record_failure();
@@ -527,12 +697,12 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
                 let rerank = args
                     .get("rerank")
                     .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
+                    .unwrap_or_else(|| self.config_snapshot().map(|c| c.rerank).unwrap_or(false));
                 let top_k = args
                     .get("top_k")
                     .and_then(|v| v.as_u64())
                     .unwrap_or(10)
-                    .min(50);
+                    .clamp(1, 50);
                 let config = match self.config_snapshot() {
                     Ok(c) => c,
                     Err(e) => return json!({"error": e}).to_string(),
@@ -567,19 +737,20 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
                     }
                 }
             }
-            "mem0_conclude" => {
-                let conclusion = args
-                    .get("conclusion")
+            "mem0_add" | "mem0_conclude" => {
+                let content = args
+                    .get("content")
+                    .or_else(|| args.get("conclusion"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
-                if conclusion.is_empty() {
-                    return json!({"error": "Missing required parameter: conclusion"}).to_string();
+                if content.is_empty() {
+                    return json!({"error": "Missing required parameter: content"}).to_string();
                 }
                 let config = match self.config_snapshot() {
                     Ok(c) => c,
                     Err(e) => return json!({"error": e}).to_string(),
                 };
-                let messages = vec![json!({"role":"user","content": conclusion})];
+                let messages = vec![json!({"role":"user","content": content})];
                 match Self::add_messages(&config, messages, Some(false)) {
                     Ok(()) => {
                         self.record_success();
@@ -591,6 +762,37 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
                     }
                 }
             }
+            "mem0_update" => {
+                let memory_id = args.get("memory_id").and_then(Value::as_str).unwrap_or("");
+                let text = args.get("text").and_then(Value::as_str).unwrap_or("");
+                let config = match self.config_snapshot() {
+                    Ok(c) => c,
+                    Err(e) => return json!({"error": e}).to_string(),
+                };
+                match Self::update_memory(&config, memory_id, text) {
+                    Ok(v) => {
+                        self.record_success();
+                        json!({"result": "Memory updated.", "memory_id": memory_id, "response": v})
+                            .to_string()
+                    }
+                    Err(e) => json!({"error": format!("Update failed: {e}")}).to_string(),
+                }
+            }
+            "mem0_delete" => {
+                let memory_id = args.get("memory_id").and_then(Value::as_str).unwrap_or("");
+                let config = match self.config_snapshot() {
+                    Ok(c) => c,
+                    Err(e) => return json!({"error": e}).to_string(),
+                };
+                match Self::delete_memory(&config, memory_id) {
+                    Ok(v) => {
+                        self.record_success();
+                        json!({"result": "Memory deleted.", "memory_id": memory_id, "response": v})
+                            .to_string()
+                    }
+                    Err(e) => json!({"error": format!("Delete failed: {e}")}).to_string(),
+                }
+            }
             _ => json!({"error": format!("Unknown tool: {}", tool_name)}).to_string(),
         }
     }
@@ -600,8 +802,15 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
     }
 
     fn get_config_schema(&self) -> Option<Value> {
+        let mode = std::env::var("MEM0_MODE")
+            .ok()
+            .map(|value| normalize_mem0_mode(&value))
+            .unwrap_or_else(|| "platform".to_string());
+        let api_key_required = mode != "oss";
         Some(json!([
-            {"key": "api_key", "description": "Mem0 Platform API key", "secret": true, "required": true, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "mode", "description": "Mem0 mode", "default": "platform", "choices": ["platform", "oss"], "env_var": "MEM0_MODE"},
+            {"key": "api_key", "description": "Mem0 API key", "secret": true, "required": api_key_required, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "host", "description": "Self-hosted Mem0 URL (alias for base_url)", "default": "", "env_var": "MEM0_HOST"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "base_url", "description": "Mem0 API base URL", "default": "https://api.mem0.ai/v1", "env_var": "MEM0_BASE_URL"},
@@ -618,6 +827,10 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::time::Duration as StdDuration;
 
     struct EnvGuard {
         key: &'static str,
@@ -657,7 +870,20 @@ mod tests {
     fn test_mem0_tool_schemas() {
         let plugin = Mem0MemoryPlugin::new();
         let schemas = plugin.get_tool_schemas();
-        assert_eq!(schemas.len(), 3);
+        let names = schemas
+            .iter()
+            .filter_map(|schema| schema.get("name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "mem0_list",
+                "mem0_search",
+                "mem0_add",
+                "mem0_update",
+                "mem0_delete"
+            ]
+        );
     }
 
     #[test]
@@ -704,6 +930,107 @@ mod tests {
             .expect("write config");
 
         assert!(Mem0MemoryPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_mem0_host_env_activates_provider_and_sets_base_url() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("MEM0_API_KEY");
+        let _base = EnvGuard::remove("MEM0_BASE_URL");
+        let _host = EnvGuard::set("MEM0_HOST", "http://127.0.0.1:24220/");
+
+        assert!(Mem0MemoryPlugin::new().is_available());
+        let cfg = Mem0Config::load(tmp.path().to_str().expect("utf8"));
+        assert_eq!(cfg.mode, "oss");
+        assert_eq!(cfg.base_url, "http://127.0.0.1:24220");
+    }
+
+    #[test]
+    fn test_mem0_config_schema_marks_api_key_optional_in_oss_mode() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let _mode = EnvGuard::set("MEM0_MODE", "oss");
+
+        let schema = Mem0MemoryPlugin::new().get_config_schema().expect("schema");
+        let api_key = schema
+            .as_array()
+            .expect("array")
+            .iter()
+            .find(|item| item.get("key").and_then(Value::as_str) == Some("api_key"))
+            .expect("api key field");
+        assert_eq!(api_key.get("required"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn test_validate_mem0_memory_id_rejects_paths() {
+        assert_eq!(
+            validate_mem0_memory_id(" mem-123 ").expect("valid"),
+            "mem-123"
+        );
+        assert!(validate_mem0_memory_id("mem/123").is_err());
+        assert!(validate_mem0_memory_id("mem-123?delete=true").is_err());
+    }
+
+    fn one_shot_json_server(body: &'static str) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            stream
+                .set_read_timeout(Some(StdDuration::from_secs(2)))
+                .expect("timeout");
+            let mut buf = [0u8; 8192];
+            let n = stream.read(&mut buf).expect("read");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            tx.send(request).expect("send request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    fn test_config_for_base_url(base_url: String) -> Mem0Config {
+        Mem0Config {
+            mode: "oss".to_string(),
+            api_key: String::new(),
+            user_id: "u1".to_string(),
+            agent_id: "a1".to_string(),
+            base_url,
+            api_timeout_secs: 5.0,
+            rerank: true,
+        }
+    }
+
+    #[test]
+    fn test_mem0_update_uses_patch_memory_endpoint_without_empty_auth() {
+        let (base_url, rx) = one_shot_json_server(r#"{"status":"ok"}"#);
+        let cfg = test_config_for_base_url(base_url);
+
+        let result = Mem0MemoryPlugin::update_memory(&cfg, "mem-1", "new text").expect("update");
+
+        assert_eq!(result["status"], "ok");
+        let request = rx.recv_timeout(StdDuration::from_secs(2)).expect("request");
+        assert!(request.starts_with("PATCH /memories/mem-1 HTTP/1.1"));
+        assert!(!request.contains("Authorization: Bearer"));
+        assert!(request.contains("\"text\":\"new text\""));
+    }
+
+    #[test]
+    fn test_mem0_delete_uses_delete_memory_endpoint() {
+        let (base_url, rx) = one_shot_json_server(r#"{"status":"ok"}"#);
+        let cfg = test_config_for_base_url(base_url);
+
+        let result = Mem0MemoryPlugin::delete_memory(&cfg, "mem-2").expect("delete");
+
+        assert_eq!(result["status"], "ok");
+        let request = rx.recv_timeout(StdDuration::from_secs(2)).expect("request");
+        assert!(request.starts_with("DELETE /memories/mem-2 HTTP/1.1"));
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/openviking.rs
+++ b/crates/hermes-agent/src/memory_plugins/openviking.rs
@@ -26,12 +26,20 @@ const VIKING_SEARCH_TOOL: &str = "viking_search";
 const VIKING_READ_TOOL: &str = "viking_read";
 const VIKING_BROWSE_TOOL: &str = "viking_browse";
 const VIKING_REMEMBER_TOOL: &str = "viking_remember";
+const VIKING_FORGET_TOOL: &str = "viking_forget";
 const VIKING_ADD_RESOURCE_TOOL: &str = "viking_add_resource";
 const TOOL_STATUS_COMPLETED: &str = "completed";
 const TOOL_STATUS_ERROR: &str = "error";
 const TOOL_STATUS_PENDING: &str = "pending";
 const TOOL_STATUS_ERROR_ALIASES: &[&str] = &["error", "failed", "failure"];
 const TOOL_STATUS_COMPLETED_ALIASES: &[&str] = &["completed", "complete", "success", "succeeded"];
+const DERIVED_MEMORY_FILENAMES: &[&str] = &[
+    ".abstract.md",
+    ".overview.md",
+    ".read.md",
+    ".full.md",
+    ".relations.json",
+];
 
 fn search_schema() -> Value {
     json!({
@@ -91,6 +99,20 @@ fn remember_schema() -> Value {
                 "category": {"type": "string"}
             },
             "required": ["content"]
+        }
+    })
+}
+
+fn forget_schema() -> Value {
+    json!({
+        "name": VIKING_FORGET_TOOL,
+        "description": "Delete one OpenViking memory file by exact viking:// URI. Rejects resources, directories, summaries, broad deletes, and non-memory URIs.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "uri": {"type": "string", "description": "Exact viking:// user memory file URI ending in .md."}
+            },
+            "required": ["uri"]
         }
     })
 }
@@ -322,6 +344,55 @@ fn memory_subdir_for_target(target: &str) -> &'static str {
         "user" | "preferences" => "preferences",
         _ => DEFAULT_MEMORY_SUBDIR,
     }
+}
+
+fn memory_segment_index(parts: &[&str]) -> Option<usize> {
+    if parts.len() >= 2 && parts[0] == "user" && parts[1] == "memories" {
+        return Some(1);
+    }
+    if parts.len() >= 3 && parts[0] == "user" && parts[2] == "memories" {
+        return Some(2);
+    }
+    if parts.len() >= 4 && parts[0] == "user" && parts[1] == "peers" && parts[3] == "memories" {
+        return Some(3);
+    }
+    if parts.len() >= 5 && parts[0] == "user" && parts[2] == "peers" && parts[4] == "memories" {
+        return Some(4);
+    }
+    None
+}
+
+fn validate_forget_memory_uri(raw_uri: Option<&str>) -> Result<String, String> {
+    let uri = raw_uri.unwrap_or("").trim();
+    if uri.is_empty() {
+        return Err("uri is required".to_string());
+    }
+    if !uri.starts_with("viking://") {
+        return Err("viking_forget only accepts viking:// memory file URIs".to_string());
+    }
+    if uri.contains('?') || uri.contains('#') {
+        return Err("viking_forget requires an exact URI without query or fragment".to_string());
+    }
+    if uri.ends_with('/') || !uri.ends_with(".md") {
+        return Err("viking_forget only deletes concrete .md memory files".to_string());
+    }
+
+    let parts = uri["viking://".len()..]
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    let memories_idx = memory_segment_index(&parts)
+        .ok_or_else(|| "viking_forget only deletes user memory file URIs".to_string())?;
+    if parts.len() < memories_idx + 2 {
+        return Err("viking_forget only deletes user memory file URIs".to_string());
+    }
+
+    let filename = uri.rsplit('/').next().unwrap_or("");
+    if DERIVED_MEMORY_FILENAMES.contains(&filename) {
+        return Err("viking_forget cannot delete generated memory summary files".to_string());
+    }
+
+    Ok(uri.to_string())
 }
 
 fn build_memory_uri(user: &str, _agent: &str, subdir: &str) -> String {
@@ -1296,7 +1367,7 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         format!(
             "# OpenViking Knowledge Base\n\
              Active. Endpoint: {}.\n\
-             Use viking_search, viking_read, viking_browse, viking_remember, viking_add_resource.",
+             Use viking_search, viking_read, viking_browse, viking_remember, viking_forget, viking_add_resource.",
             ep
         )
     }
@@ -1501,6 +1572,7 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
             read_schema(),
             browse_schema(),
             remember_schema(),
+            forget_schema(),
             add_resource_schema(),
         ]
     }
@@ -1598,6 +1670,44 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
                 match st.client.post(&url).headers(h).json(&body).send() {
                     Ok(r) if r.status().is_success() => {
                         json!({"status": "stored", "uri": uri}).to_string()
+                    }
+                    Ok(r) => json!({"error": format!("HTTP {}", r.status())}).to_string(),
+                    Err(e) => json!({"error": e.to_string()}).to_string(),
+                }
+            }
+            "viking_forget" => {
+                let uri = match validate_forget_memory_uri(args.get("uri").and_then(Value::as_str))
+                {
+                    Ok(uri) => uri,
+                    Err(e) => return json!({"error": e}).to_string(),
+                };
+                let url = format!("{}/api/v1/fs", st.endpoint);
+                match st
+                    .client
+                    .delete(&url)
+                    .headers(h)
+                    .query(&[("uri", uri.as_str()), ("recursive", "false")])
+                    .send()
+                {
+                    Ok(resp) if resp.status().is_success() => {
+                        let result = resp.json::<Value>().unwrap_or(json!({}));
+                        let mut payload = json!({"status": "deleted", "uri": uri});
+                        if let Some(obj) = result.get("result").and_then(Value::as_object) {
+                            for key in [
+                                "estimated_deleted_count",
+                                "memory_cleanup",
+                                "semantic_root_uri",
+                                "semantic_status",
+                            ] {
+                                if let Some(value) = obj.get(key) {
+                                    payload[key] = value.clone();
+                                }
+                            }
+                            if let Some(result_uri) = obj.get("uri").and_then(Value::as_str) {
+                                payload["uri"] = json!(result_uri);
+                            }
+                        }
+                        payload.to_string()
                     }
                     Ok(r) => json!({"error": format!("HTTP {}", r.status())}).to_string(),
                     Err(e) => json!({"error": e.to_string()}).to_string(),
@@ -1726,6 +1836,10 @@ impl OpenVikingPrefetch {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::time::Duration as StdDuration;
 
     struct EnvGuard {
         key: &'static str,
@@ -1851,6 +1965,118 @@ mod tests {
         assert_eq!(memory_subdir_for_category("unknown"), "preferences");
         assert_eq!(memory_subdir_for_target("memory"), "patterns");
         assert_eq!(memory_subdir_for_target("user"), "preferences");
+    }
+
+    #[test]
+    fn tool_schemas_include_narrow_forget_tool() {
+        let plugin = OpenVikingMemoryPlugin::new();
+
+        let names = plugin
+            .get_tool_schemas()
+            .into_iter()
+            .filter_map(|schema| {
+                schema
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(names.iter().any(|name| name == VIKING_FORGET_TOOL));
+    }
+
+    #[test]
+    fn validate_forget_memory_uri_accepts_exact_user_memory_files() {
+        assert_eq!(
+            validate_forget_memory_uri(Some(
+                "viking://user/peers/hermes/memories/preferences/mem_abc123.md"
+            ))
+            .expect("valid"),
+            "viking://user/peers/hermes/memories/preferences/mem_abc123.md"
+        );
+        assert_eq!(
+            validate_forget_memory_uri(Some("viking://user/default/memories/profile.md"))
+                .expect("valid"),
+            "viking://user/default/memories/profile.md"
+        );
+    }
+
+    #[test]
+    fn validate_forget_memory_uri_rejects_broad_or_non_memory_targets() {
+        for uri in [
+            "",
+            "viking:/user/memories/preferences/mem_abc123.md",
+            "viking://resources/project/doc.md",
+            "viking://resources/project/memories/mem_abc123.md",
+            "viking://agent/hermes/memories/preferences/mem_abc123.md",
+            "viking://user/skills/example/SKILL.md",
+            "viking://user/sessions/session-1/messages.jsonl",
+            "viking://user/memories/preferences/",
+            "viking://user/memories/preferences/.overview.md",
+            "viking://user/memories/preferences/.abstract.md",
+            "viking://user/memories/preferences/mem_abc123.md?recursive=true",
+        ] {
+            assert!(
+                validate_forget_memory_uri(Some(uri)).is_err(),
+                "{uri} should be rejected"
+            );
+        }
+    }
+
+    fn one_shot_openviking_server(body: &'static str) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            stream
+                .set_read_timeout(Some(StdDuration::from_secs(2)))
+                .expect("timeout");
+            let mut buf = [0u8; 8192];
+            let n = stream.read(&mut buf).expect("read");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            tx.send(request).expect("send request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    #[test]
+    fn handle_tool_call_forget_deletes_exact_memory_file_uri() {
+        let uri = "viking://user/peers/hermes/memories/preferences/mem_abc123.md";
+        let body = r#"{"status":"ok","result":{"uri":"viking://user/peers/hermes/memories/preferences/mem_abc123.md","estimated_deleted_count":1}}"#;
+        let (endpoint, rx) = one_shot_openviking_server(body);
+        let plugin = OpenVikingMemoryPlugin::new();
+        *plugin.state.lock().unwrap() = Some(VikingState {
+            client: Client::new(),
+            endpoint,
+            api_key: "test-key".to_string(),
+            account: "acct".to_string(),
+            user: "usr".to_string(),
+            agent: "hermes".to_string(),
+            session_id: "sid".to_string(),
+            turn_count: 0,
+        });
+
+        let result: Value = serde_json::from_str(
+            &plugin.handle_tool_call(VIKING_FORGET_TOOL, &json!({"uri": uri})),
+        )
+        .expect("json");
+
+        assert_eq!(result["status"], "deleted");
+        assert_eq!(result["uri"], uri);
+        assert_eq!(result["estimated_deleted_count"], 1);
+        let request = rx.recv_timeout(StdDuration::from_secs(2)).expect("request");
+        assert!(request.starts_with("DELETE /api/v1/fs?"));
+        assert!(request.contains("recursive=false"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-key"));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 179.0,
+        "actual": 171.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T15:56:31.017422+00:00",
+  "generated_at_utc": "2026-06-25T17:46:51.629782+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 179.0,
+    "max_queue_pending_commits": 171.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 179,
-      "ported": 414,
-      "superseded": 6343
+      "pending": 171,
+      "ported": 419,
+      "superseded": 6347
     },
     "by_target_ticket": {
       "20": 3140,
@@ -309,12 +309,12 @@
       "22": 957,
       "23": 488,
       "24": 22,
-      "25": 145,
+      "25": 146,
       "26": 2130
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7012
+    "total_commits": 7013
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 179.0,
+        "actual": 171.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T15:56:31.017422+00:00`
+Generated: `2026-06-25T17:46:51.629782+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T15:56:31.017422+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 179.0 |
+| `max_queue_pending_commits` | 171.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-25T15:56:31.017422+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7012`.
+- Upstream missing commits tracked: `7013`.
 - By target ticket:
   - `#20`: `3140`
   - `#21`: `130`
   - `#22`: `957`
   - `#23`: `488`
   - `#24`: `22`
-  - `#25`: `145`
+  - `#25`: `146`
   - `#26`: `2130`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4623,6 +4623,51 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Upstream fixes Python CLI --worktree branching from stale local HEAD. The Rust CLI in this repository has no --worktree/git-worktree creation path (rg across crates finds only TERMINAL_CWD consumption and docs/tests), so there is no Rust runtime worktree-base resolver to patch. Existing Rust terminal/file tools consume an already-materialized TERMINAL_CWD and do not create branches."
+    },
+    "6c44471bfdb8": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream lazy-installs the Python hindsight-client dependency for the embedded Python plugin. The Rust runtime has no Python Hindsight dependency or lazy install path; crates/hermes-agent/src/memory_plugins/hindsight.rs uses native reqwest HTTP clients and config-backed cloud/local_external modes."
+    },
+    "13d4b5fe2f45": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream aligns the Python hindsight-client package version. Rust Hindsight does not import or pin hindsight-client; native HTTP request code implements retain/recall/reflect behavior directly, so there is no Rust dependency version to align."
+    },
+    "7bc6f1806284": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream skips the local_embedded Hindsight daemon when running as root. Rust Hindsight does not launch an embedded daemon and normalizes legacy local/local_embedded modes to local_external HTTP, so the root daemon guard is not applicable."
+    },
+    "5e3e89cc05d3": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream adds an embedded-daemon health grace timeout for Python Hindsight. Rust Hindsight has no embedded daemon health loop; it uses bounded reqwest clients and already supports HINDSIGHT_TIMEOUT plus config timeout aliases for HTTP operations."
+    },
+    "70e7132e2ff7": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust OpenViking and memory fan-out: AgentLoop only calls MemoryManager.on_memory_write for successful non-error memory tool results, OpenViking on_memory_write remains add-only for native memory mirroring, and viking_forget is now a first-class tool that deletes only exact user memory .md viking:// URIs while rejecting resources, directories, generated summaries, broad deletes, query/fragment URIs, and non-memory targets. Focused Rust tests cover schemas, URI validation, DELETE /api/v1/fs request shape, and auth headers."
+    },
+    "c7e0501e9b58": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Already ported in Rust OpenViking: shutdown enumerates all tracked session writer queues and drains each with the configured session drain timeout before clearing provider state. Existing focused tests cover writer draining and stale writer behavior; the current OpenViking test filter passes 30 tests."
+    },
+    "b6d2ac176e27": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Mem0: MEM0_HOST is accepted as a self-hosted/OSS endpoint alias for base_url, host-only config activates the provider without a cloud API key, auth headers are omitted when api_key is empty, the system prompt identifies OSS/self-hosted mode, and config schema exposes MEM0_HOST. Focused Rust tests cover host activation and request headers."
+    },
+    "452a725ae19f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Mem0 with mode-aware schema semantics: api_key remains required for platform mode but is optional for oss/self-hosted mode, preserving the reviewed either/or auth contract while keeping the owner-only mem0.json config path. Focused Rust tests cover OSS schema required=false behavior."
+    },
+    "2e779d11a03d": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported the first-class Rust runtime surface for Mem0 v3/self-hosted management: schemas now expose mem0_list, mem0_add, mem0_update, and mem0_delete; legacy mem0_profile/mem0_conclude calls remain accepted; search/list include IDs for management; update/delete validate exact memory IDs and issue PATCH/DELETE requests with fallback endpoint shapes; self-hosted host/base_url mode is supported without empty auth headers. Python OSS setup subprocess and local vector-store provisioning are intentionally not copied into the Rust runtime."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T15:56:30.884476+00:00`
+Generated: `2026-06-25T17:46:51.495581+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7012`.
+- Range: `origin/main..upstream/main`; total commits tracked: `7013`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -11,15 +11,15 @@ Generated: `2026-06-25T15:56:30.884476+00:00`
 | #22 | GPAR-03 UX parity | 957 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
-| #25 | GPAR-06 packaging/docs/install parity | 145 |
+| #25 | GPAR-06 packaging/docs/install parity | 146 |
 | #26 | GPAR-07 upstream queue backfill | 2130 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 179 |
-| ported | 414 |
-| superseded | 6343 |
+| pending | 171 |
+| ported | 419 |
+| superseded | 6347 |
 
 ## First 100 Pending Commits
 
@@ -36,8 +36,6 @@ Generated: `2026-06-25T15:56:30.884476+00:00`
 | `d91b8d8368bb` | #26 | test(desktop): make keyVar a typed EnvVarInfo factory |
 | `b936f92b25b4` | #26 | fix(desktop): render send/prefill directive notices (/goal, /undo) (#49073) |
 | `db744e7d1e58` | #21 | feat(simplify-code): add risk-tiered application, Chesterton's Fence, slop + silent failure detection |
-| `6c44471bfdb8` | #23 | fix(hindsight): lazy-install cloud client dependency |
-| `13d4b5fe2f45` | #23 | fix(hindsight): align client version to 0.6.1 across all sources |
 | `9026a8c78974` | #22 | feat(gateway): add Raft bundled platform plugin with activity hooks |
 | `7d86178cf51a` | #26 | fix(raft): set stdin=DEVNULL on bridge subprocess |
 | `6308d3416ab9` | #26 | fix(desktop): rename "Restart messaging" -> "Restart gateway" |
@@ -91,11 +89,9 @@ Generated: `2026-06-25T15:56:30.884476+00:00`
 | `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
 | `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
-| `7bc6f1806284` | #23 | fix(hindsight): skip local_embedded daemon when running as root |
 | `587b5b9ac223` | #23 | fix(backup): capture memory-provider state stored outside HERMES_HOME (#50325) |
 | `2a4542333ee1` | #26 | fix(photon): classify Envoy overflow errors as retryable; add typing cooldown |
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
-| `5e3e89cc05d3` | #23 | feat(hindsight): configurable embedded daemon health grace timeout (#50341) |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
 | `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
@@ -106,8 +102,6 @@ Generated: `2026-06-25T15:56:30.884476+00:00`
 | `13ce8119067e` | #26 | fix: show desktop approval fallback (#46548) |
 | `e5e25836350a` | #26 | fix(desktop): relaunch on Linux after in-app update instead of hanging (#45205) |
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
-| `b6d2ac176e27` | #23 | feat(mem0): add self-hosted support via MEM0_HOST / host config |
-| `452a725ae19f` | #23 | fix(mem0): address PR review — restore docstrings, keep api_key required |
 | `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
 | `0768ed3b33e4` | #26 | docs(agents): fix stale platform adapter path in token-lock note |
@@ -118,10 +112,16 @@ Generated: `2026-06-25T15:56:30.884476+00:00`
 | `64a507da44d2` | #20 | feat(relay): handle passthrough_forward over the WS (Phase 5 §5.1, gateway half) (#50702) |
 | `61c266b0dc75` | #26 | style(desktop): soften dark-mode syntax highlighting |
 | `8845f3316c26` | #20 | fix(security): restrict dashboard plugin backend import to bundled plugins (#43719) |
-| `2e779d11a03d` | #23 | feat(mem0): v3 API, OSS mode, update/delete tools, telemetry & review fixes (#15624) |
 | `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |
 | `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |
 | `f2e37549c673` | #20 | feat(computer_use): cross-platform cua-driver (macOS/Windows/Linux) |
 | `e3505c7f73a4` | #26 | fix(computer_use): reconcile Linux gate with stale "gated off" comments |
-| `70e7132e2ff7` | #20 | fix(openviking): gate memory writes and add viking_forget |
-| `c7e0501e9b58` | #23 | fix(openviking): drain memory mirror workers on shutdown |
+| `027cb649ef80` | #20 | fix(memory): fail closed on unclear write results |
+| `79f270f54962` | #26 | fix(desktop): portal floating composer to body so it can't be clipped off-screen |
+| `aff5ae692fb2` | #26 | fix(desktop): move composer out of contain wrapper instead of portaling |
+| `ea5fa505d974` | #26 | fix(desktop): clamp floating composer to the thread area, not the whole window |
+| `de7ad8b78eae` | #26 | fix(desktop): guarantee out-of-bounds composer is reclamped on load |
+| `ff08e60c63ad` | #21 | feat(skills): add cloudflare-temporary-deploy optional skill (#50849) |
+| `0223ea5f590a` | #26 | feat(computer-use): surface macOS permission preflight in the desktop |
+| `2dfcead68367` | #26 | feat(computer-use): make the preflight cross-platform (win/linux) |
+| `a6b670d4a251` | #26 | fix(desktop): avoid stack overflow on embedded image replay |


### PR DESCRIPTION
## Summary
- Add Rust Mem0 self-hosted/OSS support via `MEM0_HOST`, mode-aware config schema, and empty-auth suppression.
- Add first-class Mem0 management tools: `mem0_list`, `mem0_add`, `mem0_update`, and `mem0_delete`, while preserving legacy `mem0_profile` and `mem0_conclude` handling.
- Add OpenViking `viking_forget` for exact user memory file deletion with fail-closed URI validation and non-recursive DELETE requests.
- Classify Hindsight embedded-Python-only upstream commits as superseded in Rust and refresh parity queue/proof docs.

## Parity Delta
- Pending queue: `179 -> 171`
- Ported: `414 -> 419`
- Superseded: `6343 -> 6347`
- Upstream tracked commits: `7012 -> 7013` after upstream advanced by one commit during refresh.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent mem0 --lib` -> 12 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent openviking --lib` -> 30 passed
- Earlier same branch before final docs-only cleanup: `cargo test -p hermes-agent --lib` -> 657 passed; `scripts/clippy-warning-gate.sh --check -- -p hermes-agent` -> `seen=200 allowlist=200 new=0 stale=0`

## Notes
- Build/test artifacts were directed to `/Volumes/wd_black/cargo-targets`.
- No OAuth/sign-in/default-model behavior changed.
