### PR TITLE
parity(queue): classify desktop-only backlog

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T18:34:05.584299+00:00`_
+_Generated from source artifacts: `2026-06-26T18:52:58.216600+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T18:34:05.418704+00:00`
-- Proof snapshot generated: `2026-06-26T18:34:05.584299+00:00`
+- Queue snapshot generated: `2026-06-26T18:52:58.048662+00:00`
+- Proof snapshot generated: `2026-06-26T18:52:58.216600+00:00`
 
 ## Gate Status
 
@@ -18,8 +18,8 @@ _Generated from source artifacts: `2026-06-26T18:34:05.584299+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=127.0, limit=0)
-- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000); max_queue_pending_commits (actual=127.0, limit=100)
+- Release gate failures: max_queue_pending_commits (actual=53.0, limit=0)
+- CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
 - CI gate warnings: none
 
 ## Test Coverage Audit
@@ -75,9 +75,9 @@ _Generated from source artifacts: `2026-06-26T18:34:05.584299+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 127 |
+| Pending | 53 |
 | Ported | 475 |
-| Superseded | 6438 |
+| Superseded | 6512 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,10 +196,10 @@
         "status": "pass"
       },
       {
-        "actual": 127.0,
+        "actual": 53.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
-        "status": "fail"
+        "status": "pass"
       }
     ],
     "mode": "tree-drift",
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T18:34:05.584299+00:00",
+  "generated_at_utc": "2026-06-26T18:52:58.216600+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 127.0,
+    "max_queue_pending_commits": 53.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 127,
+      "pending": 53,
       "ported": 475,
-      "superseded": 6438
+      "superseded": 6512
     },
     "by_target_ticket": {
       "20": 3202,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 127.0,
+        "actual": 53.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T18:34:05.584299+00:00`
+Generated: `2026-06-26T18:52:58.216600+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T18:34:05.584299+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 127.0 |
+| `max_queue_pending_commits` | 53.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5148,6 +5148,376 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust Krea payload construction: image_url/reference_image_urls are deduplicated, capped at 10, and converted to Krea image_style_references objects with {url, strength: 0.6} instead of invalid bare URL strings; regression tests assert the exact request shape."
+    },
+    "866f1d65c4aa7b8589f03b0810ef24464bf86965": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "8666fd7635bab1f66d82d180e5afffa89a57e8ba": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "461fcc096479f548a1990fe26f329649fe40c371": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "fb3d31ba8b772bbca130f829423df7e61afd7820": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "65a477f12e3581fb1771019672385ce011a94929": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "6bbacc2238997718026c7868f4b76092fe602ed8": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "f72690825e76fd205b3f475bdac75643e42bcf49": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "745c4db235bdb09beb19564f66727dc1f43e4fe2": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "7785655b4ece4deb7e8bbeeaa2a6a8342746d465": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "16aeba17078d5470f21eedb504142554169e748c": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "bef1d3e4ff6aaf8b6143ce66d7a5e6169a08a86f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "13ce8119067ead38cde7ec262f265af6f1c1551f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "e5e25836350a7041e58bb4ecfd55cba893630df4": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "a61baa96157241c2e422fd85b3527bee14b41c62": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "c6fbd5a10494541ec3f29b77bc639e6ce3441c18": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "ac128af1cec30238f21376273ce4f96088a800bd": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "61c266b0dc75562a97dc0a377a7dc141d0b0a5ac": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "d4fa2db1c5dfd961776c77a619767e9ef17abce9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "17dfc6bec4a8b7fd840d479c33e9a7b2449f805d": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "79f270f5496267ca9713d40af277e8453e528d8f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "aff5ae692fb2e09a68344c841f5a6a461fb33f3f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "ea5fa505d9743d1f6e0036480a36eaebc60d79af": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "de7ad8b78eaeab96324b9800e28f12d8b92e83a7": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "a6b670d4a251f98ca3bac91a867bb469f7ce4e93": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "3fffecbdafec0bcb08a7335da4e15181bc6ff5d6": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "cb17a9efb2dffb35ab5f827f0766d17b94fab91f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "d0af7fc954fe61c030a29be38d5c63f67f0bf7b2": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "48a8f8416937dc3168903a89d0e34f8416c24965": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "7daa6d83fcaa4822f5a6f878c5e78f0d94ff1d26": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "9fd2b2cb9fab9e5d7a49b4102ad028fa430ede1e": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "281a439ad483e6f130c2305a5e932c652778cb3b": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "66a0907c9566016b4d8f295c176e6917f67f0f04": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "7243111c57bb6fad870e2eee7eda4cfcada4d7af": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "d398076c21175458003fed2d64c8339ed8861293": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "a4a74ca9e9a0f7d7d8e731d927139ccba0a588ec": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "2de7549fe0fe06954dd7b72528ca37953d62ada1": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "743985bf1ec4c911cd5af7bec705a419d8cdd61b": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "a268dfff0a055dad7d73d45ede53a5687159a65c": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "8d1706ae5cb2e0bcffd6496d45e3c7f10e4b0cc1": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "2a75c4a8cb4aaa1f08c0a4fda9a192e52e89cec2": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "93192059c96c5ba56c28c6c41255bc63af4c95fa": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "a6485bddb855536e60baa7074573a820d3d1ee76": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "cb6edbf448e7878fd25bf6db20df4c18ed8755a7": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "65b13e9dbc9330fe34cba2d44f915b05fe4b1f33": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "00779800f650c8b875f0f9ab6f08fa33531e6494": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "9a4600c5fb9bdd21e5d035181bfc7fbdb9340497": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "2ea94c6c45814862e9ebacf80d8051b58da980f7": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "284be6cc247c46aa6e2bf2b1b271a5e7fafb5558": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "7e2db0a140dbdbcf32035f9174c3e189317f8168": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "4aeaba69225151b36ab7c23803eefb99ae140f8f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "cbe5c5689f9cb0e86903431c6337e0d87abf4b9b": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "f2c45e2c816d6e9e51416fa22436f29bcf97dc06": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "281b333cc5f048cc37e7b2075bde9c353b9a0496": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "25c31cab624e6556af09f8fe693c535578c5e8e5": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "5196575d40caa367395c5535da1c99caecef072c": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "6b3ea2cea6889d24a67fbd973868c8cca2d8a615": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "da73223f4aba9beee9c020a5fee02f243414a3d7": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "2e3efce66ebd0a144a0733333e1c0d31d9f65c5d": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "e2b801872992867c3e48630f22f939fcf0d807c9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "344415892f5d1de80fe4141e4ba3dfb76d167124": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "74352a1e61361daa87f7ec5dfe9eed41777d79cd": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "488ae376dbef8e411f30e844e8b40ba55fc97e19": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "7a7f9a5b3d1af1bab4f7d50484b836c5dceb7a50": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "68680db10d1744bcff4fd2fbc519cccc8447e0e3": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "a391523bccc35af2bdee558734600a496da02420": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "19ca295a846a8a032a01ba5da3d74c827e2e26d4": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "df514654ba5d7359fc3484ca2396892c054889fe": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "1f950e189ce7e68696298dc14ccbcf15a44eb213": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "09623b4527351b46c326c998b603d078ee87eb6c": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "6e096a850a2c82bdad4e4caa8e2d739ae34086f4": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "563d347e4d420e233a2ed77274e949d93598057f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "da5484b61ff75ac1727136ede9fbd3189935ae08": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "3b1344c18c3dc485d5d89f7a9b061d32e76e9bf9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "76074b214517109f4816ea6e83042ea65712b131": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T18:34:05.418704+00:00`
+Generated: `2026-06-26T18:52:58.048662+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-26T18:34:05.418704+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 127 |
+| pending | 53 |
 | ported | 475 |
-| superseded | 6438 |
+| superseded | 6512 |
 
 ## First 100 Pending Commits
 
@@ -31,7 +31,6 @@ Generated: `2026-06-26T18:34:05.418704+00:00`
 | `db744e7d1e58` | #21 | feat(simplify-code): add risk-tiered application, Chesterton's Fence, slop + silent failure detection |
 | `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
 | `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |
-| `866f1d65c4aa` | #26 | chore(desktop): sync package.json version fallback to 0.17.0 (#49236) |
 | `d799284b1554` | #21 | feat(optional-skills/creative-ideation): expand to v2.1.0 method library (#42402) |
 | `37fa3c58b40e` | #21 | docs(kanban-worker): document kanban_complete artifacts deliverable param (#49854) |
 | `31bdb60013c9` | #22 | docs(skills): fix himalaya CLI arg order and download flag |
@@ -50,78 +49,32 @@ Generated: `2026-06-26T18:34:05.418704+00:00`
 | `98ecd0beeba9` | #26 | docs(mcp): fix stale ~0.75s discovery-wait reference in late-refresh docstring |
 | `b1ab5a8ae1d9` | #21 | docs(antigravity-cli): add delegation patterns + output/bounding caveats |
 | `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
