### PR TITLE
parity(gateway): add relay and discord contract coverage

### DIFF
--- a/crates/hermes-config/src/loader.rs
+++ b/crates/hermes-config/src/loader.rs
@@ -2998,6 +2998,37 @@ mod tests {
     }
 
     #[test]
+    fn save_config_yaml_preserves_utf8_personality_and_prompt() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        let mut config = GatewayConfig {
+            personality: Some("mentor 🧠".to_string()),
+            system_prompt: Some(
+                "Answer with precision; preserve emoji like 🚀 and café.".to_string(),
+            ),
+            ..GatewayConfig::default()
+        };
+        config.home_dir = Some("/tmp/should-not-persist".to_string());
+
+        save_config_yaml(&path, &config).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let text = std::str::from_utf8(&bytes).expect("config.yaml must be valid UTF-8");
+        assert!(text.contains("mentor 🧠"));
+        assert!(text.contains("🚀"));
+        assert!(text.contains("café"));
+        assert!(!text.contains("should-not-persist"));
+
+        let loaded = load_from_yaml(&path).unwrap();
+        assert_eq!(loaded.personality.as_deref(), Some("mentor 🧠"));
+        assert_eq!(
+            loaded.system_prompt.as_deref(),
+            Some("Answer with precision; preserve emoji like 🚀 and café.")
+        );
+    }
+
+    #[test]
     fn load_from_yaml_expands_env_refs_but_user_config_load_preserves_templates() {
         use tempfile::tempdir;
 

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -26,6 +26,7 @@ pub mod media;
 pub mod mirror;
 pub mod pairing;
 pub mod platforms;
+pub mod relay;
 pub mod session;
 pub mod session_control;
 pub mod ssrf;
@@ -75,6 +76,11 @@ pub use delivery::{
 pub use dm::{DmDecision, DmManager};
 pub use mirror::MirrorManager;
 pub use pairing::{PairingManager, PairingState};
+pub use relay::{
+    relay_going_idle_frame, relay_inbound_ack_frame, relay_passthrough_forward_from_frame,
+    relay_policy_url, relay_relevance_policy, relay_wake_url_from_sources, RelayPassthroughForward,
+    RelayRelevancePolicy,
+};
 pub use sticker_cache::{StickerCache, StickerMeta};
 
 // Re-export adapter base

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -23,6 +23,7 @@ use hermes_core::errors::GatewayError;
 use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 
 use crate::adapter::{describe_secret, AdapterProxyConfig, BasePlatformAdapter};
+use crate::pairing::{PairingManager, PairingState};
 
 /// Maximum message length for Discord (2000 characters).
 const MAX_MESSAGE_LENGTH: usize = 2000;
@@ -1097,6 +1098,33 @@ impl DiscordInteractionAuthPolicy {
             DiscordAuthDecision::Deny(DiscordAuthDenyReason::AllowedUsersOrRoles)
         }
     }
+}
+
+/// Component button authorization with pairing-store fallback.
+///
+/// Allowlist/role policy remains authoritative. When that fails, an explicitly
+/// approved pairing entry authorizes the same Discord user id, matching the
+/// gateway-level pairing path without relaxing fail-closed behavior for unknown
+/// users.
+pub fn discord_component_allows_with_pairing(
+    policy: &DiscordInteractionAuthPolicy,
+    subject: &DiscordInteractionSubject,
+    pairing: Option<&PairingManager>,
+) -> bool {
+    if policy.component_allows(subject) {
+        return true;
+    }
+    let Some(user_id) = subject
+        .user_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    pairing
+        .and_then(|manager| manager.state(user_id))
+        .is_some_and(|state| state == PairingState::Approved)
 }
 
 /// Determine whether a Discord message may be routed without an explicit bot mention.
