### PR TITLE
parity(queue): classify docs and ci backlog

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T18:52:58.216600+00:00`_
+_Generated from source artifacts: `2026-06-26T18:55:29.935483+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T18:52:58.048662+00:00`
-- Proof snapshot generated: `2026-06-26T18:52:58.216600+00:00`
+- Queue snapshot generated: `2026-06-26T18:55:29.765911+00:00`
+- Proof snapshot generated: `2026-06-26T18:55:29.935483+00:00`
 
 ## Gate Status
 
@@ -18,7 +18,7 @@ _Generated from source artifacts: `2026-06-26T18:52:58.216600+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=53.0, limit=0)
+- Release gate failures: max_queue_pending_commits (actual=37.0, limit=0)
 - CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
 - CI gate warnings: none
 
@@ -75,9 +75,9 @@ _Generated from source artifacts: `2026-06-26T18:52:58.216600+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 53 |
+| Pending | 37 |
 | Ported | 475 |
-| Superseded | 6512 |
+| Superseded | 6528 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 53.0,
+        "actual": 37.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T18:52:58.216600+00:00",
+  "generated_at_utc": "2026-06-26T18:55:29.935483+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 53.0,
+    "max_queue_pending_commits": 37.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 53,
+      "pending": 37,
       "ported": 475,
-      "superseded": 6512
+      "superseded": 6528
     },
     "by_target_ticket": {
       "20": 3202,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 53.0,
+        "actual": 37.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T18:52:58.216600+00:00`
+Generated: `2026-06-26T18:55:29.935483+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T18:52:58.216600+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 53.0 |
+| `max_queue_pending_commits` | 37.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5518,6 +5518,86 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+    },
+    "f06508836dd4e5c56ffc14912725c12c6d941291": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "2b08a4295a650d27fc354573ef2dde87dd211103": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "9e4348f28ac114c3f88d68e2df1fb915f1c2d3b9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "f6275a59e790477092e6c70b06ba4a5d1d882615": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "df4015bbc176535e9bf58d5541186563365a2275": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "eec9c1d84ebdfd5117de0084c0b1c7bcc3ba4cb3": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "f80088f035de303d6e8c1e59764d2008571ca01a": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "0768ed3b33e43df7de05c59017c997bb5e2960f5": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "45540cfb5ef1e30c71d46166a171d88101e8fcb7": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+    },
+    "2977e7454377bdb9cb101e4d387e1df7720af8a7": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+    },
+    "56b4ef74a631bdca0bd5cc58bd43369fc227ea83": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+    },
+    "05c896cf524991f95c34ce73d2cbe985b5e0558f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+    },
+    "a0471e24648ef29ef6a3c681eb5b9917ae910258": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+    },
+    "935f2bc48daa9c7fad73f80c95d4375da18a39c1": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "8446c1570683d99859f53b27002f21f4d19c1955": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+    },
+    "a6a28ce3e2174c0be494f553ab5fd79b7039190f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T18:52:58.048662+00:00`
+Generated: `2026-06-26T18:55:29.765911+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,9 +17,9 @@ Generated: `2026-06-26T18:52:58.048662+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 53 |
+| pending | 37 |
 | ported | 475 |
-| superseded | 6512 |
+| superseded | 6528 |
 
 ## First 100 Pending Commits
 
@@ -29,20 +29,13 @@ Generated: `2026-06-26T18:52:58.048662+00:00`
 | `9362ce2575e0` | #22 | feat(skills): add html-artifact skill, fold in sketch + architecture-diagram + concept-diagrams (#48899) |
 | `92451151c642` | #22 | Revert "feat(skills): add html-artifact skill, fold in sketch + architecture-diagram + concept-diagrams (#48899)" |
 | `db744e7d1e58` | #21 | feat(simplify-code): add risk-tiered application, Chesterton's Fence, slop + silent failure detection |
-| `f06508836dd4` | #26 | docs(security): enumerate cron job scripts in §2.3 credential scoping |
 | `2bd1977d8fad` | #26 | chore: release v0.17.0 (2026.6.19) |
 | `d799284b1554` | #21 | feat(optional-skills/creative-ideation): expand to v2.1.0 method library (#42402) |
 | `37fa3c58b40e` | #21 | docs(kanban-worker): document kanban_complete artifacts deliverable param (#49854) |
 | `31bdb60013c9` | #22 | docs(skills): fix himalaya CLI arg order and download flag |
