### PR TITLE
parity(usage): hide unreliable cost cache stats

### DIFF
--- a/crates/hermes-cli/src/commands.rs
+++ b/crates/hermes-cli/src/commands.rs
@@ -6562,14 +6562,6 @@ fn usage_token_line(label: &str, usage: &hermes_core::UsageStats) -> String {
     )
 }
 
-fn format_usage_cost_usd(cost: f64) -> String {
-    if cost > 0.0 && cost < 0.0001 {
-        format!("${cost:.6}")
-    } else {
-        format!("${cost:.4}")
-    }
-}
-
 async fn handle_billing_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     let output = crate::billing::handle_billing_slash_args(args).await?;
     emit_command_output(app, output);
@@ -6616,13 +6608,6 @@ fn handle_usage_command(app: &mut App) -> Result<CommandResult, AgentError> {
         }
         None => output
             .push_str("\n  Actual session: unavailable until a provider returns usage metadata"),
-    }
-
-    if app.session_cost_usd > 0.0 {
-        output.push_str(&format!(
-            "\n  Actual cost:   {}",
-            format_usage_cost_usd(app.session_cost_usd)
-        ));
     }
 
     let nous_credits = hermes_core::credits::render_last_nous_credits_lines();
@@ -30201,7 +30186,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn usage_command_reports_actual_session_usage_and_cost() {
+    async fn usage_command_reports_actual_session_usage_without_estimated_cost() {
         let _guard = env_test_lock();
         hermes_core::credits::clear_last_nous_credits_state();
         let tmp = tempdir().expect("tempdir");
@@ -30234,7 +30219,8 @@ mod tests {
         let output = latest_ui_assistant_text(&app);
         assert!(output.contains("Last response: 12 prompt / 3 completion / 15 total tokens"));
         assert!(output.contains("Actual session: 12 prompt / 3 completion / 15 total tokens"));
-        assert!(output.contains("Actual cost:   $0.0123"));
+        assert!(!output.contains("Actual cost"));
+        assert!(!output.contains("$0.0123"));
         hermes_core::credits::clear_last_nous_credits_state();
     }
 

--- a/crates/hermes-intelligence/src/display.rs
+++ b/crates/hermes-intelligence/src/display.rs
@@ -336,7 +336,7 @@ pub fn format_usage_stats(
     model: &str,
     input_tokens: u64,
     output_tokens: u64,
-    cost_usd: Option<f64>,
+    _cost_usd: Option<f64>,
     duration_secs: Option<f64>,
 ) -> String {
     let mut out = String::new();
@@ -352,9 +352,6 @@ pub fn format_usage_stats(
         "  Total tokens:  {}",
         format_token_count(input_tokens + output_tokens)
     );
-    if let Some(cost) = cost_usd {
-        let _ = writeln!(out, "  Cost: {}", format_cost(cost));
-    }
     if let Some(dur) = duration_secs {
         let _ = writeln!(out, "  Duration: {}", format_duration_compact(dur));
     }
@@ -958,6 +955,17 @@ mod tests {
         assert_eq!(format_duration_compact(30.0), "30s");
         assert_eq!(format_duration_compact(120.0), "2m");
         assert_eq!(format_duration_compact(7200.0), "2h");
+    }
+
+    #[test]
+    fn test_format_usage_stats_hides_estimated_cost() {
+        let out = format_usage_stats("test-model", 123, 45, Some(0.0123), Some(2.0));
+
+        assert!(out.contains("Model: test-model"));
+        assert!(out.contains("Total tokens:"));
+        assert!(out.contains("Duration: 2s"));
+        assert!(!out.contains("Cost:"));
+        assert!(!out.contains("$0.0123"));
     }
 
     #[test]

--- a/crates/hermes-intelligence/src/session_insights/format.rs
+++ b/crates/hermes-intelligence/src/session_insights/format.rs
@@ -72,20 +72,8 @@ pub fn format_terminal(report: &InsightsReport) -> String {
         format_with_commas(o.total_input_tokens),
         format_with_commas(o.total_output_tokens)
     ));
-    let cache_total = o.total_cache_read_tokens + o.total_cache_write_tokens;
-    if cache_total > 0 {
-        lines.push(format!(
-            "  Cache read:        {:<12}  Cache write:     {}",
-            format_with_commas(o.total_cache_read_tokens),
-            format_with_commas(o.total_cache_write_tokens)
-        ));
-    }
-    let mut cost_str = format!("${:.2}", o.estimated_cost);
-    if !o.models_without_pricing.is_empty() {
-        cost_str.push_str(" *");
-    }
     lines.push(format!(
-        "  Total tokens:      {:<12}  Est. cost:       {cost_str}",
+        "  Total tokens:      {}",
         format_with_commas(o.total_tokens)
     ));
     if o.total_hours > 0.0 {
@@ -106,27 +94,18 @@ pub fn format_terminal(report: &InsightsReport) -> String {
         lines.push("  🤖 Models Used".into());
         lines.push(format!("  {}", "─".repeat(56)));
         lines.push(format!(
-            "  {:<30} {:>8} {:>12} {:>8}",
-            "Model", "Sessions", "Tokens", "Cost"
+            "  {:<30} {:>8} {:>12}",
+            "Model", "Sessions", "Tokens"
         ));
         for m in &report.models {
             let mut name = m.model.clone();
             name.truncate(28);
-            let cost_cell = if m.has_pricing {
-                format!("${:>6.2}", m.cost)
-            } else {
-                "     N/A".into()
-            };
             lines.push(format!(
-                "  {:<30} {:>8} {:>12} {}",
+                "  {:<30} {:>8} {:>12}",
                 name,
                 m.sessions,
-                format_with_commas(m.total_tokens),
-                cost_cell
+                format_with_commas(m.total_tokens)
             ));
-        }
-        if !o.models_without_pricing.is_empty() {
-            lines.push("  * Cost N/A for custom/self-hosted models".into());
         }
         lines.push(String::new());
     }
@@ -248,31 +227,11 @@ pub fn format_gateway(report: &InsightsReport) -> String {
         format_with_commas(o.total_messages),
         format_with_commas(o.total_tool_calls)
     ));
-    let cache_total = o.total_cache_read_tokens + o.total_cache_write_tokens;
-    if cache_total > 0 {
-        lines.push(format!(
-            "**Tokens:** {} (in: {} / out: {} / cache: {})",
-            format_with_commas(o.total_tokens),
-            format_with_commas(o.total_input_tokens),
-            format_with_commas(o.total_output_tokens),
-            format_with_commas(cache_total)
-        ));
-    } else {
-        lines.push(format!(
-            "**Tokens:** {} (in: {} / out: {})",
-            format_with_commas(o.total_tokens),
-            format_with_commas(o.total_input_tokens),
-            format_with_commas(o.total_output_tokens)
-        ));
-    }
-    let cost_note = if !o.models_without_pricing.is_empty() {
-        " _(excludes custom/self-hosted models)_"
-    } else {
-        ""
-    };
     lines.push(format!(
-        "**Est. cost:** ${:.2}{cost_note}",
-        o.estimated_cost
+        "**Tokens:** {} (in: {} / out: {})",
+        format_with_commas(o.total_tokens),
+        format_with_commas(o.total_input_tokens),
+        format_with_commas(o.total_output_tokens)
     ));
     if o.total_hours > 0.0 {
         lines.push(format!(
@@ -287,19 +246,13 @@ pub fn format_gateway(report: &InsightsReport) -> String {
     if !report.models.is_empty() {
         lines.push("**🤖 Models:**".into());
         for m in report.models.iter().take(5) {
-            let cost_str = if m.has_pricing {
-                format!("${:.2}", m.cost)
-            } else {
-                "N/A".into()
-            };
             let mut name = m.model.clone();
             name.truncate(25);
             lines.push(format!(
-                "  {} — {} sessions, {} tokens, {}",
+                "  {} — {} sessions, {} tokens",
                 name,
                 m.sessions,
-                format_with_commas(m.total_tokens),
-                cost_str
+                format_with_commas(m.total_tokens)
             ));
         }
         lines.push(String::new());

--- a/crates/hermes-intelligence/src/session_insights/mod.rs
+++ b/crates/hermes-intelligence/src/session_insights/mod.rs
@@ -447,6 +447,10 @@ mod tests {
         assert!(out.contains("Top Tools"));
         assert!(out.contains("shell"));
         assert!(out.contains("Activity Patterns"));
+        assert!(!out.contains("Cache read"));
+        assert!(!out.contains("Cache write"));
+        assert!(!out.contains("Est. cost"));
+        assert!(!out.contains("Cost N/A"));
     }
 
     #[test]
@@ -473,6 +477,8 @@ mod tests {
         assert!(out.contains("**🔧 Top Tools:**"));
         // Multi-platform present in the fixture.
         assert!(out.contains("**📱 Platforms:**"));
+        assert!(!out.contains("cache:"));
+        assert!(!out.contains("**Est. cost:**"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5083,6 +5083,11 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust Telegram rich-message delivery: pipe-table-primary Markdown now auto-routes through sendRichMessage even when rich_messages is false, while task lists/details/math still require explicit rich opt-in; encoded topic chat IDs route through sendRichMessage without reply anchors and rich edit finalization forwards message_thread_id."
+    },
+    "fd2a35b1691138b79b606e7961d3c78f7019722b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust display surfaces: CLI /usage, generic usage stats, and session-insights terminal/gateway renderers keep provider-agnostic token counts while hiding unreliable estimated cost and cache-read/write reporting; Nous credits/billing and internal cost guards remain intact."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T12:49:06.439810+00:00`
+Generated: `2026-06-26T13:27:00.209454+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T12:49:06.439810+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 140 |
-| ported | 464 |
+| pending | 139 |
+| ported | 465 |
 | superseded | 6436 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- Port upstream `fd2a35b16911` to Rust display surfaces: stop showing unreliable estimated cost and cache-read/write stats in user-facing usage/insights output.
- Keep provider-agnostic token counts visible in CLI `/usage`, generic usage stats, and session-insights terminal/gateway renderers.
- Preserve Nous credits/billing output and internal cost guards/pricing fields.
- Regenerate parity queue artifacts: pending 140 -> 139, ported 464 -> 465.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli usage_command_reports_actual_session_usage_without_estimated_cost -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-intelligence test_format_usage_stats_hides_estimated_cost -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-intelligence session_insights::tests::format_terminal_renders_header_and_overview -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-intelligence session_insights::tests::format_gateway_uses_markdown_and_caps_lists -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo check -p hermes-cli --lib`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check` -> pass, `new=0`
- `test ! -d target` -> repo-local target absent