@@ -4559,6 +4587,33 @@ mod tests {
         assert!(!policy.component_allows(&DiscordInteractionSubject::default()));
         assert!(DiscordInteractionAuthPolicy::default()
             .component_allows(&DiscordInteractionSubject::default()));
+    }
+
+    #[test]
+    fn discord_component_auth_allows_approved_pairing_store_user() {
+        let policy = DiscordInteractionAuthPolicy {
+            allowed_user_ids: ["11111"].into_iter().map(String::from).collect(),
+            ..DiscordInteractionAuthPolicy::default()
+        };
+        let pairing = PairingManager::new();
+        pairing.approve("99999");
+
+        assert!(discord_component_allows_with_pairing(
+            &policy,
+            &DiscordInteractionSubject::user("99999"),
+            Some(&pairing)
+        ));
+        assert!(!discord_component_allows_with_pairing(
+            &policy,
+            &DiscordInteractionSubject::user("77777"),
+            Some(&pairing)
+        ));
+        pairing.deny("99999");
+        assert!(!discord_component_allows_with_pairing(
+            &policy,
+            &DiscordInteractionSubject::user("99999"),
+            Some(&pairing)
+        ));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/relay.rs
+++ b/crates/hermes-gateway/src/relay.rs
@@ -1,0 +1,297 @@
+//! Relay connector protocol contracts.
+//!
+//! Hermes Ultra does not register the upstream experimental relay connector as a
+//! default platform adapter, but the gateway crate owns the stable wire
+//! contracts we need to preserve when/if a transport is enabled.
+
+use base64::{engine::general_purpose, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use url::Url;
+
+/// Connector-forwarded passthrough-plane request (`passthrough_forward`).
+///
+/// The connector edge already verified provider signatures and stripped shared
+/// identity credentials before forwarding this frame over the authenticated
+/// outbound relay socket. `body` is decoded back to the exact byte payload carried
+/// by the connector's `bodyB64` field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelayPassthroughForward {
+    pub platform: String,
+    pub bot_id: String,
+    pub method: String,
+    pub path: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+    pub buffer_id: Option<String>,
+}
+
+impl RelayPassthroughForward {
+    pub fn body_b64(&self) -> String {
+        general_purpose::STANDARD.encode(&self.body)
+    }
+}
+
+/// Decode a relay `passthrough_forward` frame.
+///
+/// Malformed base64 is tolerated as an empty body so a bad forwarded request
+/// cannot kill the relay reader loop.
+pub fn relay_passthrough_forward_from_frame(frame: &Value) -> Option<RelayPassthroughForward> {
+    if frame.get("type").and_then(Value::as_str) != Some("passthrough_forward") {
+        return None;
+    }
+    let raw = frame.get("forward")?.as_object()?;
+    let body = raw
+        .get("bodyB64")
+        .and_then(Value::as_str)
+        .and_then(|body| general_purpose::STANDARD.decode(body).ok())
+        .unwrap_or_default();
+    let headers = raw
+        .get("headers")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let pair = item.as_array()?;
+                    if pair.len() != 2 {
+                        return None;
+                    }
+                    Some((
+                        pair[0].as_str().unwrap_or_default().to_string(),
+                        pair[1].as_str().unwrap_or_default().to_string(),
+                    ))
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Some(RelayPassthroughForward {
+        platform: raw
+            .get("platform")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        bot_id: raw
+            .get("botId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        method: raw
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        path: raw
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        headers,
+        body,
+        buffer_id: frame
+            .get("bufferId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
+    })
+}
+
+pub fn relay_going_idle_frame() -> Value {
+    json!({"type": "going_idle"})
+}
+
+pub fn relay_inbound_ack_frame(buffer_id: &str) -> Option<Value> {
+    let buffer_id = buffer_id.trim();
+    (!buffer_id.is_empty()).then(|| json!({"type": "inbound_ack", "bufferId": buffer_id}))
+}
+
+/// Convert a relay dial URL to the management-plane `/relay/policy` URL.
+pub fn relay_policy_url(relay_url: &str) -> Option<String> {
+    let mut url = Url::parse(relay_url.trim().trim_end_matches('/')).ok()?;
+    let scheme = match url.scheme() {
+        "ws" | "http" => "http",
+        "wss" | "https" => "https",
+        _ => return None,
+    };
+    url.set_scheme(scheme).ok()?;
+    let path = url.path().trim_end_matches('/');
+    url.set_path(&format!("{path}/policy"));
+    Some(url.to_string())
+}
+
+/// Wake URL precedence: managed/container env first, then config.yaml.
+pub fn relay_wake_url_from_sources(
+    env_value: Option<&str>,
+    config_value: Option<&str>,
+) -> Option<String> {
+    env_value
+        .and_then(normalize_relay_urlish)
+        .or_else(|| config_value.and_then(normalize_relay_urlish))
+}
+
+fn normalize_relay_urlish(value: &str) -> Option<String> {
+    let value = value.trim().trim_end_matches('/');
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// Connector-side relevance policy projected from platform mention controls.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayRelevancePolicy {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub require_address: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub free_response_scopes: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub allow_other_bots: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+pub fn relay_relevance_policy<I, S>(
+    require_mention: Option<bool>,
+    free_response_scopes: I,
+    allow_bots: Option<&str>,
+) -> Option<RelayRelevancePolicy>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let free_response_scopes = free_response_scopes
+        .into_iter()
+        .flat_map(|item| {
+            item.as_ref()
+                .split(',')
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let allow_other_bots = allow_bots
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|value| matches!(value.as_str(), "mentions" | "all" | "true" | "1" | "yes"));
+    if require_mention.is_none() && free_response_scopes.is_empty() && !allow_other_bots {
+        return None;
+    }
+    Some(RelayRelevancePolicy {
+        require_address: require_mention,
+        free_response_scopes,
+        allow_other_bots,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_forward_decodes_exact_body_and_headers() {
+        let body = b"{\"type\":2,\"data\":{\"name\":\"ship\"}}";
+        let frame = json!({
+            "type": "passthrough_forward",
+            "bufferId": "buf-1",
+            "forward": {
+                "platform": "discord",
+                "botId": "bot-7",
+                "method": "POST",
+                "path": "/interactions",
+                "headers": [["content-type", "application/json"], ["x-extra", "1"]],
+                "bodyB64": general_purpose::STANDARD.encode(body),
+            }
+        });
+        let forward = relay_passthrough_forward_from_frame(&frame).expect("forward");
+        assert_eq!(forward.platform, "discord");
+        assert_eq!(forward.bot_id, "bot-7");
+        assert_eq!(forward.body, body);
+        assert_eq!(forward.body_b64(), general_purpose::STANDARD.encode(body));
+        assert_eq!(forward.buffer_id.as_deref(), Some("buf-1"));
+        assert_eq!(
+            forward.headers,
+            vec![
+                ("content-type".to_string(), "application/json".to_string()),
+                ("x-extra".to_string(), "1".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn passthrough_forward_tolerates_malformed_body() {
+        let frame = json!({
+            "type": "passthrough_forward",
+            "forward": {"platform": "discord", "bodyB64": "not-base64!!!"}
+        });
+        let forward = relay_passthrough_forward_from_frame(&frame).expect("forward");
+        assert!(forward.body.is_empty());
+    }
+
+    #[test]
+    fn relay_control_frames_match_connector_contract() {
+        assert_eq!(relay_going_idle_frame(), json!({"type": "going_idle"}));
+        assert_eq!(
+            relay_inbound_ack_frame(" buf-9 ").unwrap(),
+            json!({"type": "inbound_ack", "bufferId": "buf-9"})
+        );
+        assert!(relay_inbound_ack_frame("   ").is_none());
+    }
+
+    #[test]
+    fn relay_policy_url_maps_ws_to_http_management_plane() {
+        assert_eq!(
+            relay_policy_url("wss://relay.example.test/relay/").as_deref(),
+            Some("https://relay.example.test/relay/policy")
+        );
+        assert_eq!(
+            relay_policy_url("ws://127.0.0.1:8080/relay").as_deref(),
+            Some("http://127.0.0.1:8080/relay/policy")
+        );
+        assert!(relay_policy_url("file:///tmp/relay").is_none());
+    }
+
+    #[test]
+    fn wake_url_prefers_env_and_trims_trailing_slash() {
+        assert_eq!(
+            relay_wake_url_from_sources(
+                Some(" https://wake.example.test/ "),
+                Some("https://config.example.test/")
+            )
+            .as_deref(),
+            Some("https://wake.example.test")
+        );
+        assert_eq!(
+            relay_wake_url_from_sources(Some(" "), Some("https://config.example.test/")).as_deref(),
+            Some("https://config.example.test")
+        );
+        assert!(relay_wake_url_from_sources(Some(" "), Some(" ")).is_none());
+    }
+
+    #[test]
+    fn relevance_policy_projects_platform_knobs() {
+        assert!(relay_relevance_policy(None, Vec::<String>::new(), None).is_none());
+        let policy =
+            relay_relevance_policy(Some(true), ["chan-a, chan-b", "thread-1"], Some("mentions"))
+                .expect("policy");
+        assert_eq!(policy.require_address, Some(true));
+        assert_eq!(
+            policy.free_response_scopes,
+            vec![
+                "chan-a".to_string(),
+                "chan-b".to_string(),
+                "thread-1".to_string()
+            ]
+        );
+        assert!(policy.allow_other_bots);
+        assert_eq!(
+            serde_json::to_value(&policy).unwrap(),
+            json!({
+                "requireAddress": true,
+                "freeResponseScopes": ["chan-a", "chan-b", "thread-1"],
+                "allowOtherBots": true
+            })
+        );
+    }
+}

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 162.0,
+        "actual": 143.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-25T19:43:56.657118+00:00",
+  "generated_at_utc": "2026-06-25T22:03:06.987450+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 162.0,
+    "max_queue_pending_commits": 143.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 162,
-      "ported": 425,
-      "superseded": 6358
+      "pending": 143,
+      "ported": 433,
+      "superseded": 6369
     },
     "by_target_ticket": {
       "20": 3146,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 162.0,
+        "actual": 143.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-25T19:43:56.657118+00:00`
+Generated: `2026-06-25T22:03:06.987450+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-25T19:43:56.657118+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 162.0 |
+| `max_queue_pending_commits` | 143.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4723,6 +4723,101 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Superseded by Rust WhatsApp architecture: the repo has no scripts/whatsapp-bridge source tree or npm-installing bridge adapter path to mirror into HERMES_HOME; Rust WhatsApp runtime is the Cloud API adapter plus configurable bridge_url QR helper."
+    },
+    "9026a8c78974": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust platform policy: upstream added a Python Raft bundled platform plugin and tests, but Hermes Ultra does not advertise or register a Rust Raft platform adapter. The Rust gateway owns first-class native adapters under crates/hermes-gateway/src/platforms and does not import Python plugins/platforms at runtime."
+    },
+    "7d86178cf51a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by absent Rust Raft subprocess path: upstream sets stdin=DEVNULL on a Python Raft bridge subprocess, but Hermes Ultra has no Raft bridge adapter or Python subprocess launcher in the Rust gateway runtime."
+    },
+    "a7983d5ad768": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust dashboard/session architecture: upstream hides Python sidecar sessions in dashboard history, while Hermes Ultra has no Python run_agent/tui_gateway sidecar session source in the Rust runtime; gateway session sources are typed in crates/hermes-gateway/src/session_control.rs."
+    },
+    "5600105478ff": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust-native gateway adapters: upstream moved Python Slack/DingTalk/WhatsApp/Matrix/Feishu/Telegram/WeCom/email/SMS adapters into bundled plugin directories, but Hermes Ultra already implements these as first-class Rust modules under crates/hermes-gateway/src/platforms with feature gates and no Python plugin import path."
+    },
+    "2a4542333ee1": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by absent Rust Photon adapter: upstream modifies the Python Photon plugin sidecar retry/cooldown behavior. Hermes Ultra does not register a Photon platform module; CLI parsing of arbitrary --platform values is not an advertised Photon runtime surface."
+    },
+    "9578e52795e3": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by absent Rust Photon sidecar: upstream detects Python Photon sidecar death and reconnects. Hermes Ultra has no Photon sidecar process or platform adapter in crates/hermes-gateway/src/platforms."
+    },
+    "64a507da44d2": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as a first-class Rust relay protocol contract: crates/hermes-gateway/src/relay.rs decodes passthrough_forward frames, preserves bodyB64 byte parity, carries ordered headers and bufferId, and tolerates malformed base64 without killing the caller. The experimental relay adapter remains unregistered by Rust platform policy."
+    },
+    "45bc4fb37fa8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as Rust relay management-plane contracts: hermes_gateway::relay maps ws/wss relay URLs to /relay/policy, projects requireAddress/freeResponseScopes/allowOtherBots with connector camelCase serialization, and keeps the relay adapter unregistered unless explicitly scoped later."
+    },
+    "221cd60242ae": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Already ported in Rust provider controls: ollama-cloud is a known provider and the /reasoning set path applies provider extra_body reasoning effort configuration generically, with tests covering reasoning.effort normalization and clearing without introducing legacy model defaults."
+    },
+    "02050859f316": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Already ported by Rust session-resume parity work: SessionPersistence resolves compression continuation tips and ACP/session handlers preserve the active session id across load/resume rather than replacing it with a stale compressed parent."
+    },
+    "40fddc9e4c45": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as Rust relay protocol primitives: hermes_gateway::relay exposes going_idle and inbound_ack frame builders with bufferId validation and tests. The actual relay transport remains intentionally unregistered in Rust until the experimental relay adapter is scoped."
+    },
+    "6e88f7b6f7b9": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as Rust wake-url contract surface: hermes_gateway::relay resolves wake URL precedence from env/config sources, trims trailing slashes, and tests absent/env/config behavior for the connector wake primitive while keeping relay inactive by default."
+    },
+    "06cbc3bae985": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by absent Rust Photon sidecar/runtime: upstream recovers degraded Python Photon streams and sidecar state, but Hermes Ultra has no Photon adapter or sidecar process to patch."
+    },
+    "0952acbf4de8": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by absent Rust Photon sidecar: upstream labels Photon CatchUpEvents failures in JavaScript sidecar code that is not present or invoked by Hermes Ultra's Rust gateway."
+    },
+    "7f1c278db817": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by absent Rust Photon sidecar: upstream intercepts console.log in the Photon JavaScript sidecar, but Hermes Ultra does not ship or execute that sidecar."
+    },
+    "d539cd9004a1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/proven in Rust config persistence: save_config_yaml and atomic_yaml_write write UTF-8 bytes through Rust String serialization, and a focused test now round-trips emoji/personality/system_prompt text while preserving valid UTF-8 and omitting home_dir."
+    },
+    "c39b2b50eeb8": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust-only process startup: upstream hardens Python entrypoints against cwd packages named utils/proxy/ui shadowing imports. Hermes Ultra has no Python gateway/acp entrypoint import path, and scripts/check-rust-runtime-no-python.sh verifies no Rust runtime Python execution path."
+    },
+    "0d4cecb35270": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust cron architecture: upstream renames Python plugins/cron to plugins/cron_providers to avoid provider package shadowing. Hermes Ultra cron is crates/hermes-cron plus Rust gateway/api-server integrations and has no Python plugins/cron import path."
+    },
+    "7ff48a6291f5": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Discord component authorization: discord_component_allows_with_pairing now allows explicitly approved PairingManager users after allowlist/role checks fail, while denied/unpaired users remain fail-closed. Focused Rust tests cover approved, denied, and unpaired component subjects."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-25T19:43:56.129312+00:00`
+Generated: `2026-06-25T22:03:06.847934+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7021`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 162 |
-| ported | 425 |
-| superseded | 6358 |
+| pending | 143 |
+| ported | 433 |
+| superseded | 6369 |
 
 ## First 100 Pending Commits
 
