### PR TITLE
parity(moa): add virtual provider runtime

### DIFF
--- a/crates/hermes-cli/src/app.rs
+++ b/crates/hermes-cli/src/app.rs
@@ -49,7 +49,7 @@ use crate::auth::{
 };
 use crate::cli::Cli;
 use crate::commands::recover_queued_background_jobs;
-use crate::model_switch::provider_model_ids;
+use crate::model_switch::{provider_model_ids, MOA_DEFAULT_PRESET, MOA_PROVIDER};
 use crate::runtime_tool_wiring::{wire_cron_scheduler_backend, wire_stdio_clarify_backend};
 use crate::terminal_backend::build_terminal_backend;
 use crate::tui::StreamHandle;
@@ -62,8 +62,22 @@ const QUORUM_MAX_VOTER_OUTPUT_CHARS: usize = 120_000;
 const QUORUM_DEFAULT_VOTER_PASSES: usize = 6;
 const QUORUM_AGENT_CONTRACT_DEFAULT_PATH: &str =
     "/Users/sheawinkler/Documents/Projects/hermes-agent-ultra/docs/QUORUM_AGENTS.md";
+const MOA_DEFAULT_REFERENCE_MODELS: &[&str] = &[
+    "openai-codex:gpt-5.5",
+    "openrouter:deepseek/deepseek-v4-pro",
+];
+const MOA_DEFAULT_AGGREGATOR_MODEL: &str = "openrouter:anthropic/claude-opus-4.7";
 const COMPOSER_DRAFTS_FILE: &str = "composer-drafts.json";
 const MAX_COMPOSER_DRAFTS: usize = 50;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MoaRuntimePreset {
+    name: &'static str,
+    reference_models: &'static [&'static str],
+    aggregator_model: &'static str,
+    voters: usize,
+    mode: &'static str,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct ComposerDraftStore {
@@ -1533,7 +1547,94 @@ impl App {
         messages
     }
 