-| `8666fd7635ba` | #26 | fix(desktop): preserve other providers' hide-all in model visibility dialog |
-| `461fcc096479` | #26 | test(desktop): harden model-visibility toggle + dedupe default expansion |
-| `fb3d31ba8b77` | #26 | feat(desktop): add Update now button to About panel |
-| `65a477f12e35` | #26 | feat(desktop): add Update now button to About panel (#50186) |
-| `6bbacc223899` | #26 | fix(desktop): make cold-start port-announcement deadline tolerant |
-| `f72690825e76` | #26 | fix(desktop/windows): stop in-app update from cascading into a backend restart loop (#50381) |
-| `745c4db235bd` | #26 | feat(desktop/windows): show update-in-progress feedback before the desktop exits (#50419) (#50448) |
-| `7785655b4ece` | #26 | fix(desktop): keep the floating composer in-bounds so it can't be lost off-screen |
 | `37c37c9dc511` | #26 | fix(antigravity): register google-antigravity ProviderProfile + AUTHOR_MAP |
-| `16aeba17078d` | #26 | fix(desktop): clamp composer peel-off under cursor |
-| `bef1d3e4ff6a` | #26 | fix(desktop): filter undefined entries in AttachmentList to prevent refText crash on session switch (#49624) |
-| `13ce8119067e` | #26 | fix: show desktop approval fallback (#46548) |
-| `e5e25836350a` | #26 | fix(desktop): relaunch on Linux after in-app update instead of hanging (#45205) |
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
 | `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
 | `0768ed3b33e4` | #26 | docs(agents): fix stale platform adapter path in token-lock note |
 | `b9b4756ab480` | #22 | fix dashboard chat session titles |
-| `a61baa961572` | #26 | feat(desktop): PR-style file diffs in chat |
-| `c6fbd5a10494` | #26 | style(desktop): lead --dt-font-mono with bundled JetBrains Mono |
-| `ac128af1cec3` | #26 | feat(desktop): syntax-highlight inline diffs via Shiki |
-| `61c266b0dc75` | #26 | style(desktop): soften dark-mode syntax highlighting |
-| `d4fa2db1c5df` | #26 | fix(desktop): show all of a provider's models when searching the composer picker |
-| `17dfc6bec4a8` | #26 | fix(desktop): set AppUserModelID on Windows so notifications fire (#50808) |
-| `79f270f54962` | #26 | fix(desktop): portal floating composer to body so it can't be clipped off-screen |
-| `aff5ae692fb2` | #26 | fix(desktop): move composer out of contain wrapper instead of portaling |
-| `ea5fa505d974` | #26 | fix(desktop): clamp floating composer to the thread area, not the whole window |
-| `de7ad8b78eae` | #26 | fix(desktop): guarantee out-of-bounds composer is reclamped on load |
 | `ff08e60c63ad` | #21 | feat(skills): add cloudflare-temporary-deploy optional skill (#50849) |
-| `a6b670d4a251` | #26 | fix(desktop): avoid stack overflow on embedded image replay |
-| `3fffecbdafec` | #26 | feat(desktop): add timeline rail for long chat threads |
-| `cb17a9efb2df` | #26 | fix(desktop): stop auto-opening tool previews |
-| `d0af7fc954fe` | #26 | feat(desktop): detect tool previews into composer status stack |
-| `48a8f8416937` | #26 | fix(desktop): toggle preview rail and open in browser |
-| `7daa6d83fcaa` | #26 | style(desktop): soften inline code and expanded tool chrome |
 | `45540cfb5ef1` | #25 | ci: run only the lanes a PR affects (python/frontend/site) |
 | `2977e7454377` | #25 | ci: build Docker on main + release only, never on PRs |
 | `56b4ef74a631` | #25 | ci: make dependency installs resilient to transient flakes |
 | `05c896cf5249` | #25 | ci: refactor paths & clones |
 | `a0471e24648e` | #25 | fix(ci): only run supplychain checks in pr |
-| `9fd2b2cb9fab` | #26 | fix(desktop): replace native title tooltips with styled Tip component |
 | `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |
 | `935f2bc48daa` | #26 | docs(relay): add §3.4 — obligations on a future scale-to-zero behaviour layer (#51633) |