@@ -36,8 +36,6 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | `d91b8d8368bb` | #26 | test(desktop): make keyVar a typed EnvVarInfo factory |
 | `b936f92b25b4` | #26 | fix(desktop): render send/prefill directive notices (/goal, /undo) (#49073) |
 | `db744e7d1e58` | #21 | feat(simplify-code): add risk-tiered application, Chesterton's Fence, slop + silent failure detection |
-| `9026a8c78974` | #22 | feat(gateway): add Raft bundled platform plugin with activity hooks |
-| `7d86178cf51a` | #26 | fix(raft): set stdin=DEVNULL on bridge subprocess |
 | `6308d3416ab9` | #26 | fix(desktop): rename "Restart messaging" -> "Restart gateway" |
 | `553cf4f97757` | #26 | feat(desktop): restart the gateway from Cmd+K, with statusbar spinner feedback |
 | `a1639921ac44` | #26 | fix(desktop): offer a Restart gateway action on messaging save/toggle toasts |
@@ -47,7 +45,6 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | `866f1d65c4aa` | #26 | chore(desktop): sync package.json version fallback to 0.17.0 (#49236) |
 | `7a7b56d49830` | #23 | fix(windows): prefer managed node for whatsapp and desktop |
 | `d4e7dd609da6` | #23 | refactor(windows): tidy managed-node resolver helpers |
