### PR TITLE
parity(tools): add project workspace runtime

### DIFF
--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -705,8 +705,25 @@ async fn exec_rpc(
     match method {
         "project.facts" => {
             let cwd = rpc_param_str(&params, "cwd").map(PathBuf::from);
-            let facts = hermes_agent::coding_context::project_facts_for(cwd.as_deref());
+            let facts =
+                hermes_tools::tools::project_workspace::project_facts_snapshot(cwd.as_deref());
             rpc_ok(id, serde_json::json!({ "facts": facts }))
+        }
+        "project.tree" => {
+            let cwd = rpc_param_str(&params, "cwd").map(PathBuf::from);
+            let max_depth = rpc_param_u32(&params, "max_depth", 3) as usize;
+            let max_entries = rpc_param_u32(&params, "max_entries", 200) as usize;
+            let include_hidden = params
+                .get("include_hidden")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let tree = hermes_tools::tools::project_workspace::project_tree_snapshot(
+                cwd.as_deref(),
+                max_depth,
+                max_entries,
+                include_hidden,
+            );
+            rpc_ok(id, serde_json::json!({ "tree": tree }))
         }
         "verification.status" => {
             let cwd = rpc_param_str(&params, "cwd").map(PathBuf::from);

--- a/crates/hermes-http/tests/http_smoke.rs
+++ b/crates/hermes-http/tests/http_smoke.rs
@@ -162,6 +162,52 @@ async fn rpc_project_facts_returns_structured_workspace_data() {
 }
 
 #[tokio::test]
+async fn rpc_project_tree_returns_bounded_entries() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let repo = tempfile::tempdir().unwrap();
+    std::fs::write(
+        repo.path().join("Cargo.toml"),
+        "[package]\nname='rpc-tree'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join("src/lib.rs"), "pub fn rpc_tree() {}\n").unwrap();
+    std::fs::create_dir_all(repo.path().join("target/debug")).unwrap();
+    std::fs::write(repo.path().join("target/debug/ignored"), "ignored").unwrap();
+    std::fs::write(repo.path().join("z-extra-a.txt"), "extra").unwrap();
+    std::fs::write(repo.path().join("z-extra-b.txt"), "extra").unwrap();
+
+    let payload = serde_json::json!({
+        "id": "tree",
+        "method": "project.tree",
+        "params": {
+            "cwd": repo.path(),
+            "max_depth": 4,
+            "max_entries": 4
+        }
+    });
+
+    let v = post_rpc(payload).await;
+
+    assert_eq!(v["id"], "tree");
+    assert_eq!(v["error"], serde_json::Value::Null);
+    let tree = &v["result"]["tree"];
+    assert_eq!(tree["status"], "ok");
+    assert_eq!(tree["maxEntries"], 4);
+    assert_eq!(tree["truncated"], true);
+    let paths = tree["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| value["path"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert!(paths.contains(&"Cargo.toml".to_string()));
+    assert!(paths.contains(&"src".to_string()));
+    assert!(paths.contains(&"src/lib.rs".to_string()));
+    assert!(!paths.iter().any(|path| path.starts_with("target")));
+}
+
+#[tokio::test]
 async fn rpc_verification_status_returns_passive_terminal_evidence() {
     let _ = tracing_subscriber::fmt::try_init();
     let _guard = ENV_LOCK.lock().await;

--- a/crates/hermes-tools/src/backends/web.rs
+++ b/crates/hermes-tools/src/backends/web.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::sync::OnceLock;
+use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
 
@@ -111,6 +112,7 @@ const TAVILY_BASE_URL_DEFAULT: &str = "https://api.tavily.com";
 const SEARXNG_SEARCH_PATH: &str = "/search";
 const BRAVE_SEARCH_URL_DEFAULT: &str = "https://api.search.brave.com/res/v1/web/search";
 const DDG_INSTANT_ANSWER_URL_DEFAULT: &str = "https://api.duckduckgo.com/";
+const DDG_SEARCH_TIMEOUT_SECS_DEFAULT: u64 = 15;
 const PARALLEL_BASE_URL_DEFAULT: &str = "https://api.parallel.ai";
 const PARALLEL_USER_AGENT: &str = "hermes-agent-web/1.0.0";
 const FIRECRAWL_BASE_URL_DEFAULT: &str = "https://api.firecrawl.dev";
@@ -1333,24 +1335,43 @@ fn normalize_brave_results(response: &Value, limit: usize) -> Vec<Value> {
 pub struct DuckDuckGoSearchBackend {
     client: Client,
     endpoint: String,
+    timeout: Duration,
 }
 
 impl DuckDuckGoSearchBackend {
     pub fn new(endpoint: String) -> Self {
+        Self::with_timeout(
+            endpoint,
+            Duration::from_secs(DDG_SEARCH_TIMEOUT_SECS_DEFAULT),
+        )
+    }
+
+    pub fn with_timeout(endpoint: String, timeout: Duration) -> Self {
         Self {
             client: Client::new(),
             endpoint,
+            timeout: timeout.max(Duration::from_millis(50)),
         }
     }
 
     pub fn from_env() -> Result<Self, ToolError> {
-        Ok(Self::new(std::env::var("DDG_SEARCH_URL").unwrap_or_else(
-            |_| DDG_INSTANT_ANSWER_URL_DEFAULT.to_string(),
-        )))
+        let endpoint = std::env::var("DDG_SEARCH_URL")
+            .unwrap_or_else(|_| DDG_INSTANT_ANSWER_URL_DEFAULT.to_string());
+        let timeout = env_optional_nonempty("DDG_SEARCH_TIMEOUT_SECONDS")
+            .or_else(|| env_optional_nonempty("HERMES_DDGS_TIMEOUT_SECONDS"))
+            .and_then(|raw| raw.parse::<f64>().ok())
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .map(Duration::from_secs_f64)
+            .unwrap_or_else(|| Duration::from_secs(DDG_SEARCH_TIMEOUT_SECS_DEFAULT));
+        Ok(Self::with_timeout(endpoint, timeout))
     }
 
     pub fn endpoint(&self) -> &str {
         &self.endpoint
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.timeout
     }
 }
 
@@ -1371,6 +1392,7 @@ impl WebSearchBackend for DuckDuckGoSearchBackend {
                 ("no_html", "1"),
                 ("skip_disambig", "1"),
             ])
+            .timeout(self.timeout)
             .send()
             .await
             .map_err(|e| {
@@ -2680,6 +2702,8 @@ mod web_search_env_tests {
                 "BRAVE_SEARCH_API_KEY",
                 "BRAVE_SEARCH_URL",
                 "DDG_SEARCH_URL",
+                "DDG_SEARCH_TIMEOUT_SECONDS",
+                "HERMES_DDGS_TIMEOUT_SECONDS",
                 "XAI_API_KEY",
                 "XAI_BASE_URL",
                 "HERMES_WEB_BACKEND",
@@ -2931,6 +2955,48 @@ mod web_search_env_tests {
         let _scope = EnvScope::new();
         std::env::set_var("HERMES_WEB_SEARCH_BACKEND", "ddgs");
         assert_eq!(search_backend_choice_from_env(), "ddgs");
+    }
+
+    #[test]
+    fn duckduckgo_from_env_applies_bounded_timeout() {
+        let _scope = EnvScope::new();
+        std::env::set_var("DDG_SEARCH_TIMEOUT_SECONDS", "0.25");
+        let backend = DuckDuckGoSearchBackend::from_env().expect("ddg backend");
+        assert_eq!(backend.timeout(), std::time::Duration::from_millis(250));
+
+        std::env::set_var("DDG_SEARCH_TIMEOUT_SECONDS", "0");
+        let backend = DuckDuckGoSearchBackend::from_env().expect("ddg backend");
+        assert_eq!(
+            backend.timeout(),
+            std::time::Duration::from_secs(DDG_SEARCH_TIMEOUT_SECS_DEFAULT)
+        );
+    }
+
+    #[tokio::test]
+    async fn duckduckgo_search_times_out_slow_response() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(200))
+                    .set_body_json(json!({"RelatedTopics": []})),
+            )
+            .mount(&server)
+            .await;
+
+        let backend = DuckDuckGoSearchBackend::with_timeout(
+            server.uri(),
+            std::time::Duration::from_millis(50),
+        );
+        let err = backend
+            .search("slow query", 3, None)
+            .await
+            .expect_err("slow ddg response should time out");
+        assert!(err.to_string().contains("DuckDuckGo search request failed"));
     }
 
     #[test]

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -84,6 +84,7 @@ pub use tools::mixture_of_agents::MixtureOfAgentsHandler;
 pub use tools::ops_snapshot::OpsSnapshotHandler;
 pub use tools::osv_check::OsvCheckHandler;
 pub use tools::process_registry::ProcessRegistryHandler;
+pub use tools::project_workspace::{ProjectFactsHandler, ProjectTreeHandler};
 pub use tools::raw_trace_control::RawTraceControlHandler;
 pub use tools::replay_trace_control::ReplayTraceControlHandler;
 pub use tools::rl_training::{

--- a/crates/hermes-tools/src/register_builtins.rs
+++ b/crates/hermes-tools/src/register_builtins.rs
@@ -171,6 +171,22 @@ fn register_builtin_tools_with_data_dir(
         vec![],
     );
 
+    // -- Project/workspace tools ----------------------------------------------
+    reg(
+        registry,
+        "project",
+        Arc::new(crate::tools::project_workspace::ProjectFactsHandler),
+        "🗂️",
+        vec![],
+    );
+    reg(
+        registry,
+        "project",
+        Arc::new(crate::tools::project_workspace::ProjectTreeHandler),
+        "🌳",
+        vec![],
+    );
+
     // -- Vision --------------------------------------------------------------
     {
         let backend =
@@ -1215,6 +1231,8 @@ mod tests {
             "terminal",
             "process",
             "process_registry",
+            "project_facts",
+            "project_tree",
             "todo",
             "text_to_speech",
             "tts_premium",

--- a/crates/hermes-tools/src/tools/mod.rs
+++ b/crates/hermes-tools/src/tools/mod.rs
@@ -26,6 +26,7 @@ pub mod mixture_of_agents;
 pub mod ops_snapshot;
 pub mod osv_check;
 pub mod process_registry;
+pub mod project_workspace;
 pub mod raw_trace_control;
 pub mod replay_trace_control;
 pub mod rl_training;

--- a/crates/hermes-tools/src/tools/project_workspace.rs
+++ b/crates/hermes-tools/src/tools/project_workspace.rs
@@ -1,0 +1,609 @@
+//! Read-only project/workspace inspection tools.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use async_trait::async_trait;
+use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+use indexmap::IndexMap;
+use serde_json::{json, Value};
+
+const PROJECT_FACTS_TOOL: &str = "project_facts";
+const PROJECT_TREE_TOOL: &str = "project_tree";
+const MAX_FACT_FILE_BYTES: u64 = 256 * 1024;
+const DEFAULT_TREE_DEPTH: usize = 3;
+const DEFAULT_TREE_LIMIT: usize = 200;
+const MAX_TREE_DEPTH: usize = 8;
+const MAX_TREE_LIMIT: usize = 1_000;
+
+const PROJECT_MARKERS: &[&str] = &[
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+    "package.json",
+    "tsconfig.json",
+    "deno.json",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+    "composer.json",
+    "mix.exs",
+    "pubspec.yaml",
+    "CMakeLists.txt",
+    "Makefile",
+    "Dockerfile",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".cursorrules",
+];
+const CONTEXT_FILES: &[&str] = &["AGENTS.md", "CLAUDE.md", ".cursorrules"];
+const VERIFY_TARGETS: &[&str] = &[
+    "test",
+    "tests",
+    "lint",
+    "typecheck",
+    "check",
+    "build",
+    "fmt",
+    "format",
+];
+const DEFAULT_IGNORED_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".cache",
+];
+
+pub struct ProjectFactsHandler;
+pub struct ProjectTreeHandler;
+
+#[async_trait]
+impl ToolHandler for ProjectFactsHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        let cwd = optional_path(&params, "cwd");
+        Ok(project_facts_snapshot(cwd.as_deref()).to_string())
+    }
+
+    fn schema(&self) -> ToolSchema {
+        let mut props = IndexMap::new();
+        props.insert(
+            "cwd".into(),
+            json!({
+                "type": "string",
+                "description": "Optional current working directory. Defaults to process cwd."
+            }),
+        );
+        tool_schema(
+            PROJECT_FACTS_TOOL,
+            "Return read-only project/workspace facts: root, manifests, package managers, verify commands, context files, and git metadata.",
+            JsonSchema::object(props, vec![]),
+        )
+    }
+}
+
+#[async_trait]
+impl ToolHandler for ProjectTreeHandler {
+    async fn execute(&self, params: Value) -> Result<String, ToolError> {
+        let cwd = optional_path(&params, "cwd");
+        let max_depth = params
+            .get("max_depth")
+            .and_then(Value::as_u64)
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(DEFAULT_TREE_DEPTH);
+        let max_entries = params
+            .get("max_entries")
+            .and_then(Value::as_u64)
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(DEFAULT_TREE_LIMIT);
+        let include_hidden = params
+            .get("include_hidden")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        Ok(
+            project_tree_snapshot(cwd.as_deref(), max_depth, max_entries, include_hidden)
+                .to_string(),
+        )
+    }
+
+    fn schema(&self) -> ToolSchema {
+        let mut props = IndexMap::new();
+        props.insert(
+            "cwd".into(),
+            json!({"type": "string", "description": "Optional cwd inside the project. Defaults to process cwd."}),
+        );
+        props.insert(
+            "max_depth".into(),
+            json!({"type": "integer", "description": "Maximum tree depth from project root. Defaults to 3, capped at 8.", "default": DEFAULT_TREE_DEPTH}),
+        );
+        props.insert(
+            "max_entries".into(),
+            json!({"type": "integer", "description": "Maximum entries to return. Defaults to 200, capped at 1000.", "default": DEFAULT_TREE_LIMIT}),
+        );
+        props.insert(
+            "include_hidden".into(),
+            json!({"type": "boolean", "description": "Include dotfiles except .git. Defaults to false.", "default": false}),
+        );
+        tool_schema(
+            PROJECT_TREE_TOOL,
+            "Return a bounded deterministic project tree rooted at the detected workspace root. Read-only; skips heavy dependency/build directories by default.",
+            JsonSchema::object(props, vec![]),
+        )
+    }
+}
+
+pub fn project_facts_snapshot(cwd: Option<&Path>) -> Value {
+    let requested_cwd = resolve_cwd(cwd);
+    let Some(root) = workspace_root(&requested_cwd) else {
+        return json!({
+            "status": "not_applicable",
+            "reason": "workspace_root_not_detected",
+            "cwd": requested_cwd.display().to_string(),
+        });
+    };
+    let manifests = project_manifest_names(&root);
+    json!({
+        "status": "ok",
+        "root": root.display().to_string(),
+        "cwd": requested_cwd.display().to_string(),
+        "manifests": manifests,
+        "packageManagers": package_managers(&root),
+        "verifyCommands": verify_commands(&root),
+        "contextFiles": context_files(&root),
+        "git": git_snapshot(&root),
+    })
+}
+
+pub fn project_tree_snapshot(
+    cwd: Option<&Path>,
+    max_depth: usize,
+    max_entries: usize,
+    include_hidden: bool,
+) -> Value {
+    let requested_cwd = resolve_cwd(cwd);
+    let Some(root) = workspace_root(&requested_cwd) else {
+        return json!({
+            "status": "not_applicable",
+            "reason": "workspace_root_not_detected",
+            "cwd": requested_cwd.display().to_string(),
+            "entries": [],
+            "truncated": false,
+        });
+    };
+    let max_depth = max_depth.clamp(1, MAX_TREE_DEPTH);
+    let max_entries = max_entries.clamp(1, MAX_TREE_LIMIT);
+    let collect_limit = max_entries.saturating_add(1);
+    let mut entries = Vec::new();
+    collect_tree(
+        &root,
+        &root,
+        0,
+        max_depth,
+        collect_limit,
+        include_hidden,
+        &mut entries,
+    );
+    let truncated = entries.len() > max_entries;
+    entries.truncate(max_entries);
+    json!({
+        "status": "ok",
+        "root": root.display().to_string(),
+        "cwd": requested_cwd.display().to_string(),
+        "maxDepth": max_depth,
+        "maxEntries": max_entries,
+        "includeHidden": include_hidden,
+        "truncated": truncated,
+        "entries": entries,
+    })
+}
+
+fn optional_path(params: &Value, key: &str) -> Option<PathBuf> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn resolve_cwd(cwd: Option<&Path>) -> PathBuf {
+    let raw = cwd
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::var_os("TERMINAL_CWD").map(PathBuf::from))
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    raw.canonicalize().unwrap_or(raw)
+}
+
+fn workspace_root(cwd: &Path) -> Option<PathBuf> {
+    let cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    marker_root(&cwd).or_else(|| git_root(&cwd))
+}
+
+fn ancestors_nearest_first(start: &Path) -> impl Iterator<Item = PathBuf> + '_ {
+    std::iter::once(start.to_path_buf()).chain(start.ancestors().skip(1).map(Path::to_path_buf))
+}
+
+fn marker_root(cwd: &Path) -> Option<PathBuf> {
+    ancestors_nearest_first(cwd).take(12).find(|parent| {
+        PROJECT_MARKERS
+            .iter()
+            .any(|marker| parent.join(marker).exists())
+    })
+}
+
+fn git_root(cwd: &Path) -> Option<PathBuf> {
+    ancestors_nearest_first(cwd)
+        .take(12)
+        .find(|parent| parent.join(".git").exists())
+}
+
+fn project_manifest_names(root: &Path) -> Vec<String> {
+    PROJECT_MARKERS
+        .iter()
+        .copied()
+        .filter(|marker| !CONTEXT_FILES.contains(marker))
+        .filter(|marker| root.join(marker).exists())
+        .map(str::to_string)
+        .collect()
+}
+
+fn context_files(root: &Path) -> Vec<String> {
+    CONTEXT_FILES
+        .iter()
+        .copied()
+        .filter(|name| root.join(name).is_file())
+        .map(str::to_string)
+        .collect()
+}
+
+fn package_managers(root: &Path) -> Vec<String> {
+    let mut managers = Vec::new();
+    if let Some(pm) = js_package_manager(root) {
+        managers.push(pm.to_string());
+    }
+    if let Some(pm) = python_package_manager(root) {
+        managers.push(pm.to_string());
+    }
+    dedup_truncate(managers)
+}
+
+fn js_package_manager(root: &Path) -> Option<&'static str> {
+    [
+        ("pnpm-lock.yaml", "pnpm"),
+        ("bun.lockb", "bun"),
+        ("bun.lock", "bun"),
+        ("yarn.lock", "yarn"),
+        ("package-lock.json", "npm"),
+    ]
+    .iter()
+    .find_map(|(file, manager)| root.join(file).exists().then_some(*manager))
+}
+
+fn python_package_manager(root: &Path) -> Option<&'static str> {
+    [
+        ("uv.lock", "uv"),
+        ("poetry.lock", "poetry"),
+        ("Pipfile.lock", "pipenv"),
+    ]
+    .iter()
+    .find_map(|(file, manager)| root.join(file).exists().then_some(*manager))
+}
+
+fn verify_commands(root: &Path) -> Vec<String> {
+    let mut commands = Vec::new();
+    append_package_json_verify(root, &mut commands);
+    append_makefile_verify(root, &mut commands);
+    if root.join("scripts").join("run_tests.sh").is_file() {
+        commands.push("scripts/run_tests.sh".to_string());
+    }
+    if root.join("Cargo.toml").is_file() {
+        commands.push("cargo test".to_string());
+    }
+    if root.join("go.mod").is_file() {
+        commands.push("go test ./...".to_string());
+    }
+    if has_pytest_config(root) {
+        commands.push("pytest".to_string());
+    }
+    dedup_truncate(commands)
+}
+
+fn append_package_json_verify(root: &Path, commands: &mut Vec<String>) {
+    let path = root.join("package.json");
+    if !small_file(&path) {
+        return;
+    }
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+        return;
+    };
+    let Some(scripts) = value.get("scripts").and_then(Value::as_object) else {
+        return;
+    };
+    let manager = js_package_manager(root).unwrap_or("npm");
+    for target in VERIFY_TARGETS {
+        if scripts.contains_key(*target) {
+            commands.push(format!("{manager} run {target}"));
+        }
+    }
+}
+
+fn append_makefile_verify(root: &Path, commands: &mut Vec<String>) {
+    let path = root.join("Makefile");
+    if !small_file(&path) {
+        return;
+    }
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let targets = VERIFY_TARGETS
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+    for line in raw.lines() {
+        let Some((name, _)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        if !name.is_empty()
+            && !name.contains(char::is_whitespace)
+            && !name.starts_with('.')
+            && targets.contains(name)
+        {
+            commands.push(format!("make {name}"));
+        }
+    }
+}
+
+fn has_pytest_config(root: &Path) -> bool {
+    if root.join("pytest.ini").is_file() || root.join("tox.ini").is_file() {
+        return true;
+    }
+    let pyproject = root.join("pyproject.toml");
+    if !small_file(&pyproject) {
+        return false;
+    }
+    std::fs::read_to_string(pyproject)
+        .map(|raw| raw.contains("[tool.pytest"))
+        .unwrap_or(false)
+}
+
+fn small_file(path: &Path) -> bool {
+    path.metadata()
+        .map(|meta| meta.is_file() && meta.len() <= MAX_FACT_FILE_BYTES)
+        .unwrap_or(false)
+}
+
+fn dedup_truncate(values: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeMap::new();
+    for value in values {
+        seen.entry(value).or_insert(());
+    }
+    seen.into_keys().take(8).collect()
+}
+
+fn git_snapshot(root: &Path) -> Value {
+    let Some(git_root) = git_root(root) else {
+        return json!({"present": false});
+    };
+    let branch = git_output(&git_root, &["branch", "--show-current"]);
+    let head = git_output(&git_root, &["rev-parse", "--short", "HEAD"]);
+    let status = git_output(&git_root, &["status", "--short"]);
+    let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    if let Some(status) = status.as_deref() {
+        for line in status.lines() {
+            let code = line.get(..2).unwrap_or(line).trim();
+            let key = if line.starts_with("??") {
+                "untracked"
+            } else if code == "UU" || code == "AA" || code == "DD" {
+                "conflicts"
+            } else if code.chars().next().is_some_and(|c| c != ' ') {
+                "staged"
+            } else {
+                "modified"
+            };
+            *counts.entry(key).or_default() += 1;
+        }
+    }
+    json!({
+        "present": true,
+        "root": git_root.display().to_string(),
+        "branch": branch,
+        "head": head,
+        "dirty": !counts.is_empty(),
+        "statusCounts": counts,
+    })
+}
+
+fn git_output(root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+fn ignored_tree_entry(name: &str, include_hidden: bool) -> bool {
+    if name == ".git" {
+        return true;
+    }
+    if !include_hidden && name.starts_with('.') {
+        return true;
+    }
+    DEFAULT_IGNORED_DIRS.contains(&name)
+}
+
+fn collect_tree(
+    root: &Path,
+    dir: &Path,
+    depth: usize,
+    max_depth: usize,
+    max_entries: usize,
+    include_hidden: bool,
+    entries: &mut Vec<Value>,
+) {
+    if depth >= max_depth || entries.len() >= max_entries {
+        return;
+    }
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut children = read_dir.flatten().collect::<Vec<_>>();
+    children.sort_by_key(|entry| entry.file_name());
+    for entry in children {
+        if entries.len() >= max_entries {
+            return;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if ignored_tree_entry(&name, include_hidden) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let meta = entry.metadata().ok();
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(path.as_path())
+            .display()
+            .to_string();
+        let kind = if file_type.is_dir() {
+            "dir"
+        } else if file_type.is_file() {
+            "file"
+        } else if file_type.is_symlink() {
+            "symlink"
+        } else {
+            "other"
+        };
+        entries.push(json!({
+            "path": rel,
+            "name": name,
+            "kind": kind,
+            "depth": depth + 1,
+            "sizeBytes": meta.filter(|m| m.is_file()).map(|m| m.len()),
+        }));
+        if file_type.is_dir() {
+            collect_tree(
+                root,
+                &path,
+                depth + 1,
+                max_depth,
+                max_entries,
+                include_hidden,
+                entries,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_facts_reports_git_and_verify_commands() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='project-tool'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("AGENTS.md"), "# rules").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["init", "-q"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["config", "user.email", "t@example.com"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["config", "user.name", "Tester"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["add", "Cargo.toml", "AGENTS.md"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["commit", "-qm", "init"])
+            .status()
+            .unwrap();
+
+        let facts = project_facts_snapshot(Some(tmp.path()));
+
+        assert_eq!(facts["status"], "ok");
+        assert!(facts["manifests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == "Cargo.toml"));
+        assert!(facts["verifyCommands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == "cargo test"));
+        assert_eq!(facts["contextFiles"], json!(["AGENTS.md"]));
+        assert_eq!(facts["git"]["present"], true);
+        assert_eq!(facts["git"]["dirty"], false);
+    }
+
+    #[test]
+    fn project_tree_is_bounded_and_skips_heavy_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname='x'\nversion='0.1.0'\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/lib.rs"), "pub fn x() {}\n").unwrap();
+        std::fs::create_dir_all(tmp.path().join("target/debug")).unwrap();
+        std::fs::write(tmp.path().join("target/debug/big"), "ignored").unwrap();
+
+        let tree = project_tree_snapshot(Some(tmp.path()), 4, 10, false);
+        let paths = tree["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["path"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(tree["status"], "ok");
+        assert!(paths.contains(&"Cargo.toml".to_string()));
+        assert!(paths.contains(&"src".to_string()));
+        assert!(paths.contains(&"src/lib.rs".to_string()));
+        assert!(!paths.iter().any(|path| path.starts_with("target")));
+    }
+}

--- a/crates/hermes-tools/src/toolset.rs
+++ b/crates/hermes-tools/src/toolset.rs
@@ -56,6 +56,8 @@ pub const TOOLSET_SKILLS: &[&str] = &["skills_list", "skill_view", "skill_manage
 pub const TOOLSET_MEMORY: &[&str] = &["memory"];
 /// Session search tools.
 pub const TOOLSET_SESSION_SEARCH: &[&str] = &["session_search"];
+/// Project/workspace inspection tools.
+pub const TOOLSET_PROJECT: &[&str] = &["project_facts", "project_tree"];
 /// Todo/task management tools.
 pub const TOOLSET_TODO: &[&str] = &["todo"];
 /// Clarification/question tools.
@@ -138,6 +140,8 @@ pub const TOOLSET_CODING: &[&str] = &[
     "browser_vision",
     "browser_console",
     "todo",
+    "project_facts",
+    "project_tree",
     "memory",
     "session_search",
     "clarify",
@@ -262,6 +266,10 @@ impl ToolsetManager {
                 .collect(),
         ));
         self.register(Toolset::new(
+            "project",
+            TOOLSET_PROJECT.iter().map(|s| s.to_string()).collect(),
+        ));
+        self.register(Toolset::new(
             "todo",
             TOOLSET_TODO.iter().map(|s| s.to_string()).collect(),
         ));
@@ -343,6 +351,7 @@ impl ToolsetManager {
                 "skills",
                 "memory",
                 "session_search",
+                "project",
                 "todo",
                 "clarify",
                 "code_execution",
@@ -368,6 +377,7 @@ impl ToolsetManager {
                 "image_gen",
                 "memory",
                 "session_search",
+                "project",
                 "todo",
                 "code_execution",
                 "delegation",
@@ -390,6 +400,7 @@ impl ToolsetManager {
                 "skills",
                 "memory",
                 "session_search",
+                "project",
                 "todo",
                 "code_execution",
                 "delegation",
@@ -802,6 +813,8 @@ mod tests {
         assert!(tools.contains(&"video_generate".to_string()));
         assert!(tools.contains(&"spotify_playback".to_string()));
         assert!(tools.contains(&"session_search".to_string()));
+        assert!(tools.contains(&"project_facts".to_string()));
+        assert!(tools.contains(&"project_tree".to_string()));
         assert!(tools.contains(&"text_to_speech".to_string()));
         assert!(!tools.contains(&"send_message".to_string()));
         assert!(tools.contains(&"ha_call_service".to_string()));
@@ -849,6 +862,8 @@ mod tests {
             "todo",
             "memory",
             "session_search",
+            "project_facts",
+            "project_tree",
             "cronjob",
             "rl_start_training",
             "rl_test_inference",
@@ -883,6 +898,8 @@ mod tests {
             "skill_view",
             "skill_manage",
             "todo",
+            "project_facts",
+            "project_tree",
             "memory",
             "session_search",
             "clarify",

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T00:13:14.301619+00:00`_
+_Generated from source artifacts: `2026-06-26T01:04:29.460768+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T00:13:14.170796+00:00`
-- Proof snapshot generated: `2026-06-26T00:13:14.301619+00:00`
+- Queue snapshot generated: `2026-06-26T01:04:29.327488+00:00`
+- Proof snapshot generated: `2026-06-26T01:04:29.460768+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T00:13:14.301619+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=144.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=144.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=140.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=140.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-26T00:13:14.301619+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7084 |
-| Pending | 144 |
-| Ported | 439 |
-| Superseded | 6425 |
+| Total commits in queue | 7085 |
+| Pending | 140 |
+| Ported | 443 |
+| Superseded | 6426 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 144.0,
+        "actual": 140.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T00:13:14.301619+00:00",
+  "generated_at_utc": "2026-06-26T01:04:29.460768+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 144.0,
+    "max_queue_pending_commits": 140.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,12 +299,12 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 144,
-      "ported": 439,
-      "superseded": 6425
+      "pending": 140,
+      "ported": 443,
+      "superseded": 6426
     },
     "by_target_ticket": {
-      "20": 3182,
+      "20": 3183,
       "21": 130,
       "22": 959,
       "23": 488,
@@ -314,7 +314,7 @@
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7084
+    "total_commits": 7085
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 144.0,
+        "actual": 140.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T00:13:14.301619+00:00`
+Generated: `2026-06-26T01:04:29.460768+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T00:13:14.301619+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 144.0 |
+| `max_queue_pending_commits` | 140.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,9 +93,9 @@ Generated: `2026-06-26T00:13:14.301619+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7084`.
+- Upstream missing commits tracked: `7085`.
 - By target ticket:
-  - `#20`: `3182`
+  - `#20`: `3183`
   - `#21`: `130`
   - `#22`: `959`
   - `#23`: `488`

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4958,6 +4958,26 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Tooltip indentation and author-map formatting are desktop/metadata polish with no Rust runtime behavior to port."
+    },
+    "489b85ee1e2b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust DuckDuckGo web-search backend now applies a bounded wall-clock request timeout with DDG_SEARCH_TIMEOUT_SECONDS/HERMES_DDGS_TIMEOUT_SECONDS env knobs, minimum clamp, and slow-response timeout tests."
+    },
+    "4cdd1a3230b8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust project_facts records authoritative workspace metadata including detected root/cwd, manifests, package managers, verification commands, context files, and git branch/head/dirty status; exposed through tool and HTTP RPC tests."
+    },
+    "4e023f5bc990": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust HTTP project.tree RPC builds a deterministic bounded project tree from the detected workspace root, skips heavy dependency/build directories, reports truncation, and is covered by rpc_project_tree_returns_bounded_entries."
+    },
+    "4ffdedd369c1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust project workspace tools are first-class ToolHandler surfaces: project_facts and project_tree are registered in builtins, project/coding/main runtime toolsets, and covered by registry/toolset/unit tests."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,12 +1,12 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T00:13:14.170796+00:00`
+Generated: `2026-06-26T01:04:29.327488+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `7084`.
+- Range: `HEAD..upstream/main`; total commits tracked: `7085`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3182 |
+| #20 | GPAR-01 tests+CI parity | 3183 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 959 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
@@ -17,9 +17,9 @@ Generated: `2026-06-26T00:13:14.170796+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 144 |
-| ported | 439 |
-| superseded | 6425 |
+| pending | 140 |
+| ported | 443 |
+| superseded | 6426 |
 
 ## First 100 Pending Commits
 
@@ -115,7 +115,6 @@ Generated: `2026-06-26T00:13:14.170796+00:00`
 | `aab49f6927cc` | #20 | feat(pets): generation RPCs, non-blocking gallery + gateway plumbing |
 | `743985bf1ec4` | #26 | feat(pets): Pokédex generate UI — overlay, animated egg, hatch FX, manage |
 | `b674f7ba28c4` | #26 | feat(pets): offer backend setup when generation is unavailable |
-| `489b85ee1e2b` | #20 | fix(ddgs): bound DuckDuckGo search with a wall-clock timeout (#36776) |
 | `a268dfff0a05` | #26 | fix(desktop): make Agents indicator match the Spawn-tree panel |
 | `8d1706ae5cb2` | #26 | fix(desktop): wire Ctrl+B voice, declutter voice settings, stop endless TTS hang |
 | `2a75c4a8cb4a` | #26 | fix(desktop): give the gateway reconnect loop an escape hatch |
@@ -125,3 +124,4 @@ Generated: `2026-06-26T00:13:14.170796+00:00`
 | `cb6edbf448e7` | #26 | fix(desktop): skip the rev-list count when it is discarded anyway |
 | `65b13e9dbc93` | #26 | fix(desktop): route gateway restart / status / update to the active profile |
 | `00779800f650` | #26 | fix(desktop): hide platform/internal toolsets from the Skills & Tools list |
+| `9a4600c5fb9b` | #26 | fix(desktop): stop the update overlay looking frozen while it works |


### PR DESCRIPTION
## Summary
- add first-class Rust `project_facts` and `project_tree` tool handlers for workspace facts, git metadata, verification commands, context files, and bounded project trees
- expose project workspace tools through builtins plus project/coding/main runtime toolsets and HTTP `project.tree` RPC
- bound DuckDuckGo search requests with configurable wall-clock timeouts
- mark four upstream parity rows ported and regenerate parity queue/proof/dashboard

## Parity Delta
- pending: 144 -> 140
- ported: 439 -> 443
- mirrored: 76
- superseded: 6426

## Rows Closed
- `489b85ee1e2b` fix(ddgs): bound DuckDuckGo search with a wall-clock timeout (#36776)
- `4cdd1a3230b8` feat(sessions): record git workspace metadata
- `4e023f5bc990` feat(gateway): build authoritative project tree
- `4ffdedd369c1` feat(tools): add project workspace tools

## Verification
All cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0`.

- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `test ! -d target`
- OAuth/model diff guard: no touched auth/oauth/model/provider/openai/login/sign files; no added/removed `gpt-4o|4o|default_model|model:` matches in crates diff
- `cargo test -p hermes-tools project_workspace --lib`
- `cargo test -p hermes-tools duckduckgo --lib`
- `cargo test -p hermes-tools builtin_registry_registers_core_tool_surfaces_for_parity --lib`
- `cargo test -p hermes-tools test_coding_toolset_is_lean_pairing_surface --lib`
- `cargo test -p hermes-http rpc_project --test http_smoke`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-tools -p hermes-http` -> `seen=200 allowlist=200 new=0 stale=0`
