### PR TITLE
parity(runtime): prefer managed node commands

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -82,7 +82,7 @@ use crate::model_switch::{
 use crate::pairing_store::{PairingStatus, PairingStore};
 use crate::providers::canonical_provider_id;
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
-use hermes_config::{GatewayConfig, LlmProviderConfig};
+use hermes_config::{find_node_executable, GatewayConfig, LlmProviderConfig};
 
 // ---------------------------------------------------------------------------
 // CommandResult
@@ -26130,6 +26130,9 @@ fn command_on_path(command: &str) -> bool {
     if command.trim().is_empty() {
         return false;
     }
+    if is_node_family_command(command) && find_node_executable(command).is_some() {
+        return true;
+    }
     let candidate = Path::new(command);
     if candidate.components().count() > 1 {
         return candidate.exists();
@@ -26139,6 +26142,19 @@ fn command_on_path(command: &str) -> bool {
             .map(|p| p.join(command))
             .any(|p| p.exists())
     })
+}
+
+fn is_node_family_command(command: &str) -> bool {
+    let base = command
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(command)
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        base.as_str(),
+        "node" | "node.exe" | "npm" | "npm.cmd" | "npm.exe" | "npx" | "npx.cmd" | "npx.exe"
+    )
 }
 
 fn sentrux_entry() -> serde_json::Value {
@@ -27224,16 +27240,35 @@ async fn whatsapp_qr() -> Result<(), hermes_core::AgentError> {
                 "Bridge returned HTTP {}. Is the bridge server running?",
                 resp.status()
             );
-            println!("Start it with: npx hermes-whatsapp-bridge");
+            println!("Start it with: {}", whatsapp_bridge_start_command());
         }
         Err(e) => {
             println!("Could not connect to bridge at {}: {}", bridge_url, e);
             println!("\nMake sure the WhatsApp Web bridge is running:");
-            println!("  npx hermes-whatsapp-bridge");
+            println!("  {}", whatsapp_bridge_start_command());
             println!("  # or: docker run -p 3000:3000 hermes/whatsapp-bridge");
         }
     }
     Ok(())
+}
+
+fn whatsapp_bridge_start_command() -> String {
+    find_node_executable("npx")
+        .map(|path| format!("{} hermes-whatsapp-bridge", quote_shell_arg(&path)))
+        .unwrap_or_else(|| "npx hermes-whatsapp-bridge".to_string())
+}
+
+fn quote_shell_arg(path: &Path) -> String {
+    let value = path.display().to_string();
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "@%_+=:,./-\\".contains(c))
+    {
+        value
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 /// Render QR data as Unicode block art in the terminal.
@@ -28034,13 +28069,7 @@ struct AcpSetupDependencyCheck {
 }
 
 fn acp_command_exists(command: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(command)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+    command_on_path(command)
 }
 
 fn acp_setup_browser_dependency_checks<F>(
@@ -28568,6 +28597,17 @@ mod tests {
                 Some(value) => std::env::set_var(self.key, value),
                 None => std::env::remove_var(self.key),
             }
+        }
+    }
+
+    fn write_test_executable(path: &Path) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(path, b"#!/bin/sh\n").expect("write executable");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod executable");
         }
     }
 
@@ -30134,6 +30174,33 @@ mod tests {
         assert_eq!(checks[1].dependency, "browser");
         assert!(checks.iter().all(|check| check.available));
         assert!(checks.iter().all(|check| !check.interactive));
+    }
+
+    #[test]
+    fn command_on_path_prefers_managed_node_before_path() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let _path_guard = EnvVarGuard::set("PATH", "");
+        write_test_executable(&tmp.path().join("node").join("bin").join("node"));
+
+        assert!(command_on_path("node"));
+    }
+
+    #[test]
+    fn whatsapp_bridge_start_command_prefers_managed_npx() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let _path_guard = EnvVarGuard::set("PATH", "");
+        let npx = tmp.path().join("node").join("bin").join("npx");
+        write_test_executable(&npx);
+
+        let command = whatsapp_bridge_start_command();
+
+        assert_ne!(command, "npx hermes-whatsapp-bridge");
+        assert!(command.contains("npx"));
+        assert!(command.contains("hermes-whatsapp-bridge"));
     }
 
     #[test]

