### PR TITLE
parity(session): skip routing-index sentinels

### DIFF
--- a/crates/hermes-gateway/src/channel_directory.rs
+++ b/crates/hermes-gateway/src/channel_directory.rs
@@ -227,6 +227,9 @@ pub fn build_from_sessions_in(
     hermes_home_path: impl AsRef<Path>,
     platform_name: &str,
 ) -> Vec<ChannelEntry> {
+    // `sessions/sessions.json` is a gateway routing index, not the CLI/TUI
+    // session list. Python Hermes may include `_` metadata sentinels there so
+    // humans who inspect it directly do not confuse it with state.db.
     let platform_name = normalize_platform(platform_name);
     let sessions_path = hermes_home_path
         .as_ref()
@@ -242,7 +245,13 @@ pub fn build_from_sessions_in(
 
     let mut seen = BTreeSet::new();
     let mut entries = Vec::new();
-    for session in sessions.values() {
+    for (key, session) in &sessions {
+        if is_sessions_index_metadata_key(key) {
+            continue;
+        }
+        let Some(session) = session.as_object() else {
+            continue;
+        };
         let Some(origin) = session.get("origin").and_then(Value::as_object) else {
             continue;
         };
@@ -265,6 +274,10 @@ pub fn build_from_sessions_in(
         entries.push(entry);
     }
     entries
+}
+
+fn is_sessions_index_metadata_key(key: &str) -> bool {
+    key.trim_start().starts_with('_')
 }
 
 pub fn resolve_channel_name(platform_name: &str, name: &str) -> Option<String> {
@@ -726,9 +739,11 @@ mod tests {
         std::fs::write(
             sessions_dir.join("sessions.json"),
             serde_json::json!({
+                "_README": "Gateway routing index only; full sessions live in state.db.",
                 "group_root": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat"}, "chat_type": "group"},
                 "topic_a": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat", "thread_id": "17585"}, "chat_type": "group"},
                 "topic_b": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat", "thread_id": "17587"}, "chat_type": "group"},
+                "_metadata": {"origin": {"platform": "telegram", "chat_id": "should-not-load"}},
                 "dup": {"origin": {"platform": "telegram", "chat_id": "-1001", "chat_name": "Coaching Chat"}, "chat_type": "group"},
                 "discord": {"origin": {"platform": "discord", "chat_id": "999"}}
             })
@@ -746,6 +761,30 @@ mod tests {
         assert!(names.contains("Coaching Chat"));
         assert!(names.contains("Coaching Chat / topic 17585"));
         assert!(names.contains("Coaching Chat / topic 17587"));
+    }
+
+    #[test]
+    fn build_from_sessions_skips_readme_sentinel_and_non_session_values() {
+        let tmp = tempdir().expect("tmp");
+        let sessions_dir = tmp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+        std::fs::write(
+            sessions_dir.join("sessions.json"),
+            serde_json::json!({
+                "_README": "Gateway routing index ONLY; all sessions live in state.db.",
+                "_README_OBJECT": {"origin": {"platform": "slack", "chat_id": "bad"}},
+                "not_an_object": true,
+                "slack_dm": {"origin": {"platform": "slack", "chat_id": "D123", "chat_name": "Ada"}, "chat_type": "dm"}
+            })
+            .to_string(),
+        )
+        .expect("write sessions");
+
+        let entries = build_from_sessions_in(tmp.path(), "slack");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "D123");
+        assert_eq!(entries[0].name, "Ada");
+        assert_eq!(entries[0].kind.as_deref(), Some("dm"));
     }
 
     #[test]

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T10:33:55.190433+00:00`_
+_Generated from source artifacts: `2026-06-26T11:06:18.269413+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T10:33:55.048190+00:00`
-- Proof snapshot generated: `2026-06-26T10:33:55.190433+00:00`
+- Queue snapshot generated: `2026-06-26T11:06:17.942717+00:00`
+- Proof snapshot generated: `2026-06-26T11:06:18.269413+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T10:33:55.190433+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=145.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=145.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=144.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=144.0, limit=100)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-26T10:33:55.190433+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 145 |
-| Ported | 459 |
+| Pending | 144 |
+| Ported | 460 |
 | Superseded | 6436 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 145.0,
+        "actual": 144.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T10:33:55.190433+00:00",
+  "generated_at_utc": "2026-06-26T11:06:18.269413+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 145.0,
+    "max_queue_pending_commits": 144.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 145,
-      "ported": 459,
+      "pending": 144,
+      "ported": 460,
       "superseded": 6436
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 145.0,
+        "actual": 144.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T10:33:55.190433+00:00`
+Generated: `2026-06-26T11:06:18.269413+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T10:33:55.190433+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 145.0 |
+| `max_queue_pending_commits` | 144.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5058,6 +5058,11 @@
       "disposition": "ported",
       "notes": "Rust email gateway now rejects spoofed From-header authorization when email/global allowlists are active unless allow-all or EMAIL_TRUST_FROM_HEADER opt-out is configured. The IMAP ingestion path fetches Authentication-Results, verifies DMARC/SPF/DKIM relaxed domain alignment with optional EMAIL_AUTHSERV_ID pinning, normalizes From addresses before emitting IncomingMessage identities, and has feature-gated email parser/auth tests.",
       "owner": "rust-runtime"
+    },
+    "0ef86febe25f": {
+      "disposition": "ported",
+      "notes": "Rust channel directory sessions.json reader now explicitly treats sessions/sessions.json as a gateway routing index, skips underscore-prefixed metadata/readme sentinel keys and non-session values, and has regression tests preserving real route entries while ignoring _README-style metadata. Rust has no Python SessionStore sessions.json writer; CLI/TUI session lists remain backed by Rust session persistence/state surfaces.",
+      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T10:33:55.048190+00:00`
+Generated: `2026-06-26T11:06:17.942717+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T10:33:55.048190+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 145 |
-| ported | 459 |
+| pending | 144 |
+| ported | 460 |
 | superseded | 6436 |
 
 ## First 100 Pending Commits
@@ -97,7 +97,6 @@ Generated: `2026-06-26T10:33:55.048190+00:00`
 | `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |
 | `935f2bc48daa` | #26 | docs(relay): add §3.4 — obligations on a future scale-to-zero behaviour layer (#51633) |
 | `281a439ad483` | #26 | fix(desktop): guard composer mutations when the composer core isn't bound (#51728) |
-| `0ef86febe25f` | #20 | docs(sessions): clarify sessions.json is the gateway routing index, not the session list (#51726) |
 | `a911bcda18cf` | #22 | docs: stop recommending pip install; curl installer is the only supported path (#51743) |
 | `8446c1570683` | #26 | docs(chronos): pin hop-1 auth to the hosted-agent bootstrap token |
 | `66a0907c9566` | #26 | fix(desktop): keep configured onboarding state on fallback runtime probes |
@@ -125,3 +124,4 @@ Generated: `2026-06-26T10:33:55.048190+00:00`
 | `7e2db0a140db` | #26 | fix(desktop): stop refText crash on undefined composer attachment holes |
 | `4aeaba692251` | #26 | test(desktop): cover undefined/null attachment holes in ref helpers |
 | `cbe5c5689f9c` | #26 | perf(desktop): bound tool-result rendering so big /learn runs don't freeze (#52273) |
+| `f2c45e2c816d` | #26 | fix(desktop): limit pending tool shimmer to action verb |


### PR DESCRIPTION
## Summary
- port upstream sessions.json routing-index sentinel hardening into the Rust channel-directory reader
- explicitly skip underscore-prefixed metadata/readme keys and non-session values in sessions/sessions.json
- add regression coverage proving _README-style metadata is ignored while real route entries survive
- mark upstream 0ef86febe25f as ported and regenerate parity artifacts

## Verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway channel_directory -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-gateway --lib --tests --no-deps -- -D warnings -A clippy::derivable_impls -A clippy::needless_borrows_for_generic_args -A clippy::manual_is_multiple_of -A clippy::collapsible_if -A clippy::await_holding_lock -A clippy::field_reassign_with_default
- test ! -d target

## Notes
- Rust has no Python SessionStore sessions.json writer; the runtime-equivalent slice is compatibility/read-hardening for the routing index consumed by Rust channel discovery. CLI/TUI session lists remain backed by Rust session persistence/state surfaces.