-| `281a439ad483` | #26 | fix(desktop): guard composer mutations when the composer core isn't bound (#51728) |
 | `a911bcda18cf` | #22 | docs: stop recommending pip install; curl installer is the only supported path (#51743) |
 | `8446c1570683` | #26 | docs(chronos): pin hop-1 auth to the hosted-agent bootstrap token |
-| `66a0907c9566` | #26 | fix(desktop): keep configured onboarding state on fallback runtime probes |
-| `7243111c57bb` | #26 | test(desktop): cover fallback timeout onboarding downgrade regression |
-| `d398076c2117` | #26 | fix(desktop): show non-blocking notification on fallback runtime probe |
-| `a4a74ca9e9a0` | #26 | fix(desktop): use notify() with stable id for fallback notification |
 | `6da615c77cf8` | #26 | fix(desktop): scope onboarding runtime check to connected provider |
 | `d8fe1c0b4195` | #20 | test(desktop): cover scoped onboarding runtime readiness checks |
-| `2de7549fe0fe` | #26 | feat(desktop): remember window size/position/maximized across launches (salvage #39154) |
 | `aab49f6927cc` | #20 | feat(pets): generation RPCs, non-blocking gallery + gateway plumbing |
-| `743985bf1ec4` | #26 | feat(pets): Pokédex generate UI — overlay, animated egg, hatch FX, manage |
 | `b674f7ba28c4` | #26 | feat(pets): offer backend setup when generation is unavailable |
