### PR TITLE
parity(memory): fail closed and backup provider state

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -2401,6 +2401,17 @@ impl AgentLoop {
         Some((action, target, content))
     }
 
+    fn memory_tool_result_succeeded(content: &str) -> bool {
+        let Ok(value) = serde_json::from_str::<Value>(content) else {
+            return false;
+        };
+        let Some(object) = value.as_object() else {
+            return false;
+        };
+        object.get("success").and_then(Value::as_bool) == Some(true)
+            && object.get("staged").and_then(Value::as_bool) != Some(true)
+    }
+
     fn notify_memory_writes(&self, tool_calls: &[ToolCall], results: &[ToolResult]) {
         if self.config.skip_memory {
             return;
@@ -2413,6 +2424,9 @@ impl AgentLoop {
         };
         for result in results {
             if result.is_error {
+                continue;
+            }
+            if !Self::memory_tool_result_succeeded(&result.content) {
                 continue;
             }
             let Some(tc) = tool_calls.iter().find(|tc| tc.id == result.tool_call_id) else {
@@ -15354,6 +15368,25 @@ mod tests {
         assert_eq!(event.0, "remove");
         assert_eq!(event.1, "memory");
         assert_eq!(event.2, "obsolete fact");
+    }
+
+    #[test]
+    fn memory_tool_result_succeeded_fails_closed_on_unclear_shapes() {
+        assert!(AgentLoop::memory_tool_result_succeeded(
+            r#"{"success":true,"message":"Entry added."}"#
+        ));
+        for content in [
+            r#"{"success":false,"message":"failed"}"#,
+            r#"{"success":true,"staged":true}"#,
+            r#"{"message":"Entry added."}"#,
+            "not json",
+            "[]",
+        ] {
+            assert!(
+                !AgentLoop::memory_tool_result_succeeded(content),
+                "{content} should not be mirrored"
+            );
+        }
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_manager.rs
+++ b/crates/hermes-agent/src/memory_manager.rs
@@ -114,6 +114,13 @@ pub trait MemoryProviderPlugin: Send + Sync {
         let _ = (action, target, content);
     }
 
+    /// Extra provider state stored outside HERMES_HOME that should travel with
+    /// `hermes backup`. This must be config/env-only: no initialization and no
+    /// network calls.
+    fn backup_paths(&self) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
     // -- Extended lifecycle (Python-equivalent) --
 
     /// Check if the provider is available and configured.

--- a/crates/hermes-agent/src/memory_plugins/hindsight.rs
+++ b/crates/hermes-agent/src/memory_plugins/hindsight.rs
@@ -352,6 +352,12 @@ impl MemoryProviderPlugin for HindsightPlugin {
         "hindsight"
     }
 
+    fn backup_paths(&self) -> Vec<std::path::PathBuf> {
+        dirs::home_dir()
+            .map(|home| vec![home.join(".hindsight")])
+            .unwrap_or_default()
+    }
+
     fn is_available(&self) -> bool {
         let api_key = std::env::var("HINDSIGHT_API_KEY").unwrap_or_default();
         let api_url = std::env::var("HINDSIGHT_API_URL").unwrap_or_default();

--- a/crates/hermes-agent/src/memory_plugins/honcho.rs
+++ b/crates/hermes-agent/src/memory_plugins/honcho.rs
@@ -602,6 +602,12 @@ impl MemoryProviderPlugin for HonchoMemoryPlugin {
         "honcho"
     }
 
+    fn backup_paths(&self) -> Vec<std::path::PathBuf> {
+        dirs::home_dir()
+            .map(|home| vec![home.join(".honcho")])
+            .unwrap_or_default()
+    }
+
     fn is_available(&self) -> bool {
         let hermes_home = config_io::default_hermes_home();
         let config = HonchoConfig::from_config_file(&hermes_home.to_string_lossy());

--- a/crates/hermes-agent/src/memory_plugins/openviking.rs
+++ b/crates/hermes-agent/src/memory_plugins/openviking.rs
@@ -33,13 +33,7 @@ const TOOL_STATUS_ERROR: &str = "error";
 const TOOL_STATUS_PENDING: &str = "pending";
 const TOOL_STATUS_ERROR_ALIASES: &[&str] = &["error", "failed", "failure"];
 const TOOL_STATUS_COMPLETED_ALIASES: &[&str] = &["completed", "complete", "success", "succeeded"];
-const DERIVED_MEMORY_FILENAMES: &[&str] = &[
-    ".abstract.md",
-    ".overview.md",
-    ".read.md",
-    ".full.md",
-    ".relations.json",
-];
+const GENERATED_MEMORY_SUMMARY_FILENAMES: &[&str] = &[".abstract.md", ".overview.md"];
 
 fn search_schema() -> Value {
     json!({
@@ -388,7 +382,7 @@ fn validate_forget_memory_uri(raw_uri: Option<&str>) -> Result<String, String> {
     }
 
     let filename = uri.rsplit('/').next().unwrap_or("");
-    if DERIVED_MEMORY_FILENAMES.contains(&filename) {
+    if GENERATED_MEMORY_SUMMARY_FILENAMES.contains(&filename) {
         return Err("viking_forget cannot delete generated memory summary files".to_string());
     }
 
@@ -1310,6 +1304,12 @@ impl MemoryProviderPlugin for OpenVikingMemoryPlugin {
         "openviking"
     }
 
+    fn backup_paths(&self) -> Vec<PathBuf> {
+        dirs::home_dir()
+            .map(|home| vec![home.join(".openviking")])
+            .unwrap_or_default()
+    }
+
     fn is_available(&self) -> bool {
         std::env::var("OPENVIKING_ENDPOINT")
             .map(|s| !s.trim().is_empty())
@@ -1999,6 +1999,11 @@ mod tests {
                 .expect("valid"),
             "viking://user/default/memories/profile.md"
         );
+        assert_eq!(
+            validate_forget_memory_uri(Some("viking://user/default/memories/.full.md"))
+                .expect("valid"),
+            "viking://user/default/memories/.full.md"
+        );
     }
 
     #[test]
@@ -2014,6 +2019,7 @@ mod tests {
             "viking://user/memories/preferences/",
             "viking://user/memories/preferences/.overview.md",
             "viking://user/memories/preferences/.abstract.md",
+            "viking://user/memories/preferences/.relations.json",
             "viking://user/memories/preferences/mem_abc123.md?recursive=true",
         ] {
             assert!(

--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -28202,6 +28202,197 @@ pub async fn handle_cli_acp(
     Ok(())
 }
 
+const CLI_BACKUP_HERMES_PREFIX: &str = "hermes";
+const CLI_BACKUP_EXTERNAL_PREFIX: &str = "external";
+
+fn backup_secret_like_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(name, ".env" | "auth.json" | "state.db")
+        || path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| matches!(ext, "env" | "json" | "conf"))
+}
+
+fn safe_relative_archive_path(path: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => out.push(part),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    if out.as_os_str().is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn backup_collect_regular_files(base: &Path) -> Vec<PathBuf> {
+    let Ok(meta) = std::fs::symlink_metadata(base) else {
+        return Vec::new();
+    };
+    if meta.file_type().is_symlink() {
+        return Vec::new();
+    }
+    if meta.is_file() {
+        return vec![base.to_path_buf()];
+    }
+    if !meta.is_dir() {
+        return Vec::new();
+    }
+
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            files.extend(backup_collect_regular_files(&path));
+        } else if meta.is_file() {
+            files.push(path);
+        }
+    }
+    files
+}
+
+fn collect_memory_provider_external_backup_files(
+    hermes_dir: &Path,
+    home_dir: &Path,
+) -> Vec<(PathBuf, PathBuf)> {
+    let Ok(home_resolved) = home_dir.canonicalize() else {
+        return Vec::new();
+    };
+    let hermes_resolved = hermes_dir.canonicalize().ok();
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+
+    for provider in hermes_agent::memory_plugins::discover_available_providers() {
+        for declared in provider.backup_paths() {
+            let Ok(resolved) = declared.canonicalize() else {
+                continue;
+            };
+            if !resolved.starts_with(&home_resolved) {
+                continue;
+            }
+            if hermes_resolved
+                .as_ref()
+                .is_some_and(|hermes| resolved.starts_with(hermes))
+            {
+                continue;
+            }
+            for file in backup_collect_regular_files(&resolved) {
+                let Ok(file_resolved) = file.canonicalize() else {
+                    continue;
+                };
+                if !seen.insert(file_resolved.clone()) {
+                    continue;
+                }
+                let Ok(rel_to_home) = file_resolved.strip_prefix(&home_resolved) else {
+                    continue;
+                };
+                let mut archive_path = PathBuf::from(CLI_BACKUP_EXTERNAL_PREFIX);
+                archive_path.push(rel_to_home);
+                out.push((file_resolved, archive_path));
+            }
+        }
+    }
+
+    out
+}
+
+fn restore_archive_entry_target(
+    member: &Path,
+    hermes_dir: &Path,
+    home_dir: &Path,
+) -> Option<PathBuf> {
+    let safe = safe_relative_archive_path(member)?;
+    let mut components = safe.components();
+    let first = components.next()?.as_os_str().to_string_lossy().to_string();
+    let rel: PathBuf = components.as_path().to_path_buf();
+    if rel.as_os_str().is_empty() {
+        return None;
+    }
+    match first.as_str() {
+        CLI_BACKUP_EXTERNAL_PREFIX => Some(home_dir.join(rel)),
+        CLI_BACKUP_HERMES_PREFIX => Some(hermes_dir.join(rel)),
+        _ => Some(hermes_dir.join(safe)),
+    }
+}
+
+fn restore_backup_archive(
+    archive: &mut tar::Archive<flate2::read::GzDecoder<std::fs::File>>,
+    hermes_dir: &Path,
+    home_dir: &Path,
+) -> Result<(usize, usize), hermes_core::AgentError> {
+    std::fs::create_dir_all(hermes_dir).map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
+    let mut restored = 0usize;
+    let mut restored_external = 0usize;
+
+    let entries = archive
+        .entries()
+        .map_err(|e| hermes_core::AgentError::Io(format!("Read archive error: {}", e)))?;
+    for entry in entries {
+        let mut entry = entry
+            .map_err(|e| hermes_core::AgentError::Io(format!("Archive entry error: {}", e)))?;
+        let entry_path = entry
+            .path()
+            .map_err(|e| hermes_core::AgentError::Io(format!("Archive path error: {}", e)))?
+            .into_owned();
+        let Some(target) = restore_archive_entry_target(&entry_path, hermes_dir, home_dir) else {
+            continue;
+        };
+        let is_external = safe_relative_archive_path(&entry_path)
+            .and_then(|p| p.components().next().map(|c| c.as_os_str().to_owned()))
+            .is_some_and(|first| first == CLI_BACKUP_EXTERNAL_PREFIX);
+        let entry_type = entry.header().entry_type();
+
+        if entry_type.is_dir() {
+            std::fs::create_dir_all(&target)
+                .map_err(|e| hermes_core::AgentError::Io(format!("Create dir error: {}", e)))?;
+            continue;
+        }
+        if !(entry_type.is_file() || entry_type == tar::EntryType::Regular) {
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| hermes_core::AgentError::Io(format!("Create dir error: {}", e)))?;
+        }
+        entry
+            .unpack(&target)
+            .map_err(|e| hermes_core::AgentError::Io(format!("Extract error: {}", e)))?;
+        if is_external {
+            restored_external += 1;
+            if backup_secret_like_file(&target) {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(mut permissions) = std::fs::metadata(&target).map(|m| m.permissions())
+                    {
+                        permissions.set_mode(0o600);
+                        let _ = std::fs::set_permissions(&target, permissions);
+                    }
+                }
+            }
+        }
+        restored += 1;
+    }
+
+    Ok((restored, restored_external))
+}
+
 /// Handle `hermes backup [output]`.
 pub async fn handle_cli_backup(output: Option<String>) -> Result<(), hermes_core::AgentError> {
     let hermes_dir = hermes_config::hermes_home();
@@ -28226,11 +28417,23 @@ pub async fn handle_cli_backup(output: Option<String>) -> Result<(), hermes_core
     let mut tar = tar::Builder::new(enc);
     tar.append_dir_all("hermes", &hermes_dir)
         .map_err(|e| hermes_core::AgentError::Io(format!("Tar error: {}", e)))?;
+    let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let external_files = collect_memory_provider_external_backup_files(&hermes_dir, &home_dir);
+    for (file, archive_path) in &external_files {
+        tar.append_path_with_name(file, archive_path)
+            .map_err(|e| hermes_core::AgentError::Io(format!("Tar external error: {}", e)))?;
+    }
     tar.finish()
         .map_err(|e| hermes_core::AgentError::Io(format!("Tar finish error: {}", e)))?;
 
     let size = std::fs::metadata(&out).map(|m| m.len()).unwrap_or(0);
     println!("Backup complete: {} ({} KB)", out, size / 1024);
+    if !external_files.is_empty() {
+        println!(
+            "Included {} memory-provider file(s) stored outside HERMES_HOME.",
+            external_files.len()
+        );
+    }
     Ok(())
 }
 
@@ -28252,14 +28455,21 @@ pub async fn handle_cli_import(path: String) -> Result<(), hermes_core::AgentErr
         .map_err(|e| hermes_core::AgentError::Io(format!("Cannot open {}: {}", path, e)))?;
     let dec = flate2::read::GzDecoder::new(file);
     let mut archive = tar::Archive::new(dec);
-    archive
-        .unpack(&hermes_dir)
-        .map_err(|e| hermes_core::AgentError::Io(format!("Extract error: {}", e)))?;
+    let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let (restored, restored_external) =
+        restore_backup_archive(&mut archive, &hermes_dir, &home_dir)?;
 
     println!(
-        "Import complete. Files restored to {}",
+        "Import complete. {} files restored to {}",
+        restored,
         hermes_dir.display()
     );
+    if restored_external > 0 {
+        println!(
+            "Restored {} memory-provider file(s) outside HERMES_HOME.",
+            restored_external
+        );
+    }
     Ok(())
 }
 
@@ -28416,6 +28626,134 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Python plugin command dispatch is disabled"));
+    }
+
+    fn tar_gz_entry_names(path: &Path) -> Vec<String> {
+        let file = std::fs::File::open(path).expect("open archive");
+        let dec = flate2::read::GzDecoder::new(file);
+        let mut archive = tar::Archive::new(dec);
+        archive
+            .entries()
+            .expect("entries")
+            .filter_map(|entry| {
+                entry
+                    .ok()
+                    .and_then(|entry| entry.path().ok().map(|path| path.to_string_lossy().into()))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn backup_restore_target_rejects_absolute_and_parent_paths() {
+        let hermes = Path::new("/tmp/hermes");
+        let home = Path::new("/tmp/home");
+
+        assert!(restore_archive_entry_target(Path::new("../escape"), hermes, home).is_none());
+        assert!(
+            restore_archive_entry_target(Path::new("external/../escape"), hermes, home).is_none()
+        );
+        assert_eq!(
+            restore_archive_entry_target(Path::new("hermes/config.yaml"), hermes, home),
+            Some(hermes.join("config.yaml"))
+        );
+        assert_eq!(
+            restore_archive_entry_target(Path::new("external/.openviking/auth.json"), hermes, home),
+            Some(home.join(".openviking/auth.json"))
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_backup_import_strips_hermes_archive_prefix() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let hermes_home = tmp.path().join("hermes-home");
+        let fake_home = tmp.path().join("home");
+        std::fs::create_dir_all(&hermes_home).expect("hermes home");
+        std::fs::create_dir_all(&fake_home).expect("fake home");
+        std::fs::write(hermes_home.join("config.yaml"), "model: dynamic\n").expect("write config");
+        let _home_guard = TempHomeGuard::new(&hermes_home);
+        let _unix_home = EnvVarGuard::set("HOME", &fake_home);
+        let _openviking_endpoint = EnvVarGuard::remove("OPENVIKING_ENDPOINT");
+        let _hindsight_mode = EnvVarGuard::remove("HINDSIGHT_MODE");
+        let archive = tmp.path().join("backup.tar.gz");
+
+        handle_cli_backup(Some(archive.to_string_lossy().to_string()))
+            .await
+            .expect("backup");
+        std::fs::remove_file(hermes_home.join("config.yaml")).expect("remove config");
+        handle_cli_import(archive.to_string_lossy().to_string())
+            .await
+            .expect("import");
+
+        assert_eq!(
+            std::fs::read_to_string(hermes_home.join("config.yaml")).expect("restored config"),
+            "model: dynamic\n"
+        );
+        assert!(!hermes_home.join("hermes/config.yaml").exists());
+    }
+
+    #[tokio::test]
+    async fn cli_backup_import_round_trips_openviking_external_state() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let hermes_home = tmp.path().join("hermes-home");
+        let fake_home = tmp.path().join("home");
+        let openviking_dir = fake_home.join(".openviking");
+        std::fs::create_dir_all(&hermes_home).expect("hermes home");
+        std::fs::create_dir_all(&openviking_dir).expect("openviking dir");
+        std::fs::write(
+            hermes_home.join("openviking.json"),
+            r#"{"enabled":true,"endpoint":"http://127.0.0.1:1933"}"#,
+        )
+        .expect("write openviking config");
+        std::fs::write(openviking_dir.join("auth.json"), r#"{"token":"secret"}"#)
+            .expect("write auth");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            openviking_dir.join("auth.json"),
+            openviking_dir.join("link.json"),
+        )
+        .expect("symlink");
+        let _home_guard = TempHomeGuard::new(&hermes_home);
+        let _unix_home = EnvVarGuard::set("HOME", &fake_home);
+        let _openviking_endpoint = EnvVarGuard::remove("OPENVIKING_ENDPOINT");
+        let _openviking_key = EnvVarGuard::remove("OPENVIKING_API_KEY");
+        let archive = tmp.path().join("backup.tar.gz");
+
+        handle_cli_backup(Some(archive.to_string_lossy().to_string()))
+            .await
+            .expect("backup");
+
+        let entries = tar_gz_entry_names(&archive);
+        assert!(entries
+            .iter()
+            .any(|entry| entry == "external/.openviking/auth.json"));
+        assert!(!entries
+            .iter()
+            .any(|entry| entry == "external/.openviking/link.json"));
+
+        std::fs::remove_dir_all(&openviking_dir).expect("remove external");
+        handle_cli_import(archive.to_string_lossy().to_string())
+            .await
+            .expect("import");
+
+        let restored = openviking_dir.join("auth.json");
+        assert_eq!(
+            std::fs::read_to_string(&restored).expect("restored auth"),
+            r#"{"token":"secret"}"#
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&restored)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T17:46:51.629782+00:00",
+  "generated_at_utc": "2026-06-25T18:58:02.699515+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -300,21 +300,21 @@
     "by_disposition": {
       "mirrored": 76,
       "pending": 171,
-      "ported": 419,
-      "superseded": 6347
+      "ported": 421,
+      "superseded": 6353
     },
     "by_target_ticket": {
-      "20": 3140,
+      "20": 3146,
       "21": 130,
       "22": 957,
       "23": 488,
       "24": 22,
       "25": 146,
-      "26": 2130
+      "26": 2132
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7013
+    "total_commits": 7021
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T17:46:51.629782+00:00`
+Generated: `2026-06-25T18:58:02.699515+00:00`
 
 ## Gate Status
 
@@ -93,13 +93,13 @@ Generated: `2026-06-25T17:46:51.629782+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7013`.
+- Upstream missing commits tracked: `7021`.
 - By target ticket:
-  - `#20`: `3140`
+  - `#20`: `3146`
   - `#21`: `130`
   - `#22`: `957`
   - `#23`: `488`
   - `#24`: `22`
   - `#25`: `146`
-  - `#26`: `2130`
+  - `#26`: `2132`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4668,6 +4668,16 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported the first-class Rust runtime surface for Mem0 v3/self-hosted management: schemas now expose mem0_list, mem0_add, mem0_update, and mem0_delete; legacy mem0_profile/mem0_conclude calls remain accepted; search/list include IDs for management; update/delete validate exact memory IDs and issue PATCH/DELETE requests with fallback endpoint shapes; self-hosted host/base_url mode is supported without empty auth headers. Python OSS setup subprocess and local vector-store provisioning are intentionally not copied into the Rust runtime."
+    },
+    "027cb649ef80": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust memory fan-out and OpenViking validation: AgentLoop only mirrors built-in memory writes to external providers when the memory tool returns structured JSON with success=true and staged!=true, failing closed for unclear/non-object/non-JSON tool results. OpenViking viking_forget now treats only .abstract.md and .overview.md as generated summaries, so concrete user memory files such as .full.md remain deletable while non-.md sidecars are rejected by the exact-file guard. Focused Rust tests cover the fail-closed gate and URI validation."
+    },
+    "587b5b9ac223": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust CLI backup/import and memory provider trait: MemoryProviderPlugin exposes config-only backup_paths, Honcho/Hindsight/OpenViking declare their home-scoped dotdirs, hermes backup archives existing regular external provider files under a reserved external/ archive prefix only when they live under HOME and outside HERMES_HOME, and hermes import safely restores hermes/ entries into HERMES_HOME while restoring external/ entries to HOME with traversal checks and 0600 tightening for credential-shaped files. Focused Rust tests cover prefix stripping, OpenViking external state round-trip, and traversal rejection."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T17:46:51.495581+00:00`
+Generated: `2026-06-25T18:58:02.554663+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7013`.
+- Range: `origin/main..upstream/main`; total commits tracked: `7021`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3140 |
+| #20 | GPAR-01 tests+CI parity | 3146 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 957 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 22 |
 | #25 | GPAR-06 packaging/docs/install parity | 146 |
-| #26 | GPAR-07 upstream queue backfill | 2130 |
+| #26 | GPAR-07 upstream queue backfill | 2132 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
 | pending | 171 |
-| ported | 419 |
-| superseded | 6347 |
+| ported | 421 |
+| superseded | 6353 |
 
 ## First 100 Pending Commits
 
@@ -89,7 +89,6 @@ Generated: `2026-06-25T17:46:51.495581+00:00`
 | `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
 | `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
-| `587b5b9ac223` | #23 | fix(backup): capture memory-provider state stored outside HERMES_HOME (#50325) |
 | `2a4542333ee1` | #26 | fix(photon): classify Envoy overflow errors as retryable; add typing cooldown |
 | `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
@@ -116,7 +115,6 @@ Generated: `2026-06-25T17:46:51.495581+00:00`
 | `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |
 | `f2e37549c673` | #20 | feat(computer_use): cross-platform cua-driver (macOS/Windows/Linux) |
 | `e3505c7f73a4` | #26 | fix(computer_use): reconcile Linux gate with stale "gated off" comments |
-| `027cb649ef80` | #20 | fix(memory): fail closed on unclear write results |
 | `79f270f54962` | #26 | fix(desktop): portal floating composer to body so it can't be clipped off-screen |
 | `aff5ae692fb2` | #26 | fix(desktop): move composer out of contain wrapper instead of portaling |
 | `ea5fa505d974` | #26 | fix(desktop): clamp floating composer to the thread area, not the whole window |
@@ -125,3 +123,5 @@ Generated: `2026-06-25T17:46:51.495581+00:00`
 | `0223ea5f590a` | #26 | feat(computer-use): surface macOS permission preflight in the desktop |
 | `2dfcead68367` | #26 | feat(computer-use): make the preflight cross-platform (win/linux) |
 | `a6b670d4a251` | #26 | fix(desktop): avoid stack overflow on embedded image replay |
+| `3fffecbdafec` | #26 | feat(desktop): add timeline rail for long chat threads |
+| `ba9e3a491bfa` | #23 | feat(memory): Honcho OAuth connect — desktop and CLI flows + token refresh (#44335) |


### PR DESCRIPTION
## Summary
- Fail closed on built-in memory write fan-out: external memory providers now only receive mirrored writes when the memory tool returns structured JSON with `success: true` and `staged != true`.
- Correct OpenViking `viking_forget` generated-summary validation so concrete user memory files such as `.full.md` remain deletable while generated `.abstract.md`/`.overview.md` summaries stay blocked.
- Add Rust-native memory provider backup hooks and backup/import support for home-scoped external provider state (`~/.honcho`, `~/.hindsight`, `~/.openviking`).
- Replace raw backup archive unpacking with safe entry restoration that strips the `hermes/` archive prefix into `HERMES_HOME`, restores `external/` entries under `HOME`, blocks traversal, skips symlinks, and tightens credential-shaped external files to `0600` on Unix.

## Parity Delta
- Ported upstream `027cb649ef80` (`fix(memory): fail closed on unclear write results`).
- Ported upstream `587b5b9ac223` (`fix(backup): capture memory-provider state stored outside HERMES_HOME`).
- Queue after refresh against `origin/main..upstream/main`: `pending=171`, `ported=421`, `superseded=6353`, tracked upstream commits `7021`.
- Pending count stayed flat because upstream advanced while this batch was in progress; ported count increased by 2.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent memory_tool_result_succeeded --lib` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent validate_forget_memory_uri --lib` -> 2 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli backup --lib` -> 4 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent --lib` -> 658 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-agent -p hermes-cli` -> `seen=200 allowlist=200 new=0 stale=0`

## Notes
- Build/test artifacts were directed to `/Volumes/wd_black/cargo-targets`.
- No OAuth/sign-in/default-model behavior changed.