-| `a7983d5ad768` | #20 | fix(dashboard): hide sidecar sessions from history (#49269) |
 | `d799284b1554` | #21 | feat(optional-skills/creative-ideation): expand to v2.1.0 method library (#42402) |
 | `8ebe37f6ad2d` | #26 | feat(desktop): notify renderer when GPU acceleration is disabled due to remote display |
 | `1b7b4d138a67` | #26 | fix(desktop): handle slash exec dispatch payloads (#49358) |
@@ -56,7 +53,6 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | `eed78d6ebb51` | #26 | fix(desktop): composer popout polish — peel-off placement, panels, chip editing |
 | `ae8db1ab531b` | #26 | fix(desktop): mute hidden link-title window so historical links don't autoplay audio |
 | `7eb9678c5470` | #26 | test(desktop): cover link-title window audio muting |
-| `5600105478ff` | #20 | refactor(gateway): migrate slack/dingtalk/whatsapp/matrix/feishu/telegram/wecom/email/sms adapters to bundled plugins |
 | `404fe730b7a2` | #26 | fix: add tooltips to right sidebar header buttons |
 | `838daca9f4cf` | #26 | chore(desktop): format tooltip indentation + author map for #49697 |
 | `75b36a138f43` | #22 | feat(pets): TUI pet pane, picker + gateway RPCs |
