### PR TITLE
parity(telegram): self-heal polling outages

### DIFF
--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -112,8 +112,8 @@ use hermes_gateway::platforms::slack::{SlackAdapter, SlackConfig};
 use hermes_gateway::platforms::sms::{SmsAdapter, SmsConfig};
 #[cfg(feature = "gateway-telegram")]
 use hermes_gateway::platforms::telegram::{
-    IncomingMessage as TelegramIncomingMessage, TelegramAdapter, TelegramConfig,
-    TelegramTextBatcher,
+    IncomingMessage as TelegramIncomingMessage, PollResult as TelegramPollResult, TelegramAdapter,
+    TelegramConfig, TelegramTextBatcher,
 };
 #[cfg(feature = "gateway-webhook")]
 use hermes_gateway::platforms::webhook::{WebhookAdapter, WebhookConfig, WebhookPayload};
@@ -6495,6 +6495,17 @@ fn telegram_routable_topic_thread(thread_id: Option<i64>) -> Option<i64> {
 }
 
 #[cfg(feature = "gateway-telegram")]
+const TELEGRAM_POLLING_RECONNECT_ERROR_THRESHOLD: u64 = 3;
+
+#[cfg(feature = "gateway-telegram")]
+const TELEGRAM_POLLING_STOPPED_RECHECK_MS: u64 = 500;
+
+#[cfg(feature = "gateway-telegram")]
+fn telegram_polling_should_pause_for_reconnect(consecutive_errors: u64) -> bool {
+    consecutive_errors >= TELEGRAM_POLLING_RECONNECT_ERROR_THRESHOLD
+}
+
+#[cfg(feature = "gateway-telegram")]
 fn telegram_gateway_message(msg: TelegramIncomingMessage) -> GatewayIncomingMessage {
     let text = msg.text.unwrap_or_else(|| {
         if msg.is_voice {
@@ -6538,26 +6549,41 @@ async fn route_telegram_message(gateway: &Gateway, msg: TelegramIncomingMessage)
 
 #[cfg(feature = "gateway-telegram")]
 async fn run_telegram_poll_loop(gateway: Arc<Gateway>, adapter: Arc<TelegramAdapter>) {
-    if adapter.config().polling {
-        if let Err(err) = adapter.delete_webhook(false).await {
-            tracing::warn!("Telegram deleteWebhook before polling failed: {}", err);
-        }
-    }
-
     let batch_delay = std::time::Duration::from_millis(adapter.config().text_batch_delay_ms);
     let mut text_batcher = TelegramTextBatcher::new(batch_delay);
+    let mut webhook_cleared = false;
 
     loop {
         if !adapter.is_running() {
-            break;
+            webhook_cleared = false;
+            tokio::time::sleep(std::time::Duration::from_millis(
+                TELEGRAM_POLLING_STOPPED_RECHECK_MS,
+            ))
+            .await;
+            continue;
+        }
+
+        if !adapter.config().polling {
+            tokio::time::sleep(std::time::Duration::from_millis(
+                TELEGRAM_POLLING_STOPPED_RECHECK_MS,
+            ))
+            .await;
+            continue;
+        }
+
+        if !webhook_cleared {
+            if let Err(err) = adapter.delete_webhook(false).await {
+                tracing::warn!("Telegram deleteWebhook before polling failed: {}", err);
+            }
+            webhook_cleared = true;
         }
 
         for msg in text_batcher.drain_ready() {
             route_telegram_message(&gateway, msg).await;
         }
 
-        match adapter.get_updates().await {
-            Ok(updates) => {
+        match adapter.poll_with_backoff().await {
+            TelegramPollResult::Updates(updates) => {
                 for update in updates {
                     if !adapter.should_process_update(&update) {
                         continue;
@@ -6596,9 +6622,29 @@ async fn run_telegram_poll_loop(gateway: Arc<Gateway>, adapter: Arc<TelegramAdap
                     }
                 }
             }
-            Err(err) => {
-                tracing::warn!("Telegram polling error: {}", err);
-                tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+            TelegramPollResult::Backoff { error, delay_ms } => {
+                let consecutive_errors = adapter.consecutive_error_count();
+                if telegram_polling_should_pause_for_reconnect(consecutive_errors)
+                    && adapter.polling_reconnect_threshold_reached(
+                        TELEGRAM_POLLING_RECONNECT_ERROR_THRESHOLD,
+                    )
+                {
+                    tracing::warn!(
+                        consecutive_errors,
+                        error = %error,
+                        "Telegram polling exceeded reconnect threshold; pausing poll loop until gateway watcher restarts adapter"
+                    );
+                    adapter.mark_polling_unhealthy();
+                    continue;
+                }
+
+                tracing::warn!(
+                    consecutive_errors,
+                    delay_ms,
+                    error = %error,
+                    "Telegram polling error; backing off"
+                );
+                adapter.sleep_backoff().await;
             }
         }
     }
@@ -16448,6 +16494,21 @@ mod tests {
         let routed = telegram_gateway_message(incoming);
         assert_eq!(routed.chat_id, "208214988");
         assert!(routed.is_dm);
+    }
+
+    #[cfg(feature = "gateway-telegram")]
+    #[test]
+    fn telegram_polling_pause_threshold_matches_reconnect_policy() {
+        assert!(!telegram_polling_should_pause_for_reconnect(0));
+        assert!(!telegram_polling_should_pause_for_reconnect(
+            TELEGRAM_POLLING_RECONNECT_ERROR_THRESHOLD - 1
+        ));
+        assert!(telegram_polling_should_pause_for_reconnect(
+            TELEGRAM_POLLING_RECONNECT_ERROR_THRESHOLD
+        ));
+        assert!(telegram_polling_should_pause_for_reconnect(
+            TELEGRAM_POLLING_RECONNECT_ERROR_THRESHOLD + 1
+        ));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/platforms/telegram.rs
+++ b/crates/hermes-gateway/src/platforms/telegram.rs
@@ -37,6 +37,10 @@ const RICH_MESSAGE_MAX_CHARS: usize = 32_768;
 /// Default long-polling timeout in seconds.
 const DEFAULT_POLL_TIMEOUT: u64 = 30;
 
+/// Extra time allowed beyond Telegram's long-poll window before treating a
+/// getUpdates request as wedged and handing it to the reconnect ladder.
+const DEFAULT_POLL_STALL_GRACE_SECONDS: u64 = 15;
+
 /// Initial backoff delay for reconnection (in milliseconds).
 const INITIAL_BACKOFF_MS: u64 = 1000;
 
@@ -223,6 +227,14 @@ fn default_true() -> bool {
 
 fn default_poll_timeout() -> u64 {
     DEFAULT_POLL_TIMEOUT
+}
+
+fn poll_stall_grace_seconds() -> u64 {
+    std::env::var("TELEGRAM_POLL_STALL_GRACE_SECONDS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(DEFAULT_POLL_STALL_GRACE_SECONDS)
 }
 
 fn default_reply_to_mode() -> String {
@@ -521,7 +533,7 @@ pub enum ChatKind {
 }
 
 impl ChatKind {
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_telegram_type(s: &str) -> Self {
         match s {
             "private" => ChatKind::Private,
             "group" => ChatKind::Group,
@@ -1529,7 +1541,7 @@ impl TelegramAdapter {
     }
 
     pub fn should_process_message(&self, msg: &TelegramMessage, is_command: bool) -> bool {
-        let chat_kind = ChatKind::from_str(&msg.chat.chat_type);
+        let chat_kind = ChatKind::from_telegram_type(&msg.chat.chat_type);
         if !chat_kind.is_group_like() {
             return true;
         }
@@ -2310,7 +2322,9 @@ impl TelegramAdapter {
             "allowed_updates": ["message", "callback_query"],
         });
 
-        let resp: TelegramResponse<Vec<Update>> = self.post_json(&url, &body).await?;
+        let resp: TelegramResponse<Vec<Update>> = self
+            .post_json_with_request_timeout(&url, &body, Some(self.poll_request_timeout()))
+            .await?;
 
         if let Some(updates) = resp.result {
             if let Some(last) = updates.last() {
@@ -2389,6 +2403,23 @@ impl TelegramAdapter {
         self.consecutive_errors.load(Ordering::SeqCst)
     }
 
+    pub fn polling_reconnect_threshold_reached(&self, threshold: u64) -> bool {
+        threshold > 0 && self.consecutive_error_count() >= threshold
+    }
+
+    pub fn mark_polling_unhealthy(&self) {
+        self.base.mark_stopped();
+    }
+
+    pub fn poll_request_timeout(&self) -> Duration {
+        Duration::from_secs(
+            self.config
+                .poll_timeout
+                .saturating_add(poll_stall_grace_seconds())
+                .max(1),
+        )
+    }
+
     pub fn is_polling_conflict_error(err: &GatewayError) -> bool {
         let message = err.to_string().to_ascii_lowercase();
         message.contains("409")
@@ -2460,7 +2491,7 @@ impl TelegramAdapter {
 
         let reply_to_message_id = msg.reply_to_message.as_ref().map(|r| r.message_id);
 
-        let chat_type = ChatKind::from_str(&msg.chat.chat_type);
+        let chat_type = ChatKind::from_telegram_type(&msg.chat.chat_type);
         let is_group = chat_type.is_group_like();
 
         let (cb_id, cb_data) = match callback {
@@ -2501,7 +2532,7 @@ impl TelegramAdapter {
         let message_id = msg.map(|m| m.message_id).unwrap_or(0);
 
         let chat_type = msg
-            .map(|m| ChatKind::from_str(&m.chat.chat_type))
+            .map(|m| ChatKind::from_telegram_type(&m.chat.chat_type))
             .unwrap_or(ChatKind::Private);
         let is_group = chat_type.is_group_like();
 
@@ -2849,10 +2880,23 @@ impl TelegramAdapter {
         url: &str,
         body: &serde_json::Value,
     ) -> Result<TelegramResponse<T>, GatewayError> {
+        self.post_json_with_request_timeout(url, body, None).await
+    }
+
+    async fn post_json_with_request_timeout<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        body: &serde_json::Value,
+        request_timeout: Option<Duration>,
+    ) -> Result<TelegramResponse<T>, GatewayError> {
         let mut retries = 0u32;
 
         loop {
-            let resp = self.client.post(url).json(body).send().await.map_err(|e| {
+            let mut request = self.client.post(url).json(body);
+            if let Some(timeout) = request_timeout {
+                request = request.timeout(timeout);
+            }
+            let resp = request.send().await.map_err(|e| {
                 GatewayError::ConnectionFailed(format!("Telegram API request failed: {}", e))
             })?;
 
@@ -3177,8 +3221,11 @@ fn parse_approval_callback(data: &str) -> Option<(ApprovalChoice, u64)> {
 mod tests {
     use super::*;
     use serde_json::Value;
+    use std::sync::Mutex;
     use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct JsonFieldAbsent(&'static str);
 
@@ -4693,12 +4740,15 @@ mod tests {
 
     #[test]
     fn chat_kind_from_str_variants() {
-        assert_eq!(ChatKind::from_str("private"), ChatKind::Private);
-        assert_eq!(ChatKind::from_str("group"), ChatKind::Group);
-        assert_eq!(ChatKind::from_str("supergroup"), ChatKind::Supergroup);
-        assert_eq!(ChatKind::from_str("channel"), ChatKind::Channel);
+        assert_eq!(ChatKind::from_telegram_type("private"), ChatKind::Private);
+        assert_eq!(ChatKind::from_telegram_type("group"), ChatKind::Group);
         assert_eq!(
-            ChatKind::from_str("something"),
+            ChatKind::from_telegram_type("supergroup"),
+            ChatKind::Supergroup
+        );
+        assert_eq!(ChatKind::from_telegram_type("channel"), ChatKind::Channel);
+        assert_eq!(
+            ChatKind::from_telegram_type("something"),
             ChatKind::Unknown("something".into())
         );
     }
@@ -5064,6 +5114,93 @@ mod tests {
         assert_eq!(vals[5], 32_000);
         assert_eq!(vals[6], 60_000);
         assert_eq!(vals[7], 60_000);
+    }
+
+    #[test]
+    fn telegram_poll_request_timeout_adds_stall_grace() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var("TELEGRAM_POLL_STALL_GRACE_SECONDS").ok();
+        std::env::set_var("TELEGRAM_POLL_STALL_GRACE_SECONDS", "4");
+
+        let mut cfg = test_config();
+        cfg.poll_timeout = 7;
+        let adapter = test_adapter(cfg);
+
+        assert_eq!(adapter.poll_request_timeout(), Duration::from_secs(11));
+
+        match previous {
+            Some(value) => std::env::set_var("TELEGRAM_POLL_STALL_GRACE_SECONDS", value),
+            None => std::env::remove_var("TELEGRAM_POLL_STALL_GRACE_SECONDS"),
+        }
+    }
+
+    #[test]
+    fn telegram_polling_threshold_marks_adapter_unhealthy() {
+        let adapter = test_adapter(test_config());
+        adapter.base.mark_running();
+        adapter.consecutive_errors.store(3, Ordering::SeqCst);
+
+        assert!(adapter.is_running());
+        assert!(adapter.polling_reconnect_threshold_reached(3));
+
+        adapter.mark_polling_unhealthy();
+
+        assert!(!adapter.is_running());
+    }
+
+    #[tokio::test]
+    async fn telegram_delete_webhook_can_preserve_pending_updates() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/deleteWebhook"))
+            .and(body_partial_json(serde_json::json!({
+                "drop_pending_updates": false
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": true
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        adapter
+            .delete_webhook(false)
+            .await
+            .expect("deleteWebhook should preserve pending updates when requested");
+    }
+
+    #[tokio::test]
+    async fn telegram_get_updates_advances_offset_after_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/botfake_token_12345/getUpdates"))
+            .and(body_partial_json(serde_json::json!({
+                "offset": 0,
+                "timeout": 30,
+                "allowed_updates": ["message", "callback_query"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [
+                    {"update_id": 41},
+                    {"update_id": 42}
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut adapter = test_adapter(test_config());
+        adapter.api_base = format!("{}/botfake_token_12345", server.uri());
+
+        let updates = adapter.get_updates().await.expect("updates");
+
+        assert_eq!(updates.len(), 2);
+        assert_eq!(adapter.poll_offset.load(Ordering::SeqCst), 43);
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5063,6 +5063,21 @@
       "disposition": "ported",
       "notes": "Rust channel directory sessions.json reader now explicitly treats sessions/sessions.json as a gateway routing index, skips underscore-prefixed metadata/readme sentinel keys and non-session values, and has regression tests preserving real route entries while ignoring _README-style metadata. Rust has no Python SessionStore sessions.json writer; CLI/TUI session lists remain backed by Rust session persistence/state surfaces.",
       "owner": "rust-runtime"
+    },
+    "8501caf51f6d0ff5782a0a00c85a319a449d781b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Telegram gateway polling: getUpdates requests now have bounded poll-window-plus-grace timeouts, polling errors flow through exponential backoff counters, and sustained failures mark the adapter unhealthy so the gateway reconnect watcher can restart it without losing the resident poll task."
+    },
+    "ce802e932c645304badf0112e175e77f23b86a5b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by Rust resident polling lifecycle: the Telegram poll task stays alive while the adapter is stopped instead of exiting or busy-spinning, then resumes after start() marks the adapter running again. The Python test-double get_me spin failure is not present in Rust."
+    },
+    "43b8ba41816b6790e3bae852eb32277dc4dc6915": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/proven in Rust: the Telegram CLI poll loop calls deleteWebhook(drop_pending_updates=false), preserves Bot API queued updates across reconnects, advances getUpdates offsets only after successful responses, and keeps the poll sidecar resident so watcher start() can recover after outages."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T11:06:17.942717+00:00`
+Generated: `2026-06-26T11:38:24.734853+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7116`.
+- Range: `main..upstream/main`; total commits tracked: `7116`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -17,8 +17,8 @@ Generated: `2026-06-26T11:06:17.942717+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 144 |
-| ported | 460 |
+| pending | 141 |
+| ported | 463 |
 | superseded | 6436 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- bound Telegram getUpdates long-poll requests with poll-window plus stall-grace timeout
- keep the Rust Telegram poll sidecar resident across stopped/restarted adapter states
- route polling errors through adapter backoff counters and mark sustained failures unhealthy so the gateway reconnect watcher can recover
- preserve Bot API queued updates on reconnect via deleteWebhook(drop_pending_updates=false) and add offset/queue regression coverage
- mark upstream Telegram reconnect commits 8501caf51f6d, ce802e932c64, and 43b8ba41816b as ported in the parity queue

## Verification
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features telegram telegram_ -- --nocapture (44 passed)
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli --no-default-features --features gateway-telegram telegram_polling_pause_threshold_matches_reconnect_policy -- --nocapture (1 passed)
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-gateway --features telegram --lib --tests --no-deps -- -D warnings -A clippy::derivable_impls -A clippy::needless_borrows_for_generic_args -A clippy::manual_is_multiple_of -A clippy::collapsible_if -A clippy::await_holding_lock -A clippy::field_reassign_with_default
- git diff --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- test ! -d target

Note: broad hermes-cli clippy with gateway-telegram was attempted and is blocked by unrelated pre-existing lint debt across alpha_runtime/auth/commands/tui; the focused CLI test compiles and passes the changed gateway-telegram path.