--- a/crates/hermes-config/src/lib.rs
+++ b/crates/hermes-config/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod config;
 pub mod loader;
 pub mod managed_gateway;
+pub mod managed_node;
 pub mod merge;
 pub mod paths;
 pub mod platform;
@@ -44,6 +45,11 @@ pub use managed_gateway::{
     resolve_openai_audio_api_key, GatewayBuilder, GatewaySchemeError, ManagedToolGatewayConfig,
     ModalBackendState, ModalMode, NousProviderState, ResolveOptions, SelectedBackend, TokenReader,
     DEFAULT_TOOL_GATEWAY_DOMAIN,
+};
+pub use managed_node::{
+    find_hermes_node_executable, find_hermes_node_executable_in, find_node_executable,
+    iter_hermes_node_dirs, iter_hermes_node_dirs_in, with_hermes_node_path_var,
+    with_hermes_node_path_var_for_home,
 };
 pub use merge::{deep_merge, merge_configs};
 pub use paths::{

--- a/crates/hermes-config/src/managed_node.rs
+++ b/crates/hermes-config/src/managed_node.rs
@@ -1,0 +1,253 @@
+//! Hermes-managed Node.js resolver.
+//!
+//! Upstream Python prefers a Hermes-managed portable Node/npm before PATH so
+//! Windows installs are not broken by an elevation-triggering or stale system
+//! Node. Keep this Rust helper in `hermes-config` so CLI, gateway, and tools
+//! can share the same lookup and PATH-prepend rules.
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::paths::hermes_home;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodePlatform {
+    Windows,
+    Posix,
+}
+
+impl NodePlatform {
+    fn current() -> Self {
+        if cfg!(windows) {
+            Self::Windows
+        } else {
+            Self::Posix
+        }
+    }
+}
+
+/// Return Hermes-managed Node.js directories in preferred lookup order.
+///
+/// Windows portable installs unpack directly into `<HERMES_HOME>/node`; POSIX
+/// installs usually expose binaries under `<HERMES_HOME>/node/bin`. Include
+/// both shapes on every platform so migrated installs keep working.
+pub fn iter_hermes_node_dirs() -> Vec<PathBuf> {
+    iter_hermes_node_dirs_in(hermes_home())
+}
+
+/// Return managed Node lookup directories for an explicit Hermes home.
+pub fn iter_hermes_node_dirs_in(home: impl AsRef<Path>) -> Vec<PathBuf> {
+    iter_hermes_node_dirs_for_platform(home.as_ref(), NodePlatform::current())
+}
+
+fn iter_hermes_node_dirs_for_platform(home: &Path, platform: NodePlatform) -> Vec<PathBuf> {
+    let node_dir = home.join("node");
+    let bin_dir = node_dir.join("bin");
+    match platform {
+        NodePlatform::Windows => vec![node_dir, bin_dir],
+        NodePlatform::Posix => vec![bin_dir, node_dir],
+    }
+}
+
+/// Return a Hermes-managed Node/npm executable path, if installed.
+pub fn find_hermes_node_executable(command: &str) -> Option<PathBuf> {
+    find_hermes_node_executable_in(command, hermes_home())
+}
+
+/// Return a Hermes-managed Node/npm executable path under an explicit home.
+pub fn find_hermes_node_executable_in(command: &str, home: impl AsRef<Path>) -> Option<PathBuf> {
+    find_hermes_node_executable_for_platform(command, home.as_ref(), NodePlatform::current())
+}
+
+fn find_hermes_node_executable_for_platform(
+    command: &str,
+    home: &Path,
+    platform: NodePlatform,
+) -> Option<PathBuf> {
+    let names = candidate_node_command_names_for_platform(command, platform);
+    for directory in iter_hermes_node_dirs_for_platform(home, platform) {
+        for name in &names {
+            let candidate = directory.join(name);
+            if executable_candidate_exists_for_platform(&candidate, platform) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a Node.js command, preferring Hermes-managed installs before PATH.
+pub fn find_node_executable(command: &str) -> Option<PathBuf> {
+    find_hermes_node_executable(command).or_else(|| find_node_executable_on_path(command))
+}
+
+fn find_node_executable_on_path(command: &str) -> Option<PathBuf> {
+    let command = command.trim();
+    if command.is_empty() {
+        return None;
+    }
+    let command_path = Path::new(command);
+    if command_path.components().count() > 1 || command_path.is_absolute() {
+        return executable_candidate_exists_for_platform(command_path, NodePlatform::current())
+            .then(|| command_path.to_path_buf());
+    }
+
+    let names = candidate_node_command_names_for_platform(command, NodePlatform::current());
+    let paths = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&paths) {
+        for name in &names {
+            let candidate = dir.join(name);
+            if executable_candidate_exists_for_platform(&candidate, NodePlatform::current()) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Return PATH with existing Hermes-managed Node directories prepended.
+pub fn with_hermes_node_path_var(existing_path: Option<OsString>) -> OsString {
+    with_hermes_node_path_var_for_home(existing_path, hermes_home())
+}
+
+/// Return PATH with explicit-home managed Node directories prepended.
+pub fn with_hermes_node_path_var_for_home(
+    existing_path: Option<OsString>,
+    home: impl AsRef<Path>,
+) -> OsString {
+    let existing_dirs: Vec<PathBuf> = existing_path
+        .as_ref()
+        .map(std::env::split_paths)
+        .into_iter()
+        .flatten()
+        .filter(|path| !path.as_os_str().is_empty())
+        .collect();
+    let mut seen: HashSet<OsString> = existing_dirs
+        .iter()
+        .map(|path| path.as_os_str().to_os_string())
+        .collect();
+    let mut merged = Vec::new();
+    for dir in iter_hermes_node_dirs_in(home) {
+        if dir.is_dir() && seen.insert(dir.as_os_str().to_os_string()) {
+            merged.push(dir);
+        }
+    }
+    merged.extend(existing_dirs);
+    std::env::join_paths(merged).unwrap_or_default()
+}
+
+fn candidate_node_command_names_for_platform(command: &str, platform: NodePlatform) -> Vec<String> {
+    let base = command.rsplit(['/', '\\']).next().unwrap_or(command).trim();
+    if base.is_empty() {
+        return Vec::new();
+    }
+    if platform != NodePlatform::Windows || base.contains('.') {
+        return vec![base.to_string()];
+    }
+    match base.to_ascii_lowercase().as_str() {
+        "npm" => vec!["npm.cmd".into(), "npm.exe".into(), "npm".into()],
+        "npx" => vec!["npx.cmd".into(), "npx.exe".into(), "npx".into()],
+        "node" => vec!["node.exe".into(), "node".into()],
+        _ => vec![
+            format!("{base}.cmd"),
+            format!("{base}.exe"),
+            base.to_string(),
+        ],
+    }
+}
+
+fn executable_candidate_exists_for_platform(path: &Path, platform: NodePlatform) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    if platform == NodePlatform::Windows {
+        return true;
+    }
+    is_unix_executable(path)
+}
+
+#[cfg(unix)]
+fn is_unix_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|meta| meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_unix_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path, executable: bool) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(path, b"#!/bin/sh\n").expect("write");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = if executable { 0o755 } else { 0o644 };
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = executable;
+        }
+    }
+
+    #[test]
+    fn windows_prefers_root_node_and_cmd_shims() {
+        let tmp = tempdir().expect("tempdir");
+        let root_npm = tmp.path().join("node").join("npm.cmd");
+        let bin_npm = tmp.path().join("node").join("bin").join("npm.exe");
+        touch(&root_npm, false);
+        touch(&bin_npm, false);
+
+        let resolved =
+            find_hermes_node_executable_for_platform("npm", tmp.path(), NodePlatform::Windows)
+                .expect("npm");
+
+        assert_eq!(resolved, root_npm);
+        assert_eq!(
+            candidate_node_command_names_for_platform("npx", NodePlatform::Windows),
+            vec!["npx.cmd", "npx.exe", "npx"]
+        );
+    }
+
+    #[test]
+    fn posix_prefers_bin_and_requires_executable_bit() {
+        let tmp = tempdir().expect("tempdir");
+        let root_node = tmp.path().join("node").join("node");
+        let bin_node = tmp.path().join("node").join("bin").join("node");
+        touch(&root_node, true);
+        touch(&bin_node, false);
+
+        let resolved =
+            find_hermes_node_executable_for_platform("node", tmp.path(), NodePlatform::Posix)
+                .expect("node");
+
+        assert_eq!(resolved, root_node);
+    }
+
+    #[test]
+    fn path_var_prepends_existing_managed_dirs_without_duplicates() {
+        let tmp = tempdir().expect("tempdir");
+        let node_dir = tmp.path().join("node");
+        let bin_dir = node_dir.join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("mkdir");
+        let existing =
+            std::env::join_paths([bin_dir.clone(), PathBuf::from("/usr/bin")]).expect("join");
+
+        let merged = with_hermes_node_path_var_for_home(Some(existing), tmp.path());
+        let parts: Vec<PathBuf> = std::env::split_paths(&merged).collect();
+
+        assert_eq!(parts[0], node_dir);
+        assert_eq!(parts[1], bin_dir);
+        assert_eq!(parts[2], PathBuf::from("/usr/bin"));
+    }
+}

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T02:09:56.508501+00:00`_
+_Generated from source artifacts: `2026-06-26T03:15:26.858931+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T02:09:56.382205+00:00`
-- Proof snapshot generated: `2026-06-26T02:09:56.508501+00:00`
+- Queue snapshot generated: `2026-06-26T03:15:26.708571+00:00`
+- Proof snapshot generated: `2026-06-26T03:15:26.858931+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T02:09:56.508501+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=147.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=147.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=146.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=146.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-26T02:09:56.508501+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7099 |
-| Pending | 147 |
-| Ported | 450 |
-| Superseded | 6426 |
+| Total commits in queue | 7101 |
+| Pending | 146 |
+| Ported | 452 |
+| Superseded | 6427 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 147.0,
+        "actual": 146.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T02:09:56.508501+00:00",
+  "generated_at_utc": "2026-06-26T03:15:26.858931+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 147.0,
+    "max_queue_pending_commits": 146.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,12 +299,12 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 147,
-      "ported": 450,
-      "superseded": 6426
+      "pending": 146,
+      "ported": 452,
+      "superseded": 6427
     },
     "by_target_ticket": {
-      "20": 3189,
+      "20": 3191,
       "21": 130,
       "22": 960,
       "23": 488,
@@ -314,7 +314,7 @@
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7099
+    "total_commits": 7101
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 147.0,
+        "actual": 146.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T02:09:56.508501+00:00`
+Generated: `2026-06-26T03:15:26.858931+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T02:09:56.508501+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 147.0 |
+| `max_queue_pending_commits` | 146.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,9 +93,9 @@ Generated: `2026-06-26T02:09:56.508501+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7099`.
+- Upstream missing commits tracked: `7101`.
 - By target ticket:
-  - `#20`: `3189`
+  - `#20`: `3191`
   - `#21`: `130`
   - `#22`: `960`
   - `#23`: `488`

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5013,6 +5013,16 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust MCP HTTP and SSE transports seed MCP-Protocol-Version before initialize; transport tests cover both request builders."
+    },
+    "7a7b56d49830": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust hermes-config exposes a managed Node/npm/npx resolver that prefers Hermes-managed portable Node before PATH, and CLI dependency checks plus WhatsApp bridge-start guidance use it; managed-node and CLI tests cover the behavior."
+    },
+    "d4e7dd609da6": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust managed-node resolver computes candidate command names once, mirrors platform-specific node/bin ordering, and prepends existing managed Node dirs without duplicate PATH entries; tests cover Windows and POSIX ordering."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,12 +1,12 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T02:09:56.382205+00:00`
+Generated: `2026-06-26T03:15:26.708571+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `7099`.
+- Range: `HEAD..upstream/main`; total commits tracked: `7101`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3189 |
+| #20 | GPAR-01 tests+CI parity | 3191 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 960 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
@@ -17,9 +17,9 @@ Generated: `2026-06-26T02:09:56.382205+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 147 |
-| ported | 450 |
-| superseded | 6426 |
+| pending | 146 |
+| ported | 452 |
+| superseded | 6427 |
 
 ## First 100 Pending Commits
 