-| `2b08a4295a65` | #26 | docs(README.zh-CN): update Windows install from 'not supported' to native PowerShell |
-| `9e4348f28ac1` | #25 | docs(windows): document uv.exe AV false positive |
-| `f6275a59e790` | #26 | docs(contributing): add "search first" guidance to cut duplicate PRs |
 | `46cc0345ae8a` | #21 | docs(skills): add hermes-agent verification rule |
 | `5eb158e3173d` | #21 | docs(hermes-agent skill): document project context files and their discovery rules |
 | `2609bcccca30` | #25 | feat(i18n): add complete Spanish translation |
-| `df4015bbc176` | #26 | docs: session lifecycle documentation |
-| `eec9c1d84ebd` | #26 | docs(agents): clarify background delegation durability |
-| `f80088f035de` | #26 | docs: add missing Prerequisites/How to Run sections to SKILL.md template |
 | `242962e1f5a0` | #22 | docs(providers): clarify vllm qwen reasoning output |
 | `95d970a7521c` | #21 | docs: sharpen software-development skills |
 | `defeda8c559f` | #22 | docs: sync documentation with current implementation |
@@ -53,18 +46,10 @@ Generated: `2026-06-26T18:52:58.048662+00:00`
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
 | `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
-| `0768ed3b33e4` | #26 | docs(agents): fix stale platform adapter path in token-lock note |
 | `b9b4756ab480` | #22 | fix dashboard chat session titles |
 | `ff08e60c63ad` | #21 | feat(skills): add cloudflare-temporary-deploy optional skill (#50849) |
-| `45540cfb5ef1` | #25 | ci: run only the lanes a PR affects (python/frontend/site) |
-| `2977e7454377` | #25 | ci: build Docker on main + release only, never on PRs |
-| `56b4ef74a631` | #25 | ci: make dependency installs resilient to transient flakes |
-| `05c896cf5249` | #25 | ci: refactor paths & clones |
-| `a0471e24648e` | #25 | fix(ci): only run supplychain checks in pr |
 | `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |
-| `935f2bc48daa` | #26 | docs(relay): add §3.4 — obligations on a future scale-to-zero behaviour layer (#51633) |
 | `a911bcda18cf` | #22 | docs: stop recommending pip install; curl installer is the only supported path (#51743) |
-| `8446c1570683` | #26 | docs(chronos): pin hop-1 auth to the hosted-agent bootstrap token |
 | `6da615c77cf8` | #26 | fix(desktop): scope onboarding runtime check to connected provider |
 | `d8fe1c0b4195` | #20 | test(desktop): cover scoped onboarding runtime readiness checks |
 | `aab49f6927cc` | #20 | feat(pets): generation RPCs, non-blocking gallery + gateway plumbing |
@@ -72,7 +57,6 @@ Generated: `2026-06-26T18:52:58.048662+00:00`
 | `1fe013ee16f1` | #20 | feat(pets): polish generate flow and reduce hatch CPU pressure |
 | `e92b5c6af8be` | #20 | feat(pets): quality-first OpenRouter model chain + stronger atlas gates + global pet-gen notifications |
 | `7078d9d1e29d` | #26 | fix(pets): raise generation timeouts for the slow quality-first model path |
-| `a6a28ce3e217` | #25 | fix(ci): run CI on all PRs to anywhere |
 | `b8d220f2684c` | #26 | feat(desktop): wire project settings and shell chrome |
 | `890e890281e4` | #26 | chore(desktop): update package lock |
 | `e7d2f0b93ca2` | #24 | fix(windows): suppress console flashes and harden gateway restarts |


### PR DESCRIPTION
## Summary
- Classify 16 pending upstream commits that are pure repo docs or pure CI/workflow changes as non-Rust-runtime superseded.
- Exclude skills catalogs, provider/OAuth, install/docker, pet-generation, gateway-mixed, config-mixed, and runtime files for separate handling.
- Regenerate queue/proof/dashboard artifacts.

## Parity Delta
- `pending`: 53 -> 37
- `superseded`: 6512 -> 6528
- `ported`: 475 unchanged
- `mirrored`: 76 unchanged

## Verification
- Selector guard: `selected=16 bad=0`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `test ! -d target`
