### PR TITLE
parity(queue): close dashboard session title slice

### DIFF
--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T18:55:29.935483+00:00`_
+_Generated from source artifacts: `2026-06-26T19:01:29.899735+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T18:55:29.765911+00:00`
-- Proof snapshot generated: `2026-06-26T18:55:29.935483+00:00`
+- Queue snapshot generated: `2026-06-26T19:01:29.777273+00:00`
+- Proof snapshot generated: `2026-06-26T19:01:29.899735+00:00`
 
 ## Gate Status
 
@@ -18,7 +18,7 @@ _Generated from source artifacts: `2026-06-26T18:55:29.935483+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=37.0, limit=0)
+- Release gate failures: max_queue_pending_commits (actual=36.0, limit=0)
 - CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
 - CI gate warnings: none
 
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-26T18:55:29.935483+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 37 |
-| Ported | 475 |
+| Pending | 36 |
+| Ported | 476 |
 | Superseded | 6528 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 37.0,
+        "actual": 36.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T18:55:29.935483+00:00",
+  "generated_at_utc": "2026-06-26T19:01:29.899735+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 37.0,
+    "max_queue_pending_commits": 36.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 37,
-      "ported": 475,
+      "pending": 36,
+      "ported": 476,
       "superseded": 6528
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 37.0,
+        "actual": 36.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T18:55:29.935483+00:00`
+Generated: `2026-06-26T19:01:29.899735+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T18:55:29.935483+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 37.0 |
+| `max_queue_pending_commits` | 36.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -3164,6 +3164,11 @@
       "disposition": "superseded",
       "notes": "Opening chats in separate Electron windows is desktop-only and not part of the Rust CLI/gateway runtime."
     },
+    "b9b4756ab4805437003b55127c369dc18ce22b3b": {
+      "disposition": "ported",
+      "notes": "Rust ACP/gateway already port the dashboard session-title contract: session.title/session-title normalizes and persists explicit titles, emits session_info_update with title payloads, and session/list, /status, and /sessions prefer explicit titles over history-derived fallbacks. Focused ACP and gateway tests cover live runtime-only title updates, event propagation, persistence, and title surfacing.",
+      "owner": "rust-runtime"
+    },
     "b9f1ac8c1022": {
       "disposition": "superseded",
       "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T18:55:29.765911+00:00`
+Generated: `2026-06-26T19:01:29.777273+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T18:55:29.765911+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 37 |
-| ported | 475 |
+| pending | 36 |
+| ported | 476 |
 | superseded | 6528 |
 
 ## First 100 Pending Commits
@@ -46,7 +46,6 @@ Generated: `2026-06-26T18:55:29.765911+00:00`
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
 | `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
-| `b9b4756ab480` | #22 | fix dashboard chat session titles |
 | `ff08e60c63ad` | #21 | feat(skills): add cloudflare-temporary-deploy optional skill (#50849) |
 | `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |
 | `a911bcda18cf` | #22 | docs: stop recommending pip install; curl installer is the only supported path (#51743) |


### PR DESCRIPTION
## Summary
- marks upstream `b9b4756ab480` dashboard chat session-title fix as ported by existing Rust ACP/gateway title behavior
- regenerates the parity queue/proof/dashboard artifacts
- moves pending from 37 to 36 and ported from 475 to 476

## Evidence
- Rust ACP `session.title` / `session-title` normalizes and persists explicit titles
- ACP emits `session_info_update` with title payloads and `session/list` prefers explicit titles over history-derived fallback titles
- Rust gateway `/title`, `/status`, and `/sessions` surface explicit title metadata

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-acp session_title -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway gateway_title_command_persists_and_surfaces_session_title -- --nocapture`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `test ! -d target`