### PR TITLE
parity(acp): add live session title RPC

### DIFF
--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -989,7 +989,7 @@ impl HermesAcpHandler {
         };
         self.event_sink.push(AcpEvent::session_info_update(
             session_id,
-            session_title_from_history(&state.history),
+            session_display_title(&state),
             session_info_refresh_timestamp(),
         ));
     }
@@ -1440,9 +1440,14 @@ fn session_meta_from_params(
     .map(str::trim)
     .filter(|home| !home.is_empty())
     .map(ToOwned::to_owned);
+    let title = param_str(p, "title")
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned);
     Ok(SessionMetaUpdate {
         profile,
         home,
+        title,
         ..SessionMetaUpdate::default()
     })
 }
@@ -1648,6 +1653,16 @@ fn session_title_from_history(history: &[Value]) -> Option<String> {
     })
 }
 
+fn session_display_title(session: &SessionState) -> Option<String> {
+    session
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| session_title_from_history(&session.history))
+}
+
 fn session_info_value(session: &SessionState) -> Value {
     json!({
         "sessionId": session.session_id,
@@ -1659,7 +1674,7 @@ fn session_info_value(session: &SessionState) -> Value {
         "historyLen": session.history.len(),
         "createdAt": session.created_at.to_string(),
         "updatedAt": session.updated_at.to_string(),
-        "title": session_title_from_history(&session.history),
+        "title": session_display_title(session),
     })
 }
 
@@ -2125,6 +2140,55 @@ impl AcpHandler for HermesAcpHandler {
                         request.id,
                         json!({"configOptions": [{"configId": key, "value": value}]}),
                     ),
+                    None => AcpResponse::error(
+                        request.id,
+                        -32602,
+                        format!("Session not found: {}", session_id),
+                    ),
+                }
+            }
+
+            AcpMethod::SessionTitle => {
+                let Some(p) = params_obj(&request.params) else {
+                    return AcpResponse::error(request.id, -32602, "Missing params");
+                };
+                let session_id = param_str_any(p, &["sessionId", "session_id"]).unwrap_or("");
+                let title = param_str(p, "title").map(str::trim).unwrap_or("");
+
+                if session_id.trim().is_empty() {
+                    return AcpResponse::error(
+                        request.id,
+                        -32602,
+                        "Missing session_id/sessionId for session.title",
+                    );
+                }
+                if title.is_empty() {
+                    return AcpResponse::error(
+                        request.id,
+                        -32602,
+                        "Missing non-empty title for session.title",
+                    );
+                }
+
+                match self.session_manager.update_session_meta(
+                    session_id,
+                    SessionMetaUpdate {
+                        title: Some(title.to_string()),
+                        ..SessionMetaUpdate::default()
+                    },
+                ) {
+                    Some(state) => {
+                        self.emit_session_info_update(session_id);
+                        let title = state.title.clone().unwrap_or_else(|| title.to_string());
+                        AcpResponse::success(
+                            request.id,
+                            json!({
+                                "sessionId": state.session_id,
+                                "session_id": state.session_id,
+                                "title": title,
+                            }),
+                        )
+                    }
                     None => AcpResponse::error(
                         request.id,
                         -32602,
@@ -2848,6 +2912,118 @@ mod tests {
             state.config_options.get("sandbox").map(String::as_str),
             Some("workspace-write")
         );
+    }
+
+    #[tokio::test]
+    async fn test_session_title_rpc_updates_live_session_and_persists() {
+        let persisted = Arc::new(std::sync::Mutex::new(Vec::<SessionState>::new()));
+        let persisted_for_cb = persisted.clone();
+        let session_manager = Arc::new(SessionManager::new().with_persist_callback(move |state| {
+            persisted_for_cb
+                .lock()
+                .expect("persisted lock")
+                .push(state.clone());
+        }));
+        let handler = HermesAcpHandler::new(
+            session_manager,
+            Arc::new(EventSink::default()),
+            Arc::new(PermissionStore::new()),
+        );
+        let state = handler.session_manager.create_session("/runtime-only");
+        let session_id = state.session_id;
+        handler.session_manager.set_history(
+            &session_id,
+            vec![json!({"role": "user", "content": "fallback history title"})],
+        );
+        persisted.lock().expect("persisted lock").clear();
+
+        let response = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session.title".into(),
+                params: Some(json!({
+                    "session_id": session_id,
+                    "title": "  My branch  "
+                })),
+            })
+            .await;
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("title result");
+        assert_eq!(result["sessionId"], session_id);
+        assert_eq!(result["session_id"], session_id);
+        assert_eq!(result["title"], "My branch");
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.title.as_deref(), Some("My branch"));
+
+        {
+            let persisted = persisted.lock().expect("persisted lock");
+            assert_eq!(persisted.len(), 1);
+            assert_eq!(persisted[0].session_id, session_id);
+            assert_eq!(persisted[0].title.as_deref(), Some("My branch"));
+        }
+
+        let events = handler.event_sink.drain_for_session(&session_id);
+        let info_updates = events
+            .iter()
+            .filter(|event| event.kind == AcpEventKind::SessionInfoUpdate)
+            .collect::<Vec<_>>();
+        assert_eq!(info_updates.len(), 1);
+        assert_eq!(info_updates[0].title.as_deref(), Some("My branch"));
+
+        let listed = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session/list".into(),
+                params: Some(json!({"cwd": "/runtime-only"})),
+            })
+            .await
+            .result
+            .expect("list result");
+        let sessions = listed["sessions"].as_array().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["title"], "My branch");
+    }
+
+    #[tokio::test]
+    async fn test_session_title_rpc_rejects_empty_and_missing_session() {
+        let handler = make_handler();
+        let session_id = create_session(&handler).await;
+
+        let empty = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/title".into(),
+                params: Some(json!({"sessionId": session_id, "title": "   "})),
+            })
+            .await;
+        assert_eq!(empty.error.as_ref().map(|err| err.code), Some(-32602));
+        assert_eq!(
+            handler
+                .session_manager
+                .get_session(&session_id)
+                .unwrap()
+                .title,
+            None
+        );
+
+        let missing = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(2)),
+                method: "session.title".into(),
+                params: Some(json!({"sessionId": "missing", "title": "Name"})),
+            })
+            .await;
+        assert_eq!(missing.error.as_ref().map(|err| err.code), Some(-32602));
+        assert!(missing
+            .error
+            .as_ref()
+            .is_some_and(|err| err.message.contains("Session not found")));
     }
 
     #[tokio::test]

