### PR TITLE
parity(runtime): harden gateway and MCP schemas

### DIFF
--- a/crates/hermes-agent/src/bedrock.rs
+++ b/crates/hermes-agent/src/bedrock.rs
@@ -2333,6 +2333,7 @@ mod tests {
                 properties: None,
                 required: None,
                 additional_properties: None,
+                defs: None,
             },
         )];
         let converted = convert_tools_to_bedrock(&tools);

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -33,7 +33,8 @@ pub use tool_schema::{tool_schema, JsonSchema, ToolSchema};
 
 // Re-export schema sanitizer helpers
 pub use schema_sanitizer::{
-    sanitize_tool_parameters, sanitize_tool_schemas, strip_pattern_and_format, strip_slash_enum,
+    normalize_schema_definitions_refs, sanitize_tool_parameters, sanitize_tool_schemas,
+    strip_pattern_and_format, strip_slash_enum,
 };
 
 // Re-export trait definitions

--- a/crates/hermes-core/src/schema_sanitizer.rs
+++ b/crates/hermes-core/src/schema_sanitizer.rs
@@ -20,6 +20,12 @@ pub fn sanitize_tool_parameters(params: &Value) -> Value {
     root
 }
 
+pub fn normalize_schema_definitions_refs(schema: &Value) -> Value {
+    let mut normalized = schema.clone();
+    normalize_schema_definitions_refs_node(&mut normalized);
+    normalized
+}
+
 pub fn strip_pattern_and_format(tools: Option<&mut Value>) -> usize {
     let Some(tools) = tools else {
         return 0;
@@ -40,6 +46,44 @@ pub fn strip_slash_enum(tools: Option<&mut Value>) -> usize {
         stripped += strip_slash_enum_in_schema(params);
     });
     stripped
+}
+
+fn normalize_schema_definitions_refs_node(node: &mut Value) {
+    match node {
+        Value::Object(obj) => {
+            if let Some(Value::String(reference)) = obj.get_mut("$ref") {
+                if let Some(tail) = reference.strip_prefix("#/definitions/") {
+                    *reference = format!("#/$defs/{tail}");
+                }
+            }
+
+            if let Some(definitions) = obj.remove("definitions") {
+                match obj.get_mut("$defs") {
+                    Some(Value::Object(existing)) => {
+                        if let Value::Object(incoming) = definitions {
+                            for (key, value) in incoming {
+                                existing.entry(key).or_insert(value);
+                            }
+                        }
+                    }
+                    Some(_) => {}
+                    None => {
+                        obj.insert("$defs".to_string(), definitions);
+                    }
+                }
+            }
+
+            for value in obj.values_mut() {
+                normalize_schema_definitions_refs_node(value);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                normalize_schema_definitions_refs_node(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn default_object_schema() -> Value {
@@ -468,6 +512,41 @@ mod tests {
     fn empty_and_none_tools_are_stable() {
         assert_eq!(sanitize_tool_schemas(Some(&json!([]))), Some(json!([])));
         assert_eq!(sanitize_tool_schemas(None), None);
+    }
+
+    #[test]
+    fn normalize_schema_definitions_refs_rewrites_draft7_refs() {
+        let normalized = normalize_schema_definitions_refs(&json!({
+            "type": "object",
+            "properties": {
+                "item": {"$ref": "#/definitions/Item"},
+                "items": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Item"}
+                }
+            },
+            "definitions": {
+                "Item": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                        "child": {"$ref": "#/definitions/Child"}
+                    }
+                },
+                "Child": {"type": "string"}
+            }
+        }));
+
+        assert!(normalized.get("definitions").is_none());
+        assert_eq!(normalized["properties"]["item"]["$ref"], "#/$defs/Item");
+        assert_eq!(
+            normalized["properties"]["items"]["items"]["$ref"],
+            "#/$defs/Item"
+        );
+        assert_eq!(
+            normalized["$defs"]["Item"]["properties"]["child"]["$ref"],
+            "#/$defs/Child"
+        );
     }
 
     #[test]

--- a/crates/hermes-core/src/tool_schema.rs
+++ b/crates/hermes-core/src/tool_schema.rs
@@ -15,6 +15,8 @@ pub struct JsonSchema {
         skip_serializing_if = "Option::is_none"
     )]
     pub additional_properties: Option<bool>,
+    #[serde(rename = "$defs", skip_serializing_if = "Option::is_none")]
+    pub defs: Option<IndexMap<String, serde_json::Value>>,
 }
 
 impl JsonSchema {
@@ -25,6 +27,7 @@ impl JsonSchema {
             properties: None,
             required: None,
             additional_properties: None,
+            defs: None,
         }
     }
 
@@ -35,6 +38,7 @@ impl JsonSchema {
             properties: Some(properties),
             required: Some(required),
             additional_properties: Some(false),
+            defs: None,
         }
     }
 }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -1377,8 +1377,30 @@ impl Gateway {
         let trimmed = input.trim();
         let mut parts = trimmed.splitn(2, char::is_whitespace);
         let cmd = parts.next().unwrap_or(trimmed).to_string();
-        let args = parts.next().unwrap_or_default().trim().to_string();
+        let args = Self::normalize_slash_command_arg_dashes(parts.next().unwrap_or_default())
+            .trim()
+            .to_string();
         (cmd, args)
+    }
+
+    fn normalize_slash_command_text(input: &str) -> String {
+        let (cmd, args) = Self::split_slash_command(input);
+        if args.is_empty() {
+            cmd
+        } else {
+            format!("{cmd} {args}")
+        }
+    }
+
+    fn normalize_slash_command_arg_dashes(args: &str) -> String {
+        let mut normalized = args.to_string();
+        for dash in ['\u{2012}', '\u{2013}', '\u{2014}', '\u{2015}', '\u{2212}'] {
+            normalized = normalized.replace(&format!("{dash}{dash}"), "--");
+        }
+        for dash in ['\u{2012}', '\u{2013}', '\u{2015}', '\u{2212}'] {
+            normalized = normalized.replace(dash, "-");
+        }
+        normalized.replace('\u{2014}', "--")
     }
 
     async fn run_quick_exec(
@@ -1562,17 +1584,18 @@ impl Gateway {
         incoming: &IncomingMessage,
         session_key: &str,
     ) -> Result<SlashCommandOutcome, GatewayError> {
-        if let Some(reply) = self.resolve_quick_command(&incoming.text).await? {
+        let command_text = Self::normalize_slash_command_text(&incoming.text);
+        if let Some(reply) = self.resolve_quick_command(&command_text).await? {
             self.send_message(&incoming.platform, &incoming.chat_id, &reply, None)
                 .await?;
             return Ok(SlashCommandOutcome::Handled);
         }
 
-        let result = handle_command(&incoming.text);
+        let result = handle_command(&command_text);
         if matches!(result, GatewayCommandResult::Unknown(_)) {
-            match self.resolve_skill_slash_command(&incoming.text) {
+            match self.resolve_skill_slash_command(&command_text) {
                 Ok(Some(message)) => {
-                    if let Some(command_name) = Self::extract_command_name(&incoming.text) {
+                    if let Some(command_name) = Self::extract_command_name(&command_text) {
                         self.emit_hook_event(
                             &format!("command:{}", command_name),
                             serde_json::json!({
@@ -1602,7 +1625,7 @@ impl Gateway {
             }
         }
         if !matches!(result, GatewayCommandResult::Unknown(_)) {
-            if let Some(command_name) = Self::extract_command_name(&incoming.text) {
+            if let Some(command_name) = Self::extract_command_name(&command_text) {
                 self.emit_hook_event(
                     &format!("command:{}", command_name),
                     serde_json::json!({
@@ -1626,7 +1649,7 @@ impl Gateway {
             SlashCommandOutcome::Handled
         } else {
             SlashCommandOutcome::ForwardToAgent {
-                message: incoming.text.clone(),
+                message: command_text,
             }
         })
     }
@@ -4179,6 +4202,23 @@ mod tests {
             .expect("alias reply");
 
         assert!(reply.contains("Status information"));
+    }
+
+    #[test]
+    fn split_slash_command_normalizes_ios_dashes_in_args_only() {
+        let (cmd, args) =
+            Gateway::split_slash_command("  /queue  deploy —fast ——dry-run –target prod ‒scope −1");
+
+        assert_eq!(cmd, "/queue");
+        assert_eq!(args, "deploy --fast --dry-run -target prod -scope -1");
+
+        let (cmd, args) = Gateway::split_slash_command("/model glm-5.2 —provider zai —session");
+        assert_eq!(cmd, "/model");
+        assert_eq!(args, "glm-5.2 --provider zai --session");
+        assert_eq!(
+            Gateway::normalize_slash_command_text(" /model glm-5.2 —provider zai —session "),
+            "/model glm-5.2 --provider zai --session"
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -14,7 +14,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::Engine as _;
-use hermes_core::{JsonSchema, ToolError, ToolHandler, ToolSchema};
+use hermes_core::{
+    normalize_schema_definitions_refs, JsonSchema, ToolError, ToolHandler, ToolSchema,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, info, warn};
@@ -507,13 +509,18 @@ struct McpToolDefinition {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(rename = "inputSchema")]
-    pub input_schema: JsonSchema,
+    pub input_schema: Value,
 }
 
 /// Response from tools/list method.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct ToolsListResponse {
     pub tools: Vec<McpToolDefinition>,
+}
+
+fn mcp_input_schema_to_json_schema(input_schema: Value) -> JsonSchema {
+    let normalized = normalize_schema_definitions_refs(&input_schema);
+    serde_json::from_value(normalized).unwrap_or_else(|_| JsonSchema::new("object"))
 }
 
 /// Response from resources/list method.
@@ -820,7 +827,7 @@ impl McpClient {
             .map(|t| ToolSchema {
                 name: t.name,
                 description: t.description.unwrap_or_default(),
-                parameters: t.input_schema,
+                parameters: mcp_input_schema_to_json_schema(t.input_schema),
             })
             .collect();
 
@@ -2471,9 +2478,9 @@ impl McpManager {
 mod tests {
     use super::{
         cache_mcp_image_block, is_stale_transport_error, mcp_call_timeout_duration,
-        mcp_keepalive_interval_duration, validate_mcp_server_config, LlmCallback, McpClient,
-        McpManager, McpServerConfig, SamplingConfig, DEFAULT_MCP_KEEPALIVE_INTERVAL_SECS,
-        MIN_MCP_KEEPALIVE_INTERVAL_SECS,
+        mcp_input_schema_to_json_schema, mcp_keepalive_interval_duration,
+        validate_mcp_server_config, LlmCallback, McpClient, McpManager, McpServerConfig,
+        SamplingConfig, DEFAULT_MCP_KEEPALIVE_INTERVAL_SECS, MIN_MCP_KEEPALIVE_INTERVAL_SECS,
     };
     use crate::transport::McpTransport;
     use crate::McpError;
@@ -2488,6 +2495,24 @@ mod tests {
         responses: VecDeque<serde_json::Value>,
         closed: Arc<AtomicBool>,
         sent: Arc<Mutex<Vec<serde_json::Value>>>,
+    }
+
+    #[test]
+    fn mcp_input_schema_normalizes_draft7_definitions() {
+        let schema = mcp_input_schema_to_json_schema(json!({
+            "type": "object",
+            "properties": {
+                "item": {"$ref": "#/definitions/Item"}
+            },
+            "definitions": {
+                "Item": {"type": "string"}
+            }
+        }));
+        let rendered = serde_json::to_value(schema).expect("schema json");
+
+        assert!(rendered.get("definitions").is_none());
+        assert_eq!(rendered["properties"]["item"]["$ref"], "#/$defs/Item");
+        assert_eq!(rendered["$defs"]["Item"]["type"], "string");
     }
 
     impl FakeTransport {

--- a/crates/hermes-mcp/src/server.rs
+++ b/crates/hermes-mcp/src/server.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
-use hermes_core::ToolSchema;
+use hermes_core::{normalize_schema_definitions_refs, ToolSchema};
 use hermes_tools::ToolRegistry;
 
 use crate::client::ResourceInfo;
@@ -155,6 +155,7 @@ impl McpServer {
         // Convert hermes-core JsonSchema to a JSON Value for MCP
         let input_schema = serde_json::to_value(&schema.parameters)
             .unwrap_or_else(|_| serde_json::json!({"type": "object"}));
+        let input_schema = normalize_schema_definitions_refs(&input_schema);
 
         McpToolInfo {
             name: schema.name.clone(),
@@ -485,7 +486,7 @@ mod tests {
     use crate::client::ResourceInfo;
     use crate::coerce_mcp_tool_arguments_for_schema;
     use async_trait::async_trait;
-    use hermes_core::{tool_schema, ToolError, ToolHandler, ToolSchema};
+    use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
     use hermes_tools::ToolRegistry;
     use serde_json::{json, Value};
     use std::sync::Arc;
@@ -559,6 +560,33 @@ mod tests {
             None,
         );
         Arc::new(registry)
+    }
+
+    #[test]
+    fn tool_schema_to_mcp_preserves_normalized_defs() {
+        let schema = ToolSchema::new(
+            "with_defs",
+            "Schema with defs",
+            serde_json::from_value::<JsonSchema>(json!({
+                "type": "object",
+                "properties": {
+                    "item": {"$ref": "#/definitions/Item"}
+                },
+                "$defs": {
+                    "Item": {"type": "string"}
+                }
+            }))
+            .expect("schema"),
+        );
+
+        let mcp = McpServer::tool_schema_to_mcp(&schema);
+
+        assert_eq!(
+            mcp.input_schema["properties"]["item"]["$ref"],
+            "#/$defs/Item"
+        );
+        assert_eq!(mcp.input_schema["$defs"]["Item"]["type"], "string");
+        assert!(mcp.input_schema.get("definitions").is_none());
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T01:04:29.460768+00:00`_
+_Generated from source artifacts: `2026-06-26T02:09:56.508501+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T01:04:29.327488+00:00`
-- Proof snapshot generated: `2026-06-26T01:04:29.460768+00:00`
+- Queue snapshot generated: `2026-06-26T02:09:56.382205+00:00`
+- Proof snapshot generated: `2026-06-26T02:09:56.508501+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T01:04:29.460768+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=140.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=140.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=147.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=147.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,9 +74,9 @@ _Generated from source artifacts: `2026-06-26T01:04:29.460768+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7085 |
-| Pending | 140 |
-| Ported | 443 |
+| Total commits in queue | 7099 |
+| Pending | 147 |
+| Ported | 450 |
 | Superseded | 6426 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 140.0,
+        "actual": 147.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T01:04:29.460768+00:00",
+  "generated_at_utc": "2026-06-26T02:09:56.508501+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 140.0,
+    "max_queue_pending_commits": 147.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,22 +299,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 140,
-      "ported": 443,
+      "pending": 147,
+      "ported": 450,
       "superseded": 6426
     },
     "by_target_ticket": {
-      "20": 3183,
+      "20": 3189,
       "21": 130,
-      "22": 959,
+      "22": 960,
       "23": 488,
       "24": 23,
       "25": 146,
-      "26": 2156
+      "26": 2163
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7085
+    "total_commits": 7099
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 140.0,
+        "actual": 147.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T01:04:29.460768+00:00`
+Generated: `2026-06-26T02:09:56.508501+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T01:04:29.460768+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 140.0 |
+| `max_queue_pending_commits` | 147.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-26T01:04:29.460768+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7085`.
+- Upstream missing commits tracked: `7099`.
 - By target ticket:
-  - `#20`: `3183`
+  - `#20`: `3189`
   - `#21`: `130`
-  - `#22`: `959`
+  - `#22`: `960`
   - `#23`: `488`
   - `#24`: `23`
   - `#25`: `146`
-  - `#26`: `2156`
+  - `#26`: `2163`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -4978,6 +4978,41 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust project workspace tools are first-class ToolHandler surfaces: project_facts and project_tree are registered in builtins, project/coding/main runtime toolsets, and covered by registry/toolset/unit tests."
+    },
+    "2f48c58b85b8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust gateway now normalizes iOS/mobile Unicode dash variants at the slash-argument boundary for quick, builtin, and skill slash routing; existing /model parser Unicode-dash coverage remains green."
+    },
+    "f5af6520d0bf": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust ToolCall includes extra_content and OpenAI-compatible response parsing preserves Gemini thought_signature payloads; provider test_parse_openai_response_with_tool_call_extra_content covers the behavior."
+    },
+    "1dfcda4e3c19": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust approval guard includes env/config overwrite detection for redirection, tee, and copy/move/install paths; test_sensitive_write_patterns_require_confirmation covers the guard."
+    },
+    "b848ce2c79bf": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust approval regexes cover absolute and project env/config writes, including absolute .env targets, with test_sensitive_write_patterns_require_confirmation exercising those cases."
+    },
+    "4a0c02b7dcb0": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust file tools resolve bookkeeping paths against live terminal cwd before TERMINAL_CWD/process cwd; resolve_tool_path_prefers_live_cwd_then_terminal_cwd covers the behavior."
+    },
+    "24f139e16a6f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust MCP schema handling normalizes draft-07 definitions to $defs and rewrites #/definitions refs at client intake and server export, with core/client/server tests."
+    },
+    "3ccda2aa059f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust MCP HTTP and SSE transports seed MCP-Protocol-Version before initialize; transport tests cover both request builders."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,24 +1,24 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T01:04:29.327488+00:00`
+Generated: `2026-06-26T02:09:56.382205+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `7085`.
+- Range: `HEAD..upstream/main`; total commits tracked: `7099`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3183 |
+| #20 | GPAR-01 tests+CI parity | 3189 |
 | #21 | GPAR-02 skills parity | 130 |
-| #22 | GPAR-03 UX parity | 959 |
+| #22 | GPAR-03 UX parity | 960 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 23 |
 | #25 | GPAR-06 packaging/docs/install parity | 146 |
-| #26 | GPAR-07 upstream queue backfill | 2156 |
+| #26 | GPAR-07 upstream queue backfill | 2163 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 140 |
-| ported | 443 |
+| pending | 147 |
+| ported | 450 |
 | superseded | 6426 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- Normalize mobile/iOS Unicode dash variants for gateway slash-command arguments before quick, built-in, skill, hook, and agent-forward routing.
- Preserve/normalize MCP JSON Schema definitions by supporting `$defs` in `JsonSchema`, migrating draft-07 `definitions`, and rewriting `#/definitions/...` refs at MCP client intake and server export.
- Close verified runtime parity rows for existing ToolCall extra content, approval env/config overwrite guards, file live-cwd path resolution, MCP protocol headers, and the new gateway/MCP schema work.

## Parity
- Added queue overrides: `2f48c58b85b8`, `f5af6520d0bf`, `1dfcda4e3c19`, `b848ce2c79bf`, `4a0c02b7dcb0`, `24f139e16a6f`, `3ccda2aa059f`.
- Regenerated queue/proof/dashboard.
- Upstream inflow moved tracked commits to `7099`; current summary is `mirrored=76`, `pending=147`, `ported=450`, `superseded=6426`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-gateway split_slash_command_normalizes_ios_dashes_in_args_only --lib`
- `cargo test -p hermes-gateway test_model_switch_parses_scope_provider_and_unicode_dashes --lib`
- `cargo test -p hermes-core normalize_schema_definitions_refs_rewrites_draft7_refs --lib`
- `cargo test -p hermes-mcp mcp_input_schema_normalizes_draft7_definitions --lib`
- `cargo test -p hermes-mcp tool_schema_to_mcp_preserves_normalized_defs --lib`
- `cargo test -p hermes-mcp test_http_transport_seeds_protocol_header --lib`
- `cargo test -p hermes-mcp test_http_sse_transport_seeds_protocol_header --lib`
- `cargo test -p hermes-agent test_parse_openai_response_with_tool_call_extra_content --lib`
- `cargo test -p hermes-tools test_sensitive_write_patterns_require_confirmation --lib`
- `cargo test -p hermes-tools resolve_tool_path_prefers_live_cwd_then_terminal_cwd --lib`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-core -p hermes-gateway -p hermes-mcp -p hermes-agent` (`seen=200 allowlist=200 new=0 stale=0`)

## Guards
- All Rust build artifacts use `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets`; repo-local `target` is absent.
- OAuth/sign-in/model default guard clean: no auth/oauth/login/model-switch/provider/openai files touched, and no `gpt-4o`/`4o` default-model diff in `crates`.
