### PR TITLE
parity(image): add OpenRouter-compatible backend

### DIFF
--- a/crates/hermes-tools/src/backends/image_gen.rs
+++ b/crates/hermes-tools/src/backends/image_gen.rs
@@ -11,6 +11,10 @@
 //!    `HERMES_IMAGE_GEN_PROVIDER=openai-codex` routes through the ChatGPT
 //!    Codex Responses `image_generation` tool and saves the PNG under
 //!    `$HERMES_HOME/cache/images/`.
+//! 4. **OpenRouter-compatible image output**: `image_gen.provider: openrouter`
+//!    or `nous` uses OpenAI-style `/chat/completions` image output with
+//!    reference-image grounding and stores returned images under
+//!    `$HERMES_HOME/cache/images/`.
 //!
 //! The active transport is reflected in the response JSON (`transport`
 //! field) for observability.
@@ -41,6 +45,13 @@ const DEFAULT_CODEX_IMAGE_CHAT_MODEL: &str = "gpt-5.5";
 const DEFAULT_CODEX_IMAGE_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const CODEX_IMAGE_INSTRUCTIONS: &str = "You are an assistant that must fulfill image generation requests by using the image_generation tool when provided.";
 const CODEX_CLOUDFLARE_ORIGINATOR: &str = "codex_cli_rs";
+const DEFAULT_OPENROUTER_COMPAT_IMAGE_MODEL: &str = "google/gemini-2.5-flash-image";
+const DEFAULT_OPENROUTER_IMAGE_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const DEFAULT_NOUS_IMAGE_BASE_URL: &str = "https://inference.nousresearch.com/v1";
+const OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES: usize = 3;
+const OPENROUTER_COMPAT_TIMEOUT_SECS: u64 = 180;
+const OPENROUTER_COMPAT_HTTP_REFERER: &str = "https://github.com/NousResearch/hermes-agent";
+const OPENROUTER_COMPAT_X_TITLE: &str = "Hermes Agent";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FalSizeStyle {
@@ -129,12 +140,86 @@ pub struct OpenAICodexImageGenConfig {
     output_dir: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenRouterCompatImageProviderKind {
+    OpenRouter,
+    Nous,
+}
+
+impl OpenRouterCompatImageProviderKind {
+    fn provider_id(self) -> &'static str {
+        match self {
+            Self::OpenRouter => "openrouter",
+            Self::Nous => "nous",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::OpenRouter => "OpenRouter",
+            Self::Nous => "Nous Portal",
+        }
+    }
+
+    fn config_key(self) -> &'static str {
+        self.provider_id()
+    }
+
+    fn model_env_var(self) -> &'static str {
+        match self {
+            Self::OpenRouter => "OPENROUTER_IMAGE_MODEL",
+            Self::Nous => "NOUS_IMAGE_MODEL",
+        }
+    }
+
+    fn api_key_env_vars(self) -> &'static [&'static str] {
+        match self {
+            Self::OpenRouter => &["OPENROUTER_API_KEY"],
+            Self::Nous => &["NOUS_API_KEY"],
+        }
+    }
+
+    fn base_url_env_vars(self) -> &'static [&'static str] {
+        match self {
+            Self::OpenRouter => &["OPENROUTER_IMAGE_BASE_URL", "OPENROUTER_BASE_URL"],
+            Self::Nous => &["NOUS_IMAGE_BASE_URL", "NOUS_BASE_URL"],
+        }
+    }
+
+    fn default_base_url(self) -> &'static str {
+        match self {
+            Self::OpenRouter => DEFAULT_OPENROUTER_IMAGE_BASE_URL,
+            Self::Nous => DEFAULT_NOUS_IMAGE_BASE_URL,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenRouterCompatImageGenConfig {
+    provider: OpenRouterCompatImageProviderKind,
+    api_key: Option<String>,
+    base_url: String,
+    model: String,
+    output_dir: PathBuf,
+}
+
 /// Image generation backend using ChatGPT/Codex OAuth and the Responses
 /// `image_generation` tool.
 #[derive(Debug)]
 pub struct OpenAICodexImageGenBackend {
     client: Client,
     config: OpenAICodexImageGenConfig,
+}
+
+/// OpenRouter-compatible image generation over `/chat/completions`.
+///
+/// This serves both OpenRouter and Nous Portal: both accept `modalities:
+/// ["image", "text"]`, reference images as `image_url` parts, and return
+/// generated image URLs under `choices[].message.images`.
+#[derive(Debug)]
+pub struct OpenRouterCompatImageGenBackend {
+    client: Client,
+    config: OpenRouterCompatImageGenConfig,
 }
 
 /// Image generation backend using fal.ai (direct or via Nous-managed
@@ -338,11 +423,97 @@ impl OpenAICodexImageGenBackend {
     }
 }
 
