### PR TITLE
parity(compressor): preserve caller-owned logging

### DIFF
--- a/crates/hermes-agent/src/compression.rs
+++ b/crates/hermes-agent/src/compression.rs
@@ -1338,6 +1338,21 @@ mod tests {
     }
 
     #[test]
+    fn constructor_with_logging_enabled_is_reentrant() {
+        let cfg = CompressorConfig {
+            quiet_mode: false,
+            ..CompressorConfig::default()
+        };
+        let aux = aux_with_provider(CannedSummaryProvider::new("x"));
+
+        let first = ContextCompressor::new(cfg.clone(), aux.clone());
+        let second = ContextCompressor::new(cfg, aux);
+
+        assert_eq!(first.compression_count(), 0);
+        assert_eq!(second.compression_count(), 0);
+    }
+
+    #[test]
     fn budget_clamped_between_min_and_ceiling() {
         let cfg = CompressorConfig {
             context_length: 1_000_000,

--- a/crates/hermes-protocol-parity-tests/tests/fixtures/protocol_differential_contracts.json
+++ b/crates/hermes-protocol-parity-tests/tests/fixtures/protocol_differential_contracts.json
@@ -16,6 +16,12 @@
       "expected": { "canonical": "SendMessage" }
     },
     {
+      "id": "acp-session-title-canonical",
+      "kind": "acp_method_alias",
+      "input": { "method": "session.title" },
+      "expected": { "canonical": "SessionTitle" }
+    },
+    {
       "id": "acp-success-response-envelope",
       "kind": "acp_success_response",
       "input": {

--- a/crates/hermes-protocol-parity-tests/tests/protocol_differential_contracts.rs
+++ b/crates/hermes-protocol-parity-tests/tests/protocol_differential_contracts.rs
@@ -88,6 +88,7 @@ fn acp_method_label(method: &str) -> String {
         AcpMethod::SetSessionModel => "SetSessionModel",
         AcpMethod::SetSessionMode => "SetSessionMode",
         AcpMethod::SetConfigOption => "SetConfigOption",
+        AcpMethod::SessionTitle => "SessionTitle",
         AcpMethod::CreateConversation => "CreateConversation",
         AcpMethod::SendMessage => "SendMessage",
         AcpMethod::GetHistory => "GetHistory",

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T19:01:29.899735+00:00`_
+_Generated from source artifacts: `2026-06-26T19:15:01.390994+00:00`_
 
 ## Snapshot
 
 - Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
 - Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T19:01:29.777273+00:00`
-- Proof snapshot generated: `2026-06-26T19:01:29.899735+00:00`
+- Queue snapshot generated: `2026-06-26T19:15:01.247235+00:00`
+- Proof snapshot generated: `2026-06-26T19:15:01.390994+00:00`
 
 ## Gate Status
 
@@ -18,7 +18,7 @@ _Generated from source artifacts: `2026-06-26T19:01:29.899735+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=36.0, limit=0)
+- Release gate failures: max_queue_pending_commits (actual=35.0, limit=0)
 - CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
 - CI gate warnings: none
 
@@ -75,8 +75,8 @@ _Generated from source artifacts: `2026-06-26T19:01:29.899735+00:00`_
 | Metric | Value |
 | --- | ---: |
 | Total commits in queue | 7116 |
-| Pending | 36 |
-| Ported | 476 |
+| Pending | 35 |
+| Ported | 477 |
 | Superseded | 6528 |
 
 ## Tree/Patch Drift

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 36.0,
+        "actual": 35.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T19:01:29.899735+00:00",
+  "generated_at_utc": "2026-06-26T19:15:01.390994+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 36.0,
+    "max_queue_pending_commits": 35.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 36,
-      "ported": 476,
+      "pending": 35,
+      "ported": 477,
       "superseded": 6528
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 36.0,
+        "actual": 35.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T19:01:29.899735+00:00`
+Generated: `2026-06-26T19:15:01.390994+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T19:01:29.899735+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 36.0 |
+| `max_queue_pending_commits` | 35.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -172,6 +172,11 @@
       "disposition": "ported",
       "notes": "Rust Hindsight session-switch flushing routes through retain_hindsight_turns and the same document/update-mode targeting helper used by normal auto-retain batches."
     },
+    "0a7ae28ebc1a5e1c86cc43d78c215fb224b618a8": {
+      "disposition": "ported",
+      "notes": "Rust ContextCompressor is library-safe by construction: it only emits tracing events through caller-owned subscribers and does not initialize or replace global logging from the constructor. Added focused regression coverage proving logging-enabled compressor construction is reentrant, pinning the upstream root-logger regression class.",
+      "owner": "rust-runtime"
+    },
     "0a865e5948cb": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T19:01:29.777273+00:00`
+Generated: `2026-06-26T19:15:01.247235+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7116`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-26T19:01:29.777273+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 36 |
-| ported | 476 |
+| pending | 35 |
+| ported | 477 |
 | superseded | 6528 |
 
 ## First 100 Pending Commits
@@ -44,7 +44,6 @@ Generated: `2026-06-26T19:01:29.777273+00:00`
 | `72e4cca00ecc` | #26 | docs(config): correct MCP docs path in cli-config.yaml.example |
 | `37c37c9dc511` | #26 | fix(antigravity): register google-antigravity ProviderProfile + AUTHOR_MAP |
 | `84e1d31e5442` | #22 | refactor(kanban): fold worker/orchestrator skills into injected guidance (#50473) |
-| `0a7ae28ebc1a` | #26 | fix(compressor): remove logging.basicConfig from library class __init__ |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
 | `ff08e60c63ad` | #21 | feat(skills): add cloudflare-temporary-deploy optional skill (#50849) |
 | `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |


### PR DESCRIPTION
## Summary
- ports upstream `0a7ae28` compressor logging behavior to Rust by pinning `ContextCompressor` construction as caller-owned logging/tracing
- adds a focused Rust regression test proving logging-enabled compressor construction is reentrant
- fixes the protocol parity test fixture/helper for the existing `session.title` ACP method so the baseline-aware clippy gate compiles all targets
- regenerates parity queue/proof/dashboard artifacts, moving pending from 36 to 35 and ported from 476 to 477

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent constructor_with_logging_enabled_is_reentrant -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-protocol-parity-tests protocol_differential_fixture_matches_runtime_serialization -- --nocapture`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check` (`new=0`, stale=10)
- `test ! -d target`

## Notes
- strict `cargo clippy -p hermes-agent --lib --no-deps -- -D warnings` still fails on the existing hermes-agent baseline warnings; the repo allowlist gate passed with no new warnings.
- all cargo artifacts were kept on `/Volumes/wd_black/cargo-targets`.