-| `a268dfff0a05` | #26 | fix(desktop): make Agents indicator match the Spawn-tree panel |
-| `8d1706ae5cb2` | #26 | fix(desktop): wire Ctrl+B voice, declutter voice settings, stop endless TTS hang |
-| `2a75c4a8cb4a` | #26 | fix(desktop): give the gateway reconnect loop an escape hatch |
-| `93192059c96c` | #26 | fix(desktop): let the session watchdog heal a stuck "looping" turn |
 | `1fe013ee16f1` | #20 | feat(pets): polish generate flow and reduce hatch CPU pressure |
-| `a6485bddb855` | #26 | fix(desktop): don't report a bogus update count for a shallow checkout |
-| `cb6edbf448e7` | #26 | fix(desktop): skip the rev-list count when it is discarded anyway |
-| `65b13e9dbc93` | #26 | fix(desktop): route gateway restart / status / update to the active profile |
-| `00779800f650` | #26 | fix(desktop): hide platform/internal toolsets from the Skills & Tools list |
-| `9a4600c5fb9b` | #26 | fix(desktop): stop the update overlay looking frozen while it works |
-| `2ea94c6c4581` | #26 | fix(pets): make inline generate cancel discard draft flow |
-| `284be6cc247c` | #26 | Merge pull request #52210 from helix4u/fix/desktop-update-progress-visibility |
-| `7e2db0a140db` | #26 | fix(desktop): stop refText crash on undefined composer attachment holes |
-| `4aeaba692251` | #26 | test(desktop): cover undefined/null attachment holes in ref helpers |
-| `cbe5c5689f9c` | #26 | perf(desktop): bound tool-result rendering so big /learn runs don't freeze (#52273) |
-| `f2c45e2c816d` | #26 | fix(desktop): limit pending tool shimmer to action verb |
-| `281b333cc5f0` | #26 | test(desktop): cover localized tool title shimmer |
 | `e92b5c6af8be` | #20 | feat(pets): quality-first OpenRouter model chain + stronger atlas gates + global pet-gen notifications |
 | `7078d9d1e29d` | #26 | fix(pets): raise generation timeouts for the slow quality-first model path |
+| `a6a28ce3e217` | #25 | fix(ci): run CI on all PRs to anywhere |
+| `b8d220f2684c` | #26 | feat(desktop): wire project settings and shell chrome |
+| `890e890281e4` | #26 | chore(desktop): update package lock |
+| `e7d2f0b93ca2` | #24 | fix(windows): suppress console flashes and harden gateway restarts |
+| `ff813659880f` | #26 | feat(desktop): in-app spot editor for the file preview pane |
+| `233ef98afe2f` | #20 | fix(docker): skip symlinked stage2 chown targets (#52789) |


### PR DESCRIPTION
## Summary
- Classify 74 pending upstream commits whose touched files are strictly under `apps/desktop/` or `apps/bootstrap-installer/` as superseded by the Rust-first shipped surface policy.
- Exclude mixed commits touching Python gateway/provider/install/runtime files for separate Rust evidence.
- Regenerate parity queue/proof/dashboard artifacts.

## Parity Delta
- `pending`: 127 -> 53
- `superseded`: 6438 -> 6512
- `ported`: 475 unchanged
- `mirrored`: 76 unchanged

## Verification
- Override guard script: `selected=74 bad=0` for strict desktop/bootstrap-only file samples
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `test ! -d target`

## Notes
This PR intentionally does not classify mixed commits such as provider OAuth, pet generation, docker/install, Python gateway, docs+config, or CI changes. Those remain pending for separate Rust implementation or evidence-backed classification.