+    fn moa_provider_is_virtual(provider: &str) -> bool {
+        normalize_runtime_provider_name(provider) == MOA_PROVIDER
+    }
+
+    fn moa_preset_name_for_model(provider_model: &str) -> Option<String> {
+        let trimmed = provider_model.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let (provider, preset) = trimmed
+            .split_once(':')
+            .map(|(provider, preset)| (provider.trim(), preset.trim()))
+            .unwrap_or((trimmed, MOA_DEFAULT_PRESET));
+        if !Self::moa_provider_is_virtual(provider) {
+            return None;
+        }
+        let preset = if preset.is_empty() {
+            MOA_DEFAULT_PRESET
+        } else {
+            preset
+        };
+        Some(preset.to_ascii_lowercase())
+    }
+
+    fn moa_virtual_model_name(provider_model: &str) -> Option<String> {
+        let preset = Self::moa_preset_name_for_model(provider_model)?;
+        let canonical = format!("{MOA_PROVIDER}:{preset}");
+        Self::moa_runtime_preset_for_model(&canonical)?;
+        Some(canonical)
+    }
+
+    fn moa_runtime_preset_for_model(provider_model: &str) -> Option<MoaRuntimePreset> {
+        match Self::moa_preset_name_for_model(provider_model)?.as_str() {
+            MOA_DEFAULT_PRESET => Some(MoaRuntimePreset {
+                name: MOA_DEFAULT_PRESET,
+                reference_models: MOA_DEFAULT_REFERENCE_MODELS,
+                aggregator_model: MOA_DEFAULT_AGGREGATOR_MODEL,
+                voters: MOA_DEFAULT_REFERENCE_MODELS.len(),
+                mode: "moa",
+            }),
+            _ => None,
+        }
+    }
+
+    fn moa_quorum_policy_for_current_model(&self) -> Option<QuorumPolicy> {
+        let preset = Self::moa_runtime_preset_for_model(&self.current_model)?;
+        Some(QuorumPolicy {
+            enabled: true,
+            voters: preset.voters,
+            models: preset
+                .reference_models
+                .iter()
+                .map(|model| (*model).to_string())
+                .collect(),
+            mode: format!("{}-{}", preset.mode, preset.name),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+        })
+    }
+
+    fn quorum_synthesis_model_for_original(original_model: &str) -> String {
+        Self::moa_runtime_preset_for_model(original_model)
+            .map(|preset| preset.aggregator_model.to_string())
+            .unwrap_or_else(|| original_model.trim().to_string())
+    }
+
     fn quorum_mode_armed_for_turn(&self) -> Option<QuorumPolicy> {
+        let has_user_turn = self
+            .messages
+            .iter()
+            .any(|m| m.role == hermes_core::MessageRole::User);
+        if let Some(policy) = self.moa_quorum_policy_for_current_model() {
+            if !has_user_turn {
+                Self::emit_lifecycle_event(
+                    &self.stream_handle_shared,
+                    "moa virtual model selected but no user turn present yet; waiting for next user prompt",
+                );
+                return None;
+            }
+            Self::emit_lifecycle_event(
+                &self.stream_handle_shared,
+                format!(
+                    "moa virtual model {} routes this turn through {} reference voters",
+                    self.current_model, policy.voters
+                ),
+            );
+            return Some(policy);
+        }
+
         let policy = match load_quorum_policy() {
             Ok(policy) => policy,
             Err(err) => {
@@ -1561,10 +1662,6 @@ impl App {
                     .unwrap_or_default()
                     .starts_with(QUORUM_HINT_PREFIX)
         });
-        let has_user_turn = self
-            .messages
-            .iter()
-            .any(|m| m.role == hermes_core::MessageRole::User);
         if !has_user_turn {
             if self.quorum_armed_once || has_hint {
                 Self::emit_lifecycle_event(
@@ -2877,6 +2974,36 @@ impl App {
         if next_model.is_empty() {
             return Err(AgentError::Config("model cannot be empty".to_string()));
         }
+        if let Some(preset) = Self::moa_preset_name_for_model(next_model) {
+            let Some(next_model) = Self::moa_virtual_model_name(next_model) else {
+                return Err(AgentError::Config(format!(
+                    "unsupported MoA preset '{preset}'; supported presets: {MOA_DEFAULT_PRESET}"
+                )));
+            };
+            self.current_model = next_model;
+            sync_runtime_model_env(&self.config, &self.current_model);
+            match SessionPersistence::new(&self.state_root)
+                .update_session_model(&self.session_id, &self.current_model)
+            {
+                Ok(true) => tracing::debug!(
+                    "Persisted virtual MoA model switch for session {} to {}",
+                    self.session_id,
+                    self.current_model
+                ),
+                Ok(false) => {}
+                Err(err) => {
+                    tracing::debug!(
+                        "Failed to persist virtual MoA model switch to session DB: {}",
+                        err
+                    )
+                }
+            }
+            tracing::info!(
+                "Switched model to virtual MoA preset: {}",
+                self.current_model
+            );
+            return Ok(());
+        }
 
         let next_agent = self.build_agent_for_model(next_model)?;
         self.current_model = next_model.to_string();
@@ -3327,6 +3454,7 @@ impl App {
         if self.current_model != original_model {
             self.switch_model(&original_model);
         }
+        let synthesis_model = Self::quorum_synthesis_model_for_original(&original_model);
         let artifact_path = self.persist_quorum_artifact(&policy, &outcomes)?;
         Self::emit_lifecycle_event(
             &self.stream_handle_shared,
@@ -3357,6 +3485,9 @@ impl App {
             )));
         }
 
+        if self.current_model != synthesis_model {
+            self.try_switch_model(&synthesis_model)?;
+        }
         let synthesis_system = Self::build_quorum_synthesis_prompt(&policy, &outcomes);
         let mut synthesis_system_sections = Vec::new();
         if let Some((contract_path, contract_text)) = quorum_contract.as_ref() {
@@ -3376,13 +3507,30 @@ impl App {
             "quorum synthesis from voter outputs",
             75,
         );
-        let result = self
+        let synthesis_result = self
             .run_messages_with_current_agent_tools(
                 synthesis_messages,
                 true,
                 Self::quorum_synthesis_tools_enabled(),
             )
-            .await?;
+            .await;
+        if self.current_model != original_model {
+            if let Err(err) = self.try_switch_model(&original_model) {
+                tracing::warn!(
+                    model = %original_model,
+                    error = %err,
+                    "Failed to restore original model after quorum synthesis"
+                );
+                Self::emit_lifecycle_event(
+                    &self.stream_handle_shared,
+                    format!(
+                        "warning: failed to restore original model after quorum synthesis: {}",
+                        err
+                    ),
+                );
+            }
+        }
+        let result = synthesis_result?;
         let total_turns = result.total_turns;
         let synthesis_text = Self::extract_last_assistant_output(&result.messages);
         if let Err(err) =
@@ -4660,6 +4808,70 @@ mod tests {
     }
 
     #[test]
+    fn moa_virtual_model_switch_updates_session_without_rebuilding_agent() {
+        let _guard = env_test_lock();
+        let env_keys = [
+            "HERMES_MODEL",
+            "HERMES_INFERENCE_MODEL",
+            "HERMES_INFERENCE_PROVIDER",
+            "HERMES_TUI_PROVIDER",
+        ];
+        let saved_env: Vec<(&str, Option<String>)> = env_keys
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = build_minimal_test_app_with_state_root(tmp.path().to_path_buf());
+        let original_agent_model = app.agent.config.model.clone();
+        let persistence = SessionPersistence::new(tmp.path());
+        persistence
+            .persist_session(
+                &app.session_id,
+                &[hermes_core::Message::user("hello")],
+                Some(&app.current_model),
+                Some("cli"),
+                None,
+                None,
+            )
+            .unwrap();
+
+        app.try_switch_model("mixture-of-agents:default")
+            .expect("virtual moa switch");
+
+        assert_eq!(app.current_model, "moa:default");
+        assert_eq!(
+            app.agent.config.model, original_agent_model,
+            "virtual model selection should not rebuild the current concrete agent"
+        );
+        assert_eq!(
+            persistence.get_session_model(&app.session_id).unwrap(),
+            Some("moa:default".to_string())
+        );
+        assert_eq!(
+            std::env::var("HERMES_MODEL").ok().as_deref(),
+            Some("moa:default")
+        );
+        assert_eq!(
+            std::env::var("HERMES_INFERENCE_PROVIDER").ok().as_deref(),
+            Some("moa")
+        );
+
+        let err = app
+            .try_switch_model("moa:unknown")
+            .expect_err("unsupported preset should fail closed");
+        assert!(err.to_string().contains("unsupported MoA preset"));
+        assert_eq!(app.current_model, "moa:default");
+
+        for (key, value) in saved_env {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
     fn model_switch_preflight_warning_is_ui_only_and_keeps_messages_clean() {
         let mut app = build_minimal_test_app();
         app.current_model = "anthropic:claude-sonnet-4-6".to_string();
@@ -5118,6 +5330,36 @@ mod tests {
             Some(v) => std::env::set_var("HERMES_HOME", v),
             None => std::env::remove_var("HERMES_HOME"),
         }
+    }
+
+    #[test]
+    fn moa_virtual_model_arms_quorum_without_global_policy() {
+        let mut app = build_minimal_test_app();
+        app.current_model = "moa:default".to_string();
+        app.messages = vec![hermes_core::Message::user("solve with moa")];
+
+        let policy = app
+            .quorum_mode_armed_for_turn()
+            .expect("moa model should arm quorum fan-out");
+
+        assert!(policy.enabled);
+        assert_eq!(policy.voters, 2);
+        assert_eq!(
+            policy.models,
+            vec![
+                "openai-codex:gpt-5.5".to_string(),
+                "openrouter:deepseek/deepseek-v4-pro".to_string()
+            ]
+        );
+        assert_eq!(policy.mode, "moa-default");
+        assert_eq!(
+            App::quorum_synthesis_model_for_original("moa:default"),
+            "openrouter:anthropic/claude-opus-4.7"
+        );
+        assert_eq!(
+            App::quorum_synthesis_model_for_original("anthropic:claude-sonnet-4-6"),
+            "anthropic:claude-sonnet-4-6"
+        );
     }
 
     #[test]

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -17,6 +17,8 @@ use sha2::{Digest, Sha256};
 use crate::providers::{canonical_provider_id, provider_capability_for};
 const NOUS_DEFAULT_INFERENCE_BASE_URL: &str = "https://inference-api.nousresearch.com/v1";
 const PROVIDER_CATALOG_CACHE_VERSION: u32 = 2;
+pub const MOA_PROVIDER: &str = "moa";
+pub const MOA_DEFAULT_PRESET: &str = "default";
 const OLLAMA_LOCAL_DEFAULT_BASE_URL: &str = "http://127.0.0.1:11434/v1";
 const LLAMA_CPP_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080/v1";
 const VLLM_DEFAULT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
@@ -45,6 +47,7 @@ const CURATED_PROVIDER_MODELS: &[(&str, &[&str])] = &[
             "tencent/hy3-preview",
         ],
     ),
+    (MOA_PROVIDER, &[MOA_DEFAULT_PRESET]),
     (
         "novita",
         &[
@@ -547,13 +550,15 @@ pub fn normalize_provider_model(input: &str) -> Result<String, AgentError> {
                 .to_string(),
         ));
     }
+    let canonical_provider = canonical_provider_id(trimmed);
     if !trimmed.contains(':')
-        && curated_provider_slugs()
-            .iter()
-            .any(|provider| provider.eq_ignore_ascii_case(trimmed))
+        && curated_provider_slugs().iter().any(|provider| {
+            provider.eq_ignore_ascii_case(trimmed)
+                || provider.eq_ignore_ascii_case(canonical_provider.as_str())
+        })
     {
         return Err(AgentError::Config(format!(
-            "`{trimmed}` is a provider, not a model. Use `{trimmed}:<model-id>`."
+            "`{trimmed}` is a provider, not a model. Use `{canonical_provider}:<model-id>`."
         )));
     }
     if trimmed.contains(':') {
@@ -645,6 +650,7 @@ pub fn provider_picker_description(provider: &str) -> &'static str {
                 "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"
             }
             "openrouter" => "OpenRouter (Pay-per-use API aggregator)",
+            "moa" => "Mixture of Agents (virtual provider backed by Rust quorum fan-out)",
             "novita" => "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)",
             "anthropic" => "Anthropic (Claude models via API key or Claude Code)",
             "openai-codex" => "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)",
@@ -1235,6 +1241,9 @@ pub async fn provider_model_ids_with_client(
     if curated.is_empty() {
         return Vec::new();
     }
+    if catalog_provider == MOA_PROVIDER {
+        return curated.iter().map(|model| model.to_string()).collect();
+    }
     if let Some(cached) = load_provider_catalog_cache(catalog_provider) {
         if !cached.is_empty() {
             return cached;
@@ -1430,7 +1439,7 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        cached_provider_catalog_status, clear_provider_catalog_cache,
+        cached_provider_catalog_status, clear_provider_catalog_cache, curated_provider_slugs,
         is_models_dev_preferred_provider, load_provider_catalog_cache, merge_with_models_dev,
         normalize_provider_model, persist_provider_catalog_cache, provider_catalog_cache_path,
         provider_catalog_entries, provider_catalog_entries_for_config,
@@ -1498,6 +1507,8 @@ mod tests {
     fn normalize_provider_model_rejects_list_and_bare_provider_names() {
         assert!(normalize_provider_model("list").is_err());
         assert!(normalize_provider_model("nous").is_err());
+        assert!(normalize_provider_model("mixture").is_err());
+        assert!(normalize_provider_model("mixture-of-agents").is_err());
         assert_eq!(
             normalize_provider_model("nous:openai/gpt-5.5-pro").expect("valid provider model"),
             "nous:openai/gpt-5.5-pro"
@@ -1596,6 +1607,14 @@ mod tests {
         assert!(provider_curated_models("koboldcpp").contains(&"koboldcpp"));
         assert!(provider_curated_models("text-generation-webui").contains(&"oobabooga"));
         assert!(provider_curated_models("tabbyapi").contains(&"exllamav2"));
+    }
+
+    #[test]
+    fn moa_virtual_provider_is_listed_as_static_preset_catalog() {
+        assert_eq!(provider_curated_models("moa"), &["default"]);
+        assert_eq!(provider_curated_models("mixture-of-agents"), &["default"]);
+        assert!(provider_picker_description("moa").contains("virtual provider"));
+        assert!(curated_provider_slugs().contains(&"moa"));
     }
 
     #[test]
@@ -1899,6 +1918,27 @@ mod tests {
         // Smoke-test the function shape with unknown providers only, avoiding network use.
         let entries = provider_catalog_entries(&["unknown-provider"]).await;
         assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn moa_provider_model_ids_bypass_dynamic_catalog_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = ScopedCatalogEnv::new(tmp.path());
+        let client = seeded_client(json!({
+            "moa": {
+                "models": {
+                    "shadow": {"tool_call": true}
+                }
+            }
+        }));
+
+        let out = provider_model_ids_with_client("mixture", &client).await;
+
+        assert_eq!(out, vec!["default".to_string()]);
+        assert!(
+            !provider_catalog_cache_path("moa").exists(),
+            "virtual provider catalog should not be persisted to dynamic cache"
+        );
     }
 
     #[tokio::test]

--- a/crates/hermes-core/src/providers.rs
+++ b/crates/hermes-core/src/providers.rs
@@ -2,6 +2,7 @@ pub const KNOWN_PROVIDERS: &[&str] = &[
     "openai",
     "anthropic",
     "openrouter",
+    "moa",
     "codex",
     "openai-codex",
     "custom",
@@ -103,6 +104,7 @@ pub fn canonical_provider_id(provider: &str) -> String {
     match normalized.as_str() {
         "codex" => "openai-codex".to_string(),
         "claude" | "claude-code" => "anthropic".to_string(),
+        "mixture" | "mixture-of-agents" | "mixture_of_agents" => "moa".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
@@ -311,6 +313,9 @@ mod tests {
     #[test]
     fn canonical_provider_id_normalizes_common_aliases() {
         assert_eq!(canonical_provider_id("moonshot"), "kimi");
+        assert_eq!(canonical_provider_id("mixture"), "moa");
+        assert_eq!(canonical_provider_id("mixture-of-agents"), "moa");
+        assert_eq!(canonical_provider_id("mixture_of_agents"), "moa");
         assert_eq!(canonical_provider_id("gemini-cli"), "google-gemini-cli");
         assert_eq!(canonical_provider_id("ollama"), "ollama-local");
         assert_eq!(canonical_provider_id("llama.cpp"), "llama-cpp");

--- a/crates/hermes-provider-runtime/src/lib.rs
+++ b/crates/hermes-provider-runtime/src/lib.rs
@@ -364,6 +364,7 @@ pub fn normalize_runtime_provider_name(provider: &str) -> String {
     match normalized.as_str() {
         "codex" => "openai-codex".to_string(),
         "claude" | "claude-code" => "anthropic".to_string(),
+        "mixture" | "mixture-of-agents" | "mixture_of_agents" => "moa".to_string(),
         "nous_api" | "nousapi" | "nous-portal-api" => "nous-api".to_string(),
         "qwen-cli" | "qwen-portal" => "qwen-oauth".to_string(),
         "gemini-cli" | "gemini-oauth" => "google-gemini-cli".to_string(),
@@ -525,6 +526,8 @@ pub fn allow_no_api_key(
 ) -> bool {
     local_backends::is_local_backend_provider(runtime_provider)
         || local_backends::is_local_backend_provider(provider_name)
+        || runtime_provider == "moa"
+        || provider_name == "moa"
         || runtime_provider == "bedrock"
         || provider_name == "bedrock"
         || base_url.is_some_and(local_backends::is_local_or_private_base_url)
@@ -699,6 +702,11 @@ pub fn build_provider_with_auth_resolver(
 ) -> Arc<dyn LlmProvider> {
     let (provider_name, model_name) = resolve_provider_and_model(config, model);
     let runtime_provider = normalize_runtime_provider_name(provider_name.as_str());
+    if runtime_provider == "moa" {
+        return Arc::new(NoBackendProvider {
+            model: model.to_string(),
+        });
+    }
     let model_name = hermes_agent::model_normalize::normalize_model_for_provider(
         model_name.as_str(),
         runtime_provider.as_str(),
@@ -1175,6 +1183,13 @@ mod tests {
         assert_eq!(local.base_url.as_deref(), Some("http://127.0.0.1:8080/v1"));
         assert!(!local.api_key_present);
         assert!(local.local_no_key_allowed);
+
+        let moa = provider_runtime_diagnostic(&local_cfg, "moa:default");
+        assert_eq!(moa.runtime_provider, "moa");
+        assert_eq!(moa.model, "default");
+        assert!(moa.base_url.is_none());
+        assert!(!moa.api_key_present);
+        assert!(moa.local_no_key_allowed);
     }
 
     #[test]
@@ -1664,6 +1679,9 @@ mod tests {
             normalize_runtime_provider_name("nous-portal-api"),
             "nous-api"
         );
+        assert_eq!(normalize_runtime_provider_name("mixture"), "moa");
+        assert_eq!(normalize_runtime_provider_name("mixture-of-agents"), "moa");
+        assert_eq!(normalize_runtime_provider_name("mixture_of_agents"), "moa");
         assert_eq!(normalize_runtime_provider_name("moonshot"), "kimi");
         assert_eq!(normalize_runtime_provider_name("novita-ai"), "novita");
         assert_eq!(
@@ -1943,6 +1961,7 @@ mod tests {
         assert!(allow_no_api_key("ollama-local", "ollama-local", None));
         assert!(allow_no_api_key("lmstudio", "lmstudio", None));
         assert!(allow_no_api_key("koboldcpp", "koboldcpp", None));
+        assert!(allow_no_api_key("moa", "moa", None));
         assert!(allow_no_api_key(
             "text-generation-webui",
             "text-generation-webui",

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5133,6 +5133,11 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported by eliminating the silent fallback path in Rust: session.title returns an explicit JSON-RPC error for missing sessions and empty titles, while successful live-session title updates emit an observable session_info_update event and persist through the Rust manager callback."
+    },
+    "c6575df92781a5b6859845b39ee59d7f07a8cf31": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust as a first-class virtual MoA provider: model/provider catalogs expose moa:default, provider identity/startup diagnostics treat MoA as a no-key virtual provider instead of a generic API backend, CLI model switching persists moa:default without rebuilding a fake agent, and selected MoA turns automatically route through Rust quorum fan-out with upstream-style reference voters and a concrete aggregator model before restoring the visible virtual selection."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T16:55:04.772488+00:00`
+Generated: `2026-06-26T17:21:43.590412+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T16:55:04.772488+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 130 |
-| ported | 472 |
+| pending | 129 |
+| ported | 473 |
 | superseded | 6438 |
 
 ## First 100 Pending Commits


### PR DESCRIPTION
## Summary
- Adds `moa` as a Rust virtual provider/model catalog entry with `moa:default`.
- Treats MoA as a no-key virtual provider in provider identity/startup diagnostics and prevents accidental GenericProvider fallback.
- Routes selected `moa:default` turns through existing Rust quorum fan-out with reference voters, switches to a concrete aggregator for synthesis, then restores the visible virtual model.
- Updates the upstream parity queue for `c6575df92781` from pending to ported (`pending 130 -> 129`, `ported 472 -> 473`).

## Verification
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `test ! -d target`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli --lib moa -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli --lib normalize_provider_model_rejects_list_and_bare_provider_names -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-core --lib canonical_provider_id_normalizes_common_aliases -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-provider-runtime --lib provider_runtime_diagnostic_reports_openai_pro_and_local_no_key -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-provider-runtime --lib normalize_runtime_provider_name_covers_local_and_cloud_aliases -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-provider-runtime --lib allow_no_api_key_for_local_backends_and_private_base_urls -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo clippy -p hermes-core -p hermes-provider-runtime --lib --no-deps -- -D warnings`

Note: strict `cargo clippy -p hermes-cli --lib --no-deps -- -D warnings` was attempted and is blocked by existing unrelated baseline warnings in `auth.rs`, `commands.rs`, `tui.rs`, and `alpha_runtime.rs`; no MoA-specific diagnostics were emitted before the baseline failure.