@@ -86,8 +82,6 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
 | `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
-| `2a4542333ee1` | #26 | fix(photon): classify Envoy overflow errors as retryable; add typing cooldown |
-| `9578e52795e3` | #26 | fix(photon): detect unexpected sidecar death and trigger reconnect |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
 | `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
@@ -105,7 +99,6 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | `a61baa961572` | #26 | feat(desktop): PR-style file diffs in chat |
 | `c6fbd5a10494` | #26 | style(desktop): lead --dt-font-mono with bundled JetBrains Mono |
 | `ac128af1cec3` | #26 | feat(desktop): syntax-highlight inline diffs via Shiki |
-| `64a507da44d2` | #20 | feat(relay): handle passthrough_forward over the WS (Phase 5 §5.1, gateway half) (#50702) |
 | `61c266b0dc75` | #26 | style(desktop): soften dark-mode syntax highlighting |
 | `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |
 | `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |
@@ -121,7 +114,14 @@ Generated: `2026-06-25T19:43:56.129312+00:00`
 | `d0af7fc954fe` | #26 | feat(desktop): detect tool previews into composer status stack |
 | `48a8f8416937` | #26 | fix(desktop): toggle preview rail and open in browser |
 | `7daa6d83fcaa` | #26 | style(desktop): soften inline code and expanded tool chrome |