@@ -32,8 +32,6 @@ Generated: `2026-06-26T02:09:56.382205+00:00`
 | `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
 | `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |
 | `866f1d65c4aa` | #26 | chore(desktop): sync package.json version fallback to 0.17.0 (#49236) |
-| `7a7b56d49830` | #23 | fix(windows): prefer managed node for whatsapp and desktop |
-| `d4e7dd609da6` | #23 | refactor(windows): tidy managed-node resolver helpers |
 | `d799284b1554` | #21 | feat(optional-skills/creative-ideation): expand to v2.1.0 method library (#42402) |
 | `37fa3c58b40e` | #21 | docs(kanban-worker): document kanban_complete artifacts deliverable param (#49854) |
 | `31bdb60013c9` | #22 | docs(skills): fix himalaya CLI arg order and download flag |
@@ -125,3 +123,5 @@ Generated: `2026-06-26T02:09:56.382205+00:00`
 | `65b13e9dbc93` | #26 | fix(desktop): route gateway restart / status / update to the active profile |
 | `00779800f650` | #26 | fix(desktop): hide platform/internal toolsets from the Skills & Tools list |
 | `9a4600c5fb9b` | #26 | fix(desktop): stop the update overlay looking frozen while it works |
+| `2ea94c6c4581` | #26 | fix(pets): make inline generate cancel discard draft flow |
+| `284be6cc247c` | #26 | Merge pull request #52210 from helix4u/fix/desktop-update-progress-visibility |