+impl OpenRouterCompatImageGenConfig {
+    pub fn new(provider: OpenRouterCompatImageProviderKind, api_key: Option<String>) -> Self {
+        Self {
+            provider,
+            api_key,
+            base_url: resolve_openrouter_compat_base_url(provider),
+            model: resolve_openrouter_compat_model(provider),
+            output_dir: hermes_config::hermes_home().join("cache").join("images"),
+        }
+    }
+
+    pub fn from_env_or_config(
+        provider: OpenRouterCompatImageProviderKind,
+    ) -> Result<Self, ToolError> {
+        let api_key = resolve_openrouter_compat_api_key(provider);
+        let cfg = Self::new(provider, api_key);
+        if cfg.api_key.as_deref().is_none_or(str::is_empty) {
+            return Err(ToolError::ExecutionFailed(format!(
+                "{} image generation requires credentials. Set {} or configure image_gen.{}.api_key.",
+                provider.display_name(),
+                provider.api_key_env_vars().join("/"),
+                provider.config_key()
+            )));
+        }
+        Ok(cfg)
+    }
+
+    pub fn unconfigured(provider: OpenRouterCompatImageProviderKind) -> Self {
+        Self::new(provider, None)
+    }
+
+    pub fn provider(&self) -> OpenRouterCompatImageProviderKind {
+        self.provider
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl OpenRouterCompatImageGenBackend {
+    pub fn from_config(config: OpenRouterCompatImageGenConfig) -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(Duration::from_secs(OPENROUTER_COMPAT_TIMEOUT_SECS))
+                .build()
+                .unwrap_or_else(|err| {
+                    tracing::warn!(
+                        "failed to build OpenRouter-compatible image HTTP client: {}",
+                        err
+                    );
+                    Client::new()
+                }),
+            config,
+        }
+    }
+
+    pub fn from_env_or_config(
+        provider: OpenRouterCompatImageProviderKind,
+    ) -> Result<Self, ToolError> {
+        Ok(Self::from_config(
+            OpenRouterCompatImageGenConfig::from_env_or_config(provider)?,
+        ))
+    }
+
+    pub fn unconfigured(provider: OpenRouterCompatImageProviderKind) -> Self {
+        Self::from_config(OpenRouterCompatImageGenConfig::unconfigured(provider))
+    }
+
+    pub fn config(&self) -> &OpenRouterCompatImageGenConfig {
+        &self.config
+    }
+
+    fn chat_completions_url(&self) -> String {
+        format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        )
+    }
+}
+
 /// Configured built-in image generation backend.
 #[derive(Debug)]
 pub enum ImageGenRuntimeBackend {
     Fal(FalImageGenBackend),
     OpenAICodex(OpenAICodexImageGenBackend),
+    OpenRouterCompat(OpenRouterCompatImageGenBackend),
 }
 
 impl ImageGenRuntimeBackend {
@@ -351,6 +522,24 @@ impl ImageGenRuntimeBackend {
             Some("openai-codex") => OpenAICodexImageGenBackend::from_env_or_auth_store()
                 .unwrap_or_else(|_| OpenAICodexImageGenBackend::unconfigured())
                 .into(),
+            Some("openrouter") => OpenRouterCompatImageGenBackend::from_env_or_config(
+                OpenRouterCompatImageProviderKind::OpenRouter,
+            )
+            .unwrap_or_else(|_| {
+                OpenRouterCompatImageGenBackend::unconfigured(
+                    OpenRouterCompatImageProviderKind::OpenRouter,
+                )
+            })
+            .into(),
+            Some("nous") => OpenRouterCompatImageGenBackend::from_env_or_config(
+                OpenRouterCompatImageProviderKind::Nous,
+            )
+            .unwrap_or_else(|_| {
+                OpenRouterCompatImageGenBackend::unconfigured(
+                    OpenRouterCompatImageProviderKind::Nous,
+                )
+            })
+            .into(),
             _ => FalImageGenBackend::from_env_or_managed()
                 .unwrap_or_else(|_| FalImageGenBackend::new(String::new()))
                 .into(),
@@ -361,6 +550,7 @@ impl ImageGenRuntimeBackend {
         match self {
             Self::Fal(_) => "fal",
             Self::OpenAICodex(_) => "openai-codex",
+            Self::OpenRouterCompat(backend) => backend.config.provider.provider_id(),
         }
     }
 
@@ -368,6 +558,13 @@ impl ImageGenRuntimeBackend {
         match self {
             Self::Fal(_) => vec!["FAL_KEY".into()],
             Self::OpenAICodex(_) => vec!["HERMES_OPENAI_CODEX_API_KEY".into()],
+            Self::OpenRouterCompat(backend) => backend
+                .config
+                .provider
+                .api_key_env_vars()
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
         }
     }
 }
@@ -381,6 +578,12 @@ impl From<FalImageGenBackend> for ImageGenRuntimeBackend {
 impl From<OpenAICodexImageGenBackend> for ImageGenRuntimeBackend {
     fn from(value: OpenAICodexImageGenBackend) -> Self {
         Self::OpenAICodex(value)
+    }
+}
+
+impl From<OpenRouterCompatImageGenBackend> for ImageGenRuntimeBackend {
+    fn from(value: OpenRouterCompatImageGenBackend) -> Self {
+        Self::OpenRouterCompat(value)
     }
 }
 
@@ -570,11 +773,147 @@ impl ImageGenBackend for OpenAICodexImageGenBackend {
 }
 
 #[async_trait]
+impl ImageGenBackend for OpenRouterCompatImageGenBackend {
+    async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError> {
+        let prompt = request.prompt.trim();
+        if prompt.is_empty() {
+            return Err(ToolError::InvalidParams(
+                "Prompt is required and must be a non-empty string.".into(),
+            ));
+        }
+        let token = self
+            .config
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                ToolError::ExecutionFailed(format!(
+                    "{} image generation requires credentials. Set {} or configure image_gen.{}.api_key.",
+                    self.config.provider.display_name(),
+                    self.config.provider.api_key_env_vars().join("/"),
+                    self.config.provider.config_key()
+                ))
+            })?;
+        let aspect = openrouter_compat_aspect_from_tool_size(request.size.as_deref());
+        let references = openrouter_compat_reference_image_parts(&request)?
+            .into_iter()
+            .take(OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES)
+            .collect::<Vec<_>>();
+        let body = openrouter_compat_chat_payload(
+            self.config.model.as_str(),
+            prompt,
+            aspect,
+            references.as_slice(),
+        );
+        let resp = self
+            .client
+            .post(self.chat_completions_url())
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .header("HTTP-Referer", OPENROUTER_COMPAT_HTTP_REFERER)
+            .header("X-Title", OPENROUTER_COMPAT_X_TITLE)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    ToolError::ExecutionFailed(format!(
+                        "{} image generation timed out ({}s)",
+                        self.config.provider.display_name(),
+                        OPENROUTER_COMPAT_TIMEOUT_SECS
+                    ))
+                } else if e.is_connect() {
+                    ToolError::ExecutionFailed(format!(
+                        "{} image generation connection error: {e}",
+                        self.config.provider.display_name()
+                    ))
+                } else {
+                    ToolError::ExecutionFailed(format!(
+                        "{} image generation request failed: {e}",
+                        self.config.provider.display_name()
+                    ))
+                }
+            })?;
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!(
+                "Failed to read {} image response: {e}",
+                self.config.provider.display_name()
+            ))
+        })?;
+        if !status.is_success() {
+            let message = openrouter_compat_error_message(&text);
+            return Err(ToolError::ExecutionFailed(format!(
+                "{} image generation failed ({status}): {message}",
+                self.config.provider.display_name()
+            )));
+        }
+        let data: Value = serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!(
+                "{} returned invalid JSON: {e}",
+                self.config.provider.display_name()
+            ))
+        })?;
+        let images = extract_openrouter_compat_images(&data);
+        let first = images.first().ok_or_else(|| {
+            ToolError::ExecutionFailed(format!(
+                "{} returned no image. Ensure the model '{}' supports image output.",
+                self.config.provider.display_name(),
+                self.config.model
+            ))
+        })?;
+        let image_path = save_openrouter_compat_generated_image(
+            &self.client,
+            first,
+            &self.config.output_dir,
+            self.config.provider.provider_id(),
+        )
+        .await?;
+        let image = image_path.to_string_lossy().to_string();
+        let modality = if request.has_image_inputs() {
+            "image"
+        } else {
+            "text"
+        };
+        Ok(json!({
+            "success": true,
+            "image": image,
+            "images": [{
+                "url": image,
+                "source_url": first,
+                "path": image_path.to_string_lossy(),
+                "width": 0,
+                "height": 0,
+            }],
+            "provider": self.config.provider.provider_id(),
+            "transport": "openrouter-compatible",
+            "model": self.config.model,
+            "prompt": prompt,
+            "aspect_ratio": aspect,
+            "modality": modality,
+            "source_images": references.len(),
+        })
+        .to_string())
+    }
+
+    fn capabilities(&self) -> ImageGenCapabilities {
+        ImageGenCapabilities {
+            provider: Some(self.config.provider.provider_id().to_string()),
+            model: Some(self.config.model.clone()),
+            modalities: vec!["text".to_string(), "image".to_string()],
+            max_reference_images: OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES,
+        }
+    }
+}
+
+#[async_trait]
 impl ImageGenBackend for ImageGenRuntimeBackend {
     async fn generate(&self, request: ImageGenerateRequest) -> Result<String, ToolError> {
         match self {
             Self::Fal(backend) => backend.generate(request).await,
             Self::OpenAICodex(backend) => backend.generate(request).await,
+            Self::OpenRouterCompat(backend) => backend.generate(request).await,
         }
     }
 
@@ -582,6 +921,7 @@ impl ImageGenBackend for ImageGenRuntimeBackend {
         match self {
             Self::Fal(backend) => backend.capabilities(),
             Self::OpenAICodex(backend) => backend.capabilities(),
+            Self::OpenRouterCompat(backend) => backend.capabilities(),
         }
     }
 }