-| `45bc4fb37fa8` | #20 | feat(relay): declare relevance policy to the connector + document the management plane (#51248) |
 | `45540cfb5ef1` | #25 | ci: run only the lanes a PR affects (python/frontend/site) |
 | `2977e7454377` | #25 | ci: build Docker on main + release only, never on PRs |
 | `56b4ef74a631` | #25 | ci: make dependency installs resilient to transient flakes |
+| `05c896cf5249` | #25 | ci: refactor paths & clones |
+| `a0471e24648e` | #25 | fix(ci): only run supplychain checks in pr |
+| `9fd2b2cb9fab` | #26 | fix(desktop): replace native title tooltips with styled Tip component |
+| `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |
+| `72bfc48e63a1` | #22 | feat(tui): track background subagents in the status bar (#51485) |
+| `935f2bc48daa` | #26 | docs(relay): add §3.4 — obligations on a future scale-to-zero behaviour layer (#51633) |
+| `281a439ad483` | #26 | fix(desktop): guard composer mutations when the composer core isn't bound (#51728) |
+| `0ef86febe25f` | #20 | docs(sessions): clarify sessions.json is the gateway routing index, not the session list (#51726) |


### PR DESCRIPTION
## Summary
- Add `hermes_gateway::relay` Rust protocol contracts for relay `passthrough_forward`, `going_idle`, `inbound_ack`, wake URL precedence, `/relay/policy` URL projection, and connector relevance-policy serialization.
- Add Discord component authorization helper that permits approved `PairingManager` users after allowlist/role checks fail, while preserving fail-closed behavior for denied/unpaired users.
- Add UTF-8 config persistence proof for `save_config_yaml` / `load_from_yaml` with emoji/personality/system prompt content.
- Classify 19 upstream backend/runtime commits with evidence; queue pending moves `162 -> 143`.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway relay --lib` -> 6 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway discord_component_auth_allows_approved_pairing_store_user --lib --features discord` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-config save_config_yaml_preserves_utf8_personality_and_prompt --lib` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-gateway -p hermes-config --features discord` -> `seen=200 allowlist=200 new=0 stale=0`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`

## Notes
- The relay connector remains intentionally unregistered by default; this PR ports stable Rust protocol contracts without adding a half-wired network adapter.
- No OAuth/sign-in or model default changes are included.
