### PR TITLE
parity(acp): emit session info on resume

### DIFF
--- a/crates/hermes-acp/src/events.rs
+++ b/crates/hermes-acp/src/events.rs
@@ -435,6 +435,7 @@ impl AcpEvent {
         session_id: &str,
         title: Option<String>,
         updated_at: String,
+        content: Option<Value>,
     ) -> Self {
         Self {
             kind: AcpEventKind::SessionInfoUpdate,
@@ -449,7 +450,7 @@ impl AcpEvent {
             arguments: None,
             result: None,
             status: None,
-            content: None,
+            content,
             text: None,
             api_call_count: None,
             error: None,

--- a/crates/hermes-acp/src/handler.rs
+++ b/crates/hermes-acp/src/handler.rs
@@ -991,6 +991,7 @@ impl HermesAcpHandler {
             session_id,
             session_display_title(&state),
             session_info_refresh_timestamp(),
+            Some(session_info_value(&state)),
         ));
     }
 
@@ -1423,6 +1424,22 @@ fn param_str_any<'a>(p: &'a serde_json::Map<String, Value>, keys: &[&str]) -> Op
 fn session_meta_from_params(
     p: &serde_json::Map<String, Value>,
 ) -> Result<SessionMetaUpdate, String> {
+    let model = param_str_any(p, &["model", "modelId", "model_id"])
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(ToOwned::to_owned);
+    let provider = param_str(p, "provider")
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .map(ToOwned::to_owned);
+    let api_mode = param_str_any(p, &["apiMode", "api_mode"])
+        .map(str::trim)
+        .filter(|mode| !mode.is_empty())
+        .map(ToOwned::to_owned);
+    let base_url = param_str_any(p, &["baseUrl", "base_url"])
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToOwned::to_owned);
     let profile = match param_str(p, "profile").map(str::trim) {
         Some("") | None => None,
         Some(profile) if valid_session_profile(profile) => Some(profile.to_string()),
@@ -1444,10 +1461,30 @@ fn session_meta_from_params(
         .map(str::trim)
         .filter(|title| !title.is_empty())
         .map(ToOwned::to_owned);
+    let mut config_options = HashMap::new();
+    for (key, aliases) in [
+        (
+            "reasoning_effort",
+            &["reasoningEffort", "reasoning_effort"][..],
+        ),
+        ("service_tier", &["serviceTier", "service_tier"][..]),
+    ] {
+        if let Some(value) = param_str_any(p, aliases)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            config_options.insert(key.to_string(), value.to_string());
+        }
+    }
     Ok(SessionMetaUpdate {
+        model,
+        provider,
+        api_mode,
+        base_url,
         profile,
         home,
         title,
+        config_options,
         ..SessionMetaUpdate::default()
     })
 }
