### PR TITLE
parity(gateway): add startup provider fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,6 +1802,7 @@ dependencies = [
  "hermes-config",
  "hermes-core",
  "hermes-gateway",
+ "hermes-provider-runtime",
  "hermes-telemetry",
  "hermes-tools",
  "http-body-util",

--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -30,7 +30,7 @@ use hermes_intelligence::{build_model_switch_preflight_warning, estimate_message
 pub use hermes_provider_runtime::{
     active_llm_provider_config, allow_no_api_key, normalize_runtime_provider_name,
     provider_api_key_from_env, provider_base_url_from_env, provider_default_base_url,
-    resolve_provider_and_model,
+    resolve_provider_and_model, select_startup_model_with_fallback_and_auth_resolver,
 };
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_tools::ToolRegistry;
@@ -2187,6 +2187,12 @@ impl App {
             .clone()
             .unwrap_or_else(|| "gpt-5.5".to_string());
         let current_model = resolve_startup_model(&config, &configured_model);
+        let current_model = select_startup_model_with_fallback_and_auth_resolver(
+            &config,
+            &current_model,
+            Some(&provider_oauth_token_from_auth_state),
+        )
+        .selected_model;
         let current_personality = config.personality.clone();
 
         sync_runtime_model_env(&config, &current_model);
@@ -6504,7 +6510,13 @@ pub fn build_runtime_cron_scheduler(
     tools: &ToolRegistry,
 ) -> CronScheduler {
     let persistence = Arc::new(FileJobPersistence::with_dir(data_dir));
-    let provider = build_provider(config, model);
+    let model = select_startup_model_with_fallback_and_auth_resolver(
+        config,
+        model,
+        Some(&provider_oauth_token_from_auth_state),
+    )
+    .selected_model;
+    let provider = build_provider(config, &model);
     let runner = Arc::new(CronRunner::new(
         provider,
         Arc::new(bridge_tool_registry_excluding(tools, &["cronjob"])),
@@ -6648,7 +6660,7 @@ fn default_rtk_raw_mode() -> bool {
     }
 }
 
-fn provider_oauth_token_from_auth_state(provider: &str) -> Option<String> {
+pub fn provider_oauth_token_from_auth_state(provider: &str) -> Option<String> {
     let provider_key = match normalize_runtime_provider_name(provider).as_str() {
         "openai" => "openai",
         "openai-codex" | "codex" => "openai-codex",

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -18,6 +18,7 @@ use hermes_auth::{
 };
 use hermes_cli::app::{
     bridge_tool_registry, build_agent_config, build_provider, provider_api_key_from_env,
+    provider_oauth_token_from_auth_state, select_startup_model_with_fallback_and_auth_resolver,
 };
 use hermes_cli::auth::{
     clear_provider_auth_state, discover_existing_anthropic_oauth, discover_existing_nous_oauth,
@@ -4594,6 +4595,12 @@ fn build_agent_for_gateway_context(
 ) -> AgentLoop {
     let effective_model =
         resolve_model_for_gateway(config.model.as_deref().unwrap_or("gpt-5.5"), ctx);
+    let effective_model = select_startup_model_with_fallback_and_auth_resolver(
+        config,
+        &effective_model,
+        Some(&provider_oauth_token_from_auth_state),
+    )
+    .selected_model;
     let provider = build_provider(config, &effective_model);
     let mut agent_config = build_agent_config(config, &effective_model);
     if let Some(personality) = ctx.personality.clone() {
@@ -10089,6 +10096,12 @@ fn build_live_cron_scheduler(cli: &Cli, data_dir: &Path) -> Result<CronScheduler
         .model
         .clone()
         .unwrap_or_else(|| "gpt-5.5".to_string());
+    let current_model = select_startup_model_with_fallback_and_auth_resolver(
+        &config,
+        &current_model,
+        Some(&provider_oauth_token_from_auth_state),
+    )
+    .selected_model;
     let provider = build_provider(&config, &current_model);
 
     let tool_registry = Arc::new(ToolRegistry::new());

--- a/crates/hermes-http/Cargo.toml
+++ b/crates/hermes-http/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 hermes-core = { workspace = true }
 hermes-agent = { workspace = true }
+hermes-provider-runtime = { workspace = true }
 hermes-tools = { workspace = true }
 hermes-config = { workspace = true }
 hermes-gateway = { workspace = true }

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Environment (see also `security` module):
 //! - `HERMES_HTTP_MAX_BODY_BYTES` — max JSON body size for POST routes (default 2 MiB).
+//!
 //! Policy HTTP routes are intentionally omitted (Hermes Python does not expose them).
 
 mod security;
@@ -29,12 +30,6 @@ use axum::{Json, Router};
 use chrono::Utc;
 use futures::StreamExt;
 use hermes_agent::agent_loop::ToolRegistry as AgentToolRegistry;
-use hermes_agent::provider::{
-    AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
-};
-use hermes_agent::providers_extra::{
-    CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,
-};
 use hermes_agent::session_persistence::SessionPersistence;
 use hermes_agent::smart_model_routing::ApiMode;
 use hermes_agent::{
@@ -48,19 +43,15 @@ use hermes_core::traits::{ParseMode, PlatformAdapter};
 use hermes_core::{AgentError, LlmProvider, Message, MessageRole, StreamChunk};
 use hermes_gateway::gateway::{GatewayConfig as RuntimeGatewayConfig, IncomingMessage};
 use hermes_gateway::{DmManager, Gateway, GatewayRuntimeContext, SessionManager};
+use hermes_provider_runtime::{
+    build_provider as build_runtime_provider, select_startup_model_with_fallback,
+};
 use hermes_tools::ToolRegistry;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 pub const HTTP_PLATFORM: &str = "http";
 const SESSION_KEY_HEADER: &str = "x-hermes-session-key";
-const COPILOT_BASE_URL: &str = "https://api.githubcopilot.com";
-const GEMINI_OPENAI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
-const GMI_BASE_URL: &str = "https://api.gmi-serving.com/v1";
-const ARCEE_BASE_URL: &str = "https://api.arcee.ai/api/v1";
-const XIAOMI_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
-const TENCENT_TOKENHUB_BASE_URL: &str = "https://tokenhub.tencentmaas.com/v1";
-
 #[derive(Clone, Default)]
 pub struct ChatOutboundBuffer {
     inner: Arc<Mutex<HashMap<String, Vec<String>>>>,
@@ -1002,80 +993,7 @@ pub fn bridge_tool_registry(tools: &ToolRegistry) -> AgentToolRegistry {
 }
 
 pub fn build_provider(config: &GatewayConfig, model: &str) -> Arc<dyn LlmProvider> {
-    let (raw_provider_name, model_name) = model.split_once(':').unwrap_or(("openai", model));
-    let provider_name = canonical_gateway_provider_name(raw_provider_name);
-    let provider_config = config
-        .llm_providers
-        .get(raw_provider_name)
-        .or_else(|| config.llm_providers.get(provider_name));
-    let api_key = provider_config
-        .and_then(|c| c.api_key.clone())
-        .unwrap_or_default();
-    if api_key.is_empty() {
-        return Arc::new(GenericProvider::new(
-            "https://api.openai.com/v1".to_string(),
-            "missing-api-key",
-            model_name,
-        ));
-    }
-
-    let base_url = provider_config.and_then(|c| c.base_url.clone());
-    match provider_name {
-        "openai" => {
-            let mut p = OpenAiProvider::new(&api_key).with_model(model_name);
-            if let Some(url) = base_url {
-                p = p.with_base_url(url);
-            }
-            Arc::new(p)
-        }
-        "anthropic" => {
-            let mut p = AnthropicProvider::new(&api_key).with_model(model_name);
-            if let Some(url) = base_url {
-                p = p.with_base_url(url);
-            }
-            Arc::new(p)
-        }
-        "openrouter" => Arc::new(OpenRouterProvider::new(&api_key).with_model(model_name)),
-        "qwen" => Arc::new(QwenProvider::new(&api_key).with_model(model_name)),
-        "kimi" | "moonshot" => Arc::new(KimiProvider::new(&api_key).with_model(model_name)),
-        "minimax" => Arc::new(MiniMaxProvider::new(&api_key).with_model(model_name)),
-        "nous" => Arc::new(NousProvider::new(&api_key).with_model(model_name)),
-        "copilot" => Arc::new(
-            CopilotProvider::new(
-                base_url.unwrap_or_else(|| COPILOT_BASE_URL.to_string()),
-                &api_key,
-            )
-            .with_model(model_name),
-        ),
-        _ => {
-            let url = base_url
-                .or_else(|| default_gateway_base_url(provider_name).map(str::to_string))
-                .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
-            Arc::new(GenericProvider::new(url, &api_key, model_name))
-        }
-    }
-}
-
-fn canonical_gateway_provider_name(provider: &str) -> &str {
-    match provider.trim().to_ascii_lowercase().as_str() {
-        "google" | "google-gemini" | "google-ai-studio" => "gemini",
-        "gmi-cloud" | "gmicloud" => "gmi",
-        "arcee-ai" | "arceeai" => "arcee",
-        "mimo" | "xiaomi-mimo" => "xiaomi",
-        "tencent" | "tokenhub" | "tencent-cloud" | "tencentmaas" => "tencent-tokenhub",
-        _ => provider,
-    }
-}
-
-fn default_gateway_base_url(provider: &str) -> Option<&'static str> {
-    match provider {
-        "gemini" => Some(GEMINI_OPENAI_BASE_URL),
-        "gmi" => Some(GMI_BASE_URL),
-        "arcee" => Some(ARCEE_BASE_URL),
-        "xiaomi" => Some(XIAOMI_BASE_URL),
-        "tencent-tokenhub" => Some(TENCENT_TOKENHUB_BASE_URL),
-        _ => None,
-    }
+    build_runtime_provider(config, model)
 }
 
 fn resolve_model_for_gateway(default_model: &str, ctx: &GatewayRuntimeContext) -> String {
@@ -1108,6 +1026,8 @@ fn build_agent_for_gateway_context(
 ) -> AgentLoop {
     let effective_model =
         resolve_model_for_gateway(config.model.as_deref().unwrap_or("dynamic"), ctx);
+    let effective_model =
+        select_startup_model_with_fallback(config, &effective_model).selected_model;
     let provider = build_provider(config, &effective_model);
     let mut agent_config = build_agent_config(config, &effective_model);
     if let Some(personality) = ctx.personality.clone() {
@@ -1165,11 +1085,15 @@ fn resolve_model(default_model: &str, provider: Option<&str>, model: Option<&str
 mod tests {
     use super::*;
     use hermes_config::LlmProviderConfig;
+    use hermes_provider_runtime::{
+        normalize_runtime_provider_name, provider_default_base_url, ARCEE_BASE_URL,
+        GEMINI_BASE_URL, GMI_BASE_URL, TENCENT_TOKENHUB_BASE_URL, XIAOMI_BASE_URL,
+    };
 
     #[test]
     fn gateway_provider_aliases_resolve_to_direct_provider_defaults() {
         let cases = [
-            ("google-ai-studio", "gemini", GEMINI_OPENAI_BASE_URL),
+            ("google-ai-studio", "gemini", GEMINI_BASE_URL),
             ("gmicloud", "gmi", GMI_BASE_URL),
             ("arcee-ai", "arcee", ARCEE_BASE_URL),
             ("mimo", "xiaomi", XIAOMI_BASE_URL),
@@ -1177,8 +1101,8 @@ mod tests {
         ];
 
         for (alias, canonical, base_url) in cases {
-            assert_eq!(canonical_gateway_provider_name(alias), canonical);
-            assert_eq!(default_gateway_base_url(canonical), Some(base_url));
+            assert_eq!(normalize_runtime_provider_name(alias), canonical);
+            assert_eq!(provider_default_base_url(canonical), Some(base_url));
         }
     }
 

--- a/crates/hermes-http/src/security.rs
+++ b/crates/hermes-http/src/security.rs
@@ -304,8 +304,10 @@ mod tests {
 
     #[test]
     fn policy_guard_admin_header() {
-        let mut p = PolicyGuardConfig::default();
-        p.admin_key = Some(Arc::from("secret-token"));
+        let p = PolicyGuardConfig {
+            admin_key: Some(Arc::from("secret-token")),
+            ..PolicyGuardConfig::default()
+        };
         let mut ok = HeaderMap::new();
         ok.insert(
             axum::http::HeaderName::from_static("x-hermes-policy-admin"),

--- a/crates/hermes-provider-runtime/src/lib.rs
+++ b/crates/hermes-provider-runtime/src/lib.rs
@@ -80,6 +80,26 @@ pub struct ProviderRuntimeDiagnostic {
     pub uses_openai_pro_backend: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartupModelSelection {
+    pub requested_model: String,
+    pub selected_model: String,
+    pub fallback_used: bool,
+    pub skipped_unavailable_models: Vec<String>,
+}
+
+impl StartupModelSelection {
+    pub fn primary(model: impl Into<String>) -> Self {
+        let model = model.into();
+        Self {
+            requested_model: model.clone(),
+            selected_model: model,
+            fallback_used: false,
+            skipped_unavailable_models: Vec::new(),
+        }
+    }
+}
+
 pub fn local_backend_specs() -> &'static [LocalBackendSpec] {
     local_backends::local_backend_specs()
 }
@@ -110,6 +130,14 @@ pub fn provider_runtime_diagnostic(
     config: &GatewayConfig,
     model: &str,
 ) -> ProviderRuntimeDiagnostic {
+    provider_runtime_diagnostic_with_auth_resolver(config, model, None)
+}
+
+pub fn provider_runtime_diagnostic_with_auth_resolver(
+    config: &GatewayConfig,
+    model: &str,
+    oauth_token_resolver: Option<&OAuthTokenResolver<'_>>,
+) -> ProviderRuntimeDiagnostic {
     let (provider_name, model_name) = resolve_provider_and_model(config, model);
     let runtime_provider = normalize_runtime_provider_name(provider_name.as_str());
     let provider_config =
@@ -125,6 +153,7 @@ pub fn provider_runtime_diagnostic(
         provider_config,
         provider_name.as_str(),
         runtime_provider.as_str(),
+        oauth_token_resolver,
     );
     let local_no_key_allowed = allow_no_api_key(
         provider_name.as_str(),
@@ -135,7 +164,9 @@ pub fn provider_runtime_diagnostic(
         .and_then(|c| c.api_key.as_deref())
         .and_then(resolve_api_key_literal_or_env_ref)
         .or_else(|| provider_api_key_from_env(provider_name.as_str()))
-        .or_else(|| provider_api_key_from_env(runtime_provider.as_str()));
+        .or_else(|| provider_api_key_from_env(runtime_provider.as_str()))
+        .or_else(|| oauth_token_resolver.and_then(|resolver| resolver(provider_name.as_str())))
+        .or_else(|| oauth_token_resolver.and_then(|resolver| resolver(runtime_provider.as_str())));
     let uses_openai_pro_backend = matches!(runtime_provider.as_str(), "openai-codex" | "codex")
         || (runtime_provider == "openai"
             && api_key_for_backend_probe
@@ -157,6 +188,7 @@ fn provider_runtime_api_key_source(
     provider_config: Option<&LlmProviderConfig>,
     provider_name: &str,
     runtime_provider: &str,
+    oauth_token_resolver: Option<&OAuthTokenResolver<'_>>,
 ) -> (bool, Option<String>) {
     if let Some(config) = provider_config {
         if config
@@ -187,7 +219,122 @@ fn provider_runtime_api_key_source(
     if provider_api_key_from_env(runtime_provider).is_some() {
         return (true, Some(format!("provider_env:{runtime_provider}")));
     }
+    if oauth_token_resolver
+        .and_then(|resolver| resolver(provider_name))
+        .is_some()
+    {
+        return (true, Some(format!("oauth_resolver:{provider_name}")));
+    }
+    if oauth_token_resolver
+        .and_then(|resolver| resolver(runtime_provider))
+        .is_some()
+    {
+        return (true, Some(format!("oauth_resolver:{runtime_provider}")));
+    }
     (false, None)
+}
+
+fn model_has_startup_backend(
+    config: &GatewayConfig,
+    model: &str,
+    oauth_token_resolver: Option<&OAuthTokenResolver<'_>>,
+) -> bool {
+    let diag = provider_runtime_diagnostic_with_auth_resolver(config, model, oauth_token_resolver);
+    diag.api_key_present || diag.local_no_key_allowed
+}
+
+pub fn configured_model_fallback_chain(config: &GatewayConfig) -> Vec<String> {
+    if let Ok(raw) = std::env::var("HERMES_FALLBACK_MODELS") {
+        let parsed: Vec<String> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .collect();
+        if !parsed.is_empty() {
+            return dedupe_model_chain(parsed);
+        }
+    }
+
+    if let Ok(raw) = std::env::var("HERMES_FALLBACK_MODEL") {
+        let value = raw.trim();
+        if !value.is_empty() {
+            return vec![value.to_string()];
+        }
+    }
+
+    let mut chain = config.fallback_models.clone();
+    if let Some(model) = config.fallback_model.as_deref() {
+        chain.push(model.to_string());
+    }
+    dedupe_model_chain(chain)
+}
+
+fn dedupe_model_chain(chain: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for model in chain {
+        let trimmed = model.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if seen.insert(trimmed.to_ascii_lowercase()) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+pub fn select_startup_model_with_fallback(
+    config: &GatewayConfig,
+    requested_model: &str,
+) -> StartupModelSelection {
+    select_startup_model_with_fallback_and_auth_resolver(config, requested_model, None)
+}
+
+pub fn select_startup_model_with_fallback_and_auth_resolver(
+    config: &GatewayConfig,
+    requested_model: &str,
+    oauth_token_resolver: Option<&OAuthTokenResolver<'_>>,
+) -> StartupModelSelection {
+    let requested = requested_model.trim();
+    let requested = if requested.is_empty() {
+        "gpt-5.5"
+    } else {
+        requested
+    };
+
+    if model_has_startup_backend(config, requested, oauth_token_resolver) {
+        return StartupModelSelection::primary(requested.to_string());
+    }
+
+    let mut skipped = vec![requested.to_string()];
+    for fallback in configured_model_fallback_chain(config) {
+        if fallback.eq_ignore_ascii_case(requested) {
+            continue;
+        }
+        if model_has_startup_backend(config, &fallback, oauth_token_resolver) {
+            tracing::warn!(
+                "startup provider for '{}' has no configured credentials; using fallback model '{}'",
+                requested,
+                fallback
+            );
+            return StartupModelSelection {
+                requested_model: requested.to_string(),
+                selected_model: fallback,
+                fallback_used: true,
+                skipped_unavailable_models: skipped,
+            };
+        }
+        skipped.push(fallback);
+    }
+
+    StartupModelSelection {
+        requested_model: requested.to_string(),
+        selected_model: requested.to_string(),
+        fallback_used: false,
+        skipped_unavailable_models: skipped,
+    }
 }
 
 pub fn active_llm_provider_config<'a>(
@@ -1055,6 +1202,216 @@ mod tests {
         let (provider, model) = resolve_provider_and_model(&cfg, "my-model");
         assert_eq!(provider, "custom");
         assert_eq!(model, "my-model");
+    }
+
+    #[test]
+    fn startup_model_selector_keeps_primary_when_credentials_exist() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+        ]);
+        for key in [
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+        ] {
+            std::env::remove_var(key);
+        }
+
+        let mut cfg = GatewayConfig {
+            fallback_models: vec!["anthropic:claude-sonnet-4-6".to_string()],
+            ..GatewayConfig::default()
+        };
+        cfg.llm_providers.insert(
+            "openai".to_string(),
+            LlmProviderConfig {
+                api_key: Some("primary-key".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let selection = select_startup_model_with_fallback(&cfg, "openai:dynamic");
+
+        assert_eq!(selection.selected_model, "openai:dynamic");
+        assert!(!selection.fallback_used);
+        assert!(selection.skipped_unavailable_models.is_empty());
+    }
+
+    #[test]
+    fn startup_model_selector_uses_first_credentialed_fallback() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_OPENROUTER_API_KEY",
+            "OPENROUTER_API_KEY",
+            "HERMES_ANTHROPIC_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ]);
+        for key in [
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_OPENROUTER_API_KEY",
+            "OPENROUTER_API_KEY",
+            "HERMES_ANTHROPIC_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ] {
+            std::env::remove_var(key);
+        }
+
+        let mut cfg = GatewayConfig {
+            fallback_models: vec![
+                "openrouter:anthropic/claude-sonnet-4.6".to_string(),
+                "anthropic:claude-sonnet-4-6".to_string(),
+            ],
+            ..GatewayConfig::default()
+        };
+        cfg.llm_providers.insert(
+            "anthropic".to_string(),
+            LlmProviderConfig {
+                api_key: Some("fallback-key".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let selection = select_startup_model_with_fallback(&cfg, "openai:dynamic");
+
+        assert_eq!(selection.requested_model, "openai:dynamic");
+        assert_eq!(selection.selected_model, "anthropic:claude-sonnet-4-6");
+        assert!(selection.fallback_used);
+        assert_eq!(
+            selection.skipped_unavailable_models,
+            vec![
+                "openai:dynamic".to_string(),
+                "openrouter:anthropic/claude-sonnet-4.6".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn startup_model_selector_honors_env_fallback_override() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_NOUS_API_KEY",
+            "NOUS_API_KEY",
+        ]);
+        for key in [
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_NOUS_API_KEY",
+            "NOUS_API_KEY",
+        ] {
+            std::env::remove_var(key);
+        }
+        std::env::set_var("HERMES_FALLBACK_MODELS", "nous:Hermes-4");
+
+        let mut cfg = GatewayConfig {
+            fallback_models: vec!["anthropic:claude-sonnet-4-6".to_string()],
+            ..GatewayConfig::default()
+        };
+        cfg.llm_providers.insert(
+            "nous".to_string(),
+            LlmProviderConfig {
+                api_key: Some("nous-fallback-key".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let selection = select_startup_model_with_fallback(&cfg, "openai:dynamic");
+
+        assert_eq!(selection.selected_model, "nous:Hermes-4");
+        assert!(selection.fallback_used);
+    }
+
+    #[test]
+    fn startup_model_selector_keeps_local_no_key_backend() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "OLLAMA_API_KEY",
+            "OLLAMA_LOCAL_API_KEY",
+        ]);
+        for key in [
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "OLLAMA_API_KEY",
+            "OLLAMA_LOCAL_API_KEY",
+        ] {
+            std::env::remove_var(key);
+        }
+
+        let cfg = GatewayConfig::default();
+        let selection = select_startup_model_with_fallback(&cfg, "ollama:llama3.3");
+
+        assert_eq!(selection.selected_model, "ollama:llama3.3");
+        assert!(!selection.fallback_used);
+    }
+
+    #[test]
+    fn startup_model_selector_uses_oauth_resolver_as_primary_credentials() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(&[
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+        ]);
+        for key in [
+            "HERMES_FALLBACK_MODELS",
+            "HERMES_FALLBACK_MODEL",
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+        ] {
+            std::env::remove_var(key);
+        }
+
+        let mut cfg = GatewayConfig {
+            fallback_models: vec!["anthropic:claude-sonnet-4-6".to_string()],
+            ..GatewayConfig::default()
+        };
+        cfg.llm_providers.insert(
+            "anthropic".to_string(),
+            LlmProviderConfig {
+                api_key: Some("fallback-key".to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let resolver = |provider: &str| {
+            if provider == "openai" {
+                Some("oauth-token".to_string())
+            } else {
+                None
+            }
+        };
+        let diagnostic =
+            provider_runtime_diagnostic_with_auth_resolver(&cfg, "openai:dynamic", Some(&resolver));
+        let selection = select_startup_model_with_fallback_and_auth_resolver(
+            &cfg,
+            "openai:dynamic",
+            Some(&resolver),
+        );
+
+        assert_eq!(
+            diagnostic.api_key_source.as_deref(),
+            Some("oauth_resolver:openai")
+        );
+        assert_eq!(selection.selected_model, "openai:dynamic");
+        assert!(!selection.fallback_used);
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T07:48:22.877943+00:00`_
+_Generated from source artifacts: `2026-06-26T08:50:22.940104+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T07:48:22.730388+00:00`
-- Proof snapshot generated: `2026-06-26T07:48:22.877943+00:00`
+- Queue snapshot generated: `2026-06-26T08:50:22.801292+00:00`
+- Proof snapshot generated: `2026-06-26T08:50:22.940104+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T07:48:22.877943+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=147.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=147.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=146.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=146.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-26T07:48:22.877943+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 147 |
-| Ported | 457 |
+| Pending | 146 |
+| Ported | 458 |
 | Superseded | 6436 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 147.0,
+        "actual": 146.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T07:48:22.877943+00:00",
+  "generated_at_utc": "2026-06-26T08:50:22.940104+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 147.0,
+    "max_queue_pending_commits": 146.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 147,
-      "ported": 457,
+      "pending": 146,
+      "ported": 458,
       "superseded": 6436
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 147.0,
+        "actual": 146.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T07:48:22.877943+00:00`
+Generated: `2026-06-26T08:50:22.940104+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T07:48:22.877943+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 147.0 |
+| `max_queue_pending_commits` | 146.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5048,6 +5048,11 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Rust image_generate now supports OpenRouter-compatible OpenRouter and Nous Portal backends with provider selection, env/config/auth-store credential resolution, /chat/completions image-output payloads, local reference-image data URI inlining, generated image cache saves for data URI/HTTP responses, and mocked tests for payload/header/auth/error paths."
+    },
+    "f44415e71a26": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Rust startup/gateway provider construction now applies init-time fallback selection before building the agent/provider when the primary model has no configured credentials, while preserving local no-key backends and OAuth auth-store resolver credentials. Covered by provider-runtime, CLI startup-model, and HTTP provider alias/config tests."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T07:48:22.730388+00:00`
+Generated: `2026-06-26T08:50:22.801292+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T07:48:22.730388+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 147 |
-| ported | 457 |
+| pending | 146 |
+| ported | 458 |
 | superseded | 6436 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- Port upstream init-time provider fallback behavior into Rust startup/gateway construction.
- Add shared provider-runtime startup fallback selection with config/env fallback chains, local no-key backend handling, and OAuth auth-store resolver support.
- Wire fallback selection into CLI/TUI startup, live cron scheduler, CLI gateway agent construction, and hermes-http gateway agent construction.
- Reuse the shared provider-runtime builder from hermes-http so provider construction and startup selection use the same credential rules.
- Update parity artifacts for upstream f44415e71a26; queue pending 147 -> 146, ported 457 -> 458.

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo check -p hermes-cli -p hermes-http -p hermes-provider-runtime
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-provider-runtime startup_model_selector -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-http gateway_provider_aliases_resolve_to_direct_provider_defaults -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-http build_agent_config_maps_provider_request_timeout_seconds -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-http policy_guard_admin_header -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli startup_model -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-provider-runtime --lib --tests --no-deps -- -D warnings
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-http --lib --tests --no-deps -- -D warnings

Note: unadjusted clippy over the scoped package set is blocked by pre-existing hermes-config lint debt; local --no-deps clippy passed for the touched crates.