@@ -1114,6 +1454,8 @@ fn normalize_image_provider(value: &str) -> Option<&'static str> {
             Some("openai-codex")
         }
         "fal" | "fal-ai" | "fal_ai" => Some("fal"),
+        "openrouter" | "open-router" | "or" => Some("openrouter"),
+        "nous" | "nous-portal" | "nous_api" | "nous-api" | "nousapi" => Some("nous"),
         _ => None,
     }
 }
@@ -1129,9 +1471,13 @@ fn configured_image_provider() -> Option<String> {
 }
 
 fn load_image_gen_config() -> Option<serde_yaml::Value> {
-    let raw = std::fs::read_to_string(hermes_config::paths::config_path()).ok()?;
-    let root: serde_yaml::Value = serde_yaml::from_str(&raw).ok()?;
+    let root = load_config_yaml_root()?;
     yaml_get(&root, "image_gen").cloned()
+}
+
+fn load_config_yaml_root() -> Option<serde_yaml::Value> {
+    let raw = std::fs::read_to_string(hermes_config::paths::config_path()).ok()?;
+    serde_yaml::from_str(&raw).ok()
 }
 
 fn yaml_get<'a>(value: &'a serde_yaml::Value, key: &str) -> Option<&'a serde_yaml::Value> {
@@ -1145,6 +1491,467 @@ fn yaml_get_str<'a>(value: &'a serde_yaml::Value, key: &str) -> Option<&'a str> 
         .as_str()
         .map(str::trim)
         .filter(|v| !v.is_empty())