--- a/crates/hermes-acp/src/protocol.rs
+++ b/crates/hermes-acp/src/protocol.rs
@@ -89,6 +89,7 @@ pub enum AcpMethod {
     SetSessionModel,
     SetSessionMode,
     SetConfigOption,
+    SessionTitle,
 
     // -- Legacy / compatibility --
     CreateConversation,
@@ -119,6 +120,9 @@ impl From<&str> for AcpMethod {
             "session/set_mode" | "set_session_mode" => Self::SetSessionMode,
             "session/set_config" | "session/set_config_option" | "set_config_option" => {
                 Self::SetConfigOption
+            }
+            "session.title" | "session/title" | "session/set_title" | "set_session_title" => {
+                Self::SessionTitle
             }
 
             // Legacy methods
@@ -459,6 +463,8 @@ mod tests {
             AcpMethod::from("session/set_config_option"),
             AcpMethod::SetConfigOption
         );
+        assert_eq!(AcpMethod::from("session.title"), AcpMethod::SessionTitle);
+        assert_eq!(AcpMethod::from("session/title"), AcpMethod::SessionTitle);
         assert_eq!(
             AcpMethod::from("conversation.create"),
             AcpMethod::CreateConversation

--- a/crates/hermes-acp/src/session.rs
+++ b/crates/hermes-acp/src/session.rs
@@ -14,10 +14,11 @@ use serde_json::Value;
 // ---------------------------------------------------------------------------
 
 /// Lifecycle phase of an ACP session.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionPhase {
     /// Session created, awaiting first prompt.
+    #[default]
     Created,
     /// Session is actively processing a prompt.
     Active,
@@ -29,12 +30,6 @@ pub enum SessionPhase {
     Cancelled,
     /// Session encountered an unrecoverable error.
     Failed,
-}
-
-impl Default for SessionPhase {
-    fn default() -> Self {
-        Self::Created
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -52,6 +47,7 @@ pub struct SessionState {
     pub base_url: Option<String>,
     pub profile: Option<String>,
     pub home: Option<String>,
+    pub title: Option<String>,
     pub phase: SessionPhase,
     pub history: Vec<Value>,
     pub mode: Option<String>,
@@ -82,6 +78,7 @@ pub struct SessionMetaUpdate {
     pub base_url: Option<String>,
     pub profile: Option<String>,
     pub home: Option<String>,
+    pub title: Option<String>,
     pub config_options: HashMap<String, String>,
 }
 
@@ -100,6 +97,7 @@ impl SessionState {
             base_url: None,
             profile: None,
             home: None,
+            title: None,
             phase: SessionPhase::Created,
             history: Vec::new(),
             mode: None,
@@ -165,9 +163,11 @@ impl From<&SessionState> for SessionInfo {
 ///
 /// Sessions are held in-memory for fast access. A persistence callback can be
 /// provided to sync state to a database or disk.
+type PersistCallback = dyn Fn(&SessionState) + Send + Sync;
+
 pub struct SessionManager {
     sessions: Mutex<HashMap<String, SessionState>>,
-    on_persist: Option<Box<dyn Fn(&SessionState) + Send + Sync>>,
+    on_persist: Option<Box<PersistCallback>>,
 }
 
 impl SessionManager {
@@ -388,6 +388,7 @@ impl SessionManager {
         new_state.base_url = original.base_url.clone();
         new_state.profile = original.profile.clone();
         new_state.home = original.home.clone();
+        new_state.title = original.title.clone();
         new_state.mode = original.mode.clone();
         new_state.config_options = original.config_options.clone();
         new_state.history = original.history.clone();
@@ -469,6 +470,9 @@ fn apply_session_meta(state: &mut SessionState, update: SessionMetaUpdate) {
     }
     if let Some(home) = update.home.and_then(normalize_meta_string) {
         state.home = Some(home);
+    }
+    if let Some(title) = update.title.and_then(normalize_meta_string) {
+        state.title = Some(title);
     }
     for (key, value) in update.config_options {
         let key = key.trim();
@@ -633,6 +637,41 @@ mod tests {
     }
 
     #[test]
+    fn update_session_meta_sets_title_and_persists_once() {
+        use std::sync::{Arc, Mutex};
+
+        let persisted = Arc::new(Mutex::new(Vec::<SessionState>::new()));
+        let persisted_for_cb = persisted.clone();
+        let mgr = SessionManager::new().with_persist_callback(move |state| {
+            persisted_for_cb
+                .lock()
+                .expect("persisted lock")
+                .push(state.clone());
+        });
+        let state = mgr.create_session("/tmp");
+        let sid = state.session_id;
+        persisted.lock().expect("persisted lock").clear();
+
+        let updated = mgr
+            .update_session_meta(
+                &sid,
+                SessionMetaUpdate {
+                    title: Some("  My branch  ".to_string()),
+                    ..SessionMetaUpdate::default()
+                },
+            )
+            .expect("session exists");
+
+        assert_eq!(updated.title.as_deref(), Some("My branch"));
+        let stored = mgr.get_session(&sid).expect("session exists");
+        assert_eq!(stored.title.as_deref(), Some("My branch"));
+
+        let persisted = persisted.lock().expect("persisted lock");
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].title.as_deref(), Some("My branch"));
+    }
+
+    #[test]
     fn profile_home_metadata_flows_through_create_update_and_fork() {
         let mgr = SessionManager::new();
         let state = mgr.create_session_with_meta(
@@ -640,12 +679,14 @@ mod tests {
             SessionMetaUpdate {
                 profile: Some("work".to_string()),
                 home: Some("/profiles/work".to_string()),
+                title: Some("Original title".to_string()),
                 provider: Some("openrouter".to_string()),
                 ..SessionMetaUpdate::default()
             },
         );
         assert_eq!(state.profile.as_deref(), Some("work"));
         assert_eq!(state.home.as_deref(), Some("/profiles/work"));
+        assert_eq!(state.title.as_deref(), Some("Original title"));
 
         let updated = mgr
             .update_session_meta(
@@ -678,6 +719,7 @@ mod tests {
         assert_eq!(forked.profile.as_deref(), Some("scratch"));
         assert_eq!(forked.home.as_deref(), Some("/profiles/scratch"));
         assert_eq!(forked.provider.as_deref(), Some("openrouter"));
+        assert_eq!(forked.title.as_deref(), Some("Original title"));
     }
 
     #[test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5093,6 +5093,21 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust display surfaces: CLI /usage, generic usage stats, and session-insights terminal/gateway renderers keep provider-agnostic token counts while hiding unreliable estimated cost and cache-read/write reporting; Nous credits/billing and internal cost guards remain intact."
+    },
+    "0e47f68a479aa4de70f588b6bf40f3f5ac3470e0": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust ACP: session.title/session-title RPC updates the live in-memory SessionState title via SessionManager, persists through the existing callback path, emits session_info_update, and makes session/list prefer explicit titles over history-derived titles. This covers runtime-only branched/new sessions before any stored DB row exists."
+    },
+    "7f43378931f3f3ed619588ba50d08779c82ea1eb": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as Rust ACP regression coverage: tests prove session.title renames a live runtime-only session without REST, persists exactly once, updates session_info_update/list surfaces, maps session.title and session/title method aliases, and rejects empty-title or missing-session RPC calls."
+    },
+    "ed81f0b633c7c2ee9526b63be34fe0e5b13ab701": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported by eliminating the silent fallback path in Rust: session.title returns an explicit JSON-RPC error for missing sessions and empty titles, while successful live-session title updates emit an observable session_info_update event and persist through the Rust manager callback."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T14:50:33.227123+00:00`
+Generated: `2026-06-26T16:17:41.023197+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T14:50:33.227123+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 138 |
-| ported | 466 |
+| pending | 135 |
+| ported | 469 |
 | superseded | 6436 |
 
 ## First 100 Pending Commits
@@ -53,9 +53,6 @@ Generated: `2026-06-26T14:50:33.227123+00:00`
 | `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
 | `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
 | `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
-| `0e47f68a479a` | #26 | fix(desktop): rename branched session via session.title RPC |
-| `7f43378931f3` | #26 | test(desktop): cover renameSessionPreferringRpc routing |
-| `ed81f0b633c7` | #26 | fix(desktop): log session.title RPC failure before REST fallback |
 | `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
 | `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
 | `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
@@ -125,3 +122,6 @@ Generated: `2026-06-26T14:50:33.227123+00:00`
 | `4aeaba692251` | #26 | test(desktop): cover undefined/null attachment holes in ref helpers |
 | `cbe5c5689f9c` | #26 | perf(desktop): bound tool-result rendering so big /learn runs don't freeze (#52273) |
 | `f2c45e2c816d` | #26 | fix(desktop): limit pending tool shimmer to action verb |
+| `281b333cc5f0` | #26 | test(desktop): cover localized tool title shimmer |
+| `e92b5c6af8be` | #20 | feat(pets): quality-first OpenRouter model chain + stronger atlas gates + global pet-gen notifications |
+| `7078d9d1e29d` | #26 | fix(pets): raise generation timeouts for the slow quality-first model path |


### PR DESCRIPTION
## Summary
- Add first-class Rust ACP `session.title` / `session/title` handling for live runtime sessions.
- Store explicit session titles in `SessionState`, persist via the existing `SessionManager` callback path, and prefer explicit titles in `session/list` plus `session_info_update` events.
- Cover the upstream branched-session rename class with Rust tests and mark the three upstream `session.title` desktop commits as ported in parity ledgers.
- Clean up two small pre-existing `hermes-acp` clippy issues encountered by the scoped crate lint gate.

## Verification
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-acp session_title -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-acp --all-targets --no-deps -- -D warnings`
- `test ! -d target`

## Parity Delta
- Pending: `138 -> 135`
- Ported: `466 -> 469`
- Upstream commits ported: `0e47f68a479a`, `7f43378931f3`, `ed81f0b633c7`