### PR DESCRIPTION
## Summary
- Add a Rust-native Hermes-managed Node/npm/npx resolver in `hermes-config`.
- Prefer Hermes-managed portable Node before PATH for CLI dependency checks and WhatsApp bridge-start guidance.
- Mirror upstream Windows/POSIX lookup ordering, Windows `.cmd` shim preference, POSIX executable-bit checks, and PATH-prepend behavior without duplicates.

## Parity
- Marked upstream commits `7a7b56d49830` and `d4e7dd609da6` as ported.
- Regenerated queue/proof/dashboard.
- Current queue summary: `mirrored=76`, `pending=146`, `ported=452`, `superseded=6427`, `total_commits=7101`.
- Note: upstream inflow added two tracked commits during regeneration, so pending moved `147 -> 146` net despite two new ported overrides.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `cargo test -p hermes-config managed_node --lib` (`3 passed`)
- `cargo test -p hermes-cli command_on_path_prefers_managed_node_before_path --lib`
- `cargo test -p hermes-cli whatsapp_bridge_start_command_prefers_managed_npx --lib`
- `cargo test -p hermes-cli test_acp_setup_browser_dependency_checks_forward_yes_flag --lib`
- `scripts/clippy-warning-gate.sh --check -- -p hermes-config -p hermes-cli` (`seen=200 allowlist=200 new=0 stale=0`)

## Guards
- All Rust build artifacts use `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets`; repo-local `target` is absent.
- OAuth/sign-in/model-default guard clean: no auth/oauth/login/model-switch/provider/openai files touched, and no `gpt-4o`/`4o` default-model diff in `crates`.
