### PR TITLE
parity(model): preserve nested model config

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -82,7 +82,9 @@ use crate::model_switch::{
 use crate::pairing_store::{PairingStatus, PairingStore};
 use crate::providers::canonical_provider_id;
 use crate::skin_engine::{canonical_skin_name, BUILTIN_SKINS};
-use hermes_config::{find_node_executable, GatewayConfig, LlmProviderConfig};
+use hermes_config::{
+    find_node_executable, set_user_config_value, GatewayConfig, LlmProviderConfig,
+};
 
 // ---------------------------------------------------------------------------
 // CommandResult
@@ -4297,12 +4299,51 @@ fn run_model_picker_select(
 
 fn persist_current_model_selection(app: &App) -> Result<PathBuf, AgentError> {
     let cfg_path = app.state_root.join("config.yaml");
-    let mut disk = hermes_config::load_user_config_file(&cfg_path)
-        .map_err(|e| AgentError::Config(e.to_string()))?;
-    disk.model = Some(app.current_model.clone());
-    hermes_config::save_config_yaml(&cfg_path, &disk)
-        .map_err(|e| AgentError::Config(e.to_string()))?;
+    if config_uses_nested_model_block(&cfg_path)? {
+        let (provider, model_id) = split_provider_model(&app.current_model);
+        let model_id = model_id.trim();
+        let provider = provider.trim();
+        set_user_config_value(&app.state_root, "model.default", model_id)
+            .map_err(|e| AgentError::Config(e.to_string()))?;
+        if !provider.is_empty() {
+            set_user_config_value(&app.state_root, "model.provider", provider)
+                .map_err(|e| AgentError::Config(e.to_string()))?;
+        }
+        if let Some(base_url) = app
+            .config
+            .llm_providers
+            .get(provider)
+            .and_then(|cfg| cfg.base_url.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            set_user_config_value(&app.state_root, "model.base_url", base_url)
+                .map_err(|e| AgentError::Config(e.to_string()))?;
+        }
+    } else {
+        set_user_config_value(&app.state_root, "model", &app.current_model)
+            .map_err(|e| AgentError::Config(e.to_string()))?;
+    }
     Ok(cfg_path)
+}
+
+fn config_uses_nested_model_block(path: &Path) -> Result<bool, AgentError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| AgentError::Io(format!("read {}: {}", path.display(), e)))?;
+    if text.trim().is_empty() {
+        return Ok(false);
+    }
+    let value: serde_yaml::Value =
+        serde_yaml::from_str(&text).map_err(|e| AgentError::Config(e.to_string()))?;
+    let Some(root) = value.as_mapping() else {
+        return Ok(false);
+    };
+    Ok(root
+        .get(serde_yaml::Value::String("model".to_string()))
+        .is_some_and(serde_yaml::Value::is_mapping))
 }
 
 fn format_model_persistence_note(app: &App) -> String {
@@ -32337,6 +32378,83 @@ install_command: "uv pip install -r requirements.txt"
         assert!(out.contains("cache_cleared: no"));
         assert!(out.contains("catalog_total: 2"));
         assert!(out.contains("models_sample: model-a, model-b"));
+    }
+
+    #[tokio::test]
+    async fn model_persistence_preserves_nested_model_siblings() {
+        let tmp = tempdir().expect("tempdir");
+        let _home_guard = TempHomeGuard::new(tmp.path());
+        let mut app = build_test_app_with_stream(tmp.path()).await;
+        let config_path = app.state_root.join("config.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+model:
+  default: old-model
+  provider: old-provider
+  base_url: https://old.example.com/v1
+  model_slots:
+    primary: keep-me
+llm_providers:
+  anthropic:
+    base_url: https://api.anthropic.com
+"#,
+        )
+        .expect("write nested model config");
+
+        let mut cfg = (*app.config).clone();
+        cfg.llm_providers.insert(
+            "anthropic".to_string(),
+            LlmProviderConfig {
+                base_url: Some("https://api.anthropic.com".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+        app.config = Arc::new(cfg);
+        app.current_model = "anthropic:claude-sonnet-4-6".to_string();
+
+        let persisted_path =
+            persist_current_model_selection(&app).expect("persist model selection");
+        assert_eq!(persisted_path, config_path);
+
+        let raw: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        let model = raw
+            .get("model")
+            .and_then(serde_yaml::Value::as_mapping)
+            .expect("model block preserved");
+        assert_eq!(
+            model
+                .get(serde_yaml::Value::String("default".to_string()))
+                .and_then(serde_yaml::Value::as_str),
+            Some("claude-sonnet-4-6")
+        );
+        assert_eq!(
+            model
+                .get(serde_yaml::Value::String("provider".to_string()))
+                .and_then(serde_yaml::Value::as_str),
+            Some("anthropic")
+        );
+        assert_eq!(
+            model
+                .get(serde_yaml::Value::String("base_url".to_string()))
+                .and_then(serde_yaml::Value::as_str),
+            Some("https://api.anthropic.com")
+        );
+        assert_eq!(
+            model
+                .get(serde_yaml::Value::String("model_slots".to_string()))
+                .and_then(serde_yaml::Value::as_mapping)
+                .and_then(|slots| {
+                    slots
+                        .get(serde_yaml::Value::String("primary".to_string()))
+                        .and_then(serde_yaml::Value::as_str)
+                }),
+            Some("keep-me")
+        );
+
+        let loaded = hermes_config::load_user_config_file(&config_path).expect("load config");
+        assert_eq!(loaded.model.as_deref(), Some("anthropic:claude-sonnet-4-6"));
     }
 
     #[tokio::test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T04:15:25.843732+00:00`_
+_Generated from source artifacts: `2026-06-26T05:06:31.609033+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T04:15:25.650694+00:00`
-- Proof snapshot generated: `2026-06-26T04:15:25.843732+00:00`
+- Queue snapshot generated: `2026-06-26T05:06:31.353327+00:00`
+- Proof snapshot generated: `2026-06-26T05:06:31.609033+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T04:15:25.843732+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=145.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=145.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=149.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=149.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-26T04:15:25.843732+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7103 |
-| Pending | 145 |
-| Ported | 454 |
-| Superseded | 6428 |
+| Total commits in queue | 7116 |
+| Pending | 149 |
+| Ported | 455 |
+| Superseded | 6436 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 145.0,
+        "actual": 149.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T04:15:25.843732+00:00",
+  "generated_at_utc": "2026-06-26T05:06:31.609033+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 145.0,
+    "max_queue_pending_commits": 149.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,22 +299,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 145,
-      "ported": 454,
-      "superseded": 6428
+      "pending": 149,
+      "ported": 455,
+      "superseded": 6436
     },
     "by_target_ticket": {
-      "20": 3193,
+      "20": 3202,
       "21": 130,
       "22": 960,
       "23": 488,
       "24": 23,
       "25": 146,
-      "26": 2163
+      "26": 2167
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7103
+    "total_commits": 7116
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 145.0,
+        "actual": 149.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T04:15:25.843732+00:00`
+Generated: `2026-06-26T05:06:31.609033+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T04:15:25.843732+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 145.0 |
+| `max_queue_pending_commits` | 149.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-26T04:15:25.843732+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7103`.
+- Upstream missing commits tracked: `7116`.
 - By target ticket:
-  - `#20`: `3193`
+  - `#20`: `3202`
   - `#21`: `130`
   - `#22`: `960`
   - `#23`: `488`
   - `#24`: `23`
   - `#25`: `146`
-  - `#26`: `2163`
+  - `#26`: `2167`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5033,6 +5033,11 @@
       "disposition": "ported",
       "notes": "Rust shared CLI UI preview path now compacts terminal/execute_code/read_file previews for CLI, TUI, and gateway plain progress, and intelligence cute messages use the same compact labels. Focused tests cover shell plumbing, multi-command probes, execute_code, and read_file ranges.",
       "owner": "rust-runtime"
+    },
+    "b85c46054036": {
+      "disposition": "ported",
+      "notes": "Rust /model persistence now uses targeted raw-YAML config writes. Existing Python-style nested model blocks update model.default/provider/base_url without replacing sibling keys such as model_slots, while scalar Rust configs still update top-level model. Focused hermes-cli regression covers sibling preservation and runtime reload normalization.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T04:15:25.650694+00:00`
+Generated: `2026-06-26T05:06:31.353327+00:00`
 
-- Range: `HEAD..upstream/main`; total commits tracked: `7103`.
+- Range: `HEAD..upstream/main`; total commits tracked: `7116`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3193 |
+| #20 | GPAR-01 tests+CI parity | 3202 |
 | #21 | GPAR-02 skills parity | 130 |
 | #22 | GPAR-03 UX parity | 960 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 488 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 23 |
 | #25 | GPAR-06 packaging/docs/install parity | 146 |
-| #26 | GPAR-07 upstream queue backfill | 2163 |
+| #26 | GPAR-07 upstream queue backfill | 2167 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 145 |
-| ported | 454 |
-| superseded | 6428 |
+| pending | 149 |
+| ported | 455 |
+| superseded | 6436 |
 
 ## First 100 Pending Commits
 
@@ -105,7 +105,6 @@ Generated: `2026-06-26T04:15:25.650694+00:00`
 | `7243111c57bb` | #26 | test(desktop): cover fallback timeout onboarding downgrade regression |
 | `d398076c2117` | #26 | fix(desktop): show non-blocking notification on fallback runtime probe |
 | `a4a74ca9e9a0` | #26 | fix(desktop): use notify() with stable id for fallback notification |
-| `b85c46054036` | #20 | fix(tui): targeted save_config_value for model persistence (#48305) |
 | `6da615c77cf8` | #26 | fix(desktop): scope onboarding runtime check to connected provider |
 | `d8fe1c0b4195` | #20 | test(desktop): cover scoped onboarding runtime readiness checks |
 | `2de7549fe0fe` | #26 | feat(desktop): remember window size/position/maximized across launches (salvage #39154) |
@@ -125,3 +124,4 @@ Generated: `2026-06-26T04:15:25.650694+00:00`
 | `9a4600c5fb9b` | #26 | fix(desktop): stop the update overlay looking frozen while it works |
 | `2ea94c6c4581` | #26 | fix(pets): make inline generate cancel discard draft flow |
 | `284be6cc247c` | #26 | Merge pull request #52210 from helix4u/fix/desktop-update-progress-visibility |
+| `7e2db0a140db` | #26 | fix(desktop): stop refText crash on undefined composer attachment holes |


### PR DESCRIPTION
## What changed
- Routed `/model` default persistence through `hermes_config::set_user_config_value` targeted YAML writes.
- Preserves Python-style nested `model:` blocks by writing `model.default`, `model.provider`, and known `model.base_url` instead of replacing the entire block.
- Keeps scalar Rust-style configs on the existing top-level `model` key.
- Added a regression that verifies `model.model_slots` survives and the config reload normalizes to `anthropic:claude-sonnet-4-6`.
- Marked upstream `b85c46054036` as ported and regenerated parity docs.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli model_persistence_preserves_nested_model_siblings --lib` -> 1 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli model_switch_command_ --lib` -> 2 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- lib-only clippy allowlist gate for `hermes-cli` -> `seen=148 allowlist=200 new=0`
- repo-local `target` absent; build artifacts used `/Volumes/wd_black/cargo-targets`

## Notes
- Queue regeneration observed upstream inflow: tracked queue `7103 -> 7116`; this PR still ports `b85c46054036`, while net pending changes reflect new upstream commits entering the range.
