### PR TITLE
parity(ui): compact tool previews

### DIFF
--- a/crates/hermes-cli-ui/src/lib.rs
+++ b/crates/hermes-cli-ui/src/lib.rs
@@ -261,7 +261,7 @@ fn command_catalog_matches_filter(command: &str, description: &str, query: &str)
     }
     let cmd = command.to_ascii_lowercase();
     let desc = description.to_ascii_lowercase();
-    cmd.contains(&q) || desc.contains(&q.trim_start_matches('/'))
+    cmd.contains(&q) || desc.contains(q.trim_start_matches('/'))
 }
 
 fn command_match_score(query: &str, cmd: &str, desc: &str) -> Option<i32> {

--- a/crates/hermes-cli-ui/src/tool_preview.rs
+++ b/crates/hermes-cli-ui/src/tool_preview.rs
@@ -1,12 +1,317 @@
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 fn truncate_chars(input: &str, max_len: usize) -> String {
-    if input.chars().count() <= max_len {
+    if max_len == 0 || input.chars().count() <= max_len {
         return input.to_string();
     }
     let mut out: String = input.chars().take(max_len.saturating_sub(3)).collect();
     out.push_str("...");
     out
+}
+
+fn oneline(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn shell_basename(head: &str) -> &str {
+    head.rsplit_once('/').map(|(_, tail)| tail).unwrap_or(head)
+}
+
+fn is_shell_silent_head(head: &str) -> bool {
+    matches!(
+        head,
+        "cd" | "pushd"
+            | "popd"
+            | "export"
+            | "set"
+            | "unset"
+            | "source"
+            | "."
+            | "true"
+            | "false"
+            | ":"
+    )
+}
+
+fn is_shell_pipe_tail_head(head: &str) -> bool {
+    matches!(head, "head" | "tail" | "wc" | "sort" | "uniq")
+}
+
+fn is_env_assignment(word: &str) -> bool {
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('_') | Some('A'..='Z') | Some('a'..='z'))
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn split_shell_words(segment: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut buf = String::new();
+    let mut quote: Option<char> = None;
+    let mut prev = '\0';
+
+    for ch in segment.chars() {
+        if let Some(active_quote) = quote {
+            buf.push(ch);
+            if ch == active_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        if matches!(ch, '\'' | '"') {
+            quote = Some(ch);
+            buf.push(ch);
+        } else if ch.is_whitespace() {
+            if !buf.is_empty() {
+                words.push(std::mem::take(&mut buf));
+            }
+        } else {
+            buf.push(ch);
+        }
+        prev = ch;
+    }
+
+    if !buf.is_empty() {
+        words.push(buf);
+    }
+    words
+}
+
+fn strip_shell_pipe_tail(segment: &str) -> String {
+    let words = split_shell_words(segment);
+    let mut out = Vec::new();
+
+    for (index, word) in words.iter().enumerate() {
+        if word == "|"
+            && words
+                .get(index + 1)
+                .map(|head| is_shell_pipe_tail_head(shell_basename(head)))
+                .unwrap_or(false)
+        {
+            break;
+        }
+        out.push(word.as_str());
+    }
+
+    out.join(" ").trim().to_string()
+}
+
+fn split_shell_compound(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut buf = String::new();
+    let mut quote: Option<char> = None;
+    let mut prev = '\0';
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if let Some(active_quote) = quote {
+            buf.push(ch);
+            if ch == active_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        if matches!(ch, '\'' | '"') {
+            quote = Some(ch);
+            buf.push(ch);
+            prev = ch;
+            continue;
+        }
+
+        let compound_separator = match ch {
+            '&' if chars.peek() == Some(&'&') => {
+                chars.next();
+                true
+            }
+            '|' if chars.peek() == Some(&'|') => {
+                chars.next();
+                true
+            }
+            ';' | '\n' => true,
+            _ => false,
+        };
+
+        if compound_separator {
+            let segment = strip_shell_pipe_tail(buf.trim());
+            if !segment.is_empty() {
+                segments.push(segment);
+            }
+            buf.clear();
+        } else {
+            buf.push(ch);
+        }
+        prev = ch;
+    }
+
+    let segment = strip_shell_pipe_tail(buf.trim());
+    if !segment.is_empty() {
+        segments.push(segment);
+    }
+    segments
+}
+
+fn shell_head_word(segment: &str) -> String {
+    split_shell_words(segment)
+        .into_iter()
+        .find(|word| !is_env_assignment(word))
+        .map(|word| shell_basename(&word).to_string())
+        .unwrap_or_default()
+}
+
+fn is_redirect_operator(word: &str) -> bool {
+    let stripped = word.trim_start_matches(|ch: char| ch.is_ascii_digit());
+    matches!(stripped, ">" | ">>" | "<")
+}
+
+fn is_redirect_dup(word: &str) -> bool {
+    let stripped = word.trim_start_matches(|ch: char| ch.is_ascii_digit());
+    let Some((op, fd)) = stripped.split_once('&') else {
+        return false;
+    };
+    matches!(op, ">" | "<") && fd.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn clean_shell_segment(segment: &str) -> String {
+    let words = split_shell_words(segment);
+    let mut out = Vec::new();
+    let mut index = 0;
+
+    while index < words.len() {
+        let word = &words[index];
+        if is_redirect_operator(word) {
+            index += 2;
+            continue;
+        }
+        if is_redirect_dup(word) {
+            index += 1;
+            continue;
+        }
+        out.push(word.as_str());
+        index += 1;
+    }
+
+    out.join(" ").trim().to_string()
+}
+
+fn is_shell_boundary_echo(segment: &str) -> bool {
+    let words = split_shell_words(segment);
+    if words
+        .first()
+        .map(|word| shell_basename(word) == "echo")
+        .unwrap_or(false)
+    {
+        let rest = words
+            .iter()
+            .skip(1)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(" ");
+        return rest.contains("--")
+            || rest.contains("_exit=")
+            || rest.contains("exit=")
+            || rest.contains("$?")
+            || rest.contains("${PIPESTATUS")
+            || rest.contains("PIPESTATUS");
+    }
+    false
+}
+
+fn summarize_shell_command(command: &str) -> String {
+    let original = oneline(command);
+    if original.is_empty() {
+        return String::new();
+    }
+
+    let segments = split_shell_compound(&original);
+    if segments.len() <= 1 {
+        let cleaned =
+            clean_shell_segment(segments.first().map(String::as_str).unwrap_or(&original));
+        return if cleaned.is_empty() {
+            original
+        } else {
+            cleaned
+        };
+    }
+
+    let core = segments
+        .iter()
+        .filter_map(|segment| {
+            let cleaned = clean_shell_segment(segment);
+            let head = shell_head_word(&cleaned);
+            if cleaned.is_empty() || is_shell_silent_head(&head) || is_shell_boundary_echo(&cleaned)
+            {
+                None
+            } else {
+                Some(cleaned)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    match core.as_slice() {
+        [] => original,
+        [single] => single.clone(),
+        [first, rest @ ..] => format!(
+            "{} + {} {}",
+            first,
+            rest.len(),
+            if rest.len() == 1 {
+                "command"
+            } else {
+                "commands"
+            }
+        ),
+    }
+}
+
+fn path_basename(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    normalized
+        .rsplit('/')
+        .find(|part| !part.is_empty())
+        .unwrap_or(normalized.as_str())
+        .to_string()
+}
+
+fn value_to_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
+        .or_else(|| value.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
+}
+
+fn read_file_line_label(map: &Map<String, Value>) -> Option<String> {
+    let offset = map.get("offset").and_then(value_to_i64)?;
+    if offset <= 0 {
+        return None;
+    }
+    let limit = map.get("limit").and_then(value_to_i64).unwrap_or(0);
+    if limit <= 1 {
+        Some(format!("L{offset}"))
+    } else {
+        Some(format!("L{}-{}", offset, offset + limit - 1))
+    }
+}
+
+fn read_file_preview(map: &Map<String, Value>) -> Option<String> {
+    let path = map
+        .get("path")
+        .or_else(|| map.get("file"))
+        .or_else(|| map.get("filepath"))
+        .and_then(value_to_scalar_string)?;
+    let label = path_basename(path.trim());
+    if label.is_empty() {
+        return None;
+    }
+    Some(match read_file_line_label(map) {
+        Some(line_label) => format!("{label} {line_label}"),
+        None => label,
+    })
 }
 
 fn value_to_scalar_string(value: &Value) -> Option<String> {
@@ -164,8 +469,24 @@ pub fn build_tool_preview_from_value(
         return preview.filter(|s| !s.trim().is_empty());
     }
 
+    if matches!(tool_name, "terminal" | "execute_code") {
+        let key = if tool_name == "execute_code" {
+            "code"
+        } else {
+            "command"
+        };
+        let command = map.get(key).and_then(value_to_scalar_string)?;
+        let preview = summarize_shell_command(&command);
+        return (!preview.trim().is_empty()).then(|| truncate_chars(&preview, max_len));
+    }
+
+    if tool_name == "read_file" {
+        return read_file_preview(map).map(|preview| truncate_chars(&preview, max_len));
+    }
+
     let primary_key = match tool_name {
         "terminal" => Some("command"),
+        "execute_code" => Some("code"),
         "web_search" => Some("query"),
         "web_extract" => Some("urls"),
         "web_crawl" => Some("url"),
@@ -347,6 +668,70 @@ mod tests {
     }
 
     #[test]
+    fn terminal_preview_compacts_shell_plumbing() {
+        let preview = build_tool_preview_from_value(
+            "terminal",
+            &json!({
+                "command": "cd /Users/brooklyn/www/bb-rainbows && pnpm run lint 2>&1 | tail -20; echo \"lint_exit=${PIPESTATUS[0]}\""
+            }),
+            80,
+        )
+        .unwrap();
+
+        assert_eq!(preview, "pnpm run lint");
+    }
+
+    #[test]
+    fn terminal_preview_compacts_multi_command_probe() {
+        let preview = build_tool_preview_from_value(
+            "terminal",
+            &json!({
+                "command": "which node pnpm corepack; node -v; echo \"---\"; corepack --version 2>&1; echo \"---pnpm via corepack---\"; pnpm --version 2>&1 | tail -5"
+            }),
+            80,
+        )
+        .unwrap();
+
+        assert_eq!(preview, "which node pnpm corepack + 3 commands");
+    }
+
+    #[test]
+    fn execute_code_preview_uses_shell_summary() {
+        let preview = build_tool_preview_from_value(
+            "execute_code",
+            &json!({"code": "cd /tmp/demo && python -m pytest -q 2>&1 | tail -5; echo \"exit=$?\""}),
+            80,
+        )
+        .unwrap();
+
+        assert_eq!(preview, "python -m pytest -q");
+    }
+
+    #[test]
+    fn read_file_preview_uses_basename_and_requested_line_range() {
+        let preview = build_tool_preview_from_value(
+            "read_file",
+            &json!({"path":"./src/main.ts", "offset":25, "limit":10}),
+            80,
+        )
+        .unwrap();
+
+        assert_eq!(preview, "main.ts L25-34");
+    }
+
+    #[test]
+    fn read_file_preview_accepts_string_line_numbers() {
+        let preview = build_tool_preview_from_value(
+            "read_file",
+            &json!({"path":"C:\\repo\\package.json", "offset":"1", "limit":"5"}),
+            80,
+        )
+        .unwrap();
+
+        assert_eq!(preview, "package.json L1-5");
+    }
+
+    #[test]
     fn emoji_map_covers_process_and_todo() {
         assert_eq!(tool_emoji("process"), "⚙️");
         assert_eq!(tool_emoji("todo"), "📋");
@@ -374,7 +759,7 @@ mod tests {
         let msg = build_gateway_tool_progress_message(
             "sms",
             "terminal",
-            &json!({"command":"cargo test --workspace --quiet"}),
+            &json!({"command":"cd /repo && cargo test --workspace --quiet 2>&1 | tail -20; echo \"exit=$?\""}),
             "all",
             24,
         )
@@ -382,6 +767,8 @@ mod tests {
 
         assert!(msg.starts_with("💻 terminal: "));
         assert!(!msg.contains("```bash"));
+        assert!(msg.contains("cargo test --workspace"));
+        assert!(!msg.contains("tail -20"));
     }
 
     #[test]

--- a/crates/hermes-intelligence/src/display.rs
+++ b/crates/hermes-intelligence/src/display.rs
@@ -116,6 +116,21 @@ pub fn build_tool_preview(
         };
     }
 
+    if matches!(tool_name, "terminal" | "execute_code") {
+        let key = if tool_name == "execute_code" {
+            "code"
+        } else {
+            "command"
+        };
+        let command = obj.get(key).and_then(value_to_preview_string)?;
+        let preview = summarize_shell_command(&command);
+        return (!preview.trim().is_empty()).then(|| truncate(&preview, max_len));
+    }
+
+    if tool_name == "read_file" {
+        return read_file_preview(obj).map(|preview| truncate(&preview, max_len));
+    }
+
     // Look up the primary argument for this tool
     let key = primary_args.get(tool_name).copied().or_else(|| {
         for fallback in &[
@@ -213,13 +228,19 @@ pub fn get_cute_tool_message(
         "terminal" => format!(
             "{} 💻 $         {}  {}",
             prefix,
-            trunc(&get_str("command"), 42),
+            trunc(
+                &build_tool_preview(tool_name, args, 0).unwrap_or_else(|| get_str("command")),
+                42
+            ),
             dur
         ),
         "read_file" => format!(
             "{} 📖 read      {}  {}",
             prefix,
-            path_trunc(&get_str("path"), 35),
+            trunc(
+                &build_tool_preview(tool_name, args, 0).unwrap_or_else(|| get_str("path")),
+                42
+            ),
             dur
         ),
         "write_file" => format!(
@@ -252,9 +273,11 @@ pub fn get_cute_tool_message(
             format!("{} 🌐 navigate  {}  {}", prefix, trunc(&domain, 35), dur)
         }
         "execute_code" => {
-            let code = get_str("code");
-            let first_line = code.lines().next().unwrap_or("").trim();
-            format!("{} 🐍 exec      {}  {}", prefix, trunc(first_line, 35), dur)
+            let preview = build_tool_preview(tool_name, args, 0).unwrap_or_else(|| {
+                let code = get_str("code");
+                code.lines().next().unwrap_or("").trim().to_string()
+            });
+            format!("{} 🐍 exec      {}  {}", prefix, trunc(&preview, 35), dur)
         }
         _ => {
             let preview = build_tool_preview(tool_name, args, 35).unwrap_or_default();
@@ -581,11 +604,328 @@ fn oneline(text: &str) -> String {
 }
 
 fn truncate(text: &str, max: usize) -> String {
-    if text.len() > max {
+    if max > 0 && text.len() > max {
         format!("{}...", &text[..max.saturating_sub(3)])
     } else {
         text.to_string()
     }
+}
+
+fn value_to_preview_string(value: &serde_json::Value) -> Option<String> {
+    if let Some(s) = value.as_str() {
+        Some(s.to_string())
+    } else if let Some(n) = value.as_i64() {
+        Some(n.to_string())
+    } else if let Some(n) = value.as_u64() {
+        Some(n.to_string())
+    } else if let Some(b) = value.as_bool() {
+        Some(b.to_string())
+    } else if let Some(arr) = value.as_array() {
+        arr.first().and_then(value_to_preview_string)
+    } else {
+        None
+    }
+}
+
+fn shell_basename(head: &str) -> &str {
+    head.rsplit_once('/').map(|(_, tail)| tail).unwrap_or(head)
+}
+
+fn is_shell_silent_head(head: &str) -> bool {
+    matches!(
+        head,
+        "cd" | "pushd"
+            | "popd"
+            | "export"
+            | "set"
+            | "unset"
+            | "source"
+            | "."
+            | "true"
+            | "false"
+            | ":"
+    )
+}
+
+fn is_shell_pipe_tail_head(head: &str) -> bool {
+    matches!(head, "head" | "tail" | "wc" | "sort" | "uniq")
+}
+
+fn is_env_assignment(word: &str) -> bool {
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('_') | Some('A'..='Z') | Some('a'..='z'))
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn split_shell_words(segment: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut buf = String::new();
+    let mut quote: Option<char> = None;
+    let mut prev = '\0';
+
+    for ch in segment.chars() {
+        if let Some(active_quote) = quote {
+            buf.push(ch);
+            if ch == active_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        if matches!(ch, '\'' | '"') {
+            quote = Some(ch);
+            buf.push(ch);
+        } else if ch.is_whitespace() {
+            if !buf.is_empty() {
+                words.push(std::mem::take(&mut buf));
+            }
+        } else {
+            buf.push(ch);
+        }
+        prev = ch;
+    }
+
+    if !buf.is_empty() {
+        words.push(buf);
+    }
+    words
+}
+
+fn strip_shell_pipe_tail(segment: &str) -> String {
+    let words = split_shell_words(segment);
+    let mut out = Vec::new();
+
+    for (index, word) in words.iter().enumerate() {
+        if word == "|"
+            && words
+                .get(index + 1)
+                .map(|head| is_shell_pipe_tail_head(shell_basename(head)))
+                .unwrap_or(false)
+        {
+            break;
+        }
+        out.push(word.as_str());
+    }
+
+    out.join(" ").trim().to_string()
+}
+
+fn split_shell_compound(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut buf = String::new();
+    let mut quote: Option<char> = None;
+    let mut prev = '\0';
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if let Some(active_quote) = quote {
+            buf.push(ch);
+            if ch == active_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        if matches!(ch, '\'' | '"') {
+            quote = Some(ch);
+            buf.push(ch);
+            prev = ch;
+            continue;
+        }
+
+        let compound_separator = match ch {
+            '&' if chars.peek() == Some(&'&') => {
+                chars.next();
+                true
+            }
+            '|' if chars.peek() == Some(&'|') => {
+                chars.next();
+                true
+            }
+            ';' | '\n' => true,
+            _ => false,
+        };
+
+        if compound_separator {
+            let segment = strip_shell_pipe_tail(buf.trim());
+            if !segment.is_empty() {
+                segments.push(segment);
+            }
+            buf.clear();
+        } else {
+            buf.push(ch);
+        }
+        prev = ch;
+    }
+
+    let segment = strip_shell_pipe_tail(buf.trim());
+    if !segment.is_empty() {
+        segments.push(segment);
+    }
+    segments
+}
+
+fn shell_head_word(segment: &str) -> String {
+    split_shell_words(segment)
+        .into_iter()
+        .find(|word| !is_env_assignment(word))
+        .map(|word| shell_basename(&word).to_string())
+        .unwrap_or_default()
+}
+
+fn is_redirect_operator(word: &str) -> bool {
+    let stripped = word.trim_start_matches(|ch: char| ch.is_ascii_digit());
+    matches!(stripped, ">" | ">>" | "<")
+}
+
+fn is_redirect_dup(word: &str) -> bool {
+    let stripped = word.trim_start_matches(|ch: char| ch.is_ascii_digit());
+    let Some((op, fd)) = stripped.split_once('&') else {
+        return false;
+    };
+    matches!(op, ">" | "<") && fd.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn clean_shell_segment(segment: &str) -> String {
+    let words = split_shell_words(segment);
+    let mut out = Vec::new();
+    let mut index = 0;
+
+    while index < words.len() {
+        let word = &words[index];
+        if is_redirect_operator(word) {
+            index += 2;
+            continue;
+        }
+        if is_redirect_dup(word) {
+            index += 1;
+            continue;
+        }
+        out.push(word.as_str());
+        index += 1;
+    }
+
+    out.join(" ").trim().to_string()
+}
+
+fn is_shell_boundary_echo(segment: &str) -> bool {
+    let words = split_shell_words(segment);
+    if words
+        .first()
+        .map(|word| shell_basename(word) == "echo")
+        .unwrap_or(false)
+    {
+        let rest = words
+            .iter()
+            .skip(1)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(" ");
+        return rest.contains("--")
+            || rest.contains("_exit=")
+            || rest.contains("exit=")
+            || rest.contains("$?")
+            || rest.contains("${PIPESTATUS")
+            || rest.contains("PIPESTATUS");
+    }
+    false
+}
+
+fn summarize_shell_command(command: &str) -> String {
+    let original = oneline(command);
+    if original.is_empty() {
+        return String::new();
+    }
+
+    let segments = split_shell_compound(&original);
+    if segments.len() <= 1 {
+        let cleaned =
+            clean_shell_segment(segments.first().map(String::as_str).unwrap_or(&original));
+        return if cleaned.is_empty() {
+            original
+        } else {
+            cleaned
+        };
+    }
+
+    let core = segments
+        .iter()
+        .filter_map(|segment| {
+            let cleaned = clean_shell_segment(segment);
+            let head = shell_head_word(&cleaned);
+            if cleaned.is_empty() || is_shell_silent_head(&head) || is_shell_boundary_echo(&cleaned)
+            {
+                None
+            } else {
+                Some(cleaned)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    match core.as_slice() {
+        [] => original,
+        [single] => single.clone(),
+        [first, rest @ ..] => format!(
+            "{} + {} {}",
+            first,
+            rest.len(),
+            if rest.len() == 1 {
+                "command"
+            } else {
+                "commands"
+            }
+        ),
+    }
+}
+
+fn path_basename(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    normalized
+        .rsplit('/')
+        .find(|part| !part.is_empty())
+        .unwrap_or(normalized.as_str())
+        .to_string()
+}
+
+fn value_to_i64(value: &serde_json::Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
+        .or_else(|| value.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
+}
+
+fn read_file_line_label(map: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    let offset = map.get("offset").and_then(value_to_i64)?;
+    if offset <= 0 {
+        return None;
+    }
+    let limit = map.get("limit").and_then(value_to_i64).unwrap_or(0);
+    if limit <= 1 {
+        Some(format!("L{offset}"))
+    } else {
+        Some(format!("L{}-{}", offset, offset + limit - 1))
+    }
+}
+
+fn read_file_preview(map: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    let path = map
+        .get("path")
+        .or_else(|| map.get("file"))
+        .or_else(|| map.get("filepath"))
+        .and_then(value_to_preview_string)?;
+    let label = path_basename(path.trim());
+    if label.is_empty() {
+        return None;
+    }
+    Some(match read_file_line_label(map) {
+        Some(line_label) => format!("{label} {line_label}"),
+        None => label,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -631,6 +971,66 @@ mod tests {
         let args = serde_json::json!({"command": "ls -la"});
         let preview = build_tool_preview("terminal", &args, 0);
         assert_eq!(preview, Some("ls -la".to_string()));
+    }
+
+    #[test]
+    fn test_terminal_preview_compacts_shell_plumbing() {
+        let args = serde_json::json!({
+            "command": "cd /Users/brooklyn/www/bb-rainbows && pnpm run lint 2>&1 | tail -20; echo \"lint_exit=${PIPESTATUS[0]}\""
+        });
+        let preview = build_tool_preview("terminal", &args, 0);
+        assert_eq!(preview, Some("pnpm run lint".to_string()));
+    }
+
+    #[test]
+    fn test_terminal_preview_compacts_multi_command_probe() {
+        let args = serde_json::json!({
+            "command": "which node pnpm corepack; node -v; echo \"---\"; corepack --version 2>&1; echo \"---pnpm via corepack---\"; pnpm --version 2>&1 | tail -5"
+        });
+        let preview = build_tool_preview("terminal", &args, 0);
+        assert_eq!(
+            preview,
+            Some("which node pnpm corepack + 3 commands".to_string())
+        );
+    }
+
+    #[test]
+    fn test_execute_code_preview_uses_shell_summary() {
+        let args = serde_json::json!({
+            "code": "cd /tmp/demo && python -m pytest -q 2>&1 | tail -5; echo \"exit=$?\""
+        });
+        let preview = build_tool_preview("execute_code", &args, 0);
+        assert_eq!(preview, Some("python -m pytest -q".to_string()));
+    }
+
+    #[test]
+    fn test_read_file_preview_uses_basename_and_line_range() {
+        let args = serde_json::json!({"path":"./src/main.ts", "offset":25, "limit":10});
+        let preview = build_tool_preview("read_file", &args, 0);
+        assert_eq!(preview, Some("main.ts L25-34".to_string()));
+    }
+
+    #[test]
+    fn test_cute_tool_messages_use_compact_previews() {
+        let terminal = get_cute_tool_message(
+            "terminal",
+            &serde_json::json!({
+                "command": "cd /repo && cargo test -p hermes-cli-ui 2>&1 | tail -20; echo \"exit=$?\""
+            }),
+            0.1,
+            None,
+        );
+        assert!(terminal.contains("cargo test -p hermes-cli-ui"));
+        assert!(!terminal.contains("tail -20"));
+
+        let read = get_cute_tool_message(
+            "read_file",
+            &serde_json::json!({"path":"/tmp/work/src/lib.rs", "offset": 7, "limit": 2}),
+            0.1,
+            None,
+        );
+        assert!(read.contains("lib.rs L7-8"));
+        assert!(!read.contains("/tmp/work"));
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T03:15:26.858931+00:00`_
+_Generated from source artifacts: `2026-06-26T04:15:25.843732+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T03:15:26.708571+00:00`
-- Proof snapshot generated: `2026-06-26T03:15:26.858931+00:00`
+- Queue snapshot generated: `2026-06-26T04:15:25.650694+00:00`
+- Proof snapshot generated: `2026-06-26T04:15:25.843732+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T03:15:26.858931+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=146.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=146.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=145.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=145.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-26T03:15:26.858931+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7101 |
-| Pending | 146 |
-| Ported | 452 |
-| Superseded | 6427 |
+| Total commits in queue | 7103 |
+| Pending | 145 |
+| Ported | 454 |
+| Superseded | 6428 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 146.0,
+        "actual": 145.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T03:15:26.858931+00:00",
+  "generated_at_utc": "2026-06-26T04:15:25.843732+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 146.0,
+    "max_queue_pending_commits": 145.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,12 +299,12 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 146,
-      "ported": 452,
-      "superseded": 6427
+      "pending": 145,
+      "ported": 454,
+      "superseded": 6428
     },
     "by_target_ticket": {
-      "20": 3191,
+      "20": 3193,
       "21": 130,
       "22": 960,
       "23": 488,
@@ -314,7 +314,7 @@
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7101
+    "total_commits": 7103
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 146.0,
+        "actual": 145.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T03:15:26.858931+00:00`
+Generated: `2026-06-26T04:15:25.843732+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T03:15:26.858931+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 146.0 |
+| `max_queue_pending_commits` | 145.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,9 +93,9 @@ Generated: `2026-06-26T03:15:26.858931+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7101`.
+- Upstream missing commits tracked: `7103`.
 - By target ticket:
-  - `#20`: `3191`
+  - `#20`: `3193`
   - `#21`: `130`
   - `#22`: `960`
   - `#23`: `488`

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5023,6 +5023,16 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust managed-node resolver computes candidate command names once, mirrors platform-specific node/bin ordering, and prepends existing managed Node dirs without duplicate PATH entries; tests cover Windows and POSIX ordering."
+    },
+    "41f302fa73f5": {
+      "disposition": "ported",
+      "notes": "Rust CLI/TUI/gateway and intelligence display now render compact tool row titles/previews for terminal and execute_code shell wrappers plus read_file basename/line ranges, matching the desktop compact-title behavior while preserving raw args for details/copy.",
+      "owner": "rust-runtime"
+    },
+    "f3d6d9bbd335": {
+      "disposition": "ported",
+      "notes": "Rust shared CLI UI preview path now compacts terminal/execute_code/read_file previews for CLI, TUI, and gateway plain progress, and intelligence cute messages use the same compact labels. Focused tests cover shell plumbing, multi-command probes, execute_code, and read_file ranges.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,12 +1,12 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T03:15:26.708571+00:00`
+Generated: `2026-06-26T04:15:25.650694+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `7101`.
+- Range: `HEAD..upstream/main`; total commits tracked: `7103`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3191 |
+| #20 | GPAR-01 tests+CI parity | 3193 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 960 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
@@ -17,9 +17,9 @@ Generated: `2026-06-26T03:15:26.708571+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 146 |
-| ported | 452 |
-| superseded | 6427 |
+| pending | 145 |
+| ported | 454 |
+| superseded | 6428 |
 
 ## First 100 Pending Commits
 


### PR DESCRIPTION
## What changed
- Added compact Rust preview rendering for terminal and execute_code wrappers in CLI/TUI/gateway shared UI code.
- Added read_file basename plus requested line-range labels, including string numeric offsets/limits.
- Updated intelligence display and cute tool completion lines to use the compact terminal/read_file/execute_code labels.
- Ported upstream compact-preview parity entries for `f3d6d9bbd335` and `41f302fa73f5`; left bounded desktop result rendering `cbe5c5689f9c` pending because that is a separate desktop renderer/OOM surface.
- Fixed one existing `hermes-cli-ui` clippy cleanup that blocked narrow `-D warnings` verification.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli-ui tool_preview --lib` -> 13 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-intelligence display --lib` -> 11 passed
- custom lib-only clippy allowlist gate for `hermes-cli-ui` and `hermes-intelligence` -> `seen=22 allowlist=200 new=0`
- repo-local `target` absent; build artifacts used `/Volumes/wd_black/cargo-targets`