+}
+
+fn yaml_get_any_str<'a>(value: &'a serde_yaml::Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| yaml_get_str(value, key))
+}
+
+fn yaml_provider_section(
+    root: &serde_yaml::Value,
+    provider: OpenRouterCompatImageProviderKind,
+) -> Option<&serde_yaml::Value> {
+    let aliases: &[&str] = match provider {
+        OpenRouterCompatImageProviderKind::OpenRouter => &["openrouter"],
+        OpenRouterCompatImageProviderKind::Nous => &["nous", "nous-api", "nous_api", "nousapi"],
+    };
+    for parent in ["llm_providers", "providers"] {
+        if let Some(table) = yaml_get(root, parent) {
+            for alias in aliases {
+                if let Some(section) = yaml_get(table, alias) {
+                    return Some(section);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn scoped_image_provider_config(
+    provider: OpenRouterCompatImageProviderKind,
+) -> Option<serde_yaml::Value> {
+    let cfg = load_image_gen_config()?;
+    yaml_get(&cfg, provider.config_key()).cloned()
+}
+
+fn resolve_openrouter_compat_model(provider: OpenRouterCompatImageProviderKind) -> String {
+    if let Some(value) = env_optional_nonempty(provider.model_env_var()) {
+        return value;
+    }
+    scoped_image_provider_config(provider)
+        .as_ref()
+        .and_then(|cfg| yaml_get_str(cfg, "model"))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| DEFAULT_OPENROUTER_COMPAT_IMAGE_MODEL.to_string())
+}
+
+fn resolve_openrouter_compat_base_url(provider: OpenRouterCompatImageProviderKind) -> String {
+    if let Some(value) = scoped_image_provider_config(provider)
+        .as_ref()
+        .and_then(|cfg| {
+            yaml_get_any_str(cfg, &["base_url", "inference_base_url"]).map(ToOwned::to_owned)
+        })
+    {
+        return value.trim_end_matches('/').to_string();
+    }
+    if let Some(root) = load_config_yaml_root() {
+        if let Some(value) = yaml_provider_section(&root, provider)
+            .and_then(|cfg| yaml_get_any_str(cfg, &["base_url", "inference_base_url"]))
+        {
+            return value.trim_end_matches('/').to_string();
+        }
+    }
+    for key in provider.base_url_env_vars() {
+        if let Some(value) = env_optional_nonempty(key) {
+            return value.trim_end_matches('/').to_string();
+        }
+    }
+    if provider == OpenRouterCompatImageProviderKind::Nous {
+        if let Some(value) = read_provider_auth_string("nous", &["inference_base_url"]) {
+            return value.trim_end_matches('/').to_string();
+        }
+    }
+    provider.default_base_url().to_string()
+}
+
+fn resolve_openrouter_compat_api_key(
+    provider: OpenRouterCompatImageProviderKind,
+) -> Option<String> {
+    if let Some(value) = scoped_image_provider_config(provider)
+        .as_ref()
+        .and_then(resolve_api_key_from_yaml_provider_section)
+    {
+        return Some(value);
+    }
+    if let Some(root) = load_config_yaml_root() {
+        if let Some(value) = yaml_provider_section(&root, provider)
+            .and_then(resolve_api_key_from_yaml_provider_section)
+        {
+            return Some(value);
+        }
+    }
+    for key in provider.api_key_env_vars() {
+        if let Some(value) = env_optional_nonempty(key) {
+            return Some(value);
+        }
+    }
+    if provider == OpenRouterCompatImageProviderKind::Nous {
+        if let Some(value) = env_optional_nonempty("TOOL_GATEWAY_USER_TOKEN") {
+            return Some(value);
+        }
+    }
+    read_provider_auth_string(
+        provider.provider_id(),
+        &["agent_key", "api_key", "access_token"],
+    )
+    .or_else(|| read_provider_auth_tokens_string(provider.provider_id(), "access_token"))
+}
+
+fn resolve_api_key_from_yaml_provider_section(section: &serde_yaml::Value) -> Option<String> {
+    if let Some(value) = yaml_get_str(section, "api_key").and_then(resolve_env_ref_or_literal) {
+        return Some(value);
+    }
+    if let Some(env_name) = yaml_get_str(section, "api_key_env") {
+        return env_optional_nonempty(env_name);
+    }
+    None
+}
+
+fn resolve_env_ref_or_literal(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(env_name) = trimmed
+        .strip_prefix("${")
+        .and_then(|value| value.strip_suffix('}'))
+    {
+        return env_optional_nonempty(env_name);
+    }
+    Some(trimmed.to_string())
+}
+
+fn openrouter_compat_aspect_from_tool_size(size: Option<&str>) -> &'static str {
+    match size.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("landscape") | Some("16:9") | Some("1536x1024") => "16:9",
+        Some("portrait") | Some("9:16") | Some("1024x1536") => "9:16",
+        _ => "1:1",
+    }
+}
+
+fn openrouter_compat_chat_payload(
+    model: &str,
+    prompt: &str,
+    aspect_ratio: &str,
+    reference_image_parts: &[String],
+) -> Value {
+    let mut content = vec![json!({"type": "text", "text": prompt})];
+    content.extend(reference_image_parts.iter().map(|url| {
+        json!({
+            "type": "image_url",
+            "image_url": {"url": url},
+        })
+    }));
+    json!({
+        "model": model,
+        "modalities": ["image", "text"],
+        "messages": [{
+            "role": "user",
+            "content": content,
+        }],
+        "image_config": {"aspect_ratio": aspect_ratio},
+    })
+}
+
+fn openrouter_compat_reference_image_parts(
+    request: &ImageGenerateRequest,
+) -> Result<Vec<String>, ToolError> {
+    request
+        .source_image_urls()
+        .into_iter()
+        .take(OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES)
+        .filter_map(|reference| openrouter_compat_image_url_part(reference.as_str()).transpose())
+        .collect()
+}
+
+fn openrouter_compat_image_url_part(reference: &str) -> Result<Option<String>, ToolError> {
+    let reference = reference.trim();
+    if reference.is_empty() {
+        return Ok(None);
+    }
+    if reference.starts_with("http://")
+        || reference.starts_with("https://")
+        || reference.starts_with("data:")
+    {
+        return Ok(Some(reference.to_string()));
+    }
+    let path = Path::new(reference);
+    let raw = match std::fs::read(path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Could not read reference image {}: {err}",
+                path.display()
+            )));
+        }
+    };
+    let mime = mime_type_for_path(path);
+    Ok(Some(format!("data:{mime};base64,{}", STANDARD.encode(raw))))
+}
+
+fn mime_type_for_path(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("bmp") => "image/bmp",
+        Some("svg") => "image/svg+xml",
+        _ => "image/png",
+    }
+}
+
+fn extension_for_mime(mime: Option<&str>) -> &'static str {
+    match mime
+        .unwrap_or_default()
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+    {
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/svg+xml" => "svg",
+        _ => "png",
+    }
+}
+
+fn extract_openrouter_compat_images(payload: &Value) -> Vec<String> {
+    payload
+        .get("choices")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|choice| choice.get("message"))
+        .filter_map(|message| message.get("images"))
+        .filter_map(Value::as_array)
+        .flatten()
+        .filter_map(|image| image.get("image_url"))
+        .filter_map(|image_url| image_url.get("url"))
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn openrouter_compat_error_message(raw: &str) -> String {
+    serde_json::from_str::<Value>(raw)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(|error| error.get("message").or(Some(error)))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|message| !message.is_empty())
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| raw.chars().take(500).collect())
+}
+
+async fn save_openrouter_compat_generated_image(
+    client: &Client,
+    image_url: &str,
+    output_dir: &Path,
+    provider: &str,
+) -> Result<PathBuf, ToolError> {
+    if image_url.trim_start().starts_with("data:") {
+        save_openrouter_compat_data_uri(image_url, output_dir, provider)
+    } else {
+        save_openrouter_compat_remote_image(client, image_url, output_dir, provider).await
+    }
+}
+
+fn save_openrouter_compat_data_uri(
+    data_uri: &str,
+    output_dir: &Path,
+    provider: &str,
+) -> Result<PathBuf, ToolError> {
+    let (header, encoded) = data_uri.split_once(',').ok_or_else(|| {
+        ToolError::ExecutionFailed("Generated image data URI did not contain base64 data".into())
+    })?;
+    let mime = header
+        .strip_prefix("data:")
+        .and_then(|value| value.split_once(';').map(|(mime, _)| mime))
+        .filter(|value| !value.trim().is_empty());
+    let bytes = STANDARD.decode(encoded.trim()).map_err(|e| {
+        ToolError::ExecutionFailed(format!(
+            "Generated image data URI was not valid base64: {e}"
+        ))
+    })?;
+    write_openrouter_compat_image_bytes(
+        output_dir,
+        provider,
+        extension_for_mime(mime),
+        bytes.as_slice(),
+    )
+}
+
+async fn save_openrouter_compat_remote_image(
+    client: &Client,
+    image_url: &str,
+    output_dir: &Path,
+    provider: &str,
+) -> Result<PathBuf, ToolError> {
+    let resp = client.get(image_url).send().await.map_err(|e| {
+        ToolError::ExecutionFailed(format!(
+            "Could not download generated image {image_url}: {e}"
+        ))
+    })?;
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+    if !status.is_success() {
+        return Err(ToolError::ExecutionFailed(format!(
+            "Could not download generated image {image_url}: HTTP {status}"
+        )));
+    }
+    let ext = url_extension(image_url)
+        .unwrap_or_else(|| extension_for_mime(content_type.as_deref()).to_string());
+    let bytes = resp.bytes().await.map_err(|e| {
+        ToolError::ExecutionFailed(format!("Could not read generated image {image_url}: {e}"))
+    })?;
+    write_openrouter_compat_image_bytes(output_dir, provider, ext.as_str(), bytes.as_ref())
+}
+
+fn write_openrouter_compat_image_bytes(
+    output_dir: &Path,
+    provider: &str,
+    ext: &str,
+    bytes: &[u8],
+) -> Result<PathBuf, ToolError> {
+    std::fs::create_dir_all(output_dir).map_err(|e| {
+        ToolError::ExecutionFailed(format!(
+            "Could not create image cache directory {}: {e}",
+            output_dir.display()
+        ))
+    })?;
+    let safe_provider = provider.replace(|ch: char| !ch.is_ascii_alphanumeric(), "_");
+    let safe_ext = ext
+        .trim_start_matches('.')
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>();
+    let safe_ext = if safe_ext.is_empty() {
+        "png"
+    } else {
+        safe_ext.as_str()
+    };
+    let path = output_dir.join(format!(
+        "{}_gen_{}.{}",
+        safe_provider,
+        uuid::Uuid::new_v4().simple(),
+        safe_ext
+    ));
+    std::fs::write(&path, bytes).map_err(|e| {
+        ToolError::ExecutionFailed(format!("Could not save image {}: {e}", path.display()))
+    })?;
+    Ok(path)
+}
+
+fn url_extension(raw_url: &str) -> Option<String> {
+    let parsed = url::Url::parse(raw_url).ok()?;
+    Path::new(parsed.path())
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::trim)
+        .filter(|ext| !ext.is_empty())
+        .map(|ext| ext.trim_start_matches('.').to_ascii_lowercase())
+        .filter(|ext| {
+            matches!(
+                ext.as_str(),
+                "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "svg"
+            )
+        })
+}
+
+fn read_provider_auth_string(provider: &str, keys: &[&str]) -> Option<String> {
+    provider_auth_values(provider)
+        .into_iter()
+        .find_map(|value| {
+            keys.iter().find_map(|key| {
+                value
+                    .get(*key)
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+            })
+        })
+}
+
+fn read_provider_auth_tokens_string(provider: &str, key: &str) -> Option<String> {
+    provider_auth_values(provider)
+        .into_iter()
+        .find_map(|value| {
+            value
+                .get("tokens")
+                .and_then(|tokens| tokens.get(key))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn provider_auth_values(provider: &str) -> Vec<Value> {
+    let mut out = Vec::new();
+    for path in provider_auth_candidate_paths(provider) {
+        let Ok(raw) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        if let Some(provider_value) = value
+            .get("providers")
+            .and_then(|providers| providers.get(provider))
+            .cloned()
+        {
+            out.push(provider_value);
+        } else if value.as_object().is_some() {
+            out.push(value);
+        }
+    }
+    out
+}
+
+fn provider_auth_candidate_paths(provider: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(path) = env_optional_nonempty("HERMES_AUTH_FILE") {
+        paths.push(PathBuf::from(path));
+    }
+    if provider == "nous" {
+        if let Some(path) = env_optional_nonempty("HERMES_NOUS_OAUTH_FILE") {
+            paths.push(PathBuf::from(path));
+        }
+        if let Some(home) = env_optional_nonempty("HOME") {
+            paths.push(PathBuf::from(home).join(".hermes").join(".nous_oauth.json"));
+        }
+    }
+    paths.push(hermes_config::paths::auth_json_path());
+    dedup_paths(paths)
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for path in paths {
+        if !out.iter().any(|existing: &PathBuf| existing == &path) {
+            out.push(path);
+        }
+    }
+    out
 }
 
 fn resolve_codex_image_tier() -> CodexImageTier {
@@ -1473,6 +2280,15 @@ mod fal_managed_tests {
                 "HERMES_CODEX_IMAGE_CHAT_MODEL",
                 "OPENAI_CODEX_IMAGE_CHAT_MODEL",
                 "HERMES_AUTH_FILE",
+                "OPENROUTER_API_KEY",
+                "OPENROUTER_IMAGE_MODEL",
+                "OPENROUTER_IMAGE_BASE_URL",
+                "OPENROUTER_BASE_URL",
+                "NOUS_API_KEY",
+                "NOUS_IMAGE_MODEL",
+                "NOUS_IMAGE_BASE_URL",
+                "NOUS_BASE_URL",
+                "HERMES_NOUS_OAUTH_FILE",
                 "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
                 "TOOL_GATEWAY_USER_TOKEN",
                 "TOOL_GATEWAY_DOMAIN",
@@ -1702,6 +2518,150 @@ mod fal_managed_tests {
         )
         .expect("write config");
         assert_eq!(selected_image_provider(), Some("fal"));
+
+        std::fs::write(
+            hermes_config::paths::config_path(),
+            "image_gen:\n  provider: openrouter\n",
+        )
+        .expect("write config");
+        assert_eq!(selected_image_provider(), Some("openrouter"));
+
+        std::env::set_var("HERMES_IMAGE_GEN_PROVIDER", "nous-portal");
+        assert_eq!(selected_image_provider(), Some("nous"));
+    }
+
+    #[test]
+    fn openrouter_config_resolves_env_and_scoped_config() {
+        let _g = EnvScope::new();
+        std::env::set_var("OPENROUTER_API_KEY", "sk-or-env");
+        std::env::set_var("OPENROUTER_IMAGE_MODEL", "black-forest-labs/flux.2-pro");
+        let cfg = OpenRouterCompatImageGenConfig::from_env_or_config(
+            OpenRouterCompatImageProviderKind::OpenRouter,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.provider(),
+            OpenRouterCompatImageProviderKind::OpenRouter
+        );
+        assert_eq!(cfg.model(), "black-forest-labs/flux.2-pro");
+        assert_eq!(cfg.base_url(), DEFAULT_OPENROUTER_IMAGE_BASE_URL);
+
+        std::env::remove_var("OPENROUTER_IMAGE_MODEL");
+        std::env::remove_var("OPENROUTER_API_KEY");
+        std::fs::write(
+            hermes_config::paths::config_path(),
+            "image_gen:\n  provider: openrouter\n  openrouter:\n    model: google/gemini-3.1-flash-image-preview\n    api_key: config-openrouter-key\n    base_url: https://or.example/v1/\n",
+        )
+        .expect("write config");
+        let cfg = OpenRouterCompatImageGenConfig::from_env_or_config(
+            OpenRouterCompatImageProviderKind::OpenRouter,
+        )
+        .unwrap();
+        assert_eq!(cfg.model(), "google/gemini-3.1-flash-image-preview");
+        assert_eq!(cfg.base_url(), "https://or.example/v1");
+    }
+
+    #[test]
+    fn nous_config_reads_auth_store_agent_key_and_inference_base_url() {
+        let g = EnvScope::new();
+        let auth_path = g.auth_path();
+        std::env::set_var("HERMES_AUTH_FILE", &auth_path);
+        std::fs::write(
+            &auth_path,
+            r#"{
+              "version": 1,
+              "providers": {
+                "nous": {
+                  "access_token": "portal-access",
+                  "agent_key": "nous-agent-key",
+                  "inference_base_url": "https://inference.nousresearch.com/v1/"
+                }
+              }
+            }"#,
+        )
+        .expect("write auth");
+
+        let cfg = OpenRouterCompatImageGenConfig::from_env_or_config(
+            OpenRouterCompatImageProviderKind::Nous,
+        )
+        .unwrap();
+        assert_eq!(cfg.provider(), OpenRouterCompatImageProviderKind::Nous);
+        assert_eq!(cfg.base_url(), "https://inference.nousresearch.com/v1");
+        assert_eq!(cfg.api_key.as_deref(), Some("nous-agent-key"));
+    }
+
+    #[test]
+    fn openrouter_reference_images_inline_local_files_and_clamp() {
+        let g = EnvScope::new();
+        let ref_a = g.home.join("base.png");
+        let ref_b = g.home.join("ref-b.png");
+        let ref_c = g.home.join("ref-c.png");
+        let ref_d = g.home.join("ref-d.png");
+        std::fs::write(&ref_a, b"\x89PNG\r\n").expect("write ref a");
+        std::fs::write(&ref_b, b"b").expect("write ref b");
+        std::fs::write(&ref_c, b"c").expect("write ref c");
+        std::fs::write(&ref_d, b"d").expect("write ref d");
+        let mut request = image_request("same pet sprite");
+        request.image_url = Some(ref_a.to_string_lossy().to_string());
+        request.reference_image_urls = vec![
+            ref_b.to_string_lossy().to_string(),
+            ref_c.to_string_lossy().to_string(),
+            ref_d.to_string_lossy().to_string(),
+        ];
+
+        let parts = openrouter_compat_reference_image_parts(&request).unwrap();
+        assert_eq!(parts.len(), OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES);
+        assert!(parts[0].starts_with("data:image/png;base64,"));
+        assert_eq!(
+            STANDARD
+                .decode(parts[0].split_once(',').unwrap().1)
+                .unwrap(),
+            b"\x89PNG\r\n"
+        );
+
+        let payload = openrouter_compat_chat_payload(
+            DEFAULT_OPENROUTER_COMPAT_IMAGE_MODEL,
+            "same pet sprite",
+            openrouter_compat_aspect_from_tool_size(Some("portrait")),
+            parts.as_slice(),
+        );
+        assert_eq!(payload["modalities"], json!(["image", "text"]));
+        assert_eq!(payload["image_config"]["aspect_ratio"], "9:16");
+        assert_eq!(
+            payload["messages"][0]["content"][0],
+            json!({"type": "text", "text": "same pet sprite"})
+        );
+        assert_eq!(
+            payload["messages"][0]["content"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|item| item["type"] == "image_url")
+                .count(),
+            OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES
+        );
+    }
+
+    #[test]
+    fn openrouter_capabilities_advertise_reference_grounding() {
+        let backend = OpenRouterCompatImageGenBackend::unconfigured(
+            OpenRouterCompatImageProviderKind::OpenRouter,
+        );
+        let caps = backend.capabilities();
+        assert_eq!(caps.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            caps.model.as_deref(),
+            Some(DEFAULT_OPENROUTER_COMPAT_IMAGE_MODEL)
+        );
+        assert!(caps.supports_image_input());
+        assert_eq!(
+            caps.max_reference_images,
+            OPENROUTER_COMPAT_MAX_REFERENCE_IMAGES
+        );
+
+        let runtime: ImageGenRuntimeBackend = backend.into();
+        assert_eq!(runtime.provider_label(), "openrouter");
+        assert_eq!(runtime.required_env_vars(), vec!["OPENROUTER_API_KEY"]);
     }
 
     #[test]
@@ -1855,6 +2815,157 @@ mod fal_managed_tests {
         let image = payload["image"].as_str().expect("image path");
         assert!(image.contains("cache/images/openai_codex_gpt_image_2_high_"));
         assert_eq!(std::fs::read(image).unwrap(), b"\x89PNG\r\n\x1a\n");
+    }
+
+    #[tokio::test]
+    async fn openrouter_image_generate_posts_chat_completions_and_saves_data_uri() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvScope::new();
+        let server = MockServer::start().await;
+        std::env::set_var("OPENROUTER_API_KEY", "sk-or-test");
+        std::env::set_var("OPENROUTER_IMAGE_BASE_URL", server.uri());
+        std::env::set_var("OPENROUTER_IMAGE_MODEL", "google/gemini-2.5-flash-image");
+
+        let image_b64 = STANDARD.encode(b"test-image-data");
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("Authorization", "Bearer sk-or-test"))
+            .and(header("HTTP-Referer", OPENROUTER_COMPAT_HTTP_REFERER))
+            .and(header("X-Title", OPENROUTER_COMPAT_X_TITLE))
+            .and(body_partial_json(json!({
+                "model": "google/gemini-2.5-flash-image",
+                "modalities": ["image", "text"],
+                "image_config": {"aspect_ratio": "1:1"},
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "a tiny rust crab pet"}]
+                }]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "images": [{
+                            "type": "image_url",
+                            "image_url": {"url": format!("data:image/png;base64,{image_b64}")}
+                        }]
+                    }
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = OpenRouterCompatImageGenBackend::from_env_or_config(
+            OpenRouterCompatImageProviderKind::OpenRouter,
+        )
+        .unwrap();
+        let output = backend
+            .generate(ImageGenerateRequest {
+                prompt: "a tiny rust crab pet".to_string(),
+                size: Some("square".to_string()),
+                style: None,
+                n: None,
+                image_url: None,
+                reference_image_urls: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let payload: Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(payload["success"], true);
+        assert_eq!(payload["provider"], "openrouter");
+        assert_eq!(payload["transport"], "openrouter-compatible");
+        assert_eq!(payload["model"], "google/gemini-2.5-flash-image");
+        assert_eq!(payload["aspect_ratio"], "1:1");
+        let image = payload["image"].as_str().expect("image path");
+        assert!(image.contains("cache/images/openrouter_gen_"));
+        assert_eq!(std::fs::read(image).unwrap(), b"test-image-data");
+    }
+
+    #[tokio::test]
+    async fn nous_image_generate_posts_to_resolved_base_url_and_downloads_remote_image() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvScope::new();
+        let server = MockServer::start().await;
+        std::env::set_var("NOUS_API_KEY", "nous-key");
+        std::env::set_var("NOUS_IMAGE_BASE_URL", server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/generated.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(b"downloaded-image"),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("Authorization", "Bearer nous-key"))
+            .and(body_partial_json(json!({
+                "model": DEFAULT_OPENROUTER_COMPAT_IMAGE_MODEL,
+                "modalities": ["image", "text"],
+                "image_config": {"aspect_ratio": "16:9"},
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "message": {
+                        "images": [{
+                            "image_url": {"url": format!("{}/generated.png", server.uri())}
+                        }]
+                    }
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = OpenRouterCompatImageGenBackend::from_env_or_config(
+            OpenRouterCompatImageProviderKind::Nous,
+        )
+        .unwrap();
+        let mut request = image_request("a portal pet");
+        request.size = Some("landscape".to_string());
+        let output = backend.generate(request).await.unwrap();
+        let payload: Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(payload["success"], true);
+        assert_eq!(payload["provider"], "nous");
+        assert_eq!(payload["aspect_ratio"], "16:9");
+        let image = payload["image"].as_str().expect("image path");
+        assert!(image.contains("cache/images/nous_gen_"));
+        assert_eq!(std::fs::read(image).unwrap(), b"downloaded-image");
+    }
+
+    #[tokio::test]
+    async fn openrouter_image_generate_errors_when_response_has_no_images() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvScope::new();
+        let server = MockServer::start().await;
+        std::env::set_var("OPENROUTER_API_KEY", "sk-or-test");
+        std::env::set_var("OPENROUTER_IMAGE_BASE_URL", server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{"message": {"content": "no image"}}]
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = OpenRouterCompatImageGenBackend::from_env_or_config(
+            OpenRouterCompatImageProviderKind::OpenRouter,
+        )
+        .unwrap();
+        let err = backend
+            .generate(image_request("missing output"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("returned no image"));
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -134,6 +134,8 @@ pub use backends::file::{LocalPatchBackend, LocalSearchBackend};
 pub use backends::homeassistant::HaRestBackend;
 pub use backends::image_gen::{
     FalImageGenBackend, ImageGenRuntimeBackend, OpenAICodexImageGenBackend,
+    OpenRouterCompatImageGenBackend, OpenRouterCompatImageGenConfig,
+    OpenRouterCompatImageProviderKind,
 };
 pub use backends::memory::FileMemoryBackend;
 pub use backends::messaging::SignalMessagingBackend;

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T05:58:31.724877+00:00`_
+_Generated from source artifacts: `2026-06-26T07:48:22.877943+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T05:58:24.709736+00:00`
-- Proof snapshot generated: `2026-06-26T05:58:31.724877+00:00`
+- Queue snapshot generated: `2026-06-26T07:48:22.730388+00:00`
+- Proof snapshot generated: `2026-06-26T07:48:22.877943+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T05:58:31.724877+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=148.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=148.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=147.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=147.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-26T05:58:31.724877+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 148 |
-| Ported | 456 |
+| Pending | 147 |
+| Ported | 457 |
 | Superseded | 6436 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 148.0,
+        "actual": 147.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T05:58:31.724877+00:00",
+  "generated_at_utc": "2026-06-26T07:48:22.877943+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 148.0,
+    "max_queue_pending_commits": 147.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 148,
-      "ported": 456,
+      "pending": 147,
+      "ported": 457,
       "superseded": 6436
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 148.0,
+        "actual": 147.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T05:58:31.724877+00:00`
+Generated: `2026-06-26T07:48:22.877943+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T05:58:31.724877+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 148.0 |
+| `max_queue_pending_commits` | 147.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5043,6 +5043,11 @@
       "disposition": "ported",
       "notes": "Rust Honcho now parses host-scoped OAuth grants, refreshes near-expiry hch-at access tokens with the stored refresh token, serializes rotation with process and best-effort file locks, persists rotated apiKey/oauth metadata owner-only while preserving unrelated config, sends refreshed Authorization/X-API-Key headers, and lets memory setup preserve existing OAuth grants without requiring a pasted cloud API key. Desktop Electron connect UI is intentionally absent from the Rust-first surface.",
       "owner": "rust-runtime"
+    },
+    "3faf768cdef0": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust image_generate now supports OpenRouter-compatible OpenRouter and Nous Portal backends with provider selection, env/config/auth-store credential resolution, /chat/completions image-output payloads, local reference-image data URI inlining, generated image cache saves for data URI/HTTP responses, and mocked tests for payload/header/auth/error paths."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T05:58:24.709736+00:00`
+Generated: `2026-06-26T07:48:22.730388+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T05:58:24.709736+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 148 |
-| ported | 456 |
+| pending | 147 |
+| ported | 457 |
 | superseded | 6436 |
 
 ## First 100 Pending Commits
@@ -107,7 +107,6 @@ Generated: `2026-06-26T05:58:24.709736+00:00`
 | `6da615c77cf8` | #26 | fix(desktop): scope onboarding runtime check to connected provider |
 | `d8fe1c0b4195` | #20 | test(desktop): cover scoped onboarding runtime readiness checks |
 | `2de7549fe0fe` | #26 | feat(desktop): remember window size/position/maximized across launches (salvage #39154) |
-| `3faf768cdef0` | #20 | feat(pets): OpenRouter + Nous Portal image backend |
 | `aab49f6927cc` | #20 | feat(pets): generation RPCs, non-blocking gallery + gateway plumbing |
 | `743985bf1ec4` | #26 | feat(pets): Pokédex generate UI — overlay, animated egg, hatch FX, manage |
 | `b674f7ba28c4` | #26 | feat(pets): offer backend setup when generation is unavailable |
@@ -125,3 +124,4 @@ Generated: `2026-06-26T05:58:24.709736+00:00`
 | `284be6cc247c` | #26 | Merge pull request #52210 from helix4u/fix/desktop-update-progress-visibility |
 | `7e2db0a140db` | #26 | fix(desktop): stop refText crash on undefined composer attachment holes |
 | `4aeaba692251` | #26 | test(desktop): cover undefined/null attachment holes in ref helpers |
+| `cbe5c5689f9c` | #26 | perf(desktop): bound tool-result rendering so big /learn runs don't freeze (#52273) |


### PR DESCRIPTION
## Summary
- add Rust image_generate backend support for OpenRouter and Nous Portal via OpenAI-style /chat/completions image output
- support provider selection, env/config/auth-store credential resolution, reference-image data URI inlining, and generated image cache saves for data URI/HTTP responses
- mark upstream 3faf768cdef0 as ported and regenerate parity queue/proof/dashboard artifacts

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-tools backends::image_gen -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo build -p hermes-tools
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-tools --lib --no-deps -- -D warnings -A clippy::too_many_arguments -A clippy::manual_checked_ops -A clippy::manual_clamp -A clippy::manual_contains -A clippy::manual_range_contains -A clippy::manual_is_multiple_of -A clippy::manual_pattern_char_comparison -A clippy::manual_strip -A clippy::op_ref

Note: unadjusted clippy -p hermes-tools --all-targets -- -D warnings is currently blocked by pre-existing workspace/hermes-tools lint debt outside this diff.