@@ -1666,8 +1703,12 @@ fn session_display_title(session: &SessionState) -> Option<String> {
 fn session_info_value(session: &SessionState) -> Value {
     json!({
         "sessionId": session.session_id,
+        "session_id": session.session_id,
         "cwd": session.cwd,
         "model": session.model,
+        "provider": session.provider,
+        "apiMode": session.api_mode,
+        "baseUrl": session.base_url,
         "profile": session.profile,
         "home": session.home,
         "phase": session.phase,
@@ -1795,6 +1836,7 @@ impl AcpHandler for HermesAcpHandler {
 
                 if let Some(state) = self.session_manager.update_session_meta(session_id, meta) {
                     self.register_session_mcp_servers(&state, mcp_servers).await;
+                    self.emit_session_info_update(&state.session_id);
                     self.replay_session_history(&state);
                     self.advertise_available_commands(&state.session_id);
                     self.emit_usage_update(&state.session_id);
@@ -2471,6 +2513,20 @@ mod tests {
         }
     }
 
+    struct ForbiddenPromptExecutor;
+
+    #[async_trait::async_trait]
+    impl AcpPromptExecutor for ForbiddenPromptExecutor {
+        async fn execute_prompt(
+            &self,
+            _session: &SessionState,
+            _user_text: &str,
+            _history: &[Value],
+        ) -> Result<PromptExecutionOutput, String> {
+            panic!("session resume must not execute or build a prompt executor");
+        }
+    }
+
     #[derive(Default)]
     struct SteeringPromptExecutor {
         steers: std::sync::Mutex<Vec<String>>,
@@ -2972,6 +3028,14 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(info_updates.len(), 1);
         assert_eq!(info_updates[0].title.as_deref(), Some("My branch"));
+        let content = info_updates[0]
+            .content
+            .as_ref()
+            .expect("session info content");
+        assert_eq!(content["sessionId"], session_id);
+        assert_eq!(content["session_id"], session_id);
+        assert_eq!(content["cwd"], "/runtime-only");
+        assert_eq!(content["title"], "My branch");
 
         let listed = handler
             .handle_request(AcpRequest {
@@ -3215,10 +3279,13 @@ mod tests {
             })
             .await;
         assert!(resumed.error.is_none());
-        assert_available_commands_update(
-            handler.event_sink.drain_for_session(&session_id),
-            &session_id,
+        let resume_events = handler.event_sink.drain_for_session(&session_id);
+        assert_eq!(resume_events[0].kind, AcpEventKind::SessionInfoUpdate);
+        assert_eq!(
+            resume_events[0].content.as_ref().expect("session info")["cwd"],
+            "/work"
         );
+        assert_available_commands_update(resume_events[1..].to_vec(), &session_id);
 
         let forked = handler
             .handle_request(AcpRequest {
@@ -3345,9 +3412,14 @@ mod tests {
         assert!(resumed.error.is_none());
 
         let events = handler.event_sink.drain_for_session(&session_id);
-        assert_eq!(events[0].kind, AcpEventKind::AgentThoughtChunk);
+        assert_eq!(events[0].kind, AcpEventKind::SessionInfoUpdate);
         assert_eq!(
-            events[0].content.as_ref().unwrap()["text"],
+            events[0].content.as_ref().expect("session info")["cwd"],
+            "/tmp"
+        );
+        assert_eq!(events[1].kind, AcpEventKind::AgentThoughtChunk);
+        assert_eq!(
+            events[1].content.as_ref().unwrap()["text"],
             "Reasoning persisted without assistant text."
         );
         assert_eq!(
@@ -3355,6 +3427,98 @@ mod tests {
             AcpEventKind::AvailableCommandsUpdate
         );
         assert_eq!(events.last().unwrap().kind, AcpEventKind::UsageUpdate);
+    }
+
+    #[tokio::test]
+    async fn test_resume_session_updates_runtime_metadata_without_prompt_execution() {
+        let handler = HermesAcpHandler::new(
+            Arc::new(SessionManager::new()),
+            Arc::new(EventSink::default()),
+            Arc::new(PermissionStore::new()),
+        )
+        .with_prompt_executor(Arc::new(ForbiddenPromptExecutor));
+        let state = handler.session_manager.create_session_with_meta(
+            "/old",
+            SessionMetaUpdate {
+                model: Some("dynamic".to_string()),
+                provider: Some("openrouter".to_string()),
+                api_mode: Some("chat".to_string()),
+                base_url: Some("https://old.example/v1".to_string()),
+                profile: Some("work".to_string()),
+                home: Some("/profiles/work".to_string()),
+                title: Some("Old workspace".to_string()),
+                ..SessionMetaUpdate::default()
+            },
+        );
+        let session_id = state.session_id;
+        handler.session_manager.set_history(
+            &session_id,
+            vec![json!({"role": "user", "content": "replay me"})],
+        );
+
+        let resumed = handler
+            .handle_request(AcpRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "session/resume".into(),
+                params: Some(json!({
+                    "sessionId": session_id,
+                    "cwd": "/workspace/repo",
+                    "modelId": "dynamic",
+                    "provider": "openrouter",
+                    "apiMode": "responses",
+                    "baseUrl": "https://router.example/v1",
+                    "profile": "research",
+                    "homeDir": "/profiles/research",
+                    "title": "  Active workspace  ",
+                    "reasoningEffort": "medium",
+                    "serviceTier": "auto"
+                })),
+            })
+            .await;
+        assert!(resumed.error.is_none());
+
+        let state = handler.session_manager.get_session(&session_id).unwrap();
+        assert_eq!(state.cwd, "/workspace/repo");
+        assert_eq!(state.model.as_deref(), Some("dynamic"));
+        assert_eq!(state.provider.as_deref(), Some("openrouter"));
+        assert_eq!(state.api_mode.as_deref(), Some("responses"));
+        assert_eq!(state.base_url.as_deref(), Some("https://router.example/v1"));
+        assert_eq!(state.profile.as_deref(), Some("research"));
+        assert_eq!(state.home.as_deref(), Some("/profiles/research"));
+        assert_eq!(state.title.as_deref(), Some("Active workspace"));
+        assert_eq!(
+            state
+                .config_options
+                .get("reasoning_effort")
+                .map(String::as_str),
+            Some("medium")
+        );
+        assert_eq!(
+            state.config_options.get("service_tier").map(String::as_str),
+            Some("auto")
+        );
+
+        let events = handler.event_sink.drain_for_session(&session_id);
+        assert_eq!(events[0].kind, AcpEventKind::SessionInfoUpdate);
+        assert_eq!(events[0].title.as_deref(), Some("Active workspace"));
+        let info = events[0].content.as_ref().expect("session info content");
+        assert_eq!(info["sessionId"], session_id);
+        assert_eq!(info["session_id"], session_id);
+        assert_eq!(info["cwd"], "/workspace/repo");
+        assert_eq!(info["model"], "dynamic");
+        assert_eq!(info["provider"], "openrouter");
+        assert_eq!(info["apiMode"], "responses");
+        assert_eq!(info["baseUrl"], "https://router.example/v1");
+        assert_eq!(info["profile"], "research");
+        assert_eq!(info["home"], "/profiles/research");
+        assert_eq!(info["title"], "Active workspace");
+        assert!(events
+            .iter()
+            .any(|event| event.kind == AcpEventKind::UserMessageChunk));
+        assert!(events
+            .iter()
+            .any(|event| event.kind == AcpEventKind::AvailableCommandsUpdate));
     }
 
     #[tokio::test]

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -534,6 +534,11 @@
       "disposition": "ported",
       "notes": "Rust build_agent_config now honors HERMES_MAX_TOKENS as the highest-precedence output-token override and falls back to active provider config caps for CLI and gateway-created agents, with focused precedence tests."
     },
+    "1ca1f9f2c7a1": {
+      "disposition": "superseded",
+      "notes": "Upstream DRYs Python tui_gateway deferred-session scaffolding only. Ultra's Rust ACP resume path is handled by typed SessionManager/handler code and now has focused non-building resume metadata tests, so the Python refactor has no Rust runtime port target.",
+      "owner": "rust-runtime"
+    },
     "1ca29723f0ea": {
       "disposition": "ported",
       "notes": "Ported in Rust: preflight-warning generation is no longer swallowed silently; warning/persistence outcomes are built after actual config-write evidence, config-save failures are logged with tracing::warn and surfaced in replies, and CLI/gateway/TUI switch responses consistently surface warning text through UI-only channels where applicable.",
@@ -1049,6 +1054,11 @@
     "3be9fb73173e": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "3bf00e459af7": {
+      "disposition": "ported",
+      "notes": "Rust ACP resume is non-building by default: session/resume updates typed metadata, emits a session_info_update payload, replays history, and never invokes the prompt executor on the response path. Resume now accepts runtime identity fields and focused tests prove deferred/non-executing behavior.",
+      "owner": "rust-runtime"
     },
     "3bfbb3f2a025": {
       "disposition": "superseded",
@@ -1734,6 +1744,11 @@
     "628f9040df43": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "62af32efe7c0": {
+      "disposition": "ported",
+      "notes": "Rust ACP keeps active session metadata backend-authoritative: resume accepts cwd/profile/home/title plus runtime identity fields, emits session_info_update with cwd/model/provider/apiMode/baseUrl/profile/home/title, and tests prove clients can realign from Rust session state without invoking prompt execution.",
+      "owner": "rust-runtime"
     },
     "62c2f5d8d2a6": {
       "disposition": "superseded",
@@ -3374,6 +3389,11 @@
       "disposition": "superseded",
       "notes": "Electron desktop icon padding changes do not affect the Rust CLI/gateway runtime or local parity gates."
     },
+    "c4c590e4a14a": {
+      "disposition": "ported",
+      "notes": "Rust ACP avoids the upstream slow cold-resume class by design and now pins it with tests: session/resume returns after metadata update/history replay without prompt-agent execution, restores runtime identity fields, and emits session_info_update before command/usage events. Rust GatewayAgentCache already provides active-aware LRU/idle eviction for cached agents where that cache abstraction is used.",
+      "owner": "rust-runtime"
+    },
     "c4b8f5efee8c": {
       "disposition": "ported",
       "notes": "Rust corrupt-store backup derives the backup filename from the canonical store basename and writes only within the original store parent directory, matching the upstream path-injection hardening intent."
@@ -4272,6 +4292,11 @@
     "f764b0400ad7": {
       "disposition": "superseded",
       "notes": "Deleting the active profile fallback is a desktop profile-switcher/delete-dialog behavior. Rust CLI profile delete already clears the active marker when deleting the active profile and does not maintain an Electron active-profile rail."
+    },
+    "f7bf740640e4": {
+      "disposition": "superseded",
+      "notes": "Upstream fixes a recycled Electron runtimeId warm-cache mismatch in apps/desktop. Ultra has no desktop ClientSessionState runtime-id cache; Rust ACP emits backend session_id/session metadata directly on resume/title updates, so there is no cross-wired runtime-id fast path to port.",
+      "owner": "rust-runtime"
     },
     "f7c1cbe66ffa": {
       "disposition": "superseded",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T16:17:41.023197+00:00`
+Generated: `2026-06-26T16:55:04.772488+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-26T16:17:41.023197+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 135 |
-| ported | 469 |
-| superseded | 6436 |
+| pending | 130 |
+| ported | 472 |
+| superseded | 6438 |
 
 ## First 100 Pending Commits
 


### PR DESCRIPTION
## Summary
- make ACP session_info_update events carry the typed session info payload
- make session/resume accept runtime identity metadata (model/provider/apiMode/baseUrl/reasoning/service tier), emit session_info_update before replay, and remain non-building/non-executing
- close five upstream parity rows: c4c590e4a14a, 3bf00e459af7, 1ca1f9f2c7a1, f7bf740640e4, 62af32efe7c0

## Verification
- cargo fmt --all --check
- scripts/check-rust-runtime-no-python.sh
- scripts/check-runtime-placeholders.sh
- git diff --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-acp resume_session -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-acp -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-acp --all-targets --no-deps -- -D warnings
- test ! -d target